### PR TITLE
feat(kaizen): LlmClient aclose()/async-context-manager + opt-in HTTP pooling (#1388)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [Unreleased] — LlmClient lifecycle: aclose() + async context manager + opt-in HTTP pooling
+
+### Added
+
+- **`LlmClient` now exposes a lifecycle surface — `aclose()` + `__aenter__`/`__aexit__`
+  — with opt-in persistent HTTP-transport pooling** (#1388). Previously
+  `kaizen.llm.client.LlmClient` had no `close()`/`aclose()`/`__aexit__`; once a
+  client held a persistent HTTP transport its socket was released only at GC,
+  emitting `ResourceWarning: unclosed <socket.socket ...>` and failing any run
+  under `-W error::ResourceWarning`. The change is strictly additive and
+  backward-compatible:
+  - One-shot callers are unchanged: `await LlmClient.from_deployment(d).embed(...)`
+    still constructs and closes a fresh `LlmHttpClient` per `embed()` call —
+    nothing is held between calls, so nothing leaks and no warning is emitted.
+  - New managed mode pools the transport: `async with LlmClient.from_deployment(d)
+as client:` eagerly creates ONE persistent `LlmHttpClient` on entry, reuses
+    it across every `embed()` in the scope (amortizing SSRF-resolver +
+    connection-pool setup, and surviving per-call errors), and deterministically
+    closes it on exit. `await client.aclose()` is the explicit (idempotent)
+    close; a no-op when no transport was created.
+  - `__del__` is WARN-ONLY, mirroring `LlmHttpClient.__del__`: a managed client
+    that pooled a transport and was never closed emits a `ResourceWarning`
+    naming `aclose`; it never calls close from the finalizer (async cleanup in
+    `__del__` deadlocks on CPython's root logging lock per
+    `rules/patterns.md` § "Async Resource Cleanup"). One-shot unmanaged callers
+    hold no transport, so they emit no warning.
+  - No sync `close()` is provided: a sync wrapper would need `asyncio.run()` and
+    break inside any active event loop (`rules/patterns.md` § "Paired Public
+    Surface").
+    Regression coverage:
+    `tests/regression/test_issue_1388_llmclient_resourcewarning.py` (the
+    after-close GC path overrides pytest.ini's global `ignore::ResourceWarning`
+    with `error::ResourceWarning` so the no-leak assertion is real).
+
 ## [2.27.1] — 2026-06-17 — PEP 563 Signatures: structured output no longer silently empties
 
 ### Fixed

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -37,9 +37,11 @@ landed and exercised by a Tier 2 end-to-end test. Shipping a public
 from __future__ import annotations
 
 import logging
+from types import TracebackType
 from typing import List, Optional
 
 import httpx
+
 from kaizen.llm.deployment import EmbedOptions, LlmDeployment, WireProtocol
 from kaizen.llm.errors import InvalidResponse, ProviderError, RateLimited, Timeout
 from kaizen.llm.http_client import LlmHttpClient
@@ -85,6 +87,36 @@ class LlmClient:
     `ClassificationPolicy` is the canonical producer. See
     `rules/observability.md` § 8 and the §6.5 security test at
     `tests/unit/llm/security/test_llmclient_redacts_classified_prompt_fields.py`.
+
+    # Lifecycle
+
+    `LlmClient` is usable as a one-shot object OR as an async context
+    manager with an opt-in pooled HTTP transport:
+
+        # One-shot (unmanaged): a fresh LlmHttpClient is constructed and
+        # closed per embed() call. No lifecycle method needed; nothing
+        # is held between calls, so nothing leaks.
+        vectors = await LlmClient.from_deployment(d).embed(texts, model=m)
+
+        # Managed (pooled): a single persistent LlmHttpClient is created
+        # on context-entry and reused across every embed() in the scope,
+        # then deterministically closed on exit. Reuse amortizes the
+        # SSRF-resolver + connection-pool setup across calls.
+        async with LlmClient.from_deployment(d) as client:
+            a = await client.embed(["text a"], model=m)
+            b = await client.embed(["text b"], model=m)  # same transport
+
+    `aclose()` (idempotent) closes the pooled transport when one was
+    created; a managed client MUST be closed via `await client.aclose()`
+    or by exiting its `async with` block. The `__del__` finalizer emits
+    `ResourceWarning` if a managed client created a transport and was
+    never closed (per `rules/patterns.md` § "Async Resource Cleanup"); it
+    does NOT call close from `__del__` -- that deadlocks on CPython's root
+    logging lock when the finalizer fires during GC. There is deliberately
+    NO sync `close()`: a sync wrapper would need `asyncio.run()` and break
+    inside any active event loop (`rules/patterns.md` § "Paired Public
+    Surface"). One-shot unmanaged callers hold no transport, so they emit
+    no warning and need no close.
     """
 
     def __init__(
@@ -97,6 +129,13 @@ class LlmClient:
         self._deployment = deployment
         self._classification_policy = classification_policy
         self._caller_clearance = caller_clearance
+        # Opt-in pooled HTTP transport. Stays None for one-shot callers
+        # (each embed() constructs + closes its own client). Set only on
+        # the managed (async-context-manager) path, where it is the
+        # persistent transport reused across embed() calls and closed at
+        # aclose().
+        self._http_client: Optional[LlmHttpClient] = None
+        self._managed: bool = False
         logger.debug(
             "llm_client.constructed",
             extra={
@@ -220,6 +259,49 @@ class LlmClient:
         )
 
     # -----------------------------------------------------------------
+    # Lifecycle — async context manager + aclose() (#1388)
+    # -----------------------------------------------------------------
+
+    async def __aenter__(self) -> "LlmClient":
+        """Enter managed mode and eagerly pool the persistent HTTP transport.
+
+        Marks the client managed so subsequent ``embed()`` calls reuse one
+        ``LlmHttpClient`` instead of constructing a fresh one per call. The
+        transport is created HERE (before any concurrent ``embed()``) so two
+        racing ``embed()`` calls cannot each construct a transport; ``embed()``
+        retains a lazy fallback for managed clients that somehow reach it with
+        no transport yet.
+        """
+        self._managed = True
+        if self._deployment is not None and self._http_client is None:
+            self._http_client = LlmHttpClient(
+                deployment_preset=self._deployment.wire.name,
+                timeout=60.0,
+            )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        """Close the pooled transport on context exit. Delegates to aclose()."""
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the pooled HTTP transport, if one was created. Idempotent.
+
+        Closes and drops the persistent ``LlmHttpClient`` so a subsequent
+        managed ``embed()`` re-pools a fresh transport and ``__del__`` sees
+        ``None`` (no ResourceWarning). A no-op when no transport was created
+        (one-shot callers, or a managed client closed twice).
+        """
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    # -----------------------------------------------------------------
     # embed() — the first wire-send method on LlmClient (#462)
     # -----------------------------------------------------------------
 
@@ -330,8 +412,28 @@ class LlmClient:
 
         # LlmHttpClient owns SSRF (via SafeDnsResolver) + structured
         # logging. NEVER construct httpx.AsyncClient directly here.
+        #
+        # Transport acquisition, three cases:
+        #   1. Caller injected http_client= → caller owns it; embed() never
+        #      closes it (owns_client stays False).
+        #   2. Managed client (async-context-manager) with no injection →
+        #      reuse the INSTANCE-pooled transport, lazily creating it if the
+        #      managed scope somehow reached embed() before __aenter__ pooled
+        #      one. The INSTANCE owns it; embed() must NOT close it per-call
+        #      (it is closed at aclose()), so owns_client is False.
+        #   3. Unmanaged client with no injection → construct a fresh transport
+        #      per call and close it in the error/finally paths below
+        #      (owns_client stays True). UNCHANGED legacy one-shot behavior.
         owns_client = http_client is None
-        if owns_client:
+        if owns_client and self._managed:
+            if self._http_client is None:
+                self._http_client = LlmHttpClient(
+                    deployment_preset=wire.name,
+                    timeout=60.0,
+                )
+            http_client = self._http_client
+            owns_client = False  # instance owns it; closed at aclose(), not here
+        elif owns_client:
             http_client = LlmHttpClient(
                 deployment_preset=wire.name,
                 timeout=60.0,
@@ -448,6 +550,24 @@ class LlmClient:
             prefix_norm = prefix if prefix.startswith("/") else "/" + prefix
             return f"{base}{prefix_norm}{suffix_norm}"
         return f"{base}{suffix_norm}"
+
+    def __del__(self) -> None:
+        # Emit ResourceWarning ONLY; never call aclose()/close() from the
+        # finalizer. Mirrors LlmHttpClient.__del__ — async cleanup in __del__
+        # deadlocks on CPython's root logging lock when the finalizer fires
+        # during GC (see rules/patterns.md § "Async Resource Cleanup"). Only a
+        # managed client that pooled a transport and was never closed holds a
+        # non-None _http_client here; one-shot unmanaged callers hold None and
+        # emit no warning (no false positives).
+        if self._http_client is not None:
+            import warnings
+
+            warnings.warn(
+                "LlmClient not closed; call await client.aclose() "
+                "or use it as an async context manager",
+                ResourceWarning,
+                stacklevel=2,
+            )
 
 
 __all__ = ["LlmClient"]

--- a/packages/kailash-kaizen/tests/integration/llm/test_llmclient_lifecycle_wiring.py
+++ b/packages/kailash-kaizen/tests/integration/llm/test_llmclient_lifecycle_wiring.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 2 wiring test: LlmClient managed-mode HTTP transport pooling (#1388).
+
+Sibling of `test_llmclient_embed_wiring.py`. Exercises the opt-in pooled
+lifecycle end-to-end: under `async with`, two sequential `embed()` calls REUSE
+ONE `LlmHttpClient` (asserted by object identity), the persistent transport is
+open mid-scope, and closed after the scope exits.
+
+The object-identity / pooling assertions run against the SSRF connect-time
+rejection path — no credential, no network egress: enter the managed scope, call
+`embed()` against `https://localhost/...`. The URL-safety guard passes that at
+deployment construction (it cannot resolve the hostname to know it is loopback),
+so `embed()` reaches the HTTP layer; the `SafeDnsResolver` then rejects the
+`127.0.0.1` resolution at connect time inside the transport, raising
+`EndpointError` before any TCP SYN leaves the box. The test asserts the
+persistent client is (a) the SAME object across two such attempts and (b) NOT
+closed mid-scope (per-call errors must not close the instance-owned transport).
+The real-network path is gated on `OPENAI_API_KEY` like the existing embed test.
+
+NOTE on host choice: a literal private/metadata IP (e.g. `169.254.169.254`) is
+rejected by the URL-safety guard at deployment CONSTRUCTION, so `embed()` is
+never reached and the pooling assertion never runs. A loopback HOSTNAME
+(`localhost`) passes construction and defers the rejection to the connect-time
+resolver inside `embed()` — which is exactly the path that exercises the pooled
+transport.
+
+Per `rules/testing.md` Tier 2 policy: real infrastructure, NO mocking of the
+wire layer. The SSRF guard fires against a real DNS/IP check, not a mock.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.deployment import LlmDeployment
+from kaizen.llm.errors import EndpointError
+
+_EMBED_MODEL = "text-embedding-3-small"
+
+
+# ---------------------------------------------------------------------------
+# Pooling via the SSRF-rejection path — always runs, no credential needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_managed_embed_reuses_one_http_client_across_calls() -> None:
+    """Under `async with`, two embed() calls reuse ONE LlmHttpClient.
+
+    Uses the connect-time SSRF-rejection path (`https://localhost/...` resolves
+    to loopback) so no real embedding credential and no network egress is
+    required. Each embed() reaches the HTTP layer and raises EndpointError when
+    `SafeDnsResolver` rejects `127.0.0.1` at connect; the assertions prove the
+    INSTANCE-pooled transport (a) is the same object across both calls and (b)
+    survives the per-call error (NOT closed), so it can be reused — exactly the
+    pooling contract #1388 adds.
+    """
+    # docker_model_runner accepts a caller-provided base_url + uses the
+    # OpenAiChat wire (the embed() dispatch key). A loopback HOSTNAME passes the
+    # construction-time URL-safety guard (the guard cannot resolve the hostname's
+    # IP) and defers rejection to the connect-time resolver inside embed().
+    deployment = LlmDeployment.docker_model_runner(
+        base_url="https://localhost/engines",
+        model=_EMBED_MODEL,
+    )
+
+    async with LlmClient.from_deployment(deployment) as client:
+        # __aenter__ eagerly pooled the transport.
+        assert client._http_client is not None
+        first_transport = client._http_client
+        assert first_transport.is_closed is False
+
+        # Call 1 — SSRF guard rejects at connect time.
+        with pytest.raises(EndpointError):
+            await client.embed(["ssrf attempt 1"], model=_EMBED_MODEL)
+
+        # The instance-owned transport survives the per-call error: same object,
+        # still open (NOT closed by the error path — owns_client is False).
+        assert client._http_client is first_transport
+        assert client._http_client.is_closed is False
+
+        # Call 2 — reuses the SAME transport object.
+        with pytest.raises(EndpointError):
+            await client.embed(["ssrf attempt 2"], model=_EMBED_MODEL)
+
+        assert client._http_client is first_transport
+        assert client._http_client.is_closed is False
+
+    # After the managed scope: transport closed + reference dropped.
+    assert first_transport.is_closed is True
+    assert client._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Pooling via the real OpenAI path — gated on OPENAI_API_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_managed_embed_reuses_http_client_real_openai() -> None:
+    """Real OpenAI: two managed embed() calls reuse one pooled transport.
+
+    Confirms the pooling contract on the success path (not just SSRF rejection):
+    the same LlmHttpClient object serves both real embedding requests and is
+    closed only after the managed scope exits.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key or not api_key.startswith("sk-"):
+        pytest.skip(
+            "OPENAI_API_KEY missing or placeholder; real-network pooling test "
+            "requires a real credential"
+        )
+    model = os.environ.get("OPENAI_EMBEDDING_MODEL", _EMBED_MODEL)
+
+    deployment = LlmDeployment.openai(api_key=api_key, model=model)
+    async with LlmClient.from_deployment(deployment) as client:
+        pooled = client._http_client
+        assert pooled is not None
+        assert pooled.is_closed is False
+
+        v1 = await client.embed(["hello"], model=model)
+        assert client._http_client is pooled  # reused, not reconstructed
+        assert pooled.is_closed is False
+
+        v2 = await client.embed(["world"], model=model)
+        assert client._http_client is pooled  # still the same transport
+        assert pooled.is_closed is False
+
+        assert len(v1) == 1 and len(v2) == 1
+        assert len(v1[0]) > 0 and len(v2[0]) > 0
+
+    assert pooled.is_closed is True
+    assert client._http_client is None

--- a/packages/kailash-kaizen/tests/regression/test_issue_1388_llmclient_resourcewarning.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1388_llmclient_resourcewarning.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #1388 — LlmClient ResourceWarning lifecycle.
+
+Issue #1388: `kaizen.llm.client.LlmClient` exposed no
+`close()`/`aclose()`/`__aexit__` lifecycle method. Once the client held a
+persistent HTTP transport, the socket was released only at GC ->
+`ResourceWarning: unclosed <socket.socket ...>`, which fails any run under
+`-W error::ResourceWarning`.
+
+Acceptance criteria (#1388):
+  1. `LlmClient` exposes `aclose()` AND `__aenter__`/`__aexit__` that
+     deterministically close the underlying HTTP transport.
+  2. After an explicit close, no `unclosed <socket.socket ...>` ResourceWarning
+     is emitted at GC.
+
+NOTE: `packages/kailash-kaizen/pytest.ini` globally does `ignore::ResourceWarning`
+(line 38). The first test below overrides that locally via
+`@pytest.mark.filterwarnings("error::ResourceWarning")` so the "no warning after
+close" assertion is REAL — a leaked socket would raise, not be silently swallowed.
+The second test uses `warnings.catch_warnings()` + `simplefilter("always")` so the
+WARN-path is observed even under the global ignore.
+"""
+
+from __future__ import annotations
+
+import gc
+import warnings
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.deployment import LlmDeployment
+
+_PLACEHOLDER_KEY = "sk-test-1388-regression-key"
+_EMBED_MODEL = "text-embedding-3-small"
+
+
+def _deployment() -> LlmDeployment:
+    return LlmDeployment.openai(api_key=_PLACEHOLDER_KEY, model=_EMBED_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: after an explicit close, GC emits NO ResourceWarning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("error::ResourceWarning")
+async def test_issue_1388_managed_client_no_resourcewarning_after_async_with() -> None:
+    """After `async with LlmClient ...` exits, GC emits NO ResourceWarning.
+
+    The `error::ResourceWarning` filter OVERRIDES pytest.ini's global
+    `ignore::ResourceWarning` for this test, so a leaked transport socket would
+    raise the warning as an error and fail the test rather than be silenced.
+    """
+    deployment = _deployment()
+    async with LlmClient.from_deployment(deployment) as client:
+        # Managed scope pooled a real LlmHttpClient transport.
+        assert client._http_client is not None
+    # Exited: transport closed + reference dropped. GC must not warn.
+    assert client._http_client is None
+
+    del deployment, client
+    gc.collect()  # would raise ResourceWarning-as-error if a socket leaked
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("error::ResourceWarning")
+async def test_issue_1388_explicit_aclose_no_resourcewarning_at_gc() -> None:
+    """After explicit `await client.aclose()`, GC emits NO ResourceWarning.
+
+    Covers the non-context-manager path: a managed client closed by an explicit
+    aclose() call (not via __aexit__) must also leave nothing to leak at GC.
+    """
+    deployment = _deployment()
+    client = LlmClient.from_deployment(deployment)
+    await client.__aenter__()  # enter managed mode + pool the transport
+    assert client._http_client is not None
+
+    await client.aclose()
+    assert client._http_client is None
+
+    del deployment, client
+    gc.collect()  # would raise ResourceWarning-as-error if a socket leaked
+
+
+# ---------------------------------------------------------------------------
+# Warn-path is wired: an UNCLOSED managed client warns at __del__
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_issue_1388_unclosed_managed_client_warns_at_del() -> None:
+    """An unclosed managed client that pooled a transport WARNS at __del__.
+
+    Proves the warn-path is wired (not silently swallowed): the finalizer emits
+    a ResourceWarning whose message names `aclose`, directing the caller to the
+    fix. Uses `catch_warnings(record=True)` so the warning is observed even
+    under pytest.ini's global `ignore::ResourceWarning`.
+
+    Runs under `@pytest.mark.asyncio` so `__aenter__` / the pooled transport's
+    `aclose()` are awaited in pytest-asyncio's own managed event loop — NO
+    throwaway `asyncio.new_event_loop()` is created, so the test leaks neither
+    an event loop nor its selector self-pipe sockets (the finalizer warning
+    under test is LlmClient's, not the test harness's own).
+    """
+    client = LlmClient.from_deployment(_deployment())
+    # Enter managed mode + pool a real transport, awaited in the running loop.
+    await client.__aenter__()
+    pooled = client._http_client
+    assert pooled is not None  # a real transport was pooled
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del client  # refcount hits 0 -> LlmClient.__del__ fires (pooled holds the transport)
+        gc.collect()
+
+    resource_warnings = [w for w in caught if issubclass(w.category, ResourceWarning)]
+    # At least one ResourceWarning, naming aclose, from LlmClient.__del__.
+    messages = [str(w.message) for w in resource_warnings]
+    assert any("aclose" in m for m in messages), (
+        "unclosed managed LlmClient did not emit a ResourceWarning naming "
+        f"`aclose` at __del__; got: {messages}"
+    )
+
+    # Clean up the pooled transport we deliberately leaked so this test does not
+    # itself leave a dangling socket for a sibling test to trip over.
+    await pooled.aclose()

--- a/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 1 unit tests: LlmClient lifecycle surface (#1388).
+
+`LlmClient` exposed no `close()`/`aclose()`/`__aexit__` lifecycle method, so a
+persistent HTTP transport was released only at GC -> `ResourceWarning: unclosed
+<socket.socket ...>`, failing any run under `-W error::ResourceWarning`. These
+tests pin the new additive lifecycle API:
+
+* `dir(LlmClient)` now exposes `aclose` / `__aenter__` / `__aexit__`.
+* `aclose()` is idempotent and a no-op when no transport was created.
+* `async with` sets `_managed`, eagerly pools `_http_client`, and drops it on exit.
+* Backward-compat: an unmanaged client holds no transport and emits NO
+  ResourceWarning at GC.
+
+No network: these construct deployments but never call `embed()`, so they run
+without credentials. `sk-test-...` is a placeholder, never sent over the wire.
+"""
+
+from __future__ import annotations
+
+import gc
+import warnings
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.deployment import LlmDeployment
+
+# A model-key-consistent placeholder. No network call is made by any test in
+# this file (no embed()), so the key is never validated or transmitted.
+_PLACEHOLDER_KEY = "sk-test-1234567890abcdef"
+_EMBED_MODEL = "text-embedding-3-small"
+
+
+def _deployment() -> LlmDeployment:
+    return LlmDeployment.openai(api_key=_PLACEHOLDER_KEY, model=_EMBED_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Structural: the lifecycle surface exists
+# ---------------------------------------------------------------------------
+
+
+def test_llmclient_exposes_lifecycle_methods() -> None:
+    """dir(LlmClient) includes aclose / __aenter__ / __aexit__ (#1388 AC-1)."""
+    surface = dir(LlmClient)
+    for name in ("aclose", "__aenter__", "__aexit__"):
+        assert name in surface, f"LlmClient missing lifecycle method {name!r}"
+
+
+def test_lifecycle_methods_are_coroutines() -> None:
+    """aclose / __aenter__ / __aexit__ are async — deterministic close."""
+    import inspect
+
+    assert inspect.iscoroutinefunction(LlmClient.aclose)
+    assert inspect.iscoroutinefunction(LlmClient.__aenter__)
+    assert inspect.iscoroutinefunction(LlmClient.__aexit__)
+
+
+# ---------------------------------------------------------------------------
+# aclose() idempotence on a never-pooled client (no-op path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_noop_idempotent_when_no_transport() -> None:
+    """aclose() on a client that never created a transport is a safe no-op.
+
+    Calling it twice MUST NOT raise — covers the one-shot caller who builds a
+    client, never enters a managed scope, and (harmlessly) closes it.
+    """
+    client = LlmClient.from_deployment(_deployment())
+    assert client._http_client is None
+
+    await client.aclose()  # no transport -> no-op
+    await client.aclose()  # idempotent: still no-op, no error
+    assert client._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Managed (async-context-manager) pooling + deterministic close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_with_pools_then_closes_and_drops_transport() -> None:
+    """`async with` sets _managed, eagerly pools _http_client, drops it on exit.
+
+    Inside the scope the persistent transport exists and is open; after the
+    block it is closed AND the reference is dropped (so __del__ sees None and a
+    re-entered managed embed() re-pools a fresh transport).
+    """
+    deployment = _deployment()
+    async with LlmClient.from_deployment(deployment) as client:
+        assert client._managed is True
+        assert client._http_client is not None
+        assert client._http_client.is_closed is False
+        pooled = client._http_client
+
+    # After the block: transport closed and reference dropped.
+    assert pooled.is_closed is True
+    assert client._http_client is None
+
+
+@pytest.mark.asyncio
+async def test_aclose_idempotent_after_managed_scope() -> None:
+    """A second aclose() after the managed scope already closed is a no-op."""
+    deployment = _deployment()
+    async with LlmClient.from_deployment(deployment) as client:
+        assert client._http_client is not None
+    # __aexit__ already called aclose(); calling again MUST NOT raise.
+    await client.aclose()
+    assert client._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: unmanaged client holds nothing, warns nothing at GC
+# ---------------------------------------------------------------------------
+
+
+def test_unmanaged_client_holds_no_transport_and_warns_nothing_at_gc() -> None:
+    """An unmanaged LlmClient.from_deployment(d) emits NO ResourceWarning at GC.
+
+    This is the additive-API guarantee: one-shot callers who never enter a
+    managed scope hold `_http_client is None`, so __del__ short-circuits and
+    emits no warning — zero behavior change vs the pre-#1388 surface.
+    """
+    client = LlmClient.from_deployment(_deployment())
+    assert client._http_client is None
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del client
+        gc.collect()
+
+    resource_warnings = [w for w in caught if issubclass(w.category, ResourceWarning)]
+    assert resource_warnings == [], (
+        "unmanaged LlmClient emitted a ResourceWarning at GC; the additive "
+        f"lifecycle must not warn for one-shot callers: {[str(w.message) for w in resource_warnings]}"
+    )


### PR DESCRIPTION
## Summary

`kaizen.llm.client.LlmClient` exposed no lifecycle method — `dir(LlmClient)` had no `close`/`aclose`/`__aexit__`. This closes the API-surface gap **additively**: a managed (`async with`) client now pools one SSRF-guarded `LlmHttpClient` across `embed()` calls and closes it deterministically; one-shot callers are byte-for-byte unchanged.

Fixes #1388.

## What changed

`LlmClient` (`packages/kailash-kaizen/src/kaizen/llm/client.py`):
- **`aclose()`** (idempotent) + **`__aenter__`/`__aexit__`** — deterministically close the pooled HTTP transport.
- **Opt-in connection pooling** — `__aenter__` eagerly creates one persistent `LlmHttpClient` (before any concurrent `embed()`); `embed()` reuses it (`owns_client=False`, so per-call errors don't close it), amortizing the SSRF-resolver + pool setup across calls.
- **Backward-compatible** — `embed()`'s transport acquisition is now 3-case: caller-injected `http_client=` (caller owns), managed (instance-pooled), and **unmanaged → UNCHANGED fresh-per-call construct+close**. Existing `await LlmClient.from_deployment(d).embed(...)` callers hold nothing, leak nothing, warn nothing.
- **`__del__` is warn-only** — mirrors `LlmHttpClient.__del__`; emits `ResourceWarning` (naming `aclose`) only if a managed client pooled a transport and was never closed. Never calls close from the finalizer (CPython logging-lock deadlock per `rules/patterns.md` § Async Resource Cleanup). No sync `close()` (would need `asyncio.run()` and break inside event loops).

## User-flow walk receipts

**AC#1 — lifecycle surface present:**
```
$ .venv/bin/python -c "from kaizen.llm import LlmClient; print(sorted(m for m in dir(LlmClient) if m in ('close','aclose','__aexit__','__aenter__','shutdown')))"
['__aenter__', '__aexit__', 'aclose']
```

**AC#2 — no ResourceWarning after close (standalone, `-W error::ResourceWarning`):**
```
$ .venv/bin/python -W error::ResourceWarning prove_1388_noleak.py
NOLEAK_OK: managed-close + warns-at-del both clean; warning observed: LlmClient not closed; call await client.
exit=0
```
(managed `async with` exits with the transport closed + reference dropped; GC emits no `ResourceWarning`. The negative control confirms an unclosed managed client *does* warn at `__del__`.)

## Tests

- **Tier 1 unit** — `tests/unit/llm/test_llmclient_lifecycle.py` (surface present, idempotent `aclose`, managed-scope pools+closes, unmanaged holds nothing & no warning).
- **Tier 2 wiring** — `tests/integration/llm/test_llmclient_lifecycle_wiring.py` (transport object-identity reuse across `embed()` within a scope; closed after exit).
- **Regression** — `tests/regression/test_issue_1388_llmclient_resourcewarning.py` (overrides `pytest.ini`'s global `ignore::ResourceWarning` with `error::ResourceWarning` so the no-leak assertion is real; `@pytest.mark.asyncio` throughout — no throwaway event loops).

Results: new tests **10 passed, 1 skipped** (skip = `OPENAI_API_KEY`-gated real-network case); broader kaizen LLM suite **1021 passed** (no regression from the `embed()` change); `pytest --collect-only` → 13872 collected, exit 0.

## Redteam

Multi-round, evidence-gated redteam (3 diverse lenses/round: code-review + security + independent Bash verification) — **converged at 2 consecutive clean rounds** (`cleanStreak: 2`). Round 1 of the first pass surfaced one MEDIUM (a test-hygiene event-loop leak in the regression file, **not** a production bug — the verify lens proved the production transport is correctly closed); fixed by converting the warns-at-del test to `@pytest.mark.asyncio`. Re-run converged clean across all lenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
