### PR TITLE
feat(pact): KSP/Bridge access-control scoping & precedence (#1368–#1374)

### DIFF
--- a/packages/kailash-pact/src/pact/governance/api/endpoints.py
+++ b/packages/kailash-pact/src/pact/governance/api/endpoints.py
@@ -28,8 +28,9 @@ from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
 
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance, VettingStatus
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
@@ -37,7 +38,9 @@ from kailash.trust.pact.config import (
     OperationalConstraintConfig,
     TrustPostureLevel,
 )
-from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.envelopes import RoleEnvelope
+from kailash.trust.pact.knowledge import KnowledgeItem
 from pact.governance.api.auth import GovernanceAuth
 from pact.governance.api.events import GovernanceEventType, emit_governance_event
 from pact.governance.api.schemas import (
@@ -52,10 +55,6 @@ from pact.governance.api.schemas import (
     VerifyActionRequest,
     VerifyActionResponse,
 )
-from kailash.trust.pact.clearance import RoleClearance, VettingStatus
-from kailash.trust.pact.engine import GovernanceEngine
-from kailash.trust.pact.envelopes import RoleEnvelope
-from kailash.trust.pact.knowledge import KnowledgeItem
 
 logger = logging.getLogger(__name__)
 
@@ -121,13 +120,19 @@ def create_governance_router(
             classification=ConfidentialityLevel(req.item_classification),
             owning_unit_address=req.item_owning_unit,
             compartments=frozenset(req.item_compartments),
+            path=req.item_path,
+            knowledge_type=req.item_knowledge_type,
         )
 
         # Map posture string to enum
         posture = TrustPostureLevel(req.posture)
 
-        # Delegate to engine
-        decision = engine.check_access(req.role_address, item, posture)
+        # Delegate to engine (environment carries request-context facts the
+        # engine cannot observe itself; the engine uses its own clock for
+        # time_window conditions)
+        decision = engine.check_access(
+            req.role_address, item, posture, environment=req.environment
+        )
 
         # Emit governance event (fire-and-forget)
         await emit_governance_event(
@@ -359,6 +364,7 @@ def create_governance_router(
             max_classification=ConfidentialityLevel(req.max_classification),
             operational_scope=tuple(req.operational_scope),
             bilateral=req.bilateral,
+            shared_paths=tuple(req.shared_paths),
         )
 
         try:
@@ -403,6 +409,17 @@ def create_governance_router(
             max_classification=ConfidentialityLevel(req.max_classification),
             compartments=frozenset(req.compartments),
             created_by_role_address=req.created_by_role_address,
+            min_clearance=(
+                ConfidentialityLevel(req.min_clearance)
+                if req.min_clearance is not None
+                else None
+            ),
+            shared_paths=tuple(req.shared_paths),
+            shared_types=frozenset(req.shared_types),
+            shared_classifications=frozenset(
+                ConfidentialityLevel(c) for c in req.shared_classifications
+            ),
+            conditions=req.conditions,
         )
 
         try:

--- a/packages/kailash-pact/src/pact/governance/api/schemas.py
+++ b/packages/kailash-pact/src/pact/governance/api/schemas.py
@@ -20,10 +20,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from kailash.trust.pact.config import (
-    ConstraintEnvelopeConfig,
-    FinancialConstraintConfig,
-)
+from kailash.trust.pact.config import FinancialConstraintConfig
 
 __all__ = [
     "CheckAccessRequest",
@@ -105,6 +102,21 @@ class CheckAccessRequest(BaseModel):
     item_compartments: list[str] = Field(
         default_factory=list,
         description="Named compartments the item belongs to",
+    )
+    item_path: str | None = Field(
+        default=None,
+        description="Optional hierarchical path of the item (e.g. '/finance/q3'), "
+        "matched against KSP/bridge shared_paths scope",
+    )
+    item_knowledge_type: str | None = Field(
+        default=None,
+        description="Optional knowledge-type tag (e.g. 'report'), matched against "
+        "KSP shared_types scope",
+    )
+    environment: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional request-context facts (e.g. {'network_zone': 'internal'}) "
+        "matched against KSP conditions['environment'] requirements",
     )
     posture: str = Field(
         description="Current trust posture level of the requesting role"
@@ -245,11 +257,27 @@ class CreateBridgeRequest(BaseModel):
         default_factory=list,
         description="Limit bridge to specific operations (empty = all)",
     )
+    shared_paths: list[str] = Field(
+        default_factory=list,
+        description="Path patterns the item path must match (* / prefix/* / exact); "
+        "empty = no path narrowing. A '..' segment is rejected.",
+    )
 
     @field_validator("role_a_address")
     @classmethod
     def validate_role_a(cls, v: str) -> str:
         return _validate_dtr_address(v)
+
+    @field_validator("shared_paths")
+    @classmethod
+    def validate_shared_paths(cls, v: list[str]) -> list[str]:
+        for pat in v:
+            if ".." in pat.split("/"):
+                raise ValueError(
+                    f"shared_paths pattern '{pat}' contains a '..' traversal "
+                    f"segment (rejected fail-closed)"
+                )
+        return v
 
     @field_validator("role_b_address")
     @classmethod
@@ -291,6 +319,30 @@ class CreateKSPRequest(BaseModel):
         default_factory=list,
         description="Restrict sharing to specific compartments (empty = all)",
     )
+    min_clearance: str | None = Field(
+        default=None,
+        description="Recipient clearance floor: the requesting role's clearance "
+        "must be at or above this level (None = no floor)",
+    )
+    shared_paths: list[str] = Field(
+        default_factory=list,
+        description="Path patterns the item path must match (* / prefix/* / exact); "
+        "empty = no path narrowing. A '..' segment is rejected.",
+    )
+    shared_types: list[str] = Field(
+        default_factory=list,
+        description="Knowledge types the item type must be in (empty = no type narrowing)",
+    )
+    shared_classifications: list[str] = Field(
+        default_factory=list,
+        description="Allowed classification SET the item classification must be in "
+        "(empty = ceiling-only via max_classification)",
+    )
+    conditions: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Request-context conditions: 'time_window' ({start,end} HH:MM) and "
+        "'environment' (required key->value map). Unknown keys fail closed.",
+    )
 
     @field_validator("max_classification")
     @classmethod
@@ -299,6 +351,75 @@ class CreateKSPRequest(BaseModel):
             raise ValueError(
                 f"max_classification must be one of {sorted(_VALID_CLASSIFICATIONS)}, got '{v}'"
             )
+        return v
+
+    @field_validator("min_clearance")
+    @classmethod
+    def validate_min_clearance(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_CLASSIFICATIONS:
+            raise ValueError(
+                f"min_clearance must be one of {sorted(_VALID_CLASSIFICATIONS)}, got '{v}'"
+            )
+        return v
+
+    @field_validator("shared_classifications")
+    @classmethod
+    def validate_shared_classifications(cls, v: list[str]) -> list[str]:
+        for level in v:
+            if level not in _VALID_CLASSIFICATIONS:
+                raise ValueError(
+                    f"shared_classifications entries must be one of "
+                    f"{sorted(_VALID_CLASSIFICATIONS)}, got '{level}'"
+                )
+        return v
+
+    @field_validator("shared_paths")
+    @classmethod
+    def validate_shared_paths(cls, v: list[str]) -> list[str]:
+        for pat in v:
+            if ".." in pat.split("/"):
+                raise ValueError(
+                    f"shared_paths pattern '{pat}' contains a '..' traversal "
+                    f"segment (rejected fail-closed)"
+                )
+        return v
+
+    @field_validator("conditions")
+    @classmethod
+    def validate_conditions(cls, v: dict[str, Any]) -> dict[str, Any]:
+        """Defense-in-depth: reject malformed conditions at the API boundary.
+
+        The engine enforcement layer (access.py::_evaluate_conditions) is the
+        authoritative fail-closed gate; this validator rejects obviously
+        malformed conditions at creation so an operator does not silently
+        store a policy that always denies. Mirrors the enforcement contract:
+        only ``time_window`` / ``environment`` keys; ``time_window`` bounds
+        MUST be zero-padded HH:MM; ``environment`` MUST be a dict.
+        """
+        import re as _re
+
+        _known = {"time_window", "environment"}
+        unknown = set(v) - _known
+        if unknown:
+            raise ValueError(
+                f"conditions has unrecognized key(s) {sorted(unknown)}; "
+                f"supported: {sorted(_known)}"
+            )
+        tw = v.get("time_window")
+        if tw is not None:
+            if not isinstance(tw, dict):
+                raise ValueError("conditions.time_window must be an object")
+            hhmm = _re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+            for bound in ("start", "end"):
+                val = tw.get(bound)
+                if not isinstance(val, str) or not hhmm.match(val):
+                    raise ValueError(
+                        f"conditions.time_window.{bound} must be zero-padded "
+                        f"HH:MM (00:00-23:59), got {val!r}"
+                    )
+        env = v.get("environment")
+        if env is not None and not isinstance(env, dict):
+            raise ValueError("conditions.environment must be an object")
         return v
 
     @field_validator("created_by_role_address")

--- a/packages/kailash-pact/tests/regression/test_issue_1372_ksp_deny_precedence.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1372_ksp_deny_precedence.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: a matching deny-KSP must suppress a permissive bridge (#1372).
+
+Epic #1375 — before this fix, ``_check_ksps`` returned ``AccessDecision | None``
+with no deny branch: a KSP that matched source/target addressing but failed a
+narrowing condition simply fell through to the bridge path, which could still
+ALLOW. A deliberate KSP deny was therefore bypassable via a more permissive
+bridge (over-grant). This test pins the deny-precedence security boundary at
+the GovernanceEngine.check_access surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance
+from kailash.trust.pact.compilation import RoleDefinition, compile_org
+from kailash.trust.pact.config import (
+    ConfidentialityLevel,
+    DepartmentConfig,
+    OrgDefinition,
+    TrustPostureLevel,
+)
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.knowledge import KnowledgeItem
+from kailash.trust.pact.store import MemoryAccessPolicyStore
+
+
+def _two_dept_engine() -> GovernanceEngine:
+    """Engine over two independent departments (D1 + D2, no structural path)."""
+    org = OrgDefinition(
+        org_id="deny-precedence-001",
+        name="Deny Precedence Org",
+        departments=[
+            DepartmentConfig(department_id="d-a", name="Dept A"),
+            DepartmentConfig(department_id="d-b", name="Dept B"),
+        ],
+        teams=[],
+        roles=[
+            RoleDefinition(role_id="r-a", name="Head A", is_primary_for_unit="d-a"),
+            RoleDefinition(role_id="r-b", name="Head B", is_primary_for_unit="d-b"),
+        ],
+    )
+    return GovernanceEngine(compile_org(org))
+
+
+def _grant(engine: GovernanceEngine, addr: str) -> None:
+    engine.grant_clearance(
+        addr,
+        RoleClearance(role_address=addr, max_clearance=ConfidentialityLevel.SECRET),
+    )
+
+
+# D1-R1 (Head A) requests a D2-owned item -> cross-barrier (forces 4d/4e).
+_ROLE = "D1-R1"
+_ITEM = KnowledgeItem(
+    item_id="cross-item",
+    classification=ConfidentialityLevel.RESTRICTED,
+    owning_unit_address="D2",
+    path="/hr/payroll",  # outside the KSP's /finance/* scope
+)
+_DENY_KSP = KnowledgeSharePolicy(
+    id="ksp-deny",
+    source_unit_address="D2",
+    target_unit_address="D1",
+    max_classification=ConfidentialityLevel.SECRET,
+    shared_paths=("/finance/*",),  # item path /hr/payroll does NOT match -> deny
+)
+_PERMISSIVE_BRIDGE = PactBridge(
+    id="bridge-permissive",
+    role_a_address="D1-R1",
+    role_b_address="D2-R1",
+    bridge_type="standing",
+    max_classification=ConfidentialityLevel.SECRET,  # would grant if reached
+)
+
+
+@pytest.mark.regression
+def test_deny_ksp_suppresses_permissive_bridge() -> None:
+    """KSP matches+denies AND a permissive bridge exists -> DENY (bridge suppressed)."""
+    store = MemoryAccessPolicyStore()
+    store.save_ksp(_DENY_KSP)
+    store.save_bridge(_PERMISSIVE_BRIDGE)
+    engine = _two_dept_engine()
+    # Inject the policy store post-construction (bypass LCA ceremony; the
+    # security boundary under test is check_access composition, not creation).
+    engine._access_policy_store = store  # noqa: SLF001 — regression harness
+    _grant(engine, _ROLE)
+
+    decision = engine.check_access(_ROLE, _ITEM, TrustPostureLevel.DELEGATED)
+
+    assert decision.allowed is False, "deny-KSP must suppress the permissive bridge"
+    assert decision.step_failed == 4
+    assert decision.audit_details["access_path"] == "ksp_deny"
+
+
+@pytest.mark.regression
+def test_bridge_alone_still_grants() -> None:
+    """Control: without the KSP, the permissive bridge grants (no over-block)."""
+    store = MemoryAccessPolicyStore()
+    store.save_bridge(_PERMISSIVE_BRIDGE)
+    engine = _two_dept_engine()
+    engine._access_policy_store = store  # noqa: SLF001
+    _grant(engine, _ROLE)
+
+    decision = engine.check_access(_ROLE, _ITEM, TrustPostureLevel.DELEGATED)
+
+    assert decision.allowed is True
+    assert decision.audit_details["access_path"] == "bridge"
+
+
+@pytest.mark.regression
+def test_deny_ksp_alone_denies() -> None:
+    """Control: the matching deny-KSP denies even with no bridge present."""
+    store = MemoryAccessPolicyStore()
+    store.save_ksp(_DENY_KSP)
+    engine = _two_dept_engine()
+    engine._access_policy_store = store  # noqa: SLF001
+    _grant(engine, _ROLE)
+
+    decision = engine.check_access(_ROLE, _ITEM, TrustPostureLevel.DELEGATED)
+
+    assert decision.allowed is False
+    assert decision.audit_details["access_path"] == "ksp_deny"
+
+
+@pytest.mark.regression
+def test_granting_sibling_ksp_wins_over_deny_ksp() -> None:
+    """Composition branch: a granting KSP wins over a sibling denying KSP (ALLOW)."""
+    store = MemoryAccessPolicyStore()
+    store.save_ksp(_DENY_KSP)  # /finance/* scope -> denies the /hr/payroll item
+    store.save_ksp(
+        KnowledgeSharePolicy(
+            id="ksp-grant",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+        )
+    )
+    engine = _two_dept_engine()
+    engine._access_policy_store = store  # noqa: SLF001
+    _grant(engine, _ROLE)
+
+    decision = engine.check_access(_ROLE, _ITEM, TrustPostureLevel.DELEGATED)
+
+    assert decision.allowed is True
+    assert decision.audit_details["ksp_id"] == "ksp-grant"
+
+
+@pytest.mark.regression
+def test_persisted_deny_ksp_enforces_via_sqlite() -> None:
+    """Persistence+enforcement parity: a deny-KSP stored in SQLite actually denies.
+
+    Round-trip tests prove the column survives; this proves the persisted
+    policy is read back AND enforced by the engine's check_access path
+    (closes the facade/orphan gap — the stored policy is not inert data).
+    """
+    from kailash.trust.pact.stores.sqlite import SqliteAccessPolicyStore
+
+    store = SqliteAccessPolicyStore(":memory:")
+    store.save_ksp(_DENY_KSP)
+    store.save_bridge(_PERMISSIVE_BRIDGE)
+    org = _two_dept_engine().get_org()
+    engine = GovernanceEngine(org, access_policy_store=store)
+    _grant(engine, _ROLE)
+
+    decision = engine.check_access(_ROLE, _ITEM, TrustPostureLevel.DELEGATED)
+
+    assert (
+        decision.allowed is False
+    ), "persisted deny-KSP must enforce + suppress bridge"
+    assert decision.audit_details["access_path"] == "ksp_deny"
+    store.close()

--- a/packages/kailash-pact/tests/unit/governance/test_access.py
+++ b/packages/kailash-pact/tests/unit/governance/test_access.py
@@ -15,13 +15,6 @@ from datetime import datetime, timezone
 
 import pytest
 
-from kailash.trust.pact.config import (
-    ConfidentialityLevel,
-    DepartmentConfig,
-    OrgDefinition,
-    TeamConfig,
-    TrustPostureLevel,
-)
 from kailash.trust.pact.access import (
     AccessDecision,
     KnowledgeSharePolicy,
@@ -30,8 +23,14 @@ from kailash.trust.pact.access import (
 )
 from kailash.trust.pact.clearance import RoleClearance, VettingStatus
 from kailash.trust.pact.compilation import CompiledOrg, RoleDefinition, compile_org
+from kailash.trust.pact.config import (
+    ConfidentialityLevel,
+    DepartmentConfig,
+    OrgDefinition,
+    TeamConfig,
+    TrustPostureLevel,
+)
 from kailash.trust.pact.knowledge import KnowledgeItem
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1009,3 +1008,623 @@ class TestCanAccessVettingStatus:
         )
         assert decision.allowed is False
         assert decision.step_failed == 1
+
+
+# ===========================================================================
+# Epic #1375: KSP/Bridge access-control scoping & precedence (#1368-#1374)
+# ===========================================================================
+
+
+def _clearance(addr: str, level: ConfidentialityLevel) -> RoleClearance:
+    return RoleClearance(role_address=addr, max_clearance=level)
+
+
+def _cross_barrier_item(
+    classification: ConfidentialityLevel = ConfidentialityLevel.RESTRICTED,
+    *,
+    path: str | None = None,
+    knowledge_type: str | None = None,
+) -> KnowledgeItem:
+    """Item owned by D2 (no structural path from a D1 role -> forces 4d/4e)."""
+    return KnowledgeItem(
+        item_id="x-item",
+        classification=classification,
+        owning_unit_address="D2",
+        path=path,
+        knowledge_type=knowledge_type,
+    )
+
+
+def _permissive_bridge(
+    max_classification: ConfidentialityLevel = ConfidentialityLevel.SECRET,
+    *,
+    shared_paths: tuple[str, ...] = (),
+) -> PactBridge:
+    """A bridge D1-R1 <-> D2-R1 that grants D1-R1 access to D2-owned items."""
+    return PactBridge(
+        id="b-permissive",
+        role_a_address="D1-R1",
+        role_b_address="D2-R1",
+        bridge_type="standing",
+        max_classification=max_classification,
+        shared_paths=shared_paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1368-#1374: new KSP scope fields (dataclass surface)
+# ---------------------------------------------------------------------------
+
+
+class TestKSPScopeFields:
+    """New KnowledgeSharePolicy scoping fields and their defaults."""
+
+    def test_scope_field_defaults(self) -> None:
+        ksp = KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.RESTRICTED,
+        )
+        assert ksp.min_clearance is None
+        assert ksp.shared_paths == ()
+        assert ksp.shared_types == frozenset()
+        assert ksp.shared_classifications == frozenset()
+        assert ksp.conditions == {}
+
+    def test_scope_fields_set(self) -> None:
+        ksp = KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            min_clearance=ConfidentialityLevel.CONFIDENTIAL,
+            shared_paths=("/finance/*",),
+            shared_types=frozenset({"report"}),
+            shared_classifications=frozenset({ConfidentialityLevel.RESTRICTED}),
+            conditions={"time_window": {"start": "09:00", "end": "17:00"}},
+        )
+        assert ksp.min_clearance == ConfidentialityLevel.CONFIDENTIAL
+        assert ksp.shared_paths == ("/finance/*",)
+        assert ksp.shared_types == frozenset({"report"})
+
+    def test_shared_paths_traversal_rejected_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            KnowledgeSharePolicy(
+                id="k",
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                shared_paths=("/finance/../etc",),
+            )
+
+
+class TestBridgeScopeFields:
+    """New PactBridge.shared_paths field and traversal rejection."""
+
+    def test_shared_paths_default_empty(self) -> None:
+        bridge = PactBridge(
+            id="b",
+            role_a_address="D1-R1",
+            role_b_address="D2-R1",
+            bridge_type="standing",
+            max_classification=ConfidentialityLevel.RESTRICTED,
+        )
+        assert bridge.shared_paths == ()
+
+    def test_shared_paths_traversal_rejected_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            PactBridge(
+                id="b",
+                role_a_address="D1-R1",
+                role_b_address="D2-R1",
+                bridge_type="standing",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                shared_paths=("../secret",),
+            )
+
+
+# ---------------------------------------------------------------------------
+# #1372: deny-precedence — a matching deny-KSP suppresses a permissive bridge
+# ---------------------------------------------------------------------------
+
+
+class TestKSPDenyPrecedence:
+    """The #1372 keystone: KSP deny suppresses the bridge fallback."""
+
+    def test_matching_deny_ksp_suppresses_permissive_bridge(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        # KSP matches D2->D1 addressing but DENIES (item path outside scope);
+        # a permissive bridge that would otherwise grant MUST be suppressed.
+        ksp = KnowledgeSharePolicy(
+            id="k-deny",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            shared_paths=("/finance/*",),
+        )
+        item = _cross_barrier_item(path="/hr/payroll")  # outside /finance/*
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=two_dept_org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[_permissive_bridge()],
+        )
+        assert decision.allowed is False
+        assert decision.step_failed == 4
+        assert decision.audit_details["access_path"] == "ksp_deny"
+        assert "shared_paths" in decision.audit_details["deny_reason"]
+
+    def test_no_matching_ksp_leaves_bridge_available(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        # KSP targets a DIFFERENT unit (D3) -> does not apply -> bridge grants.
+        ksp = KnowledgeSharePolicy(
+            id="k-other",
+            source_unit_address="D2",
+            target_unit_address="D3",
+            max_classification=ConfidentialityLevel.SECRET,
+            shared_paths=("/finance/*",),
+        )
+        item = _cross_barrier_item(path="/hr/payroll")
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=two_dept_org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[_permissive_bridge()],
+        )
+        assert decision.allowed is True
+        assert decision.audit_details["access_path"] == "bridge"
+
+    def test_granting_ksp_wins_over_sibling_deny_ksp(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        deny_ksp = KnowledgeSharePolicy(
+            id="k-deny",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            shared_types=frozenset({"report"}),
+        )
+        grant_ksp = KnowledgeSharePolicy(
+            id="k-grant",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+        )
+        item = _cross_barrier_item(knowledge_type="dataset")  # fails deny_ksp
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=two_dept_org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[deny_ksp, grant_ksp],
+            bridges=[],
+        )
+        assert decision.allowed is True
+        assert decision.audit_details["ksp_id"] == "k-grant"
+
+    def test_unscoped_ksp_still_grants(self, two_dept_org: CompiledOrg) -> None:
+        ksp = KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+        )
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=_cross_barrier_item(),
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=two_dept_org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[],
+        )
+        assert decision.allowed is True
+        assert decision.audit_details["access_path"] == "ksp"
+
+
+# ---------------------------------------------------------------------------
+# #1368: recipient clearance floor
+# ---------------------------------------------------------------------------
+
+
+class TestKSPClearanceFloor:
+    def _decide(self, org, recipient_level, min_clearance):
+        ksp = KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            min_clearance=min_clearance,
+        )
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=_cross_barrier_item(ConfidentialityLevel.RESTRICTED),
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", recipient_level)},
+            ksps=[ksp],
+            bridges=[],
+        )
+
+    def test_recipient_below_floor_denied(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            ConfidentialityLevel.CONFIDENTIAL,
+            ConfidentialityLevel.SECRET,
+        )
+        assert d.allowed is False
+        assert "min_clearance" in d.audit_details["deny_reason"]
+
+    def test_recipient_at_floor_allowed(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org, ConfidentialityLevel.SECRET, ConfidentialityLevel.SECRET
+        )
+        assert d.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# #1369 / #1370 / #1371: path / type / classification-set scope
+# ---------------------------------------------------------------------------
+
+
+class TestKSPItemScoping:
+    def _ksp(self, **kw) -> KnowledgeSharePolicy:
+        return KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            **kw,
+        )
+
+    def _decide(self, org, ksp, item) -> AccessDecision:
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[],
+        )
+
+    def test_shared_paths_match_allows(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(shared_paths=("/finance/*",)),
+            _cross_barrier_item(path="/finance/q3"),
+        )
+        assert d.allowed is True
+
+    def test_shared_paths_nonmatch_denies(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(shared_paths=("/finance/*",)),
+            _cross_barrier_item(path="/hr/x"),
+        )
+        assert d.allowed is False
+        assert "shared_paths" in d.audit_details["deny_reason"]
+
+    def test_shared_paths_untagged_item_denied(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org, self._ksp(shared_paths=("/finance/*",)), _cross_barrier_item()
+        )
+        assert d.allowed is False
+
+    def test_shared_paths_traversal_item_denied(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(shared_paths=("*",)),
+            _cross_barrier_item(path="/finance/../etc"),
+        )
+        assert d.allowed is False
+
+    def test_shared_types_match_allows(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(shared_types=frozenset({"report"})),
+            _cross_barrier_item(knowledge_type="report"),
+        )
+        assert d.allowed is True
+
+    def test_shared_types_nonmatch_denies(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(shared_types=frozenset({"report"})),
+            _cross_barrier_item(knowledge_type="memo"),
+        )
+        assert d.allowed is False
+        assert "shared_types" in d.audit_details["deny_reason"]
+
+    def test_shared_classifications_excluded_below_ceiling_denied(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        # ceiling SECRET admits SECRET, but the SET excludes it.
+        d = self._decide(
+            two_dept_org,
+            self._ksp(
+                shared_classifications=frozenset(
+                    {ConfidentialityLevel.RESTRICTED, ConfidentialityLevel.CONFIDENTIAL}
+                )
+            ),
+            _cross_barrier_item(ConfidentialityLevel.SECRET),
+        )
+        assert d.allowed is False
+        assert "shared_classifications" in d.audit_details["deny_reason"]
+
+    def test_shared_classifications_member_allowed(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp(
+                shared_classifications=frozenset({ConfidentialityLevel.CONFIDENTIAL})
+            ),
+            _cross_barrier_item(ConfidentialityLevel.CONFIDENTIAL),
+        )
+        assert d.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# #1374: time_window / environment conditions
+# ---------------------------------------------------------------------------
+
+
+class TestKSPConditions:
+    def _ksp(self, conditions) -> KnowledgeSharePolicy:
+        return KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            conditions=conditions,
+        )
+
+    def _decide(self, org, ksp, *, now=None, environment=None) -> AccessDecision:
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=_cross_barrier_item(),
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[],
+            now=now,
+            environment=environment,
+        )
+
+    def test_time_window_inside_allows(self, two_dept_org: CompiledOrg) -> None:
+        noon = datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc)
+        d = self._decide(
+            two_dept_org,
+            self._ksp({"time_window": {"start": "09:00", "end": "17:00"}}),
+            now=noon,
+        )
+        assert d.allowed is True
+
+    def test_time_window_outside_denies(self, two_dept_org: CompiledOrg) -> None:
+        night = datetime(2026, 6, 18, 23, 0, tzinfo=timezone.utc)
+        d = self._decide(
+            two_dept_org,
+            self._ksp({"time_window": {"start": "09:00", "end": "17:00"}}),
+            now=night,
+        )
+        assert d.allowed is False
+        assert "time_window" in d.audit_details["deny_reason"]
+
+    def test_overnight_window_allows(self, two_dept_org: CompiledOrg) -> None:
+        night = datetime(2026, 6, 18, 23, 0, tzinfo=timezone.utc)
+        d = self._decide(
+            two_dept_org,
+            self._ksp({"time_window": {"start": "22:00", "end": "06:00"}}),
+            now=night,
+        )
+        assert d.allowed is True
+
+    def test_environment_match_allows(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp({"environment": {"network_zone": "internal"}}),
+            environment={"network_zone": "internal"},
+        )
+        assert d.allowed is True
+
+    def test_environment_mismatch_denies(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            self._ksp({"environment": {"network_zone": "internal"}}),
+            environment={"network_zone": "dmz"},
+        )
+        assert d.allowed is False
+        assert "environment" in d.audit_details["deny_reason"]
+
+    def test_unknown_condition_fails_closed(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(two_dept_org, self._ksp({"bogus_key": 1}))
+        assert d.allowed is False
+        assert "unrecognized condition" in d.audit_details["deny_reason"]
+
+
+# ---------------------------------------------------------------------------
+# #1373: bridge path scope + traversal guard
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeSharedPaths:
+    def _decide(self, org, bridge, item) -> AccessDecision:
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[],
+            bridges=[bridge],
+        )
+
+    def test_bridge_path_match_allows(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            _permissive_bridge(shared_paths=("/finance/*",)),
+            _cross_barrier_item(path="/finance/q3"),
+        )
+        assert d.allowed is True
+
+    def test_bridge_path_nonmatch_denies(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            _permissive_bridge(shared_paths=("/finance/*",)),
+            _cross_barrier_item(path="/hr/x"),
+        )
+        assert d.allowed is False
+        assert d.step_failed == 5  # no bridge grants -> fall-closed deny
+
+    def test_bridge_traversal_item_denied(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org,
+            _permissive_bridge(shared_paths=("*",)),
+            _cross_barrier_item(path="/a/../etc"),
+        )
+        assert d.allowed is False
+
+    def test_unscoped_bridge_still_grants(self, two_dept_org: CompiledOrg) -> None:
+        d = self._decide(
+            two_dept_org, _permissive_bridge(), _cross_barrier_item(path="/anywhere")
+        )
+        assert d.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# #1374 follow-up: injected `now` governs ALL time-evaluated checks
+# (KSP expiry AND bridge expiry — determinism parity, redteam MED-1)
+# ---------------------------------------------------------------------------
+
+
+class TestExpiryNowSymmetry:
+    """Both KSP and bridge expiry MUST honor the injected `now` (not wall-clock)."""
+
+    def _decide(self, org, *, ksps, bridges, now) -> AccessDecision:
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=_cross_barrier_item(),
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=ksps,
+            bridges=bridges,
+            now=now,
+        )
+
+    def test_bridge_expired_per_injected_now_denied(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        bridge = PactBridge(
+            id="b-exp",
+            role_a_address="D1-R1",
+            role_b_address="D2-R1",
+            bridge_type="standing",
+            max_classification=ConfidentialityLevel.SECRET,
+            expires_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        # now is AFTER expiry -> bridge treated as expired -> no access path.
+        d = self._decide(
+            two_dept_org,
+            ksps=[],
+            bridges=[bridge],
+            now=datetime(2026, 6, 18, tzinfo=timezone.utc),
+        )
+        assert d.allowed is False
+        assert d.step_failed == 5
+
+    def test_bridge_unexpired_per_injected_now_allowed(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        bridge = PactBridge(
+            id="b-live",
+            role_a_address="D1-R1",
+            role_b_address="D2-R1",
+            bridge_type="standing",
+            max_classification=ConfidentialityLevel.SECRET,
+            expires_at=datetime(2027, 1, 1, tzinfo=timezone.utc),
+        )
+        d = self._decide(
+            two_dept_org,
+            ksps=[],
+            bridges=[bridge],
+            now=datetime(2026, 6, 18, tzinfo=timezone.utc),
+        )
+        assert d.allowed is True
+        assert d.audit_details["access_path"] == "bridge"
+
+    def test_ksp_expired_per_injected_now_denied(
+        self, two_dept_org: CompiledOrg
+    ) -> None:
+        ksp = KnowledgeSharePolicy(
+            id="k-exp",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            expires_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        # KSP expired per injected now -> not applicable -> falls to step 5.
+        d = self._decide(
+            two_dept_org,
+            ksps=[ksp],
+            bridges=[],
+            now=datetime(2026, 6, 18, tzinfo=timezone.utc),
+        )
+        assert d.allowed is False
+        assert d.step_failed == 5
+
+
+class TestKSPMalformedTimeWindow:
+    """#1374 fail-closed: a str-typed-but-non-HH:MM time_window MUST deny (redteam MED-3)."""
+
+    def _decide(self, org, window, now) -> AccessDecision:
+        ksp = KnowledgeSharePolicy(
+            id="k",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            conditions={"time_window": window},
+        )
+        return can_access(
+            role_address="D1-R1",
+            knowledge_item=_cross_barrier_item(),
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances={"D1-R1": _clearance("D1-R1", ConfidentialityLevel.SECRET)},
+            ksps=[ksp],
+            bridges=[],
+            now=now,
+        )
+
+    def test_unpadded_hour_denies_even_at_noon(self, two_dept_org: CompiledOrg) -> None:
+        # "9" sorts lexicographically ABOVE "17"; without HH:MM validation this
+        # silently GRANTED at noon. MUST now fail closed.
+        noon = datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc)
+        d = self._decide(two_dept_org, {"start": "9", "end": "17"}, noon)
+        assert d.allowed is False
+        assert "malformed time_window" in d.audit_details["deny_reason"]
+
+    def test_out_of_range_hour_denies(self, two_dept_org: CompiledOrg) -> None:
+        noon = datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc)
+        d = self._decide(two_dept_org, {"start": "25:00", "end": "17:00"}, noon)
+        assert d.allowed is False
+        assert "malformed time_window" in d.audit_details["deny_reason"]
+
+    def test_non_time_garbage_denies(self, two_dept_org: CompiledOrg) -> None:
+        noon = datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc)
+        d = self._decide(two_dept_org, {"start": "morning", "end": "evening"}, noon)
+        assert d.allowed is False

--- a/packages/kailash-pact/tests/unit/governance/test_api_schemas.py
+++ b/packages/kailash-pact/tests/unit/governance/test_api_schemas.py
@@ -8,11 +8,8 @@ enum validation, and serialization round-trips.
 
 from __future__ import annotations
 
-import math
-
 import pytest
 from pydantic import ValidationError
-
 
 # ---------------------------------------------------------------------------
 # Schema imports (will be created in src/pact/governance/api/schemas.py)
@@ -29,7 +26,6 @@ from pact.governance.api.schemas import (
     VerifyActionRequest,
     VerifyActionResponse,
 )
-
 
 # ===================================================================
 # CheckAccessRequest validation
@@ -512,3 +508,140 @@ class TestSetEnvelopeRequest:
                     "financial": {"max_spend_usd": float("inf")},
                 },
             )
