### PR TITLE
release: kailash-kaizen 2.28.0

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
-## [Unreleased] — LlmClient lifecycle: aclose() + async context manager + opt-in HTTP pooling
+## [2.28.0] — 2026-06-19 — LlmClient lifecycle: aclose() + async context manager + opt-in HTTP pooling
 
 ### Added
 

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.27.1"
+version = "2.28.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.27.1"
+__version__ = "2.28.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
Release-prep for **kailash-kaizen 2.28.0** — the additive `LlmClient` lifecycle surface (`aclose()` + async context manager + opt-in HTTP pooling).

Minor bump (new public API, backward-compatible). Metadata-only diff: `pyproject.toml` + `__init__.py` version anchors → `2.28.0`; CHANGELOG `[Unreleased]` → `[2.28.0] — 2026-06-19`.

Feature landed in PR #1390 (full PR-gate matrix green; redteam converged 2 clean rounds). Sibling-drift sweep: all 9 packages at PyPI parity — kaizen-only release.

## Related issues
Closes #1388 (released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)