### PR TITLE
feat(pact): KSP YAML scope-field expressiveness + structured deny observability

### DIFF
--- a/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: KSP-deny decisions carry discrete, SIEM-queryable audit fields.
+
+Epic #1375 follow-up (security-reviewer R1 Finding 5 — SIEM queryability). The
+KSP Step-4d deny path historically collapsed all structured deny-context into a
+single free-text ``deny_reason`` string, so a SIEM could not query "which
+narrowing condition denied" or "which compartments were missing" without regex.
+
+This pins the parity with the Step-3 clearance compartment-deny (which already
+emits discrete ``missing_compartments`` / ``item_compartments``): every KSP deny
+now emits a ``deny_code`` discriminator plus condition-specific discrete fields
+spread as top-level ``audit_details`` keys, while keeping the human
+``deny_reason`` string for backward compatibility. ``/explain`` surfaces the
+``deny_code`` + denying KSP id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.trust.pact.access import KnowledgeSharePolicy, can_access
+from kailash.trust.pact.clearance import RoleClearance
+from kailash.trust.pact.compilation import RoleDefinition, compile_org
+from kailash.trust.pact.config import (
+    ConfidentialityLevel,
+    DepartmentConfig,
+    OrgDefinition,
+    TrustPostureLevel,
+)
+from kailash.trust.pact.explain import explain_access
+from kailash.trust.pact.knowledge import KnowledgeItem
+
+_ROLE = "D1-R1"
+
+
+def _two_dept_org():
+    """Two independent departments (D1 + D2, no structural access path)."""
+    org = OrgDefinition(
+        org_id="ksp-deny-obs-001",
+        name="KSP Deny Observability Org",
+        departments=[
+            DepartmentConfig(department_id="d-a", name="Dept A"),
+            DepartmentConfig(department_id="d-b", name="Dept B"),
+        ],
+        teams=[],
+        roles=[
+            RoleDefinition(role_id="r-a", name="Head A", is_primary_for_unit="d-a"),
+            RoleDefinition(role_id="r-b", name="Head B", is_primary_for_unit="d-b"),
+        ],
+    )
+    return compile_org(org)
+
+
+def _secret_clearance() -> dict[str, RoleClearance]:
+    # SECRET clearance holding both compartments so the requesting role passes
+    # the Step-3 clearance checks and the KSP narrowing (Step-4d) is reached.
+    return {
+        _ROLE: RoleClearance(
+            role_address=_ROLE,
+            max_clearance=ConfidentialityLevel.SECRET,
+            compartments=frozenset({"alpha", "beta"}),
+        )
+    }
+
+
+def _deny_decision(item: KnowledgeItem, ksp: KnowledgeSharePolicy):
+    """Run can_access for a cross-barrier D2-owned item under one deny-KSP."""
+    return can_access(
+        role_address=_ROLE,
+        knowledge_item=item,
+        posture=TrustPostureLevel.DELEGATING,
+        compiled_org=_two_dept_org(),
+        clearances=_secret_clearance(),
+        ksps=[ksp],
+        bridges=[],
+    )
+
+
+@pytest.mark.regression
+def test_path_scope_deny_emits_discrete_fields() -> None:
+    """A shared_paths mismatch emits deny_code=path_scope + discrete fields."""
+    item = KnowledgeItem(
+        item_id="cross-item",
+        classification=ConfidentialityLevel.RESTRICTED,
+        owning_unit_address="D2",
+        path="/hr/payroll",  # outside /finance/*
+    )
+    ksp = KnowledgeSharePolicy(
+        id="ksp-deny-path",
+        source_unit_address="D2",
+        target_unit_address="D1",
+        max_classification=ConfidentialityLevel.SECRET,
+        shared_paths=("/finance/*",),
+    )
+    decision = _deny_decision(item, ksp)
+
+    assert decision.allowed is False
+    ad = decision.audit_details
+    assert ad["access_path"] == "ksp_deny"
+    assert ad["ksp_id"] == "ksp-deny-path"
+    assert ad["deny_code"] == "path_scope"
+    assert ad["item_path"] == "/hr/payroll"
+    assert ad["ksp_shared_paths"] == ["/finance/*"]
+    # Back-compat: the human string survives.
+    assert "does not match KSP shared_paths" in ad["deny_reason"]
+
+
+@pytest.mark.regression
+def test_compartment_scope_deny_emits_discrete_fields() -> None:
+    """A KSP compartment narrowing emits deny_code=compartment_scope + fields.
+
+    The item is RESTRICTED (so the Step-3 SECRET/TOP_SECRET clearance
+    compartment check is skipped) and the requesting role holds 'alpha', so the
+    deny originates at the KSP narrowing (Step-4d, #1375), not at clearance.
+    """
+    item = KnowledgeItem(
+        item_id="cross-item",
+        classification=ConfidentialityLevel.RESTRICTED,
+        owning_unit_address="D2",
+        compartments=frozenset({"alpha"}),
+    )
+    ksp = KnowledgeSharePolicy(
+        id="ksp-deny-comp",
+        source_unit_address="D2",
+        target_unit_address="D1",
+        max_classification=ConfidentialityLevel.SECRET,
+        compartments=frozenset({"beta"}),  # does NOT authorize 'alpha'
+    )
+    decision = _deny_decision(item, ksp)
+
+    assert decision.allowed is False
+    ad = decision.audit_details
+    assert ad["access_path"] == "ksp_deny"
+    assert ad["deny_code"] == "compartment_scope"
+    # SIEM parity with the Step-3 clearance compartment-deny shape.
+    assert ad["missing_compartments"] == ["alpha"]
+    assert ad["item_compartments"] == ["alpha"]
+    assert ad["ksp_compartments"] == ["beta"]
+    assert "not authorized by KSP compartments" in ad["deny_reason"]
+
+
+@pytest.mark.regression
+def test_type_scope_deny_emits_discrete_fields() -> None:
+    """A shared_types mismatch emits deny_code=type_scope + discrete fields."""
+    item = KnowledgeItem(
+        item_id="cross-item",
+        classification=ConfidentialityLevel.RESTRICTED,
+        owning_unit_address="D2",
+        knowledge_type="memo",
+    )
+    ksp = KnowledgeSharePolicy(
+        id="ksp-deny-type",
+        source_unit_address="D2",
+        target_unit_address="D1",
+        max_classification=ConfidentialityLevel.SECRET,
+        shared_types=frozenset({"report"}),
+    )
+    decision = _deny_decision(item, ksp)
+
+    assert decision.allowed is False
+    ad = decision.audit_details
+    assert ad["deny_code"] == "type_scope"
+    assert ad["item_knowledge_type"] == "memo"
+    assert ad["ksp_shared_types"] == ["report"]
+
+
+@pytest.mark.regression
+def test_classification_ceiling_deny_emits_discrete_fields() -> None:
+    """A classification ceiling breach emits deny_code=classification_ceiling."""
+    item = KnowledgeItem(
+        item_id="cross-item",
+        classification=ConfidentialityLevel.SECRET,
+        owning_unit_address="D2",
+    )
+    ksp = KnowledgeSharePolicy(
+        id="ksp-deny-ceiling",
+        source_unit_address="D2",
+        target_unit_address="D1",
+        max_classification=ConfidentialityLevel.RESTRICTED,  # below SECRET item
+    )
+    decision = _deny_decision(item, ksp)
+
+    assert decision.allowed is False
+    ad = decision.audit_details
+    assert ad["deny_code"] == "classification_ceiling"
+    assert ad["item_classification"] == "secret"
+    assert ad["ksp_max_classification"] == "restricted"
+
+
+@pytest.mark.regression
+def test_explain_surfaces_ksp_deny_code() -> None:
+    """/explain renders the deny_code discriminator + denying KSP id."""
+    item = KnowledgeItem(
+        item_id="cross-item",
+        classification=ConfidentialityLevel.RESTRICTED,
+        owning_unit_address="D2",
+        path="/hr/payroll",
+    )
+    ksp = KnowledgeSharePolicy(
+        id="ksp-deny-path",
+        source_unit_address="D2",
+        target_unit_address="D1",
+        max_classification=ConfidentialityLevel.SECRET,
+        shared_paths=("/finance/*",),
+    )
+    explanation = explain_access(
+        role_address=_ROLE,
+        knowledge_item=item,
+        posture=TrustPostureLevel.DELEGATING,
+        compiled_org=_two_dept_org(),
+        clearances=_secret_clearance(),
+        ksps=[ksp],
+        bridges=[],
+    )
+
+    assert "DENY (ksp-deny-path) [path_scope]" in explanation
+    assert "DENIED by KSP 'ksp-deny-path' (path_scope)" in explanation
+    assert "suppressed by deny-KSP" in explanation