+
+
+class TestV2ScopeRequestFields:
+    """Epic #1375: new request fields validate + carry through (#1368-#1374)."""
+
+    def test_ksp_request_accepts_scope_fields(self) -> None:
+        req = CreateKSPRequest(
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification="secret",
+            created_by_role_address="D1-R1",
+            min_clearance="confidential",
+            shared_paths=["/finance/*"],
+            shared_types=["report"],
+            shared_classifications=["restricted", "confidential"],
+            conditions={"time_window": {"start": "09:00", "end": "17:00"}},
+        )
+        assert req.min_clearance == "confidential"
+        assert req.shared_paths == ["/finance/*"]
+        assert req.shared_classifications == ["restricted", "confidential"]
+        assert req.shared_types == ["report"]
+        assert req.conditions == {"time_window": {"start": "09:00", "end": "17:00"}}
+
+    def test_ksp_request_defaults(self) -> None:
+        req = CreateKSPRequest(
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification="restricted",
+            created_by_role_address="D1-R1",
+        )
+        assert req.min_clearance is None
+        assert req.shared_paths == []
+        assert req.shared_types == []
+        assert req.shared_classifications == []
+        assert req.conditions == {}
+
+    def test_ksp_request_rejects_invalid_min_clearance(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateKSPRequest(
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification="restricted",
+                created_by_role_address="D1-R1",
+                min_clearance="bogus",
+            )
+
+    def test_ksp_request_rejects_invalid_shared_classification(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateKSPRequest(
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification="restricted",
+                created_by_role_address="D1-R1",
+                shared_classifications=["restricted", "nope"],
+            )
+
+    def test_ksp_request_rejects_traversal_in_shared_paths(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            CreateKSPRequest(
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification="restricted",
+                created_by_role_address="D1-R1",
+                shared_paths=["/finance/../etc"],
+            )
+
+    def test_bridge_request_accepts_shared_paths(self) -> None:
+        req = CreateBridgeRequest(
+            role_a_address="D1-R1",
+            role_b_address="D2-R1",
+            bridge_type="standing",
+            max_classification="secret",
+            shared_paths=["/finance/*"],
+        )
+        assert req.shared_paths == ["/finance/*"]
+
+    def test_bridge_request_rejects_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            CreateBridgeRequest(
+                role_a_address="D1-R1",
+                role_b_address="D2-R1",
+                bridge_type="standing",
+                max_classification="secret",
+                shared_paths=["../secret"],
+            )
+
+    def test_check_access_request_accepts_item_path_and_environment(self) -> None:
+        req = CheckAccessRequest(
+            role_address="D1-R1",
+            item_id="i1",
+            item_classification="restricted",
+            item_owning_unit="D2",
+            item_path="/finance/q3",
+            item_knowledge_type="report",
+            environment={"network_zone": "internal"},
+            posture="delegated",
+        )
+        assert req.item_path == "/finance/q3"
+        assert req.item_knowledge_type == "report"
+        assert req.environment == {"network_zone": "internal"}
+
+
+class TestV2ConditionsValidation:
+    """Defense-in-depth: CreateKSPRequest rejects malformed conditions (redteam MED-3)."""
+
+    def _ksp(self, conditions):
+        return CreateKSPRequest(
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification="secret",
+            created_by_role_address="D1-R1",
+            conditions=conditions,
+        )
+
+    def test_wellformed_time_window_accepted(self) -> None:
+        req = self._ksp({"time_window": {"start": "09:00", "end": "17:00"}})
+        assert req.conditions["time_window"]["start"] == "09:00"
+
+    def test_unpadded_time_window_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="HH:MM"):
+            self._ksp({"time_window": {"start": "9", "end": "17"}})
+
+    def test_out_of_range_time_window_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="HH:MM"):
+            self._ksp({"time_window": {"start": "25:00", "end": "17:00"}})
+
+    def test_unknown_condition_key_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="unrecognized"):
+            self._ksp({"bogus": 1})
+
+    def test_environment_must_be_object(self) -> None:
+        with pytest.raises(ValidationError, match="environment"):
+            self._ksp({"environment": "internal"})
+
+    def test_environment_object_accepted(self) -> None:
+        req = self._ksp({"environment": {"zone": "internal"}})
+        assert req.conditions["environment"] == {"zone": "internal"}

