### PR TITLE
feat(core): real vector + retrieval backends + honest pool metrics (kailash 2.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.0] - 2026-06-17
+
+### Added
+
+- **Real in-memory vector backend for `VectorDatabaseNode`**: `provider="memory"`
+  is now a working backend with real `upsert`/`query`/`delete`/`fetch`,
+  cosine/euclidean/dot similarity ranking, metadata storage + equality
+  filtering, and an optional `max_vectors` capacity cap. Previously every
+  operation returned fabricated results (`doc_0..doc_4`, invented scores,
+  `[0.1]*dimension` fetches).
+- **Real Okapi BM25 and TF-IDF scoring for `RelevanceScorerNode`**: the `bm25`
+  and `tfidf` similarity methods now compute real lexical relevance over chunk
+  text via a new optional `query` text parameter. Previously both returned a
+  constant `0.5` for every chunk.
+
+### Changed
+
+- **(Behavior change)** `VectorDatabaseNode` external providers
+  (`pinecone`/`weaviate`/`milvus`/`qdrant`/`chroma`) now raise a clear typed
+  `NodeConfigurationError` directing users to `provider="memory"` instead of
+  silently returning fabricated search results.
+- `RelevanceScorerNode` `bm25`/`tfidf` without a `query` text input now raise a
+  clear `ValueError` instead of returning a constant score.
+
+### Fixed
+
+- **Fabricated connection-pool metrics** in `WorkflowConnectionPool`:
+  `get_pool_statistics()` / `_get_pool_status()` returned hardcoded
+  `avg_query_time_ms=50.0`, `avg_latency_ms=0.0`, `queue_depth=0`, and
+  `capabilities=["read","write"]` — `avg_latency_ms` and `capabilities` fed
+  `query_router` routing decisions. Now real query-time tracking, real queue
+  depth, and honest omission where no real signal exists.
+- Latent `VectorDatabaseNode.configure()` `AttributeError` (it called a
+  non-existent base `configure()`); the documented `configure()` → `execute()`
+  flow now works.
+- `RelevanceScorerNode` removed a hardcoded fallback query string and all
+  `print()` debug output.
+
 ## [2.37.0] - 2026-06-17
 
 ### Added

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -180,10 +180,15 @@ RAG Components
 
    from kailash.nodes.data.retrieval import RelevanceScorerNode
 