--- a/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import pytest
 
-from kailash.trust.pact.access import KnowledgeSharePolicy, can_access
+from kailash.trust.pact.access import KnowledgeSharePolicy, KspDenyDetail, can_access
 from kailash.trust.pact.clearance import RoleClearance
 from kailash.trust.pact.compilation import RoleDefinition, compile_org
 from kailash.trust.pact.config import (
@@ -186,6 +186,28 @@ def test_classification_ceiling_deny_emits_discrete_fields() -> None:
     assert ad["deny_code"] == "classification_ceiling"
     assert ad["item_classification"] == "secret"
     assert ad["ksp_max_classification"] == "restricted"
+
+
+@pytest.mark.regression
+def test_ksp_deny_detail_rejects_reserved_audit_key() -> None:
+    """A discrete field key colliding with a reserved audit key fails closed.
+
+    Spreading KspDenyDetail.fields into the deny audit_details is dict
+    last-wins; a future condition adding a field named like a fixed audit key
+    would silently overwrite it and corrupt the SIEM-queryable deny shape.
+    Construction rejects the collision loudly instead.
+    """
+    # Sanity: a well-formed (namespace-prefixed) field is accepted.
+    ok = KspDenyDetail(
+        code="compartment_scope",
+        message="...",
+        fields={"missing_compartments": ["alpha"]},
+    )
+    assert ok.fields["missing_compartments"] == ["alpha"]
+
+    for reserved in ("ksp_id", "access_path", "deny_code", "deny_reason", "step"):
+        with pytest.raises(ValueError, match="reserved KSP-deny audit keys"):
+            KspDenyDetail(code="path_scope", message="...", fields={reserved: "x"})
 
 
 @pytest.mark.regression

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "AccessDecision",
     "KnowledgeSharePolicy",
+    "KspDenyDetail",
     "PactBridge",
     "can_access",
 ]

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -351,6 +351,34 @@ class AccessDecision:
         )
 
 
