### PR TITLE
chore(release): kailash 2.39.0 + kailash-pact 0.13.0 (PACT scoping #1375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.39.0] - 2026-06-18
+
+### Added
+
+- **PACT KSP/Bridge access-control scoping & precedence** (`kailash.trust.pact`,
+  epic #1375 — closes #1368–#1374). Per-policy narrowing controls that were
+  previously inexpressible, so policies over-granted:
+  - `KnowledgeSharePolicy` gains `min_clearance` (recipient clearance floor,
+    #1368), `shared_paths` (path-prefix scope, #1369), `shared_types`
+    (knowledge-type scope, #1370), `shared_classifications` (allowed-level SET
+    beyond the `max_classification` ceiling, #1371), and `conditions`
+    (request-context `time_window`/`environment`, #1374).
+  - `KnowledgeItem` gains `path` and `knowledge_type` (#1369/#1370).
+  - `PactBridge` gains `shared_paths` with a `..` traversal guard, fail-closed
+    at construction AND enforcement (#1373).
+  - `can_access` / `GovernanceEngine.check_access` / `explain_access` accept
+    keyword-only `now` and `environment` for time/context-conditioned policies
+    (#1374). Unknown condition keys and malformed (non-`HH:MM`) time windows
+    fail closed.
+
+### Changed
+
+- **Deny-precedence in `can_access` Step 4d** (#1372): a `KnowledgeSharePolicy`
+  that matches the source/target addressing but fails a narrowing condition now
+  DENIES and suppresses the bridge fallback. Previously a deliberate KSP deny
+  was bypassable via a more permissive bridge (over-grant). A granting sibling
+  KSP still wins; absence of any applicable KSP still leaves the bridge path
+  available. All new scope fields default to "match-all", so the change is
+  backward-compatible.
+- `SqliteAccessPolicyStore` schema advanced to v2 with an additive, in-place
+  `v1→v2` column migration; backup/restore preserves every new scope field.
+
 ## [2.38.3] - 2026-06-18
 
 ### Added

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,27 @@
 # PACT Changelog
 
+## [0.13.0] — 2026-06-18 — feat: KSP/Bridge access-control scoping & precedence (#1368–#1374)
+
+Exposes the new core PACT access-control scoping API (epic #1375) through the
+governance REST surface and bumps the SDK floor to the version that provides it.
+
+### Added
+
+- `CreateKSPRequest` accepts `min_clearance`, `shared_paths`, `shared_types`,
+  `shared_classifications`, and `conditions`, with validators that reject a
+  `..` traversal segment in `shared_paths`, a non-`HH:MM` `time_window` bound,
+  and an unrecognized `conditions` key (fail-closed, defense-in-depth atop the
+  core enforcement layer).
+- `CreateBridgeRequest` accepts `shared_paths` (`..` rejected).
+- `CheckAccessRequest` accepts `item_path`, `item_knowledge_type`, and
+  `environment`; the check-access handler threads them into the engine.
+
+### Changed
+
+- Requires `kailash>=2.39.0` (the core release providing the
+  `KnowledgeSharePolicy`/`PactBridge`/`KnowledgeItem` scope fields and the
+  `check_access` `now`/`environment` parameters this package now calls).
+
 ## [0.12.1] — 2026-06-18 — chore: release un-bumped comment-only source change
 
 Patch release cutting the previously-unreleased `7abe1a2c2` source commit (reworded

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.12.1"
+version = "0.13.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ dependencies = [
     #   (engine.py:1216 inside method). Move to [execution] extra.
     # - psycopg / psycopg_pool — ORPHANS, zero imports anywhere. DELETE.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.16.0",
+    "kailash>=2.39.0",
     "click>=8.0",
 ]
 

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.38.3"
+version = "2.39.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.38.3"
+__version__ = "2.39.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Release-prep for epic #1375 (PACT KSP/Bridge access-control scoping & precedence, feature merged in #1376).

## Version bumps
- **kailash** 2.38.3 → **2.39.0** (minor — new backward-compatible `trust.pact` API: KSP/Bridge scope fields, deny-precedence, `can_access`/`check_access`/`explain_access` `now`+`environment`, SQLite v1→v2 migration)
- **kailash-pact** 0.12.1 → **0.13.0** (minor — new governance REST request fields + fail-closed `conditions` validator) + SDK pin `kailash>=2.16.0` → `>=2.39.0`

## Scope
Metadata-only diff (version anchors + CHANGELOG ×2 + the pact SDK pin) → `release/v*` branch auto-skips the PR-gate matrix. The feature code + tests already landed green in #1376 (CI 29 pass / 0 fail; 5-round redteam converged).

Tags `v2.39.0` + `pact-v0.13.0` (pushed individually post-merge) trigger the OIDC `publish-pypi.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)