### PR TITLE
feat(pact): apply YAML governance specs to the runtime engine (#1386)

### DIFF
--- a/packages/kailash-pact/src/pact/engine.py
+++ b/packages/kailash-pact/src/pact/engine.py
@@ -850,22 +850,33 @@ class PactEngine:
             FileNotFoundError: If the YAML file does not exist.
         """
         from kailash.trust.pact.engine import GovernanceEngine
-        from kailash.trust.pact.yaml_loader import load_org_yaml
+        from kailash.trust.pact.yaml_loader import load_org_from_dict, load_org_yaml
+        from kailash.trust.pact.yaml_resolvers import apply_governance_specs
 
         if isinstance(org, (str, Path)):
-            # Load from YAML file
+            # Load from YAML file (parses org + the four governance-spec lists).
             loaded = load_org_yaml(org)
-            org_def = loaded.org_definition
         elif isinstance(org, dict):
-            # Build OrgDefinition from dict -- use the YAML loader's parsing
-            # by writing to a temporary in-memory representation
-            org_def = _org_def_from_dict(org)
+            # Same parse semantics from an in-memory mapping, so the dict path
+            # also applies clearances/envelopes/bridges/ksps (it previously
+            # dropped them).
+            loaded = load_org_from_dict(org)
         else:
             raise TypeError(
                 f"org must be a str path, Path, or dict, got {type(org).__name__}"
             )
 
-        return GovernanceEngine(org_def, store_backend=store_backend)
+        engine = GovernanceEngine(loaded.org_definition, store_backend=store_backend)
+
+        # Apply the YAML-loaded governance specs so YAML-authored governance
+        # actually takes effect at enforcement (issue #1386). A YAML-authored
+        # bridge expresses the org designer's intent, which IS the LCA approval
+        # create_bridge requires (see yaml_resolvers.apply_governance_specs).
+        # Fail-closed: any unresolved ref, invalid level, NaN/Inf constraint, or
+        # monotonic-tightening violation aborts engine construction.
+        apply_governance_specs(engine, loaded)
+
+        return engine
 
     # -------------------------------------------------------------------
     # Absorbed governance capabilities (PR#7 of issue #567)
@@ -1297,69 +1308,6 @@ def _extract_constraints_dict(envelope: Any) -> dict[str, Any]:
             else str(expires_at)
         )
     return constraints
-
-
-def _org_def_from_dict(data: dict[str, Any]) -> Any:
-    """Build an OrgDefinition from a raw dict.
-
-    Mirrors the structure expected by the YAML loader but without
-    needing a physical file.
-
-    Args:
-        data: Dict with org_id, name, departments, teams, roles.
-
-    Returns:
-        An OrgDefinition instance.
-
-    Raises:
-        ValueError: If required fields are missing.
-    """
-    from kailash.trust.pact.compilation import RoleDefinition
-    from kailash.trust.pact.config import DepartmentConfig, OrgDefinition, TeamConfig
-
-    if "org_id" not in data:
-        raise ValueError("org dict must contain 'org_id'")
-    if "name" not in data:
-        raise ValueError("org dict must contain 'name'")
-
-    departments = []
-    for d in data.get("departments", []):
-        departments.append(
-            DepartmentConfig(
-                department_id=d["id"],
-                name=d.get("name", d["id"]),
-            )
-        )
-
-    teams = []
-    for t in data.get("teams", []):
-        teams.append(
-            TeamConfig(
-                id=t["id"],
-                name=t.get("name", t["id"]),
-                workspace=f"ws-{t['id']}",
-            )
-        )
-
-    roles = []
-    for r in data.get("roles", []):
-        roles.append(
-            RoleDefinition(
-                role_id=r["id"],
-                name=r.get("name", r["id"]),
-                reports_to_role_id=r.get("reports_to"),
-                is_primary_for_unit=r.get("heads"),
-                agent_id=r.get("agent"),
-            )
-        )
-
-    return OrgDefinition(
-        org_id=data["org_id"],
-        name=data["name"],
-        departments=departments,
-        teams=teams,
-        roles=roles,
-    )
 
 
 class _ReadOnlyGovernanceView:

--- a/packages/kailash-pact/tests/unit/governance/test_yaml_apply.py
+++ b/packages/kailash-pact/tests/unit/governance/test_yaml_apply.py
@@ -1,0 +1,461 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+"""Tier-2 tests for the YAML -> runtime governance-spec engine-application layer.
+
+Issue #1386 disposition (X): governance specs authored in a unified YAML org
+file (clearances / envelopes / bridges / ksps) MUST take effect at enforcement
+when an engine is built from that YAML. These tests author real YAML, build a
+real GovernanceEngine (memory store backend -- the real engine, no mocking per
+testing.md Tier 2/3), and assert enforcement via ``check_access`` /
+``compute_envelope``. Fail-closed cases assert that a misauthored spec aborts
+engine construction rather than silently under-enforcing.
+
+PACT access model note: ``check_access`` step 1 requires the REQUESTING role to
+hold a clearance at or above the item's classification, independent of any
+KSP/bridge that grants the cross-unit path. The base org below therefore grants
+the reading roles a RESTRICTED clearance so the KSP/bridge/deny-precedence tests
+exercise the cross-unit path (not the step-1 clearance gate); the clearance test
+uses its own org to isolate clearance level as the deciding factor.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kailash.trust.pact.config import ConfidentialityLevel, TrustPostureLevel
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.envelopes import MonotonicTighteningError
+from kailash.trust.pact.exceptions import PactError
+from kailash.trust.pact.knowledge import KnowledgeItem
+from kailash.trust.pact.yaml_loader import ClearanceSpec, ConfigurationError, KspSpec
+from kailash.trust.pact.yaml_resolvers import resolve_clearance, resolve_ksp
+from pact.engine import PactEngine
+
+# A 3-level org: CEO -> {Eng head (heads d-eng), Fin head (heads d-fin)};
+# Eng head -> Eng junior. Eng and Fin are sibling units that cannot read each
+# other's data without an explicit KSP or bridge. Reading roles carry a
+# RESTRICTED clearance so the step-1 clearance gate passes for RESTRICTED items.
+_BASE_ORG = """
+org_id: apply-test
+name: Apply Test Org
+departments:
+  - id: d-eng
+  - id: d-fin
+roles:
+  - id: r-ceo
+  - id: r-eng-head
+    heads: d-eng
+    reports_to: r-ceo
+  - id: r-eng-junior
+    reports_to: r-eng-head
+  - id: r-fin-head
+    heads: d-fin
+    reports_to: r-ceo
+clearances:
+  - role: r-eng-head
+    level: restricted
+  - role: r-eng-junior
+    level: restricted
+  - role: r-fin-head
+    level: restricted
+"""
+
+
+def _build_from_yaml(yaml_text: str, tmp_path: Path) -> GovernanceEngine:
+    """Write YAML to a file and build a runtime GovernanceEngine from it."""
+    org_file = tmp_path / "org.yaml"
+    org_file.write_text(textwrap.dedent(yaml_text))
+    return PactEngine._create_governance_engine(str(org_file), "memory")
+
+
+def _role(engine: GovernanceEngine, role_id: str) -> str:
+    node = engine.get_org().get_node_by_role_id(role_id)
+    assert node is not None, f"role {role_id} not found"
+    return node.address
+
+
+def _unit(engine: GovernanceEngine, unit_id: str) -> str:
+    node = engine.get_org().get_node_by_unit_id(unit_id)
+    assert node is not None, f"unit {unit_id} not found"
+    return node.address
+
+
+def _can_read(
+    engine: GovernanceEngine,
+    role_id: str,
+    unit_id: str,
+    *,
+    classification: ConfidentialityLevel = ConfidentialityLevel.RESTRICTED,
+    path: str | None = None,
+    item_id: str = "i",
+) -> bool:
+    item = KnowledgeItem(
+        item_id=item_id,
+        classification=classification,
+        owning_unit_address=_unit(engine, unit_id),
+        path=path,
+        description="",
+    )
+    return engine.check_access(
+        role_address=_role(engine, role_id),
+        knowledge_item=item,
+        posture=TrustPostureLevel.SHARED_PLANNING,
+    ).allowed
+
+
+# ---------------------------------------------------------------------------
+# KSP applied: grants + shared_paths narrows
+# ---------------------------------------------------------------------------
+
+
+class TestYamlKspApplied:
+    def test_yaml_ksp_grants_and_shared_paths_narrows(self, tmp_path: Path) -> None:
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+ksps:
+  - id: k-eng-to-fin
+    source: d-eng
+    target: d-fin
+    max_classification: confidential
+    shared_paths: ["public/*"]
+""",
+            tmp_path,
+        )
+        # KSP applied -> Finance can read the path-matching item ...
+        assert _can_read(engine, "r-fin-head", "d-eng", path="public/report") is True
+        # ... but the shared_paths filter narrows: the non-matching path is denied.
+        assert _can_read(engine, "r-fin-head", "d-eng", path="internal/report") is False
+
+    def test_no_ksp_means_cross_unit_denied(self, tmp_path: Path) -> None:
+        """Baseline: without a KSP, cross-unit access is denied (no path)."""
+        engine = _build_from_yaml(_BASE_ORG, tmp_path)
+        assert _can_read(engine, "r-fin-head", "d-eng", path="public/report") is False
+
+
+# ---------------------------------------------------------------------------
+# Clearance applied: enables an access that fails without it (level is the gate)
+# ---------------------------------------------------------------------------
+
+
+class TestYamlClearanceApplied:
+    _ORG = """
+org_id: clearance-test
+name: Clearance Test Org
+departments:
+  - id: d-fin
+roles:
+  - id: r-ceo
+  - id: r-fin-head
+    heads: d-fin
+    reports_to: r-ceo
+clearances:
+  - role: r-fin-head
+    level: %s
+"""
+
+    def test_yaml_clearance_level_is_the_gate(self, tmp_path: Path) -> None:
+        # Sequential builds: each engine is constructed before the next write,
+        # so reusing tmp_path (overwriting org.yaml) is safe.
+        insufficient = _build_from_yaml(self._ORG % "restricted", tmp_path)
+        sufficient = _build_from_yaml(self._ORG % "confidential", tmp_path)
+
+        # CONFIDENTIAL own-unit item: RESTRICTED clearance denies, CONFIDENTIAL allows.
+        assert (
+            _can_read(
+                insufficient,
+                "r-fin-head",
+                "d-fin",
+                classification=ConfidentialityLevel.CONFIDENTIAL,
+            )
+            is False
+        )
+        assert (
+            _can_read(
+                sufficient,
+                "r-fin-head",
+                "d-fin",
+                classification=ConfidentialityLevel.CONFIDENTIAL,
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Envelope applied: tightens; widening fails closed; parent-before-child order
+# ---------------------------------------------------------------------------
+
+
+class TestYamlEnvelopeApplied:
+    def test_yaml_envelope_tightens(self, tmp_path: Path) -> None:
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    financial:
+      max_spend_usd: 100.0
+""",
+            tmp_path,
+        )
+        effective = engine.compute_envelope(_role(engine, "r-eng-head"))
+        assert effective is not None
+        assert effective.financial is not None
+        assert effective.financial.max_spend_usd == 100.0
+
+    def test_yaml_envelope_parent_before_child_ordering(self, tmp_path: Path) -> None:
+        """A child envelope whose defining role also has a YAML envelope is
+        applied after its parent (topological order) and tightens correctly."""
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+envelopes:
+  - target: r-eng-junior
+    defined_by: r-eng-head
+    financial:
+      max_spend_usd: 50.0
+  - target: r-eng-head
+    defined_by: r-ceo
+    financial:
+      max_spend_usd: 100.0
+""",
+            tmp_path,
+        )
+        head_env = engine.compute_envelope(_role(engine, "r-eng-head"))
+        junior_env = engine.compute_envelope(_role(engine, "r-eng-junior"))
+        assert head_env is not None and head_env.financial is not None
+        assert junior_env is not None and junior_env.financial is not None
+        assert head_env.financial.max_spend_usd == 100.0
+        assert junior_env.financial.max_spend_usd == 50.0
+
+    def test_yaml_envelope_widening_fails_closed(self, tmp_path: Path) -> None:
+        """A child envelope wider than its YAML parent aborts construction."""
+        with pytest.raises((MonotonicTighteningError, PactError)):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    financial:
+      max_spend_usd: 100.0
+  - target: r-eng-junior
+    defined_by: r-eng-head
+    financial:
+      max_spend_usd: 1000.0
+""",
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Bridge applied: grants cross-unit access (LCA-approved from YAML)
+# ---------------------------------------------------------------------------
+
+
+class TestYamlBridgeApplied:
+    def test_yaml_bridge_grants_cross_unit_access(self, tmp_path: Path) -> None:
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+bridges:
+  - id: b-eng-fin
+    role_a: r-eng-head
+    role_b: r-fin-head
+    type: standing
+    max_classification: restricted
+""",
+            tmp_path,
+        )
+        # Without the bridge eng-head cannot read d-fin; with it, it can.
+        assert _can_read(engine, "r-eng-head", "d-fin") is True
+
+    def test_no_bridge_means_cross_unit_denied(self, tmp_path: Path) -> None:
+        engine = _build_from_yaml(_BASE_ORG, tmp_path)
+        assert _can_read(engine, "r-eng-head", "d-fin") is False
+
+
+# ---------------------------------------------------------------------------
+# Deny-precedence: a denying KSP suppresses a permissive bridge (YAML path)
+# ---------------------------------------------------------------------------
+
+
+class TestYamlDenyPrecedence:
+    def test_denying_ksp_suppresses_permissive_bridge(self, tmp_path: Path) -> None:
+        # Bridge would grant eng-head <-> fin-head; a KSP fin->eng that matches
+        # the addressing but narrows by path is matching-but-denying for the
+        # non-matching path, and suppresses the bridge fallback.
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+bridges:
+  - id: b-eng-fin
+    role_a: r-eng-head
+    role_b: r-fin-head
+    type: standing
+    max_classification: secret
+ksps:
+  - id: k-fin-to-eng
+    source: d-fin
+    target: d-eng
+    max_classification: secret
+    shared_paths: ["allowed/*"]
+""",
+            tmp_path,
+        )
+        # Matching-but-denying KSP (path miss) suppresses the permissive bridge.
+        assert _can_read(engine, "r-eng-head", "d-fin", path="confidential/x") is False
+        # KSP grants the path-matching item.
+        assert _can_read(engine, "r-eng-head", "d-fin", path="allowed/x") is True
+
+
+# ---------------------------------------------------------------------------
+# dict-path parity: specs applied from an in-memory dict too
+# ---------------------------------------------------------------------------
+
+
+class TestDictPathParity:
+    def test_dict_path_applies_ksp(self) -> None:
+        org = {
+            "org_id": "apply-test",
+            "name": "Apply Test Org",
+            "departments": [{"id": "d-eng"}, {"id": "d-fin"}],
+            "roles": [
+                {"id": "r-ceo"},
+                {"id": "r-eng-head", "heads": "d-eng", "reports_to": "r-ceo"},
+                {"id": "r-fin-head", "heads": "d-fin", "reports_to": "r-ceo"},
+            ],
+            "clearances": [{"role": "r-fin-head", "level": "restricted"}],
+            "ksps": [
+                {
+                    "id": "k-eng-to-fin",
+                    "source": "d-eng",
+                    "target": "d-fin",
+                    "max_classification": "confidential",
+                    "shared_paths": ["public/*"],
+                }
+            ],
+        }
+        engine = PactEngine._create_governance_engine(org, "memory")
+        assert _can_read(engine, "r-fin-head", "d-eng", path="public/report") is True
+        assert _can_read(engine, "r-fin-head", "d-eng", path="internal/report") is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: misauthored specs abort engine construction
+# ---------------------------------------------------------------------------
+
+
+class TestYamlApplyFailClosed:
+    def test_ksp_unknown_source_unit_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+ksps:
+  - id: k-bad
+    source: d-nonexistent
+    target: d-fin
+    max_classification: confidential
+""",
+                tmp_path,
+            )
+
+    def test_clearance_unknown_role_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError):
+            _build_from_yaml(
+                """
+org_id: bad
+name: Bad
+departments:
+  - id: d-fin
+roles:
+  - id: r-fin-head
+    heads: d-fin
+clearances:
+  - role: r-nonexistent
+    level: secret
+""",
+                tmp_path,
+            )
+
+    def test_ksp_invalid_classification_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+ksps:
+  - id: k-bad-level
+    source: d-eng
+    target: d-fin
+    max_classification: ultra-mega-secret
+""",
+                tmp_path,
+            )
+
+    def test_ksp_path_traversal_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+ksps:
+  - id: k-traversal
+    source: d-eng
+    target: d-fin
+    max_classification: confidential
+    shared_paths: ["../secrets/*"]
+""",
+                tmp_path,
+            )
+
+    def test_envelope_nan_gradient_threshold_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    gradient_thresholds:
+      financial:
+        auto_approve_threshold: .nan
+        flag_threshold: 10.0
+        hold_threshold: 20.0
+""",
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Audit attribution: YAML-resolved specs name the org-definition authority
+# ---------------------------------------------------------------------------
+
+
+class TestYamlAuthorityAttribution:
+    def test_resolved_specs_carry_yaml_authority_attribution(
+        self, tmp_path: Path
+    ) -> None:
+        # A YAML-authored clearance/KSP records the org-definition author as the
+        # grantor/creator (not an empty/anonymous string) for the audit trail.
+        engine = _build_from_yaml(_BASE_ORG, tmp_path)
+        compiled = engine.get_org()
+
+        _, clearance = resolve_clearance(
+            ClearanceSpec(role_id="r-fin-head", level="restricted"), compiled
+        )
+        assert clearance.granted_by_role_address == "yaml-org-definition"
+
+        ksp = resolve_ksp(
+            KspSpec(
+                id="k",
+                source="d-eng",
+                target="d-fin",
+                max_classification="confidential",
+            ),
+            compiled,
+        )
+        assert ksp.created_by_role_address == "yaml-org-definition"

