### PR TITLE
fix(kaizen): PEP 563 Signatures no longer silently empty structured output (#1352)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.27.1] — 2026-06-17 — PEP 563 Signatures: structured output no longer silently empties
+
+### Fixed
+
+- **`Signature` defined under `from __future__ import annotations` (PEP 563) no
+  longer breaks `JSONOutputParser`** (#1352). PEP 563 stores each field's
+  annotation as a _string_ (`'str'`, `'List[dict]'`) instead of a type object;
+  the parser's `isinstance(value, expected_type)` then raised
+  `TypeError: isinstance() arg 2 must be a type ...`, which was swallowed by the
+  parser's own `except (json.JSONDecodeError, TypeError)` — silently degrading a
+  valid JSON response to `{}`. Two layers fix it:
+  - `SignatureMeta` resolves string annotations to real type objects at
+    class-construction time (using the defining module's globals, exactly as
+    `typing.get_type_hints` would), so stored field types are identical with or
+    without PEP 563.
+  - `JSONOutputParser._convert_to_type` defensively returns the value unchanged
+    if an annotation string ever survives construction (dynamically-exec'd
+    Signatures, unresolvable forward refs) instead of raising and discarding the
+    parse.
+    Regression coverage: `tests/regression/test_issue_1352_pep563_signature_parser.py`.
+
 ## [2.27.0] — 2026-06-11 — RAG node honesty: strip simulated-capability over-claims
 
 ### Deprecated

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.27.0"
+version = "2.27.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.27.0"
+__version__ = "2.27.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/execution/parser.py
+++ b/packages/kailash-kaizen/src/kaizen/execution/parser.py
@@ -144,6 +144,18 @@ class JSONOutputParser(OutputParser):
         field_def = signature.output_fields.get(field_name, {})
         expected_type = field_def.get("type", str)
 
+        # PEP 563 fallback (issue #1352): if the field's expected type is still
+        # an annotation *string* — i.e. resolution at signature-build time could
+        # not run (a dynamically exec'd Signature whose module is absent from
+        # sys.modules, or an unresolvable forward ref) — we cannot pass it to
+        # isinstance(). Doing so raises `TypeError: isinstance() arg 2 must be a
+        # real type`, which parse() swallows, silently discarding an otherwise
+        # valid JSON response. Return the value unchanged instead. Normal
+        # Signatures never reach this branch: SignatureMeta resolves the string
+        # to a real annotation object at class-construction time.
+        if isinstance(expected_type, str):
+            return value
+
         # Unwrap subscripted generics (List[X], Dict[K, V], Optional[X],
         # Union[...]) before any isinstance check. On Python 3.9+,
         # `isinstance(value, typing.List[...])` raises

--- a/packages/kailash-kaizen/src/kaizen/signatures/core.py
+++ b/packages/kailash-kaizen/src/kaizen/signatures/core.py
@@ -22,6 +22,7 @@ Performance Requirements:
 import logging
 import re
 import time
+import typing
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
@@ -113,6 +114,51 @@ class OutputField:
             self.desc = desc
 
         self.metadata = kwargs
+
+
+def _field_map_has_string_type(field_map: Optional[Dict[str, Dict[str, Any]]]) -> bool:
+    """True if any field in the map still stores its type as a string."""
+    if not field_map:
+        return False
+    return any(isinstance(fd.get("type"), str) for fd in field_map.values())
+
+
+def _resolve_signature_field_types(cls: type) -> None:
+    """Resolve PEP 563 string annotations on a built Signature subclass, in place.
+
+    Under ``from __future__ import annotations`` (PEP 563) every annotation in a
+    class body is stored as its source *string* (``'str'``, ``'List[dict]'``)
+    rather than a type object. The structured-output parser type-checks each
+    output field with ``isinstance(value, expected_type)``; a string predicate
+    raises ``TypeError: isinstance() arg 2 must be a type ...``, which the JSON
+    parser swallows — silently degrading a valid response to ``{}`` (issue
+    #1352). ``typing.get_type_hints`` resolves the class's annotations against
+    its own module globals, so the stored field type becomes identical whether
+    or not the Signature's module uses PEP 563.
+
+    Best-effort: if resolution fails (an unresolvable forward reference anywhere
+    on the class), the field types keep their string form and the parser's
+    defensive guard handles them — signature construction never raises. Skipped
+    entirely when no field stores a string type (the eager, non-PEP-563 case).
+    """
+    inputs = getattr(cls, "_signature_inputs", None)
+    outputs = getattr(cls, "_signature_outputs", None)
+    if not _field_map_has_string_type(inputs) and not _field_map_has_string_type(
+        outputs
+    ):
+        return
+    try:
+        hints = typing.get_type_hints(cls)
+    except Exception:
+        # Unresolvable annotation somewhere on the class — keep string forms;
+        # the parser's defensive guard coerces them (never raise here).
+        return
+    for field_map in (inputs, outputs):
+        if not field_map:
+            continue
+        for field_name, field_def in field_map.items():
+            if isinstance(field_def.get("type"), str) and field_name in hints:
+                field_def["type"] = hints[field_name]
 
 
 class SignatureMeta(type):
@@ -210,6 +256,13 @@ class SignatureMeta(type):
         )
 
         cls = super().__new__(mcs, name, bases, namespace)
+
+        # Resolve PEP 563 string annotations to real type objects so the
+        # structured-output parser's isinstance() type-check works identically
+        # with or without `from __future__ import annotations` (issue #1352).
+        # Runs after class creation so typing.get_type_hints can resolve against
+        # the class's own module globals.
+        _resolve_signature_field_types(cls)
 
         return cls
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_1352_pep563_signature_parser.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1352_pep563_signature_parser.py
@@ -1,0 +1,153 @@
+"""Regression test for issue #1352 — PEP 563 string annotations break parsing.
+
+Bug: a ``Signature`` defined in a module using ``from __future__ import
+annotations`` (PEP 563) stored each output field's expected type as the
+annotation **string** (``'str'``, ``'List[dict]'``) instead of a real type
+object. ``JSONOutputParser._convert_to_type`` then ran
+``isinstance(value, expected_type)`` with ``expected_type == 'str'``, raising
+``TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union``.
+That TypeError was swallowed by ``JSONOutputParser.parse``'s own
+``except (json.JSONDecodeError, TypeError)`` block, so a **valid JSON response
+was silently marked unparseable** and structured output degraded to ``{}``.
+
+The note in #1141's fix (subscripted generics) only covered the no-future path:
+under PEP 563 even ``List[dict]`` arrives as the string ``'List[dict]'``, so
+``typing.get_origin(...)`` returns ``None`` and execution still reached the
+buggy ``isinstance`` line.
+
+This module deliberately uses ``from __future__ import annotations`` so the
+signatures below exercise the REAL PEP 563 code path: the module is registered
+in ``sys.modules`` (pytest imports it), so ``SignatureMeta`` resolves each
+annotation string against this module's globals exactly as ``get_type_hints``
+would. Tests assert the runtime SHAPE of the parsed output, not source strings,
+and are deterministic + offline (no network / DB).
+
+Two layers are covered:
+  * the root-cause fix in ``SignatureMeta`` (string annotations resolved to
+    real type objects at class-construction time);
+  * the defensive fallback in ``JSONOutputParser._convert_to_type`` (a string
+    type that survives construction returns the value as-is, never raising).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import pytest
+
+from kaizen.execution.parser import JSONOutputParser, ResponseParser
+from kaizen.signatures import InputField, OutputField, Signature
+
+
+class Pep563Extract(Signature):
+    """Signature defined under PEP 563 — annotations arrive as strings."""
+
+    text: str = InputField(description="The source text")
+    items: List[dict] = OutputField(description="A list of dict records")
+    label: str = OutputField(description="A scalar label")
+
+
+class Pep563OptionalList(Signature):
+    """Optional[List[Dict]] OutputField, under PEP 563 (cf. #1141 no-future)."""
+
+    query: str = InputField(description="The user query")
+    rows: Optional[List[Dict]] = OutputField(description="Optional list of dicts")
+
+
+@pytest.mark.regression
+def test_pep563_signature_resolves_field_types_to_real_objects():
+    """SignatureMeta resolves PEP 563 annotation strings to real type objects.
+
+    Pre-fix the stored types were the bare strings 'List[dict]' / 'str'. The
+    decisive assertion is that the stored ``type`` is NOT a string — it is a
+    real type object the parser can pass to isinstance().
+    """
+    fields = Pep563Extract().output_fields
+    assert not isinstance(fields["items"]["type"], str), fields["items"]["type"]
+    assert not isinstance(fields["label"]["type"], str), fields["label"]["type"]
+    assert fields["label"]["type"] is str
+
+
+@pytest.mark.regression
+def test_pep563_valid_json_parses_to_success_not_empty():
+    """Valid JSON parses with success=True under PEP 563 (was False, {} pre-fix)."""
+    sig = Pep563Extract()
+    parser = JSONOutputParser()
+
+    result = parser.parse(
+        '{"items": [{"k": "v"}], "label": "ok"}', list(sig.output_fields), sig
+    )
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    items = result.structured_output["items"]
+    assert isinstance(items, list)
+    assert items == [{"k": "v"}]
+    assert result.structured_output["label"] == "ok"
+
+
+@pytest.mark.regression
+def test_pep563_optional_list_dict_parses_under_future_import():
+    """Optional[List[Dict]] resolves + parses under PEP 563 too (#1141 + #1352)."""
+    sig = Pep563OptionalList()
+    parser = JSONOutputParser()
+
+    result = parser.parse(
+        '{"rows": [{"id": 1}, {"id": 2}]}', list(sig.output_fields), sig
+    )
+
+    assert result.success is True
+    rows = result.structured_output["rows"]
+    assert isinstance(rows, list)
+    assert rows == [{"id": 1}, {"id": 2}]
+
+
+@pytest.mark.regression
+def test_pep563_end_to_end_uses_json_not_keyvalue_fallthrough():
+    """Through the full ResponseParser, a PEP 563 signature resolves via
+    json_parsing — NOT a KeyValueOutputParser fallthrough returning garbage."""
+    sig = Pep563Extract()
+    out = ResponseParser().parse_response(
+        '{"items": [{"k": "v"}], "label": "ok"}', list(sig.output_fields), sig
+    )
+    assert isinstance(out["items"], list)
+    assert out["items"] == [{"k": "v"}]
+    assert out["label"] == "ok"
+
+
+@pytest.mark.regression
+def test_parser_tolerates_unresolved_string_type_without_crashing():
+    """Defensive layer: a string `type` that survives signature construction
+    (e.g. a dynamically exec'd Signature whose module is absent from
+    sys.modules, or an unresolvable forward ref) must NOT raise TypeError and
+    discard a valid JSON parse — the value is returned unchanged.
+    """
+
+    class _StringTypeSignature:
+        # Mimics a field map where resolution could not run: type is a string.
+        output_fields = {"label": {"type": "str"}, "items": {"type": "List[dict]"}}
+
+    sig = _StringTypeSignature()
+    parser = JSONOutputParser()
+
+    result = parser.parse(
+        '{"label": "ok", "items": [{"k": "v"}]}', list(sig.output_fields), sig
+    )
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    assert result.structured_output["label"] == "ok"
+    assert result.structured_output["items"] == [{"k": "v"}]
+
+
+@pytest.mark.regression
+def test_malformed_json_still_reports_failure_under_pep563():
+    """The fix must NOT mask a genuine json.JSONDecodeError (cf. #1141)."""
+    sig = Pep563Extract()
+    parser = JSONOutputParser()
+
+    result = parser.parse('{"items": [{"k": "v"}', list(sig.output_fields), sig)
+
+    assert result.success is False
+    assert result.errors
+    assert "JSON parsing failed" in result.errors[0]


### PR DESCRIPTION
## Summary

A Kaizen `Signature` defined in a module using `from __future__ import annotations` (PEP 563) silently produced **empty structured output** (`{}`) for valid JSON LLM responses.

PEP 563 stores each output field's annotation as a *string* (`'str'`, `'List[dict]'`) instead of a type object. `JSONOutputParser._convert_to_type` then ran `isinstance(value, 'str')` → `TypeError: isinstance() arg 2 must be a type ...`, which the parser's own `except (json.JSONDecodeError, TypeError)` swallowed — degrading a valid response to `{}` with no error surfaced. PEP 563 is common (and the default style in many codebases), so any Signature module using it got silent structured-output failure.

## Fix (two layers)

- **Root cause** — `SignatureMeta` now resolves string annotations to real type objects after class creation via `typing.get_type_hints` (resolving against the class's own module globals — the fix the issue reporter suggested). Stored field types are identical with or without PEP 563. Best-effort: if resolution fails (unresolvable forward ref), field types keep their string form and the parser guard handles them — construction never raises.
- **Defense-in-depth** — `JSONOutputParser._convert_to_type` returns the value unchanged if an annotation string ever survives construction (dynamically-`exec`'d Signatures whose module isn't in `sys.modules`, unresolvable forward refs) instead of raising and discarding the parse.

## Verification

- New regression suite: `tests/regression/test_issue_1352_pep563_signature_parser.py` (6 tests — the module itself uses PEP 563 so the signatures exercise the real path; asserts resolved types, successful parse, end-to-end `ResponseParser`, the parser-guard fallback, and that malformed JSON still reports failure).
- Existing `#1141` parser regression + full `tests/unit/signatures/` suite green (217 passed).
- Cross-SDK: PEP 563 is Python-intrinsic — no kailash-rs equivalent.

Version bump: kailash-kaizen 2.27.0 → 2.27.1.

## Related issues

Fixes #1352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)