### PR TITLE
fix(pact): enforce KSP.compartments narrowing at step 4d (#1375 follow-up)

### DIFF
--- a/packages/kailash-pact/tests/unit/governance/test_engine.py
+++ b/packages/kailash-pact/tests/unit/governance/test_engine.py
@@ -983,3 +983,134 @@ class TestVerifyActionResourceScopingThroughEngine:
         )
         assert blocked.access_decision is not None
         assert blocked.access_decision.allowed is False
+
+
+class TestKSPCompartmentScopingThroughEngine:
+    """#1375 follow-up: KSP.compartments narrowing enforced at step 4d.
+
+    KnowledgeSharePolicy.compartments was a documented narrowing field accepted
+    but read by NONE of the six prior narrowing conditions in
+    _evaluate_ksp_conditions -- a zero-tolerance Rule 3c silent-drop. Condition
+    7 now enforces it fail-closed: an item is shareable under a KSP only if
+    every compartment it carries is in the KSP's authorized set
+    (item.compartments subset of ksp.compartments). Empty ksp.compartments =
+    no narrowing (empty = all).
+
+    Behavioral tests through the engine surface (NOT source-grep). Items are
+    RESTRICTED so the step-3 SECRET+ clearance compartment check does not fire;
+    the only compartment gate exercised is the new 4d KSP-compartment check.
+    """
+
+    # Source: Student Affairs (D1-R1-D3). Target: Finance team (D1-R1-D2-R1-T2).
+    # Finance Director D1-R1-D2-R1-T2-R1 holds RESTRICTED clearance, no
+    # compartments -- matches the existing KSP-scoping tests' addressing.
+    _SOURCE = "D1-R1-D3"
+    _TARGET = "D1-R1-D2-R1-T2"
+    _ROLE = "D1-R1-D2-R1-T2-R1"
+
+    def _ksp(
+        self, compartments: frozenset[str], ksp_id: str = "ksp-compartment"
+    ) -> KnowledgeSharePolicy:
+        return KnowledgeSharePolicy(
+            id=ksp_id,
+            source_unit_address=self._SOURCE,
+            target_unit_address=self._TARGET,
+            max_classification=ConfidentialityLevel.RESTRICTED,
+            created_by_role_address="D1-R1",
+            compartments=compartments,
+        )
+
+    def _item(self, compartments: frozenset[str], item_id: str) -> KnowledgeItem:
+        return KnowledgeItem(
+            item_id=item_id,
+            classification=ConfidentialityLevel.RESTRICTED,
+            owning_unit_address=self._SOURCE,
+            compartments=compartments,
+            description="Student fee records",
+        )
+
+    @pytest.mark.regression
+    def test_ksp_compartment_grant_exact_match(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """KSP compartments={FINANCE}, item in {FINANCE} -> allowed (subset holds)."""
+        engine_from_compiled.create_ksp(self._ksp(frozenset({"FINANCE"})))
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(frozenset({"FINANCE"}), "fees-finance-grant"),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is True
+
+    @pytest.mark.regression
+    def test_ksp_empty_compartments_no_narrowing(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """Default empty KSP compartments imposes no compartment narrowing (empty = all)."""
+        engine_from_compiled.create_ksp(self._ksp(frozenset()))
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(
+                frozenset({"FINANCE", "HR"}), "fees-empty-ksp-grant"
+            ),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is True
+
+    @pytest.mark.regression
+    def test_ksp_compartment_deny_disjoint(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """KSP compartments={FINANCE}, item in {HR} -> denied at 4d (HR not authorized)."""
+        engine_from_compiled.create_ksp(self._ksp(frozenset({"FINANCE"})))
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(frozenset({"HR"}), "fees-hr-deny"),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is False
+        # Deny lands at the KSP grant/deny step (4d), not the no-path step (5):
+        # the KSP applied-and-denied; it was not skipped.
+        assert decision.step_failed == 4
+
+    @pytest.mark.regression
+    def test_ksp_compartment_deny_subset_fail_closed(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """KSP compartments={FINANCE}, item in {FINANCE, HR} -> denied (fail-closed).
+
+        Subset semantics: an item carrying ANY compartment the KSP does not
+        authorize is denied, even when one of its compartments IS authorized.
+        """
+        engine_from_compiled.create_ksp(self._ksp(frozenset({"FINANCE"})))
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(
+                frozenset({"FINANCE", "HR"}), "fees-superset-deny"
+            ),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is False
+        assert decision.step_failed == 4
+
+    @pytest.mark.regression
+    def test_ksp_compartment_deny_suppresses_no_path_fallthrough(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """A matching-but-compartment-denying KSP denies at 4d, not step-5 no-path.
+
+        Deny-precedence (#1372): an applicable KSP that denies on compartments
+        suppresses fallthrough to the bridge/no-path resolution. The denial is
+        attributed to the KSP (step 4d), proving the compartment condition is a
+        first-class narrowing condition that participates in deny-precedence.
+        """
+        engine_from_compiled.create_ksp(
+            self._ksp(frozenset({"FINANCE"}), ksp_id="ksp-compartment-precedence")
+        )
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(frozenset({"LEGAL"}), "fees-legal-precedence"),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is False
+        assert decision.step_failed == 4  # KSP deny, NOT step 5 (no-path)

--- a/packages/kailash-pact/tests/unit/governance/test_engine.py
+++ b/packages/kailash-pact/tests/unit/governance/test_engine.py
@@ -1114,3 +1114,31 @@ class TestKSPCompartmentScopingThroughEngine:
         )
         assert decision.allowed is False
         assert decision.step_failed == 4  # KSP deny, NOT step 5 (no-path)
+
+    @pytest.mark.regression
+    def test_ksp_compartment_deny_precedence_granting_sibling_wins(
+        self, engine_from_compiled: GovernanceEngine
+    ) -> None:
+        """A granting sibling KSP (empty compartments) wins over a compartment-deny KSP.
+
+        Pins the #1372 deny-precedence composition AT THE COMPARTMENT-CONDITION
+        layer (security-review HIGH design-judgment item): compartments is a
+        per-KSP NARROWING filter, NOT a hard edge ceiling. Two applicable KSPs on
+        the same source->target edge: ksp-A denies an {HR} item on
+        compartments={FINANCE}; ksp-B (empty compartments = no narrowing) grants.
+        A grant wins over a deny -> allowed. This is the documented, intended
+        behavior; the absolute compartment ceiling for SECRET/TOP_SECRET is the
+        step-3 clearance check, not this KSP-level narrowing.
+        """
+        engine_from_compiled.create_ksp(
+            self._ksp(frozenset({"FINANCE"}), ksp_id="ksp-compartment-deny-A")
+        )
+        engine_from_compiled.create_ksp(
+            self._ksp(frozenset(), ksp_id="ksp-grant-sibling-B")
+        )
+        decision = engine_from_compiled.check_access(
+            role_address=self._ROLE,
+            knowledge_item=self._item(frozenset({"HR"}), "fees-hr-sibling-grant"),
+            posture=TrustPostureLevel.SHARED_PLANNING,
+        )
+        assert decision.allowed is True  # granting sibling wins (deny-precedence)

--- a/specs/pact-envelopes.md
+++ b/specs/pact-envelopes.md
@@ -301,6 +301,7 @@ Evaluated BEFORE the 5-step algorithm. Can deny the request outright or narrow q
 - Non-ACTIVE vetting -> DENY (step 1)
 - Insufficient clearance -> DENY (step 2)
 - Missing compartments -> DENY (step 3)
+- Item compartment not authorized by KSP `compartments` -> DENY (step 4d; item compartments must be a subset of the KSP's compartment set, empty = all)
 - No structural, KSP, or bridge path -> DENY (step 5)
 - Internal error -> DENY (step 0, fail-closed)
 - KnowledgeFilter error -> DENY (fail-closed)

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -781,6 +781,17 @@ def _evaluate_ksp_conditions(
 ) -> str | None:
     """Evaluate every narrowing condition on an addressing-matched KSP.
 
+    Conditions, evaluated in order (first failure short-circuits):
+      1. Classification ceiling (max_classification)
+      2. Classification set membership (shared_classifications, #1371)
+      3. Recipient clearance floor (min_clearance, #1368)
+      4. Path scope (shared_paths, #1369)
+      5. Type scope (shared_types, #1370)
+      6. Request-context conditions (time_window / environment, #1374)
+      7. Compartment scope (compartments, #1375 follow-up) -- item compartments
+         MUST be a subset of the KSP's authorized compartment set; empty
+         ksp.compartments = no narrowing (empty = all).
+
     Returns the deny-reason detail string for the FIRST failing condition,
     or None if the item satisfies every condition (the KSP grants).
     """
@@ -836,6 +847,19 @@ def _evaluate_ksp_conditions(
     cond_detail = _evaluate_conditions(ksp.conditions, now, environment)
     if cond_detail is not None:
         return cond_detail
+
+    # 7. Compartment scope (ksp.compartments, #1375 follow-up)
+    # Mirrors the step-3 clearance compartment dominance at access.py:587 --
+    # an item is shareable under this KSP only if EVERY compartment it carries
+    # is authorized by the KSP's compartment set (item.compartments subset of
+    # ksp.compartments). Empty ksp.compartments = no narrowing (empty = all).
+    if ksp.compartments:
+        missing = item.compartments - ksp.compartments
+        if missing:
+            return (
+                f"item compartments {sorted(missing)} not authorized by KSP "
+                f"compartments {sorted(ksp.compartments)}"
+            )
 
     return None
 

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -174,6 +174,18 @@ class KnowledgeSharePolicy:
         target_unit_address: D/T prefix receiving access.
         max_classification: Maximum classification level shared (ceiling).
         compartments: Restrict sharing to specific compartments (empty = all).
+            This is a per-KSP NARROWING filter (enforced at step 4d as the
+            7th narrowing condition), NOT a hard compartment ceiling on the
+            source->target edge: an item is shareable under THIS KSP only if
+            every compartment it carries is authorized here
+            (``item.compartments`` subset of this set). Like the other
+            narrowing conditions, it composes under KSP deny-precedence
+            (#1372) -- a sibling KSP that affirmatively grants (e.g. one with
+            empty ``compartments``) still wins, so this field narrows THIS
+            policy, it does not ceiling the edge. The absolute compartment
+            ceiling for SECRET/TOP_SECRET items is the step-3 clearance check
+            (the requesting role's clearance must independently hold every
+            item compartment), which no KSP composition can bypass.
         created_by_role_address: Role that created this policy (audit trail).
         active: Whether this policy is currently active.
         expires_at: When this policy expires (None = no expiry).

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -861,7 +861,8 @@ def _evaluate_ksp_conditions(
         return cond_detail
 
     # 7. Compartment scope (ksp.compartments, #1375 follow-up)
-    # Mirrors the step-3 clearance compartment dominance at access.py:587 --
+    # Mirrors the step-3 clearance compartment-dominance check (the
+    # `item.compartments - role_clearance.compartments` subset test) --
     # an item is shareable under this KSP only if EVERY compartment it carries
     # is authorized by the KSP's compartment set (item.compartments subset of
     # ksp.compartments). Empty ksp.compartments = no narrowing (empty = all).


### PR DESCRIPTION
## Summary

Enforces `KnowledgeSharePolicy.compartments` — a documented narrowing field that was **accepted but read by none** of the six prior narrowing conditions in `_evaluate_ksp_conditions`. A `zero-tolerance.md` Rule 3c silent-drop **and** a spec-conformance gap (`specs/pact-envelopes.md` §6.5 mandates the field). Surfaced by the #1375 KSP/Bridge scoping redteam (R5) and deferred at the time; this is the follow-up.

Adds a 7th narrowing condition at step 4d, fail-closed, mirroring the step-3 clearance compartment-dominance check:

```python
# 7. Compartment scope (ksp.compartments)
if ksp.compartments:
    missing = item.compartments - ksp.compartments
    if missing:
        return (f"item compartments {sorted(missing)} not authorized by KSP "
                f"compartments {sorted(ksp.compartments)}")
```

**Semantics:** non-empty `ksp.compartments` ⇒ item shareable under this KSP only if `item.compartments ⊆ ksp.compartments` (fail-closed); empty ⇒ no narrowing (`empty = all`). This is a **per-KSP narrowing filter**, not a hard edge-ceiling — it composes under #1372 deny-precedence (a granting sibling KSP still wins); the absolute compartment ceiling for SECRET/TOP_SECRET remains the step-3 clearance check, which no KSP composition can bypass. Documented in the `compartments` docstring.

## Behavior change

A KSP that previously granted because `compartments` was silently ignored may now correctly deny. The field was always documented as a restriction, so this fixes a dormant bug rather than changing the contract. Bounded blast radius: only KSPs with non-empty `compartments` + items carrying unauthorized compartments. Ships as **kailash 2.39.1** (patch).

## Tests

`packages/kailash-pact/tests/unit/governance/test_engine.py::TestKSPCompartmentScopingThroughEngine` (6 behavioral tests through the engine surface): grant exact-match, empty-compartments no-narrowing, deny disjoint, deny subset/fail-closed, deny-precedence step-4d attribution, and granting-sibling-wins composition. Full pact governance suite: 1156 passed, 7 skipped.

## Redteam

Multi-round adversarial review to convergence (2 consecutive clean rounds across reviewer + security-reviewer + pact-specialist). Security review found no CRIT/HIGH within the added code; the one HIGH (sibling-KSP composition) was adjudicated as correct-as-designed and documented + directly tested.

## Related issues

Follow-up to #1375 (KSP/Bridge access-control scoping). Closes the `KSP.compartments` Rule-3c enforcement gap surfaced during that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