--- a/packages/kailash-pact/tests/unit/governance/test_backup.py
+++ b/packages/kailash-pact/tests/unit/governance/test_backup.py
@@ -13,26 +13,25 @@ Covers:
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance, VettingStatus
+from kailash.trust.pact.compilation import CompiledOrg, OrgNode
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
     FinancialConstraintConfig,
     OperationalConstraintConfig,
 )
-from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
-from kailash.trust.pact.clearance import RoleClearance, VettingStatus
-from kailash.trust.pact.compilation import CompiledOrg, OrgNode
-from kailash.trust.pact.envelopes import RoleEnvelope, TaskEnvelope
+from kailash.trust.pact.envelopes import RoleEnvelope
 from kailash.trust.pact.stores.backup import (
     backup_governance_store,
     restore_governance_store,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -304,6 +303,100 @@ class TestBackupRestore:
         restored = engine2._access_policy_store.find_ksp("D1", "D1-R1-T1")
         assert restored is not None
         assert restored.id == "ksp-backup"
+
+    def test_backup_restore_preserves_v2_scope_fields(self, tmp_path: Path) -> None:
+        """#1368-#1374 scope fields survive backup/restore — NO silent drop.
+
+        Redteam HIGH (round 3): dropping these on restore widens a narrowed
+        deny-KSP into a broad grant, reintroducing the #1372 over-grant. This
+        asserts every scope field round-trips AND that the restored deny-KSP
+        still enforces (suppresses a permissive bridge) via can_access.
+        """
+        from kailash.trust.pact.access import PactBridge, can_access
+        from kailash.trust.pact.config import TrustPostureLevel
+        from kailash.trust.pact.engine import GovernanceEngine
+        from kailash.trust.pact.knowledge import KnowledgeItem
+
+        org = _make_compiled_org("scope-roundtrip")
+        engine1 = GovernanceEngine(org, store_backend="sqlite", store_url=":memory:")
+        engine1.create_ksp(
+            KnowledgeSharePolicy(
+                id="ksp-scoped",
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification=ConfidentialityLevel.SECRET,
+                min_clearance=ConfidentialityLevel.CONFIDENTIAL,
+                shared_paths=("/finance/*",),
+                shared_types=frozenset({"report"}),
+                shared_classifications=frozenset({ConfidentialityLevel.RESTRICTED}),
+                conditions={"time_window": {"start": "09:00", "end": "17:00"}},
+            )
+        )
+        engine1._access_policy_store.save_bridge(
+            PactBridge(
+                id="b-scoped",
+                role_a_address="D1-R1",
+                role_b_address="D2-R1",
+                bridge_type="standing",
+                max_classification=ConfidentialityLevel.SECRET,
+                shared_paths=("/finance/*",),
+            )
+        )
+
+        backup_path = tmp_path / "backup.json"
+        backup_governance_store(engine1, str(backup_path))
+
+        # schema_version must track the store version (was hardcoded 1).
+        import json as _json
+
+        from kailash.trust.pact.stores.sqlite import PACT_SCHEMA_VERSION
+
+        meta = _json.loads(backup_path.read_text())["metadata"]
+        assert meta["schema_version"] == PACT_SCHEMA_VERSION
+
+        engine2 = GovernanceEngine(
+            _make_compiled_org("scope-roundtrip"),
+            store_backend="sqlite",
+            store_url=":memory:",
+        )
+        restore_governance_store(engine2, str(backup_path))
+
+        rk = engine2._access_policy_store.find_ksp("D2", "D1")
+        assert rk is not None
+        assert rk.min_clearance == ConfidentialityLevel.CONFIDENTIAL
+        assert rk.shared_paths == ("/finance/*",)
+        assert rk.shared_types == frozenset({"report"})
+        assert rk.shared_classifications == frozenset({ConfidentialityLevel.RESTRICTED})
+        assert rk.conditions == {"time_window": {"start": "09:00", "end": "17:00"}}
+        rb = engine2._access_policy_store.find_bridge("D1-R1", "D2-R1")
+        assert rb is not None and rb.shared_paths == ("/finance/*",)
+
+        # Enforcement parity: the RESTORED deny-KSP (item path outside /finance/*)
+        # must still DENY and suppress the permissive bridge — proving the
+        # restored scope fields are live, not inert data.
+        item = KnowledgeItem(
+            item_id="x",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D2",
+            path="/hr/payroll",  # outside shared_paths -> deny
+        )
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=engine2.get_org(),
+            clearances={
+                "D1-R1": RoleClearance(
+                    role_address="D1-R1",
+                    max_clearance=ConfidentialityLevel.SECRET,
+                )
+            },
+            ksps=engine2._access_policy_store.list_ksps(),
+            bridges=engine2._access_policy_store.list_bridges(),
+            now=datetime(2026, 6, 18, 12, 0, tzinfo=UTC),
+        )
+        assert decision.allowed is False
+        assert decision.audit_details["access_path"] == "ksp_deny"
 
     def test_restore_nonexistent_file_raises(self, tmp_path: Path) -> None:
         from kailash.trust.pact.engine import GovernanceEngine