+@dataclass(frozen=True)
+class KspDenyDetail:
+    """Structured deny-context for a single failing KSP narrowing condition.
+
+    A *matching-but-denying* KSP (one whose source/target addressing matched
+    but which failed a narrowing filter) carries this structured detail so the
+    deny is SIEM-queryable, mirroring the discrete audit fields the step-3
+    clearance compartment-deny already emits. The ``code`` discriminator names
+    WHICH condition failed; ``message`` is the human-readable string preserved
+    for backward compatibility; ``fields`` carries the discrete, queryable
+    values for that condition (e.g. ``missing_compartments``), spread as
+    top-level keys into the deny ``AccessDecision.audit_details``.
+
+    Attributes:
+        code: Which narrowing condition failed. One of
+            ``"classification_ceiling"``, ``"classification_set"``,
+            ``"min_clearance"``, ``"path_scope"``, ``"type_scope"``,
+            ``"condition"``, ``"compartment_scope"``.
+        message: Human-readable deny reason (back-compat with the prior
+            string return of ``_evaluate_ksp_conditions``).
+        fields: Discrete, machine-queryable values for the failed condition.
+    """
+
+    code: str
+    message: str
+    fields: dict[str, Any] = field(default_factory=dict)
+
+
 # ---------------------------------------------------------------------------
 # Knowledge cascade helper functions
 # ---------------------------------------------------------------------------
@@ -790,7 +818,7 @@ def _evaluate_ksp_conditions(
     role_clearance: RoleClearance | None,
     now: datetime,
     environment: dict[str, Any] | None,
-) -> str | None:
+) -> KspDenyDetail | None:
     """Evaluate every narrowing condition on an addressing-matched KSP.
 
     Conditions, evaluated in order (first failure short-circuits):
@@ -804,14 +832,23 @@ def _evaluate_ksp_conditions(
          MUST be a subset of the KSP's authorized compartment set; empty
          ksp.compartments = no narrowing (empty = all).
 
-    Returns the deny-reason detail string for the FIRST failing condition,
-    or None if the item satisfies every condition (the KSP grants).
+    Returns a :class:`KspDenyDetail` carrying the deny ``code`` discriminator,
+    the human ``message`` (back-compat), and discrete ``fields`` for the FIRST
+    failing condition; or None if the item satisfies every condition (the KSP
+    grants).
     """
     # 1. Classification ceiling (max_classification)
     if _CLEARANCE_ORDER[item.classification] > _CLEARANCE_ORDER[ksp.max_classification]:
