### PR TITLE
release: kailash-pact 0.12.1 + kailash-mcp 0.2.15 (sweep un-bumped src drift)

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.2.15] — 2026-06-18 — chore: release un-bumped #1258 byte-vector pins
+
+Patch release cutting the previously-unreleased `1e17d63df` source commit (#1258 —
+documented + pinned non-ASCII byte-vectors for the 4 MCP canonical encoders in
+`protocol/messages.py`). Documentation + test-vector pins only; zero runtime / API /
+behavior change. Released to keep the package source tree and PyPI in sync.
+
 ## [0.2.14] — 2026-05-09 — hotfix: aiohttp + websockets restored to core deps
 
 Hotfix release closing a pre-existing latent silent-None ImportError fallback in `transports/transports.py` that was masked by editable installs and exposed by the 0.2.13 clean-venv install verification (`pip install kailash-mcp==0.2.13` → `AttributeError: 'NoneType' object has no attribute 'ClientResponse'` at module-import time).

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.14"
+version = "0.2.15"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.14"
+__version__ = "0.2.15"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PACT Changelog
 
+## [0.12.1] — 2026-06-18 — chore: release un-bumped comment-only source change
+
+Patch release cutting the previously-unreleased `7abe1a2c2` source commit (reworded
+two `# type`-substring comments to dodge the `python-use-type-annotations` pygrep
+false positive + removed one verified-dead duplicate local import in
+`engine.py::verify_audit_chain`). No runtime behavior change; AST parses unchanged.
+Released to keep the package source tree and PyPI in sync.
+
 ## [0.12.0] — 2026-05-09 — slim-core decoupling: `[api]` + `[execution]` extras (#890)
 
 Minor release shipping the kailash-pact side of the kailash 2.18.0 / #890 slim-core decoupling. **Install-shape breaking change** — fastapi, slowapi, kailash-kaizen, and psycopg are no longer pulled by the bare `pip install kailash-pact`. Users hitting the governance HTTP API or kaizen-driven supervisor surfaces MUST install the matching extra (or `[all]` for the pre-0.12.0 install shape).

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.12.0"
+version = "0.12.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (


### PR DESCRIPTION
Metadata-only release-prep sweeping two previously-unreleased source commits already on main, so the package source trees and PyPI are in sync (pristine).

- **kailash-pact 0.12.0 → 0.12.1** — `7abe1a2c2` (comment reword to dodge a `python-use-type-annotations` pygrep false positive + one verified-dead duplicate-import removal). No runtime behavior change.
- **kailash-mcp 0.2.14 → 0.2.15** — `1e17d63df` (#1258: documented + pinned non-ASCII byte-vectors for the 4 MCP canonical encoders). Doc/test-vector only; zero runtime change.

Both are version bump (pyproject + `__init__`) + CHANGELOG only on this branch. `release/`-prefixed → PR-gate matrix auto-skips.

## Related issues

Refs #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)