### PR TITLE
chore(release): kailash 2.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.39.1] - 2026-06-19
+
+### Fixed
+
+- **PACT `KnowledgeSharePolicy.compartments` now enforced** (`kailash.trust.pact`,
+  #1375 follow-up). The documented `compartments` field was accepted but never
+  applied — a silent over-grant (zero-tolerance 3c). It is now evaluated as the
+  7th KSP narrowing condition at step 4d: an item is shareable under a KSP only
+  if every compartment it carries is authorized by the KSP's compartment set
+  (`item.compartments` ⊆ `ksp.compartments`); empty `ksp.compartments` = no
+  narrowing (all compartments allowed), consistent with `shared_paths` /
+  `shared_types`. The filter narrows the individual KSP and composes under KSP
+  deny-precedence (#1372) — a sibling KSP that affirmatively grants still wins —
+  and does NOT replace the step-3 clearance compartment ceiling, which
+  independently bounds SECRET/TOP_SECRET items regardless of KSP composition.
+
 ## [2.39.0] - 2026-06-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.39.0"
+version = "2.39.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.39.0"
+__version__ = "2.39.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release **kailash 2.39.1** — enforces `KSP.compartments` narrowing at step 4d (#1375 follow-up), closing a zero-tolerance-3c silent over-grant where the documented `compartments` field was accepted but never applied.

Code already merged via #1379. This PR carries only the release metadata (version bump + CHANGELOG).

## Changes
- `pyproject.toml` + `src/kailash/__init__.py`: 2.39.0 → 2.39.1 (atomic)
- `CHANGELOG.md`: 2.39.1 Fixed entry

## Validation
- Holistic redteam **converged** (2 consecutive clean rounds; correctness + security + governance lenses, all mechanical-evidence-backed)
- 7/7 KSP compartment tests pass; pre-commit Tier 1 green
- Core `kailash` only; kailash-pact unchanged (tests-only)

## Related issues
Follow-up to #1375 (epic #1368–#1374); code merged in #1379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)