### PR TITLE
release: kailash 2.41.0 + kailash-pact 0.14.0 (#1386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.0] - 2026-06-19
+
+### Added
+
+- **YAML governance specs now take effect at enforcement** (issue #1386,
+  `kailash.trust.pact`). `load_org_yaml` / the new `load_org_from_dict` parsed
+  `clearances` / `envelopes` / `bridges` / `ksps` from a unified YAML org file,
+  but the engine consumed only the org definition — the four governance-spec
+  lists were silently dropped, so a YAML-authored `shared_paths`, `min_clearance`,
+  bridge, or clearance had zero effect on `check_access`. The new
+  `kailash.trust.pact.yaml_resolvers` module resolves each spec to its runtime
+  type and applies it to the `GovernanceEngine` (the "engine-application layer"
+  the `KspSpec` docstring referenced). Application order: clearances → envelopes
+  (topologically parent-before-child, since `set_role_envelope` validates each
+  child against the defining role's effective envelope) → bridges (a
+  YAML-authored bridge is the org designer's LCA approval, so the loader records
+  that approval before `create_bridge`) → KSPs.
+- `kailash.trust.pact.yaml_loader.load_org_from_dict` — applies the same parse +
+  governance-spec application from an in-memory mapping (the dict construction
+  path previously dropped the spec lists).
+- `CompiledOrg.get_node_by_unit_id` — resolves a config department/team id to its
+  positional unit address (for KSP source/target resolution).
+
+### Changed
+
+- Resolution is fail-closed throughout: an unresolvable unit/role reference, an
+  invalid classification level, a `..` path-traversal pattern, a non-finite
+  (NaN/Inf) constraint, an envelope monotonic-tightening violation, or a bridge
+  with no common ancestor aborts engine construction rather than yielding a
+  silently under-enforcing engine. YAML-resolved clearances/KSPs record
+  `"yaml-org-definition"` as the grantor/creator for an attributable audit trail.
+
 ## [2.40.1] - 2026-06-19
 
 ### Fixed

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,22 @@
 # PACT Changelog
 
+## [0.14.0] — 2026-06-19 — feat: apply YAML governance specs to the runtime engine (#1386)
+
+### Added
+
+- `PactEngine` construction from a YAML file OR an in-memory dict now applies the
+  YAML-authored governance specs (`clearances` / `envelopes` / `bridges` /
+  `ksps`) to the runtime `GovernanceEngine`, so governance authored in a unified
+  org file actually takes effect at enforcement. Previously the specs were
+  parse-validated and then silently dropped (only the org definition was
+  consumed). Powered by the new `kailash.trust.pact.yaml_resolvers`
+  engine-application layer (requires `kailash>=2.41.0`).
+
+### Changed
+
+- Bumped the `kailash` floor to `>=2.41.0` (the version providing
+  `yaml_resolvers.apply_governance_specs`).
+
 ## [0.13.1] — 2026-06-19 — fix: re-export KspDenyDetail from the pact facade (#1375)
 
 ### Fixed

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.13.1"
+version = "0.14.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -36,7 +36,7 @@ dependencies = [
     #   (engine.py:1216 inside method). Move to [execution] extra.
     # - psycopg / psycopg_pool — ORPHANS, zero imports anywhere. DELETE.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.39.0",
+    "kailash>=2.41.0",
     "click>=8.0",
 ]
 

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.40.1"
+version = "2.41.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.40.1"
+__version__ = "2.41.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Release-prep (metadata-only): version anchors + CHANGELOGs for the #1386 YAML governance-spec engine-application layer (feature merged in PR #1387).

## Versions
- `kailash` 2.40.1 → **2.41.0** (minor — new public API: `yaml_resolvers`, `load_org_from_dict`, `CompiledOrg.get_node_by_unit_id`)
- `kailash-pact` 0.13.1 → **0.14.0** (minor — engine now applies YAML governance specs)
- `kailash-pact` dependency floor `kailash>=2.39.0` → `>=2.41.0` (the version providing `apply_governance_specs`)

## Notes
- Metadata-only diff → `release/v*` branch auto-skips the PR-gate matrix per branch convention.
- Main `kailash[pact]` extras left at the `>=0.8.2` floor (PyPI-resolvable; not bumped to the unreleased version per deployment.md).
- Tags `v2.41.0` + `pact-v0.14.0` pushed individually after merge to trigger the OIDC publish workflow.

## Related issues
Fixes #1386 (closed via PR #1387; this cuts the release)