### PR TITLE
fix(core): EmbeddingNode fails loud instead of fabricating random embeddings (kailash 2.38.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.1] - 2026-06-17
+
+### Changed
+
+- **(Behavior change)** `EmbeddingNode` no longer returns `np.random.randn`
+  random placeholder vectors presented as real embeddings (meaningless for any
+  similarity search). It now raises a clear typed `NodeExecutionError` — the
+  node bundles no real embedding model. Provide real embeddings from an
+  embedding provider upstream, or use `RelevanceScorerNode` with
+  `similarity_method="bm25"` / `"tfidf"` for embedding-free retrieval.
+
 ## [2.38.0] - 2026-06-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.38.0"
+version = "2.38.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.38.0"
+__version__ = "2.38.1"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/nodes/data/vector_db.py
+++ b/src/kailash/nodes/data/vector_db.py
@@ -319,19 +319,28 @@ class EmbeddingNode(Node):
             raise NodeExecutionError(f"Failed to generate embeddings: {str(e)}")
 
     def _generate_embeddings(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings for a batch of texts.
+        """Embedding generation is not implemented by this node.
 
-        This is a placeholder for actual embedding generation logic.
+        ``EmbeddingNode`` does not bundle a real embedding model. It previously
+        returned ``np.random.randn`` random placeholder vectors presented as
+        real embeddings — meaningless for any similarity search — so that
+        behavior is removed and the node now fails loudly. Supply real
+        embeddings from an embedding provider/model upstream and pass them to
+        the retrieval nodes, or use ``RelevanceScorerNode`` with
+        ``similarity_method="bm25"`` / ``"tfidf"`` for embedding-free retrieval.
 
         Args:
-            texts: List of texts to embed
+            texts: List of texts to embed (unused — no real backend exists).
 
-        Returns:
-            List of embedding vectors
+        Raises:
+            NodeExecutionError: always — there is no real embedding backend.
         """
-        # Placeholder implementation
-        dim = self._model_info.get("dimensions", 768)
-        return [np.random.randn(dim).tolist() for _ in texts]  # type: ignore[reportOptionalMemberAccess]
+        raise NodeExecutionError(
+            "EmbeddingNode does not include a real embedding model and no "
+            "longer returns random placeholder vectors. Provide real embeddings "
+            "from an embedding provider upstream, or use RelevanceScorerNode "
+            "with similarity_method='bm25'/'tfidf' for embedding-free retrieval."
+        )
 
     def _normalize_embeddings(self, embeddings: list[list[float]]) -> list[list[float]]:
         """Normalize embedding vectors to unit length.

--- a/tests/unit/nodes/test_embedding_node_gated.py
+++ b/tests/unit/nodes/test_embedding_node_gated.py
@@ -1,0 +1,32 @@
+"""Regression: EmbeddingNode no longer fabricates random embeddings.
+
+EmbeddingNode previously returned ``np.random.randn`` vectors presented as real
+embeddings (meaningless for similarity search). It now fails loudly with a clear
+typed error directing users to a real embedding provider or the embedding-free
+``bm25``/``tfidf`` retrieval path.
+"""
+
+import pytest
+
+from kailash.nodes.data.vector_db import EmbeddingNode
+from kailash.sdk_exceptions import NodeExecutionError
+
+
+@pytest.mark.regression
+def test_embedding_node_fails_loud_not_fake_random():
+    """execute() raises a clear error instead of returning random vectors."""
+    node = EmbeddingNode()
+    with pytest.raises(NodeExecutionError) as exc:
+        node.execute({"texts": ["hello world", "second text"]})
+    msg = str(exc.value)
+    assert "real embedding model" in msg
+    # Points users at the embedding-free retrieval path.
+    assert "bm25" in msg or "tfidf" in msg
+
+
+@pytest.mark.regression
+def test_embedding_node_generate_helper_raises():
+    """The fabrication site itself raises (guards against re-introduction)."""
+    node = EmbeddingNode()
+    with pytest.raises(NodeExecutionError):
+        node._generate_embeddings(["x"])


### PR DESCRIPTION
## Summary

Fast-follow to 2.38.0. Closes the **last fabricated-data path** in `src/kailash/nodes/data/vector_db.py`: `EmbeddingNode._generate_embeddings` returned `np.random.randn(dim)` random vectors presented as real embeddings — meaningless for any similarity search.

`EmbeddingNode` bundles no real embedding model, and there is **no real embedding node in core** (the `kailash.nodes.ai.*` family — `LLMAgentNode`, `EmbeddingGeneratorNode` — was migrated to Kaizen; `KaizenTextEmbeddingNode` is the real one). So embeddings can't be made real with pure code here. The node now **raises a clear typed `NodeExecutionError`** directing users to provide real embeddings upstream or use `RelevanceScorerNode` with `bm25`/`tfidf` (embedding-free retrieval, made real in 2.38.0).

## Tests

- 2 behavioral regression tests (`tests/unit/nodes/test_embedding_node_gated.py`): `execute()` raises with an actionable message; the fabrication site itself raises.
- 23 vector_db / retrieval / metadata tests still pass; ruff clean.

## Known follow-up (NOT in this PR)

The **core docs reference the whole removed `kailash.nodes.ai.*` family** (`docs/api/nodes.rst` autoclass directives, `docs/api/utils.rst` RAG examples, `docs/core/nodes.rst`) — phantom since the migration to Kaizen. That's a larger pre-existing docs-drift cleanup (repoint to `KaizenTextEmbeddingNode` / Kaizen RAG nodes), flagged for a separate docs pass.

## Related issues

None — pre-existing fake-data defect surfaced during the 2.38.0 completion audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)