### PR TITLE
fix(kaizen-agents): migrate Gemini adapters to google-genai; provider SDKs are runtime deps (#1351)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.11] — 2026-06-17 — Gemini adapters on supported google-genai SDK; provider SDKs are runtime deps
+
+### Changed
+
+- **Gemini adapters migrated from the deprecated `google.generativeai` SDK to
+  the supported `google.genai` SDK** (#1351). `delegate/adapters/google_adapter.py`
+  and `runtime_adapters/gemini_cli.py` now use `genai.Client` +
+  `client.aio.models.generate_content_stream` + `types.GenerateContentConfig` /
+  `types.Tool` / `types.ToolCodeExecution` (generation knobs moved from the model
+  object into the per-request config). No `FutureWarning` from the end-of-life
+  package on the Gemini path.
+
+### Fixed
+
+- **Provider SDKs declared as runtime dependencies** (#1351). `google-genai` and
+  the sibling `anthropic` (which had the identical defect) were declared only in
+  `[dev]` extras yet imported at runtime by their adapters — so a normal
+  `pip install kaizen-agents` raised `ImportError` on the Gemini / Anthropic path.
+  Both are now `[project.dependencies]`; the deprecated `google-generativeai` pin
+  is removed. Regression coverage:
+  `tests/regression/test_issue_1351_google_genai_migration.py`.
+
 ## [0.9.10] — 2026-06-11 — enforce the slim-core import fix via the kailash-kaizen floor
 
 ### Changed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.10"
+version = "0.9.11"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -36,6 +36,14 @@ dependencies = [
     "kailash-kaizen>=2.25.1",
     "openai>=1.30.0",
     "httpx>=0.27.0",
+    # Provider SDKs imported at runtime by the delegate / runtime adapters.
+    # anthropic: delegate/adapters/anthropic_adapter.py + orchestration/adapters.py.
+    # google-genai: delegate/adapters/google_adapter.py + runtime_adapters/gemini_cli.py
+    #   (migrated off the deprecated google-generativeai per #1351).
+    # A normal `pip install kaizen-agents` MUST resolve them or the Anthropic /
+    # Gemini paths raise ImportError at adapter construction.
+    "anthropic>=0.40.0",
+    "google-genai>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -46,10 +54,6 @@ dev = [
     "black>=23.0",
     "ruff>=0.1.0",
     "mypy>=1.0",
-    # Adapter unit tests construct the real provider clients
-    # (delegate/adapters/{anthropic_adapter.py:159, google_adapter.py:162})
-    "anthropic>=0.40.0",
-    "google-generativeai>=0.8.0",
 ]
 
 [project.urls]

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.10"
+__version__ = "0.9.11"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/google_adapter.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/google_adapter.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Google Gemini streaming chat adapter.
 
-Implements the :class:`StreamingChatAdapter` protocol using the
-``google.generativeai`` SDK.  Converts between OpenAI-format messages and
-Gemini's native content format.
+Implements the :class:`StreamingChatAdapter` protocol using the supported
+``google.genai`` SDK (the ``google-genai`` package).  Converts between
+OpenAI-format messages and Gemini's native content format.
 
-Lazy-imports the ``google-generativeai`` package so that users of other
-providers do not need it installed.
+Lazy-imports ``google.genai`` so that import of this module does not pull the
+SDK into processes that only use other providers; the package itself is a
+runtime dependency of ``kaizen-agents`` (see ``pyproject.toml``).
 """
 
 from __future__ import annotations
@@ -119,8 +120,25 @@ def _convert_tools_for_gemini(
     return [{"function_declarations": declarations}]
 
 
+def _iter_chunk_parts(chunk: Any) -> list[Any]:
+    """Yield the content parts of a ``google.genai`` streaming chunk.
+
+    The ``google.genai`` ``GenerateContentResponse`` does not expose ``parts``
+    directly (the ``google.generativeai`` SDK did); parts live under
+    ``chunk.candidates[0].content.parts``. Returns an empty list for chunks
+    with no candidate/content (e.g. a trailing usage-only chunk).
+    """
+    candidates = getattr(chunk, "candidates", None) or []
+    if not candidates:
+        return []
+    content = getattr(candidates[0], "content", None)
+    if content is None:
+        return []
+    return list(getattr(content, "parts", None) or [])
+
+
 class GoogleStreamAdapter:
-    """Adapter for Google Gemini models via the google-generativeai SDK.
+    """Adapter for Google Gemini models via the google-genai SDK.
 
     Parameters
     ----------
@@ -159,15 +177,16 @@ class GoogleStreamAdapter:
         self._default_max_tokens = default_max_tokens
 
         try:
-            import google.generativeai as genai
+            from google import genai
+            from google.genai import types as genai_types
         except ImportError as exc:
             raise ImportError(
-                "The google-generativeai package is required for Google adapters.  "
-                "Install it with: pip install google-generativeai"
+                "The google-genai package is required for Google adapters.  "
+                "Install it with: pip install google-genai"
             ) from exc
 
-        genai.configure(api_key=resolved_key)
-        self._genai = genai
+        self._client = genai.Client(api_key=resolved_key)
+        self._types = genai_types
 
     async def stream_chat(
         self,
@@ -194,21 +213,16 @@ class GoogleStreamAdapter:
         system_instruction, gemini_contents = _convert_messages_for_gemini(messages)
         gemini_tools = _convert_tools_for_gemini(tools)
 
-        generation_config = {
+        config_kwargs: dict[str, Any] = {
             "temperature": resolved_temp,
             "max_output_tokens": resolved_max,
         }
-
-        model_kwargs: dict[str, Any] = {
-            "model_name": resolved_model,
-            "generation_config": generation_config,
-        }
         if system_instruction:
-            model_kwargs["system_instruction"] = system_instruction
+            config_kwargs["system_instruction"] = system_instruction
         if gemini_tools:
-            model_kwargs["tools"] = gemini_tools
+            config_kwargs["tools"] = gemini_tools
 
-        generative_model = self._genai.GenerativeModel(**model_kwargs)
+        config = self._types.GenerateContentConfig(**config_kwargs)
 
         # Accumulate state
         content = ""
@@ -217,15 +231,18 @@ class GoogleStreamAdapter:
         usage: dict[str, int] = {}
         finish_reason: str | None = None
 
-        response = await generative_model.generate_content_async(
-            gemini_contents,
-            stream=True,
+        response = await self._client.aio.models.generate_content_stream(
+            model=resolved_model,
+            contents=gemini_contents,
+            config=config,
         )
 
         async for chunk in response:
-            # Extract text from parts
-            if chunk.parts:
-                for part in chunk.parts:
+            # Extract text from parts (google.genai nests parts under
+            # candidates[0].content.parts; see _iter_chunk_parts).
+            chunk_parts = _iter_chunk_parts(chunk)
+            if chunk_parts:
+                for part in chunk_parts:
                     # Text part
                     if hasattr(part, "text") and part.text:
                         content += part.text

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/docs/developers/03-external-adapters.md
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/docs/developers/03-external-adapters.md
@@ -4,12 +4,12 @@ External Runtime Adapters delegate execution to specialized AI platforms while m
 
 ## Available Adapters
 
-| Adapter | Provider | Key Capabilities |
-|---------|----------|------------------|
-| **LocalKaizenAdapter** | Kaizen | Works with ANY LLM, full Kaizen tool registry |
-| **ClaudeCodeAdapter** | Anthropic | Claude Code SDK native tools (Read, Write, Bash, etc.) |
-| **OpenAICodexAdapter** | OpenAI | Code Interpreter (sandboxed Python), file search |
-| **GeminiCLIAdapter** | Google | 1M context, code execution, multi-modal |
+| Adapter                | Provider  | Key Capabilities                                       |
+| ---------------------- | --------- | ------------------------------------------------------ |
+| **LocalKaizenAdapter** | Kaizen    | Works with ANY LLM, full Kaizen tool registry          |
+| **ClaudeCodeAdapter**  | Anthropic | Claude Code SDK native tools (Read, Write, Bash, etc.) |
+| **OpenAICodexAdapter** | OpenAI    | Code Interpreter (sandboxed Python), file search       |
+| **GeminiCLIAdapter**   | Google    | 1M context, code execution, multi-modal                |
 
 ## ClaudeCodeAdapter
 
@@ -32,13 +32,13 @@ result = await adapter.execute(context)
 
 ### Configuration
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `working_directory` | str | cwd | Project directory |
-| `model` | str | claude-sonnet-4-20250514 | Model to use |
-| `timeout_seconds` | float | 300 | Execution timeout |
-| `custom_tools` | List[Dict] | [] | Additional tools |
-| `max_turns` | int | None | Max conversation turns |
+| Parameter           | Type       | Default                  | Description            |
+| ------------------- | ---------- | ------------------------ | ---------------------- |
+| `working_directory` | str        | cwd                      | Project directory      |
+| `model`             | str        | claude-sonnet-4-20250514 | Model to use           |
+| `timeout_seconds`   | float      | 300                      | Execution timeout      |
+| `custom_tools`      | List[Dict] | []                       | Additional tools       |
+| `max_turns`         | int        | None                     | Max conversation turns |
 
 ### Native Tools
 
@@ -137,16 +137,16 @@ result = await adapter.execute(context)
 
 ### Configuration
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `api_key` | str | env | OpenAI API key |
-| `model` | str | gpt-4o | Model to use |
-| `enable_code_interpreter` | bool | False | Enable Python sandbox |
-| `enable_file_search` | bool | False | Enable file search |
-| `custom_tools` | List[Dict] | [] | Additional tools |
-| `temperature` | float | 0.7 | Sampling temperature |
-| `max_output_tokens` | int | 4096 | Max response tokens |
-| `timeout_seconds` | float | 300 | Execution timeout |
+| Parameter                 | Type       | Default | Description           |
+| ------------------------- | ---------- | ------- | --------------------- |
+| `api_key`                 | str        | env     | OpenAI API key        |
+| `model`                   | str        | gpt-4o  | Model to use          |
+| `enable_code_interpreter` | bool       | False   | Enable Python sandbox |
+| `enable_file_search`      | bool       | False   | Enable file search    |
+| `custom_tools`            | List[Dict] | []      | Additional tools      |
+| `temperature`             | float      | 0.7     | Sampling temperature  |
+| `max_output_tokens`       | int        | 4096    | Max response tokens   |
+| `timeout_seconds`         | float      | 300     | Execution timeout     |
 
 ### Code Interpreter
 
@@ -226,16 +226,16 @@ result = await adapter.execute(context)
 
 ### Configuration
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `api_key` | str | env | Google AI API key |
-| `model` | str | gemini-1.5-pro | Model to use |
-| `enable_code_execution` | bool | False | Enable Python execution |
-| `custom_tools` | List[Dict] | [] | Additional tools |
-| `temperature` | float | 0.7 | Sampling temperature |
-| `max_output_tokens` | int | 8192 | Max response tokens |
-| `timeout_seconds` | float | 300 | Execution timeout |
-| `safety_settings` | Dict | None | Safety configuration |
+| Parameter               | Type       | Default        | Description             |
+| ----------------------- | ---------- | -------------- | ----------------------- |
+| `api_key`               | str        | env            | Google AI API key       |
+| `model`                 | str        | gemini-1.5-pro | Model to use            |
+| `enable_code_execution` | bool       | False          | Enable Python execution |
+| `custom_tools`          | List[Dict] | []             | Additional tools        |
+| `temperature`           | float      | 0.7            | Sampling temperature    |
+| `max_output_tokens`     | int        | 8192           | Max response tokens     |
+| `timeout_seconds`       | float      | 300            | Execution timeout       |
+| `safety_settings`       | Dict       | None           | Safety configuration    |
 
 ### Key Feature: 1M Token Context
 
@@ -279,21 +279,18 @@ context = ExecutionContext(
 async def execute(self, context: ExecutionContext) -> ExecutionResult:
     await self.ensure_initialized()
 
-    # Build tools configuration
+    # Build tools configuration (folded into the request config)
     tools = self._build_tools(context)
 
-    # Generate content
-    if tools:
-        response = await asyncio.to_thread(
-            self._generative_model.generate_content,
-            context.task,
-            tools=tools,
-        )
-    else:
-        response = await asyncio.to_thread(
-            self._generative_model.generate_content,
-            context.task,
-        )
+    # Generate content via the google.genai client. Generation knobs
+    # (temperature, max_output_tokens, safety, tools) live in the per-request
+    # config, not on a model object.
+    response = await asyncio.to_thread(
+        self._client.models.generate_content,
+        model=self.model,
+        contents=context.task,
+        config=self._build_generate_config(tools),
+    )
 
     return ExecutionResult(
         output=self._extract_output(response),
@@ -326,6 +323,7 @@ success = await adapter.interrupt(
 ```
 
 Note: Not all adapters support true interruption:
+
 - **ClaudeCodeAdapter**: Kills subprocess
 - **OpenAICodexAdapter**: Cancels request
 - **GeminiCLIAdapter**: Limited support (logs warning)
@@ -350,16 +348,16 @@ if await is_gemini_available():
 
 ## Comparison Table
 
-| Feature | LocalKaizen | ClaudeCode | OpenAICodex | Gemini |
-|---------|-------------|------------|-------------|--------|
-| Works with any LLM | Yes | No | No | No |
-| Native file access | Via tools | Yes | Via upload | No |
-| Code execution | Via Bash | Yes (Bash) | Yes (Python) | Yes (Python) |
-| Streaming | Yes | Yes | Yes | Yes |
-| Vision | LLM-dependent | Yes | Yes | Yes |
-| Audio | LLM-dependent | No | No | Yes |
-| Max context | LLM-dependent | 200K | 128K | 1M |
-| Internet access | Via tools | Via tools | No | No |
+| Feature            | LocalKaizen   | ClaudeCode | OpenAICodex  | Gemini       |
+| ------------------ | ------------- | ---------- | ------------ | ------------ |
+| Works with any LLM | Yes           | No         | No           | No           |
+| Native file access | Via tools     | Yes        | Via upload   | No           |
+| Code execution     | Via Bash      | Yes (Bash) | Yes (Python) | Yes (Python) |
+| Streaming          | Yes           | Yes        | Yes          | Yes          |
+| Vision             | LLM-dependent | Yes        | Yes          | Yes          |
+| Audio              | LLM-dependent | No         | No           | Yes          |
+| Max context        | LLM-dependent | 200K       | 128K         | 1M           |
+| Internet access    | Via tools     | Via tools  | No           | No           |
 
 ## When to Use Each Adapter
 

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/gemini_cli.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/gemini_cli.py
@@ -102,7 +102,7 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
 
         # Gemini client (lazily initialized)
         self._client: Any | None = None
-        self._generative_model: Any | None = None
+        self._types: Any | None = None
 
         # Session tracking
         self._current_session_id: str | None = None
@@ -163,20 +163,16 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
         """Ensure Gemini client is initialized."""
         if self._client is None:
             try:
-                import google.generativeai as genai
-
-                genai.configure(api_key=self.api_key)
-                self._client = genai
-                self._generative_model = genai.GenerativeModel(
-                    model_name=self.model,
-                    safety_settings=self._get_safety_settings(),
-                    generation_config=self._get_generation_config(),
-                )
+                from google import genai
+                from google.genai import types as genai_types
             except ImportError:
                 raise ImportError(
-                    "Google Generative AI package not installed. "
-                    "Install with: pip install google-generativeai"
+                    "The google-genai package is required for the Gemini runtime. "
+                    "Install with: pip install google-genai"
                 ) from None
+
+            self._client = genai.Client(api_key=self.api_key)
+            self._types = genai_types
 
         await super().ensure_initialized()
 
@@ -193,16 +189,24 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
         # Production should use stricter settings
         return None
 
-    def _get_generation_config(self) -> dict[str, Any]:
-        """Get generation configuration.
+    def _build_generate_config(self, tools: list[Any] | None = None) -> Any:
+        """Build a ``google.genai`` GenerateContentConfig for one request.
 
-        Returns:
-            Generation config dict
+        Carries temperature + max_output_tokens, plus optional safety settings
+        and tools. ``self._types`` is populated by ``ensure_initialized`` (the
+        ``google.genai`` SDK moved per-request generation knobs out of the
+        model object and into the config passed to each ``generate_content``).
         """
-        return {
+        config_kwargs: dict[str, Any] = {
             "temperature": self.temperature,
             "max_output_tokens": self.max_output_tokens,
         }
+        safety = self._get_safety_settings()
+        if safety:
+            config_kwargs["safety_settings"] = safety
+        if tools:
+            config_kwargs["tools"] = tools
+        return self._types.GenerateContentConfig(**config_kwargs)
 
     async def execute(
         self,
@@ -238,18 +242,14 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
             if on_progress:
                 on_progress("calling_api", {"model": self.model})
 
-            # Generate content with tools
-            if tools:
-                response = await asyncio.to_thread(
-                    self._generative_model.generate_content,
-                    context.task,
-                    tools=tools,
-                )
-            else:
-                response = await asyncio.to_thread(
-                    self._generative_model.generate_content,
-                    context.task,
-                )
+            # Generate content (tools, if any, are folded into the request
+            # config — google.genai passes generation knobs per-call).
+            response = await asyncio.to_thread(
+                self._client.models.generate_content,
+                model=self.model,
+                contents=context.task,
+                config=self._build_generate_config(tools),
+            )
 
             # Extract output and handle function calls
             output = self._extract_output(response)
@@ -304,11 +304,11 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
 
         # Add code execution if enabled
         if self.enable_code_execution:
-            # Gemini uses special tool type for code execution
+            # Gemini uses a special tool type for code execution
             try:
-                from google.generativeai.types import Tool
+                from google.genai import types
 
-                all_tools.append(Tool(code_execution={}))
+                all_tools.append(types.Tool(code_execution=types.ToolCodeExecution()))
             except (ImportError, AttributeError):
                 logger.warning("Code execution tool not available in this version")
 
@@ -326,11 +326,13 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
         # Add function declarations as a tool
         if function_declarations:
             try:
-                from google.generativeai.types import Tool
+                from google.genai import types
 
-                all_tools.append(Tool(function_declarations=function_declarations))
+                all_tools.append(
+                    types.Tool(function_declarations=function_declarations)
+                )
             except (ImportError, AttributeError):
-                # Fallback for older API versions
+                # Fallback: a plain dict is coerced by GenerateContentConfig.
                 all_tools.append({"function_declarations": function_declarations})
 
         return all_tools if all_tools else None
@@ -411,22 +413,22 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
         try:
             tools = self._build_tools(context)
 
-            # Generate with streaming
-            response = await asyncio.to_thread(
-                self._generative_model.generate_content,
-                context.task,
-                tools=tools,
-                stream=True,
+            # Generate with streaming via the async client.
+            response = await self._client.aio.models.generate_content_stream(
+                model=self.model,
+                contents=context.task,
+                config=self._build_generate_config(tools),
             )
 
-            for chunk in response:
-                if hasattr(chunk, "text") and chunk.text:
+            async for chunk in response:
+                if getattr(chunk, "text", None):
                     yield chunk.text
-                elif hasattr(chunk, "candidates") and chunk.candidates:
+                elif getattr(chunk, "candidates", None):
                     for candidate in chunk.candidates:
-                        if hasattr(candidate, "content"):
-                            for part in candidate.content.parts:
-                                if hasattr(part, "text") and part.text:
+                        content = getattr(candidate, "content", None)
+                        if content and getattr(content, "parts", None):
+                            for part in content.parts:
+                                if getattr(part, "text", None):
                                     yield part.text
 
         finally:
@@ -509,8 +511,10 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
             await self.ensure_initialized()
             # Simple generation to verify connectivity
             response = await asyncio.to_thread(
-                self._generative_model.generate_content,
-                "Hello",
+                self._client.models.generate_content,
+                model=self.model,
+                contents="Hello",
+                config=self._build_generate_config(None),
             )
             return response is not None
         except Exception as e:

--- a/packages/kaizen-agents/tests/regression/test_issue_1351_google_genai_migration.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_1351_google_genai_migration.py
@@ -1,0 +1,140 @@
+"""Regression test for issue #1351 — Gemini adapters off deprecated SDK.
+
+Bug: the Gemini code paths imported the **deprecated** ``google.generativeai``
+package, and that package was declared **only** in ``[dev]`` extras — not as a
+runtime dependency. Two failure modes:
+
+1. Deprecation: ``google.generativeai`` is end-of-life; consumers break at
+   import once Google removes it.
+2. Undeclared runtime dependency: a normal ``pip install kaizen-agents``
+   (without ``[dev]``) does not install the SDK, so the Gemini path raises
+   ``ImportError`` at adapter construction.
+
+The fix migrates both adapters to the supported ``google.genai`` SDK and
+declares the provider SDKs (``google-genai`` + the sibling ``anthropic``, which
+had the identical undeclared-runtime-dep defect) as **runtime** dependencies.
+
+These tests assert behaviour (the constructed client is a ``google.genai``
+client; the adapter builds ``google.genai`` ``Tool`` objects) plus the manifest
+contract (runtime deps declared; deprecated dep gone). Deterministic + offline:
+``genai.Client(api_key=...)`` performs no network I/O at construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+@pytest.mark.regression
+def test_google_stream_adapter_uses_google_genai_client():
+    """GoogleStreamAdapter constructs a ``google.genai`` Client (not the old SDK)."""
+    from google import genai
+
+    from kaizen_agents.delegate.adapters.google_adapter import GoogleStreamAdapter
+
+    adapter = GoogleStreamAdapter(api_key="dummy-key", default_model="gemini-2.0-flash")
+    assert isinstance(adapter._client, genai.Client)
+
+
+@pytest.mark.regression
+def test_gemini_cli_adapter_initializes_google_genai_client():
+    """GeminiCLIAdapter.ensure_initialized builds a ``google.genai`` Client."""
+    from google import genai
+    from google.genai import types
+
+    from kaizen_agents.runtime_adapters.gemini_cli import GeminiCLIAdapter
+
+    adapter = GeminiCLIAdapter(api_key="dummy-key", model="gemini-2.0-flash")
+    asyncio.run(adapter.ensure_initialized())
+    assert isinstance(adapter._client, genai.Client)
+    assert adapter._types is types
+
+
+@pytest.mark.regression
+def test_build_tools_produces_google_genai_tool_objects():
+    """_build_tools emits ``google.genai`` types.Tool (code-exec + functions)."""
+    from google.genai import types
+
+    from kaizen_agents.runtime_adapters.gemini_cli import GeminiCLIAdapter
+
+    adapter = GeminiCLIAdapter(
+        api_key="dummy-key",
+        model="gemini-2.0-flash",
+        enable_code_execution=True,
+        custom_tools=[
+            {
+                "name": "t",
+                "description": "d",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+    )
+    asyncio.run(adapter.ensure_initialized())
+    tools = adapter._build_tools(SimpleNamespace(tools=None))
+    assert tools and all(isinstance(t, types.Tool) for t in tools)
+    # Folds into a real GenerateContentConfig without raising.
+    cfg = adapter._build_generate_config(tools)
+    assert isinstance(cfg, types.GenerateContentConfig)
+    assert len(cfg.tools) == len(tools)
+
+
+@pytest.mark.regression
+def test_google_stream_adapter_tools_coerce_into_config():
+    """_convert_tools_for_gemini output coerces into GenerateContentConfig.tools."""
+    from google.genai import types
+
+    from kaizen_agents.delegate.adapters.google_adapter import _convert_tools_for_gemini
+
+    tools = _convert_tools_for_gemini(
+        [
+            {
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            }
+        ]
+    )
+    cfg = types.GenerateContentConfig(tools=tools)
+    assert isinstance(cfg.tools[0], types.Tool)
+
+
+@pytest.mark.regression
+def test_no_deprecated_generativeai_import_in_adapter_modules():
+    """Importing the migrated modules must not pull in google.generativeai."""
+    # Importing the adapters must not register the deprecated package.
+    import kaizen_agents.delegate.adapters.google_adapter  # noqa: F401
+    import kaizen_agents.runtime_adapters.gemini_cli  # noqa: F401
+
+    assert "google.generativeai" not in sys.modules
+
+
+@pytest.mark.regression
+def test_provider_sdks_declared_as_runtime_dependencies():
+    """google-genai + anthropic are runtime deps; deprecated SDK is gone."""
+    data = tomllib.loads(_PYPROJECT.read_text())
+    runtime = data["project"]["dependencies"]
+    dev = data["project"].get("optional-dependencies", {}).get("dev", [])
+
+    def _names(specs: list[str]) -> set[str]:
+        out = set()
+        for spec in specs:
+            name = spec.split(">=")[0].split("==")[0].split("[")[0].strip()
+            out.add(name)
+        return out
+
+    runtime_names = _names(runtime)
+    assert "google-genai" in runtime_names, runtime
+    assert "anthropic" in runtime_names, runtime
+    # The deprecated SDK must not appear anywhere in the manifest.
+    assert "google-generativeai" not in runtime_names
+    assert "google-generativeai" not in _names(dev)


### PR DESCRIPTION
## Summary

The Gemini code path imported the **deprecated, end-of-life** `google.generativeai` package, declared **only** in `[dev]` extras. Two problems:

1. **Deprecation** — `google.generativeai` support has ended; consumers break at import once Google removes it (and emit a `FutureWarning` today).
2. **Undeclared runtime dependency** — a normal `pip install kaizen-agents` (no `[dev]`) does not install the SDK, so the Gemini path raised `ImportError` at adapter construction.

## Fix

- **Migrate both adapters to the supported `google.genai` SDK** — `delegate/adapters/google_adapter.py` + `runtime_adapters/gemini_cli.py` now use `genai.Client`, `client.aio.models.generate_content_stream` / `client.models.generate_content`, and `types.GenerateContentConfig` / `types.Tool` / `types.ToolCodeExecution`. Generation knobs (temperature, max tokens, safety, tools) moved from the model object into the per-request config; streaming chunks read via `candidates[0].content.parts`. The packaged developer doc that taught the removed `_generative_model` API is updated too.
- **Declare provider SDKs at runtime** — `google-genai` AND the sibling `anthropic` (which had the **identical** undeclared-runtime defect: `anthropic_adapter.py` + `orchestration/adapters.py` import it at runtime, yet it was `[dev]`-only) are now in `[project.dependencies]`; the deprecated `google-generativeai` pin is removed. Per `dependencies.md` "Declared = Imported".

## Verification

- New regression suite: `tests/regression/test_issue_1351_google_genai_migration.py` (6 tests — adapters construct a `google.genai` client, `_build_tools` emits `types.Tool`, tool dicts coerce into `GenerateContentConfig`, no `google.generativeai` in `sys.modules` after import, and the manifest declares both SDKs at runtime with the deprecated pin gone).
- Existing `tests/unit/test_adapters.py` green (43 passed) — the 2 Anthropic tests that previously failed on a no-`[dev]` venv now pass with the runtime dep.
- API surface verified against installed `google-genai` 1.71.0 (async iterator protocol, config/tool shapes, response `candidates`/`usage_metadata`).
- Migration is structurally validated offline (no live Gemini calls); the streaming network path is exercised by the existing API-key-gated integration tests.

Version bump: kaizen-agents 0.9.10 → 0.9.11.

## Related issues

Fixes #1351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)