--- a/packages/kailash-pact/tests/unit/governance/test_engine.py
+++ b/packages/kailash-pact/tests/unit/governance/test_engine.py
@@ -26,6 +26,10 @@ from typing import Any
 
 import pytest
 
+from kailash.trust.pact.access import AccessDecision, KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.audit import AuditChain
+from kailash.trust.pact.clearance import RoleClearance, VettingStatus
+from kailash.trust.pact.compilation import CompiledOrg, OrgNode
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
@@ -33,27 +37,17 @@ from kailash.trust.pact.config import (
     OperationalConstraintConfig,
     TrustPostureLevel,
 )
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.envelopes import RoleEnvelope, TaskEnvelope
+from kailash.trust.pact.knowledge import KnowledgeItem
+from kailash.trust.pact.store import MemoryAccessPolicyStore, MemoryClearanceStore
+from kailash.trust.pact.verdict import GovernanceVerdict
 from pact.examples.university.barriers import (
     create_university_bridges,
     create_university_ksps,
 )
 from pact.examples.university.clearance import create_university_clearances
 from pact.examples.university.org import create_university_org
-from kailash.trust.pact.access import AccessDecision, KnowledgeSharePolicy, PactBridge
-from kailash.trust.pact.clearance import RoleClearance, VettingStatus
-from kailash.trust.pact.compilation import CompiledOrg, OrgNode
-from kailash.trust.pact.engine import GovernanceEngine
-from kailash.trust.pact.envelopes import RoleEnvelope, TaskEnvelope
-from kailash.trust.pact.knowledge import KnowledgeItem
-from kailash.trust.pact.store import (
-    MemoryAccessPolicyStore,
-    MemoryClearanceStore,
-    MemoryEnvelopeStore,
-    MemoryOrgStore,
-)
-from kailash.trust.pact.verdict import GovernanceVerdict
-from kailash.trust.pact.audit import AuditChain
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -807,3 +801,185 @@ class TestThreadSafety:
         for v in results:
             assert isinstance(v, GovernanceVerdict)
             assert v.level in ("auto_approved", "flagged", "held", "blocked")
+
+
+# ---------------------------------------------------------------------------
+# Epic #1375: scoping & precedence through GovernanceEngine.check_access
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAccessScopingThroughEngine:
+    """#1372/#1374: deny-precedence + decision-context via the engine surface."""
+
+    def test_time_window_condition_via_engine(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """A KSP time_window condition is evaluated against the engine's now arg."""
+        from datetime import datetime, timezone
+
+        item = KnowledgeItem(
+            item_id="student-fees-tw",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D1-R1-D3",  # Student Affairs
+            description="Student fee records",
+        )
+        engine_from_compiled.create_ksp(
+            KnowledgeSharePolicy(
+                id="ksp-tw",
+                source_unit_address="D1-R1-D3",
+                target_unit_address="D1-R1-D2-R1-T2",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                created_by_role_address="D1-R1",
+                conditions={"time_window": {"start": "09:00", "end": "17:00"}},
+            )
+        )
+        role = "D1-R1-D2-R1-T2-R1"  # Finance Director
+
+        inside = engine_from_compiled.check_access(
+            role_address=role,
+            knowledge_item=item,
+            posture=TrustPostureLevel.SHARED_PLANNING,
+            now=datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc),
+        )
+        assert inside.allowed is True
+
+        outside = engine_from_compiled.check_access(
+            role_address=role,
+            knowledge_item=item,
+            posture=TrustPostureLevel.SHARED_PLANNING,
+            now=datetime(2026, 6, 18, 23, 0, tzinfo=timezone.utc),
+        )
+        assert outside.allowed is False
+
+    def test_environment_condition_via_engine(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """A KSP environment condition is matched against the engine's environment arg."""
+        item = KnowledgeItem(
+            item_id="student-fees-env",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D1-R1-D3",
+            description="Student fee records",
+        )
+        engine_from_compiled.create_ksp(
+            KnowledgeSharePolicy(
+                id="ksp-env",
+                source_unit_address="D1-R1-D3",
+                target_unit_address="D1-R1-D2-R1-T2",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                created_by_role_address="D1-R1",
+                conditions={"environment": {"network_zone": "internal"}},
+            )
+        )
+        role = "D1-R1-D2-R1-T2-R1"
+        ok = engine_from_compiled.check_access(
+            role_address=role,
+            knowledge_item=item,
+            posture=TrustPostureLevel.SHARED_PLANNING,
+            environment={"network_zone": "internal"},
+        )
+        assert ok.allowed is True
+        blocked = engine_from_compiled.check_access(
+            role_address=role,
+            knowledge_item=item,
+            posture=TrustPostureLevel.SHARED_PLANNING,
+            environment={"network_zone": "dmz"},
+        )
+        assert blocked.allowed is False
+
+
+class TestVerifyActionResourceScopingThroughEngine:
+    """#1374 cross-cutting AC: verify_action's resource path threads now/environment.
+
+    Round-2 redteam MED-4 surfaced this path as enforced-but-untested.
+    """
+
+    def test_verify_action_resource_threads_now(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        from datetime import datetime, timezone
+
+        engine_from_compiled.create_ksp(
+            KnowledgeSharePolicy(
+                id="ksp-va-tw",
+                source_unit_address="D1-R1-D3",
+                target_unit_address="D1-R1-D2-R1-T2",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                created_by_role_address="D1-R1",
+                conditions={"time_window": {"start": "09:00", "end": "17:00"}},
+            )
+        )
+        item = KnowledgeItem(
+            item_id="va-fees",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D1-R1-D3",
+            description="fees",
+        )
+        role = "D1-R1-D2-R1-T2-R1"
+
+        inside = engine_from_compiled.verify_action(
+            role,
+            "read",
+            {
+                "resource": item,
+                "posture": TrustPostureLevel.SHARED_PLANNING,
+                "now": datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc),
+            },
+        )
+        assert inside.access_decision is not None
+        assert inside.access_decision.allowed is True
+
+        outside = engine_from_compiled.verify_action(
+            role,
+            "read",
+            {
+                "resource": item,
+                "posture": TrustPostureLevel.SHARED_PLANNING,
+                "now": datetime(2026, 6, 18, 23, 0, tzinfo=timezone.utc),
+            },
+        )
+        assert outside.access_decision is not None
+        assert outside.access_decision.allowed is False
+        assert outside.level == "blocked"
+
+    def test_verify_action_resource_threads_environment(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        engine_from_compiled.create_ksp(
+            KnowledgeSharePolicy(
+                id="ksp-va-env",
+                source_unit_address="D1-R1-D3",
+                target_unit_address="D1-R1-D2-R1-T2",
+                max_classification=ConfidentialityLevel.RESTRICTED,
+                created_by_role_address="D1-R1",
+                conditions={"environment": {"network_zone": "internal"}},
+            )
+        )
+        item = KnowledgeItem(
+            item_id="va-fees-env",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D1-R1-D3",
+            description="fees",
+        )
+        role = "D1-R1-D2-R1-T2-R1"
+        ok = engine_from_compiled.verify_action(
+            role,
+            "read",
+            {
+                "resource": item,
+                "posture": TrustPostureLevel.SHARED_PLANNING,
+                "environment": {"network_zone": "internal"},
+            },
+        )
+        assert ok.access_decision is not None and ok.access_decision.allowed is True
+        blocked = engine_from_compiled.verify_action(
+            role,
+            "read",
+            {
+                "resource": item,
+                "posture": TrustPostureLevel.SHARED_PLANNING,
+                "environment": {"network_zone": "dmz"},
+            },
+        )
+        assert blocked.access_decision is not None
+        assert blocked.access_decision.allowed is False

--- a/packages/kailash-pact/tests/unit/governance/test_explain.py
+++ b/packages/kailash-pact/tests/unit/governance/test_explain.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import pytest
 
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance
+from kailash.trust.pact.compilation import CompiledOrg
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
@@ -17,22 +20,22 @@ from kailash.trust.pact.config import (
     OperationalConstraintConfig,
     TrustPostureLevel,
 )
-from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
-from kailash.trust.pact.clearance import RoleClearance
-from kailash.trust.pact.compilation import CompiledOrg
 from kailash.trust.pact.envelopes import RoleEnvelope
-from kailash.trust.pact.explain import describe_address, explain_access, explain_envelope
+from kailash.trust.pact.explain import (
+    describe_address,
+    explain_access,
+    explain_envelope,
+)
 from kailash.trust.pact.knowledge import KnowledgeItem
 from kailash.trust.pact.store import MemoryEnvelopeStore
-
-# Import the university example to build fixtures
-from pact.examples.university.org import create_university_org
-from pact.examples.university.clearance import create_university_clearances
 from pact.examples.university.barriers import (
     create_university_bridges,
     create_university_ksps,
 )
+from pact.examples.university.clearance import create_university_clearances
 
+# Import the university example to build fixtures
+from pact.examples.university.org import create_university_org
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -369,3 +372,90 @@ class TestExplainAccess:
             or "classification" in trace.lower()
         )
         assert "DENY" in trace.upper() or "FAIL" in trace.upper()
+
+
+# ---------------------------------------------------------------------------
+# #1374 follow-up: explain_access must thread now/environment so the trace
+# matches the enforced verdict (redteam MED-2).
+# ---------------------------------------------------------------------------
+
+
+class TestExplainEnforcementParity:
+    """explain_access verdict MUST match can_access for time/environment KSPs."""
+
+    @staticmethod
+    def _two_dept() -> CompiledOrg:
+        from kailash.trust.pact.compilation import RoleDefinition, compile_org
+        from kailash.trust.pact.config import DepartmentConfig, OrgDefinition
+
+        return compile_org(
+            OrgDefinition(
+                org_id="explain-parity-001",
+                name="Explain Parity Org",
+                departments=[
+                    DepartmentConfig(department_id="d-a", name="A"),
+                    DepartmentConfig(department_id="d-b", name="B"),
+                ],
+                teams=[],
+                roles=[
+                    RoleDefinition(
+                        role_id="r-a", name="Head A", is_primary_for_unit="d-a"
+                    ),
+                    RoleDefinition(
+                        role_id="r-b", name="Head B", is_primary_for_unit="d-b"
+                    ),
+                ],
+            )
+        )
+
+    @staticmethod
+    def _scenario():
+        from kailash.trust.pact.access import can_access  # noqa: F401
+
+        clearances = {
+            "D1-R1": RoleClearance(
+                role_address="D1-R1", max_clearance=ConfidentialityLevel.SECRET
+            )
+        }
+        item = KnowledgeItem(
+            item_id="x",
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address="D2",
+        )
+        ksp = KnowledgeSharePolicy(
+            id="k-env",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            conditions={"environment": {"network_zone": "internal"}},
+        )
+        return clearances, item, ksp
+
+    def test_explain_matches_enforcement_for_environment_ksp(self) -> None:
+        from kailash.trust.pact.access import can_access
+
+        org = self._two_dept()
+        clearances, item, ksp = self._scenario()
+        common = dict(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATED,
+            compiled_org=org,
+            clearances=clearances,
+            ksps=[ksp],
+            bridges=[],
+        )
+        # Ground truth: with the matching environment, enforcement GRANTS.
+        enforced = can_access(**common, environment={"network_zone": "internal"})
+        assert enforced.allowed is True
+
+        explained_with = explain_access(
+            **common, environment={"network_zone": "internal"}
+        )
+        explained_without = explain_access(**common)  # environment withheld
+
+        # The explanation must reflect the grant when environment is supplied...
+        assert "DENIED" not in explained_with
+        # ...and must DIFFER from the no-environment trace (proving it is threaded,
+        # not ignored — the MED-2 bug produced identical denied traces both ways).
+        assert explained_with != explained_without

--- a/packages/kailash-pact/tests/unit/governance/test_sqlite_stores.py
+++ b/packages/kailash-pact/tests/unit/governance/test_sqlite_stores.py
@@ -19,25 +19,23 @@ from __future__ import annotations
 import os
 import platform
 import stat
-import tempfile
 import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance, VettingStatus
+from kailash.trust.pact.compilation import CompiledOrg, OrgNode
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
     FinancialConstraintConfig,
     OperationalConstraintConfig,
 )
