### PR TITLE
feat(middleware-auth): token revocation for MiddlewareAuthManager (#1356 sibling)

### DIFF
--- a/src/kailash/middleware/auth/auth_manager.py
+++ b/src/kailash/middleware/auth/auth_manager.py
@@ -166,6 +166,25 @@ class MiddlewareAuthManager:
                 name="auth_database", connection_string=database_url
             )
 
+    def _emit_security_event(
+        self, event_type: str, severity: str, details: Dict[str, Any]
+    ) -> None:
+        """Emit a security event best-effort — observability MUST NOT break auth.
+
+        The auth decision is made by the caller (which raises the 401); security
+        logging is a side effect. If ``SecurityEventNode`` raises (bad input,
+        backend down), swallow it and record a fallback line via the module
+        logger so a logging failure can NEVER convert the caller's deliberate
+        401 into a 500. Pairs with the revoked/verification-failed call sites,
+        which raise their own ``HTTPException`` after this returns.
+        """
+        try:
+            self.security_logger.execute(
+                event_type=event_type, severity=severity, details=details
+            )
+        except Exception:  # pragma: no cover - logging failure must not break auth
+            logger.warning("security event logging failed for %s", event_type)
+
     async def create_access_token(
         self,
         user_id: str,
@@ -249,10 +268,10 @@ class MiddlewareAuthManager:
                     jti=payload.get("jti"), token=token
                 )
             ):
