### PR TITLE
release: kailash 2.38.2 (#1356 JWT pluggable revocation store)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.2] - 2026-06-18
+
+### Fixed
+
+- **(#1356) `JWTAuthManager` token revocation is now propagatable across workers.**
+  Revocation was backed by a per-instance in-memory `set`, so a token revoked on
+  one worker stayed valid on every other worker in any multi-worker / multi-pod
+  deployment — the revocation security control silently failed to take effect.
+  Token revocation now routes through a pluggable `TokenRevocationStore`
+  (exported from `kailash.middleware.auth`): inject a SHARED backend
+  (Redis / database / distributed cache) via `JWTAuthManager(revocation_store=...)`
+  and revocation propagates to every worker that shares it. The default
+  `InMemoryTokenRevocationStore` preserves the original process-local behavior
+  (single-process deployments are unaffected); the class docstring documents the
+  process-local default + the multi-worker shared-store guidance. `verify_token`
+  / `revoke_token` remain synchronous (no API break) and the revoked-token
+  exception is unchanged. The decode-failure revocation path is TTL-bounded so it
+  cannot grow the store without limit.
+
+### Added
+
+- **`TokenRevocationStore` / `InMemoryTokenRevocationStore`** in
+  `kailash.middleware.auth` — the synchronous pluggable revocation-backend
+  contract and its process-local default implementation (#1356).
+
 ## [2.38.1] - 2026-06-17
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.38.1"
+version = "2.38.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.38.1"
+__version__ = "2.38.2"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release-prep for **kailash 2.38.2** (patch). The #1356 fix already merged to main via PR #1360 (3 commits + redteam convergence). This PR bumps the version anchors + CHANGELOG only.

- `pyproject.toml`: 2.38.1 → 2.38.2
- `src/kailash/__init__.py`: `__version__` → 2.38.2
- `CHANGELOG.md`: [2.38.2] Fixed/Added entries for #1356

Branch `release/v2.38.2` → PR-gate matrix auto-skips per the `release/v*` convention (metadata-only diff).

## Related issues

Refs #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)