### PR TITLE
fix(pact,trust): holistic-redteam findings — YAML envelope governance fields (#1393) + cascade_revoke audit ground-truth (#1394)

### DIFF
--- a/packages/kailash-pact/tests/unit/governance/test_yaml_apply.py
+++ b/packages/kailash-pact/tests/unit/governance/test_yaml_apply.py
@@ -251,6 +251,77 @@ envelopes:
                 tmp_path,
             )
 
+    def test_yaml_envelope_clearance_and_depth_tighten(self, tmp_path: Path) -> None:
+        """confidentiality_clearance + max_delegation_depth authored in YAML reach
+        the runtime envelope and a child that TIGHTENS both applies cleanly.
+
+        Regression for #1393 — both fields were silently dropped before, so the
+        authored controls never reached enforcement at all.
+        """
+        engine = _build_from_yaml(
+            _BASE_ORG
+            + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    confidentiality_clearance: secret
+    max_delegation_depth: 3
+  - target: r-eng-junior
+    defined_by: r-eng-head
+    confidentiality_clearance: confidential
+    max_delegation_depth: 1
+""",
+            tmp_path,
+        )
+        head_env = engine.compute_envelope(_role(engine, "r-eng-head"))
+        junior_env = engine.compute_envelope(_role(engine, "r-eng-junior"))
+        assert head_env is not None and junior_env is not None
+        assert head_env.confidentiality_clearance == ConfidentialityLevel.SECRET
+        assert head_env.max_delegation_depth == 3
+        assert junior_env.confidentiality_clearance == ConfidentialityLevel.CONFIDENTIAL
+        assert junior_env.max_delegation_depth == 1
+
+    def test_yaml_envelope_clearance_widening_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """A child authoring a WIDER confidentiality_clearance than its YAML parent
+        aborts construction — the now-forwarded field (#1393) is
+        monotonic-tightening-checked end-to-end from YAML."""
+        with pytest.raises((MonotonicTighteningError, PactError)):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    confidentiality_clearance: confidential
+  - target: r-eng-junior
+    defined_by: r-eng-head
+    confidentiality_clearance: secret
+""",
+                tmp_path,
+            )
+
+    def test_yaml_envelope_delegation_depth_widening_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """A child authoring a DEEPER max_delegation_depth than its YAML parent
+        aborts construction (the now-forwarded field is tightening-checked)."""
+        with pytest.raises((MonotonicTighteningError, PactError)):
+            _build_from_yaml(
+                _BASE_ORG
+                + """
+envelopes:
+  - target: r-eng-head
+    defined_by: r-ceo
+    max_delegation_depth: 1
+  - target: r-eng-junior
+    defined_by: r-eng-head
+    max_delegation_depth: 3
+""",
+                tmp_path,
+            )
+
 
 # ---------------------------------------------------------------------------
 # Bridge applied: grants cross-unit access (LCA-approved from YAML)

--- a/src/kailash/trust/pact/yaml_loader.py
+++ b/src/kailash/trust/pact/yaml_loader.py
@@ -79,6 +79,22 @@ class EnvelopeSpec:
 
     Contains raw role IDs and constraint parameters before address
     resolution.
+
+    Beyond the five CARE dimension dicts, an envelope may carry two top-level
+    governance fields that map directly onto
+    :class:`~kailash.trust.pact.config.ConstraintEnvelopeConfig`. Both are
+    carried VERBATIM and coerced/validated when the envelope is resolved
+    (see :func:`kailash.trust.pact.yaml_resolvers.resolve_envelope`); omitting
+    either leaves the runtime config default in place.
+
+    Attributes:
+        confidentiality_clearance: Raw clearance-level string (e.g.
+            ``"restricted"``) capping the maximum data classification this
+            envelope's agent may access; ``None`` leaves the config default
+            (``PUBLIC``).
+        max_delegation_depth: Positive integer capping how many levels deep
+            trust may be delegated; ``None`` leaves the config default
+            (``None`` = unlimited).
     """
 
     target: str  # role_id of the target role
@@ -89,6 +105,8 @@ class EnvelopeSpec:
     data_access: dict[str, Any] | None = None
     communication: dict[str, Any] | None = None
     gradient_thresholds: dict[str, Any] | None = None
+    confidentiality_clearance: str | None = None
+    max_delegation_depth: int | None = None
 
 
 @dataclass(frozen=True)
@@ -187,7 +205,13 @@ def load_org_yaml(path: str | Path) -> LoadedOrg:
     - ``teams`` (list of ``{id, name}``)
     - ``roles`` (list of ``{id, name, reports_to?, heads?, agent?}``)
     - ``clearances`` (list of ``{role, level, compartments?, nda_signed?}``)
-    - ``envelopes`` (list of ``{target, defined_by, financial?, operational?, ...}``)
+    - ``envelopes`` (list of ``{target, defined_by, financial?, operational?,
+      temporal?, data_access?, communication?, gradient_thresholds?,
+      confidentiality_clearance?, max_delegation_depth?}``) -- the optional
+      ``confidentiality_clearance`` (clearance-level string) caps the data
+      classification the envelope's agent may access; ``max_delegation_depth``
+      (positive int) caps delegation depth. Both default to the
+      ``ConstraintEnvelopeConfig`` defaults (``PUBLIC`` / unlimited) when omitted.
     - ``bridges`` (list of ``{id, role_a, role_b, type, max_classification, bilateral?}``)
     - ``ksps`` (list of ``{id, source, target, max_classification,
       compartments?, shared_paths?, shared_types?, shared_classifications?,
@@ -589,6 +613,36 @@ def _parse_envelopes(
                 f"Envelope entry {i} is missing required 'defined_by' field in '{path}'"
             )
 
+        # --- Optional top-level governance fields (map onto
+        # ConstraintEnvelopeConfig). Carried VERBATIM; Pydantic coerces the
+        # clearance string -> ConfidentialityLevel and re-checks the gt=0
+        # delegation-depth bound at resolve time. Parse-time validation is
+        # fail-closed (a malformed value raises rather than silently
+        # defaulting the authored control). ---
+        confidentiality_clearance = entry.get("confidentiality_clearance")
+        if (
+            confidentiality_clearance is not None
+            and confidentiality_clearance not in _VALID_CLEARANCE_LEVELS
+        ):
+            raise ConfigurationError(
+                f"Envelope entry {i} (target '{target}') has invalid "
+                f"confidentiality_clearance '{confidentiality_clearance}'. "
+                f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "
+                f"In YAML file '{path}'."
+            )
+
+        max_delegation_depth = entry.get("max_delegation_depth")
+        if max_delegation_depth is not None and (
+            isinstance(max_delegation_depth, bool)
+            or not isinstance(max_delegation_depth, int)
+            or max_delegation_depth <= 0
+        ):
+            raise ConfigurationError(
+                f"Envelope entry {i} (target '{target}'): 'max_delegation_depth' "
+                f"must be a positive integer, got {max_delegation_depth!r}. "
+                f"In YAML file '{path}'."
+            )
+
         envelopes.append(
             EnvelopeSpec(
                 target=target,
@@ -599,6 +653,8 @@ def _parse_envelopes(
                 data_access=entry.get("data_access"),
                 communication=entry.get("communication"),
                 gradient_thresholds=entry.get("gradient_thresholds"),
+                confidentiality_clearance=confidentiality_clearance,
+                max_delegation_depth=max_delegation_depth,
             )
         )
 

--- a/src/kailash/trust/pact/yaml_loader.py
+++ b/src/kailash/trust/pact/yaml_loader.py
@@ -43,6 +43,19 @@ _VALID_CLEARANCE_LEVELS = frozenset(
 )
 
 
+def _is_valid_level(value: Any) -> bool:
+    """True iff ``value`` is a string naming a valid clearance level.
+
+    The ``isinstance`` guard short-circuits BEFORE the ``in`` membership test, so
+    an unhashable YAML value (a list / dict at a clearance-level position) yields
+    a fail-closed ``ConfigurationError`` at the call site rather than a raw
+    ``TypeError: unhashable type``. All clearance-level validation in this loader
+    routes through here so every level field fails closed with the same helpful
+    message.
+    """
+    return isinstance(value, str) and value in _VALID_CLEARANCE_LEVELS
+
+
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
@@ -559,7 +572,7 @@ def _parse_clearances(
                 f"in '{path}'"
             )
 
-        if level not in _VALID_CLEARANCE_LEVELS:
+        if not _is_valid_level(level):
             raise ConfigurationError(
                 f"Clearance entry {i} for role '{role_id}' has invalid level '{level}'. "
                 f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "
@@ -620,9 +633,8 @@ def _parse_envelopes(
         # fail-closed (a malformed value raises rather than silently
         # defaulting the authored control). ---
         confidentiality_clearance = entry.get("confidentiality_clearance")
-        if (
-            confidentiality_clearance is not None
-            and confidentiality_clearance not in _VALID_CLEARANCE_LEVELS
+        if confidentiality_clearance is not None and not _is_valid_level(
+            confidentiality_clearance
         ):
             raise ConfigurationError(
                 f"Envelope entry {i} (target '{target}') has invalid "
@@ -792,7 +804,7 @@ def _parse_ksps(
             entry, "shared_classifications", ksp_id, path
         )
         for level in shared_classifications:
-            if level not in _VALID_CLEARANCE_LEVELS:
+            if not _is_valid_level(level):
                 raise ConfigurationError(
                     f"KSP '{ksp_id}': invalid shared_classification '{level}'. "
                     f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "
@@ -800,7 +812,7 @@ def _parse_ksps(
                 )
 
         min_clearance = entry.get("min_clearance")
-        if min_clearance is not None and min_clearance not in _VALID_CLEARANCE_LEVELS:
+        if min_clearance is not None and not _is_valid_level(min_clearance):
             raise ConfigurationError(
                 f"KSP '{ksp_id}': invalid min_clearance '{min_clearance}'. "
                 f"Valid levels: {sorted(_VALID_CLEARANCE_LEVELS)}. "

--- a/src/kailash/trust/pact/yaml_resolvers.py
+++ b/src/kailash/trust/pact/yaml_resolvers.py
@@ -257,6 +257,17 @@ def resolve_envelope(spec: EnvelopeSpec, compiled: CompiledOrg) -> RoleEnvelope:
         config_kwargs["data_access"] = spec.data_access
     if spec.communication is not None:
         config_kwargs["communication"] = spec.communication
+    # Top-level governance fields beyond the five CARE dimensions. Pydantic
+    # coerces the clearance string -> ConfidentialityLevel (its enum values are
+    # exactly the loader's _VALID_CLEARANCE_LEVELS) and re-validates the gt=0
+    # delegation-depth bound; a bad value surfaces as the fail-closed
+    # ConfigurationError below. Forwarding these is what makes a YAML-authored
+    # confidentiality ceiling / delegation cap actually reach enforcement
+    # (issue #1386 follow-up — they were silently dropped before).
+    if spec.confidentiality_clearance is not None:
+        config_kwargs["confidentiality_clearance"] = spec.confidentiality_clearance
+    if spec.max_delegation_depth is not None:
+        config_kwargs["max_delegation_depth"] = spec.max_delegation_depth
     try:
         envelope_config = ConstraintEnvelopeConfig(**config_kwargs)
         gradient = (

--- a/src/kailash/trust/revocation/cascade.py
+++ b/src/kailash/trust/revocation/cascade.py
@@ -4,8 +4,9 @@
 """Cascade revocation with TrustStore integration.
 
 Provides a high-level ``cascade_revoke()`` function that wires the existing
-``CascadeRevocationManager`` BFS cascade into ``TrustStore`` for atomic
-chain invalidation with audit trail.
+``CascadeRevocationManager`` BFS cascade into ``TrustStore`` for best-effort
+consistent chain invalidation with audit trail (see the Consistency section
+below — this is NOT a single atomic transaction).
 
 Consistency (best-effort rollback, NOT a single transaction):
     Chain invalidation is NOT wrapped in one atomic transaction. The

--- a/src/kailash/trust/revocation/cascade.py
+++ b/src/kailash/trust/revocation/cascade.py
@@ -38,8 +38,7 @@ Cross-SDK parity (EATP D6 — kailash-py#595 / kailash-rs ISS-04):
     MUST NOT rely on event ordering for cross-SDK correlation; correlate
     on ``event.target_id`` + ``event.affected_agents`` as a set.
 
-    Parity contract (enforced by
-    ``tests/regression/test_cascade_revocation_cross_sdk_parity.py``):
+    Parity contract:
 
     1. Given an identical delegation tree seeded on both SDKs and a revoke
        of the same root node, ``set(py.revoked_agents) ==
@@ -47,11 +46,18 @@ Cross-SDK parity (EATP D6 — kailash-py#595 / kailash-rs ISS-04):
     2. Idempotency behavior is identical: a second revoke of the same
        agent returns ``success=True, events=[], revoked_agents=[]`` on
        both sides.
-    3. Partial-failure rollback contract is identical: if any chain
-       deletion fails, prior deletions are restored (best-effort) and
-       ``success=False`` is returned with error details. Any chain that
-       cannot be restored remains revoked and is reported in
-       ``revoked_agents`` (store state and result agree).
+
+    Items 1-2 (happy-path topology + idempotency parity) are pinned by
+    ``tests/regression/test_issue_595_cascade_revocation_cross_sdk_parity.py``.
+
+    3. Partial-failure rollback behavior: if any chain deletion fails, prior
+       deletions are restored (best-effort) and ``success=False`` is returned
+       with error details; any chain that cannot be restored remains revoked
+       and is reported in ``revoked_agents`` (store state and result agree).
+       This ground-truth contract is pinned single-SDK by
+       ``tests/regression/test_issue_1394_cascade_revoke_audit_divergence.py``
+       (the cross-SDK parity file above covers happy-path topology only; a
+       cross-SDK partial-failure parity case is future work, see #1394).
 """
 
 from __future__ import annotations

--- a/src/kailash/trust/revocation/cascade.py
+++ b/src/kailash/trust/revocation/cascade.py
@@ -7,12 +7,19 @@ Provides a high-level ``cascade_revoke()`` function that wires the existing
 ``CascadeRevocationManager`` BFS cascade into ``TrustStore`` for atomic
 chain invalidation with audit trail.
 
-Atomicity:
-    The function uses the TrustStore's transaction support when available
-    for atomic chain invalidation. If any chain deletion fails, all
-    previously deleted chains are restored (rolled back) to maintain
-    consistency. On partial failure, success=False is returned with
-    all chains restored and errors reported.
+Consistency (best-effort rollback, NOT a single transaction):
+    Chain invalidation is NOT wrapped in one atomic transaction. The
+    InMemory TrustStore's transaction context snapshots only ACTIVE chains
+    and cannot roll back a soft-delete (which moves a chain to the inactive
+    set), and the durable stores (sqlite / filesystem) expose no transaction
+    at all. Instead, every affected chain is snapshot before deletion; if any
+    deletion fails, the successful deletions are restored from those snapshots
+    on a best-effort basis. A chain whose restore ALSO fails remains
+    soft-deleted (revoked) and is reported in
+    ``RevocationResult.revoked_agents`` — store state and the result always
+    agree. On partial failure, ``success=False`` is returned with ``errors``
+    populated. (True cross-store atomic invalidation is tracked as a
+    follow-up; see issue referenced in the cascade tests.)
 
 Idempotency:
     Revoking an already-revoked agent is a no-op: the function returns
@@ -41,8 +48,10 @@ Cross-SDK parity (EATP D6 — kailash-py#595 / kailash-rs ISS-04):
        agent returns ``success=True, events=[], revoked_agents=[]`` on
        both sides.
     3. Partial-failure rollback contract is identical: if any chain
-       deletion fails, all prior deletions roll back, and
-       ``success=False`` with error details.
+       deletion fails, prior deletions are restored (best-effort) and
+       ``success=False`` is returned with error details. Any chain that
+       cannot be restored remains revoked and is reported in
+       ``revoked_agents`` (store state and result agree).
 """
 
 from __future__ import annotations
@@ -76,7 +85,12 @@ class RevocationResult:
             True even for no-ops (already revoked).
         events: All RevocationEvent objects created during the cascade.
             Empty if the agent was already revoked (idempotent no-op).
-        revoked_agents: List of agent IDs whose chains were soft-deleted.
+        revoked_agents: List of agent IDs whose chains are soft-deleted
+            (revoked) as a result of this call — it always matches store
+            state. On a clean cascade this is every affected agent; on a
+            partial failure whose rollback fully succeeds it is empty; on a
+            partial failure whose rollback could NOT restore some chains it is
+            exactly those still-revoked agents.
         errors: Per-agent errors encountered during chain deletion.
             Non-empty errors with success=True means partial completion
             (some chains couldn't be deleted but cascade was broadcast).
@@ -124,22 +138,35 @@ async def _rollback_chains(
     store: TrustStore,
     snapshots: Dict[str, TrustLineageChain],
     deleted_agents: List[str],
-) -> None:
+) -> List[str]:
     """Attempt to restore previously deleted chains from snapshots.
 
-    Best-effort rollback: logs errors but does not raise.
+    Best-effort rollback: it does NOT raise (so a single restore failure
+    cannot abort restoration of the remaining agents), but it RETURNS the
+    agents it could not restore so the caller can report ground truth instead
+    of assuming every deletion was undone. An agent that cannot be restored
+    remains soft-deleted (revoked) in the store.
 
     Args:
         store: TrustStore to restore chains into.
         snapshots: Pre-deletion snapshots.
         deleted_agents: List of agent IDs that were successfully deleted
             and need to be restored.
+
+    Returns:
+        The subset of ``deleted_agents`` that could NOT be restored — either
+        because no snapshot exists or because ``store_chain`` raised. These
+        chains remain soft-deleted (revoked) and the store state and the
+        returned ``RevocationResult`` agree on them.
     """
+    restore_failed: List[str] = []
     for aid in deleted_agents:
         if aid not in snapshots:
             logger.warning(
-                f"[REVOKE-ROLLBACK] No snapshot for agent '{aid}', cannot restore"
+                f"[REVOKE-ROLLBACK] No snapshot for agent '{aid}', cannot restore "
+                f"(chain remains soft-deleted/revoked)"
             )
+            restore_failed.append(aid)
             continue
         try:
             await store.store_chain(snapshots[aid])
@@ -147,8 +174,11 @@ async def _rollback_chains(
         except Exception as restore_exc:
             logger.error(
                 f"[REVOKE-ROLLBACK] Failed to restore chain for agent "
-                f"'{aid}': {type(restore_exc).__name__}: {restore_exc}"
+                f"'{aid}': {type(restore_exc).__name__}: {restore_exc} "
+                f"(chain remains soft-deleted/revoked)"
             )
+            restore_failed.append(aid)
+    return restore_failed
 
 
 async def cascade_revoke(
@@ -170,11 +200,14 @@ async def cascade_revoke(
     5. On partial failure: rolls back all deletions for consistency
     6. Returns a complete audit trail
 
-    Atomicity:
-        All chain deletions are treated as an atomic unit. If any deletion
-        fails, all previously successful deletions are rolled back (chains
-        restored from snapshots). This prevents inconsistent state where
-        some chains are deleted and others are not.
+    Consistency (best-effort rollback, NOT one atomic transaction):
+        Chain deletions are not wrapped in a single transaction (see the
+        module docstring for why the available transaction context cannot
+        roll back soft-deletes). If any deletion fails, previously successful
+        deletions are restored from snapshots on a best-effort basis; a chain
+        whose restore ALSO fails remains soft-deleted (revoked) and is
+        reported in ``revoked_agents`` — the result never claims a chain was
+        un-revoked while it is still deleted.
 
     Args:
         agent_id: The agent to revoke.
@@ -241,15 +274,28 @@ async def cascade_revoke(
                 f"[REVOKE] Failed to soft-delete chain for agent '{affected_id}': {error_msg}"
             )
 
-    # If any errors occurred, roll back all successful deletions
+    # If any errors occurred, roll back all successful deletions.
     if errors:
         logger.warning(
             f"[REVOKE] Partial failure during cascade revocation for '{agent_id}': "
             f"{len(errors)} error(s). Rolling back {len(revoked_agents)} "
             f"successful deletion(s) for consistency."
         )
-        await _rollback_chains(store, snapshots, revoked_agents)
-        revoked_agents = []  # No agents were ultimately revoked
+        restore_failed = await _rollback_chains(store, snapshots, revoked_agents)
+        # revoked_agents MUST reflect store ground truth. The rollback is
+        # best-effort: any chain whose restore failed remains soft-deleted
+        # (revoked). Reporting [] unconditionally (the prior behavior) claimed
+        # "no agents were revoked" while those chains were still deleted —
+        # diverging the audit result from store state. Report exactly the
+        # chains that remain revoked.
+        revoked_agents = restore_failed
+        if restore_failed:
+            logger.warning(
+                f"[REVOKE] Rollback incomplete for '{agent_id}': "
+                f"{len(restore_failed)} chain(s) could not be restored and remain "
+                f"soft-deleted (revoked): {sorted(restore_failed)}. Store state and "
+                f"RevocationResult.revoked_agents agree."
+            )
 
     success = len(errors) == 0
 

--- a/tests/regression/test_issue_1393_yaml_envelope_governance_fields.py
+++ b/tests/regression/test_issue_1393_yaml_envelope_governance_fields.py
@@ -65,6 +65,11 @@ def test_omitted_fields_preserve_config_defaults():
     "field, bad_value",
     [
         ("confidentiality_clearance", "nonsense"),
+        # Unhashable YAML node positions (list / dict) MUST fail closed with a
+        # ConfigurationError, not raise a raw `TypeError: unhashable type` from
+        # the `in frozenset` membership test (redteam CC-1).
+        ("confidentiality_clearance", ["public"]),
+        ("confidentiality_clearance", {"level": "public"}),
         ("max_delegation_depth", 0),
         ("max_delegation_depth", -1),
         ("max_delegation_depth", True),  # bool is not a valid positive int depth

--- a/tests/regression/test_issue_1393_yaml_envelope_governance_fields.py
+++ b/tests/regression/test_issue_1393_yaml_envelope_governance_fields.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression for issue #1393 — YAML envelope governance fields silently dropped.
+
+A YAML-authored constraint envelope's ``confidentiality_clearance`` and
+``max_delegation_depth`` were silently discarded on the way to the runtime
+engine: ``EnvelopeSpec`` had no slot for them, ``_parse_envelopes`` never read
+them, and ``resolve_envelope`` never forwarded them into
+``ConstraintEnvelopeConfig``. An operator authoring ``max_delegation_depth: 1``
+(cap delegation) got ``None`` (UNLIMITED) at enforcement, with no error.
+
+This regression pins that both fields survive load -> resolve onto the runtime
+envelope config, and that malformed values fail closed.
+
+Found by the holistic post-multi-wave redteam of the PACT KSP/Bridge epic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.trust.pact.compilation import compile_org
+from kailash.trust.pact.config import ConfidentialityLevel
+from kailash.trust.pact.yaml_loader import ConfigurationError, load_org_from_dict
+from kailash.trust.pact.yaml_resolvers import resolve_envelope
+
+pytestmark = pytest.mark.regression
+
+_BASE = {
+    "org_id": "o",
+    "name": "O",
+    "roles": [{"id": "boss"}, {"id": "worker", "reports_to": "boss"}],
+}
+
+
+def _resolve_one_envelope(envelope_entry: dict):
+    loaded = load_org_from_dict(dict(_BASE, envelopes=[envelope_entry]))
+    compiled = compile_org(loaded.org_definition)
+    return resolve_envelope(loaded.envelopes[0], compiled).envelope
+
+
+def test_authored_clearance_and_depth_reach_runtime_config():
+    """Both fields authored in YAML land on the resolved ConstraintEnvelopeConfig."""
+    cfg = _resolve_one_envelope(
+        {
+            "target": "worker",
+            "defined_by": "boss",
+            "confidentiality_clearance": "restricted",
+            "max_delegation_depth": 1,
+        }
+    )
+    assert cfg.confidentiality_clearance is ConfidentialityLevel.RESTRICTED
+    assert cfg.max_delegation_depth == 1
+
+
+def test_omitted_fields_preserve_config_defaults():
+    """Omitting the fields leaves the ConstraintEnvelopeConfig defaults intact."""
+    cfg = _resolve_one_envelope({"target": "worker", "defined_by": "boss"})
+    assert cfg.confidentiality_clearance is ConfidentialityLevel.PUBLIC
+    assert cfg.max_delegation_depth is None
+
+
+@pytest.mark.parametrize(
+    "field, bad_value",
+    [
+        ("confidentiality_clearance", "nonsense"),
+        ("max_delegation_depth", 0),
+        ("max_delegation_depth", -1),
+        ("max_delegation_depth", True),  # bool is not a valid positive int depth
+        ("max_delegation_depth", "2"),  # string is not an int
+    ],
+)
+def test_malformed_governance_field_fails_closed(field, bad_value):
+    """A malformed authored value raises ConfigurationError, never silently defaults."""
+    with pytest.raises(ConfigurationError):
+        load_org_from_dict(
+            dict(
+                _BASE,
+                envelopes=[
+                    {"target": "worker", "defined_by": "boss", field: bad_value}
+                ],
+            )
+        )

--- a/tests/regression/test_issue_1394_cascade_revoke_audit_divergence.py
+++ b/tests/regression/test_issue_1394_cascade_revoke_audit_divergence.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression for issue #1394 — cascade_revoke audit/store divergence.
+
+cascade_revoke() previously returned ``RevocationResult(success=False,
+revoked_agents=[])`` on ANY partial failure — even when the best-effort
+rollback could NOT restore an already-soft-deleted chain. Those chains remain
+revoked in the store, so the result claimed "no agents revoked" while chains
+were still deleted (store state and audit result diverged).
+
+This regression pins the ground-truth-reporting contract: any chain that the
+rollback cannot restore remains revoked AND is reported in ``revoked_agents``,
+so store state and the result always agree.
+
+Found by the holistic post-multi-wave redteam of the PACT/trust-plane surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import pytest
+
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.exceptions import TrustChainNotFoundError
+from kailash.trust.revocation.broadcaster import (
+    InMemoryDelegationRegistry,
+    InMemoryRevocationBroadcaster,
+)
+from kailash.trust.revocation.cascade import cascade_revoke
+
+pytestmark = pytest.mark.regression
+
+
+def _make_chain(agent_id: str, authority_id: str = "auth-1") -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id=f"gen-{agent_id}",
+            agent_id=agent_id,
+            authority_id=authority_id,
+            authority_type=AuthorityType.ORGANIZATION,
+            created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            signature="sig-test-genesis",
+        )
+    )
+
+
+class FailDeleteAndRestoreStore(InMemoryTrustStore):
+    """Simulates the DOUBLE failure: a chain deletion fails (triggering the
+    rollback path) AND, once armed, restoring an already-deleted chain also
+    fails. The chain whose restore fails remains soft-deleted (revoked).
+    """
+
+    def __init__(
+        self,
+        fail_delete_on: Optional[List[str]] = None,
+        fail_restore_on: Optional[List[str]] = None,
+    ):
+        super().__init__()
+        self._fail_delete_on = set(fail_delete_on or [])
+        self._fail_restore_on = set(fail_restore_on or [])
+        self._armed = False
+
+    def arm(self) -> None:
+        """Activate restore failures (after test setup has stored chains)."""
+        self._armed = True
+
+    async def delete_chain(self, agent_id: str, soft_delete: bool = True) -> None:
+        if agent_id in self._fail_delete_on:
+            raise RuntimeError(f"Simulated delete failure for agent '{agent_id}'")
+        return await super().delete_chain(agent_id, soft_delete=soft_delete)
+
+    async def store_chain(
+        self, chain: TrustLineageChain, expires_at: Optional[datetime] = None
+    ) -> str:
+        if self._armed and chain.genesis.agent_id in self._fail_restore_on:
+            raise RuntimeError(
+                f"Simulated restore failure for agent '{chain.genesis.agent_id}'"
+            )
+        return await super().store_chain(chain, expires_at=expires_at)
+
+
+async def test_unrestorable_chain_reported_in_revoked_agents(caplog):
+    """When rollback cannot restore a deleted chain, revoked_agents reports it."""
+    registry = InMemoryDelegationRegistry()
+    broadcaster = InMemoryRevocationBroadcaster()
+    # agent-A deletes successfully, then its rollback restore fails;
+    # agent-B's delete fails (which triggers the rollback path).
+    store = FailDeleteAndRestoreStore(
+        fail_delete_on=["agent-B"], fail_restore_on=["agent-A"]
+    )
+    await store.store_chain(_make_chain("agent-A"))
+    await store.store_chain(_make_chain("agent-B"))
+    registry.register_delegation("agent-A", "agent-B")
+    store.arm()  # restores of agent-A now fail
+
+    with caplog.at_level(logging.WARNING):
+        result = await cascade_revoke(
+            agent_id="agent-A",
+            store=store,
+            reason="issue-1394 double-failure ground-truth regression",
+            revoked_by="admin",
+            broadcaster=broadcaster,
+            delegation_registry=registry,
+        )
+
+    # The delete that failed is surfaced as an error; success is False.
+    assert result.success is False
+    assert "agent-B" in result.errors
+
+    # GROUND TRUTH: agent-A remains soft-deleted (revoked) because its rollback
+    # restore failed — it MUST be reported, not zeroed (the issue-1394 bug).
+    assert result.revoked_agents == ["agent-A"]
+
+    # The store agrees: agent-A's active chain is gone.
+    with pytest.raises(TrustChainNotFoundError):
+        await store.get_chain("agent-A", include_inactive=False)
+
+    # Operator-visible warning names the un-restorable chain.
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    assert any(
+        "could not be restored" in m for m in warning_messages
+    ), f"expected an unrestorable-chain warning, got: {warning_messages}"
+
+
+async def test_clean_rollback_still_reports_empty_revoked_agents():
+    """When rollback fully succeeds, prior behavior is preserved (nothing revoked)."""
+    registry = InMemoryDelegationRegistry()
+    broadcaster = InMemoryRevocationBroadcaster()
+    store = FailDeleteAndRestoreStore(fail_delete_on=["agent-B"], fail_restore_on=[])
+    await store.store_chain(_make_chain("agent-A"))
+    await store.store_chain(_make_chain("agent-B"))
+    registry.register_delegation("agent-A", "agent-B")
+    store.arm()
+
+    result = await cascade_revoke(
+        agent_id="agent-A",
+        store=store,
+        reason="issue-1394 clean-rollback control",
+        revoked_by="admin",
+        broadcaster=broadcaster,
+        delegation_registry=registry,
+    )
+
+    assert result.success is False
+    assert "agent-B" in result.errors
+    # agent-A was deleted then successfully restored -> not revoked.
+    assert result.revoked_agents == []
+    chain = await store.get_chain("agent-A", include_inactive=False)
+    assert chain.genesis.agent_id == "agent-A"

--- a/tests/trust/unit/test_cascade_revoke_atomicity.py
+++ b/tests/trust/unit/test_cascade_revoke_atomicity.py
@@ -2,15 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Unit tests for cascade_revoke() atomicity and partial failure recovery (F-03).
+Unit tests for cascade_revoke() consistency and partial failure recovery (F-03).
 
 Verifies:
-- Transaction support: uses store.transaction() when available
-- Rollback on partial failure: restores already-deleted chains
+- Rollback on partial failure: restores already-deleted chains (best-effort)
 - Success=False on partial failure with informative errors
-- Manual rollback when store lacks transaction support
-- Complete success scenario uses transactions correctly
+- revoked_agents reflects store ground truth even when rollback CANNOT restore
+  a chain (the chain stays revoked and is reported, not silently zeroed)
+- Complete success scenario removes all affected chains
 - Backward compatibility: existing callers still work
+
+Note: cascade_revoke does NOT use a single atomic transaction. The InMemory
+transaction context snapshots only active chains and cannot roll back a
+soft-delete; durable stores expose no transaction. Consistency is best-effort
+snapshot rollback with honest ground-truth reporting in ``revoked_agents``.
+See the cascade module docstring for the full contract.
 """
 
 from __future__ import annotations
@@ -24,14 +30,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.chain_store.memory import InMemoryTrustStore
 from kailash.trust.exceptions import TrustChainNotFoundError
 from kailash.trust.revocation.broadcaster import (
     InMemoryDelegationRegistry,
     InMemoryRevocationBroadcaster,
 )
 from kailash.trust.revocation.cascade import RevocationResult, cascade_revoke
-from kailash.trust.chain_store.memory import InMemoryTrustStore
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -195,7 +200,9 @@ class TestPartialFailureRecovery:
 
         assert result.success is False
         # Check that some kind of rollback/failure warning was logged
-        warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
         assert len(warning_messages) > 0
 
 
@@ -246,26 +253,33 @@ class TestCompleteSuccess:
 
 
 # ---------------------------------------------------------------------------
-# 3 -- Transaction support detection
+# 3 -- Full-cascade consistency (no atomic transaction is used)
 # ---------------------------------------------------------------------------
 
 
-class TestTransactionSupport:
-    """F-03: cascade_revoke must use transactions when the store supports them."""
+class TestFullCascadeConsistency:
+    """cascade_revoke removes all affected chains on the happy path.
 
-    async def test_inmemory_store_uses_transaction_path(self, store, registry, broadcaster):
-        """InMemoryTrustStore supports transaction(), cascade_revoke should use it."""
+    NOTE: cascade_revoke does NOT call ``store.transaction()`` — the InMemory
+    transaction context snapshots only active chains and cannot roll back a
+    soft-delete, and durable stores expose no transaction. This test asserts
+    the OBSERVABLE contract (every affected chain revoked on success); it does
+    NOT (and must not) claim a transaction path was taken.
+    """
+
+    async def test_inmemory_full_cascade_revokes_all_agents(
+        self, store, registry, broadcaster
+    ):
+        """A clean multi-agent cascade soft-deletes every affected chain."""
         await store.store_chain(_make_chain("agent-A"))
         await store.store_chain(_make_chain("agent-B"))
 
         registry.register_delegation("agent-A", "agent-B")
 
-        # The test verifies correctness of the result, which implies
-        # the transaction path was used (InMemoryTrustStore has transaction())
         result = await cascade_revoke(
             agent_id="agent-A",
             store=store,
-            reason="Transaction support test",
+            reason="Full cascade consistency test",
             revoked_by="admin",
             broadcaster=broadcaster,
             delegation_registry=registry,
@@ -273,6 +287,47 @@ class TestTransactionSupport:
 
         assert result.success is True
         assert set(result.revoked_agents) == {"agent-A", "agent-B"}
+
+    async def test_cascade_revoke_does_not_invoke_store_transaction(
+        self, store, registry, broadcaster
+    ):
+        """Pin reality: cascade_revoke never calls store.transaction().
+
+        The prior test/docstring claimed a transaction path was used. It was
+        not, and cannot be (the transaction context cannot roll back a
+        soft-delete). This guards against a future docstring re-introducing the
+        false claim without wiring the (currently infeasible) behavior.
+        """
+        await store.store_chain(_make_chain("agent-A"))
+        await store.store_chain(_make_chain("agent-B"))
+        registry.register_delegation("agent-A", "agent-B")
+
+        calls = {"n": 0}
+        original_transaction = store.transaction
+
+        def _counting_transaction(*args, **kwargs):
+            calls["n"] += 1
+            return original_transaction(*args, **kwargs)
+
+        store.transaction = _counting_transaction  # type: ignore[method-assign]
+        try:
+            result = await cascade_revoke(
+                agent_id="agent-A",
+                store=store,
+                reason="No-transaction pin",
+                revoked_by="admin",
+                broadcaster=broadcaster,
+                delegation_registry=registry,
+            )
+        finally:
+            store.transaction = original_transaction  # type: ignore[method-assign]
+
+        assert result.success is True
+        assert calls["n"] == 0, (
+            "cascade_revoke called store.transaction(); the consistency contract "
+            "is best-effort snapshot rollback, NOT transactional — update the docs "
+            "and this test together if that changes."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +338,9 @@ class TestTransactionSupport:
 class TestBackwardCompatibilityF03:
     """F-03: Existing callers and test patterns must still work."""
 
-    async def test_existing_cascade_revoke_api_unchanged(self, store, registry, broadcaster):
+    async def test_existing_cascade_revoke_api_unchanged(
+        self, store, registry, broadcaster
+    ):
         """cascade_revoke function signature and return type must be unchanged."""
         await store.store_chain(_make_chain("agent-A"))
 
@@ -302,7 +359,9 @@ class TestBackwardCompatibilityF03:
         assert isinstance(result.revoked_agents, list)
         assert isinstance(result.errors, dict)
 
-    async def test_idempotent_revocation_still_works(self, store, registry, broadcaster):
+    async def test_idempotent_revocation_still_works(
+        self, store, registry, broadcaster
+    ):
         """Re-revoking an already-revoked agent must still be a no-op."""
         await store.store_chain(_make_chain("agent-A"))
 


### PR DESCRIPTION
## Summary

Two confirmed, user-impacting defects found by a **holistic post-multi-wave redteam** of the recently-shipped PACT KSP/Bridge governance epic (#1368–#1386) + trust-plane surface — the cross-shard pass that per-shard redteams structurally could not see. Both fixed here with regression tests.

## Fix A — `fix(pact)` — YAML envelope governance fields silently dropped (HIGH, Fixes #1393)

The #1386 YAML-apply path dropped `confidentiality_clearance` and `max_delegation_depth` from authored envelopes: `EnvelopeSpec` had no slot, `_parse_envelopes` never read them, `resolve_envelope` never forwarded them. An operator authoring `max_delegation_depth: 1` (cap delegation) got `None` = **UNLIMITED** at enforcement; an authored clearance ceiling never applied — silently, no error (zero-tolerance Rule 3c).

- `EnvelopeSpec` carries both fields; `_parse_envelopes` validates them fail-closed (invalid clearance level / non-positive-int depth → `ConfigurationError`).
- `resolve_envelope` forwards both into `ConstraintEnvelopeConfig` (Pydantic coerces clearance → `ConfidentialityLevel`, re-checks `gt=0` depth).
- Loader docstring updated.

## Fix B — `fix(trust)` — `cascade_revoke` audit/store divergence + false "atomic" claim (MEDIUM, Fixes #1394)

`cascade_revoke` returned `revoked_agents=[]` on any partial failure even when the best-effort rollback **could not restore** an already-soft-deleted chain — so the audit result claimed "nothing revoked" while chains were still deleted (store/result divergence). The docstrings also claimed transaction-backed "atomic chain invalidation" that the code never invokes and that the InMemory transaction context **cannot** provide (it snapshots only active chains, not the inactive set — so a soft-delete can't be rolled back).

- `_rollback_chains` returns the agents it could not restore (no longer swallows); `revoked_agents` reflects store ground truth; a WARN names any chain left revoked.
- Docstrings reconciled to the real best-effort-rollback (non-transactional) contract.
- The false "uses transactions" unit test reconciled to assert the observable contract; a pin test asserts `cascade_revoke` does **not** call `store.transaction()`.
- Larger follow-up (durable-store transactions + inactive-set-aware rollback for true atomicity) noted in #1394.

## Provenance

Found by a sequential, evidence-gated holistic redteam (5 dimension finders → adversarial refutation of every finding). 3 dimensions (authz-precedence, security/injection, cross-shard contract) found nothing after deep reads of `access.py`/`engine.py`/`knowledge.py`/`clearance.py`/`stores/sqlite.py`/governance-API — strong evidence the core KSP/Bridge decision logic is sound. 1 finding (fire-and-forget async subscriber) was correctly refuted (revocation is store-authoritative, not broadcast-dependent).

## Test receipts (verbatim)

```
$ pytest tests/regression/test_issue_1393_*.py tests/regression/test_issue_1394_*.py \
         tests/trust/unit/test_cascade_revoke_atomicity.py -q
23 passed

$ pytest packages/kailash-pact/tests/unit/governance/ tests/trust/pact/ tests/trust/unit/ \
         tests/regression/test_issue_139{3,4}_*.py tests/regression/test_issue_595_*.py -q
5360 passed, 15 skipped, 7 warnings   # 7 warnings pre-existing + intentional (deprecated-API + unverified-context tests), none on changed surfaces

$ pre-commit run --files <changed files>
Black / isort / Ruff / type-annotations / Tier-1 tests ... Passed
```

Both fixes verified through the actual code path: the previously-dropped envelope fields now reach `ConstraintEnvelopeConfig` (clearance=RESTRICTED, depth=1); the double-failure path now reports the still-revoked agent in `revoked_agents` with store state agreeing.

## Related issues

Fixes #1393
Fixes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