-   # Multi-method similarity scoring
-   relevance_scorer = RelevanceScorerNode(
-       similarity_method="cosine",  # or "text_based"
-       top_k=3
+   # Embedding-based scoring (cosine over query/chunk embeddings)
+   relevance_scorer = RelevanceScorerNode(similarity_method="cosine", top_k=3)
+
+   # Lexical scoring: real Okapi BM25 / TF-IDF over chunk text.
+   # bm25/tfidf require a ``query`` text input and score chunk["content"]:
+   lexical_scorer = RelevanceScorerNode(similarity_method="bm25", top_k=3)
+   scored = lexical_scorer.execute(
+       query="vector search relevance",
+       chunks=[{"content": "..."}, {"content": "..."}],
    )
 
 Complete RAG Pipeline Example

--- a/packages/kailash-ml/tests/integration/rl/test_rl_align_cross_sdk_wiring.py
+++ b/packages/kailash-ml/tests/integration/rl/test_rl_align_cross_sdk_wiring.py
@@ -27,9 +27,11 @@ Both tests skip gracefully when ``kailash_align`` is not installed
 (the ``[rl-bridge]`` extra is optional, and CI matrix jobs without it
 MUST see ``skipped``, not ``errored``).
 """
+
 from __future__ import annotations
 
 import importlib
+import importlib.machinery
 import importlib.util
 import os
 
@@ -37,13 +39,140 @@ import pytest
 
 
 def _align_installed() -> bool:
-    """Return True when the optional ``[rl-bridge]`` extra is available.
+    """Return True only when the optional ``[rl-bridge]`` bridge is IMPORTABLE.
 
-    Uses ``importlib.util.find_spec`` so the probe doesn't execute
-    module-level side effects (which would populate ``BRIDGE_ADAPTERS``
-    before the test body expects them).
+    Probes ``importlib.util.find_spec`` FIRST (cheap, no module-body
+    execution) to short-circuit the common "parent package entirely absent"
+    case before any import work, then confirms the bridge actually imports.
+
+    Fails closed to ``False`` on EVERY unavailability mode, because this
+    guard runs inside the ``@pytest.mark.skipif`` decorator at collection
+    time and any propagated ``ImportError`` crashes pytest collection (a
+    collection error) instead of cleanly SKIPping:
+
+    1. **Parent package absent.** When ``kailash_align`` is not installed,
+       ``find_spec`` on the ``kailash_align.rl_bridge`` SUBMODULE raises
+       ``ModuleNotFoundError`` — it does NOT return ``None``. The
+       ``except ImportError`` arm (which subsumes ``ModuleNotFoundError``)
+       catches it → ``False``.
+    2. **Findable but not importable.** The ``rl_bridge`` package directory
+       can exist on disk (so ``find_spec`` returns a spec) while its
+       ``__init__`` raises ``ImportError`` because the ``[rl-bridge]``
+       extra's runtime deps are absent. ``find_spec`` does NOT execute the
+       module body, so a spec being *findable* does not mean the submodule
+       is *importable*; the skip MUST predicate on importability. We attempt
+       the real import and fail closed on ``ImportError`` → ``False``.
+
+    Importing the bridge here is side-effect-safe: a SUCCESSFUL import is
+    the same cached module the test body re-imports idempotently (it does
+    not double-populate ``BRIDGE_ADAPTERS``); a FAILED import populates
+    nothing. Returns True only when the bridge genuinely imports, so the
+    gated tests run; otherwise they SKIP.
     """
-    return importlib.util.find_spec("kailash_align.rl_bridge") is not None
+    try:
+        if importlib.util.find_spec("kailash_align.rl_bridge") is None:
+            return False
+        importlib.import_module("kailash_align.rl_bridge")
+        return True
+    except ImportError:
+        return False
+
+
+class _AlignAbsentFinder:
+    """Meta-path finder that simulates ``kailash_align`` being uninstalled.
+
+    When ``kailash_align`` is absent, ``importlib.util.find_spec`` on the
+    ``kailash_align.rl_bridge`` SUBMODULE raises ``ModuleNotFoundError``
+    (the parent package cannot be imported to compute the child spec).
+    This finder reproduces that condition deterministically even in
+    environments where the ``[rl-bridge]`` extra IS installed, so the
+    regression below behaviorally exercises the fail-closed guard.
+    """
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "kailash_align" or fullname.startswith("kailash_align."):
+            raise ModuleNotFoundError(f"No module named {fullname!r}")
+        return None
+
+
+@pytest.mark.regression
+def test_align_installed_fails_closed_when_dep_absent(monkeypatch) -> None:
+    """Regression: ``_align_installed()`` returns False (never raises) when
+    ``kailash_align`` is absent.
+
+    Reproduces the collection-time crash class: ``find_spec`` on a SUBMODULE
+    of an uninstalled parent package raises ``ModuleNotFoundError`` rather
+    than returning ``None``. Because ``_align_installed()`` runs inside the
+    ``@pytest.mark.skipif`` decorator at collection time, an unguarded raise
+    crashes pytest collection (1 collection error) instead of SKIPping. The
+    fix fails closed to ``False`` so the dependent tests SKIP cleanly.
+
+    The blocker is installed at the FRONT of ``sys.meta_path`` and any
+    already-resolved ``kailash_align`` modules are evicted so ``find_spec``
+    re-resolves through the blocker — making this deterministic whether or
+    not the ``[rl-bridge]`` extra is installed in the running environment.
+    """
+    import sys
+
+    # Evict any cached kailash_align* modules so find_spec re-resolves.
+    for name in list(sys.modules):
+        if name == "kailash_align" or name.startswith("kailash_align."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    blocker = _AlignAbsentFinder()
+    monkeypatch.setattr(sys, "meta_path", [blocker, *sys.meta_path])
+
+    # Sanity-check the blocker reproduces the documented raise behavior.
+    with pytest.raises(ModuleNotFoundError):
+        importlib.util.find_spec("kailash_align.rl_bridge")
+
+    # The guard MUST swallow that raise and return False (fail-closed to SKIP).
+    assert _align_installed() is False
+
+
+@pytest.mark.regression
+def test_align_installed_fails_closed_when_bridge_findable_but_not_importable(
+    monkeypatch,
+) -> None:
+    """Regression: ``_align_installed()`` returns False (never raises) when
+    ``kailash_align.rl_bridge`` is FINDABLE but its import raises.
+
+    The ``rl_bridge`` package directory can exist on disk (so ``find_spec``
+    returns a real spec) while importing it raises ``ImportError`` because
+    the optional ``[rl-bridge]`` extra's runtime deps are absent — this is
+    exactly the half-installed-extra state. ``find_spec`` does NOT execute
+    the module body, so the guard MUST attempt the import to detect this
+    mode and fail closed to SKIP rather than letting the ``ImportError``
+    propagate from the ``@skipif`` decorator and crash collection.
+
+    Deterministic regardless of the running environment: we stub
+    ``importlib.import_module`` to raise for the bridge while leaving
+    ``find_spec`` to return a (real or fabricated) non-None spec.
+    """
+    real_find_spec = importlib.util.find_spec
+    real_import_module = importlib.import_module
+
+    def _findable_spec(name, package=None):
+        if name == "kailash_align.rl_bridge":
+            # Fabricate a non-None spec so the guard proceeds to import.
+            return importlib.machinery.ModuleSpec(name, loader=None)
+        return real_find_spec(name, package)
+
+    def _import_raises(name, package=None):
+        if name == "kailash_align.rl_bridge":
+            raise ImportError("kailash_align.rl_bridge requires the [rl-bridge] extra")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _findable_spec)
+    monkeypatch.setattr(importlib, "import_module", _import_raises)
+
+    # Sanity-check the simulation: spec is findable, import raises.
+    assert importlib.util.find_spec("kailash_align.rl_bridge") is not None
+    with pytest.raises(ImportError):
+        importlib.import_module("kailash_align.rl_bridge")
+
+    # The guard MUST predicate on importability and fail closed → False.
+    assert _align_installed() is False
 
 
 @pytest.mark.integration
@@ -114,9 +243,8 @@ async def test_km_rl_train_dispatches_to_align_dpo(tmp_path):
     ``rules/orphan-detection.md`` §2a style: runs only when the extra is
     installed AND explicit E2E opt-in is signalled.
     """
-    import polars as pl
-
     import kailash_ml as km
+    import polars as pl
     from kailash_ml.engines.experiment_tracker import ExperimentTracker
     from kailash_ml.rl.protocols import RLLifecycleProtocol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.37.0"
+version = "2.38.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.37.0"
+__version__ = "2.38.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/nodes/data/retrieval.py
+++ b/src/kailash/nodes/data/retrieval.py
@@ -1,14 +1,48 @@
 """Document retrieval nodes for finding relevant content using various similarity methods."""
 
-import json
+import logging
+import math
+import re
 from typing import Any, Dict, List, Optional
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 
+logger = logging.getLogger(__name__)
+
+# Lexical-scoring tokenizer: lowercase, split on any run of non-alphanumeric chars.
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+# Okapi BM25 free parameters (standard defaults).
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase a string and split it into alphanumeric tokens.
+
+    Pure-Python tokenizer used by the lexical scoring methods (BM25, TF-IDF).
+    Splitting on non-alphanumeric runs keeps the tokenization deterministic and
+    dependency-free (no numpy / nltk required).
+    """
+    return _TOKEN_PATTERN.findall(text.lower())
+
 
 @register_node()
 class RelevanceScorerNode(Node):
-    """Scores chunk relevance using various similarity methods including embeddings similarity."""
+    """Scores chunk relevance using various similarity methods.
+
+    Supported ``similarity_method`` values:
+
+    - ``cosine``: cosine similarity over precomputed embedding vectors
+      (requires ``query_embedding`` + ``chunk_embeddings``).
+    - ``bm25``: Okapi BM25 lexical scoring over chunk text vs the ``query``
+      text (k1=1.5, b=0.75).
+    - ``tfidf``: TF-IDF cosine similarity over chunk text vs the ``query`` text.
+
+    The lexical methods (``bm25``, ``tfidf``) score the ``query`` text against
+    each chunk's ``content``; they require a ``query`` text input and raise a
+    ``ValueError`` when none is available rather than returning a constant.
+    """
 
     def get_parameters(self) -> dict[str, NodeParameter]:
         return {
@@ -17,6 +51,15 @@ class RelevanceScorerNode(Node):
                 type=list,
                 required=False,
                 description="List of chunks to score",
+            ),
+            "query": NodeParameter(
+                name="query",
+                type=str,
+                required=False,
+                description=(
+                    "Query text for lexical scoring (bm25/tfidf) and for the "
+                    "no-embeddings keyword fallback"
+                ),
             ),
             "query_embedding": NodeParameter(
                 name="query_embedding",
@@ -35,7 +78,7 @@ class RelevanceScorerNode(Node):
                 type=str,
                 required=False,
                 default="cosine",
-                description="Similarity method: cosine, bm25, tfidf, jaccard (future)",
+                description="Similarity method: cosine, bm25, tfidf",
             ),
             "top_k": NodeParameter(
                 name="top_k",
@@ -48,55 +91,75 @@ class RelevanceScorerNode(Node):
 
     def run(self, **kwargs) -> dict[str, Any]:
         chunks = kwargs.get("chunks", [])
+        query_text = kwargs.get("query") or ""
         query_embeddings = kwargs.get("query_embedding", [])
         chunk_embeddings = kwargs.get("chunk_embeddings", [])
         similarity_method = kwargs.get("similarity_method", "cosine")
         top_k = kwargs.get("top_k", 3)
 
-        print(
-            f"Debug: chunks={len(chunks)}, query_embeddings={len(query_embeddings)}, chunk_embeddings={len(chunk_embeddings)}"
+        logger.debug(
+            "relevance_scorer.run",
+            extra={
+                "chunks": len(chunks),
+                "query_embeddings": len(query_embeddings),
+                "chunk_embeddings": len(chunk_embeddings),
+                "similarity_method": similarity_method,
+                "has_query_text": bool(query_text),
+            },
         )
 
-        # Handle case when no embeddings are available
-        if not query_embeddings or not chunk_embeddings:
-            print("Debug: No embeddings available, using fallback text matching")
-            # Simple text-based fallback scoring
-            query_text = "machine learning types"  # Extract keywords from query
-            scored_chunks = []
-            for chunk in chunks:
-                content = chunk.get("content", "").lower()
-                score = sum(1 for word in query_text.split() if word in content) / len(
-                    query_text.split()
-                )
-                scored_chunk = {**chunk, "relevance_score": score}
-                scored_chunks.append(scored_chunk)
+        if similarity_method == "bm25":
+            # Lexical method: scores query terms against chunk text. Requires a
+            # query text input — fail loud rather than return a constant.
+            if not query_text:
+                raise ValueError("bm25/tfidf scoring requires a 'query' text input")
+            scored_chunks = self._bm25_scoring(chunks, query_text)
+        elif similarity_method == "tfidf":
+            if not query_text:
+                raise ValueError("bm25/tfidf scoring requires a 'query' text input")
+            scored_chunks = self._tfidf_scoring(chunks, query_text)
+        elif not query_embeddings or not chunk_embeddings:
+            # Embedding-based methods (cosine and its aliases) but no embeddings
+            # available — fall back to honest keyword matching against the real
+            # query text. With no query text there is no scoring signal, so
+            # report 0.0 rather than fabricating a query.
+            scored_chunks = self._keyword_fallback_scoring(chunks, query_text)
+        elif similarity_method == "cosine":
+            scored_chunks = self._cosine_similarity_scoring(
+                chunks, query_embeddings, chunk_embeddings
+            )
         else:
-            # Use the specified similarity method
-            if similarity_method == "cosine":
-                scored_chunks = self._cosine_similarity_scoring(
-                    chunks, query_embeddings, chunk_embeddings
-                )
-            elif similarity_method == "bm25":
-                # Future implementation
-                scored_chunks = self._bm25_scoring(
-                    chunks, query_embeddings, chunk_embeddings
-                )
-            elif similarity_method == "tfidf":
-                # Future implementation
-                scored_chunks = self._tfidf_scoring(
-                    chunks, query_embeddings, chunk_embeddings
-                )
-            else:
-                # Default to cosine
-                scored_chunks = self._cosine_similarity_scoring(
-                    chunks, query_embeddings, chunk_embeddings
-                )
+            # Default to cosine for any unrecognized embedding-based method.
+            scored_chunks = self._cosine_similarity_scoring(
+                chunks, query_embeddings, chunk_embeddings
+            )
 
         # Sort by relevance and take top_k
         scored_chunks.sort(key=lambda x: x["relevance_score"], reverse=True)
         top_chunks = scored_chunks[:top_k]
 
         return {"relevant_chunks": top_chunks}
+
+    def _keyword_fallback_scoring(
+        self, chunks: list[dict], query_text: str
+    ) -> list[dict]:
+        """Score chunks by query-term keyword overlap (no-embeddings fallback).
+
+        Uses the REAL query text when present. When no query text is available
+        there is no scoring signal, so every chunk gets an honest 0.0 — never a
+        fabricated query.
+        """
+        query_terms = _tokenize(query_text)
+        scored_chunks = []
+        for chunk in chunks:
+            if not query_terms:
+                score = 0.0
+            else:
+                content_tokens = set(_tokenize(chunk.get("content", "")))
+                matches = sum(1 for term in query_terms if term in content_tokens)
+                score = matches / len(query_terms)
+            scored_chunks.append({**chunk, "relevance_score": score})
+        return scored_chunks
 
     def _cosine_similarity_scoring(
         self, chunks: list[dict], query_embeddings: list, chunk_embeddings: list
@@ -123,21 +186,13 @@ class RelevanceScorerNode(Node):
             # Fallback
             query_embedding = []
 
-        print(
-            f"Debug: Query embedding extracted, type: {type(query_embedding)}, length: {len(query_embedding) if isinstance(query_embedding, list) else 'N/A'}"
-        )
-
         # Simple cosine similarity calculation
         def cosine_similarity(a, b):
             # Ensure embeddings are numeric lists
             if not isinstance(a, list) or not isinstance(b, list):
-                print(f"Debug: Non-list embeddings detected, a={type(a)}, b={type(b)}")
                 return 0.5  # Default similarity
 
             if len(a) == 0 or len(b) == 0:
-                print(
-                    f"Debug: Empty embeddings detected, len(a)={len(a)}, len(b)={len(b)}"
-                )
                 return 0.5
 
             try:
@@ -145,8 +200,7 @@ class RelevanceScorerNode(Node):
                 norm_a = sum(x * x for x in a) ** 0.5
                 norm_b = sum(x * x for x in b) ** 0.5
                 return dot_product / (norm_a * norm_b) if norm_a * norm_b > 0 else 0
-            except (TypeError, ValueError) as e:
-                print(f"Debug: Cosine similarity error: {e}")
+            except (TypeError, ValueError):
                 return 0.5
 
         # Score each chunk
@@ -180,21 +234,128 @@ class RelevanceScorerNode(Node):
 
         return scored_chunks
 
-    def _bm25_scoring(
-        self, chunks: list[dict], query_embeddings: list, chunk_embeddings: list
-    ) -> list[dict]:
-        """Score chunks using BM25 algorithm (future implementation)."""
-        # TODO: Implement BM25 scoring
-        # For now, return chunks with default scores
-        return [{**chunk, "relevance_score": 0.5} for chunk in chunks]
+    def _bm25_scoring(self, chunks: list[dict], query_text: str) -> list[dict]:
+        """Score chunks using the Okapi BM25 algorithm (k1=1.5, b=0.75).
 
-    def _tfidf_scoring(
-        self, chunks: list[dict], query_embeddings: list, chunk_embeddings: list
-    ) -> list[dict]:
-        """Score chunks using TF-IDF similarity (future implementation)."""
-        # TODO: Implement TF-IDF scoring
-        # For now, return chunks with default scores
-        return [{**chunk, "relevance_score": 0.5} for chunk in chunks]
+        Each chunk's ``content`` is the document; the ``query`` text supplies the
+        query terms. IDF is computed over the chunk corpus. Pure Python, no numpy.
+
+        BM25 score for a document ``D`` given query terms ``q_i``::
+
+            score(D, Q) = Σ_i IDF(q_i) * f(q_i, D) * (k1 + 1)
+                          ----------------------------------------------------
+                          f(q_i, D) + k1 * (1 - b + b * |D| / avgdl)
+
+        where ``f(q_i, D)`` is the term frequency in ``D``, ``|D|`` is the
+        document length in tokens, and ``avgdl`` is the average document length.
+        IDF uses the BM25 form ``ln(1 + (N - n + 0.5) / (n + 0.5))`` which is
+        non-negative.
+        """
+        # Tokenize the document corpus once.
+        doc_tokens = [_tokenize(chunk.get("content", "")) for chunk in chunks]
+        doc_lengths = [len(tokens) for tokens in doc_tokens]
+        num_docs = len(chunks)
+
+        if num_docs == 0:
+            return []
+
+        avgdl = sum(doc_lengths) / num_docs if num_docs else 0.0
+
+        # Document frequency: how many documents contain each term at least once.
+        doc_freq: dict[str, int] = {}
+        for tokens in doc_tokens:
+            for term in set(tokens):
+                doc_freq[term] = doc_freq.get(term, 0) + 1
+
+        # Non-negative BM25 IDF per term.
+        idf: dict[str, float] = {}
+        for term, n_q in doc_freq.items():
+            idf[term] = math.log(1.0 + (num_docs - n_q + 0.5) / (n_q + 0.5))
+
+        query_terms = _tokenize(query_text)
+
+        scored_chunks = []
+        for chunk, tokens, dl in zip(chunks, doc_tokens, doc_lengths):
+            # Term frequencies within this document.
+            tf: dict[str, int] = {}
+            for term in tokens:
+                tf[term] = tf.get(term, 0) + 1
+
+            score = 0.0
+            for term in query_terms:
+                if term not in tf:
+                    continue
+                freq = tf[term]
+                numerator = idf.get(term, 0.0) * freq * (_BM25_K1 + 1.0)
+                denominator = freq + _BM25_K1 * (
+                    1.0 - _BM25_B + _BM25_B * (dl / avgdl if avgdl > 0 else 0.0)
+                )
+                score += numerator / denominator if denominator > 0 else 0.0
+
+            scored_chunks.append({**chunk, "relevance_score": score})
+
+        return scored_chunks
+
+    def _tfidf_scoring(self, chunks: list[dict], query_text: str) -> list[dict]:
+        """Score chunks using TF-IDF cosine similarity.
+
+        Builds a TF-IDF vector for the ``query`` text and for each chunk's
+        ``content`` over the chunk corpus vocabulary, then scores each chunk by
+        the cosine similarity between its vector and the query vector. Pure
+        Python, no numpy.
+
+        TF is the raw term count in the document; IDF is the smoothed inverse
+        document frequency ``ln((1 + N) / (1 + n)) + 1`` over the chunk corpus.
+        """
+        doc_tokens = [_tokenize(chunk.get("content", "")) for chunk in chunks]
+        num_docs = len(chunks)
+
+        if num_docs == 0:
+            return []
+
+        # Document frequency over the chunk corpus.
+        doc_freq: dict[str, int] = {}
+        for tokens in doc_tokens:
+            for term in set(tokens):
+                doc_freq[term] = doc_freq.get(term, 0) + 1
+
+        # Smoothed IDF (non-negative; matches the sklearn smooth_idf convention).
+        idf: dict[str, float] = {}
+        for term, n_q in doc_freq.items():
+            idf[term] = math.log((1.0 + num_docs) / (1.0 + n_q)) + 1.0
+
+        def _tfidf_vector(tokens: list[str]) -> dict[str, float]:
+            counts: dict[str, int] = {}
+            for term in tokens:
+                counts[term] = counts.get(term, 0) + 1
+            # Only terms present in the corpus vocabulary have an IDF weight.
+            return {
+                term: count * idf[term] for term, count in counts.items() if term in idf
+            }
+
+        def _cosine(vec_a: dict[str, float], vec_b: dict[str, float]) -> float:
+            if not vec_a or not vec_b:
+                return 0.0
+            # Iterate the smaller vector for the dot product.
+            small, large = (
+                (vec_a, vec_b) if len(vec_a) <= len(vec_b) else (vec_b, vec_a)
+            )
+            dot = sum(weight * large.get(term, 0.0) for term, weight in small.items())
+            norm_a = math.sqrt(sum(w * w for w in vec_a.values()))
+            norm_b = math.sqrt(sum(w * w for w in vec_b.values()))
+            if norm_a == 0.0 or norm_b == 0.0:
+                return 0.0
+            return dot / (norm_a * norm_b)
+
+        query_vector = _tfidf_vector(_tokenize(query_text))
+
+        scored_chunks = []
+        for chunk, tokens in zip(chunks, doc_tokens):
+            chunk_vector = _tfidf_vector(tokens)
+            score = _cosine(query_vector, chunk_vector)
+            scored_chunks.append({**chunk, "relevance_score": score})
+
+        return scored_chunks
 
 
 @register_node()

--- a/src/kailash/nodes/data/vector_db.py
+++ b/src/kailash/nodes/data/vector_db.py
@@ -3,13 +3,17 @@
 This module provides nodes for interacting with vector databases and generating
 embeddings. Key features include:
 
-- Unified interface for various vector databases (Pinecone, Weaviate, Milvus, etc.)
+- A built-in in-memory vector store (``provider="memory"``) with real
+  similarity search, metadata filtering, and CRUD operations
+- A unified interface that external vector databases (Pinecone, Weaviate,
+  Milvus, Qdrant, Chroma) can integrate against
 - Embedding generation using various models (OpenAI, HuggingFace, etc.)
 - Text chunking and preprocessing
-- Vector similarity search
+- Vector similarity search (cosine / euclidean / dot)
 - Metadata filtering
 
 Design Philosophy:
+- Ship a working, dependency-light in-memory backend out of the box
 - Abstract away vector database differences
 - Support multiple embedding models
 - Provide flexible search capabilities
@@ -29,12 +33,12 @@ Example:
     >>> embedder.configure({"model": "openai", "model_name": "text-embedding-ada-002"})
     >>> result = embedder.execute({"texts": ["Hello world", "Goodbye world"]})
     >>>
-    >>> # Store in vector database
+    >>> # Store in the built-in in-memory vector store
     >>> vector_db = VectorDatabaseNode()
     >>> vector_db.configure({
-    ...     "provider": "pinecone",
+    ...     "provider": "memory",
     ...     "index_name": "my-index",
-    ...     "api_key": "your-api-key"
+    ...     "dimension": 1536,
     ... })
     >>> vector_db.execute({
     ...     "operation": "upsert",
@@ -44,6 +48,7 @@ Example:
     ... })
 """
 
+import math
 from typing import Any
 
 try:
@@ -353,11 +358,19 @@ class EmbeddingNode(Node):
 
 @register_node()
 class VectorDatabaseNode(Node):
-    """Interacts with vector databases for storing and retrieving embeddings.
+    """Stores and retrieves embeddings with a built-in in-memory vector store.
 
-    This node provides a unified interface for various vector databases including
-    Pinecone, Weaviate, Milvus, Qdrant, and others. It handles vector operations,
-    metadata management, and similarity search.
+    This node ships a real, dependency-light in-memory backend
+    (``provider="memory"``) that performs actual similarity search, metadata
+    filtering, and CRUD operations entirely in pure Python — no external
+    service or extra dependency required. ``provider="memory"`` is the working
+    default.
+
+    External providers (Pinecone, Weaviate, Milvus, Qdrant, Chroma) are
+    recognised as a unified interface, but require an external vector-DB
+    integration that is NOT bundled with ``kailash``. Selecting one without a
+    bundled client raises a clear ``NodeConfigurationError`` rather than
+    silently faking results.
 
     Design Pattern:
     - Repository pattern for data access
@@ -365,12 +378,11 @@ class VectorDatabaseNode(Node):
     - Command pattern for operations
 
     Features:
-    - Multiple vector database support
+    - Built-in in-memory vector store with real similarity search
     - CRUD operations on vectors
-    - Similarity search with filters
-    - Hybrid search (vector + keyword)
+    - Similarity search with metadata filters
+    - Cosine / euclidean / dot-product distance metrics
     - Index management
-    - Backup and restore
 
     Common Usage Patterns:
     - Storing document embeddings
@@ -391,10 +403,12 @@ class VectorDatabaseNode(Node):
     - Visualization nodes
 
     Configuration:
-        provider (str): Vector database provider
-        connection_string (str): Database connection details
+        provider (str): Vector backend. ``"memory"`` is the built-in working
+            backend; ``"pinecone"`` / ``"weaviate"`` / ``"milvus"`` /
+            ``"qdrant"`` / ``"chroma"`` require an external integration.
+        connection_string (str): Database connection details (external providers)
         index_name (str): Name of the vector index
-        dimension (int): Vector dimension size
+        dimension (int): Vector dimension size (validated on every operation)
         metric (str): Distance metric ("cosine", "euclidean", "dot")
 
     Inputs:
@@ -412,16 +426,14 @@ class VectorDatabaseNode(Node):
 
     Error Handling:
     - Connection validation
-    - Index existence checks
-    - Dimension mismatch detection
-    - Quota and limit management
+    - Dimension mismatch detection (raises ValueError)
+    - Clear typed error for unbundled external providers
 
     Example:
         >>> vector_db = VectorDatabaseNode()
         >>> vector_db.configure({
-        ...     "provider": "pinecone",
+        ...     "provider": "memory",  # built-in working backend
         ...     "index_name": "my-knowledge-base",
-        ...     "api_key": "your-api-key",
         ...     "dimension": 1536,
         ...     "metric": "cosine"
         ... })
@@ -471,6 +483,8 @@ class VectorDatabaseNode(Node):
         # Initialize node attributes
         self._client = None
         self._index = None
+        # Built-in in-memory vector store: id -> {"vector": [...], "metadata": {...}}
+        self._store: dict[str, dict[str, Any]] = {}
 
         # Call parent constructor
         super().__init__(name=self.name)
@@ -481,7 +495,11 @@ class VectorDatabaseNode(Node):
             "provider": NodeParameter(
                 name="provider",
                 type=str,
-                description="Vector database provider",
+                description=(
+                    "Vector backend: 'memory' (built-in working backend) or an "
+                    "external provider (pinecone/weaviate/milvus/qdrant/chroma) "
+                    "requiring an integration not bundled with kailash"
+                ),
                 required=True,
             ),
             "connection_string": NodeParameter(
@@ -515,6 +533,18 @@ class VectorDatabaseNode(Node):
                 required=False,
                 default="cosine",
             ),
+            "max_vectors": NodeParameter(
+                name="max_vectors",
+                type=int,
+                description=(
+                    "Optional cap on how many vectors the built-in in-memory "
+                    "store may hold; an upsert that would exceed it raises a "
+                    "typed error instead of growing the heap. Unset (default) "
+                    "means the store is bounded only by available process "
+                    "memory — set this when accepting untrusted upsert volume."
+                ),
+                required=False,
+            ),
         }
 
     def configure(self, config: dict[str, Any]) -> None:
@@ -529,7 +559,13 @@ class VectorDatabaseNode(Node):
         Raises:
             NodeConfigurationError: If connection fails
         """
-        super().configure(config)  # type: ignore[reportAttributeAccessIssue]
+        # The base Node has no ``configure`` method — configuration provided
+        # post-construction is merged into ``self.config`` (populated from
+        # __init__ kwargs, defaulting to {}). This keeps the documented
+        # ``configure() -> execute()`` user flow working.
+        if getattr(self, "config", None) is None:
+            self.config = {}
+        self.config.update(config)
 
         provider = self.config.get("provider")
         index_name = self.config.get("index_name")
@@ -538,29 +574,49 @@ class VectorDatabaseNode(Node):
             raise NodeConfigurationError("index_name is required")
 
         try:
-            # Placeholder for actual database connection
             self._connect_to_database(provider)  # type: ignore[reportArgumentType]
+        except NodeConfigurationError:
+            # Already a clear typed configuration error (e.g. unbundled external
+            # provider) — surface it verbatim rather than re-wrapping.
+            raise
         except Exception as e:
             raise NodeConfigurationError(f"Failed to connect to {provider}: {str(e)}")
 
-    def _connect_to_database(self, provider: str) -> None:
-        """Connect to the vector database.
+    # External providers recognised as a unified interface but NOT bundled.
+    _EXTERNAL_PROVIDERS = ("pinecone", "weaviate", "milvus", "qdrant", "chroma")
 
-        Establishes connection and prepares the index for operations.
-        This is a placeholder for actual connection logic.
+    def _connect_to_database(self, provider: str) -> None:
+        """Connect to the vector backend.
+
+        For ``provider="memory"`` this initializes the built-in in-memory
+        store. External providers raise a clear typed error because no client
+        or credentials are bundled with ``kailash`` — the node never fakes a
+        connection.
 
         Args:
-            provider: Database provider name
+            provider: Backend name
 
         Raises:
-            ValueError: If provider is not supported
+            NodeConfigurationError: For external providers (no bundled client).
+            ValueError: If provider is not a recognised name.
         """
-        if provider not in ["pinecone", "weaviate", "milvus", "qdrant", "chroma"]:
-            raise ValueError(f"Unsupported provider: {provider}")
+        if provider == "memory":
+            # Real per-node in-memory store; survives across operations on this
+            # node instance.
+            self._index = self.config.get("index_name")
+            return
 
-        # Placeholder for actual connection
-        self._client = f"{provider}_client"
-        self._index = self.config.get("index_name")
+        if provider in self._EXTERNAL_PROVIDERS:
+            raise NodeConfigurationError(
+                f"provider '{provider}' requires an external vector-DB "
+                "integration that is not bundled with kailash; use "
+                "provider='memory' for built-in in-memory vector search."
+            )
+
+        raise ValueError(
+            f"Unsupported provider: {provider}; use 'memory' for the built-in "
+            f"backend or one of {self._EXTERNAL_PROVIDERS} (external integration)."
+        )
 
     def run(self, **kwargs) -> dict[str, Any]:
         """Execute vector database operations.
@@ -606,18 +662,79 @@ class VectorDatabaseNode(Node):
         except Exception as e:
             raise NodeExecutionError(f"Vector operation failed: {str(e)}")
 
-    def _upsert_vectors(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Insert or update vectors in the database.
+    def _expected_dimension(self) -> int:
+        """Return the configured vector dimension."""
+        dimension = self.config.get("dimension")
+        if dimension is None:
+            raise ValueError("dimension is required for vector operations")
+        return int(dimension)
 
-        Args:
-            inputs: Vectors, IDs, and metadata
+    def _validate_dimension(self, vector: list[float], *, label: str) -> None:
+        """Raise if a vector's length does not match the configured dimension."""
+        expected = self._expected_dimension()
+        if len(vector) != expected:
+            raise ValueError(
+                f"{label} has dimension {len(vector)} but the index is "
+                f"configured for dimension {expected}"
+            )
+
+    @staticmethod
+    def _metadata_matches(
+        metadata: dict[str, Any], filter_dict: dict[str, Any]
+    ) -> bool:
+        """Return True iff metadata matches every key/value in the filter."""
+        for key, value in filter_dict.items():
+            if metadata.get(key) != value:
+                return False
+        return True
+
+    def _similarity(self, query: list[float], stored: list[float]) -> float:
+        """Compute a similarity score between two vectors (higher = closer).
+
+        Implemented in pure Python for the configured metric:
+        - ``cosine``: cosine similarity in [-1, 1]
+        - ``dot``: dot product
+        - ``euclidean``: 1 / (1 + distance), monotonic in -distance so that
+          nearer vectors rank higher
 
         Returns:
-            Upsert status
+            A score where larger values mean a closer match.
+        """
+        metric = self.config.get("metric", "cosine")
+
+        dot = sum(q * s for q, s in zip(query, stored))
+
+        if metric == "dot":
+            return dot
+
+        if metric == "euclidean":
+            dist_sq = sum((q - s) ** 2 for q, s in zip(query, stored))
+            distance = math.sqrt(dist_sq)
+            return 1.0 / (1.0 + distance)
+
+        if metric == "cosine":
+            norm_q = math.sqrt(sum(q * q for q in query))
+            norm_s = math.sqrt(sum(s * s for s in stored))
+            if norm_q == 0.0 or norm_s == 0.0:
+                return 0.0
+            return dot / (norm_q * norm_s)
+
+        raise ValueError(
+            f"Unsupported metric: {metric}; use 'cosine', 'euclidean', or 'dot'."
+        )
+
+    def _upsert_vectors(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Insert or update vectors in the in-memory store.
+
+        Args:
+            inputs: Vectors, IDs, and (optional) per-vector metadata
+
+        Returns:
+            Upsert status with the real count of stored vectors
         """
         vectors = inputs.get("vectors", [])
         ids = inputs.get("ids", [])
-        # metadata = inputs.get("metadata", [])  # TODO: Implement metadata storage
+        metadata = inputs.get("metadata", [])
 
         if not vectors or not ids:
             raise ValueError("Vectors and IDs are required for upsert")
@@ -625,87 +742,147 @@ class VectorDatabaseNode(Node):
         if len(vectors) != len(ids):
             raise ValueError("Number of vectors must match number of IDs")
 
-        # Placeholder for actual upsert
+        if metadata and len(metadata) != len(ids):
+            raise ValueError("Number of metadata entries must match number of IDs")
+
+        # Validate every vector's dimension up front so a mismatch fails loud
+        # WITHOUT partially mutating the store (atomic upsert).
+        for vector_id, vector in zip(ids, vectors):
+            self._validate_dimension(vector, label=f"vector for id '{vector_id}'")
+
+        # Enforce the optional in-memory capacity cap atomically, before any
+        # store mutation, so an over-cap upsert fails loud instead of growing
+        # the heap unbounded (see the ``max_vectors`` parameter).
+        max_vectors = self.config.get("max_vectors")
+        if max_vectors is not None:
+            new_ids = {vid for vid in ids if vid not in self._store}
+            projected = len(self._store) + len(new_ids)
+            if projected > int(max_vectors):
+                raise ValueError(
+                    f"in-memory vector store capacity exceeded: this upsert "
+                    f"would bring the total to {projected}, above "
+                    f"max_vectors={int(max_vectors)}"
+                )
+
+        # Really store each vector + its metadata, aligned by index.
+        for i, (vector_id, vector) in enumerate(zip(ids, vectors)):
+            meta = metadata[i] if metadata and i < len(metadata) else {}
+            self._store[vector_id] = {
+                "vector": list(vector),
+                "metadata": dict(meta) if meta else {},
+            }
+
         return {
             "operation": "upsert",
             "status": "success",
-            "count": len(vectors),
+            "count": len(ids),
             "index": self._index,
         }
 
     def _query_vectors(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Query similar vectors from the database.
+        """Query the most similar vectors from the in-memory store.
+
+        Computes a real similarity between the query vector and every stored
+        vector using the configured metric, optionally narrows by a metadata
+        filter, sorts by score descending, and returns the top-k real matches.
 
         Args:
             inputs: Query vector and parameters
 
         Returns:
-            Search results
+            Search results drawn from the actual store (empty when no match)
         """
         query_vector = inputs.get("query_vector")
         k = inputs.get("k", 10)
-        # filter_dict = inputs.get("filter", {})  # TODO: Implement filter-based queries
+        filter_dict = inputs.get("filter", {}) or {}
+
+        if filter_dict and not isinstance(filter_dict, dict):
+            raise ValueError(
+                "filter must be a dict of metadata key/value equality " "constraints"
+            )
 
         if not query_vector:
             raise ValueError("Query vector is required")
 
-        # Placeholder for actual query
+        self._validate_dimension(query_vector, label="query_vector")
+
+        scored: list[dict[str, Any]] = []
+        for vector_id, record in self._store.items():
+            if filter_dict and not self._metadata_matches(
+                record["metadata"], filter_dict
+            ):
+                continue
+            score = self._similarity(query_vector, record["vector"])
+            scored.append(
+                {
+                    "id": vector_id,
+                    "score": score,
+                    "metadata": dict(record["metadata"]),
+                }
+            )
+
+        scored.sort(key=lambda item: item["score"], reverse=True)
+        results = scored[:k]
+
         return {
             "operation": "query",
             "status": "success",
-            "results": [
-                {
-                    "id": f"doc_{i}",
-                    "score": 0.95 - i * 0.05,
-                    "metadata": {"title": f"Document {i}"},
-                }
-                for i in range(min(k, 5))
-            ],
-            "count": min(k, 5),
+            "results": results,
+            "count": len(results),
         }
 
     def _delete_vectors(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Delete vectors from the database.
+        """Delete vectors from the in-memory store by ID.
 
         Args:
             inputs: Vector IDs to delete
 
         Returns:
-            Deletion status
+            Deletion status with the real number of vectors removed
         """
         ids = inputs.get("ids", [])
 
         if not ids:
             raise ValueError("IDs are required for deletion")
 
-        # Placeholder for actual deletion
-        return {"operation": "delete", "status": "success", "count": len(ids)}
+        deleted = 0
+        for vector_id in ids:
+            if self._store.pop(vector_id, None) is not None:
+                deleted += 1
+
+        return {"operation": "delete", "status": "success", "count": deleted}
 
     def _fetch_vectors(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Fetch specific vectors by ID.
+        """Fetch specific vectors by ID from the in-memory store.
+
+        Returns the real stored values and metadata for each requested id.
+        Missing ids are honestly omitted from the result rather than fabricated.
 
         Args:
             inputs: Vector IDs to fetch
 
         Returns:
-            Fetched vectors and metadata
+            Fetched vectors and metadata (only for ids that exist)
         """
         ids = inputs.get("ids", [])
 
         if not ids:
             raise ValueError("IDs are required for fetch")
 
-        # Placeholder for actual fetch
+        vectors: dict[str, dict[str, Any]] = {}
+        for vector_id in ids:
+            record = self._store.get(vector_id)
+            if record is None:
+                continue
+            vectors[vector_id] = {
+                "values": list(record["vector"]),
+                "metadata": dict(record["metadata"]),
+            }
+
         return {
             "operation": "fetch",
             "status": "success",
-            "vectors": {
-                id: {
-                    "values": [0.1] * self.config.get("dimension", 768),
-                    "metadata": {"id": id},
-                }
-                for id in ids
-            },
+            "vectors": vectors,
         }
 
 

--- a/src/kailash/nodes/data/workflow_connection_pool.py
+++ b/src/kailash/nodes/data/workflow_connection_pool.py
@@ -48,6 +48,7 @@ class ConnectionPoolMetrics:
         self.queries_executed = 0
         self.query_errors = 0
         self.acquisition_wait_times: List[float] = []
+        self.query_execution_times: List[float] = []
         self.health_check_results: List[bool] = []
         self.start_time = time.time()
 
@@ -58,6 +59,17 @@ class ConnectionPoolMetrics:
         if len(self.acquisition_wait_times) > 1000:
             self.acquisition_wait_times = self.acquisition_wait_times[-1000:]
 
+    def record_query_time(self, execution_time: float):
+        """Record wall-clock time (seconds) a query took to execute.
+
+        Mirrors record_acquisition_time: a bounded rolling window of the last
+        1000 measurements is retained so avg/p99 reflect recent behavior.
+        """
+        self.query_execution_times.append(execution_time)
+        # Keep only last 1000 measurements
+        if len(self.query_execution_times) > 1000:
+            self.query_execution_times = self.query_execution_times[-1000:]
+
     def get_stats(self) -> Dict[str, Any]:
         """Get comprehensive pool statistics."""
         uptime = time.time() - self.start_time
@@ -66,6 +78,12 @@ class ConnectionPoolMetrics:
         avg_wait_time = (
             sum(self.acquisition_wait_times) / len(self.acquisition_wait_times)
             if self.acquisition_wait_times
+            else 0.0
+        )
+
+        avg_query_time = (
+            sum(self.query_execution_times) / len(self.query_execution_times)
+            if self.query_execution_times
             else 0.0
         )
 
@@ -103,6 +121,16 @@ class ConnectionPoolMetrics:
                     if self.acquisition_wait_times
                     else 0
                 ),
+                "avg_query_time_ms": avg_query_time * 1000,
+                "p99_query_time_ms": (
+                    sorted(self.query_execution_times)[
+                        int(len(self.query_execution_times) * 0.99)
+                    ]
+                    * 1000
+                    if self.query_execution_times
+                    else 0
+                ),
+                "query_samples": len(self.query_execution_times),
             },
             "health": {
                 "success_rate": health_success_rate,
@@ -643,6 +671,9 @@ class WorkflowConnectionPool(AsyncNode):
 
             # Update metrics
             self.metrics.queries_executed += 1
+            # Record the real, measured query-execution time so pool
+            # statistics report an honest avg/p99 instead of a constant.
+            self.metrics.record_query_time(result.execution_time)
             if not result.success:
                 self.metrics.query_errors += 1
                 self.metrics_collector.track_query_error(
@@ -836,16 +867,27 @@ class WorkflowConnectionPool(AsyncNode):
         connections = {}
 
         for conn_id, conn in self.all_connections.items():
-            connections[conn_id] = {
+            conn_info: Dict[str, Any] = {
                 "health_score": conn.health_score,
                 "active_queries": 1 if conn_id in self.active_connections else 0,
-                "capabilities": [
-                    "read",
-                    "write",
-                ],  # TODO: Add actual capability detection
-                "avg_latency_ms": 0.0,  # TODO: Track actual latency
-                "last_used": datetime.now().isoformat(),
             }
+
+            # Real per-connection average latency, derived from the connection
+            # actor's own execution stats. Only emit it when the connection has
+            # actually run a query — otherwise omit the key so the consumer
+            # (query_router) applies its own default. Omitting signals "no
+            # measurement yet" rather than asserting a measured 0ms; it does not
+            # fabricate a value the consumer would read as a real latency.
+            avg_latency_ms, last_used = self._connection_latency_and_last_used(conn)
+            if avg_latency_ms is not None:
+                conn_info["avg_latency_ms"] = avg_latency_ms
+            conn_info["last_used"] = last_used
+
+            # NOTE: per-connection capability detection is not yet a real
+            # signal in the pool, so the key is intentionally omitted rather
+            # than emitting a fabricated ["read", "write"] constant. The query
+            # router defaults to {"read", "write"} when the key is absent.
+            connections[conn_id] = conn_info
 
         return {
             "connections": connections,
@@ -853,6 +895,35 @@ class WorkflowConnectionPool(AsyncNode):
             "active_count": len(self.active_connections),
             "available_count": self.available_connections.qsize(),
         }
+
+    def _connection_latency_and_last_used(self, conn: Any) -> tuple:
+        """Return (avg_latency_ms, last_used_iso) from a connection's real stats.
+
+        Reads the connection actor's own execution stats
+        (``total_execution_time`` / ``queries_executed``) to compute a real
+        average latency. Returns ``(None, <now-iso>)`` when no query has run on
+        the connection (no real latency exists yet) or when the stats surface
+        is unavailable, so callers can omit the latency key instead of emitting
+        a fabricated value.
+        """
+        stats = getattr(getattr(conn, "actor", None), "stats", None)
+        if stats is None:
+            return None, datetime.now().isoformat()
+
+        executed = getattr(stats, "queries_executed", 0) or 0
+        total_time = getattr(stats, "total_execution_time", 0.0) or 0.0
+        last_used_at = getattr(stats, "last_used_at", None)
+        last_used_iso = (
+            last_used_at.isoformat()
+            if last_used_at is not None
+            else datetime.now().isoformat()
+        )
+
+        if executed <= 0:
+            return None, last_used_iso
+
+        avg_latency_ms = (total_time / executed) * 1000
+        return avg_latency_ms, last_used_iso
 
     async def adjust_pool_size(self, new_size: int) -> Dict[str, Any]:
         """Dynamically adjust pool size."""
@@ -898,6 +969,23 @@ class WorkflowConnectionPool(AsyncNode):
             "new_size": len(self.all_connections),
         }
 
+    def _pending_acquisition_waiters(self) -> int:
+        """Count consumers currently blocked waiting for a connection.
+
+        ``asyncio.Queue`` parks the futures of coroutines blocked in ``get()``
+        in its ``_getters`` deque. The deque is not pruned the instant a future
+        resolves, so we count only futures that are still pending — that is the
+        real number of acquirers waiting on an available connection right now.
+
+        Returns 0 when the underlying queue does not expose ``_getters`` (so the
+        method degrades to a truthful "no observable waiters" rather than a
+        fabricated constant).
+        """
+        getters = getattr(self.available_connections, "_getters", None)
+        if not getters:
+            return 0
+        return sum(1 for waiter in getters if not waiter.done())
+
     async def get_pool_statistics(self) -> Dict[str, Any]:
         """Get detailed pool statistics for adaptive sizing."""
         total_connections = len(self.all_connections)
@@ -915,8 +1003,11 @@ class WorkflowConnectionPool(AsyncNode):
             sum(health_scores) / len(health_scores) if health_scores else 100
         )
 
-        # Queue depth (approximate based on waiters)
-        queue_depth = 0  # TODO: Track actual queue depth
+        # Queue depth: number of consumers currently blocked in
+        # available_connections.get() waiting for a connection to free up.
+        # asyncio.Queue tracks these as pending getter futures in `_getters`;
+        # we count only the futures that are still un-resolved.
+        queue_depth = self._pending_acquisition_waiters()
 
         # Get timing metrics from pool metrics
         stats = self.metrics.get_stats()
@@ -929,7 +1020,8 @@ class WorkflowConnectionPool(AsyncNode):
             "utilization_rate": utilization_rate,
             "avg_health_score": avg_health_score,
             "avg_acquisition_time_ms": stats["performance"]["avg_acquisition_time_ms"],
-            "avg_query_time_ms": 50.0,  # TODO: Track actual query time
+            "avg_query_time_ms": stats["performance"]["avg_query_time_ms"],
+            "query_time_samples": stats["performance"]["query_samples"],
             "queries_per_second": (
                 stats["queries"]["executed"] / stats["uptime_seconds"]
                 if stats["uptime_seconds"] > 0

--- a/tests/regression/test_pool_metrics_no_fabrication.py
+++ b/tests/regression/test_pool_metrics_no_fabrication.py
@@ -1,0 +1,265 @@
+"""Regression: WorkflowConnectionPool diagnostic methods report HONEST metrics.
+
+Defect (pre-fix): the pool's public diagnostic methods returned hardcoded
+fabricated values alongside real ones:
+
+  * ``get_pool_statistics()`` returned ``avg_query_time_ms = 50.0`` (a constant
+    ``# TODO: Track actual query time``) and ``queue_depth = 0``
+    (``# TODO: Track actual queue depth``).
+  * ``_get_pool_status()`` returned ``avg_latency_ms = 0.0``
+    (``# TODO: Track actual latency``) and a hardcoded
+    ``capabilities = ["read", "write"]`` (``# TODO: Add actual capability
+    detection``).
+
+These fabricated constants were presented to callers (and the query router,
+which uses ``avg_latency_ms`` for routing) as if they were measured signals.
+
+Fix:
+
+  * Query-execution time is now instrumented: ``ConnectionPoolMetrics`` tracks a
+    bounded rolling window of real query times via ``record_query_time()``,
+    called from the real ``_execute_query`` path. ``get_pool_statistics`` reports
+    the real average; with no activity it reports ``0.0`` honestly (and a
+    ``query_time_samples`` count distinguishes "no data" from "fast queries").
+  * ``queue_depth`` reads the real pending-waiter count from the
+    ``available_connections`` queue.
+  * ``avg_latency_ms`` is derived from each connection's real execution stats,
+    and OMITTED when the connection has run no queries (rather than emitting a
+    fabricated ``0.0``).
+  * The fabricated ``capabilities`` constant is OMITTED entirely (the query
+    router supplies its own default).
+
+All assertions below are BEHAVIORAL: they construct/drive a real pool and a
+real ``ConnectionPoolMetrics`` through real activity, then assert the returned
+values reflect that activity and are NOT the old fabricated constants.
+"""
+
+import pytest
+
+from kailash.core.actors.connection_actor import QueryResult
+from kailash.nodes.data.workflow_connection_pool import (
+    ConnectionPoolMetrics,
+    WorkflowConnectionPool,
+)
+
+# Old fabricated constants the fix removed — no returned metric may equal these
+# AFTER real activity has occurred.
+_FABRICATED_QUERY_TIME_MS = 50.0
+_FABRICATED_LATENCY_MS = 0.0
+
+
+def _make_pool(**overrides) -> WorkflowConnectionPool:
+    """Construct a real pool instance (no live DB needed for diagnostics)."""
+    cfg = dict(
+        name="regression_pool",
+        database_type="postgresql",
+        host="localhost",
+        database="testdb",
+        user="u",
+        password="p",
+        min_connections=1,
+        max_connections=4,
+    )
+    cfg.update(overrides)
+    return WorkflowConnectionPool(**cfg)
+
+
+class _FakeStats:
+    """Minimal stand-in for ConnectionStats with real execution accounting."""
+
+    def __init__(self):
+        self.queries_executed = 0
+        self.total_execution_time = 0.0
+        self.health_score = 90.0
+        self.last_used_at = None
+
+
+class _FakeActor:
+    def __init__(self, conn_id):
+        self.id = conn_id
+        self.stats = _FakeStats()
+
+
+class _FakeConnection:
+    """A ConnectionActor-shaped fake whose execute() returns a real QueryResult.
+
+    It mirrors the real wrapper: ``.id``, ``.health_score``, ``.actor.stats``,
+    and an awaitable ``execute()`` that returns a ``QueryResult`` carrying a
+    real (caller-supplied) execution_time.
+    """
+
+    def __init__(self, conn_id, execution_time):
+        self.id = conn_id
+        self.actor = _FakeActor(conn_id)
+        self._execution_time = execution_time
+
+    @property
+    def health_score(self):
+        return self.actor.stats.health_score
+
+    async def execute(self, query=None, params=None, fetch_mode="all"):
+        # Record real execution accounting onto the connection's own stats,
+        # exactly as the real actor does, so per-connection latency is honest.
+        self.actor.stats.queries_executed += 1
+        self.actor.stats.total_execution_time += self._execution_time
+        return QueryResult(
+            success=True, data=[], error=None, execution_time=self._execution_time
+        )
+
+
+# ---------------------------------------------------------------------------
+# (a) avg_query_time_ms reflects real timing (or the key/value is honest 0.0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_metrics_record_query_time_drives_real_avg():
+    """ConnectionPoolMetrics computes a REAL avg/p99 from recorded query times."""
+    metrics = ConnectionPoolMetrics("unit")
+
+    # No activity yet -> honest zero, zero samples (NOT a fabricated constant).
+    stats = metrics.get_stats()
+    assert stats["performance"]["avg_query_time_ms"] == 0.0
+    assert stats["performance"]["query_samples"] == 0
+
+    # Record three real query times (seconds): 0.010, 0.020, 0.030 -> avg 0.020s.
+    for seconds in (0.010, 0.020, 0.030):
+        metrics.record_query_time(seconds)
+
+    stats = metrics.get_stats()
+    perf = stats["performance"]
+    assert perf["query_samples"] == 3
+    # avg = 20ms exactly; must reflect the real samples, never the old 50.0.
+    assert perf["avg_query_time_ms"] == pytest.approx(20.0, abs=1e-6)
+    assert perf["avg_query_time_ms"] != _FABRICATED_QUERY_TIME_MS
+    assert perf["p99_query_time_ms"] == pytest.approx(30.0, abs=1e-6)
+
+
+@pytest.mark.regression
+def test_record_query_time_window_is_bounded():
+    """The query-time window is bounded (mirrors acquisition_wait_times: 1000)."""
+    metrics = ConnectionPoolMetrics("unit")
+    for _ in range(1500):
+        metrics.record_query_time(0.001)
+    assert len(metrics.query_execution_times) == 1000
+
+
+@pytest.mark.regression
+async def test_get_pool_statistics_query_time_is_real_after_activity():
+    """get_pool_statistics avg_query_time_ms reflects REAL executed query time."""
+    pool = _make_pool()
+
+    # Before any query: honest 0.0 (NOT the fabricated 50.0 constant), 0 samples.
+    stats_before = await pool.get_pool_statistics()
+    assert stats_before["avg_query_time_ms"] == 0.0
+    assert stats_before["avg_query_time_ms"] != _FABRICATED_QUERY_TIME_MS
+    assert stats_before["query_time_samples"] == 0
+
+    # Drive the REAL _execute_query path (which calls record_query_time) with a
+    # connection whose query takes a known 25ms.
+    conn = _FakeConnection("conn_real", execution_time=0.025)
+    pool.all_connections[conn.id] = conn
+    pool.active_connections[conn.id] = conn
+
+    result = await pool._execute_query({"connection_id": conn.id, "query": "SELECT 1"})
+    assert result["success"] is True
+
+    stats_after = await pool.get_pool_statistics()
+    # The framework actually called record_query_time on the real path.
+    assert stats_after["query_time_samples"] == 1
+    assert stats_after["avg_query_time_ms"] == pytest.approx(25.0, abs=1e-6)
+    # Crucially: NOT the old fabricated constant after real activity.
+    assert stats_after["avg_query_time_ms"] != _FABRICATED_QUERY_TIME_MS
+
+
+# ---------------------------------------------------------------------------
+# (b) No returned metric equals the old fabricated constants after real activity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_no_fabricated_constants_after_real_activity():
+    """After real query activity, diagnostics carry honest values only."""
+    pool = _make_pool()
+
+    conn = _FakeConnection("conn_a", execution_time=0.040)  # 40ms, != 50ms, != 0
+    pool.all_connections[conn.id] = conn
+    pool.active_connections[conn.id] = conn
+    await pool._execute_query({"connection_id": conn.id, "query": "SELECT 1"})
+
+    # get_pool_statistics: query time is the real 40ms, never the fabricated 50.0
+    stats = await pool.get_pool_statistics()
+    assert stats["avg_query_time_ms"] == pytest.approx(40.0, abs=1e-6)
+    assert stats["avg_query_time_ms"] != _FABRICATED_QUERY_TIME_MS
+
+    # _get_pool_status: avg_latency_ms is the real 40ms, never the fabricated 0.0
+    status = await pool._get_pool_status()
+    conn_info = status["connections"][conn.id]
+    assert "avg_latency_ms" in conn_info
+    assert conn_info["avg_latency_ms"] == pytest.approx(40.0, abs=1e-6)
+    assert conn_info["avg_latency_ms"] != _FABRICATED_LATENCY_MS
+
+
+@pytest.mark.regression
+async def test_get_pool_status_omits_latency_with_no_queries_no_fabricated_zero():
+    """A connection with no queries OMITS avg_latency_ms (no fabricated 0.0)."""
+    pool = _make_pool()
+
+    conn = _FakeConnection("conn_idle", execution_time=0.0)  # never executed
+    pool.all_connections[conn.id] = conn
+
+    status = await pool._get_pool_status()
+    conn_info = status["connections"][conn.id]
+    # Honest omission: the consumer (query router) applies its own default
+    # rather than reading a fabricated 0.0 latency that would skew routing.
+    assert "avg_latency_ms" not in conn_info
+
+
+@pytest.mark.regression
+async def test_get_pool_status_omits_fabricated_capabilities_constant():
+    """The fabricated ['read','write'] capabilities constant is gone."""
+    pool = _make_pool()
+
+    conn = _FakeConnection("conn_c", execution_time=0.005)
+    pool.all_connections[conn.id] = conn
+
+    status = await pool._get_pool_status()
+    conn_info = status["connections"][conn.id]
+    # No fabricated capability list — the router defaults when absent.
+    assert "capabilities" not in conn_info
+
+
+# ---------------------------------------------------------------------------
+# (c) queue_depth reflects real waiter state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_queue_depth_reflects_real_pending_waiters():
+    """queue_depth counts REAL consumers blocked waiting for a connection."""
+    import asyncio
+
+    pool = _make_pool()
+
+    # No waiters initially -> real zero (not a TODO placeholder).
+    stats = await pool.get_pool_statistics()
+    assert stats["queue_depth"] == 0
+
+    # Park two real coroutines blocked in available_connections.get().
+    getter_tasks = [
+        asyncio.ensure_future(pool.available_connections.get()) for _ in range(2)
+    ]
+    # Yield so the getters actually register as pending waiters on the queue.
+    await asyncio.sleep(0)
+
+    stats_waiting = await pool.get_pool_statistics()
+    assert stats_waiting["queue_depth"] == 2
+
+    # Releasing connections wakes the waiters; depth returns to real zero.
+    await pool.available_connections.put(object())
+    await pool.available_connections.put(object())
+    await asyncio.gather(*getter_tasks)
+    await asyncio.sleep(0)
+
+    stats_done = await pool.get_pool_statistics()
+    assert stats_done["queue_depth"] == 0

--- a/tests/unit/nodes/test_data_retrieval.py
+++ b/tests/unit/nodes/test_data_retrieval.py
@@ -8,6 +8,129 @@ from kailash.nodes.data.retrieval import HybridRetrieverNode, RelevanceScorerNod
 class TestRelevanceScorerNode:
     """Test the RelevanceScorerNode."""
 
+    def test_bm25_scoring_ranks_matching_chunk_first(self):
+        """BM25 lexical scoring ranks the query-matching chunk first."""
+        chunks = [
+            {
+                "content": "Quantum mechanics describes entanglement of particles",
+                "chunk_id": "physics",
+            },
+            {
+                "content": "A recipe for chocolate cake with butter and sugar",
+                "chunk_id": "baking",
+            },
+            {
+                "content": "Distributed databases use sharding and replication for scaling",
+                "chunk_id": "databases",
+            },
+        ]
+        query = "database sharding replication scaling"
+
+        node = RelevanceScorerNode(similarity_method="bm25", top_k=3)
+        result = node.execute(chunks=chunks, query=query)
+
+        ranked = result["relevant_chunks"]
+        # The database chunk strongly matches the query and MUST rank first.
+        assert ranked[0]["chunk_id"] == "databases"
+        # Scores must be REAL — not the old constant 0.5, and must differ
+        # across chunks (proving per-chunk lexical computation).
+        scores = [c["relevance_score"] for c in ranked]
+        assert ranked[0]["relevance_score"] > 0.0
+        assert all(s != 0.5 for s in scores)
+        assert len(set(scores)) > 1
+        # Non-matching chunks have no query-term overlap -> zero score.
+        non_matching = {
+            c["chunk_id"]: c["relevance_score"]
+            for c in ranked
+            if c["chunk_id"] in ("physics", "baking")
+        }
+        assert all(score == 0.0 for score in non_matching.values())
+
+    def test_tfidf_scoring_ranks_matching_chunk_first(self):
+        """TF-IDF cosine scoring ranks the query-matching chunk first."""
+        chunks = [
+            {
+                "content": "Quantum mechanics describes entanglement of particles",
+                "chunk_id": "physics",
+            },
+            {
+                "content": "A recipe for chocolate cake with butter and sugar",
+                "chunk_id": "baking",
+            },
+            {
+                "content": "Distributed databases use sharding and replication for scaling",
+                "chunk_id": "databases",
+            },
+        ]
+        query = "database sharding replication scaling"
+
+        node = RelevanceScorerNode(similarity_method="tfidf", top_k=3)
+        result = node.execute(chunks=chunks, query=query)
+
+        ranked = result["relevant_chunks"]
+        assert ranked[0]["chunk_id"] == "databases"
+        scores = [c["relevance_score"] for c in ranked]
+        assert ranked[0]["relevance_score"] > 0.0
+        # TF-IDF cosine similarity is bounded in [0, 1].
+        assert all(0.0 <= s <= 1.0 for s in scores)
+        assert all(s != 0.5 for s in scores)
+        assert len(set(scores)) > 1
+
+    def test_bm25_requires_query_text(self):
+        """BM25 must fail loud (ValueError) when no query text is available."""
+        chunks = [{"content": "some content", "chunk_id": "c1"}]
+        node = RelevanceScorerNode(similarity_method="bm25")
+        # run() surfaces the raw ValueError (execute() wraps it).
+        with pytest.raises(
+            ValueError, match="bm25/tfidf scoring requires a 'query' text input"
+        ):
+            node.run(chunks=chunks, similarity_method="bm25")
+
+    def test_tfidf_requires_query_text(self):
+        """TF-IDF must fail loud (ValueError) when no query text is available."""
+        chunks = [{"content": "some content", "chunk_id": "c1"}]
+        node = RelevanceScorerNode(similarity_method="tfidf")
+        with pytest.raises(
+            ValueError, match="bm25/tfidf scoring requires a 'query' text input"
+        ):
+            node.run(chunks=chunks, similarity_method="tfidf")
+
+    def test_fallback_uses_real_query_text(self):
+        """No-embeddings fallback keyword-matches against the REAL query text."""
+        chunks = [
+            {"content": "Machine learning algorithms", "chunk_id": "chunk_1"},
+            {"content": "Dog training techniques", "chunk_id": "chunk_2"},
+            {"content": "Learning from data", "chunk_id": "chunk_3"},
+        ]
+
+        node = RelevanceScorerNode(top_k=3)
+        # No embeddings, but a real query naming "machine learning" terms.
+        result = node.execute(chunks=chunks, query="machine learning")
+
+        scored = {
+            c["chunk_id"]: c["relevance_score"] for c in result["relevant_chunks"]
+        }
+        # chunk_1 has both query terms -> full overlap (1.0).
+        assert scored["chunk_1"] == pytest.approx(1.0)
+        # chunk_2 (dog) shares no query term -> 0.0.
+        assert scored.get("chunk_2", 0.0) == pytest.approx(0.0)
+        # chunk_3 has only "learning" -> partial overlap (0.5).
+        assert scored["chunk_3"] == pytest.approx(0.5)
+
+    def test_fallback_no_signal_returns_zero(self):
+        """With neither embeddings nor query text, scores are an honest 0.0."""
+        chunks = [
+            {"content": "Machine learning algorithms", "chunk_id": "chunk_1"},
+            {"content": "Dog training techniques", "chunk_id": "chunk_2"},
+        ]
+
+        node = RelevanceScorerNode(top_k=2)
+        result = node.execute(chunks=chunks)  # no embeddings, no query text
+
+        # No scoring signal -> 0.0 for every chunk (never a fabricated query).
+        for chunk in result["relevant_chunks"]:
+            assert chunk["relevance_score"] == 0.0
+
     def test_cosine_similarity_scoring(self):
         """Test cosine similarity scoring with embeddings."""
         chunks = [
@@ -272,3 +395,69 @@ class TestHybridRetrieverNode:
             result["fusion_method"] == "invalid_strategy"
         )  # Reports what was requested
         assert len(result["hybrid_results"]) <= 2
+
+
+@pytest.mark.regression
+class TestRelevanceScorerLexicalRegression:
+    """Regression guards: BM25/TF-IDF must return REAL lexical scores.
+
+    Guards against the prior defect where ``_bm25_scoring`` and
+    ``_tfidf_scoring`` returned a constant ``relevance_score: 0.5`` for every
+    chunk, and the no-embeddings fallback used a hardcoded query string.
+    """
+
+    # Distinct content per chunk; the query terms strongly match exactly one.
+    _CHUNKS = [
+        {
+            "content": "Photosynthesis converts sunlight into chemical energy in plants",
+            "chunk_id": "biology",
+        },
+        {
+            "content": "The stock market closed higher on strong earnings reports",
+            "chunk_id": "finance",
+        },
+        {
+            "content": "Reinforcement learning trains agents via reward signals and policy gradients",
+            "chunk_id": "ml",
+        },
+    ]
+    _QUERY = "reinforcement learning agents reward policy"
+
+    @pytest.mark.parametrize("method", ["bm25", "tfidf"])
+    def test_lexical_scoring_is_real_not_constant(self, method):
+        """The matching chunk ranks first with non-constant, differing scores."""
+        node = RelevanceScorerNode(similarity_method=method, top_k=3)
+        result = node.execute(chunks=self._CHUNKS, query=self._QUERY)
+
+        ranked = result["relevant_chunks"]
+        # The ML chunk is the only one whose terms match the query.
+        assert ranked[0]["chunk_id"] == "ml"
+
+        scores = [c["relevance_score"] for c in ranked]
+        # The matching chunk has a positive real score.
+        assert ranked[0]["relevance_score"] > 0.0
+        # Proves real computation, not the old constant-0.5 stub:
+        assert all(s != 0.5 for s in scores), f"{method} returned a 0.5 score: {scores}"
+        # Scores differ across chunks (the stub made them all identical).
+        assert len(set(scores)) > 1, f"{method} scores are all equal: {scores}"
+
+    @pytest.mark.parametrize("method", ["bm25", "tfidf"])
+    def test_lexical_scoring_never_uniform_half(self, method):
+        """Guard: bm25/tfidf must never return a uniform 0.5 for all chunks."""
+        node = RelevanceScorerNode(similarity_method=method, top_k=3)
+        result = node.execute(chunks=self._CHUNKS, query=self._QUERY)
+
+        scores = [c["relevance_score"] for c in result["relevant_chunks"]]
+        uniform_half = len(scores) > 0 and all(s == 0.5 for s in scores)
+        assert (
+            not uniform_half
+        ), f"{method} regressed to the constant-0.5 stub: {scores}"
+
+    @pytest.mark.parametrize("method", ["bm25", "tfidf"])
+    def test_lexical_scoring_requires_query(self, method):
+        """bm25/tfidf must raise a clear ValueError with no query text."""
+        node = RelevanceScorerNode(similarity_method=method)
+        with pytest.raises(
+            ValueError, match="bm25/tfidf scoring requires a 'query' text input"
+        ):
+            node.run(chunks=self._CHUNKS, similarity_method=method)

--- a/tests/unit/nodes/test_vector_db_memory.py
+++ b/tests/unit/nodes/test_vector_db_memory.py
@@ -1,0 +1,358 @@
+"""Behavioral regression tests for VectorDatabaseNode's in-memory backend.
+
+These tests CALL the node and assert REAL computed results — proving the
+similarity search, metadata round-trip, filtering, fetch, and delete operations
+are backed by an actual in-memory store rather than the previously-shipped
+fabricated ``doc_0..doc_4`` / ``score = 0.95 - i*0.05`` / ``[0.1]*dimension``
+placeholders.
+
+Guards:
+- Upsert 3+ known vectors and assert the vector closest to a SPECIFIC id ranks
+  first (real similarity, not a fixed ``doc_0`` list).
+- Metadata round-trips through upsert -> query / fetch.
+- A metadata filter narrows query results.
+- Fetch returns the real stored vector; missing ids are omitted honestly.
+- Delete removes a vector for real (count + subsequent fetch/query reflect it).
+- External providers raise the honest typed ``NodeConfigurationError``.
+- No query result ever carries the old fabricated ``doc_N`` / ``Document N``.
+"""
+
+import pytest
+
+from kailash.nodes.data.vector_db import VectorDatabaseNode
+from kailash.sdk_exceptions import NodeConfigurationError, NodeExecutionError
+
+
+def _memory_node(dimension: int, metric: str = "cosine") -> VectorDatabaseNode:
+    """Build a configured in-memory VectorDatabaseNode."""
+    node = VectorDatabaseNode()
+    node.configure(
+        {
+            "provider": "memory",
+            "index_name": "test-index",
+            "dimension": dimension,
+            "metric": metric,
+        }
+    )
+    return node
+
+
+@pytest.mark.regression
+def test_query_ranks_nearest_specific_id_first_cosine():
+    """The vector closest to the query must rank first — real similarity."""
+    node = _memory_node(dimension=3, metric="cosine")
+
+    # Three well-separated directions in 3-space.
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["x_axis", "y_axis", "z_axis"],
+            "vectors": [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            "metadata": [
+                {"axis": "x"},
+                {"axis": "y"},
+                {"axis": "z"},
+            ],
+        }
+    )
+
+    # A query pointing mostly along +y must rank "y_axis" first.
+    result = node.execute(
+        {
+            "operation": "query",
+            "query_vector": [0.1, 0.9, 0.05],
+            "k": 3,
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["count"] == 3
+    top = result["results"][0]
+    assert top["id"] == "y_axis", f"expected y_axis nearest, got {top['id']}"
+    # Metadata round-trips through the query result.
+    assert top["metadata"] == {"axis": "y"}
+    # Scores are strictly descending (real ranking, not a fixed list).
+    scores = [r["score"] for r in result["results"]]
+    assert scores == sorted(scores, reverse=True)
+    assert scores[0] > scores[1] > scores[2]
+
+
+@pytest.mark.regression
+def test_query_ranks_nearest_specific_id_first_dot():
+    """Dot-product metric ranks the highest dot first."""
+    node = _memory_node(dimension=2, metric="dot")
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["small", "large"],
+            "vectors": [[1.0, 1.0], [10.0, 10.0]],
+        }
+    )
+    result = node.execute({"operation": "query", "query_vector": [1.0, 1.0], "k": 2})
+    # Dot product with [10,10] (=20) beats [1,1] (=2).
+    assert result["results"][0]["id"] == "large"
+    assert result["results"][0]["score"] == pytest.approx(20.0)
+
+
+@pytest.mark.regression
+def test_query_ranks_nearest_specific_id_first_euclidean():
+    """Euclidean metric ranks the smallest distance (closest vector) first."""
+    node = _memory_node(dimension=2, metric="euclidean")
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["near", "far"],
+            "vectors": [[1.0, 1.0], [9.0, 9.0]],
+        }
+    )
+    result = node.execute({"operation": "query", "query_vector": [1.1, 1.1], "k": 2})
+    assert result["results"][0]["id"] == "near"
+    # Similarity = 1/(1+distance); the nearer vector has the larger score.
+    assert result["results"][0]["score"] > result["results"][1]["score"]
+
+
+@pytest.mark.regression
+def test_metadata_filter_narrows_results():
+    """A metadata filter restricts the candidate set to matching vectors."""
+    node = _memory_node(dimension=2, metric="cosine")
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["a", "b", "c"],
+            "vectors": [[1.0, 0.0], [0.9, 0.1], [0.8, 0.2]],
+            "metadata": [
+                {"category": "technical"},
+                {"category": "marketing"},
+                {"category": "technical"},
+            ],
+        }
+    )
+
+    result = node.execute(
+        {
+            "operation": "query",
+            "query_vector": [1.0, 0.0],
+            "k": 10,
+            "filter": {"category": "technical"},
+        }
+    )
+
+    returned_ids = {r["id"] for r in result["results"]}
+    assert returned_ids == {"a", "c"}, returned_ids
+    assert result["count"] == 2
+    # The marketing-only vector "b" is excluded by the filter.
+    assert "b" not in returned_ids
+
+
+@pytest.mark.regression
+def test_fetch_returns_real_stored_vector_and_omits_missing():
+    """Fetch returns the actual stored values; missing ids are omitted."""
+    node = _memory_node(dimension=3)
+    stored_vector = [0.2, 0.4, 0.6]
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["real"],
+            "vectors": [stored_vector],
+            "metadata": [{"title": "Real Doc"}],
+        }
+    )
+
+    result = node.execute({"operation": "fetch", "ids": ["real", "ghost"]})
+
+    assert "real" in result["vectors"]
+    # The REAL stored vector is returned — NOT a fabricated [0.1]*dimension.
+    assert result["vectors"]["real"]["values"] == stored_vector
+    assert result["vectors"]["real"]["metadata"] == {"title": "Real Doc"}
+    # Missing id is honestly omitted, not fabricated.
+    assert "ghost" not in result["vectors"]
+
+
+@pytest.mark.regression
+def test_delete_removes_vector_for_real():
+    """Delete reports the real removed count and the vector is gone afterwards."""
+    node = _memory_node(dimension=2)
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["keep", "drop"],
+            "vectors": [[1.0, 0.0], [0.0, 1.0]],
+        }
+    )
+
+    delete_result = node.execute(
+        {"operation": "delete", "ids": ["drop", "never_existed"]}
+    )
+    # Only one of the two ids actually existed.
+    assert delete_result["count"] == 1
+
+    # The deleted vector no longer appears in fetch or query.
+    fetched = node.execute({"operation": "fetch", "ids": ["drop"]})
+    assert fetched["vectors"] == {}
+
+    queried = node.execute({"operation": "query", "query_vector": [0.0, 1.0], "k": 10})
+    remaining_ids = {r["id"] for r in queried["results"]}
+    assert remaining_ids == {"keep"}
+
+
+@pytest.mark.regression
+def test_empty_store_query_returns_empty_results():
+    """Querying an empty store returns zero real results, never fabricated docs."""
+    node = _memory_node(dimension=4)
+    result = node.execute(
+        {"operation": "query", "query_vector": [0.1, 0.2, 0.3, 0.4], "k": 5}
+    )
+    assert result["results"] == []
+    assert result["count"] == 0
+
+
+@pytest.mark.regression
+def test_metadata_round_trips_with_default_empty():
+    """Vectors upserted without metadata default to {} and round-trip."""
+    node = _memory_node(dimension=2)
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["no_meta"],
+            "vectors": [[0.5, 0.5]],
+        }
+    )
+    fetched = node.execute({"operation": "fetch", "ids": ["no_meta"]})
+    assert fetched["vectors"]["no_meta"]["metadata"] == {}
+
+
+@pytest.mark.regression
+def test_upsert_dimension_mismatch_raises():
+    """A vector whose length != configured dimension is rejected, not stored."""
+    node = _memory_node(dimension=3)
+    with pytest.raises(NodeExecutionError):
+        node.execute(
+            {
+                "operation": "upsert",
+                "ids": ["bad"],
+                "vectors": [[1.0, 2.0]],  # length 2, configured dimension 3
+            }
+        )
+    # Nothing was stored — store is still empty.
+    fetched = node.execute({"operation": "fetch", "ids": ["bad"]})
+    assert fetched["vectors"] == {}
+
+
+@pytest.mark.regression
+def test_query_dimension_mismatch_raises():
+    """A query vector whose length != configured dimension is rejected."""
+    node = _memory_node(dimension=3)
+    node.execute({"operation": "upsert", "ids": ["a"], "vectors": [[1.0, 2.0, 3.0]]})
+    with pytest.raises(NodeExecutionError):
+        node.execute({"operation": "query", "query_vector": [1.0, 2.0], "k": 1})
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "provider", ["pinecone", "weaviate", "milvus", "qdrant", "chroma"]
+)
+def test_external_provider_raises_honest_typed_error(provider):
+    """External providers fail loud with a clear typed error — never faked."""
+    node = VectorDatabaseNode()
+    with pytest.raises(NodeConfigurationError) as exc_info:
+        node.configure(
+            {
+                "provider": provider,
+                "index_name": "test-index",
+                "dimension": 8,
+            }
+        )
+    message = str(exc_info.value)
+    assert provider in message
+    assert "not bundled with kailash" in message
+    assert "provider='memory'" in message
+
+
+@pytest.mark.regression
+def test_query_results_never_contain_old_fabricated_pattern():
+    """Guard: query output must never carry the old fabricated doc_N / Document N."""
+    node = _memory_node(dimension=2)
+    node.execute(
+        {
+            "operation": "upsert",
+            "ids": ["alpha", "beta"],
+            "vectors": [[1.0, 0.0], [0.0, 1.0]],
+            "metadata": [{"title": "Alpha"}, {"title": "Beta"}],
+        }
+    )
+    result = node.execute({"operation": "query", "query_vector": [1.0, 0.0], "k": 5})
+
+    returned_ids = {r["id"] for r in result["results"]}
+    # Real stored ids only — none of the fabricated doc_0..doc_4 placeholders.
+    assert returned_ids == {"alpha", "beta"}
+    for r in result["results"]:
+        assert not r["id"].startswith("doc_"), f"fabricated id leaked: {r['id']}"
+        title = r["metadata"].get("title", "")
+        assert not title.startswith("Document "), f"fabricated title leaked: {title}"
+        # No fabricated 0.95 - i*0.05 scores: scores derive from real vectors.
+        assert r["metadata"] in ({"title": "Alpha"}, {"title": "Beta"})
+
+
+@pytest.mark.regression
+def test_max_vectors_cap_rejects_overflow_atomically():
+    """An upsert exceeding ``max_vectors`` fails loud and stores nothing extra."""
+    node = VectorDatabaseNode()
+    node.configure(
+        {
+            "provider": "memory",
+            "index_name": "capped",
+            "dimension": 2,
+            "max_vectors": 2,
+        }
+    )
+    # Fill the store to the cap.
+    node.execute(
+        {"operation": "upsert", "ids": ["a", "b"], "vectors": [[1.0, 0.0], [0.0, 1.0]]}
+    )
+    # A third NEW id would exceed the cap -> typed error; nothing is stored.
+    with pytest.raises(NodeExecutionError) as exc:
+        node.execute({"operation": "upsert", "ids": ["c"], "vectors": [[1.0, 1.0]]})
+    assert "capacity exceeded" in str(exc.value)
+    fetched = node.execute({"operation": "fetch", "ids": ["c"]})
+    assert fetched["vectors"] == {}
+    # Updating an EXISTING id adds no new id, so it stays within the cap.
+    ok = node.execute({"operation": "upsert", "ids": ["a"], "vectors": [[0.5, 0.5]]})
+    assert ok["status"] == "success"
+
+
+@pytest.mark.regression
+def test_filter_must_be_a_dict():
+    """A non-dict metadata filter raises a clear typed error, not an opaque one."""
+    node = _memory_node(dimension=2)
+    node.execute({"operation": "upsert", "ids": ["a"], "vectors": [[1.0, 0.0]]})
+    with pytest.raises(NodeExecutionError) as exc:
+        node.execute(
+            {
+                "operation": "query",
+                "query_vector": [1.0, 0.0],
+                "k": 5,
+                "filter": ["not", "a", "dict"],
+            }
+        )
+    assert "filter must be a dict" in str(exc.value)
+
+
+@pytest.mark.regression
+def test_multi_vector_upsert_is_atomic_on_dimension_mismatch():
+    """A dimension mismatch mid-batch stores NONE of the batch (atomic upsert)."""
+    node = _memory_node(dimension=3)
+    with pytest.raises(NodeExecutionError):
+        node.execute(
+            {
+                "operation": "upsert",
+                "ids": ["good", "bad"],
+                "vectors": [[1.0, 2.0, 3.0], [1.0, 2.0]],  # second is wrong dim
+            }
+        )
+    # The valid first vector must NOT have leaked into the store.
+    fetched = node.execute({"operation": "fetch", "ids": ["good", "bad"]})
+    assert fetched["vectors"] == {}


### PR DESCRIPTION
## Summary

Replaces fabricated outputs in three shipped core nodes with real implementations, and ships honest connection-pool metrics. Surfaced by a comprehensive completion audit of an already-released `main`; none of these were tracked as issues. **Minor bump (2.38.0)** because `VectorDatabaseNode` and `RelevanceScorerNode` gain real working capability.

### What changed (zero-tolerance Rule 2 — no fabricated data)

- **`WorkflowConnectionPool` pool metrics** (`fix`): `get_pool_statistics()` / `_get_pool_status()` returned hardcoded `avg_query_time_ms=50.0`, `avg_latency_ms=0.0`, `queue_depth=0`, `capabilities=["read","write"]`. `avg_latency_ms` + `capabilities` fed `query_router`'s routing decisions, so the fakes skewed connection selection. → real query-time tracking wired into `_execute_query`, real queue depth from pending waiters, honest omission where no real signal exists.
- **`VectorDatabaseNode`** (`feat`): every operation was fake (`_query_vectors` returned `doc_0..doc_4` with invented scores; `_upsert` stored nothing; `_fetch` returned `[0.1]*dim`). → real pure-Python in-memory backend (`provider="memory"`): real upsert/query/delete/fetch, cosine/euclidean/dot ranking, metadata storage + filtering, optional `max_vectors` cap, atomic upsert. External providers now raise a typed error instead of faking a connection. Also fixes a latent `configure()` `AttributeError`.
- **`RelevanceScorerNode`** (`feat`): `bm25`/`tfidf` returned a constant `0.5`; the no-embedding fallback used a hardcoded `"machine learning types"` query; debug `print()`s in production. → real Okapi BM25 (k1=1.5, b=0.75) + smoothed-IDF TF-IDF over chunk text with a new `query` param; honest `ValueError` when lexical scoring lacks a query; prints removed.
- **`kailash-ml` align skip-guard** (`test`): `find_spec` on a submodule raised when the parent package was absent, crashing collection; now fails closed to SKIP.

### Tests + reviews

- 67 new/affected unit tests pass (21 vector_db, 22 retrieval incl. unchanged HybridRetriever, 7 pool-metrics, ml skip-guard); 35 consuming `query_router`/dashboard tests pass.
- Gate-reviewed by reviewer (APPROVE) + security-reviewer; BM25/TF-IDF/cosine/euclidean/dot math independently verified to 1e-9; security findings (max_vectors cap + filter validation) applied.

### User-flow walk receipts

- `VectorDatabaseNode`: `configure(provider="memory")` → `upsert` → `query` → `fetch` → `delete` confirmed end-to-end; the vector nearest a specific id ranks first under all three metrics.
- `RelevanceScorerNode` via `WorkflowBuilder` + `LocalRuntime`: query `"python programming data science language"` ranks the python chunk first under both methods (BM25=4.73, TF-IDF=0.77).

### Known follow-ups (same file, NOT in this PR — separate scope)

- `EmbeddingNode._generate_embeddings` returns `np.random.randn` placeholder embeddings (a real `EmbeddingGeneratorNode` exists at `kailash.nodes.ai.embedding_generator`); `TextSplitterNode` has placeholder paths. Same fake-data class; flagged for a follow-up decision (gate vs migrate to the real node).

## Related issues

None — pre-existing defects surfaced by a completion audit; no prior issue. Behavior change on external vector providers documented in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)