--- a/src/kailash/trust/pact/compilation.py
+++ b/src/kailash/trust/pact/compilation.py
@@ -288,6 +288,36 @@ class CompiledOrg:
                 return node
         return None
 
+    def get_node_by_unit_id(self, unit_id: str) -> OrgNode | None:
+        """Find a department or team node by its original config unit id.
+
+        Units (departments and teams) carry positional addresses too
+        (e.g. ``"D1-R1-D3"``); KSP source/target are authored as raw config
+        unit ids and must resolve to those positional unit addresses.
+        Mirrors :meth:`get_node_by_role_id` for the unit dimension.
+
+        Args:
+            unit_id: The ``department_id`` (departments) or ``id`` (teams)
+                from the org definition.
+
+        Returns:
+            The OrgNode for that unit, or None if not found.
+        """
+        for node in self.nodes.values():
+            if (
+                node.node_type == NodeType.DEPARTMENT
+                and node.department is not None
+                and node.department.department_id == unit_id
+            ):
+                return node
+            if (
+                node.node_type == NodeType.TEAM
+                and node.team is not None
+                and node.team.id == unit_id
+            ):
+                return node
+        return None
+
     # ---- Query ----
 
     def query_by_prefix(self, prefix: str) -> list[OrgNode]:

--- a/src/kailash/trust/pact/yaml_loader.py
+++ b/src/kailash/trust/pact/yaml_loader.py
@@ -34,6 +34,7 @@ __all__ = [
     "KspSpec",
     "LoadedOrg",
     "load_org_yaml",
+    "load_org_from_dict",
 ]
 
 # Valid clearance level strings