-        return (
-            f"item classification '{item.classification.value}' exceeds KSP "
-            f"max_classification ceiling '{ksp.max_classification.value}'"
+        return KspDenyDetail(
+            code="classification_ceiling",
+            message=(
+                f"item classification '{item.classification.value}' exceeds KSP "
+                f"max_classification ceiling '{ksp.max_classification.value}'"
+            ),
+            fields={
+                "item_classification": item.classification.value,
+                "ksp_max_classification": ksp.max_classification.value,
+            },
         )
 
     # 2. Classification SET membership (shared_classifications, #1371)
@@ -820,9 +857,16 @@ def _evaluate_ksp_conditions(
         and item.classification not in ksp.shared_classifications
     ):
         allowed = sorted(c.value for c in ksp.shared_classifications)
-        return (
-            f"item classification '{item.classification.value}' not in KSP "
-            f"shared_classifications set {allowed}"
+        return KspDenyDetail(
+            code="classification_set",
+            message=(
+                f"item classification '{item.classification.value}' not in KSP "
+                f"shared_classifications set {allowed}"
+            ),
+            fields={
+                "item_classification": item.classification.value,
+                "ksp_shared_classifications": allowed,
+            },
         )
 
     # 3. Recipient clearance floor (min_clearance, #1368)
@@ -834,31 +878,56 @@ def _evaluate_ksp_conditions(
         )
         if have_level < _CLEARANCE_ORDER[ksp.min_clearance]:
             have = role_clearance.max_clearance.value if role_clearance else "none"
-            return (
-                f"recipient clearance '{have}' is below KSP min_clearance floor "
-                f"'{ksp.min_clearance.value}'"
+            return KspDenyDetail(
+                code="min_clearance",
+                message=(
+                    f"recipient clearance '{have}' is below KSP min_clearance floor "
+                    f"'{ksp.min_clearance.value}'"
+                ),
+                fields={
+                    "recipient_clearance": have,
+                    "ksp_min_clearance": ksp.min_clearance.value,
+                },
             )
 
     # 4. Path scope (shared_paths, #1369)
     if ksp.shared_paths and not _path_matches(item.path, ksp.shared_paths):
-        return (
-            f"item path {item.path!r} does not match KSP shared_paths "
-            f"{list(ksp.shared_paths)}"
+        return KspDenyDetail(
+            code="path_scope",
+            message=(
+                f"item path {item.path!r} does not match KSP shared_paths "
+                f"{list(ksp.shared_paths)}"
+            ),
+            fields={
+                "item_path": item.path,
+                "ksp_shared_paths": list(ksp.shared_paths),
+            },
         )
 
     # 5. Type scope (shared_types, #1370)
     if ksp.shared_types and (
         item.knowledge_type is None or item.knowledge_type not in ksp.shared_types
     ):
-        return (
-            f"item knowledge_type {item.knowledge_type!r} not in KSP "
-            f"shared_types {sorted(ksp.shared_types)}"
+        return KspDenyDetail(
+            code="type_scope",
+            message=(
+                f"item knowledge_type {item.knowledge_type!r} not in KSP "
+                f"shared_types {sorted(ksp.shared_types)}"
+            ),
+            fields={
+                "item_knowledge_type": item.knowledge_type,
+                "ksp_shared_types": sorted(ksp.shared_types),
+            },
         )
 
     # 6. Request-context conditions (time_window / environment, #1374)
     cond_detail = _evaluate_conditions(ksp.conditions, now, environment)
     if cond_detail is not None:
-        return cond_detail
+        return KspDenyDetail(
+            code="condition",
+            message=cond_detail,
+            fields={"condition_detail": cond_detail},
+        )
 
     # 7. Compartment scope (ksp.compartments, #1375 follow-up)
     # Mirrors the step-3 clearance compartment-dominance check (the
@@ -869,9 +938,17 @@ def _evaluate_ksp_conditions(
     if ksp.compartments:
         missing = item.compartments - ksp.compartments
         if missing:
-            return (
-                f"item compartments {sorted(missing)} not authorized by KSP "
-                f"compartments {sorted(ksp.compartments)}"
+            return KspDenyDetail(
+                code="compartment_scope",
+                message=(
+                    f"item compartments {sorted(missing)} not authorized by KSP "
+                    f"compartments {sorted(ksp.compartments)}"
+                ),
+                fields={
+                    "missing_compartments": sorted(missing),
+                    "item_compartments": sorted(item.compartments),
+                    "ksp_compartments": sorted(ksp.compartments),
+                },
             )
 
     return None
@@ -911,7 +988,7 @@ def _check_ksps(
     role_unit = _get_containment_unit(role_address, compiled_org)
     role_clearance = clearances.get(role_address)
 
-    last_deny: tuple[str, str] | None = None  # (ksp_id, deny_detail)
+    last_deny: tuple[str, KspDenyDetail] | None = None  # (ksp_id, deny_detail)
 
     for ksp in ksps:
         if not ksp.active:
@@ -981,18 +1058,23 @@ def _check_ksps(
     # >=1 applicable KSP but none granted -> DENY, suppressing the bridge.
     deny_ksp_id, deny_detail = last_deny
     logger.info(
-        "Access denied (step 4d): KSP=%s denies (%s) — role_address=%s, "
+        "Access denied (step 4d): KSP=%s denies (%s: %s) — role_address=%s, "
         "item_id=%s; bridge fallback suppressed",
         deny_ksp_id,
-        deny_detail,
+        deny_detail.code,
+        deny_detail.message,
         role_address,
         item.item_id,
     )
+    # Discrete, SIEM-queryable deny context: deny_code names which narrowing
+    # condition failed; deny_detail.fields spreads as top-level keys (e.g.
+    # missing_compartments) mirroring the step-3 clearance-deny audit shape.
+    # deny_reason (the human string) is retained for backward compatibility.
     return AccessDecision(
         allowed=False,
         reason=(
-            f"KSP '{deny_ksp_id}' denies access ({deny_detail}); a matching "
-            f"deny-KSP suppresses the bridge fallback"
+            f"KSP '{deny_ksp_id}' denies access ({deny_detail.message}); a "
+            f"matching deny-KSP suppresses the bridge fallback"
         ),
         step_failed=4,
         audit_details={
@@ -1001,7 +1083,9 @@ def _check_ksps(
             "step": "4d",
             "access_path": "ksp_deny",
             "ksp_id": deny_ksp_id,
-            "deny_reason": deny_detail,
+            "deny_reason": deny_detail.message,
+            "deny_code": deny_detail.code,
+            **deny_detail.fields,
         },
     )
 

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -351,6 +351,27 @@ class AccessDecision:
         )
 
 
+# Audit-detail keys the KSP-deny AccessDecision sets directly (see
+# ``_check_ksps``). A ``KspDenyDetail.fields`` key colliding with one of these
+# would silently overwrite the fixed key when spread into ``audit_details``
+# (dict last-wins), corrupting the SIEM-queryable deny shape. Collision is
+# rejected fail-closed at construction so a future narrowing condition cannot
+# shadow a reserved key. The established discrete-field naming convention
+# (``item_*`` / ``ksp_*`` / ``recipient_*`` / ``missing_*`` / ``condition_*``)
+# keeps every current field disjoint from this set.
+_RESERVED_KSP_DENY_AUDIT_KEYS = frozenset(
+    {
+        "role_address",
+        "item_id",
+        "step",
+        "access_path",
+        "ksp_id",
+        "deny_reason",
+        "deny_code",
+    }
+)
+
+
 @dataclass(frozen=True)
 class KspDenyDetail:
     """Structured deny-context for a single failing KSP narrowing condition.
@@ -372,11 +393,26 @@ class KspDenyDetail:
         message: Human-readable deny reason (back-compat with the prior
             string return of ``_evaluate_ksp_conditions``).
         fields: Discrete, machine-queryable values for the failed condition.
+            Keys MUST NOT collide with ``_RESERVED_KSP_DENY_AUDIT_KEYS`` --
+            a collision is rejected fail-closed at construction.
     """
 
     code: str
     message: str
     fields: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject discrete-field keys that collide with reserved audit keys."""
+        collisions = _RESERVED_KSP_DENY_AUDIT_KEYS & self.fields.keys()
+        if collisions:
+            raise ValueError(
+                f"KspDenyDetail.fields keys {sorted(collisions)} collide with "
+                f"reserved KSP-deny audit keys "
+                f"{sorted(_RESERVED_KSP_DENY_AUDIT_KEYS)}; rename the discrete "
+                f"field(s) (use the item_/ksp_/recipient_/missing_/condition_ "
+                f"naming convention) so the deny audit shape is not silently "
+                f"overwritten when spread into audit_details"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/kailash/trust/pact/explain.py
+++ b/src/kailash/trust/pact/explain.py
@@ -408,15 +408,38 @@ def explain_access(
             + (f" ({decision.reason})" if decision.reason else "")
         )
     else:
-        # All sub-steps failed
+        # All sub-steps failed. A ``ksp_deny`` access_path is the deliberate
+        # #1372 case: an applicable KSP matched the addressing but failed a
+        # narrowing condition, suppressing the bridge fallback. Surface the
+        # structured deny context (denying KSP id + deny_code discriminator +
+        # human reason) so /explain mirrors the SIEM-queryable audit fields.
+        ksp_deny = access_path == "ksp_deny"
+        deny_ksp_id = decision.audit_details.get("ksp_id", "")
+        deny_code = decision.audit_details.get("deny_code", "")
+        deny_reason = decision.audit_details.get("deny_reason", "")
+
         lines.append("Step 4: Containment check:")
         lines.append("  4a: same unit -- NO")
         lines.append("  4b: downward visibility -- NO")
         lines.append("  4c: T-inherits-D -- NO")
-        lines.append("  4d: KSP -- NO")
-        lines.append("  4e: bridge -- NO")
+        if ksp_deny:
+            ksp_extra = f" ({deny_ksp_id})" if deny_ksp_id else ""
+            code_extra = f" [{deny_code}]" if deny_code else ""
+            lines.append(f"  4d: KSP -- DENY{ksp_extra}{code_extra}")
+            lines.append("  4e: bridge -- NO (suppressed by deny-KSP)")
+        else:
+            lines.append("  4d: KSP -- NO")
+            lines.append("  4e: bridge -- NO")
 
         lines.append("")
-        lines.append("Step 5: Result -- DENIED (no access path found)")
+        if ksp_deny:
+            detail = f" -- {deny_reason}" if deny_reason else ""
+            code_label = f" ({deny_code})" if deny_code else ""
+            lines.append(
+                f"Step 5: Result -- DENIED by KSP '{deny_ksp_id}'"
+                f"{code_label}{detail}"
+            )
+        else:
+            lines.append("Step 5: Result -- DENIED (no access path found)")
 
     return "\n".join(lines)

--- a/src/kailash/trust/pact/yaml_loader.py
+++ b/src/kailash/trust/pact/yaml_loader.py
@@ -20,8 +20,8 @@ from typing import Any
 
 import yaml
 
-from kailash.trust.pact.config import DepartmentConfig, OrgDefinition, TeamConfig
 from kailash.trust.pact.compilation import RoleDefinition
+from kailash.trust.pact.config import DepartmentConfig, OrgDefinition, TeamConfig
 from kailash.trust.pact.exceptions import PactError
 
 logger = logging.getLogger(__name__)
@@ -104,12 +104,56 @@ class BridgeSpec:
 
 @dataclass(frozen=True)
 class KspSpec:
-    """A Knowledge Share Policy specification from the YAML file."""
+    """A Knowledge Share Policy specification from the YAML file.
+
+    Beyond the source/target addressing and the ``max_classification``
+    ceiling, a KSP may carry NARROWING scope filters that mirror the runtime
+    :class:`~kailash.trust.pact.access.KnowledgeSharePolicy` (see its
+    docstring for the enforcement semantics). Each scope field is a narrowing
+    filter: an empty collection (or ``None``) means "no narrowing on this
+    dimension" and preserves the policy's broad grant; a non-empty value
+    requires the item to satisfy that dimension.
+
+    Scope-field values are carried VERBATIM as the YAML author wrote them
+    (the same deferred-conversion convention the loader already uses for
+    ``max_classification``, which it keeps as a raw level string). Parse-time
+    validation is limited to shape (list / mapping / string) plus
+    classification-domain membership for the clearance-level fields; the
+    semantic fail-closed checks (``..`` path-traversal rejection, condition
+    key validity, raw-string -> ``ConfidentialityLevel`` conversion, and raw
+    dept/team id -> resolved unit address) remain owned by
+    ``KnowledgeSharePolicy`` and the engine-application layer.
+
+    Attributes:
+        id: Unique policy identifier.
+        source: Department/team ID sharing knowledge (raw, pre-resolution).
+        target: Department/team ID receiving access (raw, pre-resolution).
+        max_classification: Maximum classification level shared (raw level
+            string, e.g. ``"restricted"``).
+        compartments: Compartment names the item's compartments must be a
+            subset of (empty = no compartment narrowing).
+        shared_paths: Path-prefix patterns the item path must match
+            (empty = no path narrowing).
+        shared_types: Knowledge-type names the item type must be a member of
+            (empty = no type narrowing).
+        shared_classifications: Classification-level strings the item
+            classification must be a member of (empty = ceiling-only).
+        min_clearance: Recipient clearance floor as a raw level string, or
+            ``None`` for no floor.
+        conditions: Request-context conditions (e.g. ``time_window`` /
+            ``environment``) carried verbatim; validated at access time.
+    """
 
     id: str
     source: str  # department/team ID
     target: str  # department/team ID
     max_classification: str  # e.g. "restricted"
+    compartments: tuple[str, ...] = ()
+    shared_paths: tuple[str, ...] = ()
+    shared_types: tuple[str, ...] = ()
+    shared_classifications: tuple[str, ...] = ()
+    min_clearance: str | None = None
+    conditions: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -144,7 +188,12 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     - ``clearances`` (list of ``{role, level, compartments?, nda_signed?}``)
     - ``envelopes`` (list of ``{target, defined_by, financial?, operational?, ...}``)
     - ``bridges`` (list of ``{id, role_a, role_b, type, max_classification, bilateral?}``)
-    - ``ksps`` (list of ``{id, source, target, max_classification}``)
+    - ``ksps`` (list of ``{id, source, target, max_classification,
+      compartments?, shared_paths?, shared_types?, shared_classifications?,
+      min_clearance?, conditions?}``) -- the optional scope fields are
+      NARROWING filters mirroring ``KnowledgeSharePolicy``: an empty
+      collection or ``null`` means no narrowing on that dimension and
+      preserves the broad grant.
 
     Args:
         path: Path to the YAML file.
@@ -576,6 +625,29 @@ def _parse_bridges(
     return bridges
 
 
+def _ksp_str_tuple(
+    entry: dict[str, Any], key: str, ksp_id: str, path: Path
+) -> tuple[str, ...]:
+    """Validate an optional KSP scope field as a list of strings -> tuple.
+
+    Shape validation only (list-of-str). The empty default preserves the
+    broad grant (no narrowing on this dimension). Semantic checks live in
+    ``KnowledgeSharePolicy``.
+    """
+    val = entry.get(key, [])
+    if not isinstance(val, list):
+        raise ConfigurationError(
+            f"KSP '{ksp_id}': '{key}' must be a list, got "
+            f"{type(val).__name__}. In YAML file '{path}'."
+        )
+    if not all(isinstance(x, str) for x in val):
+        raise ConfigurationError(
+            f"KSP '{ksp_id}': '{key}' entries must all be strings. "
+            f"In YAML file '{path}'."
+        )
+    return tuple(val)
+
+
 def _parse_ksps(
     raw: list[Any],
     all_unit_ids: set[str],
@@ -613,12 +685,53 @@ def _parse_ksps(
                 f"KSP '{ksp_id}' is missing required 'max_classification' field in '{path}'"
             )
 
+        # --- Optional narrowing scope fields (backward-compatible: every
+        # field defaults to empty/None = no narrowing on that dimension).
+        # Values are carried VERBATIM; the semantic fail-closed checks
+        # ('..' path traversal, condition-key validity, raw level string ->
+        # ConfidentialityLevel, raw id -> resolved address) are owned by
+        # KnowledgeSharePolicy and the engine-application layer, NOT here. ---
+        compartments = _ksp_str_tuple(entry, "compartments", ksp_id, path)
+        shared_paths = _ksp_str_tuple(entry, "shared_paths", ksp_id, path)
+        shared_types = _ksp_str_tuple(entry, "shared_types", ksp_id, path)
+        shared_classifications = _ksp_str_tuple(
+            entry, "shared_classifications", ksp_id, path
+        )
+        for level in shared_classifications:
+            if level not in _VALID_CLEARANCE_LEVELS:
+                raise ConfigurationError(
+                    f"KSP '{ksp_id}': invalid shared_classification '{level}'. "
+                    f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "
+                    f"In YAML file '{path}'."
+                )
+
+        min_clearance = entry.get("min_clearance")
+        if min_clearance is not None and min_clearance not in _VALID_CLEARANCE_LEVELS:
+            raise ConfigurationError(
+                f"KSP '{ksp_id}': invalid min_clearance '{min_clearance}'. "
+                f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "
+                f"In YAML file '{path}'."
+            )
+
+        conditions = entry.get("conditions", {})
+        if not isinstance(conditions, dict):
+            raise ConfigurationError(
+                f"KSP '{ksp_id}': 'conditions' must be a mapping, got "
+                f"{type(conditions).__name__}. In YAML file '{path}'."
+            )
+
         ksps.append(
             KspSpec(
                 id=ksp_id,
                 source=source,
                 target=target,
                 max_classification=max_classification,
+                compartments=compartments,
+                shared_paths=shared_paths,
+                shared_types=shared_types,
+                shared_classifications=shared_classifications,
+                min_clearance=min_clearance,
+                conditions=conditions,
             )
         )
 

--- a/tests/trust/pact/unit/test_yaml_loader.py
+++ b/tests/trust/pact/unit/test_yaml_loader.py
@@ -257,6 +257,206 @@ class TestLoadWithBridgesAndKsps:
 
 
 # ---------------------------------------------------------------------------
+# Test: KSP narrowing scope fields (compartments / shared_paths /
+# shared_types / shared_classifications / min_clearance / conditions)
+# ---------------------------------------------------------------------------
+
+
+def _write_ksp_org(tmp_path: Path, ksps_block: str) -> Path:
+    """Write a minimal two-department org with the given ``ksps:`` block."""
+    content = (
+        textwrap.dedent(
+            """\
+            org_id: "ksp-scope-001"
+            name: "KSP Scope Test"
+            departments:
+              - id: d-a
+                name: Dept A
+              - id: d-b
+                name: Dept B
+            teams: []
+            roles:
+              - id: r-head-a
+                name: Head A
+                heads: d-a
+              - id: r-head-b
+                name: Head B
+                heads: d-b
+            """
+        )
+        + textwrap.dedent(ksps_block)
+    )
+    yaml_file = tmp_path / "ksp-scope.yaml"
+    yaml_file.write_text(content)
+    return yaml_file
+
+
+class TestKspScopeFields:
+    """KSP YAML entries express the full narrowing scope-field set."""
+
+    def test_ksp_scope_fields_default_empty(self, tmp_path: Path) -> None:
+        """A KSP omitting all scope keys defaults to empty/None (no narrowing)."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+            """,
+        )
+        result = load_org_yaml(yaml_file)
+
+        ksp = result.ksps[0]
+        # Backward-compat guard: empty = all = broad grant preserved.
+        assert ksp.compartments == ()
+        assert ksp.shared_paths == ()
+        assert ksp.shared_types == ()
+        assert ksp.shared_classifications == ()
+        assert ksp.min_clearance is None
+        assert ksp.conditions == {}
+
+    def test_ksp_full_scope_roundtrip(self, tmp_path: Path) -> None:
+        """All six scope fields parse verbatim, order preserved."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: secret
+                compartments: [c1, c2]
+                shared_paths: ["proj/*", "exact/path"]
+                shared_types: [doc, memo]
+                shared_classifications: [restricted, confidential]
+                min_clearance: confidential
+                conditions:
+                  time_window:
+                    start: "09:00"
+                    end: "17:00"
+            """,
+        )
+        result = load_org_yaml(yaml_file)
+
+        ksp = result.ksps[0]
+        assert ksp.compartments == ("c1", "c2")
+        assert ksp.shared_paths == ("proj/*", "exact/path")
+        assert ksp.shared_types == ("doc", "memo")
+        assert ksp.shared_classifications == ("restricted", "confidential")
+        assert ksp.min_clearance == "confidential"
+        assert ksp.conditions == {"time_window": {"start": "09:00", "end": "17:00"}}
+
+    def test_ksp_shared_classification_invalid_level(self, tmp_path: Path) -> None:
+        """An out-of-domain shared_classification raises at parse time."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                shared_classifications: [foobar]
+            """,
+        )
+        with pytest.raises(
+            ConfigurationError, match="invalid shared_classification 'foobar'"
+        ):
+            load_org_yaml(yaml_file)
+
+    def test_ksp_min_clearance_invalid_level(self, tmp_path: Path) -> None:
+        """An out-of-domain min_clearance raises at parse time."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                min_clearance: notalevel
+            """,
+        )
+        with pytest.raises(
+            ConfigurationError, match="invalid min_clearance 'notalevel'"
+        ):
+            load_org_yaml(yaml_file)
+
+    def test_ksp_compartments_not_a_list(self, tmp_path: Path) -> None:
+        """A scalar where a list is expected raises with a shape error."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                compartments: notalist
+            """,
+        )
+        with pytest.raises(ConfigurationError, match="'compartments' must be a list"):
+            load_org_yaml(yaml_file)
+
+    def test_ksp_shared_paths_non_string_elements(self, tmp_path: Path) -> None:
+        """Non-string list elements raise a type error."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                shared_paths: [123]
+            """,
+        )
+        with pytest.raises(
+            ConfigurationError, match="'shared_paths' entries must all be strings"
+        ):
+            load_org_yaml(yaml_file)
+
+    def test_ksp_conditions_not_a_mapping(self, tmp_path: Path) -> None:
+        """A list where a mapping is expected raises a shape error."""
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                conditions: [x]
+            """,
+        )
+        with pytest.raises(ConfigurationError, match="'conditions' must be a mapping"):
+            load_org_yaml(yaml_file)
+
+    def test_ksp_traversal_path_not_rejected_at_parse(self, tmp_path: Path) -> None:
+        """The spec layer is a faithful DTO: ``..`` traversal in shared_paths
+        PARSES successfully here. The fail-closed rejection of ``..`` segments
+        is owned by KnowledgeSharePolicy.__post_init__ (access.py), NOT the
+        YAML parser -- splitting that check across two layers would be the
+        three-way-drift trap. Do NOT "fix" this by adding parse-time rejection.
+        """
+        yaml_file = _write_ksp_org(
+            tmp_path,
+            """\
+            ksps:
+              - id: ksp-a-to-b
+                source: d-a
+                target: d-b
+                max_classification: restricted
+                shared_paths: ["../etc"]
+            """,
+        )
+        result = load_org_yaml(yaml_file)
+        assert result.ksps[0].shared_paths == ("../etc",)
+
+
+# ---------------------------------------------------------------------------
 # Test: Invalid YAML
 # ---------------------------------------------------------------------------
 
@@ -269,7 +469,9 @@ class TestInvalidYaml:
         yaml_file = tmp_path / "bad.yaml"
         yaml_file.write_text("foo: [bar: baz")
 
-        with pytest.raises(ConfigurationError, match="[Ff]ailed.*pars|[Ii]nvalid.*YAML"):
+        with pytest.raises(
+            ConfigurationError, match="[Ff]ailed.*pars|[Ii]nvalid.*YAML"
+        ):
             load_org_yaml(yaml_file)
 
     def test_missing_required_field_raises(self, tmp_path: Path) -> None:
@@ -326,7 +528,9 @@ class TestInvalidYaml:
 
     def test_nonexistent_file_raises(self) -> None:
         """Attempting to load a file that does not exist raises ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="[Nn]ot found|[Dd]oes not exist|[Nn]o such"):
+        with pytest.raises(
+            ConfigurationError, match="[Nn]ot found|[Dd]oes not exist|[Nn]o such"
+        ):
             load_org_yaml("/nonexistent/path/to/org.yaml")
 
     def test_empty_yaml_raises(self, tmp_path: Path) -> None:
@@ -432,7 +636,9 @@ class TestRoundtripUniversityExample:
         assert len(role_ids) == 12
 
         # Agent assignment
-        irb = next(r for r in result.org_definition.roles if r.role_id == "r-irb-director")
+        irb = next(
+            r for r in result.org_definition.roles if r.role_id == "r-irb-director"
+        )
         assert irb.agent_id == "agent-irb"
 
         # Clearances


### PR DESCRIPTION
## Summary

Completes two gaps in the KnowledgeSharePolicy (KSP) scoping arc that shipped in #1368–#1374 (runtime enforcement) but stopped short of the **config surface** and the **audit surface**:

- **F8 — KSP YAML DSL scope-field expressiveness.** The runtime `KnowledgeSharePolicy` enforces six narrowing scope filters, but the YAML `KspSpec` carried only `id/source/target/max_classification` — so an org defined in YAML could not actually *use* any of the scoping features the engine now enforces. The YAML `ksps:` block now accepts `compartments`, `shared_paths`, `shared_types`, `shared_classifications`, `min_clearance`, and `conditions`. Every field is optional and defaults to empty/None (no narrowing = broad grant), so existing YAML is byte-identical in behaviour.
- **F9 — KSP-deny structured observability.** A KSP deny collapsed all its context into one free-text `deny_reason` string, so a SIEM couldn't query *which* condition denied or *which* compartments were missing without regex — unlike the step-3 clearance deny, which already emits discrete `missing_compartments` fields. KSP denials now carry a `deny_code` discriminator plus condition-specific discrete fields (e.g. `missing_compartments`, `item_path`, `ksp_shared_types`) as top-level `audit_details` keys; the human `deny_reason` string is kept for backward compatibility, and `/explain` surfaces the `deny_code` + denying KSP id.

Plus a fail-closed hardening (from redteam): a `KspDenyDetail.fields` key colliding with a reserved audit key is rejected at construction so it can never silently overwrite the deny audit shape.

`KspSpec` stays a pure frozen DTO — **no `to_policy()` adapter** is added: no `src/` code consumes `LoadedOrg.ksps` today, and a ksps-only converter would be an asymmetric orphan ahead of a holistic engine-application layer (designed across all four spec types). The fail-closed semantic checks (`..` traversal, condition-key validity, raw-string→enum, raw-id→resolved-address) remain owned by `KnowledgeSharePolicy`/the apply-layer — the parser is a faithful DTO, not a second validation layer.

## Related issues

Part of #1375 (`[pact] Epic: KnowledgeSharePolicy + Bridge access-control scoping & precedence`). F9 closes the security-reviewer "SIEM queryability" finding for the KSP deny path.

## Commits

- `feat(pact): express KSP narrowing scope fields in the YAML DSL` (F8)
- `feat(pact): emit discrete SIEM-queryable fields on KSP-deny decisions` (F9)
- `harden(pact): reject KSP-deny field keys colliding with reserved audit keys`
- `chore(pact): export KspDenyDetail in access.py __all__`

## Tests

- 8 new F8 tests (`tests/trust/pact/unit/test_yaml_loader.py`) — scope-field roundtrip, defaults/back-compat, shape + classification-domain validation, parse-time-DTO boundary (`..` parses; rejection is the runtime's job).
- 6 new F9 tests (`packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py`) — discrete fields per deny code (path/compartment/type/classification), back-compat `deny_reason`, `/explain` surfacing, and the reserved-key collision guard.
- Core `tests/trust/pact/` suite: **1243 passed** (no regression). Deny-precedence #1372 + fail-closed behaviour unchanged.

> Note: 11 pre-existing failures in `packages/kailash-pact/tests/unit/test_enforcement_modes|test_pact_engine|test_per_node_governance` are `EnvModelMissing` in `GovernedSupervisor` (`KAIZEN_DEFAULT_MODEL` unset locally) — a kaizen-integration env gap verified present on `main` (`c78474289`) before this diff, unrelated to KSP.

## Redteam — converged (2 consecutive clean rounds)

Multi-lens, evidence-gated, sequential-dispatch redteam (reviewer + security-reviewer + pact-specialist). `converged: true, clean_streak: 2, rounds_run: 2` — every lens genuinely ran in both rounds (evidence gate), **zero CRIT/HIGH/MED**. Findings dispositioned: reviewer NIT (audit-key collision) → applied as the hardening commit; reviewer NIT (`KspDenyDetail` not in `__all__`) → applied as the chore commit; security-reviewer LOW (INFO-disclosure) → verified pre-existing module-wide posture, F9 does not increase disclosure (INFO logs `code`+`message` == the old `deny_reason` string; discrete fields go to `audit_details` only).

## User-flow walk receipts

`load_org_yaml` on a YAML org carrying all six KSP scope fields:
```
compartments=('payroll',) shared_paths=('/finance/*',) shared_types=('report',)
shared_classifications=('restricted','confidential') min_clearance=confidential
conditions={'time_window': {'start': '09:00', 'end': '17:00'}}
```
A KSP compartment-narrowing deny via `can_access` + `explain_access`:
```
deny_code='compartment_scope'  missing_compartments=['alpha']  ksp_compartments=['beta']
deny_reason="item compartments ['alpha'] not authorized by KSP compartments ['beta']"
  4d: KSP -- DENY (ksp-deny-comp) [compartment_scope]
  4e: bridge -- NO (suppressed by deny-KSP)
  Step 5: Result -- DENIED by KSP 'ksp-deny-comp' (compartment_scope) -- ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)