### PR TITLE
fix(pact): re-export KspDenyDetail from package facades (#1375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.40.1] - 2026-06-19
+
+### Fixed
+
+- `KspDenyDetail` (the F9 KSP-deny observability type) is now importable from
+  the `kailash.trust.pact` package facade, matching its siblings
+  (`AccessDecision`, `KnowledgeSharePolicy`, `PactBridge`). It was present in
+  `kailash.trust.pact.access.__all__` but never lifted into the package
+  `__init__`, so `from kailash.trust.pact import KspDenyDetail` raised
+  `ImportError`. Surfaced by the epic #1375 holistic post-multi-wave redteam
+  (orphan-detection Rule 6). A structural parity regression test now pins
+  every `access.__all__` symbol importable from both facades.
+
 ## [2.40.0] - 2026-06-19
 
 ### Added

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,18 @@
 # PACT Changelog
 
+## [0.13.1] — 2026-06-19 — fix: re-export KspDenyDetail from the pact facade (#1375)
+
+### Fixed
+
+- `KspDenyDetail` (the F9 KSP-deny observability type) is now importable as
+  `from pact import KspDenyDetail`, matching its access-enforcement siblings
+  (`AccessDecision`, `KnowledgeSharePolicy`, `PactBridge`). It was declared in
+  `kailash.trust.pact.access.__all__` but never re-exported through the package
+  facades, so the import raised `ImportError`. Surfaced by the epic #1375
+  holistic post-multi-wave redteam (orphan-detection Rule 6). A structural
+  parity regression test pins every `access.__all__` symbol importable from
+  both the `kailash.trust.pact` and `pact` facades.
+
 ## [0.13.0] — 2026-06-18 — feat: KSP/Bridge access-control scoping & precedence (#1368–#1374)
 
 Exposes the new core PACT access-control scoping API (epic #1375) through the

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.13.0"
+version = "0.13.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (
@@ -52,6 +52,7 @@ from kailash.trust.pact import (  # Error hierarchy; Addressing; Compilation; Cl
     GrammarError,
     KnowledgeItem,
     KnowledgeSharePolicy,
+    KspDenyDetail,
     KspSpec,
     LoadedOrg,
     MemoryAccessPolicyStore,
@@ -193,6 +194,7 @@ __all__ = [
     # Access enforcement
     "AccessDecision",
     "KnowledgeSharePolicy",
+    "KspDenyDetail",
     "PactBridge",
     "can_access",
     # Agent mapping

--- a/packages/kailash-pact/tests/regression/test_issue_1375_ksp_export_parity.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1375_ksp_export_parity.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: every public access-enforcement symbol is importable from both facades.
+
+Epic #1375 holistic-redteam finding (orphan-detection Rule 6). The F9 deny-
+observability type ``KspDenyDetail`` was added to
+``kailash.trust.pact.access.__all__`` but NOT lifted into the package public API
+at ``kailash.trust.pact`` / ``pact`` the way its siblings (``AccessDecision``,
+``KnowledgeSharePolicy``, ``PactBridge``) were. A symbol both advertised
+(module ``__all__``) and hidden (absent from the package facade) is the exact
+inconsistency orphan-detection.md Rule 6 blocks — ``from pact import
+KspDenyDetail`` raised ``ImportError`` while its siblings resolved.
+
+This pins parity structurally: EVERY entry in
+``kailash.trust.pact.access.__all__`` MUST be importable from BOTH the
+``kailash.trust.pact`` core facade AND the ``pact`` distribution facade, and the
+two MUST resolve to the same object. A future addition to ``access.__all__``
+that forgets the facade re-export fails this test loudly.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+ACCESS = importlib.import_module("kailash.trust.pact.access")
+CORE_FACADE = importlib.import_module("kailash.trust.pact")
+PACT_FACADE = importlib.import_module("pact")
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("symbol", sorted(ACCESS.__all__))
+def test_access_symbol_reexported_from_both_facades(symbol: str) -> None:
+    """Each access.__all__ symbol resolves from both facades to the same object."""
+    assert hasattr(CORE_FACADE, symbol), (
+        f"{symbol!r} is in kailash.trust.pact.access.__all__ but not importable "
+        f"from kailash.trust.pact (orphan-detection Rule 6: advertised + hidden)"
+    )
+    assert hasattr(PACT_FACADE, symbol), (
+        f"{symbol!r} is in kailash.trust.pact.access.__all__ but not importable "
+        f"from the pact distribution facade (orphan-detection Rule 6)"
+    )
+    core_obj = getattr(CORE_FACADE, symbol)
+    pact_obj = getattr(PACT_FACADE, symbol)
+    assert core_obj is pact_obj, (
+        f"{symbol!r} resolves to different objects via kailash.trust.pact "
+        f"({core_obj!r}) vs pact ({pact_obj!r}) — re-export divergence"
+    )
+
+
+@pytest.mark.regression
+def test_access_symbol_in_both_facade_dunder_all() -> None:
+    """Each access.__all__ symbol is declared in both facades' __all__ contract."""
+    missing_core = [s for s in ACCESS.__all__ if s not in CORE_FACADE.__all__]
+    missing_pact = [s for s in ACCESS.__all__ if s not in PACT_FACADE.__all__]
+    assert (
+        not missing_core
+    ), f"access.__all__ symbols absent from kailash.trust.pact.__all__: {missing_core}"
+    assert (
+        not missing_pact
+    ), f"access.__all__ symbols absent from pact.__all__: {missing_pact}"
+
+
+@pytest.mark.regression
+def test_ksp_deny_detail_specifically_importable() -> None:
+    """Direct pin for the F9 type whose omission triggered this regression."""
+    from kailash.trust.pact import KspDenyDetail as CoreType
+    from pact import KspDenyDetail as PactType
+
+    assert CoreType is PactType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.40.0"
+version = "2.40.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.40.0"
+__version__ = "2.40.1"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/trust/pact/__init__.py
+++ b/src/kailash/trust/pact/__init__.py
@@ -5,6 +5,7 @@
 from kailash.trust.pact.access import (
     AccessDecision,
     KnowledgeSharePolicy,
+    KspDenyDetail,
     PactBridge,
     can_access,
 )
@@ -124,6 +125,7 @@ __all__ = [
     # Access enforcement (Ref-2003 through 2006)
     "AccessDecision",
     "KnowledgeSharePolicy",
+    "KspDenyDetail",
     "PactBridge",
     "can_access",
     # Agent mapping (Ref-7017)


### PR DESCRIPTION
## Summary

The F9 KSP-deny observability type `KspDenyDetail` was added to
`kailash.trust.pact.access.__all__` (commit `f3d7c6ebe`) but never lifted into
the `kailash.trust.pact` package `__init__` the way its three siblings
(`AccessDecision`, `KnowledgeSharePolicy`, `PactBridge`) were. So
`from kailash.trust.pact import KspDenyDetail` and `from pact import KspDenyDetail`
raised `ImportError` while every sibling resolved — a symbol both **advertised**
(module `__all__`) and **hidden** (package facade), the exact inconsistency
orphan-detection Rule 6 blocks.

This was surfaced by the **epic #1375 holistic post-multi-wave redteam** — the
cross-shard gate (`agents.md` § "Holistic Post-Multi-Wave Redteam Before Plan
Close") run over the union of merged KSP shards (PRs #1376 + #1379 + #1382)
before declaring the cluster converged. It was the single confirmed finding
(MEDIUM, 3/3 adversarial-verify lenses).

## Fix

- Re-export `KspDenyDetail` from `src/kailash/trust/pact/__init__.py` (import + `__all__`).
- Re-export `KspDenyDetail` from `packages/kailash-pact/src/pact/__init__.py` (re-export + `__all__`).
- New structural parity regression test (`test_issue_1375_ksp_export_parity.py`)
  pinning EVERY `access.__all__` symbol importable from **both** facades, so a
  future `access.__all__` addition that forgets the re-export fails loudly.
- Version bumps: `kailash` 2.40.0 → 2.40.1, `kailash-pact` 0.13.0 → 0.13.1
  (both package `__init__` surfaces changed).

## Verification

```
$ python -c "from kailash.trust.pact import KspDenyDetail; from pact import KspDenyDetail; print('OK')"
OK
$ pytest packages/kailash-pact/tests/regression/test_issue_1375_ksp_export_parity.py -q
7 passed
$ pytest packages/kailash-pact/tests/regression/ .../governance/test_{access,explain,yaml_loader,engine,api_schemas,backup,sqlite_stores}.py -q
293 passed
$ pytest packages/kailash-pact/tests/ --collect-only -q   # 1622 tests collected
```

## Related issues

Epic #1375 (KnowledgeSharePolicy + Bridge access-control scoping & precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)