@@ -196,7 +197,7 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
       preserves the broad grant.
 
     Args:
-        path: Path to the YAML file.
+        path: str | Path to the YAML file.
 
     Returns:
         A LoadedOrg containing the OrgDefinition and all governance specs.
@@ -226,15 +227,52 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     except yaml.YAMLError as exc:
         raise ConfigurationError(f"Failed to parse YAML from '{path}': {exc}") from exc
 
+    return _loaded_org_from_data(data, path)
+
+
+def load_org_from_dict(data: Any, source: str = "<in-memory dict>") -> LoadedOrg:
+    """Load a unified org definition from an already-parsed mapping.
+
+    Identical parse + reference-validation semantics as :func:`load_org_yaml`,
+    but reads from a Python ``dict`` instead of a YAML file. This is the entry
+    point engines use when an org is supplied as a raw dict, so the dict path
+    parses (and the caller can apply) the SAME four governance-spec lists the
+    file path does -- closing the gap where dict-sourced orgs silently dropped
+    ``clearances`` / ``envelopes`` / ``bridges`` / ``ksps``.
+
+    Args:
+        data: The org-definition mapping (same shape as a parsed YAML file).
+        source: A label used in error messages (defaults to a synthetic tag).
+
+    Returns:
+        A LoadedOrg containing the OrgDefinition and all governance specs.
+
+    Raises:
+        ConfigurationError: If the mapping is invalid, required fields are
+            missing, or references are broken.
+    """
+    return _loaded_org_from_data(data, source)
+
+
+def _loaded_org_from_data(data: Any, source: str | Path) -> LoadedOrg:
+    """Parse a unified org-definition mapping into a LoadedOrg.
+
+    Shared core for :func:`load_org_yaml` (file path) and
+    :func:`load_org_from_dict` (dict path); ``source`` is the path or label
+    used in error messages. ``data`` is validated to be a mapping here so the
+    single guard serves both the file (``yaml.safe_load`` output) and dict
+    entry points.
+    """
     if not isinstance(data, dict):
         raise ConfigurationError(
-            f"YAML org definition must be a mapping (dict), got {type(data).__name__}. "
-            f"Ensure the file is not empty and starts with key-value pairs."
+            f"org definition must be a mapping (dict), got {type(data).__name__}. "
+            f"Ensure the source is not empty and starts with key-value pairs. "
+            f"In '{source}'."
         )
 
     # --- Validate required top-level fields ---
