### PR TITLE
release: kailash 2.38.3 (#1356 sibling — MiddlewareAuthManager token revocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.3] - 2026-06-18
+
+### Added
+
+- **`MiddlewareAuthManager` token revocation** (sibling of #1356). The legacy
+  nodes-based JWT verifier (`kailash.middleware.auth.MiddlewareAuthManager`) had
+  no revocation capability at all — no `jti` claim, no revocation-store
+  consultation in `verify_token`, and no `revoke_token` method, so an issued
+  token could never be invalidated before its natural expiry. It now reuses the
+  SAME pluggable `TokenRevocationStore` introduced for `JWTAuthManager` in
+  #1356: tokens carry a `jti` claim, `verify_token` rejects revoked tokens
+  (HTTP 401 `Token has been revoked`), and a new `async revoke_token(token)`
+  records the revocation. Inject a SHARED backend via
+  `MiddlewareAuthManager(revocation_store=...)` so revocation propagates across
+  every worker; the default `InMemoryTokenRevocationStore` is process-local
+  (`enable_blacklist=True` by default). Purely additive — existing token claims
+  are unchanged and pre-2.38.3 tokens (no `jti`) still verify. The
+  decode-failure revoke path is TTL-bounded at `token_expiry_hours` so an
+  attacker cannot grow the store with unique invalid strings.
+
+### Fixed
+
+- **`MiddlewareAuthManager.verify_token` / `verify_api_key` returned an internal
+  error instead of HTTP 401 on an invalid token.** The security-event log calls
+  passed `severity="warning"`, which is not a valid `SeverityLevel`
+  (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`), so `SecurityEventNode` raised
+  `ValueError` — meaning every invalid or expired token escaped `verify_token`
+  as an unhandled exception rather than a clean 401. The severity is now
+  `MEDIUM`, and security-event logging is best-effort (a logging-backend failure
+  can no longer convert an auth rejection into a 500).
+
 ## [2.38.2] - 2026-06-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.38.2"
+version = "2.38.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.38.2"
+__version__ = "2.38.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Patch release cutting the `MiddlewareAuthManager` token-revocation work merged in PR #1365.

## Scope
- **`kailash` core only**: `2.38.2 → 2.38.3` (patch). No sibling drift — all 8 sub-packages at PyPI parity.
- Metadata-only diff (version anchors + CHANGELOG); the code already landed on main via #1365.

## What shipped (PR #1365, 3-round /redteam converged, all lenses APPROVE, bypass-proof)
- `MiddlewareAuthManager` token revocation via the #1356 `TokenRevocationStore` (jti claim + `verify_token` revocation check + async `revoke_token`; shared-store cross-worker propagation).
- Pre-existing bug fix: invalid/expired tokens now return a clean HTTP 401 instead of escaping as an internal error (`severity="warning"` → `"MEDIUM"`; best-effort security-event logging).

## Why patch
Fundamentally a security fix + bug fix (the new API is the mechanism), matching the #1356 patch precedent (2.38.2).

## Related issues
Sibling of #1356 (kailash 2.38.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)