-                self.security_logger.execute(
-                    event_type="token_revoked",
-                    severity="MEDIUM",
-                    details={"reason": "token presented after revocation"},
+                self._emit_security_event(
+                    "token_revoked",
+                    "MEDIUM",
+                    {"reason": "token presented after revocation"},
                 )
                 raise HTTPException(status_code=401, detail="Token has been revoked")
 
@@ -268,11 +287,9 @@ class MiddlewareAuthManager:
             # than masking it as a generic "Invalid authentication token".
             raise
         except Exception as e:
-            # Log security event
-            self.security_logger.execute(
-                event_type="token_verification_failed",
-                severity="MEDIUM",
-                details={"error": str(e)},
+            # Log security event (best-effort — never lets logging break the 401).
+            self._emit_security_event(
+                "token_verification_failed", "MEDIUM", {"error": str(e)}
             )
             raise HTTPException(status_code=401, detail="Invalid authentication token")
 
@@ -417,11 +434,9 @@ class MiddlewareAuthManager:
         except HTTPException:
             raise
         except Exception as e:
-            # Log security event
-            self.security_logger.execute(
-                event_type="api_key_verification_failed",
-                severity="MEDIUM",
-                details={"error": str(e)},
+            # Log security event (best-effort — never lets logging break the 401).
+            self._emit_security_event(
+                "api_key_verification_failed", "MEDIUM", {"error": str(e)}
             )
             raise HTTPException(status_code=401, detail="Invalid API key")
 

--- a/src/kailash/middleware/auth/auth_manager.py
+++ b/src/kailash/middleware/auth/auth_manager.py
@@ -9,6 +9,7 @@ Moved from middleware/auth.py to resolve directory/file confusion.
 
 import logging
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -40,6 +41,7 @@ from ...nodes.security import (
     SecurityEventNode,
 )
 from ...nodes.transform import DataTransformer
+from .revocation import InMemoryTokenRevocationStore, TokenRevocationStore
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +78,8 @@ class MiddlewareAuthManager:
         enable_api_keys: bool = True,
         enable_audit: bool = True,
         database_url: Optional[str] = None,
+        enable_blacklist: bool = True,
+        revocation_store: Optional[TokenRevocationStore] = None,
     ):
         """
         Initialize SDK Auth Manager.
@@ -86,10 +90,32 @@ class MiddlewareAuthManager:
             enable_api_keys: Enable API key authentication
             enable_audit: Enable audit logging
             database_url: Database URL for persistence
+            enable_blacklist: Enable token revocation. When True (default) a
+                ``TokenRevocationStore`` is held and ``verify_token`` rejects
+                revoked tokens; when False no store is held and revocation is a
+                no-op (issue #1356 sibling).
+            revocation_store: Backend that records and checks token revocation.
+                When ``enable_blacklist`` is True and this is omitted, a
+                process-local :class:`InMemoryTokenRevocationStore` is used —
+                revocations are visible only within this worker. In a
+                multi-worker deployment supply a shared backend (Redis, database,
+                distributed cache) implementing :class:`TokenRevocationStore` so
+                revocation propagates to every worker. Ignored when
+                ``enable_blacklist`` is False.
         """
         self.token_expiry_hours = token_expiry_hours
         self.enable_api_keys = enable_api_keys
         self.enable_audit = enable_audit
+        self.enable_blacklist = enable_blacklist
+
+        # Token revocation backend (issue #1356 sibling — MiddlewareAuthManager).
+        # When blacklisting is enabled, use the injected shared store if provided,
+        # else a process-local default. A SHARED store propagates revocation across
+        # every worker that shares it; the default InMemoryTokenRevocationStore is
+        # process-local. When disabled, no store is held and revocation is a no-op.
+        self._revocation_store: Optional[TokenRevocationStore] = None
+        if enable_blacklist:
+            self._revocation_store = revocation_store or InMemoryTokenRevocationStore()
 
         # Initialize SDK security nodes
         self._initialize_security_nodes(secret_key or "", database_url or "")
@@ -162,6 +188,10 @@ class MiddlewareAuthManager:
             "user_id": user_id,
             "permissions": permissions or [],
             "metadata": metadata or {},
+            # jti (JWT ID) is the canonical revocation identity a shared
+            # TokenRevocationStore keys on, so revocation propagates across
+            # workers (issue #1356 sibling).
+            "jti": str(uuid.uuid4()),
             "exp": datetime.now(timezone.utc)
             + timedelta(hours=self.token_expiry_hours),
             "iat": datetime.now(timezone.utc),
@@ -207,20 +237,106 @@ class MiddlewareAuthManager:
             # Verify JWT token
             payload = jwt.decode(token, self.secret_key, algorithms=["HS256"])
 
+            # Reject revoked tokens (issue #1356 sibling). Checked AFTER decode so
+            # the revocation identity (jti) is available — the key a shared store
+            # uses so revocation propagates across workers. Pass BOTH jti AND token:
+            # revoke() keys on `jti or token`, so a token revoked before its jti
+            # was known (decode-failure path) is keyed by raw token; dropping
+            # `token=` here would silently stop enforcing those revocations.
+            if (
+                self._revocation_store is not None
+                and self._revocation_store.is_revoked(
+                    jti=payload.get("jti"), token=token
+                )
+            ):
+                self.security_logger.execute(
+                    event_type="token_revoked",
+                    severity="MEDIUM",
+                    details={"reason": "token presented after revocation"},
+                )
+                raise HTTPException(status_code=401, detail="Token has been revoked")
+
             # Check expiration
             if payload.get("exp", 0) < datetime.now(timezone.utc).timestamp():
                 raise HTTPException(status_code=401, detail="Token has expired")
 
             return payload
 
+        except HTTPException:
+            # A deliberate auth rejection (revoked / expired) already carries its
+            # own status + detail + security-event log — propagate it as-is rather
+            # than masking it as a generic "Invalid authentication token".
+            raise
         except Exception as e:
             # Log security event
             self.security_logger.execute(
                 event_type="token_verification_failed",
-                severity="warning",
+                severity="MEDIUM",
                 details={"error": str(e)},
             )
             raise HTTPException(status_code=401, detail="Invalid authentication token")
+
+    async def revoke_token(self, token: str) -> None:
+        """
+        Revoke an access token so subsequent ``verify_token`` calls reject it.
+
+        With a shared :class:`TokenRevocationStore` this propagates to every
+        worker that shares it; with the default in-memory store it is
+        process-local (issue #1356 sibling — MiddlewareAuthManager). When
+        ``enable_blacklist`` is False this is a no-op.
+
+        Args:
+            token: JWT token string to revoke. A malformed/expired token is still
+                recorded (by raw token string) so a token presented for
+                revocation is never silently ignored.
+        """
+        if self._revocation_store is None:
+            return
+
+        user_id: Optional[str] = None
+        try:
+            payload = jwt.decode(token, self.secret_key, algorithms=["HS256"])
+            user_id = payload.get("user_id")
+            jti = payload.get("jti")
+            exp = payload.get("exp")
+            expires_at = datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
+            self._revocation_store.revoke(jti=jti, token=token, expires_at=expires_at)
+        except Exception:
+            # Even if verification fails, revoke by raw token string so a
+            # malformed/expired token presented for revocation is still recorded.
+            # Bound the entry's TTL so an attacker spamming revoke with unique
+            # invalid strings cannot grow the store without limit. The longest a
+            # legitimately-issued access token can remain presentable is
+            # token_expiry_hours; cap the entry there so a FORGED far-future `exp`
+            # in an unverified token cannot extend the entry's lifetime beyond it
+            # (no presentable token outlives the cap, so the entry self-purges
+            # without ever evicting a still-valid token).
+            ttl_cap = datetime.now(timezone.utc) + timedelta(
+                hours=self.token_expiry_hours
+            )
+            expires_at = ttl_cap
+            try:
+                unverified = jwt.decode(
+                    token, options={"verify_signature": False, "verify_exp": False}
+                )
+                exp = unverified.get("exp")
+                if exp:
+                    expires_at = min(
+                        datetime.fromtimestamp(exp, tz=timezone.utc), ttl_cap
+                    )
+            except Exception:
+                expires_at = ttl_cap
+            self._revocation_store.revoke(jti=None, token=token, expires_at=expires_at)
+
+        # Audit log
+        if self.enable_audit:
+            self.audit_logger.execute(
+                user_id=user_id or "unknown",
+                action="revoke_token",
+                resource_type="jwt_token",
+                resource_id=user_id or "unknown",
+                details={"revoked": True},
+            )
 
     async def create_api_key(
         self, user_id: str, key_name: str, permissions: Optional[List[str]] = None
@@ -304,7 +420,7 @@ class MiddlewareAuthManager:
             # Log security event
             self.security_logger.execute(
                 event_type="api_key_verification_failed",
-                severity="warning",
+                severity="MEDIUM",
                 details={"error": str(e)},
             )
             raise HTTPException(status_code=401, detail="Invalid API key")

--- a/tests/unit/middleware/test_middleware_auth_revocation.py
+++ b/tests/unit/middleware/test_middleware_auth_revocation.py
@@ -1,0 +1,296 @@
+"""Tests for MiddlewareAuthManager token revocation (sibling of issue #1356).
+
+`MiddlewareAuthManager` is a second, independent JWT verifier in the same
+package as `JWTAuthManager`. Before this change it had NO revocation capability:
+`verify_token` did `jwt.decode` + a manual exp check with no revocation
+consultation, no `jti` claim, and no `revoke_token` method — so a token could
+never be invalidated before its natural expiry. #1356 fixed the equivalent gap
+in `JWTAuthManager` via a pluggable `TokenRevocationStore`; this change wires the
+SAME shared contract into `MiddlewareAuthManager`, so one store can back BOTH
+managers in a deployment and revocation propagates across every worker.
+
+These tests pin the contract:
+- a `jti` claim is issued (the shared-store revocation key),
+- `verify_token` rejects a revoked token with the specific 'revoked' message,
+- revocation propagates via a shared store (the multi-worker scenario),
+- the default store is documented-process-local,
+- `enable_blacklist=False` keeps revocation a no-op,
+- the decode-failure fallback records by raw token AND is TTL-bounded,
+- backward compat: a pre-change token (no jti) still verifies,
+- the FastAPI dependency rejects a revoked bearer token.
+
+It ALSO regression-pins a pre-existing bug fixed alongside the feature: an
+invalid/expired token MUST surface a clean `HTTPException(401)` — the prior
+`severity="warning"` (not a valid `SeverityLevel`) made the security-event log
+raise `ValueError`, which escaped `verify_token` as a non-401 error.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+from starlette.exceptions import HTTPException
+
+from kailash.middleware.auth import InMemoryTokenRevocationStore, TokenRevocationStore
+from kailash.middleware.auth.auth_manager import MiddlewareAuthManager
+
+SECRET = "a-very-long-secret-key-at-least-32-chars!"
+
+
+def _mgr(**overrides) -> MiddlewareAuthManager:
+    # enable_audit=False keeps the unit tests free of audit-node side effects;
+    # the revocation path does not depend on audit logging.
+    overrides.setdefault("secret_key", SECRET)
+    overrides.setdefault("enable_audit", False)
+    return MiddlewareAuthManager(**overrides)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_access_token_carries_jti():
+    """create_access_token stamps a jti — the canonical revocation identity."""
+    mgr = _mgr()
+    token = await mgr.create_access_token("u1", ["read"])
+    payload = pyjwt.decode(token, SECRET, algorithms=["HS256"])
+    assert "jti" in payload and payload["jti"], "access token has no jti claim"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_revoked_token_rejected_with_revoked_message():
+    """A manager rejects a token it revoked, with the specific 'revoked' detail.
+
+    Pins the post-decode ordering: a non-expired revoked token surfaces the
+    revocation reason (not a generic decode error), so callers can distinguish
+    revoked from malformed.
+    """
+    mgr = _mgr()
+    token = await mgr.create_access_token("u9")
+    assert (await mgr.verify_token(token))["user_id"] == "u9"
+
+    await mgr.revoke_token(token)
+
+    with pytest.raises(HTTPException) as exc:
+        await mgr.verify_token(token)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Token has been revoked"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_revocation_propagates_via_shared_store():
+    """Two managers sharing ONE store reject a token revoked on either.
+
+    Models two worker processes that share a distributed revocation backend —
+    the multi-worker scenario #1356 was about, now extended to
+    MiddlewareAuthManager.
+    """
+    shared = InMemoryTokenRevocationStore()
+    worker_a = _mgr(revocation_store=shared)
+    worker_b = _mgr(revocation_store=shared)
+
+    token = await worker_a.create_access_token("u1")
+    assert (await worker_a.verify_token(token))["user_id"] == "u1"
+    assert (await worker_b.verify_token(token))["user_id"] == "u1"
+
+    await worker_a.revoke_token(token)
+
+    with pytest.raises(HTTPException):
+        await worker_a.verify_token(token)
+    # The fix: worker_b — which never called revoke — also rejects it.
+    with pytest.raises(HTTPException):
+        await worker_b.verify_token(token)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_default_store_is_process_local():
+    """The default (no shared store) is process-local — documented limitation.
+
+    Multi-worker deployments MUST inject a shared store (see
+    test_revocation_propagates_via_shared_store).
+    """
+    worker_a = _mgr()  # default in-memory store
+    worker_b = _mgr()  # separate default store
+
+    token = await worker_a.create_access_token("u1")
+    await worker_a.revoke_token(token)
+
+    with pytest.raises(HTTPException):
+        await worker_a.verify_token(token)
+    # Process-local default: worker_b still accepts (separate in-memory store).
+    assert (await worker_b.verify_token(token))["user_id"] == "u1"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_blacklist_disabled_means_no_store_and_no_revocation():
+    """enable_blacklist=False holds no store and keeps revocation a no-op."""
+    mgr = _mgr(enable_blacklist=False)
+    assert mgr._revocation_store is None
+    token = await mgr.create_access_token("u1")
+    await mgr.revoke_token(token)  # no-op
+    # Token still verifies because revocation is disabled.
+    assert (await mgr.verify_token(token))["user_id"] == "u1"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_revoke_when_decode_fails_records_raw_token():
+    """A malformed token presented to revoke_token is recorded by raw string.
+
+    Preserves the 'revoke even if verification fails' behavior so a token
+    presented for revocation is never silently ignored.
+    """
+    store = InMemoryTokenRevocationStore()
+    mgr = _mgr(revocation_store=store)
+    garbage = "not.a.valid.jwt"
+    await mgr.revoke_token(garbage)
+    assert store.is_revoked(token=garbage) is True
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_revoke_fallback_caps_forged_future_exp_at_token_expiry():
+    """A forged far-future exp on an unverifiable token cannot extend entry TTL.
+
+    The decode-failure fallback reads exp from an UNVERIFIED decode
+    (attacker-controllable). The entry TTL MUST be capped at the access-token
+    lifetime so a forged exp=year-3000 cannot pin the entry for centuries.
+    """
+    store = InMemoryTokenRevocationStore()
+    mgr = _mgr(revocation_store=store, token_expiry_hours=24)
+    far_future = datetime(3000, 1, 1, tzinfo=timezone.utc)
+    forged = pyjwt.encode(
+        {"user_id": "x", "exp": far_future},
+        "a-different-secret-key-also-32-chars-x!",  # foreign key → verify fails
+        algorithm="HS256",
+    )
+    await mgr.revoke_token(forged)  # fails verify -> fallback with forged future exp
+    stored_exp = store._revoked[forged]  # inspect the entry's bound TTL
+    cap = datetime.now(timezone.utc) + timedelta(hours=24)
+    assert stored_exp is not None
+    assert stored_exp <= cap, "forged future exp was not capped at token_expiry_hours"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_revoke_unverifiable_already_expired_token_self_purges():
+    """A revoked-but-already-expired unverifiable token does NOT linger forever."""
+    store = InMemoryTokenRevocationStore()
+    mgr = _mgr(revocation_store=store)
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    foreign = pyjwt.encode(
+        {"user_id": "x", "jti": "j1", "exp": past},
+        "a-different-secret-key-also-32-chars-x!",
+        algorithm="HS256",
+    )
+    await mgr.revoke_token(foreign)  # fails verify -> fallback bounded by past exp
+    assert store.is_revoked(token=foreign) is False
+    assert store.count() == 0
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_backward_compat_token_without_jti_still_verifies():
+    """A pre-change token (no jti claim) still verifies — not falsely rejected.
+
+    Guards the upgrade path: tokens minted before this change carry no jti, so
+    is_revoked(jti=None, token=...) keys only on the raw token against an empty
+    store and returns False.
+    """
+    mgr = _mgr()
+    legacy = pyjwt.encode(
+        {
+            "user_id": "old",
+            "permissions": [],
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    assert "jti" not in pyjwt.decode(legacy, SECRET, algorithms=["HS256"])
+    assert (await mgr.verify_token(legacy))["user_id"] == "old"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_custom_revocation_store_protocol_shape():
+    """A custom in-process backend satisfying the contract works end-to-end."""
+
+    class DictStore(TokenRevocationStore):
+        def __init__(self):
+            self.revoked: set[str] = set()
+
+        def revoke(self, *, jti=None, token=None, expires_at=None):
+            ident = jti or token
+            if ident:
+                self.revoked.add(ident)
+
+        def is_revoked(self, *, jti=None, token=None):
+            return any(i and i in self.revoked for i in (jti, token))
+
+    store = DictStore()
+    mgr = _mgr(revocation_store=store)
+    token = await mgr.create_access_token("custom")
+    await mgr.revoke_token(token)
+    assert len(store.revoked) == 1
+    with pytest.raises(HTTPException):
+        await mgr.verify_token(token)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_invalid_token_raises_clean_401_not_valueerror():
+    """Regression: invalid/expired tokens surface HTTPException(401), not ValueError.
+
+    Before the fix, verify_token's error path logged the security event with
+    severity="warning" — not a valid SeverityLevel (CRITICAL/HIGH/MEDIUM/LOW/INFO)
+    — so SecurityEventNode raised ValueError, which escaped verify_token as a
+    non-401 error. The fix maps the severity to a valid level.
+    """
+    mgr = _mgr()
+    with pytest.raises(HTTPException) as exc:
+        await mgr.verify_token("garbage.token.value")
+    assert exc.value.status_code == 401
+
+    # Expired token: also a clean 401, not a ValueError.
+    expired_mgr = _mgr(token_expiry_hours=-1)
+    expired = await expired_mgr.create_access_token("u2")
+    with pytest.raises(HTTPException) as exc2:
+        await expired_mgr.verify_token(expired)
+    assert exc2.value.status_code == 401
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_dependency_rejects_revoked_bearer_token():
+    """End-to-end through the FastAPI dependency: a revoked bearer token → 401.
+
+    The user-facing composition: get_current_user_dependency calls verify_token;
+    a revoked token makes it fall through to the final 'Not authenticated' 401.
+    """
+    from fastapi.security import HTTPAuthorizationCredentials
+    from starlette.requests import Request
+
+    mgr = _mgr()
+    token = await mgr.create_access_token("u1", ["read"])
+    dep = mgr.get_current_user_dependency()
+
+    scope = {"type": "http", "headers": [], "method": "GET", "path": "/"}
+    request = Request(scope)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    # Before revocation: the dependency resolves the user.
+    user = await dep(request, creds)
+    assert user["user_id"] == "u1"
+
+    await mgr.revoke_token(token)
+
+    # After revocation: verify_token raises 401; the dependency has no API key
+    # fallback header, so it surfaces the final 401.
+    with pytest.raises(HTTPException) as exc:
+        await dep(request, creds)
+    assert exc.value.status_code == 401

--- a/tests/unit/middleware/test_middleware_auth_revocation.py
+++ b/tests/unit/middleware/test_middleware_auth_revocation.py
@@ -266,6 +266,27 @@ async def test_invalid_token_raises_clean_401_not_valueerror():
 
 @pytest.mark.regression
 @pytest.mark.asyncio
+async def test_revoke_token_audit_path_does_not_raise():
+    """revoke_token with enable_audit=True (the PRODUCTION default) exercises the
+    audit_logger.execute path and must not raise.
+
+    Pins the audit branch against the same kwarg/severity-mismatch bug class that
+    made the security-event log raise ValueError before this change — every other
+    test in this file sets enable_audit=False, so this is the only coverage of the
+    `if self.enable_audit: self.audit_logger.execute(...)` block in revoke_token.
+    """
+    # enable_audit defaults True; do NOT use the _mgr helper (it forces it off).
+    mgr = MiddlewareAuthManager(secret_key=SECRET, enable_audit=True)
+    token = await mgr.create_access_token("u-audit")
+    await mgr.revoke_token(token)  # audit logging runs here; must not raise
+    # The revocation still took effect through the audited path.
+    with pytest.raises(HTTPException) as exc:
+        await mgr.verify_token(token)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
 async def test_dependency_rejects_revoked_bearer_token():
     """End-to-end through the FastAPI dependency: a revoked bearer token → 401.
 

--- a/tests/unit/middleware/test_middleware_auth_revocation.py
+++ b/tests/unit/middleware/test_middleware_auth_revocation.py
@@ -287,6 +287,33 @@ async def test_revoke_token_audit_path_does_not_raise():
 
 @pytest.mark.regression
 @pytest.mark.asyncio
+async def test_logging_failure_does_not_break_revocation_401():
+    """A SecurityEventNode failure MUST NOT convert the revoked-token 401 into a 500.
+
+    Regression for the R1/R2 bypass-lens finding: security-event logging is
+    best-effort (`_emit_security_event` swallows backend failures), so a revoked
+    token still surfaces a clean HTTPException(401) — never a raw exception / 500 —
+    even if the logging backend raises. The auth decision is fail-closed and
+    independent of observability.
+    """
+    mgr = _mgr()
+    token = await mgr.create_access_token("u1")
+    await mgr.revoke_token(token)
+
+    # Fault-inject: the security-event logging backend raises (e.g. backend down).
+    def _boom(*args, **kwargs):
+        raise RuntimeError("security log backend down")
+
+    mgr.security_logger.execute = _boom  # type: ignore[assignment]
+
+    with pytest.raises(HTTPException) as exc:
+        await mgr.verify_token(token)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Token has been revoked"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
 async def test_dependency_rejects_revoked_bearer_token():
     """End-to-end through the FastAPI dependency: a revoked bearer token → 401.
 

--- a/workspaces/issue-1356-jwt-revocation/journal/0002-DECISION-middleware-auth-revocation-implemented.md
+++ b/workspaces/issue-1356-jwt-revocation/journal/0002-DECISION-middleware-auth-revocation-implemented.md
@@ -1,0 +1,88 @@
+---
+type: DECISION
+date: 2026-06-18
+author: co-authored
+project: issue-1356-jwt-revocation
+topic: MiddlewareAuthManager token revocation (F1 sibling of #1356) implemented
+phase: implement
+tags: [auth, jwt, revocation, security, cross-sdk, "1356-sibling"]
+---
+
+# DECISION — MiddlewareAuthManager token revocation implemented (F1)
+
+Closes the F1 gap recorded in `0001-GAP-sibling-verifier-no-revocation.md`:
+`MiddlewareAuthManager.verify_token` had no revocation capability (no `jti`, no
+store consultation, no `revoke_token`). User directive this session: continue to
+convergence under `/autonomize`.
+
+## Approach chosen — Option 2 (own injectable store), NOT Option 1 (delegate)
+
+The gap journal offered two fixes: (1) delegate verification to `JWTAuthManager`,
+or (2) give `MiddlewareAuthManager` its own injectable `TokenRevocationStore` +
+jti issuance. **Chose Option 2** because:
+
+- It reuses the EXACT shared `TokenRevocationStore` ABC that #1356 shipped
+  (`kailash/middleware/auth/revocation.py`), so ONE shared store can back BOTH
+  managers in a deployment — the cross-worker propagation #1356 was about.
+- Option 1 would force `MiddlewareAuthManager` to adopt `JWTAuthManager`'s token
+  format/claims (different shape: `sub`/`tenant_id`/`token_type` vs
+  `user_id`/`permissions`/`metadata`), a breaking change to its token contract.
+  Option 2 is purely additive: it ADDS a `jti` claim, leaving existing claims
+  intact.
+
+## Changes (all in `src/kailash/middleware/auth/auth_manager.py`)
+
+1. `__init__`: `enable_blacklist: bool = True` (matches `JWTConfig.enable_blacklist`
+   default) + `revocation_store: Optional[TokenRevocationStore] = None`; wires
+   `self._revocation_store = (revocation_store or InMemoryTokenRevocationStore())
+if enable_blacklist else None` — mirrors `JWTAuthManager.__init__`.
+2. `create_access_token`: adds `"jti": str(uuid.uuid4())` (the shared-store key).
+3. `verify_token`: after decode, rejects `is_revoked(jti=, token=)` (BOTH passed
+   per the #1356 invariant) with `HTTPException(401, "Token has been revoked")`;
+   restructured the `except` so a deliberate 401 (revoked/expired) propagates
+   with its real detail (`except HTTPException: raise` before the generic catch).
+4. `revoke_token` (NEW, **async** per `patterns.md` paired-surface rule — create/
+   verify/revoke must share async-ness): verify→extract jti+exp→revoke;
+   decode-failure fallback revokes by raw token with TTL capped at
+   `token_expiry_hours` (forged-future-exp defense, mirrors #1356).
+
+## Pre-existing bug found + fixed (zero-tolerance Rule 1 — same file)
+
+Three `security_logger.execute(severity="warning")` sites (1 new + 2 pre-existing
+in `verify_token`/`verify_api_key`) passed an INVALID `SeverityLevel` — valid
+values are `CRITICAL/HIGH/MEDIUM/LOW/INFO`. `SecurityEventNode` raised
+`ValueError("'warning' is not a valid SeverityLevel")`, so before this change
+EVERY invalid/expired token escaped `verify_token` as a raw `ValueError`, not a
+clean 401. Fixed all three `"warning"→"MEDIUM"`. Regression-pinned by
+`test_invalid_token_raises_clean_401_not_valueerror`.
+
+## Tests
+
+`tests/unit/middleware/test_middleware_auth_revocation.py` — 12 regression tests:
+jti issuance, revoked-rejection-with-message, shared-store propagation,
+process-local default, `enable_blacklist=False` no-op, decode-failure raw-token
+record, forged-future-exp TTL cap, already-expired self-purge, backward-compat
+(pre-jti token still verifies), custom-store protocol shape, clean-401 regression,
+end-to-end FastAPI-dependency rejection. All 12 pass; #1356's 10 tests still pass.
+
+## Cross-SDK (F2 — NOT acted on this session)
+
+`cross-sdk-inspection.md` MUST-1: kailash-rs JWT middleware should be inspected
+for the same MiddlewareAuthManager-equivalent revocation gap. That is cross-repo
+(`esperie-enterprise/kailash-rs`, private) → human-gated per
+`repo-scope-discipline.md`; needs its own kailash-rs session. Surfaced, not acted.
+
+## For Discussion
+
+1. Counterfactual: if a deployment runs `MiddlewareAuthManager` AND
+   `JWTAuthManager` side by side but injects the shared store into only one,
+   revocations made through the other won't propagate — is documenting "inject
+   the same store into both" sufficient, or should a future Nexus auth facade
+   construct one store and pass it to both managers?
+2. The decode-failure fallback caps the TTL at `token_expiry_hours`; an operator
+   who sets a very long `token_expiry_hours` (e.g. 720h) gives forged-exp entries
+   a 30-day floor in the store. Is that acceptable, or should the cap be a
+   separate, shorter bound?
+3. `enable_blacklist=True` is the secure default and is backward-compatible
+   (additive jti + empty-store no-op). Should any existing deployment expect a
+   behavior change? (Analysis says no — confirm against any in-tree consumer.)

--- a/workspaces/issue-1356-jwt-revocation/journal/0003-DECISION-middleware-auth-revocation-redteam-convergence.md
+++ b/workspaces/issue-1356-jwt-revocation/journal/0003-DECISION-middleware-auth-revocation-redteam-convergence.md
@@ -1,0 +1,89 @@
+---
+type: DECISION
+date: 2026-06-18
+author: agent
+project: issue-1356-jwt-revocation
+topic: MiddlewareAuthManager revocation (F1) — redteam convergence + R1/R2 hardening
+phase: redteam
+tags: [auth, jwt, revocation, security, redteam, convergence, "1356-sibling"]
+relates_to: 0002-DECISION-middleware-auth-revocation-implemented
+---
+
+# DECISION — F1 redteam converged (R1 + R2), two LOW findings fixed
+
+Extends `0002` (which described the implement-phase 12-test state). Records the
+adversarial redteam-to-convergence on PR #1365 and the fixes it produced.
+
+## Redteam method
+
+4-lens adversarial review per round (concurrency capped at 3 per
+`worktree-isolation.md` Rule 4 after a 4-wide launch hit the synchronized
+server throttle), each lens producing schema'd findings, then adversarial
+verify of every MED+ finding:
+
+- **reviewer** (code correctness + mechanical sweeps)
+- **security-reviewer** (threat model: bypass / accept-on-error / DoS / leakage)
+- **closure-parity** (gap actually closed by delivered+tested code; #1356 parity)
+- **bypass-attacker** (ran a 9-vector Python probe attempting real bypasses)
+
+## Round receipts (durable, per `verify-resource-existence.md` MUST-4)
+
+- **R1** (workflow task `wxc08pd6a`): 4/4 lenses returned. reviewer APPROVE;
+  security + closure APPROVE_WITH_FIXES; bypass APPROVE (no bypass reproduced
+  across 9 vectors; fail-closed-on-store-down confirmed). 1 MED raised
+  (revocation-vs-expiration ordering) → **adversarially REFUTED** (jwt.decode
+  validates exp first; both paths reject). 0 confirmed-actionable MED+.
+- **R2** (workflow task `wfyx8e1j2`, after the R1 LOW fix): **all 4 lenses
+  APPROVE; 0 confirmed-actionable MED+.** Two consecutive clean rounds on the
+  security-critical surface = converged.
+
+## Fixes applied during convergence
+
+1. **R1 LOW (closure)** — `revoke_token`'s audit-log path (`enable_audit=True`,
+   the production default) had no test coverage; every test used
+   `enable_audit=False`. Added `test_revoke_token_audit_path_does_not_raise`
+   (commit 07ad10741). Same kwarg/severity-mismatch bug class as the severity
+   fix two lines away.
+2. **R2 LOW (bypass)** — a `SecurityEventNode.execute` failure inside the
+   revoked / verification-failed branch escaped `verify_token` as a raw
+   exception (HTTP 500) instead of a clean 401 (fail-closed availability defect,
+   NOT a bypass — the token was still rejected). Added a best-effort
+   `_emit_security_event` helper that swallows logging-backend failures (records
+   a fallback line via the module logger) and rewired all 3 security-event sites
+   (`token_revoked`, `token_verification_failed`, `api_key_verification_failed`)
+   through it. A logging failure can no longer convert a 401 into a 500. Pinned
+   by `test_logging_failure_does_not_break_revocation_401`.
+
+## Test count
+
+14 regression tests in `tests/unit/middleware/test_middleware_auth_revocation.py`
+(12 at implement-time per `0002`, +1 audit-path R1, +1 best-effort-logging R2).
+All 14 pass; #1356's 10 tests still pass (24 total). Count produced by
+`pytest --collect-only -q | grep -c '::'`.
+
+## Dispositioned, NOT changed (with rationale)
+
+- Decode-failure fallback re-decodes the token twice — **intentional parity**
+  with #1356's `jwt_auth.py`; changing it would diverge from the proven reference.
+- `details=` payload dropped by `SecurityEventNode` — **pre-existing node
+  behavior**; `event_type` already conveys the reason; changing the node is
+  out of scope for this PR.
+- Revocation-before-expiration ordering / manual exp check dead code — **INFO,
+  pre-existing**; jwt.decode validates exp first, so it is unreachable for
+  tokens carrying an exp claim. Not introduced by this PR.
+- Two tests inspect the store's private `_revoked` dict — **parity** with the
+  #1356 test pattern (no public API exposes the stored TTL to assert the cap).
+
+## For Discussion
+
+1. Counterfactual: the best-effort `_emit_security_event` now swallows ALL
+   SecurityEventNode failures — does silently dropping a security-event log
+   (with only a module-logger fallback) ever hide a signal an operator needs,
+   or is fail-closed-on-auth strictly the right trade for an auth hot path?
+2. The R2 bypass finding was availability-only (500 vs 401). Should the
+   #1356 `JWTAuthManager` reference adopt the same best-effort pattern for
+   cross-manager consistency, or is its non-raising stdlib logger already safe?
+3. Two consecutive clean rounds (R1 refuted-MED+R2 all-APPROVE) plus a post-fix
+   confirmation round is the convergence bar applied here — is that the right
+   rigor for a security-critical auth change, or is a single clean round after
+   the last fix sufficient given the fix is a defensive try/except?


### PR DESCRIPTION
## Summary

`MiddlewareAuthManager.verify_token` — the legacy nodes-based JWT verifier in
`kailash.middleware.auth`, exported as public API — had **no token-revocation
capability**: no `jti` claim, no revocation-store consultation, no `revoke_token`
method. A token could never be invalidated before its natural expiry. This was
surfaced by #1356's Round-1 security-reviewer as a sibling gap (#1356 fixed the
equivalent gap in `JWTAuthManager`).

This PR wires the **same pluggable `TokenRevocationStore`** #1356 shipped
(`kailash/middleware/auth/revocation.py`) into `MiddlewareAuthManager`, so one
shared store can back **both** managers in a deployment and revocation propagates
across every worker (the multi-worker scenario #1356 was about).

## What changed (`src/kailash/middleware/auth/auth_manager.py`)

- **`__init__`**: `enable_blacklist: bool = True` (matches `JWTConfig.enable_blacklist`) + injectable `revocation_store: Optional[TokenRevocationStore] = None`. Mirrors `JWTAuthManager.__init__`.
- **`create_access_token`**: stamps a `jti` claim (the shared-store revocation key).
- **`verify_token`**: after decode, rejects `is_revoked(jti=, token=)` (both passed per the #1356 invariant) with `HTTPException(401, "Token has been revoked")`; restructured the `except` so a deliberate auth 401 (revoked/expired) propagates with its real detail instead of being masked as a generic failure.
- **`revoke_token`** (new, **async** — paired-surface consistency per `patterns.md`): verify→extract `jti`+`exp`→revoke; decode-failure fallback revokes by raw token with TTL capped at `token_expiry_hours` (forged-future-exp defense, mirrors #1356).

**Backward-compatible & secure-by-default:** purely additive (adds a `jti` claim; existing `user_id`/`permissions`/`metadata` claims unchanged); pre-change tokens (no `jti`) still verify against an empty store; new ctor args are keyword defaults so existing call sites are unaffected.

## Pre-existing bug fixed (zero-tolerance Rule 1, same file)

Three `security_logger.execute(severity="warning")` sites (1 new + 2 pre-existing in `verify_token`/`verify_api_key`) passed an **invalid `SeverityLevel`** — valid values are `CRITICAL/HIGH/MEDIUM/LOW/INFO`. `SecurityEventNode` raised `ValueError("'warning' is not a valid SeverityLevel")`, so **every invalid/expired token already escaped `verify_token` as a raw `ValueError`, not a clean 401**. Mapped all three to `"MEDIUM"`. Regression-pinned.

## Tests

`tests/unit/middleware/test_middleware_auth_revocation.py` — 14 regression tests: jti issuance · revoked-rejection-with-message · shared-store propagation · process-local default · `enable_blacklist=False` no-op · decode-failure raw-token record · forged-future-exp TTL cap · already-expired self-purge · backward-compat (pre-`jti` token still verifies) · custom-store protocol shape · clean-401 regression · end-to-end FastAPI-dependency rejection. All 12 pass; #1356's 10 tests still pass.

## Cross-SDK note

Per `cross-sdk-inspection.md` MUST-1, kailash-rs JWT middleware should be inspected for the same revocation gap. That is cross-repo (private) and **human-gated** — surfaced here, not acted on in this session.

## Related issues

Sibling of #1356 (kailash 2.38.2). No separate issue was filed — the gap was recorded in the #1356 workspace journal (`0001-GAP-sibling-verifier-no-revocation.md`) and picked up under autonomous continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)