-    _require_field(data, "org_id", path)
-    _require_field(data, "name", path)
+    _require_field(data, "org_id", source)
+    _require_field(data, "name", source)
 
     org_id: str = data["org_id"]
     name: str = data["name"]
@@ -243,17 +281,17 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     raw_depts = data.get("departments", [])
     if not isinstance(raw_depts, list):
         raise ConfigurationError(
-            f"'departments' must be a list, got {type(raw_depts).__name__} in '{path}'"
+            f"'departments' must be a list, got {type(raw_depts).__name__} in '{source}'"
         )
-    departments = _parse_departments(raw_depts, path)
+    departments = _parse_departments(raw_depts, source)
 
     # --- Parse teams ---
     raw_teams = data.get("teams", [])
     if not isinstance(raw_teams, list):
         raise ConfigurationError(
-            f"'teams' must be a list, got {type(raw_teams).__name__} in '{path}'"
+            f"'teams' must be a list, got {type(raw_teams).__name__} in '{source}'"
         )
-    teams = _parse_teams(raw_teams, path)
+    teams = _parse_teams(raw_teams, source)
 
     # --- Build lookup indexes for reference validation ---
     dept_ids = {d.department_id for d in departments}
@@ -264,45 +302,45 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     raw_roles = data.get("roles", [])
     if not isinstance(raw_roles, list):
         raise ConfigurationError(
-            f"'roles' must be a list, got {type(raw_roles).__name__} in '{path}'"
+            f"'roles' must be a list, got {type(raw_roles).__name__} in '{source}'"
         )
-    roles = _parse_roles(raw_roles, all_unit_ids, path)
+    roles = _parse_roles(raw_roles, all_unit_ids, source)
 
     # --- Validate role references ---
     role_ids = {r.role_id for r in roles}
-    _validate_role_references(roles, role_ids, path)
+    _validate_role_references(roles, role_ids, source)
 
     # --- Parse clearances ---
     raw_clearances = data.get("clearances", [])
     if not isinstance(raw_clearances, list):
         raise ConfigurationError(
-            f"'clearances' must be a list, got {type(raw_clearances).__name__} in '{path}'"
+            f"'clearances' must be a list, got {type(raw_clearances).__name__} in '{source}'"
         )
-    clearances = _parse_clearances(raw_clearances, role_ids, path)
+    clearances = _parse_clearances(raw_clearances, role_ids, source)
 
     # --- Parse envelopes ---
     raw_envelopes = data.get("envelopes", [])
     if not isinstance(raw_envelopes, list):
         raise ConfigurationError(
-            f"'envelopes' must be a list, got {type(raw_envelopes).__name__} in '{path}'"
+            f"'envelopes' must be a list, got {type(raw_envelopes).__name__} in '{source}'"
         )
-    envelopes = _parse_envelopes(raw_envelopes, role_ids, path)
+    envelopes = _parse_envelopes(raw_envelopes, role_ids, source)
 
     # --- Parse bridges ---
     raw_bridges = data.get("bridges", [])
     if not isinstance(raw_bridges, list):
         raise ConfigurationError(
-            f"'bridges' must be a list, got {type(raw_bridges).__name__} in '{path}'"
+            f"'bridges' must be a list, got {type(raw_bridges).__name__} in '{source}'"
         )
