### PR TITLE
fix(middleware-auth): pluggable shared token-revocation store (#1356)

### DIFF
--- a/src/kailash/middleware/auth/__init__.py
+++ b/src/kailash/middleware/auth/__init__.py
@@ -26,6 +26,7 @@ from .exceptions import (
 # Import without circular dependencies
 from .jwt_auth import JWTAuthManager
 from .models import AuthenticationResult, JWTConfig, TokenPair, TokenPayload, UserClaims
+from .revocation import InMemoryTokenRevocationStore, TokenRevocationStore
 from .utils import generate_key_pair, generate_secret_key, parse_bearer_token
 
 # Import other components (check for circular deps)
@@ -52,6 +53,9 @@ __all__ = [
     "TokenPair",
     "UserClaims",
     "AuthenticationResult",
+    # Token revocation
+    "TokenRevocationStore",
+    "InMemoryTokenRevocationStore",
     # Exceptions
     "AuthenticationError",
     "TokenExpiredError",

--- a/src/kailash/middleware/auth/jwt_auth.py
+++ b/src/kailash/middleware/auth/jwt_auth.py
@@ -524,7 +524,26 @@ class JWTAuthManager:
         except Exception:
             # Even if verification fails, revoke by raw token string so a
             # malformed/expired token presented for revocation is still recorded.
-            self._revocation_store.revoke(jti=None, token=token)
+            # Bound the entry's TTL so an attacker spamming revoke with unique
+            # invalid strings cannot grow the store without limit: derive exp
+            # from an unverified decode when possible, else fall back to the
+            # longest token lifetime (no presentable token outlives it, so the
+            # entry self-purges without ever evicting a still-valid token).
+            expires_at: Optional[datetime] = None
+            try:
+                unverified = jwt.decode(
+                    token, options={"verify_signature": False, "verify_exp": False}
+                )
+                exp = unverified.get("exp")
+                if exp:
+                    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc)
+            except Exception:
+                expires_at = None
+            if expires_at is None:
+                expires_at = datetime.now(timezone.utc) + timedelta(
+                    days=self.config.refresh_token_expire_days
+                )
+            self._revocation_store.revoke(jti=None, token=token, expires_at=expires_at)
 
     def revoke_refresh_token(self, jti: str):
         """Revoke specific refresh token."""

--- a/src/kailash/middleware/auth/jwt_auth.py
+++ b/src/kailash/middleware/auth/jwt_auth.py
@@ -29,6 +29,7 @@ from .exceptions import (
 
 # Import models and utilities (no circular dependencies)
 from .models import JWTConfig, RefreshTokenData, TokenPair, TokenPayload
+from .revocation import InMemoryTokenRevocationStore, TokenRevocationStore
 from .utils import generate_secret_key, is_token_expired
 
 logger = logging.getLogger(__name__)
@@ -42,11 +43,28 @@ class JWTAuthManager:
     - Support for both HS256 (default) and RSA algorithms
     - RSA key pair generation and rotation (when using RSA)
     - Refresh token management
-    - Token blacklisting
+    - Token revocation via a pluggable revocation store
     - Comprehensive audit logging
     - Rate limiting protection
 
     This consolidates both JWTAuthManager and KailashJWTAuthManager functionality.
+
+    Token revocation in multi-worker deployments
+    ---------------------------------------------
+    Token revocation is backed by a :class:`TokenRevocationStore`. By default
+    (``revocation_store`` omitted, ``config.enable_blacklist=True``) an in-memory
+    :class:`InMemoryTokenRevocationStore` is used, which is **process-local**: a
+    token revoked through one worker is NOT rejected by other workers. For any
+    multi-worker / multi-pod deployment supply a SHARED store (Redis, database,
+    distributed cache) implementing :class:`TokenRevocationStore` via the
+    ``revocation_store`` constructor argument so revocation propagates to every
+    worker that shares it (issue #1356).
+
+    Known process-local state (NOT covered by ``revocation_store``): refresh-token
+    tracking (``refresh_access_token`` / ``revoke_refresh_token`` /
+    ``revoke_all_user_tokens``) and rate-limit accounting are also per-instance
+    in-memory and behave per-worker. Shared-backend coverage for those is tracked
+    separately; only access-token revocation propagates through the store.
     """
 
     def __init__(
@@ -55,6 +73,7 @@ class JWTAuthManager:
         secret_key: Optional[str] = None,
         algorithm: Optional[str] = None,
         use_rsa: Optional[bool] = None,
+        revocation_store: Optional[TokenRevocationStore] = None,
         **kwargs,
     ):
         """
@@ -65,6 +84,14 @@ class JWTAuthManager:
             secret_key: Secret key for HS256 (overrides config)
             algorithm: Algorithm to use (overrides config)
             use_rsa: Whether to use RSA (overrides config)
+            revocation_store: Backend that records and checks token revocation.
+                When ``config.enable_blacklist`` is True and this is omitted, a
+                process-local :class:`InMemoryTokenRevocationStore` is used —
+                which means a token revoked on one worker is NOT rejected by
+                other workers. Supply a SHARED store (Redis, database,
+                distributed cache) implementing :class:`TokenRevocationStore` so
+                revocation propagates across every worker that shares it
+                (issue #1356). Ignored when ``config.enable_blacklist`` is False.
             **kwargs: Additional config parameters
         """
         self.config = config or JWTConfig()
@@ -93,10 +120,12 @@ class JWTAuthManager:
         self._key_id = str(uuid.uuid4())
         self._key_generated_at = datetime.now(timezone.utc)
 
-        # Token tracking
-        self._blacklisted_tokens: Optional[set] = (
-            set() if self.config.enable_blacklist else None
-        )
+        # Token revocation backend. When blacklisting is enabled, use the
+        # injected shared store if provided, else a process-local default.
+        # When disabled, no store is held and revocation is a no-op.
+        self._revocation_store: Optional[TokenRevocationStore] = None
+        if self.config.enable_blacklist:
+            self._revocation_store = revocation_store or InMemoryTokenRevocationStore()
         self._refresh_tokens: Dict[str, Dict[str, Any]] = {}
         self._failed_attempts: Dict[str, List[datetime]] = {}
 
@@ -373,10 +402,6 @@ class JWTAuthManager:
             raise ImportError("PyJWT package is required for JWT operations")
 
         try:
-            # Check if token is blacklisted
-            if self._blacklisted_tokens and token in self._blacklisted_tokens:
-                raise jwt.InvalidTokenError("Token has been revoked")
-
             # Get verification key based on algorithm
             if self.config.use_rsa or self.config.algorithm.startswith("RS"):
                 # RSA verification
@@ -407,6 +432,17 @@ class JWTAuthManager:
                     issuer=self.config.issuer,
                     audience=self.config.audience,
                 )
+
+            # Reject revoked tokens. Checked AFTER decode so the revocation
+            # identity (jti) is available — this is what a shared store keys on
+            # so revocation propagates across workers (issue #1356).
+            if (
+                self._revocation_store is not None
+                and self._revocation_store.is_revoked(
+                    jti=payload.get("jti"), token=token
+                )
+            ):
+                raise jwt.InvalidTokenError("Token has been revoked")
 
             return payload
 
@@ -471,18 +507,24 @@ class JWTAuthManager:
             raise
 
     def revoke_token(self, token: str):
-        """Add token to blacklist."""
-        if self._blacklisted_tokens is None:
+        """Revoke a token via the revocation store.
+
+        With a shared store this propagates to every worker that shares it; with
+        the default in-memory store it is process-local (issue #1356).
+        """
+        if self._revocation_store is None:
             return
         try:
             payload = self.verify_token(token)
             jti = payload.get("jti")
-            if jti:
-                self._blacklisted_tokens.add(token)
-                logger.info(f"Revoked token {jti}")
+            exp = payload.get("exp")
+            expires_at = datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
+            self._revocation_store.revoke(jti=jti, token=token, expires_at=expires_at)
+            logger.info(f"Revoked token {jti}" if jti else "Revoked token")
         except Exception:
-            # Even if verification fails, add to blacklist
-            self._blacklisted_tokens.add(token)
+            # Even if verification fails, revoke by raw token string so a
+            # malformed/expired token presented for revocation is still recorded.
+            self._revocation_store.revoke(jti=None, token=token)
 
     def revoke_refresh_token(self, jti: str):
         """Revoke specific refresh token."""
@@ -564,7 +606,9 @@ class JWTAuthManager:
         return {
             "active_refresh_tokens": len(self._refresh_tokens),
             "blacklisted_tokens": (
-                len(self._blacklisted_tokens) if self._blacklisted_tokens else 0
+                self._revocation_store.count()
+                if self._revocation_store is not None
+                else 0
             ),
             "key_id": self._key_id,
             "key_age_days": (

--- a/src/kailash/middleware/auth/jwt_auth.py
+++ b/src/kailash/middleware/auth/jwt_auth.py
@@ -436,6 +436,10 @@ class JWTAuthManager:
             # Reject revoked tokens. Checked AFTER decode so the revocation
             # identity (jti) is available — this is what a shared store keys on
             # so revocation propagates across workers (issue #1356).
+            # INVARIANT: pass BOTH jti AND token — revoke() keys on `jti or token`,
+            # so a token revoked before its jti was known (decode-failure path) is
+            # keyed by raw token; dropping `token=` here would silently stop
+            # enforcing those revocations.
             if (
                 self._revocation_store is not None
                 and self._revocation_store.is_revoked(
@@ -525,24 +529,27 @@ class JWTAuthManager:
             # Even if verification fails, revoke by raw token string so a
             # malformed/expired token presented for revocation is still recorded.
             # Bound the entry's TTL so an attacker spamming revoke with unique
-            # invalid strings cannot grow the store without limit: derive exp
-            # from an unverified decode when possible, else fall back to the
-            # longest token lifetime (no presentable token outlives it, so the
-            # entry self-purges without ever evicting a still-valid token).
-            expires_at: Optional[datetime] = None
+            # invalid strings cannot grow the store without limit. The longest a
+            # legitimately-issued token can remain presentable is the refresh
+            # window; cap the entry there so a FORGED far-future `exp` in an
+            # unverified token cannot extend the entry's lifetime beyond it
+            # (no presentable token outlives the cap, so the entry self-purges
+            # without ever evicting a still-valid token).
+            ttl_cap = datetime.now(timezone.utc) + timedelta(
+                days=self.config.refresh_token_expire_days
+            )
+            expires_at = ttl_cap
             try:
                 unverified = jwt.decode(
                     token, options={"verify_signature": False, "verify_exp": False}
                 )
                 exp = unverified.get("exp")
                 if exp:
-                    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc)
+                    expires_at = min(
+                        datetime.fromtimestamp(exp, tz=timezone.utc), ttl_cap
+                    )
             except Exception:
-                expires_at = None
-            if expires_at is None:
-                expires_at = datetime.now(timezone.utc) + timedelta(
-                    days=self.config.refresh_token_expire_days
-                )
+                expires_at = ttl_cap
             self._revocation_store.revoke(jti=None, token=token, expires_at=expires_at)
 
     def revoke_refresh_token(self, jti: str):
@@ -621,7 +628,15 @@ class JWTAuthManager:
         return base64.urlsafe_b64encode(number_bytes).decode("ascii").rstrip("=")
 
     def get_stats(self) -> Dict[str, Any]:
-        """Get authentication manager statistics."""
+        """Get authentication manager statistics.
+
+        Note: ``blacklisted_tokens`` retains the legacy field name (the config
+        flag ``enable_blacklist`` likewise) for backward compatibility; the
+        underlying mechanism is the revocation store. The value is the store's
+        ``count()`` — an int for the in-memory default, but it MAY be ``None``
+        for a shared backend that cannot cheaply count (per the
+        ``TokenRevocationStore.count`` contract), meaning "unknown".
+        """
         return {
             "active_refresh_tokens": len(self._refresh_tokens),
             "blacklisted_tokens": (

--- a/src/kailash/middleware/auth/revocation.py
+++ b/src/kailash/middleware/auth/revocation.py
@@ -1,0 +1,177 @@
+"""
+Token Revocation Store for Kailash Middleware JWT Authentication.
+
+`JWTAuthManager` historically backed token revocation with an in-memory ``set``
+scoped to a single manager instance. In any multi-worker / multi-pod deployment
+(the default production topology) a token revoked on one worker stayed valid on
+every other worker until natural expiry — the revocation security control
+silently failed to take effect (issue #1356).
+
+This module introduces a pluggable revocation backend so revocation can
+propagate across every worker that shares the same store. The contract is
+**synchronous** by design: ``JWTAuthManager.verify_token`` / ``revoke_token`` are
+synchronous public API on the per-request hot path, so the store must be callable
+without an event loop. A shared backend (Redis, a database table, a distributed
+cache) is supplied by the deployment by implementing :class:`TokenRevocationStore`;
+the SDK ships the contract plus the process-local :class:`InMemoryTokenRevocationStore`
+default that preserves the original single-process behavior.
+
+Example — propagating revocation across workers via a shared backend::
+
+    from kailash.middleware.auth import (
+        JWTAuthManager, JWTConfig, TokenRevocationStore,
+    )
+
+    class RedisRevocationStore(TokenRevocationStore):
+        def __init__(self, client):
+            self._client = client  # a synchronous redis client
+
+        def revoke(self, *, jti, token=None, expires_at=None):
+            key = f"jwt:revoked:{jti or token}"
+            ttl = None
+            if expires_at is not None:
+                from datetime import datetime, timezone
+                ttl = max(1, int((expires_at - datetime.now(timezone.utc)).total_seconds()))
+            self._client.set(key, "1", ex=ttl)
+
+        def is_revoked(self, *, jti=None, token=None):
+            for ident in (jti, token):
+                if ident and self._client.exists(f"jwt:revoked:{ident}"):
+                    return True
+            return False
+
+    store = RedisRevocationStore(redis_client)
+    cfg = JWTConfig(secret_key="...")
+    # Every worker constructed with the same shared store sees revocations.
+    manager = JWTAuthManager(config=cfg, revocation_store=store)
+"""
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TokenRevocationStore(ABC):
+    """Synchronous contract for a JWT revocation backend.
+
+    Implementations decide where revocation state lives. The default
+    :class:`InMemoryTokenRevocationStore` keeps it in-process (single-worker
+    only); a production deployment supplies a shared backend (Redis, database,
+    distributed cache) so a token revoked on one worker is rejected on all of
+    them.
+
+    A revoked token is identified by its ``jti`` (JWT ID claim) when available.
+    When a token cannot be decoded at revocation time, it is revoked by its raw
+    token string instead, so ``is_revoked`` accepts both identifiers.
+    """
+
+    @abstractmethod
+    def revoke(
+        self,
+        *,
+        jti: Optional[str] = None,
+        token: Optional[str] = None,
+        expires_at: Optional[datetime] = None,
+    ) -> None:
+        """Record a token as revoked.
+
+        Args:
+            jti: The token's ``jti`` claim, when decodable. Preferred identifier.
+            token: The raw token string. Used as a fallback identifier when the
+                token could not be decoded (so ``jti`` is unknown).
+            expires_at: When the token naturally expires. Backends that support
+                TTL SHOULD use it to evict the entry once the token can no
+                longer be presented, bounding store growth. ``None`` means the
+                entry has no known expiry and is retained until evicted.
+        """
+
+    @abstractmethod
+    def is_revoked(
+        self,
+        *,
+        jti: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> bool:
+        """Return True if the token identified by ``jti`` or ``token`` is revoked."""
+
+    def count(self) -> Optional[int]:
+        """Number of currently-revoked entries, or ``None`` if unknown.
+
+        Used for diagnostics (`JWTAuthManager.get_stats`). External backends that
+        cannot cheaply count MAY return ``None``; the default in-memory store
+        returns an exact count.
+        """
+        return None
+
+
+class InMemoryTokenRevocationStore(TokenRevocationStore):
+    """Process-local revocation store (the default).
+
+    Preserves the original single-process behavior: revocations are visible only
+    within the worker that performed them. Thread-safe. Entries with a known
+    ``expires_at`` are purged lazily once expired so the store does not grow
+    without bound for short-lived tokens.
+
+    WARNING: This store is process-local. In a multi-worker / multi-pod
+    deployment a token revoked through one worker's manager will NOT be rejected
+    by other workers. Supply a shared :class:`TokenRevocationStore` backend
+    (Redis, database, distributed cache) to propagate revocation across workers.
+    """
+
+    def __init__(self) -> None:
+        # identifier -> expires_at (or None when no expiry is known)
+        self._revoked: dict[str, Optional[datetime]] = {}
+        self._lock = threading.Lock()
+
+    def revoke(
+        self,
+        *,
+        jti: Optional[str] = None,
+        token: Optional[str] = None,
+        expires_at: Optional[datetime] = None,
+    ) -> None:
+        # Prefer the jti (canonical revocation identity); fall back to the raw
+        # token only when the token could not be decoded (jti unknown). One
+        # entry per revoked token keeps count() == number of revoked tokens.
+        ident = jti or token
+        if not ident:
+            return
+        with self._lock:
+            self._purge_expired_locked()
+            self._revoked[ident] = expires_at
+
+    def is_revoked(
+        self,
+        *,
+        jti: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> bool:
+        with self._lock:
+            self._purge_expired_locked()
+            for ident in (jti, token):
+                if ident and ident in self._revoked:
+                    return True
+            return False
+
+    def count(self) -> int:
+        with self._lock:
+            self._purge_expired_locked()
+            return len(self._revoked)
+
+    def _purge_expired_locked(self) -> None:
+        """Drop entries whose token has naturally expired. Caller holds the lock."""
+        now = datetime.now(timezone.utc)
+        expired = [
+            ident
+            for ident, exp in self._revoked.items()
+            if exp is not None and exp <= now
+        ]
+        for ident in expired:
+            del self._revoked[ident]
+
+
+__all__ = ["TokenRevocationStore", "InMemoryTokenRevocationStore"]

--- a/tests/unit/middleware/test_jwt_revocation_store.py
+++ b/tests/unit/middleware/test_jwt_revocation_store.py
@@ -75,13 +75,18 @@ def test_default_store_is_process_local():
 
 
 @pytest.mark.regression
-def test_same_manager_rejects_revoked_token():
-    """Baseline: a manager rejects a token it revoked itself (unchanged behavior)."""
+def test_same_manager_rejects_revoked_token_with_revoked_message():
+    """A manager rejects a token it revoked, with the specific 'revoked' message.
+
+    Pins the post-decode ordering: a non-expired revoked token surfaces the
+    revocation reason (not a generic decode error), which is the observability
+    contract callers rely on to distinguish revoked from malformed.
+    """
     mgr = JWTAuthManager(config=_cfg())
     token = mgr.create_token_pair(user_id="u9").access_token
     assert mgr.verify_token(token)["sub"] == "u9"
     mgr.revoke_token(token)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Token has been revoked"):
         mgr.verify_token(token)
 
 
@@ -144,6 +149,33 @@ def test_revocation_store_protocol_shape():
     assert len(store.revoked) == 1
     with pytest.raises(Exception):
         mgr.verify_token(token)
+
+
+@pytest.mark.regression
+def test_revoke_unverifiable_token_is_ttl_bounded_from_unverified_exp():
+    """Decode-failure fallback bounds entry TTL from the token's exp (no permanent growth).
+
+    A token signed with a foreign key fails verification, so revoke_token takes
+    the fallback path. The fallback extracts exp via an unverified decode and
+    bounds the entry — so a revoked-but-already-expired token does NOT linger in
+    the store forever (the M2 unbounded-growth defense).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    import jwt as pyjwt
+
+    store = InMemoryTokenRevocationStore()
+    mgr = JWTAuthManager(config=_cfg(), revocation_store=store)
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    foreign = pyjwt.encode(
+        {"sub": "x", "jti": "j1", "exp": past},
+        "a-different-secret-key-also-32-chars-x!",
+        algorithm="HS256",
+    )
+    mgr.revoke_token(foreign)  # fails verify -> fallback -> bounded by past exp
+    # Past exp -> the entry self-purges; it is not retained permanently.
+    assert store.is_revoked(token=foreign) is False
+    assert store.count() == 0
 
 
 @pytest.mark.regression

--- a/tests/unit/middleware/test_jwt_revocation_store.py
+++ b/tests/unit/middleware/test_jwt_revocation_store.py
@@ -1,0 +1,159 @@
+"""Regression tests for issue #1356 — JWTAuthManager token revocation is process-local.
+
+Before the fix, ``JWTAuthManager`` backed token revocation with an in-memory
+``set`` scoped to one manager instance, so a token revoked on one worker stayed
+valid on every other worker in a multi-worker deployment. The fix introduces a
+pluggable ``TokenRevocationStore``: a SHARED store propagates revocation across
+every manager that shares it; the default ``InMemoryTokenRevocationStore`` is
+process-local (the documented original behavior).
+
+These tests pin the chosen contract (acceptance criteria of #1356):
+- revocation propagates via a shared store, and
+- the default store is documented-process-local.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.middleware.auth import (
+    InMemoryTokenRevocationStore,
+    JWTAuthManager,
+    JWTConfig,
+    TokenRevocationStore,
+)
+
+SECRET = "a-very-long-secret-key-at-least-32-chars!"
+
+
+def _cfg(**overrides) -> JWTConfig:
+    return JWTConfig(secret_key=SECRET, algorithm="HS256", **overrides)
+
+
+@pytest.mark.regression
+def test_revocation_propagates_via_shared_store():
+    """The fix: two managers sharing ONE store reject a token revoked on either.
+
+    Models two worker processes that share a distributed revocation backend.
+    """
+    shared = InMemoryTokenRevocationStore()
+    worker_a = JWTAuthManager(config=_cfg(), revocation_store=shared)
+    worker_b = JWTAuthManager(config=_cfg(), revocation_store=shared)
+
+    token = worker_a.create_token_pair(user_id="u1").access_token
+    # Both accept it before revocation.
+    assert worker_a.verify_token(token)["sub"] == "u1"
+    assert worker_b.verify_token(token)["sub"] == "u1"
+
+    worker_a.revoke_token(token)
+
+    with pytest.raises(Exception):
+        worker_a.verify_token(token)
+    # The fix: worker_b — which never called revoke — also rejects it.
+    with pytest.raises(Exception):
+        worker_b.verify_token(token)
+
+
+@pytest.mark.regression
+def test_default_store_is_process_local():
+    """The default (no shared store) is process-local — documented limitation.
+
+    This is the original behavior the issue described; it is preserved by design
+    for single-process deployments. Multi-worker deployments MUST inject a shared
+    store (see ``test_revocation_propagates_via_shared_store``).
+    """
+    worker_a = JWTAuthManager(config=_cfg())  # default in-memory store
+    worker_b = JWTAuthManager(config=_cfg())  # separate default store
+
+    token = worker_a.create_token_pair(user_id="u1").access_token
+    worker_a.revoke_token(token)
+
+    with pytest.raises(Exception):
+        worker_a.verify_token(token)
+    # Process-local default: worker_b still accepts (separate in-memory store).
+    assert worker_b.verify_token(token)["sub"] == "u1"
+
+
+@pytest.mark.regression
+def test_same_manager_rejects_revoked_token():
+    """Baseline: a manager rejects a token it revoked itself (unchanged behavior)."""
+    mgr = JWTAuthManager(config=_cfg())
+    token = mgr.create_token_pair(user_id="u9").access_token
+    assert mgr.verify_token(token)["sub"] == "u9"
+    mgr.revoke_token(token)
+    with pytest.raises(Exception):
+        mgr.verify_token(token)
+
+
+@pytest.mark.regression
+def test_revoke_when_decode_fails_still_records():
+    """Preserves the original 'revoke even if verification fails' behavior.
+
+    A malformed/garbage token presented to ``revoke_token`` is recorded by raw
+    token string rather than silently ignored.
+    """
+    store = InMemoryTokenRevocationStore()
+    mgr = JWTAuthManager(config=_cfg(), revocation_store=store)
+    garbage = "not.a.valid.jwt"
+    mgr.revoke_token(garbage)
+    assert store.is_revoked(token=garbage) is True
+
+
+@pytest.mark.regression
+def test_blacklist_disabled_means_no_store_and_no_revocation():
+    """enable_blacklist=False keeps revocation a no-op (no store held)."""
+    mgr = JWTAuthManager(config=_cfg(enable_blacklist=False))
+    assert mgr._revocation_store is None
+    token = mgr.create_token_pair(user_id="u1").access_token
+    mgr.revoke_token(token)  # no-op
+    # Token still verifies because revocation is disabled.
+    assert mgr.verify_token(token)["sub"] == "u1"
+
+
+@pytest.mark.regression
+def test_get_stats_reports_one_entry_per_revoked_token():
+    """get_stats counts one revoked entry per token (jti-keyed, not double-counted)."""
+    mgr = JWTAuthManager(config=_cfg())
+    t1 = mgr.create_token_pair(user_id="u1").access_token
+    t2 = mgr.create_token_pair(user_id="u2").access_token
+    mgr.revoke_token(t1)
+    mgr.revoke_token(t2)
+    assert mgr.get_stats()["blacklisted_tokens"] == 2
+
+
+@pytest.mark.regression
+def test_revocation_store_protocol_shape():
+    """Structural: a custom in-process backend can implement the contract."""
+
+    class DictStore(TokenRevocationStore):
+        def __init__(self):
+            self.revoked: set[str] = set()
+
+        def revoke(self, *, jti=None, token=None, expires_at=None):
+            ident = jti or token
+            if ident:
+                self.revoked.add(ident)
+
+        def is_revoked(self, *, jti=None, token=None):
+            return any(i and i in self.revoked for i in (jti, token))
+
+    store = DictStore()
+    mgr = JWTAuthManager(config=_cfg(), revocation_store=store)
+    token = mgr.create_token_pair(user_id="custom").access_token
+    mgr.revoke_token(token)
+    assert len(store.revoked) == 1
+    with pytest.raises(Exception):
+        mgr.verify_token(token)
+
+
+@pytest.mark.regression
+def test_in_memory_store_purges_expired_entries():
+    """Expired revocation entries are purged so the store does not grow unbounded."""
+    from datetime import datetime, timedelta, timezone
+
+    store = InMemoryTokenRevocationStore()
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    store.revoke(jti="expired-jti", expires_at=past)
+    # Lazy purge on next access drops the expired entry.
+    assert store.is_revoked(jti="expired-jti") is False
+    assert store.count() == 0

--- a/tests/unit/middleware/test_jwt_revocation_store.py
+++ b/tests/unit/middleware/test_jwt_revocation_store.py
@@ -179,6 +179,35 @@ def test_revoke_unverifiable_token_is_ttl_bounded_from_unverified_exp():
 
 
 @pytest.mark.regression
+def test_revoke_fallback_caps_forged_future_exp_at_refresh_window():
+    """A forged far-future exp on an unverifiable token cannot extend the entry TTL.
+
+    The decode-failure fallback reads exp from an UNVERIFIED decode (attacker-
+    controllable). The entry TTL MUST be capped at the longest legitimate token
+    lifetime so a forged exp=year-3000 cannot pin the entry in the store for
+    centuries (sec LOW-1).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    import jwt as pyjwt
+
+    store = InMemoryTokenRevocationStore()
+    cfg = _cfg()
+    mgr = JWTAuthManager(config=cfg, revocation_store=store)
+    far_future = datetime(3000, 1, 1, tzinfo=timezone.utc)
+    forged = pyjwt.encode(
+        {"sub": "x", "exp": far_future},
+        "a-different-secret-key-also-32-chars-x!",
+        algorithm="HS256",
+    )
+    mgr.revoke_token(forged)  # fails verify -> fallback with forged future exp
+    stored_exp = store._revoked[forged]  # inspect the entry's bound TTL
+    cap = datetime.now(timezone.utc) + timedelta(days=cfg.refresh_token_expire_days)
+    assert stored_exp is not None
+    assert stored_exp <= cap, "forged future exp was not capped at the refresh window"
+
+
+@pytest.mark.regression
 def test_in_memory_store_purges_expired_entries():
     """Expired revocation entries are purged so the store does not grow unbounded."""
     from datetime import datetime, timedelta, timezone

--- a/workspaces/issue-1356-jwt-revocation/02-plans/00-plan.md
+++ b/workspaces/issue-1356-jwt-revocation/02-plans/00-plan.md
@@ -1,0 +1,80 @@
+# Issue #1356 — JWTAuthManager token revocation is process-local
+
+## Problem (verified against src/kailash/middleware/auth/jwt_auth.py @ 9f68ec637)
+
+- `verify_token` (line 377) checks `self._blacklisted_tokens` — an in-memory `set`
+  scoped to ONE manager instance.
+- `revoke_token` (line 473) adds to that same in-memory set.
+- In any multi-worker / multi-pod deployment (the default production topology),
+  a token revoked on worker A stays valid on worker B until natural expiry.
+- The class docstring lists "Token blacklisting" as a security best practice with
+  NO caveat that it is process-local.
+
+## Decision: pluggable shared revocation store (acceptance option 1, root-cause)
+
+Per `/autonomize` (optimal/root-cause) + user memory `project_optimal_outcome`
+("always choose optimal architecture"), fix the control rather than document the gap.
+
+### Constraint that shapes the design
+
+`verify_token()` / `revoke_token()` are **synchronous** public API on the
+per-request hot path. Making them async to fit an async store (the
+infrastructure/\*\_store.py idiom) is a breaking API change to a widely-used
+surface. → The revocation-store contract is **synchronous**.
+
+### Design (matches the established Protocol-backend-+-facade idiom, sync variant)
+
+New file `src/kailash/middleware/auth/revocation.py`:
+
+- `TokenRevocationStore(ABC)` — sync contract:
+  - `revoke(*, jti, token=None, expires_at=None) -> None`
+  - `is_revoked(*, jti=None, token=None) -> bool`
+  - `count() -> int | None` (None = unknown for external stores; used by get_stats)
+- `InMemoryTokenRevocationStore(TokenRevocationStore)` — DEFAULT, preserves exact
+  current single-process behavior; keys by jti AND raw token (fallback for
+  tokens that fail to decode at revoke time); TTL-aware lazy purge via expires_at.
+
+Wiring into `JWTAuthManager`:
+
+- `__init__(..., revocation_store: Optional[TokenRevocationStore] = None)`.
+  - `enable_blacklist=False` → `self._revocation_store = None` (current no-op).
+  - else → injected store, or `InMemoryTokenRevocationStore()` default.
+- `verify_token`: decode first, then ONE `is_revoked(jti=jti, token=token)` check
+  before returning payload; keep raising `jwt.InvalidTokenError("Token has been
+revoked")` (NO exception-class change → no caller breakage).
+- `revoke_token`: decode → jti + exp → `store.revoke(jti, token, expires_at)`;
+  on decode failure → `store.revoke(jti=None, token=token)` (preserves "revoke
+  even if verification fails").
+- `get_stats`: `self._revocation_store.count()` (was `len(self._blacklisted_tokens)`).
+- `_blacklisted_tokens` removed (private attr; zero src/test callers besides this file).
+
+A SHARED backend (Redis/DB) is supplied by the user implementing the Protocol;
+the SDK ships the contract + the in-memory default. This is the "injectable
+revocation backend" the acceptance criteria names.
+
+### Scope boundary (one shard, one invariant: revocation propagation)
+
+- IN scope: access-token revocation blacklist (the filed issue).
+- Documented as known process-local (NOT silently): refresh-token tracking
+  (`_refresh_tokens`) and rate-limit (`_failed_attempts`) — same bug class, but
+  expanding the store to cover them exceeds one shard + the issue. Surfaced to
+  user as a follow-up, not silently dropped.
+
+## Tests (regression)
+
+1. `test_revocation_propagates_via_shared_store` — two managers sharing ONE
+   `InMemoryTokenRevocationStore` instance (models a shared backend): revoke on
+   A → B rejects. The fix's core contract.
+2. `test_default_store_is_process_local` — two managers, default (separate)
+   stores: documents the in-memory default is process-local by design.
+3. `test_revoke_token_when_verification_fails_still_revokes` — preserves the
+   line-484 "revoke even if decode fails" behavior.
+4. `test_revocation_store_protocol_shape` — structural: contract methods present.
+5. `test_get_stats_reports_revocation_count`.
+
+## Cross-SDK (rules/cross-sdk-inspection.md)
+
+kailash-rs JWT middleware is a SIBLING repo (`esperie-enterprise/kailash-rs`,
+private). `rules/repo-scope-discipline.md` blocks reading it from this session.
+→ Surface to user as a human-gated cross-SDK filing (upstream-issue-hygiene),
+do NOT act cross-repo autonomously.

--- a/workspaces/issue-1356-jwt-revocation/04-validate/00-convergence.md
+++ b/workspaces/issue-1356-jwt-revocation/04-validate/00-convergence.md
@@ -1,0 +1,35 @@
+# Issue #1356 — /redteam Convergence Record
+
+**Branch:** `fix/issue-1356-jwt-revocation-store` · **HEAD:** `1c2c313b6` (3 commits) · **Posture:** L5_DELEGATED
+
+## Convergence criteria
+
+| Criterion                         | Status | Evidence                                                                  |
+| --------------------------------- | ------ | ------------------------------------------------------------------------- |
+| 0 CRITICAL                        | ✅     | none in any round                                                         |
+| 0 HIGH                            | ✅     | R1 found H1 → re-classified as separate-shard follow-up (sound per R2+R3) |
+| 2 consecutive clean rounds        | ✅     | R2 (0 CRIT/HIGH/MED, LOWs only) + R3 (CONVERGED, no new findings)         |
+| Acceptance criteria 100% verified | ✅     | analyst R2 closure table — both halves delivered                          |
+| New code has new tests            | ✅     | 10 regression tests import the new module; `pytest -q` → 10 passed        |
+| No mock data                      | ✅     | N/A — backend security fix, no frontend                                   |
+| Log-triage gate                   | ✅     | no WARN+ in test output                                                   |
+
+## Round history (receipts: agent task IDs)
+
+- **R1** security-reviewer (`a46723682a125030d`): M2 (MED, unbounded store growth) + M3 (ordering observability) + H1 (HIGH, sibling verifier) + 2 LOW. M2/M3 fixed in commit `e96c2759e`.
+- **R2** security-reviewer (`aabbad2c69f41a4cb`) + reviewer (`aba853695815c8fba`) + analyst (`affd1fac674ef47f2`): 0 CRIT/HIGH/MED. M2/M3 verified fixed, H1 disposition sound. 2 new LOW (forged-exp TTL; dual-identifier coupling) + 2 reviewer LOW. All fixed in commit `1c2c313b6`.
+- **R3** security-reviewer (`a42ae6af79f369ee7`): **CONVERGED** — LOW fixes verified correct, 0 CRIT/HIGH/MED, no new findings.
+
+## Mechanical sweeps (R2 reviewer, verbatim)
+
+- `grep -rn "_blacklisted_tokens" src/` → empty (old attribute fully removed)
+- `__all__` → `['InMemoryTokenRevocationStore', 'TokenRevocationStore']`
+- `pytest --collect-only tests/unit/middleware/` → 48 collected, exit 0
+- `mypy src/kailash/middleware/auth/revocation.py` → Success
+- circular-imports → 9 passed
+
+## Deferred (separate shards — see journal 0001)
+
+- **H1**: `MiddlewareAuthManager.verify_token` (legacy nodes-based auth, no jti, no revoke method) has no revocation capability at all. Distinct from #1356 (which is JWTAuthManager). Retrofitting is a new feature → follow-up issue (human-gated filing).
+- **Cross-SDK**: kailash-rs JWT middleware parity inspection (`cross-sdk-inspection.md`) — cross-repo, human-gated.
+- **Scope (documented, not dropped)**: refresh-token tracking + rate-limiting remain process-local — disclosed in the class docstring.

--- a/workspaces/issue-1356-jwt-revocation/journal/0001-GAP-sibling-verifier-no-revocation.md
+++ b/workspaces/issue-1356-jwt-revocation/journal/0001-GAP-sibling-verifier-no-revocation.md
@@ -1,0 +1,44 @@
+# GAP — MiddlewareAuthManager has no token revocation (sibling of #1356)
+
+**Type:** GAP · **Surfaced by:** /redteam Round 1 security-reviewer (#1356) · **Date:** 2026-06-17
+
+## Finding
+
+`src/kailash/middleware/auth/auth_manager.py::MiddlewareAuthManager.verify_token`
+(lines ~193-223) is a SECOND, independent JWT verifier in the same package
+(exported, gated behind `_has_access_control`). It does `jwt.decode` + a manual
+exp check with **no revocation consultation, no jti claim, and no `revoke_token`
+method**. It is the legacy nodes-based ("was SDKAuthManager") auth system.
+
+This is NOT the #1356 bug (process-local revocation in `JWTAuthManager`). The two
+managers share **no** revocation state. `MiddlewareAuthManager` simply has no
+revocation capability at all.
+
+## Why deferred (not fixed in the #1356 PR)
+
+Per `autonomous-execution.md` Rule 4: a same-class gap is fixed in-shard only if
+it fits the shard budget. Retrofitting revocation onto `MiddlewareAuthManager` is
+a NEW FEATURE, not a call-site sweep:
+
+- its tokens carry no `jti` → either change the token format (breaking) or
+  revoke by raw-token-string only;
+- it needs a new `revoke_token` API + store wiring;
+- it requires deciding which manager is the canonical production auth path.
+
+This exceeds one shard and is a distinct design decision → tracked follow-up.
+R2 + R3 security-reviewer confirmed the disposition sound: #1356 is fully closed
+for `JWTAuthManager`.
+
+## Disposition
+
+- File a follow-up GH issue (HUMAN-GATED per `upstream-issue-hygiene.md` — drafted,
+  awaiting user approval to file).
+- Recommended fix when picked up: wire `MiddlewareAuthManager` to delegate
+  verification to `JWTAuthManager`, OR give it its own injectable
+  `TokenRevocationStore` + jti issuance.
+
+## Cross-SDK (cross-sdk-inspection.md)
+
+kailash-rs JWT middleware should be inspected for the same revocation-propagation
+gap. Cross-repo (`esperie-enterprise/kailash-rs`, private) → human-gated; not
+acted on from this session per `repo-scope-discipline.md`.


### PR DESCRIPTION
## Summary

`JWTAuthManager` backed token revocation with a per-instance in-memory `set`, so a token revoked on one worker stayed valid on every other worker in any multi-worker / multi-pod deployment — the revocation security control silently failed to take effect (#1356).

This introduces a synchronous, pluggable `TokenRevocationStore`:
- `verify_token` / `revoke_token` stay **synchronous** (they're on the per-request hot path; making them async would break every caller), so the store contract is sync.
- Default `InMemoryTokenRevocationStore` preserves the original process-local behavior.
- An injectable **shared** backend (Redis / DB / distributed cache) propagates revocation across every worker that shares it — supplied via `JWTAuthManager(revocation_store=...)`.
- `verify_token` checks the store **after decode**, keyed on `jti` (the canonical revocation identity a shared store keys on); the existing `jwt.InvalidTokenError("Token has been revoked")` is unchanged (no caller breakage).

## Acceptance criteria (#1356)

- [x] `revoke_token()` propagates via a pluggable shared store (injectable backend) **and** the docstring documents the process-local default + multi-worker guidance.
- [x] Regression tests assert the chosen contract — cross-instance shared-store propagation **and** the documented single-process default.

## Scope (documented, not silently dropped)

Access-token revocation is fixed. Refresh-token tracking and rate-limit accounting remain per-instance in-memory — disclosed in the class docstring as a known limitation.

## /redteam — converged (3 rounds, L5)

- R1: surfaced unbounded-store-growth (M2) + ordering observability (M3) → fixed; sibling-verifier gap (H1) → separate-shard follow-up.
- R2: 0 critical/high/medium; 4 LOW (forged-`exp` TTL, dual-identifier coupling, naming, count-None) → all hardened.
- R3: **CONVERGED** — LOW fixes verified, no new findings.

## Tests

10 regression tests (`tests/unit/middleware/test_jwt_revocation_store.py`), all pass; 58 middleware tests pass; collection exit 0; clean logs.

```
$ .venv/bin/python -m pytest tests/unit/middleware/test_jwt_revocation_store.py -q
.......... 10 passed
```

## Follow-up (tracked, not in this PR)

`MiddlewareAuthManager` (separate legacy verifier) has no revocation capability at all — distinct from #1356; recorded as a GAP for a separate shard.

## Related issues

Fixes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)