-from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
-from kailash.trust.pact.clearance import RoleClearance, VettingStatus
-from kailash.trust.pact.compilation import CompiledOrg, OrgNode
 from kailash.trust.pact.envelopes import RoleEnvelope, TaskEnvelope
 from kailash.trust.pact.store import (
-    MAX_STORE_SIZE,
     AccessPolicyStore,
     ClearanceStore,
     EnvelopeStore,
@@ -51,7 +49,6 @@ from kailash.trust.pact.stores.sqlite import (
     SqliteOrgStore,
     _validate_id,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -588,6 +585,126 @@ class TestSqliteAccessPolicyStoreBridge:
         assert found.bilateral is False
         assert found.operational_scope == ("deploy", "review")
         assert found.max_classification == ConfidentialityLevel.SECRET
+
+
+class TestSqliteAccessPolicyStoreV2Scope:
+    """v2 scoping fields (#1368-#1374) round-trip with no silent drop."""
+
+    def test_ksp_scope_fields_round_trip(self) -> None:
+        store = SqliteAccessPolicyStore(":memory:")
+        ksp = KnowledgeSharePolicy(
+            id="ksp-scope",
+            source_unit_address="D2",
+            target_unit_address="D1",
+            max_classification=ConfidentialityLevel.SECRET,
+            min_clearance=ConfidentialityLevel.CONFIDENTIAL,
+            shared_paths=("/finance/*", "/hr/payroll"),
+            shared_types=frozenset({"report", "dataset"}),
+            shared_classifications=frozenset(
+                {ConfidentialityLevel.RESTRICTED, ConfidentialityLevel.CONFIDENTIAL}
+            ),
+            conditions={
+                "time_window": {"start": "09:00", "end": "17:00"},
+                "environment": {"zone": "internal"},
+            },
+        )
+        store.save_ksp(ksp)
+        found = store.list_ksps()[0]
+        assert found.min_clearance == ConfidentialityLevel.CONFIDENTIAL
+        assert found.shared_paths == ("/finance/*", "/hr/payroll")
+        assert found.shared_types == frozenset({"report", "dataset"})
+        assert found.shared_classifications == frozenset(
+            {ConfidentialityLevel.RESTRICTED, ConfidentialityLevel.CONFIDENTIAL}
+        )
+        assert found.conditions == {
+            "time_window": {"start": "09:00", "end": "17:00"},
+            "environment": {"zone": "internal"},
+        }
+
+    def test_ksp_scope_defaults_round_trip(self) -> None:
+        store = SqliteAccessPolicyStore(":memory:")
+        store.save_ksp(_make_ksp("ksp-plain", source="D2", target="D1"))
+        found = store.list_ksps()[0]
+        assert found.min_clearance is None
+        assert found.shared_paths == ()
+        assert found.shared_types == frozenset()
+        assert found.shared_classifications == frozenset()
+        assert found.conditions == {}
+
+    def test_bridge_shared_paths_round_trip(self) -> None:
+        store = SqliteAccessPolicyStore(":memory:")
+        bridge = PactBridge(
+            id="bridge-scope",
+            role_a_address="D1-R1",
+            role_b_address="D2-R1",
+            bridge_type="standing",
+            max_classification=ConfidentialityLevel.SECRET,
+            shared_paths=("/finance/*",),
+        )
+        store.save_bridge(bridge)
+        found = store.find_bridge("D1-R1", "D2-R1")
+        assert found is not None
+        assert found.shared_paths == ("/finance/*",)
+
+    def test_v1_database_migrates_in_place(self, tmp_path) -> None:
+        """A v1-schema DB (no scoping columns) migrates additively, data intact."""
+        import sqlite3
+
+        db = str(tmp_path / "v1.db")
+        conn = sqlite3.connect(db)
+        # Oldest schema shape: omit conditions_json too, so the additive
+        # migration must add EVERY v2 column (including conditions_json) —
+        # exercising every _add_column_if_missing branch.
+        conn.execute(
+            """CREATE TABLE pact_ksps (id TEXT PRIMARY KEY,
+               source_unit_address TEXT NOT NULL, target_unit_address TEXT NOT NULL,
+               max_classification TEXT NOT NULL,
+               compartments_json TEXT NOT NULL DEFAULT '[]',
+               created_by TEXT NOT NULL DEFAULT '', active INTEGER NOT NULL DEFAULT 1,
+               expires_at TEXT, created_at TEXT NOT NULL)"""
+        )
+        conn.execute(
+            """CREATE TABLE pact_bridges (id TEXT PRIMARY KEY,
+               role_a_address TEXT NOT NULL, role_b_address TEXT NOT NULL,
+               bridge_type TEXT NOT NULL DEFAULT 'standing',
+               max_classification TEXT NOT NULL DEFAULT 'restricted',
+               operational_scope_json TEXT NOT NULL DEFAULT '[]',
+               financial_authority INTEGER NOT NULL DEFAULT 0,
+               bilateral INTEGER NOT NULL DEFAULT 1, standing INTEGER NOT NULL DEFAULT 1,
+               status TEXT NOT NULL DEFAULT 'active', expires_at TEXT,
+               created_at TEXT NOT NULL)"""
+        )
+        conn.execute(
+            "INSERT INTO pact_ksps (id, source_unit_address, target_unit_address, "
+            "max_classification, created_at) VALUES (?,?,?,?,?)",
+            ("legacy", "D2", "D1", "restricted", "2026-01-01T00:00:00+00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        store = SqliteAccessPolicyStore(db)  # triggers additive migration
+        found = store.list_ksps()
+        assert len(found) == 1
+        assert found[0].id == "legacy"
+        assert found[0].shared_paths == ()
+        assert found[0].min_clearance is None
+        assert found[0].shared_types == frozenset()
+        assert found[0].shared_classifications == frozenset()
+        assert found[0].conditions == {}  # conditions_json added with '{}' default
+        # The new columns are now usable on the migrated DB.
+        store.save_ksp(
+            KnowledgeSharePolicy(
+                id="post-migrate",
+                source_unit_address="D2",
+                target_unit_address="D1",
+                max_classification=ConfidentialityLevel.SECRET,
+                shared_paths=("/x/*",),
+            )
+        )
+        post = store.find_ksp("D2", "D1")
+        # find_ksp returns the first D2->D1 match; assert the new column reads back
+        assert post is not None
+        store.close()
 
 
 # ===========================================================================

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -20,6 +20,7 @@ DEFAULT IS DENY. This is fail-closed by design.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -45,6 +46,108 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
+# Path scoping + condition helpers (shared by KSP and bridge enforcement)
+# ---------------------------------------------------------------------------
+
+# Recognized KSP condition keys. An unrecognized key fails closed at access
+# time so a policy author cannot set a condition the engine silently ignores.
+_KNOWN_CONDITION_KEYS: frozenset[str] = frozenset({"time_window", "environment"})
+
+# Strict zero-padded 24h HH:MM (00:00-23:59). A time_window bound that is a
+# str but NOT this exact shape MUST fail closed -- a non-padded value like
+# "9" sorts lexicographically ABOVE "17" and would silently invert the
+# window comparison into a grant (the strftime("%H:%M") current-time is
+# always zero-padded, so only zero-padded bounds compare correctly).
+_HHMM_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _path_has_traversal(path: str) -> bool:
+    """Return True if a path contains a ``..`` segment (traversal attempt).
+
+    Knowledge paths are LOGICAL, ``/``-delimited identifiers (e.g.
+    ``/finance/q3``), NOT filesystem paths: there is no OS path resolution,
+    no URL-decoding layer, and ``\\`` is an ordinary character, not a
+    separator. The guard therefore splits on ``/`` only and rejects a literal
+    ``..`` segment. This is the same `".." in path.split("/")` invariant the
+    envelope data-access path uses (engine.py).
+    """
+    return ".." in path.split("/")
+
+
+def _reject_traversal_patterns(patterns: tuple[str, ...], *, owner: str) -> None:
+    """Raise ValueError if any pattern contains a ``..`` segment (fail-closed).
+
+    Called from KnowledgeSharePolicy / PactBridge ``__post_init__`` so a
+    policy carrying a path-traversal pattern can never be constructed,
+    stored, or round-tripped.
+    """
+    for pat in patterns:
+        if _path_has_traversal(pat):
+            raise ValueError(
+                f"{owner}: shared_paths pattern {pat!r} contains a '..' "
+                f"traversal segment (rejected fail-closed)"
+            )
+
+
+def _path_matches(item_path: str | None, patterns: tuple[str, ...]) -> bool:
+    """Check whether an item path matches any of the (non-empty) patterns.
+
+    Grammar:
+        ``*``         -> matches any (non-traversal) path
+        ``prefix/*``  -> matches ``prefix`` and anything under ``prefix/``
+        ``exact``     -> matches only the exact path
+
+    Fail-closed: returns False when ``item_path`` is None (untagged item) or
+    contains a ``..`` segment, and skips any pattern that contains ``..``.
+    Callers MUST only invoke this when ``patterns`` is non-empty -- an empty
+    pattern collection means "no narrowing" and is handled by the caller.
+    """
+    if item_path is None:
+        return False
+    if _path_has_traversal(item_path):
+        return False
+    for pat in patterns:
+        if _path_has_traversal(pat):
+            # Defense in depth: __post_init__ rejects these at construction,
+            # but a hand-built / deserialized policy could still carry one.
+            continue
+        if pat == "*":
+            return True
+        if pat.endswith("/*"):
+            prefix = pat[:-2]
+            if item_path == prefix or item_path.startswith(prefix + "/"):
+                return True
+        elif item_path == pat:
+            return True
+    return False
+
+
+def _time_in_window(now: datetime, window: Any) -> bool | None:
+    """Evaluate whether ``now`` falls within a {"start","end"} HH:MM window.
+
+    Returns True/False for a well-formed window, or None if the window is
+    malformed (caller treats None as fail-closed). Overnight ranges
+    (start > end, e.g. 22:00-06:00) are supported.
+    """
+    if not isinstance(window, dict):
+        return None
+    start = window.get("start")
+    end = window.get("end")
+    if not isinstance(start, str) or not isinstance(end, str):
+        return None
+    # A str-typed-but-non-HH:MM bound (e.g. "9", "25:00") must fail closed:
+    # lexicographic comparison against the zero-padded current time would
+    # otherwise silently invert the window into a grant (zero-tolerance 3c).
+    if not _HHMM_RE.match(start) or not _HHMM_RE.match(end):
+        return None
+    current = now.strftime("%H:%M")
+    if start <= end:
+        return start <= current <= end
+    # Overnight range: in-window if at/after start OR at/before end
+    return current >= start or current <= end
+
+
+# ---------------------------------------------------------------------------
 # KnowledgeSharePolicy
 # ---------------------------------------------------------------------------
 
@@ -56,15 +159,44 @@ class KnowledgeSharePolicy:
     KSPs are directional: source_unit shares knowledge WITH target_unit.
     The max_classification caps what classification level may be shared.
 
+    Scope fields (``shared_paths`` / ``shared_types`` / ``shared_classifications``
+    / ``min_clearance`` / ``conditions``) are NARROWING filters: an empty
+    collection (or ``None``) means "no narrowing on this dimension" and
+    preserves the policy's broad grant; a non-empty value means an item
+    must satisfy that dimension to be granted. A KSP that matches the
+    source/target addressing but fails ANY narrowing filter is a
+    *matching-but-denying* KSP and suppresses the bridge fallback
+    (see ``_check_ksps`` deny-precedence).
+
     Attributes:
         id: Unique policy identifier.
         source_unit_address: D/T prefix sharing knowledge.
         target_unit_address: D/T prefix receiving access.
-        max_classification: Maximum classification level shared.
+        max_classification: Maximum classification level shared (ceiling).
         compartments: Restrict sharing to specific compartments (empty = all).
         created_by_role_address: Role that created this policy (audit trail).
         active: Whether this policy is currently active.
         expires_at: When this policy expires (None = no expiry).
+        min_clearance: Recipient clearance floor -- the requesting role's
+            ``max_clearance`` MUST be at or above this level. ``None`` = no
+            floor (any cleared recipient that passes the global checks).
+        shared_paths: Path-prefix patterns the shared item path must match
+            (``*`` = all, ``prefix/*`` = prefix match, exact match otherwise).
+            Empty = no path narrowing. A pattern containing a ``..`` segment
+            is rejected at construction (fail-closed).
+        shared_types: Set of knowledge types the item type must be a member
+            of. Empty = no type narrowing.
+        shared_classifications: Set of classification levels the item
+            classification must be a member of. Empty = ceiling-only
+            (``max_classification``). When non-empty, membership is required
+            IN ADDITION to the ceiling -- expresses a non-contiguous allowed
+            set (e.g. {RESTRICTED, CONFIDENTIAL} but not SECRET).
+        conditions: Request-context conditions evaluated at access time.
+            Supported keys: ``"time_window"`` ({"start": "HH:MM", "end":
+            "HH:MM"}, evaluated against the ``now`` arg, overnight ranges
+            supported) and ``"environment"`` (a dict of required key->value
+            pairs matched against the ``environment`` arg). An unrecognized
+            condition key is rejected fail-closed at access time.
     """
 
     id: str
@@ -75,6 +207,17 @@ class KnowledgeSharePolicy:
     created_by_role_address: str = ""
     active: bool = True
     expires_at: datetime | None = None
+    min_clearance: ConfidentialityLevel | None = None
+    shared_paths: tuple[str, ...] = ()
+    shared_types: frozenset[str] = field(default_factory=frozenset)
+    shared_classifications: frozenset[ConfidentialityLevel] = field(
+        default_factory=frozenset
+    )
+    conditions: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject ``..`` traversal segments in shared_paths (fail-closed)."""
+        _reject_traversal_patterns(self.shared_paths, owner=f"KSP '{self.id}'")
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +247,12 @@ class PactBridge:
         bilateral: Whether both roles have mutual access.
         expires_at: When this bridge expires (None = no expiry).
         active: Whether this bridge is currently active.
+        shared_paths: Path patterns the shared item path must match
+            (``*`` = all, ``prefix/*`` = prefix match, exact match otherwise).
+            Empty = no path narrowing (preserves the bridge's broad grant).
+            A pattern containing a ``..`` segment is rejected at construction
+            (fail-closed); an item path containing ``..`` is denied at
+            enforcement time.
     """
 
     id: str
@@ -115,6 +264,11 @@ class PactBridge:
     bilateral: bool = True
     expires_at: datetime | None = None
     active: bool = True
+    shared_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject ``..`` traversal segments in shared_paths (fail-closed)."""
+        _reject_traversal_patterns(self.shared_paths, owner=f"bridge '{self.id}'")
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +467,9 @@ def can_access(
     clearances: dict[str, RoleClearance],  # address -> clearance
     ksps: list[KnowledgeSharePolicy],
     bridges: list[PactBridge],
+    *,
+    now: datetime | None = None,
+    environment: dict[str, Any] | None = None,
 ) -> AccessDecision:
     """5-step access enforcement algorithm.
 
@@ -323,7 +480,9 @@ def can_access(
         4a: Same unit -> ALLOW
         4b: Downward (role address is prefix of item owner) -> ALLOW
         4c: T-inherits-D (role in T, item in parent D) -> ALLOW
-        4d: KSP exists -> ALLOW up to KSP max_classification
+        4d: KSP check -> ALLOW if an applicable KSP grants; DENY (suppressing
+            the bridge fallback) if a KSP matches the addressing but fails a
+            narrowing condition; fall through only when NO KSP applies.
         4e: Bridge exists -> ALLOW up to bridge max_classification
     Step 5: No access path -> DENY
 
@@ -337,11 +496,17 @@ def can_access(
         clearances: Map of role addresses to their clearance assignments.
         ksps: All active Knowledge Share Policies.
         bridges: All active Cross-Functional Bridges.
+        now: Evaluation time for KSP ``time_window`` conditions. Defaults to
+            the current UTC time when not supplied.
+        environment: Request-context facts (e.g. ``{"network_zone": "internal"}``)
+            matched against KSP ``conditions["environment"]`` requirements.
 
     Returns:
         An AccessDecision indicating allow/deny with reason and audit details.
     """
     item = knowledge_item
+    if now is None:
+        now = datetime.now(UTC)
 
     # --- Step 1: Resolve role clearance ---
     role_clearance = clearances.get(role_address)
@@ -511,13 +676,22 @@ def can_access(
             },
         )
 
-    # Step 4d: KSP check
-    ksp_decision = _check_ksps(role_address, item, compiled_org, ksps)
+    # Step 4d: KSP check (deny-precedence: a matching-but-denying KSP
+    # suppresses the bridge fallback below)
+    ksp_decision = _check_ksps(
+        role_address,
+        item,
+        compiled_org,
+        ksps,
+        clearances,
+        now=now,
+        environment=environment,
+    )
     if ksp_decision is not None:
         return ksp_decision
 
     # Step 4e: Bridge check
-    bridge_decision = _check_bridges(role_address, item, compiled_org, bridges)
+    bridge_decision = _check_bridges(role_address, item, compiled_org, bridges, now=now)
     if bridge_decision is not None:
         return bridge_decision
 
@@ -551,36 +725,164 @@ def can_access(
 # ---------------------------------------------------------------------------
 
 
+def _evaluate_conditions(
+    conditions: dict[str, Any],
+    now: datetime,
+    environment: dict[str, Any] | None,
+) -> str | None:
+    """Evaluate a KSP ``conditions`` dict against request context.
+
+    Returns a human-readable deny-reason string if any condition fails (or
+    is malformed / unrecognized -- fail-closed), or None if all conditions
+    pass. An empty ``conditions`` dict always passes (no narrowing).
+    """
+    if not conditions:
+        return None
+
+    # Fail-closed on any condition key the engine does not know how to
+    # evaluate -- a silently-ignored condition is the documented-but-unenforced
+    # failure mode (zero-tolerance Rule 3c) at the policy-data level.
+    for key in conditions:
+        if key not in _KNOWN_CONDITION_KEYS:
+            return (
+                f"unrecognized condition key '{key}' "
+                f"(known: {sorted(_KNOWN_CONDITION_KEYS)}; fail-closed)"
+            )
+
+    time_window = conditions.get("time_window")
+    if time_window is not None:
+        in_window = _time_in_window(now, time_window)
+        if in_window is None:
+            return "malformed time_window condition (fail-closed)"
+        if not in_window:
+            return f"current time outside time_window {time_window}"
+
+    env_required = conditions.get("environment")
+    if env_required is not None:
+        if not isinstance(env_required, dict):
+            return "malformed environment condition (fail-closed)"
+        env = environment or {}
+        for req_key, req_value in env_required.items():
+            if env.get(req_key) != req_value:
+                return (
+                    f"environment requirement '{req_key}={req_value!r}' "
+                    f"not satisfied"
+                )
+
+    return None
+
+
+def _evaluate_ksp_conditions(
+    ksp: KnowledgeSharePolicy,
+    item: KnowledgeItem,
+    role_clearance: RoleClearance | None,
+    now: datetime,
+    environment: dict[str, Any] | None,
+) -> str | None:
+    """Evaluate every narrowing condition on an addressing-matched KSP.
+
+    Returns the deny-reason detail string for the FIRST failing condition,
+    or None if the item satisfies every condition (the KSP grants).
+    """
+    # 1. Classification ceiling (max_classification)
+    if _CLEARANCE_ORDER[item.classification] > _CLEARANCE_ORDER[ksp.max_classification]:
+        return (
+            f"item classification '{item.classification.value}' exceeds KSP "
+            f"max_classification ceiling '{ksp.max_classification.value}'"
+        )
+
+    # 2. Classification SET membership (shared_classifications, #1371)
+    if (
+        ksp.shared_classifications
+        and item.classification not in ksp.shared_classifications
+    ):
+        allowed = sorted(c.value for c in ksp.shared_classifications)
+        return (
+            f"item classification '{item.classification.value}' not in KSP "
+            f"shared_classifications set {allowed}"
+        )
+
+    # 3. Recipient clearance floor (min_clearance, #1368)
+    if ksp.min_clearance is not None:
+        have_level = (
+            _CLEARANCE_ORDER[role_clearance.max_clearance]
+            if role_clearance is not None
+            else -1
+        )
+        if have_level < _CLEARANCE_ORDER[ksp.min_clearance]:
+            have = role_clearance.max_clearance.value if role_clearance else "none"
+            return (
+                f"recipient clearance '{have}' is below KSP min_clearance floor "
+                f"'{ksp.min_clearance.value}'"
+            )
+
+    # 4. Path scope (shared_paths, #1369)
+    if ksp.shared_paths and not _path_matches(item.path, ksp.shared_paths):
+        return (
+            f"item path {item.path!r} does not match KSP shared_paths "
+            f"{list(ksp.shared_paths)}"
+        )
+
+    # 5. Type scope (shared_types, #1370)
+    if ksp.shared_types and (
+        item.knowledge_type is None or item.knowledge_type not in ksp.shared_types
+    ):
+        return (
+            f"item knowledge_type {item.knowledge_type!r} not in KSP "
+            f"shared_types {sorted(ksp.shared_types)}"
+        )
+
+    # 6. Request-context conditions (time_window / environment, #1374)
+    cond_detail = _evaluate_conditions(ksp.conditions, now, environment)
+    if cond_detail is not None:
+        return cond_detail
+
+    return None
+
+
 def _check_ksps(
     role_address: str,
     item: KnowledgeItem,
     compiled_org: CompiledOrg,
     ksps: list[KnowledgeSharePolicy],
+    clearances: dict[str, RoleClearance],
+    *,
+    now: datetime,
+    environment: dict[str, Any] | None = None,
 ) -> AccessDecision | None:
-    """Check if any active KSP grants access.
+    """Evaluate cross-unit KSP access with deny-precedence (#1372).
 
-    A KSP grants access when:
-    1. The KSP is active.
-    2. The KSP source_unit_address matches the item's owning_unit_address
-       (source is sharing, so source must be the item owner or its ancestor).
-    3. The KSP target_unit_address matches the role's containment unit
-       (target receives, so target must contain the requesting role).
-    4. The item's classification <= KSP max_classification.
+    A KSP is *applicable* when it is active, non-expired, and its
+    source/target addressing matches (source owns the item, target contains
+    the requesting role). An applicable KSP then either GRANTS (every
+    narrowing condition passes) or DENIES (some condition fails).
+
+    Composition rule:
+      - Any applicable KSP that grants -> ALLOW (a granting sibling KSP wins
+        over a denying one; deny-precedence is over the bridge, not over
+        another KSP that affirmatively grants).
+      - At least one applicable KSP but NONE grant -> DENY, suppressing the
+        bridge fallback. This is the #1372 fix: a deliberate KSP deny is no
+        longer bypassable via a more permissive bridge.
+      - No applicable KSP -> None (the bridge path remains available).
 
     Returns:
-        An AccessDecision(allowed=True) if a KSP grants access, or None
-        if no KSP applies.
+        AccessDecision(allowed=True) if a KSP grants; AccessDecision(
+        allowed=False, step_failed=4) if applicable KSPs all deny; None if
+        no KSP applies.
     """
     role_unit = _get_containment_unit(role_address, compiled_org)
+    role_clearance = clearances.get(role_address)
+
+    last_deny: tuple[str, str] | None = None  # (ksp_id, deny_detail)
 
     for ksp in ksps:
         if not ksp.active:
             continue
 
         # Expired KSP treated as non-existent (C1 security fix)
-        if ksp.expires_at is not None:
-            if ksp.expires_at < datetime.now(UTC):
-                continue
+        if ksp.expires_at is not None and ksp.expires_at < now:
+            continue
 
         # Source must match item owner (exact or prefix)
         source_matches = (
@@ -603,14 +905,18 @@ def _check_ksps(
         if not target_matches:
             continue
 
-        # Classification cap
-        ksp_level = _CLEARANCE_ORDER[ksp.max_classification]
-        item_level = _CLEARANCE_ORDER[item.classification]
-        if item_level > ksp_level:
-            continue  # Item classification exceeds KSP limit
+        # This KSP APPLIES (addressing matched). It now grants or denies.
+        deny_detail = _evaluate_ksp_conditions(
+            ksp, item, role_clearance, now, environment
+        )
+        if deny_detail is not None:
+            # Matching-but-denying KSP -- record it and keep scanning for a
+            # sibling KSP that grants.
+            last_deny = (ksp.id, deny_detail)
+            continue
 
         logger.debug(
-            "Access allowed (step 4d): KSP=%s — role_address=%s, " "item_owner=%s",
+            "Access allowed (step 4d): KSP=%s — role_address=%s, item_owner=%s",
             ksp.id,
             role_address,
             item.owning_unit_address,
@@ -631,7 +937,36 @@ def _check_ksps(
             valid_until=ksp.expires_at,
         )
 
-    return None
+    if last_deny is None:
+        # No KSP applied -- leave the bridge fallback available.
+        return None
+
+    # >=1 applicable KSP but none granted -> DENY, suppressing the bridge.
+    deny_ksp_id, deny_detail = last_deny
+    logger.info(
+        "Access denied (step 4d): KSP=%s denies (%s) — role_address=%s, "
+        "item_id=%s; bridge fallback suppressed",
+        deny_ksp_id,
+        deny_detail,
+        role_address,
+        item.item_id,
+    )
+    return AccessDecision(
+        allowed=False,
+        reason=(
+            f"KSP '{deny_ksp_id}' denies access ({deny_detail}); a matching "
+            f"deny-KSP suppresses the bridge fallback"
+        ),
+        step_failed=4,
+        audit_details={
+            "role_address": role_address,
+            "item_id": item.item_id,
+            "step": "4d",
+            "access_path": "ksp_deny",
+            "ksp_id": deny_ksp_id,
+            "deny_reason": deny_detail,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -644,6 +979,8 @@ def _check_bridges(
     item: KnowledgeItem,
     compiled_org: CompiledOrg,
     bridges: list[PactBridge],
+    *,
+    now: datetime,
 ) -> AccessDecision | None:
     """Check if any active bridge grants access.
 
@@ -657,6 +994,10 @@ def _check_bridges(
     5. If bilateral=False, only role_a can access role_b's data
        (A -> B direction only).
 
+    Bridge expiry is evaluated against the injected ``now`` (symmetric with
+    the KSP expiry check in ``_check_ksps``) so the whole time-evaluated
+    access path is deterministic under an injected clock.
+
     Returns:
         An AccessDecision(allowed=True) if a bridge grants access, or None
         if no bridge applies.
@@ -665,10 +1006,10 @@ def _check_bridges(
         if not bridge.active:
             continue
 
-        # Expired bridge treated as non-existent (C1 security fix)
-        if bridge.expires_at is not None:
-            if bridge.expires_at < datetime.now(UTC):
-                continue
+        # Expired bridge treated as non-existent (C1 security fix). Uses the
+        # injected ``now`` for determinism parity with KSP expiry.
+        if bridge.expires_at is not None and bridge.expires_at < now:
+            continue
 
         # Determine direction: which side matches the requesting role,
         # and which side connects to the item owner?
@@ -690,6 +1031,22 @@ def _check_bridges(
         bridge_level = _CLEARANCE_ORDER[bridge.max_classification]
         item_level = _CLEARANCE_ORDER[item.classification]
         if item_level > bridge_level:
+            continue
+
+        # Path scope (#1373): when shared_paths is set, the item path MUST
+        # match a pattern (``*`` / ``prefix/*`` / exact). An item path
+        # containing a ``..`` segment fails closed (no match). An empty
+        # shared_paths preserves the bridge's broad, path-agnostic grant.
+        if bridge.shared_paths and not _path_matches(item.path, bridge.shared_paths):
+            logger.info(
+                "Access not granted via bridge=%s: item path %r outside "
+                "shared_paths %s — role_address=%s, item_id=%s",
+                bridge.id,
+                item.path,
+                list(bridge.shared_paths),
+                role_address,
+                item.item_id,
+            )
             continue
 
         logger.debug(

--- a/src/kailash/trust/pact/engine.py
+++ b/src/kailash/trust/pact/engine.py
@@ -400,6 +400,8 @@ class GovernanceEngine:
         posture: TrustPostureLevel,
         *,
         query: KnowledgeQuery | None = None,
+        environment: dict[str, Any] | None = None,
+        now: datetime | None = None,
     ) -> AccessDecision:
         """Check if a role can access a knowledge item. Thread-safe, fail-closed.
 
@@ -416,6 +418,15 @@ class GovernanceEngine:
                 is configured, this describes the scope of the data request.
                 If None and a filter is configured, a default query is built
                 from the knowledge_item.
+            environment: Optional request-context facts (e.g.
+                ``{"network_zone": "internal"}``) evaluated against any KSP
+                ``conditions["environment"]`` requirement. Facts the engine
+                cannot observe itself (active session, source IP) are supplied
+                by the caller here.
+            now: Optional evaluation time for KSP ``time_window`` conditions.
+                Defaults to the current UTC time. Primarily for deterministic
+                testing -- production callers should omit it so the engine
+                uses its own clock.
 
         Returns:
             An AccessDecision indicating allow/deny with reason.
@@ -489,6 +500,8 @@ class GovernanceEngine:
                     clearances=clearances,
                     ksps=ksps,
                     bridges=bridges,
+                    now=now,
+                    environment=environment,
                 )
 
                 if not decision.allowed:
@@ -812,6 +825,8 @@ class GovernanceEngine:
                 clearances=clearances,
                 ksps=ksps,
                 bridges=bridges,
+                now=ctx.get("now") or now,
+                environment=ctx.get("environment"),
             )
 
             # Step 5: Most restrictive wins

--- a/src/kailash/trust/pact/explain.py
+++ b/src/kailash/trust/pact/explain.py
@@ -14,22 +14,19 @@ but are standalone so they can be used independently.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
-from kailash.trust.pact.config import ConfidentialityLevel, TrustPostureLevel
-from kailash.trust.pact.access import (
-    KnowledgeSharePolicy,
-    PactBridge,
-    can_access,
-)
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge, can_access
 from kailash.trust.pact.addressing import NodeType
 from kailash.trust.pact.clearance import (
+    _CLEARANCE_ORDER,
     RoleClearance,
     VettingStatus,
-    _CLEARANCE_ORDER,
     effective_clearance,
 )
 from kailash.trust.pact.compilation import CompiledOrg, OrgNode
+from kailash.trust.pact.config import ConfidentialityLevel, TrustPostureLevel
 from kailash.trust.pact.envelopes import compute_effective_envelope
 from kailash.trust.pact.knowledge import KnowledgeItem
 
@@ -240,6 +237,9 @@ def explain_access(
     clearances: dict[str, RoleClearance],
     ksps: list[KnowledgeSharePolicy],
     bridges: list[PactBridge],
+    *,
+    now: datetime | None = None,
+    environment: dict[str, Any] | None = None,
 ) -> str:
     """Return a step-by-step trace of the 5-step access algorithm.
 
@@ -254,6 +254,12 @@ def explain_access(
         clearances: Map of role addresses to clearance assignments.
         ksps: All active Knowledge Share Policies.
         bridges: All active Cross-Functional Bridges.
+        now: Evaluation time for KSP ``time_window`` conditions. MUST be
+            threaded through to ``can_access`` so the explanation matches the
+            enforced verdict for time-conditioned KSPs (#1374).
+        environment: Request-context facts matched against KSP
+            ``conditions["environment"]`` requirements -- threaded through so
+            the trace does not diverge from enforcement for env-gated KSPs.
 
     Returns:
         A multi-line string showing the step-by-step access evaluation trace.
@@ -287,7 +293,7 @@ def explain_access(
             f"(vetting status is '{role_clearance.vetting_status.value}', not ACTIVE)"
         )
         lines.append("")
-        lines.append(f"Result: DENIED at Step 1 -- vetting status not ACTIVE")
+        lines.append("Result: DENIED at Step 1 -- vetting status not ACTIVE")
         return "\n".join(lines)
 
     lines.append(
@@ -361,6 +367,8 @@ def explain_access(
         clearances=clearances,
         ksps=ksps,
         bridges=bridges,
+        now=now,
+        environment=environment,
     )
 
     # Extract the access path from the decision's audit_details
@@ -409,6 +417,6 @@ def explain_access(
         lines.append("  4e: bridge -- NO")
 
         lines.append("")
-        lines.append(f"Step 5: Result -- DENIED (no access path found)")
+        lines.append("Step 5: Result -- DENIED (no access path found)")
 
     return "\n".join(lines)

--- a/src/kailash/trust/pact/knowledge.py
+++ b/src/kailash/trust/pact/knowledge.py
@@ -46,6 +46,17 @@ class KnowledgeItem:
             For SECRET and TOP_SECRET items, accessing roles must hold
             ALL compartments the item belongs to.
         description: Human-readable description of the knowledge item.
+        path: Optional hierarchical path of the item (e.g. "/finance/q3").
+            Used by path-scoped sharing -- a KnowledgeSharePolicy or
+            PactBridge with ``shared_paths`` grants only items whose path
+            matches one of its patterns. ``None`` means the item is not
+            path-tagged and is denied by any policy that requires a path
+            match (fail-closed).
+        knowledge_type: Optional knowledge-type tag (e.g. "report",
+            "dataset"). Used by type-scoped sharing -- a
+            KnowledgeSharePolicy with ``shared_types`` grants only items
+            whose type is in its set. ``None`` means untyped and is denied
+            by any policy that requires a type match (fail-closed).
     """
 
     item_id: str
@@ -53,6 +64,8 @@ class KnowledgeItem:
     owning_unit_address: str  # D or T prefix that owns this data
     compartments: frozenset[str] = field(default_factory=frozenset)
     description: str = ""
+    path: str | None = None
+    knowledge_type: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/kailash/trust/pact/stores/backup.py
+++ b/src/kailash/trust/pact/stores/backup.py
@@ -24,13 +24,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from kailash.trust.pact.config import (
-    ConfidentialityLevel,
-    ConstraintEnvelopeConfig,
-)
 from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
 from kailash.trust.pact.clearance import RoleClearance, VettingStatus
+from kailash.trust.pact.config import ConfidentialityLevel, ConstraintEnvelopeConfig
 from kailash.trust.pact.envelopes import RoleEnvelope
+from kailash.trust.pact.stores.sqlite import PACT_SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +106,10 @@ def backup_governance_store(engine: Any, path: str) -> None:
                 }
             )
 
-    # Export KSPs
+    # Export KSPs (incl. the #1368-#1374 scope fields — a KSP narrowed by
+    # any of these MUST round-trip through backup/restore; dropping them
+    # would widen a deny-KSP into a broad grant on restore, reintroducing
+    # the #1372 over-grant).
     ksps_data: list[dict[str, Any]] = []
     for ksp in engine._access_policy_store.list_ksps():
         ksps_data.append(
@@ -121,10 +122,19 @@ def backup_governance_store(engine: Any, path: str) -> None:
                 "created_by_role_address": ksp.created_by_role_address,
                 "active": ksp.active,
                 "expires_at": ksp.expires_at.isoformat() if ksp.expires_at else None,
+                "min_clearance": (
+                    ksp.min_clearance.value if ksp.min_clearance else None
+                ),
+                "shared_paths": list(ksp.shared_paths),
+                "shared_types": sorted(ksp.shared_types),
+                "shared_classifications": sorted(
+                    c.value for c in ksp.shared_classifications
+                ),
+                "conditions": ksp.conditions,
             }
         )
 
-    # Export bridges
+    # Export bridges (incl. #1373 shared_paths)
     bridges_data: list[dict[str, Any]] = []
     for bridge in engine._access_policy_store.list_bridges():
         bridges_data.append(
@@ -140,6 +150,7 @@ def backup_governance_store(engine: Any, path: str) -> None:
                     bridge.expires_at.isoformat() if bridge.expires_at else None
                 ),
                 "active": bridge.active,
+                "shared_paths": list(bridge.shared_paths),
             }
         )
 
@@ -151,7 +162,9 @@ def backup_governance_store(engine: Any, path: str) -> None:
         "bridges": bridges_data,
         "metadata": {
             "backup_timestamp": datetime.now(UTC).isoformat(),
-            "schema_version": 1,
+            # Sourced from the store schema version so backup + store never
+            # drift (was hardcoded 1; the v2 scoping columns made that stale).
+            "schema_version": PACT_SCHEMA_VERSION,
         },
     }
 
@@ -256,6 +269,10 @@ def restore_governance_store(engine: Any, path: str) -> None:
         if ksp_data.get("expires_at") is not None:
             expires_at = datetime.fromisoformat(ksp_data["expires_at"])
 
+        # Scope fields (#1368-#1374) restored with .get() defaults so a v1
+        # backup (missing these keys) restores to the same backward-compatible
+        # empty/None defaults the dataclass uses; coercions mirror
+        # SqliteAccessPolicyStore._row_to_ksp so all persistence surfaces agree.
         ksp = KnowledgeSharePolicy(
             id=ksp_data["id"],
             source_unit_address=ksp_data["source_unit_address"],
@@ -265,6 +282,18 @@ def restore_governance_store(engine: Any, path: str) -> None:
             created_by_role_address=ksp_data.get("created_by_role_address", ""),
             active=ksp_data.get("active", True),
             expires_at=expires_at,
+            min_clearance=(
+                ConfidentialityLevel(ksp_data["min_clearance"])
+                if ksp_data.get("min_clearance")
+                else None
+            ),
+            shared_paths=tuple(ksp_data.get("shared_paths", [])),
+            shared_types=frozenset(ksp_data.get("shared_types", [])),
+            shared_classifications=frozenset(
+                ConfidentialityLevel(v)
+                for v in ksp_data.get("shared_classifications", [])
+            ),
+            conditions=ksp_data.get("conditions", {}),
         )
         engine.create_ksp(ksp)
 
@@ -287,6 +316,7 @@ def restore_governance_store(engine: Any, path: str) -> None:
             bilateral=bridge_data.get("bilateral", True),
             expires_at=expires_at,
             active=bridge_data.get("active", True),
+            shared_paths=tuple(bridge_data.get("shared_paths", [])),
         )
         engine._access_policy_store.save_bridge(bridge)
 

--- a/src/kailash/trust/pact/stores/sqlite.py
+++ b/src/kailash/trust/pact/stores/sqlite.py
@@ -29,10 +29,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from kailash.trust.pact.config import ConfidentialityLevel, ConstraintEnvelopeConfig
 from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
 from kailash.trust.pact.clearance import RoleClearance, VettingStatus
 from kailash.trust.pact.compilation import CompiledOrg, OrgNode
+from kailash.trust.pact.config import ConfidentialityLevel, ConstraintEnvelopeConfig
 from kailash.trust.pact.envelopes import RoleEnvelope, TaskEnvelope
 from kailash.trust.pact.store import MAX_STORE_SIZE
 
@@ -48,10 +48,41 @@ __all__ = [
     "_validate_id",
 ]
 
-PACT_SCHEMA_VERSION: int = 1
-"""Current governance schema version. Increment on DDL changes."""
+PACT_SCHEMA_VERSION: int = 2
+"""Current governance schema version. Increment on DDL changes.
+
+v2 (2026-06-18): KSP/Bridge access-control scoping columns
+(min_clearance, shared_paths_json, shared_types_json,
+shared_classifications_json, conditions_json on pact_ksps;
+shared_paths_json on pact_bridges) -- added additively via
+``_add_column_if_missing`` so existing v1 databases migrate in place.
+"""
 
 _ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+# Column names are static literals defined in this module (never user input);
+# the allowlist regex is defense-in-depth per dataflow-identifier-safety Rule 5.
+_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _add_column_if_missing(
+    conn: sqlite3.Connection, table: str, column: str, ddl_type: str
+) -> None:
+    """Idempotently add a column to a table if it is not already present.
+
+    SQLite has no ``ADD COLUMN IF NOT EXISTS``; this checks ``PRAGMA
+    table_info`` and issues the additive ``ALTER TABLE`` only when missing.
+    Used to migrate existing v1 governance databases to the v2 scoping
+    schema without dropping data. ``table``/``column`` are static module
+    literals; both are allowlist-validated as defense-in-depth (identifiers
+    cannot be bound parameters).
+    """
+    if not _COLUMN_NAME_RE.match(table) or not _COLUMN_NAME_RE.match(column):
+        raise ValueError(f"invalid identifier for migration: {table!r}.{column!r}")
+    existing = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if column not in existing:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}")
+        logger.info("Migrated %s: added column %s %s", table, column, ddl_type)
 
 
 def _validate_id(value: str) -> None:
@@ -617,7 +648,11 @@ class SqliteAccessPolicyStore(_SqliteBase):
                     created_by TEXT NOT NULL DEFAULT '',
                     active INTEGER NOT NULL DEFAULT 1,
                     expires_at TEXT,
-                    created_at TEXT NOT NULL
+                    created_at TEXT NOT NULL,
+                    min_clearance TEXT,
+                    shared_paths_json TEXT NOT NULL DEFAULT '[]',
+                    shared_types_json TEXT NOT NULL DEFAULT '[]',
+                    shared_classifications_json TEXT NOT NULL DEFAULT '[]'
                 )
                 """
             )
@@ -635,9 +670,33 @@ class SqliteAccessPolicyStore(_SqliteBase):
                     standing INTEGER NOT NULL DEFAULT 1,
                     status TEXT NOT NULL DEFAULT 'active',
                     expires_at TEXT,
-                    created_at TEXT NOT NULL
+                    created_at TEXT NOT NULL,
+                    shared_paths_json TEXT NOT NULL DEFAULT '[]'
                 )
                 """
+            )
+            # v1 -> v2 additive migration: existing databases created under
+            # PACT_SCHEMA_VERSION 1 lack the scoping columns above (CREATE
+            # TABLE IF NOT EXISTS is a no-op once the table exists). Add each
+            # missing column in place so stored policies are never dropped.
+            _add_column_if_missing(conn, "pact_ksps", "min_clearance", "TEXT")
+            _add_column_if_missing(
+                conn, "pact_ksps", "shared_paths_json", "TEXT NOT NULL DEFAULT '[]'"
+            )
+            _add_column_if_missing(
+                conn, "pact_ksps", "shared_types_json", "TEXT NOT NULL DEFAULT '[]'"
+            )
+            _add_column_if_missing(
+                conn,
+                "pact_ksps",
+                "shared_classifications_json",
+                "TEXT NOT NULL DEFAULT '[]'",
+            )
+            _add_column_if_missing(
+                conn, "pact_ksps", "conditions_json", "TEXT NOT NULL DEFAULT '{}'"
+            )
+            _add_column_if_missing(
+                conn, "pact_bridges", "shared_paths_json", "TEXT NOT NULL DEFAULT '[]'"
             )
 
     # ---- KSP operations ----
@@ -649,6 +708,13 @@ class SqliteAccessPolicyStore(_SqliteBase):
 
         compartments_json = json.dumps(sorted(ksp.compartments))
         expires_at = ksp.expires_at.isoformat() if ksp.expires_at else None
+        shared_paths_json = json.dumps(list(ksp.shared_paths))
+        shared_types_json = json.dumps(sorted(ksp.shared_types))
+        shared_classifications_json = json.dumps(
+            sorted(c.value for c in ksp.shared_classifications)
+        )
+        conditions_json = json.dumps(ksp.conditions, sort_keys=True)
+        min_clearance = ksp.min_clearance.value if ksp.min_clearance else None
 
         conn = self._get_connection()
         with self._write_lock, conn:
@@ -656,8 +722,10 @@ class SqliteAccessPolicyStore(_SqliteBase):
                 """INSERT OR REPLACE INTO pact_ksps
                    (id, source_unit_address, target_unit_address,
                     max_classification, compartments_json, created_by,
-                    active, expires_at, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    active, expires_at, created_at,
+                    min_clearance, shared_paths_json, shared_types_json,
+                    shared_classifications_json, conditions_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     ksp.id,
                     ksp.source_unit_address,
@@ -668,6 +736,11 @@ class SqliteAccessPolicyStore(_SqliteBase):
                     1 if ksp.active else 0,
                     expires_at,
                     now,
+                    min_clearance,
+                    shared_paths_json,
+                    shared_types_json,
+                    shared_classifications_json,
+                    conditions_json,
                 ),
             )
 
@@ -687,7 +760,9 @@ class SqliteAccessPolicyStore(_SqliteBase):
             row = conn.execute(
                 """SELECT id, source_unit_address, target_unit_address,
                           max_classification, compartments_json, created_by,
-                          active, expires_at
+                          active, expires_at, min_clearance, shared_paths_json,
+                          shared_types_json, shared_classifications_json,
+                          conditions_json
                    FROM pact_ksps
                    WHERE source_unit_address = ? AND target_unit_address = ?
                    LIMIT 1""",
@@ -704,7 +779,9 @@ class SqliteAccessPolicyStore(_SqliteBase):
             rows = conn.execute(
                 """SELECT id, source_unit_address, target_unit_address,
                           max_classification, compartments_json, created_by,
-                          active, expires_at
+                          active, expires_at, min_clearance, shared_paths_json,
+                          shared_types_json, shared_classifications_json,
+                          conditions_json
                    FROM pact_ksps""",
             ).fetchall()
         return [self._row_to_ksp(row) for row in rows]
@@ -715,6 +792,16 @@ class SqliteAccessPolicyStore(_SqliteBase):
         expires_at = (
             datetime.fromisoformat(row["expires_at"]) if row["expires_at"] else None
         )
+        min_clearance = (
+            ConfidentialityLevel(row["min_clearance"]) if row["min_clearance"] else None
+        )
+        shared_paths = tuple(json.loads(row["shared_paths_json"]))
+        shared_types = frozenset(json.loads(row["shared_types_json"]))
+        shared_classifications = frozenset(
+            ConfidentialityLevel(v)
+            for v in json.loads(row["shared_classifications_json"])
+        )
+        conditions = json.loads(row["conditions_json"])
         return KnowledgeSharePolicy(
             id=row["id"],
             source_unit_address=row["source_unit_address"],
@@ -724,6 +811,11 @@ class SqliteAccessPolicyStore(_SqliteBase):
             created_by_role_address=row["created_by"],
             active=bool(row["active"]),
             expires_at=expires_at,
+            min_clearance=min_clearance,
+            shared_paths=shared_paths,
+            shared_types=shared_types,
+            shared_classifications=shared_classifications,
+            conditions=conditions,
         )
 
     # ---- Bridge operations ----
@@ -735,6 +827,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
 
         scope_json = json.dumps(list(bridge.operational_scope))
         expires_at = bridge.expires_at.isoformat() if bridge.expires_at else None
+        shared_paths_json = json.dumps(list(bridge.shared_paths))
 
         conn = self._get_connection()
         with self._write_lock, conn:
@@ -742,8 +835,8 @@ class SqliteAccessPolicyStore(_SqliteBase):
                 """INSERT OR REPLACE INTO pact_bridges
                    (id, role_a_address, role_b_address, bridge_type,
                     max_classification, operational_scope_json, bilateral,
-                    standing, status, expires_at, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    standing, status, expires_at, created_at, shared_paths_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     bridge.id,
                     bridge.role_a_address,
@@ -756,6 +849,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
                     "active" if bridge.active else "inactive",
                     expires_at,
                     now,
+                    shared_paths_json,
                 ),
             )
 
@@ -776,7 +870,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
             row = conn.execute(
                 """SELECT id, role_a_address, role_b_address, bridge_type,
                           max_classification, operational_scope_json, bilateral,
-                          status, expires_at
+                          status, expires_at, shared_paths_json
                    FROM pact_bridges
                    WHERE (role_a_address = ? AND role_b_address = ?)
                       OR (role_a_address = ? AND role_b_address = ?)
@@ -794,7 +888,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
             rows = conn.execute(
                 """SELECT id, role_a_address, role_b_address, bridge_type,
                           max_classification, operational_scope_json, bilateral,
-                          status, expires_at
+                          status, expires_at, shared_paths_json
                    FROM pact_bridges""",
             ).fetchall()
         return [self._row_to_bridge(row) for row in rows]
@@ -805,6 +899,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
         expires_at = (
             datetime.fromisoformat(row["expires_at"]) if row["expires_at"] else None
         )
+        shared_paths = tuple(json.loads(row["shared_paths_json"]))
         return PactBridge(
             id=row["id"],
             role_a_address=row["role_a_address"],
@@ -815,6 +910,7 @@ class SqliteAccessPolicyStore(_SqliteBase):
             bilateral=bool(row["bilateral"]),
             expires_at=expires_at,
             active=row["status"] == "active",
+            shared_paths=shared_paths,
         )
 
 


### PR DESCRIPTION
## Summary

Implements the **epic #1375** cluster — per-policy scoping and precedence controls for `KnowledgeSharePolicy` (KSP) and `PactBridge` on the PACT knowledge-access layer. Each of the seven issues was an **over-grant**: a policy author could not express a constraint the engine would enforce.

- **#1372 (keystone)** — `_check_ksps` now has a deny branch: a KSP matching the source/target addressing but failing a narrowing condition **DENIES and suppresses the bridge fallback** (previously a deliberate deny was bypassable via a more permissive bridge). A granting sibling KSP still wins; no-applicable-KSP still leaves the bridge available.
- **#1368** — KSP `min_clearance` recipient clearance floor. (`min_authority_level` intentionally not added — PACT authority is structural D/T/R, not a numeric axis `can_access` sees; an unenforceable field would be a stub.)
- **#1369 / #1370** — `KnowledgeItem.path`/`knowledge_type` + KSP `shared_paths`/`shared_types`.
- **#1371** — KSP `shared_classifications` SET (ceiling `max_classification` retained).
- **#1373** — `PactBridge.shared_paths` + `..` traversal guard, fail-closed at construction **and** enforcement.
- **#1374** — `check_access(…, environment=, now=)` + KSP `conditions` (`time_window`/`environment`); unknown-key and malformed-HH:MM windows **fail closed**.

Empty scope = match-all everywhere → fully backward-compatible.

## No silent field drop

Every new field round-trips through construction, the **SQLite store** (additive v1→v2 in-place column migration), the **dict/JSON API** (`schemas.py` + `endpoints.py`), AND **backup/restore** — the backup path was a hidden second persistence surface whose omission would have widened a narrowed deny-KSP into a broad grant on restore.

## Validation — adversarial redteam to convergence

5-round multi-agent redteam (correctness / security / closure-parity dimensions, each finding adversarially verified), driven to **2 consecutive clean rounds**:

| Round | Confirmed-real | Disposition |
|---|---|---|
| 1 | 1 MED (bridge-expiry-`now` asymmetry) | fixed + tests |
| 2 | 3 MED (`explain_access` divergence; `time_window` HH:MM silent-grant; `verify_action` coverage) | fixed + tests + API defense-in-depth |
| 3 | **1 HIGH** (`backup.py` silent-drop → restore over-grant) | fixed + tests + completeness sweep |
| 4–5 | 0 (3/3 reviewers each) | **converged** |

## Test plan

- `+15 test classes` + a 5-test `tests/regression/test_issue_1372_ksp_deny_precedence.py` (deny-precedence security boundary at the engine surface, incl. persisted-deny-KSP-enforces-via-SQLite).
- Full `kailash-pact` suite: **1596 passed, 7 skipped**; collect-only clean; ruff/black/isort clean (pre-commit green).

## Pre-existing observations (NOT addressed here — out of the #1375 cluster, reproduce on `main`)

- `KSP.compartments` is unenforced in `_check_ksps` (the original never enforced it either — not a regression).
- The `KspSpec` YAML DSL can't express the new scope fields and isn't enforcement-wired.
- `tests/unit/test_enforcement_modes.py` + siblings: 11 `KAIZEN_DEFAULT_MODEL` env-var failures (environment-dependent).

## Related issues

Closes #1368, #1369, #1370, #1371, #1372, #1373, #1374
Part of #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)