### PR TITLE
feat(events): tenant-scoped event bus for multi-tenant isolation (#1338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.37.0] - 2026-06-17
+
+### Added
+
+- **Tenant-scoped event bus (#1338, cross-SDK parity with kailash-rs #1352)**:
+  new `kailash.events.TenantScopedEventBus` (also re-exported as
+  `kailash.TenantScopedEventBus`) gives multi-tenant pub/sub isolation over a
+  shared `EventBus`. It prefixes every topic with the tenant id
+  (`"acme:order.created"` vs `"globex:order.created"`); because both backends
+  dispatch by exact `event_type` (in-memory dict key, Redis one-stream-per-type),
+  a publish on one tenant fans out **only** within that tenant — isolation is
+  structural, not a runtime filter. The wrapper keeps the same
+  `publish` / `subscribe` / `subscribe_events` shape as `EventBus`; handlers
+  receive the original payload, and `subscribe_events` delivers a `DomainEvent`
+  whose `event_type` is the logical (un-prefixed) type. Isolation-integrity
+  guards: `tenant_id` MUST NOT contain the separator; every wrapper sharing one
+  bus MUST use the same separator (a mismatched separator is refused — it could
+  otherwise map two distinct tenants onto the same topic); and bus-construction
+  kwargs are rejected (not silently dropped) when a shared bus is passed. Works
+  unchanged over the Redis Streams backend, where prefixing is the only way to
+  isolate tenants sharing one broker. Runnable example at
+  `examples/eventbus_tenant_isolation.py`.
+
 ## [2.36.0] - 2026-06-17
 
 ### Added

--- a/examples/eventbus_tenant_isolation.py
+++ b/examples/eventbus_tenant_isolation.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-tenant event isolation with the Kailash EventBus.
+
+Run:  python examples/eventbus_tenant_isolation.py
+
+A SaaS app serves many tenants from one process and one event bus. Every
+tenant must see ONLY its own events — tenant ``acme``'s ``order.created``
+must never reach tenant ``globex``'s handlers. ``TenantScopedEventBus``
+gives that isolation for free: it prefixes every topic with the tenant id
+(``"acme:order.created"`` vs ``"globex:order.created"``), and because the
+bus dispatches by exact event_type the two tenants can never cross.
+
+The same pattern works unchanged over the Redis Streams backend
+(``EventBus(backend="redis")``) — there, prefixing is the ONLY way to keep
+tenants sharing one broker isolated, because every tenant's events land on
+its own Redis stream key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from kailash import EventBus, TenantScopedEventBus
+
+
+async def main() -> None:
+    # ONE shared transport for the whole process...
+    bus = EventBus()  # in-memory default; swap for EventBus(backend="redis")
+
+    # ...one tenant-scoped facade per tenant.
+    acme = TenantScopedEventBus("acme", bus)
+    globex = TenantScopedEventBus("globex", bus)
+
+    acme_orders: list[dict] = []
+    globex_orders: list[dict] = []
+
+    async def on_acme_order(payload: dict) -> None:
+        acme_orders.append(payload)
+        print(f"  [acme handler]   received {payload}")
+
+    async def on_globex_order(payload: dict) -> None:
+        globex_orders.append(payload)
+        print(f"  [globex handler] received {payload}")
+
+    acme_sub = acme.subscribe("order.created", on_acme_order)
+    globex_sub = globex.subscribe("order.created", on_globex_order)
+
+    print("Publishing one order per tenant on the SAME bus:")
+    await acme.publish("order.created", {"order_id": "A-1", "total": 42.0})
+    await globex.publish("order.created", {"order_id": "G-1", "total": 99.0})
+    await asyncio.sleep(0.05)  # let in-memory handlers drain
+
+    # Isolation guarantee: each tenant saw ONLY its own event.
+    assert acme_orders == [{"order_id": "A-1", "total": 42.0}], acme_orders
+    assert globex_orders == [{"order_id": "G-1", "total": 99.0}], globex_orders
+    print("\nIsolation holds: acme saw 1 order, globex saw 1 order, zero cross-talk.")
+
+    await acme_sub.unsubscribe()
+    await globex_sub.unsubscribe()
+    await bus.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.36.0"
+version = "2.37.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -11,7 +11,7 @@ disabled because it does not follow ``__getattr__`` fallbacks.
 
 import warnings
 
-from kailash.events import DomainEvent, EventBus, Subscription
+from kailash.events import DomainEvent, EventBus, Subscription, TenantScopedEventBus
 from kailash.nodes.base import Node, NodeMetadata, NodeParameter
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.36.0"
+__version__ = "2.37.0"
 
 __all__ = [
     # Core workflow components
@@ -112,6 +112,8 @@ __all__ = [
     "EventBus",
     "Subscription",
     "DomainEvent",
+    # Tenant-scoped event bus (issue #1338)
+    "TenantScopedEventBus",
     # Server classes (lazy, require kailash[server])
     "WorkflowServer",
     "DurableWorkflowServer",

--- a/src/kailash/events/__init__.py
+++ b/src/kailash/events/__init__.py
@@ -14,10 +14,13 @@ Public surface:
   ``correlation_id`` for trace propagation.
 * :class:`EventBackend` / :class:`InMemoryEventBackend` /
   :class:`RedisStreamsEventBackend` — backend contract + implementations.
+* :class:`TenantScopedEventBus` — tenant-isolating facade over a shared
+  :class:`EventBus` (prefixes every topic with the tenant id so publishes
+  fan out only within the same tenant).
 
 These are also re-exported from the top-level ``kailash`` namespace::
 
-    from kailash import EventBus, Subscription
+    from kailash import EventBus, Subscription, TenantScopedEventBus
 """
 
 from __future__ import annotations
@@ -30,11 +33,13 @@ from .backends import (
 )
 from .bus import EventBus, Subscription
 from .domain_event import DomainEvent
+from .tenant import TenantScopedEventBus
 
 __all__ = [
     "EventBus",
     "Subscription",
     "DomainEvent",
+    "TenantScopedEventBus",
     "EventBackend",
     "InMemoryEventBackend",
     "RedisStreamsEventBackend",

--- a/src/kailash/events/tenant.py
+++ b/src/kailash/events/tenant.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tenant-scoped wrapper for the public :class:`kailash.EventBus`.
+
+Multi-tenant applications need pub/sub isolation: a publish on tenant
+``acme``'s bus MUST fan out only to ``acme``'s subscribers, never to
+tenant ``globex``'s. The :class:`EventBus` transport dispatches by exact
+``event_type`` match (the in-memory backend keys a dict on the type; the
+Redis Streams backend uses one stream per type), so prefixing every topic
+with the tenant id — ``"acme:order.created"`` vs ``"globex:order.created"``
+— yields complete, backend-agnostic isolation with zero changes to the
+transport.
+
+:class:`TenantScopedEventBus` is that prefixing, packaged so applications
+do not re-implement it (and drift on the isolation guarantee):
+
+    from kailash.events import EventBus, TenantScopedEventBus
+
+    bus = EventBus()                       # one shared transport
+    acme = TenantScopedEventBus("acme", bus)
+    globex = TenantScopedEventBus("globex", bus)
+
+    acme.subscribe("order.created", on_acme_order)
+    await globex.publish("order.created", {"id": "g1"})   # acme never sees it
+    await acme.publish("order.created", {"id": "a1"})     # only on_acme_order fires
+
+The wrapper keeps the same ``publish`` / ``subscribe`` / ``subscribe_events``
+shape as :class:`EventBus`; the tenant prefix is transparent to handlers
+(they receive the ORIGINAL payload, and via :meth:`subscribe_events` a
+:class:`DomainEvent` whose ``event_type`` is the LOGICAL, un-prefixed type).
+
+The same wrapper works over the Redis Streams backend, where prefixing is
+the ONLY way to isolate tenants sharing one broker — a shared
+``EventBus(backend="redis")`` plus one :class:`TenantScopedEventBus` per
+tenant keeps every tenant's events on its own stream key.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from .bus import EventBus, Subscription
+from .domain_event import DomainEvent
+
+__all__ = ["TenantScopedEventBus"]
+
+# Sentinel for "argument not supplied" so bus-construction kwargs can be
+# rejected (rather than silently ignored) when a shared bus is passed.
+_UNSET: Any = object()
+
+# Attribute stamped on a shared EventBus recording the separator the first
+# wrapper scoped it with. A later wrapper passing a DIFFERENT separator on the
+# same bus is refused — mixed separators can map two distinct tenants onto the
+# same topic (e.g. ("a","::") and ("a:",":x") both yield prefix "a::x").
+_SEPARATOR_STAMP_ATTR = "_kailash_tenant_separator"
+
+
+class TenantScopedEventBus:
+    """Tenant-isolating facade over a shared :class:`EventBus`.
+
+    Every ``event_type`` is namespaced as ``f"{tenant_id}{separator}{event_type}"``
+    before it reaches the underlying bus, so publishes and subscriptions on
+    one tenant never cross into another. Because the wrapped bus dispatches
+    by exact type, isolation is structural — not a runtime filter that could
+    be bypassed.
+
+    Args:
+        tenant_id: Stable identifier for the tenant. MUST be a non-empty
+            string and MUST NOT contain *separator* (a separator inside the
+            id would make ``f"{tenant}{sep}{type}"`` ambiguous and allow a
+            crafted id to address another tenant's topics).
+        bus: A shared :class:`EventBus` to wrap. When omitted, a private
+            in-memory :class:`EventBus` is constructed and owned by this
+            wrapper (closed by :meth:`close`). Pass a shared bus to isolate
+            multiple tenants on one transport — the common multi-tenant case.
+            ``backend`` / ``redis_url`` / ``max_subscribers`` are valid ONLY
+            when constructing a new bus (``bus=None``); supplying them
+            alongside a shared *bus* raises ``ValueError`` rather than
+            silently ignoring them.
+        separator: Delimiter between tenant id and event type. Defaults to
+            ``":"``. MUST be a non-empty string. The event type MAY itself
+            contain the separator; un-prefixing strips the known
+            ``f"{tenant_id}{separator}"`` prefix by length, not by splitting.
+            Every wrapper sharing one bus MUST use the SAME separator — the
+            first wrapper stamps it on the bus and a later wrapper passing a
+            different separator is refused (mixed separators can map two
+            distinct tenants onto the same topic).
+
+    Example:
+        >>> bus = EventBus()
+        >>> acme = TenantScopedEventBus("acme", bus)
+        >>> async def on_order(payload): ...
+        >>> sub = acme.subscribe("order.created", on_order)
+        >>> await acme.publish("order.created", {"id": "a1"})
+        >>> await sub.unsubscribe()
+    """
+
+    def __init__(
+        self,
+        tenant_id: str,
+        bus: Optional[EventBus] = None,
+        *,
+        separator: str = ":",
+        backend: Optional[str] = None,
+        redis_url: Optional[str] = None,
+        max_subscribers: Any = _UNSET,
+    ) -> None:
+        if not isinstance(separator, str) or not separator:
+            raise ValueError("separator must be a non-empty string")
+        if not isinstance(tenant_id, str) or not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
+        if separator in tenant_id:
+            raise ValueError(
+                f"tenant_id must not contain the separator {separator!r}; "
+                f"got {tenant_id!r} (a separator inside the id would let a "
+                f"crafted tenant_id address another tenant's topics)"
+            )
+        self._tenant_id = tenant_id
+        self._separator = separator
+        self._prefix = f"{tenant_id}{separator}"
+        if bus is None:
+            self._bus = EventBus(
+                backend=backend,
+                redis_url=redis_url,
+                max_subscribers=(
+                    10_000 if max_subscribers is _UNSET else max_subscribers
+                ),
+            )
+            self._owns_bus = True
+        else:
+            # A shared bus carries its own transport config; bus-construction
+            # kwargs would be silently dropped, so reject them loudly instead
+            # (zero-tolerance Rule 3c — accepted-but-unused kwargs are BLOCKED).
+            if (
+                backend is not None
+                or redis_url is not None
+                or max_subscribers is not _UNSET
+            ):
+                raise ValueError(
+                    "backend/redis_url/max_subscribers are only valid when "
+                    "constructing a new bus (bus=None); a shared bus carries "
+                    "its own config — configure it on the EventBus instead"
+                )
+            self._bus = bus
+            self._owns_bus = False
+        # Enforce one separator per bus: mixed separators on a shared bus can
+        # map two distinct tenants onto the same topic (cross-tenant leak).
+        stamped = getattr(self._bus, _SEPARATOR_STAMP_ATTR, None)
+        if stamped is None:
+            setattr(self._bus, _SEPARATOR_STAMP_ATTR, separator)
+        elif stamped != separator:
+            raise ValueError(
+                f"bus is already tenant-scoped with separator {stamped!r}; "
+                f"refusing to wrap it with a different separator {separator!r} "
+                f"— mixed separators on one bus can collide distinct tenants "
+                f"onto the same topic"
+            )
+
+    @property
+    def tenant_id(self) -> str:
+        """The tenant this wrapper scopes every topic to."""
+        return self._tenant_id
+
+    @property
+    def separator(self) -> str:
+        """The delimiter between tenant id and event type."""
+        return self._separator
+
+    @property
+    def bus(self) -> EventBus:
+        """The underlying (possibly shared) transport bus."""
+        return self._bus
+
+    @property
+    def owns_bus(self) -> bool:
+        """Whether :meth:`close` will close the underlying bus.
+
+        ``True`` when this wrapper constructed its own bus (no *bus* arg);
+        ``False`` when a shared bus was passed in (the caller owns its
+        lifecycle).
+        """
+        return self._owns_bus
+
+    def _scoped(self, event_type: str) -> str:
+        if not event_type:
+            raise ValueError("event_type must be a non-empty string")
+        return f"{self._prefix}{event_type}"
+
+    def _logical(self, scoped_event_type: str) -> str:
+        if scoped_event_type.startswith(self._prefix):
+            return scoped_event_type[len(self._prefix) :]
+        return scoped_event_type  # pragma: no cover - defensive
+
+    async def publish(
+        self,
+        event_type: str,
+        payload: Dict[str, Any],
+        *,
+        correlation_id: Optional[str] = None,
+        actor: Optional[str] = None,
+    ) -> None:
+        """Publish to this tenant's namespace only.
+
+        Same contract as :meth:`EventBus.publish`; the event reaches only
+        subscribers registered through a :class:`TenantScopedEventBus` with
+        the SAME ``tenant_id`` (and separator) on the same bus.
+        """
+        await self._bus.publish(
+            self._scoped(event_type),
+            payload,
+            correlation_id=correlation_id,
+            actor=actor,
+        )
+
+    def subscribe(
+        self,
+        event_type: str,
+        handler: Callable[[Dict[str, Any]], Awaitable[None]],
+    ) -> Subscription:
+        """Subscribe within this tenant's namespace.
+
+        The *handler* receives the ORIGINAL payload dict, exactly as with
+        :meth:`EventBus.subscribe`. It is invoked ONLY for publishes made
+        through a wrapper with the same ``tenant_id``.
+        """
+        return self._bus.subscribe(self._scoped(event_type), handler)
+
+    def subscribe_events(
+        self,
+        event_type: str,
+        handler: Callable[[DomainEvent], Awaitable[None]],
+    ) -> Subscription:
+        """Like :meth:`subscribe` but the handler receives the full
+        :class:`DomainEvent`.
+
+        The delivered event's ``event_type`` is the LOGICAL (un-prefixed)
+        type the subscriber asked for — the tenant prefix is an isolation
+        detail of the transport, not something handlers parse. All other
+        envelope fields (``payload`` / ``correlation_id`` / ``timestamp`` /
+        ``actor``) round-trip unchanged.
+        """
+
+        async def _unscope(event: DomainEvent) -> None:
+            await handler(replace(event, event_type=self._logical(event.event_type)))
+
+        return self._bus.subscribe_events(self._scoped(event_type), _unscope)
+
+    async def close(self) -> None:
+        """Release the underlying bus IF this wrapper owns it.
+
+        A wrapper constructed without a *bus* arg owns its private bus and
+        closes it here. A wrapper over a shared bus leaves the bus open —
+        the caller owns the shared transport's lifecycle.
+        """
+        if self._owns_bus:
+            await self._bus.close()
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (
+            f"TenantScopedEventBus(tenant_id={self._tenant_id!r}, "
+            f"separator={self._separator!r}, backend={self._bus.backend_name!r}, "
+            f"owns_bus={self._owns_bus})"
+        )

--- a/tests/integration/events/test_tenant_scoped_eventbus.py
+++ b/tests/integration/events/test_tenant_scoped_eventbus.py
@@ -1,0 +1,392 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 2 integration tests for ``TenantScopedEventBus`` (issue #1338).
+
+Real in-memory backend, real publish/subscribe round-trips — NO mocking
+(per the 3-tier testing rule). Cross-SDK parity with
+esperie-enterprise/kailash-rs #1352 (Rust ``kailash.events`` tenant scoping).
+
+Acceptance criteria (#1338):
+* A helper-backed tenant-prefixed-topic subscribe/publish pattern for the
+  in-memory bus.
+* A multi-tenant isolation guarantee using the SDK bus directly: a publish
+  on one tenant fans out ONLY within that tenant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+import kailash
+from kailash import DomainEvent, EventBus, Subscription, TenantScopedEventBus
+from kailash.events import TenantScopedEventBus as TFromEvents
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_bus_is_public_surface():
+    """from kailash import TenantScopedEventBus works AND it is in __all__."""
+    assert hasattr(kailash, "TenantScopedEventBus")
+    assert "TenantScopedEventBus" in kailash.__all__
+    assert "TenantScopedEventBus" in dir(kailash)
+    # Same object from both the top-level namespace and the events package.
+    assert kailash.TenantScopedEventBus is TFromEvents
+    assert "TenantScopedEventBus" in kailash.events.__all__
+
+
+def test_tenant_bus_surface_shape():
+    """publish/subscribe/subscribe_events mirror EventBus shape."""
+    pub = inspect.signature(TenantScopedEventBus.publish)
+    assert "event_type" in pub.parameters
+    assert "payload" in pub.parameters
+    assert pub.parameters["correlation_id"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert inspect.iscoroutinefunction(TenantScopedEventBus.publish)
+
+    sub = inspect.signature(TenantScopedEventBus.subscribe)
+    assert "event_type" in sub.parameters and "handler" in sub.parameters
+    assert not inspect.iscoroutinefunction(TenantScopedEventBus.subscribe)
+    assert inspect.iscoroutinefunction(TenantScopedEventBus.close)
+
+
+# ---------------------------------------------------------------------------
+# Core acceptance: multi-tenant isolation on ONE shared bus
+# ---------------------------------------------------------------------------
+
+
+async def test_isolation_publish_fans_out_within_tenant_only():
+    """A publish on one tenant reaches ONLY that tenant's subscribers."""
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+    globex = TenantScopedEventBus("globex", bus)
+
+    acme_seen: list[dict] = []
+    globex_seen: list[dict] = []
+
+    async def on_acme(payload):
+        acme_seen.append(payload)
+
+    async def on_globex(payload):
+        globex_seen.append(payload)
+
+    sa = acme.subscribe("order.created", on_acme)
+    sg = globex.subscribe("order.created", on_globex)
+
+    await globex.publish("order.created", {"id": "g1"})
+    await acme.publish("order.created", {"id": "a1"})
+    await asyncio.sleep(0.02)
+
+    assert acme_seen == [{"id": "a1"}]  # acme NEVER saw globex's event
+    assert globex_seen == [{"id": "g1"}]  # globex NEVER saw acme's event
+
+    await sa.unsubscribe()
+    await sg.unsubscribe()
+    await bus.close()
+
+
+async def test_same_logical_type_different_tenants_do_not_cross():
+    """Three tenants, same logical event_type — zero cross-talk."""
+    bus = EventBus()
+    tenants = {t: TenantScopedEventBus(t, bus) for t in ("a", "b", "c")}
+    seen: dict[str, list] = {t: [] for t in tenants}
+
+    subs = []
+    for name, tb in tenants.items():
+
+        async def _h(payload, _n=name):
+            seen[_n].append(payload)
+
+        subs.append(tb.subscribe("evt", _h))
+
+    for name, tb in tenants.items():
+        await tb.publish("evt", {"from": name})
+    await asyncio.sleep(0.03)
+
+    for name in tenants:
+        assert seen[name] == [{"from": name}], (name, seen[name])
+
+    for s in subs:
+        await s.unsubscribe()
+    await bus.close()
+
+
+async def test_subscribe_returns_subscription_payload_is_original():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+    seen: list[dict] = []
+
+    async def handler(payload):
+        seen.append(payload)
+
+    sub = acme.subscribe("order.created", handler)
+    assert isinstance(sub, Subscription)
+
+    original = {"order_id": "o-1", "items": ["x", "y"], "total": 9.5}
+    await acme.publish("order.created", original)
+    await asyncio.sleep(0.02)
+    assert seen == [original]
+    assert seen[0]["items"] == ["x", "y"]
+
+    await sub.unsubscribe()
+    # after unsubscribe, no more delivery
+    await acme.publish("order.created", {"order_id": "o-2"})
+    await asyncio.sleep(0.02)
+    assert len(seen) == 1
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# subscribe_events: full envelope, LOGICAL (un-prefixed) event_type
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_events_delivers_logical_event_type():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+    seen: list[DomainEvent] = []
+
+    async def handler(event: DomainEvent):
+        seen.append(event)
+
+    sub = acme.subscribe_events("payment.done", handler)
+    await acme.publish(
+        "payment.done", {"amt": 5}, correlation_id="trace-9", actor="svc-a"
+    )
+    await asyncio.sleep(0.02)
+
+    assert len(seen) == 1
+    # The subscriber sees the LOGICAL type, not "acme:payment.done".
+    assert seen[0].event_type == "payment.done"
+    assert seen[0].payload == {"amt": 5}
+    assert seen[0].correlation_id == "trace-9"
+    assert seen[0].actor == "svc-a"
+
+    await sub.unsubscribe()
+    await bus.close()
+
+
+async def test_subscribe_events_isolated_across_tenants():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+    globex = TenantScopedEventBus("globex", bus)
+    acme_seen: list[DomainEvent] = []
+
+    async def handler(event: DomainEvent):
+        acme_seen.append(event)
+
+    sub = acme.subscribe_events("evt", handler)
+    await globex.publish("evt", {"x": 1})  # different tenant
+    await asyncio.sleep(0.02)
+    assert acme_seen == []  # acme's full-envelope subscriber saw nothing
+
+    await acme.publish("evt", {"x": 2})
+    await asyncio.sleep(0.02)
+    assert len(acme_seen) == 1 and acme_seen[0].payload == {"x": 2}
+
+    await sub.unsubscribe()
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# event_type may itself contain the separator; un-prefix is by length
+# ---------------------------------------------------------------------------
+
+
+async def test_event_type_containing_separator_roundtrips():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)  # separator ":"
+    seen: list[DomainEvent] = []
+
+    async def handler(event: DomainEvent):
+        seen.append(event)
+
+    # event_type itself contains a colon — must survive un-prefixing intact.
+    sub = acme.subscribe_events("ns:order:created", handler)
+    await acme.publish("ns:order:created", {"k": "v"})
+    await asyncio.sleep(0.02)
+    assert len(seen) == 1
+    assert seen[0].event_type == "ns:order:created"
+    await sub.unsubscribe()
+    await bus.close()
+
+
+async def test_custom_separator_isolates_on_own_bus():
+    """A non-default separator still isolates tenants (uniform across the bus)."""
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus, separator="/")
+    globex = TenantScopedEventBus("globex", bus, separator="/")
+    a_seen: list = []
+    g_seen: list = []
+
+    async def ha(p):
+        a_seen.append(p)
+
+    async def hg(p):
+        g_seen.append(p)
+
+    sa = acme.subscribe("evt", ha)
+    sg = globex.subscribe("evt", hg)
+    await acme.publish("evt", {"sep": "slash"})
+    await globex.publish("evt", {"sep": "slash2"})
+    await asyncio.sleep(0.02)
+    assert a_seen == [{"sep": "slash"}]
+    assert g_seen == [{"sep": "slash2"}]
+    await sa.unsubscribe()
+    await sg.unsubscribe()
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation (isolation-integrity guards)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_tenant_id_rejected():
+    with pytest.raises(ValueError, match="tenant_id must be a non-empty string"):
+        TenantScopedEventBus("")
+
+
+def test_tenant_id_containing_separator_rejected():
+    # The cross-tenant-collision guard: a separator inside the id would make
+    # f"{tenant}{sep}{type}" ambiguous.
+    with pytest.raises(ValueError, match="must not contain the separator"):
+        TenantScopedEventBus("acme:evil")
+    # custom separator
+    with pytest.raises(ValueError, match="must not contain the separator"):
+        TenantScopedEventBus("a/b", separator="/")
+
+
+def test_empty_separator_rejected():
+    with pytest.raises(ValueError, match="separator must be a non-empty string"):
+        TenantScopedEventBus("acme", separator="")
+
+
+# ---------------------------------------------------------------------------
+# Uniform-separator-per-bus guard (R2 — closes mixed-separator collision)
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_separator_on_shared_bus_rejected():
+    """A second wrapper with a DIFFERENT separator on the same bus is refused."""
+    bus = EventBus()
+    TenantScopedEventBus("acme", bus, separator=":")  # stamps ":" on the bus
+    with pytest.raises(ValueError, match="already tenant-scoped with separator"):
+        TenantScopedEventBus("globex", bus, separator="/")
+
+
+def test_same_separator_on_shared_bus_allowed():
+    """Re-wrapping a bus with the SAME separator is fine (the normal case)."""
+    bus = EventBus()
+    a = TenantScopedEventBus("acme", bus, separator="::")
+    b = TenantScopedEventBus("globex", bus, separator="::")
+    assert a.bus is b.bus
+
+
+async def test_mixed_separator_cross_tenant_collision_blocked():
+    """Regression: the ('a','::') vs ('a:',':x') prefix-overlap leak is blocked.
+
+    Before the uniform-separator guard, ('a', sep='::') publishing 'xfoo'
+    (topic 'a::xfoo') leaked to ('a:', sep=':x') subscribing 'foo'
+    (topic 'a::xfoo'). The guard now refuses the second wrapper.
+    """
+    bus = EventBus()
+    TenantScopedEventBus("a", bus, separator="::")
+    with pytest.raises(ValueError, match="already tenant-scoped with separator"):
+        TenantScopedEventBus("a:", bus, separator=":x")
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# Bus-construction kwargs are rejected with a shared bus (R2 — no silent drop)
+# ---------------------------------------------------------------------------
+
+
+def test_bus_construction_kwargs_rejected_with_shared_bus():
+    bus = EventBus()
+    for kw in (
+        {"backend": "memory"},
+        {"redis_url": "redis://x"},
+        {"max_subscribers": 5},
+    ):
+        with pytest.raises(ValueError, match="only valid when constructing a new bus"):
+            TenantScopedEventBus("acme", bus, **kw)
+
+
+def test_bus_construction_kwargs_accepted_when_owning():
+    """Same kwargs ARE honored when the wrapper constructs its own bus."""
+    solo = TenantScopedEventBus("solo", backend="memory", max_subscribers=7)
+    assert solo.owns_bus is True
+    assert solo.bus.backend_name == "InMemoryEventBackend"
+
+
+def test_empty_event_type_rejected_on_publish():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+
+    async def _run():
+        with pytest.raises(ValueError, match="event_type must be a non-empty string"):
+            await acme.publish("", {})
+
+    asyncio.run(_run())
+
+
+def test_empty_event_type_rejected_on_subscribe():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+
+    async def _noop(_):
+        pass
+
+    with pytest.raises(ValueError, match="event_type must be a non-empty string"):
+        acme.subscribe("", _noop)
+
+
+# ---------------------------------------------------------------------------
+# Ownership / lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_owns_bus_when_self_constructed():
+    solo = TenantScopedEventBus("solo")  # no bus arg → constructs + owns one
+    assert solo.owns_bus is True
+    assert isinstance(solo.bus, EventBus)
+    assert solo.bus.backend_name == "InMemoryEventBackend"
+    await solo.close()  # closes the owned bus
+
+
+async def test_does_not_own_shared_bus():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus)
+    assert acme.owns_bus is False
+    assert acme.bus is bus
+
+    # close() on the wrapper MUST NOT close the shared bus — it stays usable.
+    await acme.close()
+    seen: list = []
+
+    async def h(p):
+        seen.append(p)
+
+    other = TenantScopedEventBus("globex", bus)
+    sub = other.subscribe("evt", h)
+    await other.publish("evt", {"still": "alive"})
+    await asyncio.sleep(0.02)
+    assert seen == [{"still": "alive"}]  # shared bus survived acme.close()
+    await sub.unsubscribe()
+    await bus.close()
+
+
+def test_properties_expose_config():
+    bus = EventBus()
+    acme = TenantScopedEventBus("acme", bus, separator="::")
+    assert acme.tenant_id == "acme"
+    assert acme.separator == "::"
+    assert acme.bus is bus


### PR DESCRIPTION
## Summary

Adds `kailash.events.TenantScopedEventBus` (re-exported as `kailash.TenantScopedEventBus`) — a thin facade over a shared `EventBus` that prefixes every topic with the tenant id (`acme:order.created` vs `globex:order.created`) so a publish fans out **only** within its own tenant. Isolation is **structural**: both backends dispatch by exact `event_type` (in-memory dict key, Redis one-stream-per-type), so prefixed topics can never cross — not a runtime filter that could be bypassed.

Resolves the #1338 gap (apps had to re-implement the bus to get multi-tenant isolation). Cross-SDK parity with `esperie-enterprise/kailash-rs` #1352.

## What shipped

- `TenantScopedEventBus` with `publish` / `subscribe` / `subscribe_events` / `close` mirroring `EventBus` (same param names, order, async-ness). Handlers receive the original payload; `subscribe_events` delivers a `DomainEvent` whose `event_type` is the logical (un-prefixed) type.
- Isolation-integrity guards (surfaced/closed by the redteam round):
  - `tenant_id` must not contain the separator
  - all wrappers sharing one bus must use the same separator (a mismatch is **refused** — mixed separators can map two distinct tenants onto the same topic)
  - bus-construction kwargs raise rather than silently drop when a shared bus is passed (zero-tolerance Rule 3c)
- Works unchanged over the Redis Streams backend.
- Runnable example: `examples/eventbus_tenant_isolation.py`.
- 22 Tier-2 tests (isolation, logical-type delivery, separator-in-event_type, uniform-separator guard, validation, ownership); version bump 2.36.0 → 2.37.0 + CHANGELOG.

## Acceptance criteria (#1338)

- [x] Helper-backed tenant-prefixed-topic subscribe/publish pattern for the in-memory bus
- [x] Multi-tenant isolation example using the SDK bus directly

## Testing

`pytest tests/integration/events/` → 39 passed. Collection gate exit 0. Example runs clean. pre-commit (black/isort/ruff/Tier-1/docstyle) green.

## Redteam

Parallel reviewer + security-reviewer (tenant isolation = security gate). Reviewer: APPROVE. Security-reviewer: APPROVE with one MEDIUM (mixed-separator cross-tenant collision) — empirically confirmed, then closed structurally by the uniform-separator-per-bus guard + regression test.

## Related issues

Fixes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)