-    bridges = _parse_bridges(raw_bridges, role_ids, path)
+    bridges = _parse_bridges(raw_bridges, role_ids, source)
 
     # --- Parse KSPs ---
     raw_ksps = data.get("ksps", [])
     if not isinstance(raw_ksps, list):
         raise ConfigurationError(
-            f"'ksps' must be a list, got {type(raw_ksps).__name__} in '{path}'"
+            f"'ksps' must be a list, got {type(raw_ksps).__name__} in '{source}'"
         )
-    ksps = _parse_ksps(raw_ksps, all_unit_ids, path)
+    ksps = _parse_ksps(raw_ksps, all_unit_ids, source)
 
     # --- Build OrgDefinition ---
     org_def = OrgDefinition(
@@ -314,11 +352,11 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     )
 
     logger.info(
-        "Loaded YAML org definition '%s' from '%s': "
+        "Loaded org definition '%s' from '%s': "
         "%d departments, %d teams, %d roles, "
         "%d clearances, %d envelopes, %d bridges, %d KSPs",
         org_id,
-        path,
+        source,
         len(departments),
         len(teams),
         len(roles),
@@ -342,7 +380,7 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
 # ---------------------------------------------------------------------------
 
 
-def _require_field(data: dict[str, Any], field_name: str, path: Path) -> None:
+def _require_field(data: dict[str, Any], field_name: str, path: str | Path) -> None:
     """Raise ConfigurationError if a required field is missing."""
     if field_name not in data:
         raise ConfigurationError(
@@ -351,7 +389,7 @@ def _require_field(data: dict[str, Any], field_name: str, path: Path) -> None:
         )
 
 
-def _parse_departments(raw: list[Any], path: Path) -> list[DepartmentConfig]:
+def _parse_departments(raw: list[Any], path: str | Path) -> list[DepartmentConfig]:
     """Parse department entries from YAML."""
     departments: list[DepartmentConfig] = []
     for i, entry in enumerate(raw):
@@ -369,7 +407,7 @@ def _parse_departments(raw: list[Any], path: Path) -> list[DepartmentConfig]:
     return departments
 
 
-def _parse_teams(raw: list[Any], path: Path) -> list[TeamConfig]:
+def _parse_teams(raw: list[Any], path: str | Path) -> list[TeamConfig]:
     """Parse team entries from YAML."""
     teams: list[TeamConfig] = []
     for i, entry in enumerate(raw):
@@ -391,7 +429,7 @@ def _parse_teams(raw: list[Any], path: Path) -> list[TeamConfig]:
 def _parse_roles(
     raw: list[Any],
     all_unit_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> list[RoleDefinition]:
     """Parse role entries from YAML into RoleDefinition objects."""
     roles: list[RoleDefinition] = []
@@ -447,7 +485,7 @@ def _parse_roles(
 def _validate_role_references(
     roles: list[RoleDefinition],
     role_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> None:
     """Validate that all role cross-references are valid."""
     for role in roles:
@@ -466,7 +504,7 @@ def _validate_role_references(
 def _parse_clearances(
     raw: list[Any],
     role_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> list[ClearanceSpec]:
     """Parse clearance entries from YAML."""
     clearances: list[ClearanceSpec] = []
@@ -528,7 +566,7 @@ def _parse_clearances(
 def _parse_envelopes(
     raw: list[Any],
     role_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> list[EnvelopeSpec]:
     """Parse envelope entries from YAML."""
     envelopes: list[EnvelopeSpec] = []
@@ -570,7 +608,7 @@ def _parse_envelopes(
 def _parse_bridges(
     raw: list[Any],
     role_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> list[BridgeSpec]:
     """Parse bridge entries from YAML."""
     bridges: list[BridgeSpec] = []
@@ -626,7 +664,7 @@ def _parse_bridges(
 
 
 def _ksp_str_tuple(
-    entry: dict[str, Any], key: str, ksp_id: str, path: Path
+    entry: dict[str, Any], key: str, ksp_id: str, path: str | Path
 ) -> tuple[str, ...]:
     """Validate an optional KSP scope field as a list of strings -> tuple.
 
@@ -651,7 +689,7 @@ def _ksp_str_tuple(
 def _parse_ksps(
     raw: list[Any],
     all_unit_ids: set[str],
-    path: Path,
+    path: str | Path,
 ) -> list[KspSpec]:
     """Parse KSP entries from YAML."""
     ksps: list[KspSpec] = []

--- a/src/kailash/trust/pact/yaml_resolvers.py
+++ b/src/kailash/trust/pact/yaml_resolvers.py
@@ -1,0 +1,428 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Engine-application layer: resolve YAML governance specs to runtime types.
+
+:func:`~kailash.trust.pact.yaml_loader.load_org_yaml` parses a unified YAML org
+definition into a :class:`~kailash.trust.pact.yaml_loader.LoadedOrg` carrying
+the ``OrgDefinition`` plus four governance-spec lists (``clearances``,
+``envelopes``, ``bridges``, ``ksps``). Those specs hold RAW, pre-resolution
+values (config role/unit ids, raw classification-level strings, constraint
+dicts). This module is the layer that converts each ``*Spec`` to its runtime
+type against a compiled organization and applies it to a live
+:class:`~kailash.trust.pact.engine.GovernanceEngine` so YAML-authored governance
+actually takes effect at enforcement time.
+
+Every resolver fails CLOSED: an unresolvable address, an invalid classification
+level, a NaN/Inf constraint, a path-traversal pattern, or a monotonic-tightening
+violation raises (never silently skips), so a misauthored YAML org never
+produces an engine that silently under-enforces.
+
+Apply order (see :func:`apply_governance_specs`):
+
+1. **clearances** -- independent; access decisions for SECRET/TOP_SECRET items
+   depend on the requesting role's clearance, so grant them first.
+2. **envelopes** -- applied parent-before-child (topological by the
+   defining-role -> target-role chain) because
+   :meth:`GovernanceEngine.set_role_envelope` validates each child against the
+   defining role's EFFECTIVE envelope; a child applied before its parent would
+   validate against a more-permissive structural default.
+3. **bridges** -- a YAML-authored bridge expresses the org designer's intent,
+   which IS the lowest-common-ancestor (LCA) approval that
+   :meth:`GovernanceEngine.create_bridge` requires (fail-closed). The wiring
+   therefore records the LCA approval (:meth:`GovernanceEngine.approve_bridge`)
+   on the org author's behalf, then creates the bridge.
+4. **ksps** -- no precondition. Deny-precedence (a matching-but-denying KSP
+   suppressing a permissive bridge) is enforced at access time, so the
+   bridge/KSP application order does not affect the decision.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.addressing import Address
+from kailash.trust.pact.clearance import RoleClearance
+from kailash.trust.pact.config import (
+    ConfidentialityLevel,
+    ConstraintEnvelopeConfig,
+    GradientThresholdsConfig,
+)
+from kailash.trust.pact.envelopes import RoleEnvelope
+from kailash.trust.pact.exceptions import PactError
+from kailash.trust.pact.yaml_loader import (
+    BridgeSpec,
+    ClearanceSpec,
+    ConfigurationError,
+    EnvelopeSpec,
+    KspSpec,
+    LoadedOrg,
+)
+
+if TYPE_CHECKING:
+    from kailash.trust.pact.compilation import CompiledOrg
+    from kailash.trust.pact.engine import GovernanceEngine
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "resolve_clearance",
+    "resolve_envelope",
+    "resolve_bridge",
+    "resolve_ksp",
+    "apply_governance_specs",
+]
+
+# Attribution recorded on clearances/KSPs resolved from a YAML org definition.
+# The authority is the org-definition author (see apply_governance_specs'
+# Security note); an empty grantor would read as "unknown/unattributed" in the
+# audit trail, so we name the source explicitly.
+_YAML_ORG_AUTHORITY = "yaml-org-definition"
+
+# Cap on how many addresses an unresolved-reference error enumerates, so a
+# caller that logs str(exc) cannot bleed the full org topology to aggregators
+# (observability.md Rule 8 schema-revealing-names class).
+_MAX_ADDRESS_SAMPLE = 20
+
+
+# ---------------------------------------------------------------------------
+# Shared resolution helpers (all fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def _sample_addresses(compiled: CompiledOrg) -> str:
+    """Render a bounded sample of known addresses for error messages."""
+    addresses = sorted(compiled.nodes.keys())
+    if len(addresses) <= _MAX_ADDRESS_SAMPLE:
+        return f"{addresses}"
+    shown = addresses[:_MAX_ADDRESS_SAMPLE]
+    return f"{shown} (+{len(addresses) - _MAX_ADDRESS_SAMPLE} more)"
+
+
+def _parse_level(raw: str, *, ctx: str) -> ConfidentialityLevel:
+    """Map a raw level string to a ConfidentialityLevel, fail-closed."""
+    try:
+        return ConfidentialityLevel(raw)
+    except ValueError as exc:
+        valid = sorted(level.value for level in ConfidentialityLevel)
+        raise ConfigurationError(
+            f"{ctx}: invalid classification level '{raw}'. Valid levels: {valid}."
+        ) from exc
+
+
+def _resolve_role_address(compiled: CompiledOrg, role_id: str, *, ctx: str) -> str:
+    """Resolve a config role id (or positional address) to a positional address.
+
+    Accepts a value that is already a positional D/T/R address (returned
+    unchanged) or a config ``role_id`` (resolved via the compiled org).
+    Fail-closed: an unresolvable identifier raises ConfigurationError.
+    """
+    if role_id in compiled.nodes:
+        return role_id
+    node = compiled.get_node_by_role_id(role_id)
+    if node is not None:
+        return node.address
+    raise ConfigurationError(
+        f"{ctx}: cannot resolve role '{role_id}' to a positional address or "
+        f"config role id in the compiled organization. "
+        f"Known addresses (sample): {_sample_addresses(compiled)}."
+    )
+
+
+def _resolve_unit_address(compiled: CompiledOrg, unit_id: str, *, ctx: str) -> str:
+    """Resolve a config dept/team id (or positional address) to a unit address.
+
+    KSP source/target are authored as raw config unit ids; units carry
+    positional addresses too (e.g. ``"D1-R1-D3"``). Fail-closed.
+    """
+    if unit_id in compiled.nodes:
+        return unit_id
+    node = compiled.get_node_by_unit_id(unit_id)
+    if node is not None:
+        return node.address
+    raise ConfigurationError(
+        f"{ctx}: cannot resolve unit '{unit_id}' to a positional address or "
+        f"config department/team id in the compiled organization. "
+        f"Known addresses (sample): {_sample_addresses(compiled)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-spec resolvers
+# ---------------------------------------------------------------------------
+
+
+def resolve_clearance(
+    spec: ClearanceSpec, compiled: CompiledOrg
+) -> tuple[str, RoleClearance]:
+    """Resolve a ClearanceSpec to (role_address, RoleClearance). Fail-closed."""
+    ctx = f"clearance for role '{spec.role_id}'"
+    role_address = _resolve_role_address(compiled, spec.role_id, ctx=ctx)
+    max_clearance = _parse_level(spec.level, ctx=ctx)
+    clearance = RoleClearance(
+        role_address=role_address,
+        max_clearance=max_clearance,
+        compartments=frozenset(spec.compartments),
+        granted_by_role_address=_YAML_ORG_AUTHORITY,
+        nda_signed=spec.nda_signed,
+    )
+    return role_address, clearance
+
+
+def resolve_ksp(spec: KspSpec, compiled: CompiledOrg) -> KnowledgeSharePolicy:
+    """Resolve a KspSpec to a KnowledgeSharePolicy. Fail-closed."""
+    ctx = f"KSP '{spec.id}'"
+    source = _resolve_unit_address(compiled, spec.source, ctx=f"{ctx} source")
+    target = _resolve_unit_address(compiled, spec.target, ctx=f"{ctx} target")
+    max_classification = _parse_level(spec.max_classification, ctx=ctx)
+    shared_classifications = frozenset(
+        _parse_level(level, ctx=f"{ctx} shared_classifications")
+        for level in spec.shared_classifications
+    )
+    min_clearance = (
+        _parse_level(spec.min_clearance, ctx=f"{ctx} min_clearance")
+        if spec.min_clearance is not None
+        else None
+    )
+    try:
+        return KnowledgeSharePolicy(
+            id=spec.id,
+            source_unit_address=source,
+            target_unit_address=target,
+            max_classification=max_classification,
+            compartments=frozenset(spec.compartments),
+            shared_paths=tuple(spec.shared_paths),
+            shared_types=frozenset(spec.shared_types),
+            shared_classifications=shared_classifications,
+            min_clearance=min_clearance,
+            conditions=dict(spec.conditions),
+            created_by_role_address=_YAML_ORG_AUTHORITY,
+            active=True,
+        )
+    except (ValueError, PactError) as exc:
+        # KnowledgeSharePolicy.__post_init__ rejects '..' traversal patterns.
+        raise ConfigurationError(f"{ctx}: {exc}") from exc
+
+
+def resolve_bridge(spec: BridgeSpec, compiled: CompiledOrg) -> PactBridge:
+    """Resolve a BridgeSpec to a PactBridge. Fail-closed.
+
+    Application (LCA approval) is handled by :func:`apply_governance_specs`.
+    """
+    ctx = f"bridge '{spec.id}'"
+    role_a = _resolve_role_address(compiled, spec.role_a, ctx=f"{ctx} role_a")
+    role_b = _resolve_role_address(compiled, spec.role_b, ctx=f"{ctx} role_b")
+    max_classification = _parse_level(spec.max_classification, ctx=ctx)
+    try:
+        return PactBridge(
+            id=spec.id,
+            role_a_address=role_a,
+            role_b_address=role_b,
+            bridge_type=spec.bridge_type,
+            max_classification=max_classification,
+            bilateral=spec.bilateral,
+        )
+    except (ValueError, PactError) as exc:
+        # PactBridge.__post_init__ rejects '..' traversal patterns.
+        raise ConfigurationError(f"{ctx}: {exc}") from exc
+
+
+def resolve_envelope(spec: EnvelopeSpec, compiled: CompiledOrg) -> RoleEnvelope:
+    """Resolve an EnvelopeSpec to a RoleEnvelope. Fail-closed.
+
+    The constraint dicts are coerced + validated by Pydantic
+    (``ConstraintEnvelopeConfig`` / ``GradientThresholdsConfig``), which rejects
+    NaN/Inf threshold values and unknown keys; any ValidationError is surfaced
+    as a fail-closed ConfigurationError. Monotonic-tightening is validated when
+    the envelope is applied (see :func:`apply_governance_specs`).
+    """
+    target = _resolve_role_address(
+        compiled, spec.target, ctx=f"envelope target '{spec.target}'"
+    )
+    defining = _resolve_role_address(
+        compiled, spec.defined_by, ctx=f"envelope defined_by '{spec.defined_by}'"
+    )
+    envelope_id = f"yaml-env-{spec.target}"
+    config_kwargs: dict[str, Any] = {"id": envelope_id}
+    if spec.financial is not None:
+        config_kwargs["financial"] = spec.financial
+    if spec.operational is not None:
+        config_kwargs["operational"] = spec.operational
+    if spec.temporal is not None:
+        config_kwargs["temporal"] = spec.temporal
+    if spec.data_access is not None:
+        config_kwargs["data_access"] = spec.data_access
+    if spec.communication is not None:
+        config_kwargs["communication"] = spec.communication
+    try:
+        envelope_config = ConstraintEnvelopeConfig(**config_kwargs)
+        gradient = (
+            GradientThresholdsConfig(**spec.gradient_thresholds)
+            if spec.gradient_thresholds is not None
+            else None
+        )
+    except ValidationError as exc:
+        raise ConfigurationError(
+            f"envelope target '{spec.target}': invalid constraint config: {exc}"
+        ) from exc
+    return RoleEnvelope(
+        id=envelope_id,
+        defining_role_address=defining,
+        target_role_address=target,
+        envelope=envelope_config,
+        gradient_thresholds=gradient,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _order_envelopes(
+    specs: list[EnvelopeSpec], compiled: CompiledOrg
+) -> list[EnvelopeSpec]:
+    """Topologically order envelopes parent-before-child (fail-closed on cycle).
+
+    Envelope E must be applied after envelope F when E's defining role IS F's
+    target role -- i.e. the supervisor whose boundary E tightens is itself
+    governed by a YAML envelope F. ``set_role_envelope`` validates each child
+    against the defining role's effective envelope, so the parent must be in
+    place first.
+    """
+    n = len(specs)
+    targets: list[str] = []
+    definings: list[str] = []
+    for spec in specs:
+        targets.append(
+            _resolve_role_address(
+                compiled, spec.target, ctx=f"envelope target '{spec.target}'"
+            )
+        )
+        definings.append(
+            _resolve_role_address(
+                compiled,
+                spec.defined_by,
+                ctx=f"envelope defined_by '{spec.defined_by}'",
+            )
+        )
+    by_target: dict[str, int] = {t: i for i, t in enumerate(targets)}
+
+    # Edge parent -> child when child's defining role IS parent's target role,
+    # so the parent envelope is applied first. child_indegree[i] counts how many
+    # parents envelope i must wait for (0 or 1: a role has one defining role).
+    children: list[list[int]] = [[] for _ in range(n)]
+    child_indegree = [0] * n
+    for i in range(n):
+        parent = by_target.get(definings[i])
+        if parent is not None and parent != i:
+            children[parent].append(i)
+            child_indegree[i] += 1
+
+    queue = [i for i in range(n) if child_indegree[i] == 0]
+    ordered: list[EnvelopeSpec] = []
+    while queue:
+        node = queue.pop(0)
+        ordered.append(specs[node])
+        for child in children[node]:
+            child_indegree[child] -= 1
+            if child_indegree[child] == 0:
+                queue.append(child)
+
+    if len(ordered) != n:
+        cyclic = [specs[i].target for i in range(n) if child_indegree[i] > 0]
+        raise ConfigurationError(
+            f"envelope definitions form a cycle in the defining-role -> "
+            f"target-role chain (cannot order parent-before-child): "
+            f"targets involved {sorted(cyclic)}."
+        )
+    return ordered
+
+
+def apply_governance_specs(engine: GovernanceEngine, loaded: LoadedOrg) -> None:
+    """Apply every YAML-loaded governance spec to a live GovernanceEngine.
+
+    Resolves each ``*Spec`` to its runtime type and applies it in the order
+    clearances -> envelopes (parent-before-child) -> bridges (LCA-approved) ->
+    ksps. Fail-closed throughout: any resolution or application error raises and
+    aborts construction so a misauthored org never yields a silently
+    under-enforcing engine. See the module docstring for the ordering rationale.
+
+    Security -- the org-definition source is a TRUST ROOT. Authoring or
+    modifying the YAML/dict an engine is built from confers full governance
+    authority: it grants clearances, sets envelopes, mints KSPs, and (because a
+    YAML-authored bridge IS the org designer's LCA approval) creates bridges
+    WITHOUT the runtime's interactive LCA/compliance-approval ceremony. The org
+    source MUST therefore be protected at the same level as signing keys
+    (trusted provenance, restricted write access); never build an engine from
+    an untrusted-input path. This is the same authority model the runtime
+    ``approve_bridge`` gate assumes for the LCA role -- applied here to the
+    org-definition author.
+    """
+    compiled = engine.get_org()
+
+    # 1. Clearances (independent; access for classified items depends on them).
+    for clearance_spec in loaded.clearances:
+        role_address, clearance = resolve_clearance(clearance_spec, compiled)
+        engine.grant_clearance(role_address, clearance)
+
+    # 2. Envelopes, parent-before-child. set_role_envelope raises
+    #    MonotonicTighteningError (widening) / ValueError (NaN/Inf) -- both
+    #    propagate as fail-closed errors.
+    for envelope_spec in _order_envelopes(list(loaded.envelopes), compiled):
+        envelope = resolve_envelope(envelope_spec, compiled)
+        engine.set_role_envelope(envelope)
+
+    # 3. Bridges. A YAML-authored bridge expresses the org designer's intent,
+    #    which IS the LCA approval create_bridge requires (fail-closed). Record
+    #    that approval on the org author's behalf, then create the bridge.
+    for bridge_spec in loaded.bridges:
+        bridge = resolve_bridge(bridge_spec, compiled)
+        _approve_and_create_bridge(engine, bridge)
+
+    # 4. KSPs (no precondition; deny-precedence is an access-time concern).
+    for ksp_spec in loaded.ksps:
+        ksp = resolve_ksp(ksp_spec, compiled)
+        engine.create_ksp(ksp)
+
+    logger.info(
+        "Applied YAML governance specs to engine '%s': "
+        "%d clearances, %d envelopes, %d bridges, %d KSPs",
+        engine.org_name,
+        len(loaded.clearances),
+        len(loaded.envelopes),
+        len(loaded.bridges),
+        len(loaded.ksps),
+    )
+
+
+def _approve_and_create_bridge(engine: GovernanceEngine, bridge: PactBridge) -> None:
+    """Record the LCA approval for a YAML bridge, then create it (fail-closed).
+
+    The org-definition author holds org-design authority, so a bridge declared
+    in the YAML is the LCA's approval. We compute the LCA from the two role
+    addresses and record the approval on its behalf before create_bridge (which
+    fail-closes without a valid approval).
+    """
+    try:
+        addr_a = Address.parse(bridge.role_a_address)
+        addr_b = Address.parse(bridge.role_b_address)
+    except Exception as exc:
+        raise ConfigurationError(
+            f"bridge '{bridge.id}': cannot parse role addresses "
+            f"'{bridge.role_a_address}' / '{bridge.role_b_address}': {exc}"
+        ) from exc
+
+    lca = Address.lowest_common_ancestor(addr_a, addr_b)
+    if lca is None:
+        raise ConfigurationError(
+            f"bridge '{bridge.id}': role addresses "
+            f"'{bridge.role_a_address}' and '{bridge.role_b_address}' have no "
+            f"common ancestor; a bridge requires an LCA to approve it."
+        )
+
+    engine.approve_bridge(bridge.role_a_address, bridge.role_b_address, str(lca))
+    engine.create_bridge(bridge)


### PR DESCRIPTION
## Summary

Closes the #1386 gap (disposition **X**): YAML-authored governance specs (`clearances` / `envelopes` / `bridges` / `ksps`) were parse-validated by `load_org_yaml` but `PactEngine` consumed only `org_definition`, so they were **silently dropped** and had zero enforcement effect. This adds the engine-application layer the `KspSpec` docstring already referenced.

## What changed

- **`src/kailash/trust/pact/yaml_resolvers.py`** (new) — `resolve_clearance` / `resolve_ksp` / `resolve_bridge` / `resolve_envelope` + `apply_governance_specs` orchestrator. Applies specs fail-closed in order **clearances → envelopes (topologically parent-before-child) → bridges (LCA-approved) → ksps**.
- **`yaml_loader.py`** — extracted shared `_loaded_org_from_data` core; added `load_org_from_dict` so the dict construction path applies specs too.
- **`compilation.py`** — `CompiledOrg.get_node_by_unit_id` (unit-address resolution for KSP source/target).
- **`packages/kailash-pact/src/pact/engine.py`** — `_create_governance_engine` wires both str/Path and dict inputs through the apply layer; removed the now-dead `_org_def_from_dict`.

## Design notes

- **Bridges**: `create_bridge` is fail-closed on a pre-existing LCA approval. A YAML-authored bridge expresses the org designer's intent = the LCA's approval, so the wiring records that approval (`approve_bridge`) before `create_bridge`. The org-definition source is documented as a **trust root**.
- **Envelopes**: applied parent-before-child via topological sort because `set_role_envelope` validates each child against the defining role's *effective* envelope.
- **Fail-closed**: unknown ref / invalid level / `..` path / NaN-Inf constraint / envelope widening / no-common-ancestor bridge all abort engine construction.

## Testing

- 16 Tier-2 tests (`test_yaml_apply.py`) build a **real** engine from YAML and assert enforcement per spec type, KSP deny-precedence suppressing a permissive bridge, dict-path parity, audit attribution, and all fail-closed cases.
- Full governance suite: **1179 passed, 0 failed**. `pytest --collect-only` clean (1185).

## Redteam (converged)

reviewer + pact-specialist **CLEAN**; security-reviewer PASSED on bridge auto-approval / fail-closed completeness / TOCTOU. Advisory findings fixed in-shard: trust-root Security note, attributable audit grantor (`"yaml-org-definition"` vs `""`), capped address dumps in error messages. NaN/Inf budget concern closed via `FinancialConstraintConfig`'s existing `math.isfinite` validator.

## Acceptance criteria (disposition X)

- [x] Resolvers per spec type (source/target → Address, levels → ConfidentialityLevel, scope tuples → runtime shapes); fail-closed on invalid refs.
- [x] Envelope resolver honors monotonic tightening.
- [x] `PactEngine` (YAML + dict paths) applies all four spec lists after engine construction.
- [x] Tier-2 end-to-end test per spec type.
- [x] Deny-precedence regression (denying YAML KSP suppresses permissive YAML bridge).

## Related issues

Fixes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)