### PR TITLE
chore(release): kailash 2.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.40.0] - 2026-06-19
+
+### Added
+
+- **KSP YAML DSL scope-field expressiveness** (`kailash.trust.pact.yaml_loader`,
+  part of #1375). The YAML `ksps:` block now accepts the full narrowing
+  scope-field set the runtime `KnowledgeSharePolicy` enforces — `compartments`,
+  `shared_paths` (#1369), `shared_types` (#1370), `shared_classifications`
+  (#1371), `min_clearance` (#1368), and `conditions` (#1374, e.g. a
+  `time_window`). Previously a YAML-defined org could express only
+  `max_classification`, so the scoping features the engine enforces were
+  unreachable from configuration. Every new field is optional and defaults to
+  empty/`None` (no narrowing = broad grant), so existing YAML is unchanged.
+  `KspSpec` carries the values verbatim as a frozen DTO; the fail-closed
+  semantic checks (`..` path traversal, condition-key validity, level-string →
+  `ConfidentialityLevel`, raw id → resolved address) remain owned by
+  `KnowledgeSharePolicy` and the engine-application layer.
+
+- **Structured, SIEM-queryable KSP-deny observability** (`kailash.trust.pact`,
+  part of #1375). A KSP deny now emits a `deny_code` discriminator
+  (`compartment_scope` / `path_scope` / `type_scope` / `classification_ceiling`
+  / `classification_set` / `min_clearance` / `condition`) plus
+  condition-specific discrete fields (e.g. `missing_compartments`, `item_path`,
+  `ksp_shared_types`) as top-level `AccessDecision.audit_details` keys — parity
+  with the step-3 clearance-deny audit shape — while keeping the human
+  `deny_reason` string for backward compatibility. `/explain` surfaces the
+  `deny_code` and the denying KSP id. Deny-precedence (#1372) and fail-closed
+  behaviour are unchanged. New public type `KspDenyDetail`
+  (`kailash.trust.pact.access`), whose discrete-field keys are guarded
+  fail-closed against collision with the reserved audit keys.
+
 ## [2.39.1] - 2026-06-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.39.1"
+version = "2.40.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.39.1"
+__version__ = "2.40.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Release-prep for **kailash 2.40.0** — metadata-only (`pyproject.toml`, `src/kailash/__init__.py`, `CHANGELOG.md`). The feature code shipped in #1382.

## What's in 2.40.0

- **KSP YAML DSL scope-field expressiveness** (part of #1375) — the YAML `ksps:` block now expresses the full narrowing scope-field set the runtime enforces (`compartments`, `shared_paths`, `shared_types`, `shared_classifications`, `min_clearance`, `conditions`); #1368–#1374 scoping is now reachable from configuration. Backward-compatible (all new fields optional, default empty/None).
- **Structured, SIEM-queryable KSP-deny observability** (part of #1375) — KSP denials carry a `deny_code` discriminator + discrete `audit_details` fields (parity with the step-3 clearance-deny shape); `deny_reason` string kept for back-compat. New public type `KspDenyDetail`.

## Release readiness

- Feature PR #1382 merged to main (`366eb7203`), full CI matrix green (Python 3.11–3.14 × ubuntu/windows, PACT, Trust, N6 Conformance, CodeQL).
- Redteam converged (2 consecutive clean rounds, 0 CRIT/HIGH/MED).
- Version consistent across `pyproject.toml` + `__init__.py` + `CHANGELOG.md`.
- No sibling-package drift (all 7 sub-packages in sync with PyPI).

## Related issues

Part of #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)