### PR TITLE
fix(trust)!: holistic redteam round-2 — NDA enforcement + 9 trust-plane fixes (2.42.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.0] - 2026-06-20
+
+A holistic post-multi-wave redteam of the trust-plane surface (beyond the
+2.41.1 PACT KSP/Bridge + cascade scope) surfaced ten confirmed defects across
+`kailash.trust.{pact,plane,operations,signing,enforce,revocation,vault}`. Nine
+are non-breaking correctness/security fixes; one (`nda_signed` enforcement) is a
+behavior change to knowledge-access control — hence the minor bump.
+
+### Changed
+
+- **BREAKING — `nda_signed` is now ENFORCED for SECRET / TOP_SECRET knowledge
+  access** (`kailash.trust.pact.access.can_access`). `RoleClearance.nda_signed`
+  is documented "Required for SECRET and TOP_SECRET clearance" and is
+  parsed/stored/serialized across the YAML loader, SQLite store, and backup
+  paths — but no access-decision path ever consulted it, so a role with
+  `nda_signed=False` (the field default) was granted SECRET/TOP_SECRET access.
+  `can_access` now denies SECRET+ items when `nda_signed` is `False` (fail-closed
+  with `deny detail="nda_not_signed"`). **Migration:** any `RoleClearance`
+  granting SECRET or TOP_SECRET access MUST set `nda_signed=True` (the value the
+  conformance vector + canonical fixtures already use); a default-`False` SECRET
+  clearance that previously resolved to ALLOW now resolves to DENY. CONFIDENTIAL
+  and below are unaffected.
+
+### Security
+
+- **Rotation `revoke_old_key` now invalidates the key**
+  (`kailash.trust.signing.rotation` + `kailash.trust.operations.TrustKeyManager`).
+  `revoke_old_key` emitted a `rotation_key_revoked` audit event and cleared
+  grace-period tracking but never removed the key from the key manager — so the
+  "revoked" key kept signing while the audit trail asserted revocation. A new
+  `TrustKeyManager.remove_key` tombstones the private material and
+  `revoke_old_key` now calls it.
+- **`TrustProject.verify` rejects a decision record missing its `content_hash`**
+  (`kailash.trust.plane.project`). The tamper check was guarded by
+  `if stored_hash and …`, so a decision record whose `content_hash` was stripped
+  (the field is a computed property, not a required deserialization field) slipped
+  past verification — even in `strict=True` mode. A missing/empty `content_hash`
+  is now a verification failure (strict: raises `ChainHashMismatchError`;
+  non-strict: `chain_valid=False` + integrity issue).
+- **Corrupted persisted trust posture now fails closed to PSEUDO**
+  (`kailash.trust.plane.project`). An unrecognized persisted `trust_posture` was
+  swallowed by `except (ValueError, Exception): pass`, silently downgrading the
+  agent to the permissive `SUPERVISED` constructor default. The handler now
+  narrows to `ValueError`, logs a WARN, and restores the most-restrictive posture
+  (`PSEUDO`) — never a silent autonomy widening (legacy aliases remain handled by
+  `TrustPosture._missing_`).
+- **Proximity scanning fails closed on non-finite usage**
+  (`kailash.trust.enforce.proximity`). A `NaN`/`Inf` usage value bypassed every
+  `>=` threshold comparison (`NaN >= x` is always `False`), so a corrupt budget
+  reading produced NO proximity alert. Non-finite usage now escalates to `HELD`,
+  and a non-finite limit is treated as unmeasurable (skipped, not crashed).
+
+### Fixed
+
+- **`AuditChain.from_dict` now raises on a corrupted chain**
+  (`kailash.trust.pact.audit`). The docstring promised "Raises PactError if the
+  chain is corrupted" (the P-H10 contract), but the code only logged a warning and
+  returned the corrupted chain — silently accepting a tampered audit chain as
+  valid. It now raises `PactError` with the integrity errors in `details`.
+- **Revocation broadcaster routes async-subscriber failures to the dead-letter
+  queue** (`kailash.trust.revocation.broadcaster`). Async subscriber callbacks
+  were scheduled via `ensure_future` with no done-callback, so an exception raised
+  inside the coroutine body surfaced only as an "unretrieved task exception"
+  warning — bypassing the dead-letter accounting that captures delivery failures.
+  A done-callback now records async failures the same as synchronous ones.
+- **`CredentialRotationManager` docstring reconciled to its real best-effort
+  contract** (`kailash.trust.signing.rotation`). The class advertised "atomic
+  updates to prevent partial rotations", but `rotate_key` commits the authority's
+  new key before re-signing chains and does not roll back on a re-sign failure
+  (the registry exposes no transaction primitive). The docstring now documents the
+  non-atomic, partial-rotation-possible behavior surfaced via `RotationError`.
+- **Vault retire/recommit gate labels corrected to match enforcement**
+  (`kailash.trust.vault.errors` + `registry_ops`). The `clearance-tenant-domain`
+  gate labels asserted tenant/domain scoping (CL-02a), cooling-off (CL-04), and a
+  governance-HELD action; the gates enforce capability-presence ONLY (the
+  tenant/domain + cooling-off wiring is deferred). Labels + the retire gate now
+  honestly disclose the capability-only scope and the deferred check.
+- **`GovernanceContext.effective_envelope` None docstring corrected**
+  (`kailash.trust.pact.context`). It read "maximally restrictive interpretation",
+  contradicting `compute_effective_envelope` ("maximally permissive") and the
+  engine's enforced auto-approve-on-None behavior. Corrected to the enforced
+  permissive semantics (the opt-in governance default).
+
 ## [2.41.1] - 2026-06-20
 
 ### Fixed

--- a/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1375_ksp_deny_observability.py
@@ -54,12 +54,16 @@ def _two_dept_org():
 
 def _secret_clearance() -> dict[str, RoleClearance]:
     # SECRET clearance holding both compartments so the requesting role passes
-    # the Step-3 clearance checks and the KSP narrowing (Step-4d) is reached.
+    # the Step-3 clearance checks (NDA + compartments) and the KSP narrowing
+    # (Step-4d) is reached. nda_signed=True is required for SECRET+ items now
+    # that can_access enforces the NDA gate (else a SECRET item short-circuits
+    # at Step 3 before the KSP deny_code is computed).
     return {
         _ROLE: RoleClearance(
             role_address=_ROLE,
             max_clearance=ConfidentialityLevel.SECRET,
             compartments=frozenset({"alpha", "beta"}),
+            nda_signed=True,
         )
     }
 

--- a/packages/kailash-pact/tests/unit/governance/test_access.py
+++ b/packages/kailash-pact/tests/unit/governance/test_access.py
@@ -444,6 +444,7 @@ class TestCanAccessCompartments:
                 role_address="D1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
                 compartments=frozenset({"alpha", "beta"}),
+                nda_signed=True,  # SECRET+ access requires a signed NDA
             ),
         }
         item = KnowledgeItem(
@@ -463,6 +464,39 @@ class TestCanAccessCompartments:
         )
         assert decision.allowed is True
 
+    def test_secret_item_without_nda_denied(self, simple_org: CompiledOrg) -> None:
+        """PGC-01: SECRET/TOP_SECRET access is denied without a signed NDA.
+
+        nda_signed is documented "Required for SECRET and TOP_SECRET clearance";
+        can_access enforces it fail-closed at step 3 (previously parsed/stored
+        everywhere but never consulted on the access path).
+        """
+        clearances = {
+            "D1-R1": RoleClearance(
+                role_address="D1-R1",
+                max_clearance=ConfidentialityLevel.SECRET,
+                compartments=frozenset({"alpha", "beta"}),
+                nda_signed=False,  # the governance-field-drop PGC-01 closes
+            ),
+        }
+        item = KnowledgeItem(
+            item_id="secret-item",
+            classification=ConfidentialityLevel.SECRET,
+            owning_unit_address="D1",
+            compartments=frozenset({"alpha"}),
+        )
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.CONTINUOUS_INSIGHT,
+            compiled_org=simple_org,
+            clearances=clearances,
+            ksps=[],
+            bridges=[],
+        )
+        assert decision.allowed is False
+        assert decision.audit_details.get("detail") == "nda_not_signed"
+
     def test_secret_item_missing_compartment_denies(
         self, simple_org: CompiledOrg
     ) -> None:
@@ -471,6 +505,9 @@ class TestCanAccessCompartments:
                 role_address="D1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
                 compartments=frozenset({"alpha"}),
+                # NDA signed so the test reaches the compartment check (the
+                # path it targets) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(
@@ -664,6 +701,9 @@ class TestCanAccessKSP:
             "D2-R1-T1-R1": RoleClearance(
                 role_address="D2-R1-T1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
+                # NDA signed so the test reaches the KSP classification-limit
+                # check (step 4) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(
@@ -769,6 +809,9 @@ class TestCanAccessBridge:
             "D2-R1": RoleClearance(
                 role_address="D2-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
+                # NDA signed so the test reaches the bridge classification-limit
+                # check (step 4) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(
@@ -1016,7 +1059,15 @@ class TestCanAccessVettingStatus:
 
 
 def _clearance(addr: str, level: ConfidentialityLevel) -> RoleClearance:
-    return RoleClearance(role_address=addr, max_clearance=level)
+    # SECRET+ clearances require a signed NDA (enforced in can_access); the
+    # helper sets it conformantly so KSP/cross-barrier tests exercise the
+    # policy path rather than tripping the NDA gate first.
+    return RoleClearance(
+        role_address=addr,
+        max_clearance=level,
+        nda_signed=level
+        in (ConfidentialityLevel.SECRET, ConfidentialityLevel.TOP_SECRET),
+    )
 
 
 def _cross_barrier_item(

--- a/packages/kailash-pact/tests/unit/governance/test_access_matrix.py
+++ b/packages/kailash-pact/tests/unit/governance/test_access_matrix.py
@@ -369,6 +369,10 @@ def test_clearance_level_matrix(
         role_addr: RoleClearance(
             role_address=role_addr,
             max_clearance=role_clearance,
+            # SECRET+ access requires a signed NDA (enforced in can_access).
+            # This matrix isolates the clearance-LEVEL axis, so every cell
+            # carries a signed NDA to keep level the only varying dimension.
+            nda_signed=True,
         ),
     }
     item = KnowledgeItem(
@@ -429,6 +433,10 @@ def test_posture_capping_matrix(
         role_addr: RoleClearance(
             role_address=role_addr,
             max_clearance=ConfidentialityLevel.TOP_SECRET,
+            # SECRET+ access requires a signed NDA (enforced in can_access).
+            # This matrix isolates the POSTURE-capping axis, so the clearance
+            # carries a signed NDA to keep posture the only varying dimension.
+            nda_signed=True,
         ),
     }
     item = KnowledgeItem(

--- a/packages/kailash-pact/tests/unit/governance/test_adversarial.py
+++ b/packages/kailash-pact/tests/unit/governance/test_adversarial.py
@@ -18,15 +18,6 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from kailash.trust.pact.config import (
-    ConfidentialityLevel,
-    ConstraintEnvelopeConfig,
-    DepartmentConfig,
-    OperationalConstraintConfig,
-    OrgDefinition,
-    TeamConfig,
-    TrustPostureLevel,
-)
 from kailash.trust.pact.access import (
     AccessDecision,
     KnowledgeSharePolicy,
@@ -41,14 +32,21 @@ from kailash.trust.pact.compilation import (
     RoleDefinition,
     compile_org,
 )
+from kailash.trust.pact.config import (
+    ConfidentialityLevel,
+    ConstraintEnvelopeConfig,
+    DepartmentConfig,
+    OperationalConstraintConfig,
+    OrgDefinition,
+    TeamConfig,
+    TrustPostureLevel,
+)
 from kailash.trust.pact.envelopes import (
     MonotonicTighteningError,
     RoleEnvelope,
     TaskEnvelope,
-    intersect_envelopes,
 )
 from kailash.trust.pact.knowledge import KnowledgeItem
-
 
 # ---------------------------------------------------------------------------
 # Shared fixture
@@ -351,6 +349,7 @@ class TestPostureGaming:
             role_addr: RoleClearance(
                 role_address=role_addr,
                 max_clearance=ConfidentialityLevel.SECRET,
+                nda_signed=True,  # SECRET+ access requires a signed NDA
             ),
         }
         item = KnowledgeItem(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.41.1"
+version = "2.42.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.41.1"
+__version__ = "2.42.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/trust/enforce/proximity.py
+++ b/src/kailash/trust/enforce/proximity.py
@@ -23,6 +23,7 @@ Integration:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -52,9 +53,13 @@ class ProximityConfig:
     def __post_init__(self):
         """Validate thresholds and dimension overrides."""
         if not 0.0 < self.flag_threshold < 1.0:
-            raise ValueError(f"flag_threshold must be between 0 and 1, got {self.flag_threshold}")
+            raise ValueError(
+                f"flag_threshold must be between 0 and 1, got {self.flag_threshold}"
+            )
         if not 0.0 < self.hold_threshold <= 1.0:
-            raise ValueError(f"hold_threshold must be between 0 and 1, got {self.hold_threshold}")
+            raise ValueError(
+                f"hold_threshold must be between 0 and 1, got {self.hold_threshold}"
+            )
         if self.flag_threshold >= self.hold_threshold:
             raise ValueError(
                 f"flag_threshold ({self.flag_threshold}) must be less than hold_threshold ({self.hold_threshold})"
@@ -62,14 +67,22 @@ class ProximityConfig:
         # Validate per-dimension overrides
         for dim_name, thresholds in self.dimension_overrides.items():
             if not isinstance(thresholds, tuple) or len(thresholds) != 2:
-                raise ValueError(f"dimension_overrides['{dim_name}'] must be a (flag, hold) tuple")
+                raise ValueError(
+                    f"dimension_overrides['{dim_name}'] must be a (flag, hold) tuple"
+                )
             flag, hold = thresholds
             if not 0.0 < flag < 1.0:
-                raise ValueError(f"dimension_overrides['{dim_name}'] flag must be between 0 and 1, got {flag}")
+                raise ValueError(
+                    f"dimension_overrides['{dim_name}'] flag must be between 0 and 1, got {flag}"
+                )
             if not 0.0 < hold <= 1.0:
-                raise ValueError(f"dimension_overrides['{dim_name}'] hold must be between 0 and 1, got {hold}")
+                raise ValueError(
+                    f"dimension_overrides['{dim_name}'] hold must be between 0 and 1, got {hold}"
+                )
             if flag >= hold:
-                raise ValueError(f"dimension_overrides['{dim_name}'] flag ({flag}) must be less than hold ({hold})")
+                raise ValueError(
+                    f"dimension_overrides['{dim_name}'] flag ({flag}) must be less than hold ({hold})"
+                )
 
 
 CONSERVATIVE_PROXIMITY = ProximityConfig(flag_threshold=0.70, hold_threshold=0.90)
@@ -169,15 +182,44 @@ class ProximityScanner:
         alerts: List[ProximityAlert] = []
 
         for result in results:
-            if result.limit is None or result.limit <= 0:
-                # Cannot compute usage ratio without a valid limit
+            if (
+                result.limit is None
+                or not math.isfinite(result.limit)
+                or result.limit <= 0
+            ):
+                # Cannot compute a usage ratio without a finite, positive limit.
                 continue
 
             if result.used is None:
                 continue
 
-            usage_ratio = result.used / result.limit
             dim_name = dimension_name or "unknown"
+
+            if not math.isfinite(result.used):
+                # Fail-closed: a non-finite usage value (NaN/Inf) against a
+                # valid limit is an unmeasurable/corrupt reading. NaN bypasses
+                # every ``>=`` comparison (``NaN >= x`` is always False), so
+                # without this guard the budget-proximity check would silently
+                # emit NO alert (trust-plane-security Rule 3 / MUST-NOT-5).
+                # Escalate to HELD — an unmeasurable budget is treated as
+                # breached, never silently waved through.
+                alerts.append(
+                    ProximityAlert(
+                        dimension=dim_name,
+                        usage_ratio=float("inf"),
+                        used=result.used,
+                        limit=result.limit,
+                        escalated_verdict=Verdict.HELD,
+                        original_verdict=Verdict.AUTO_APPROVED,
+                    )
+                )
+                logger.warning(
+                    f"[PROXIMITY] HOLD alert: {dim_name} usage is non-finite "
+                    f"({result.used}) — unmeasurable budget, failing closed"
+                )
+                continue
+
+            usage_ratio = result.used / result.limit
 
             # Get thresholds (per-dimension override or global)
             flag_thresh, hold_thresh = self._get_thresholds(dim_name)
@@ -207,7 +249,9 @@ class ProximityScanner:
                         original_verdict=Verdict.AUTO_APPROVED,
                     )
                 )
-                logger.info(f"[PROXIMITY] FLAG alert: {dim_name} at {usage_ratio:.1%} (threshold: {flag_thresh:.0%})")
+                logger.info(
+                    f"[PROXIMITY] FLAG alert: {dim_name} at {usage_ratio:.1%} (threshold: {flag_thresh:.0%})"
+                )
 
         return alerts
 
@@ -253,12 +297,16 @@ class ProximityScanner:
             return base_verdict
 
         # Find the highest escalation level from alerts
-        max_alert_level = max(_VERDICT_ORDER.get(a.escalated_verdict, 0) for a in alerts)
+        max_alert_level = max(
+            _VERDICT_ORDER.get(a.escalated_verdict, 0) for a in alerts
+        )
         base_level = _VERDICT_ORDER.get(base_verdict, 0)
 
         # Monotonic: only escalate, never downgrade
         if max_alert_level > base_level:
-            escalated = [v for v, level in _VERDICT_ORDER.items() if level == max_alert_level][0]
+            escalated = [
+                v for v, level in _VERDICT_ORDER.items() if level == max_alert_level
+            ][0]
             logger.info(
                 f"[PROXIMITY] Escalating verdict from {base_verdict.value} "
                 f"to {escalated.value} based on {len(alerts)} alert(s)"

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -43,13 +43,8 @@ from kailash.trust.chain import (
     VerificationLevel,
     VerificationResult,
 )
+from kailash.trust.chain_store import TrustStore
 from kailash.trust.constraint_validator import ConstraintValidator
-from kailash.trust.signing.crypto import (
-    hash_chain,
-    serialize_for_signing,
-    sign,
-    verify_signature,
-)
 from kailash.trust.exceptions import (
     AgentAlreadyEstablishedError,
     AuthorityInactiveError,
@@ -68,7 +63,12 @@ from kailash.trust.execution_context import (
     HumanOrigin,
     get_current_context,
 )
-from kailash.trust.chain_store import TrustStore
+from kailash.trust.signing.crypto import (
+    hash_chain,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
 
 # Logger for trust operations
 logger = logging.getLogger(__name__)
@@ -138,6 +138,28 @@ class TrustKeyManager:
             The private key or None if not found
         """
         return self._keys.get(key_id)
+
+    def remove_key(self, key_id: str) -> bool:
+        """
+        Invalidate a key by clearing its private material (tombstone).
+
+        Per trust-plane-security MUST-NOT-3, revocation clears the key
+        material while keeping a tombstone entry, so a subsequent ``sign()``
+        with the revoked ``key_id`` fails (the key is no longer usable)
+        instead of silently succeeding. ``get_key`` returns an empty string
+        (falsy) for a tombstoned key, distinguishable from ``None`` (never
+        registered).
+
+        Args:
+            key_id: Identifier for the key to invalidate.
+
+        Returns:
+            True if the key existed and was invalidated, False if not present.
+        """
+        if key_id in self._keys:
+            self._keys[key_id] = ""  # Clear material, keep tombstone
+            return True
+        return False
 
     async def sign(self, payload: str, key_id: str) -> str:
         """

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -661,6 +661,34 @@ def can_access(
 
     # --- Step 3: Compartment check (SECRET and TOP_SECRET only) ---
     if item_level >= _CLEARANCE_ORDER[ConfidentialityLevel.SECRET]:
+        # NDA gate: SECRET and TOP_SECRET access requires a signed NDA.
+        # RoleClearance documents nda_signed as "Required for SECRET and
+        # TOP_SECRET clearance"; enforce it fail-closed here (a documented
+        # governance control that is parsed/stored/serialized everywhere MUST
+        # be consulted on the access path, not silently dropped).
+        if not role_clearance.nda_signed:
+            logger.info(
+                "Access denied (step 3): NDA not signed for SECRET+ item — "
+                "role_address=%s, item_id=%s, item_classification=%s",
+                role_address,
+                item.item_id,
+                item.classification.value,
+            )
+            return AccessDecision(
+                allowed=False,
+                reason=(
+                    f"NDA not signed: a signed NDA is required for "
+                    f"'{item.classification.value}' classified items"
+                ),
+                step_failed=3,
+                audit_details={
+                    "role_address": role_address,
+                    "item_id": item.item_id,
+                    "step": 3,
+                    "detail": "nda_not_signed",
+                    "item_classification": item.classification.value,
+                },
+            )
         if item.compartments:
             missing = item.compartments - role_clearance.compartments
             if missing:

--- a/src/kailash/trust/pact/audit.py
+++ b/src/kailash/trust/pact/audit.py
@@ -27,6 +27,7 @@ from typing import Any
 from uuid import uuid4
 
 from kailash.trust.pact.config import VerificationLevel
+from kailash.trust.pact.exceptions import PactError
 
 logger = logging.getLogger(__name__)
 
@@ -459,6 +460,16 @@ class AuditChain:
                     "AuditChain '%s' integrity check failed after from_dict: %s",
                     chain.chain_id,
                     errors,
+                )
+                # Honor the documented contract: a corrupted audit chain MUST
+                # raise, never silently return as valid. Fail-closed — accepting
+                # a tampered/corrupted chain at the deserialization boundary
+                # defeats the tamper-evidence guarantee the audit chain exists
+                # to provide.
+                raise PactError(
+                    f"AuditChain '{chain.chain_id}' failed integrity "
+                    f"verification after deserialization",
+                    details={"chain_id": chain.chain_id, "errors": errors},
                 )
 
         return chain

--- a/src/kailash/trust/pact/context.py
+++ b/src/kailash/trust/pact/context.py
@@ -17,12 +17,12 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from kailash.trust.pact.clearance import RoleClearance
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
     TrustPostureLevel,
 )
-from kailash.trust.pact.clearance import RoleClearance
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,13 @@ class GovernanceContext:
         role_address: The D/T/R positional address of the role this context is for.
         posture: The current trust posture level.
         effective_envelope: Snapshot of the effective constraint envelope at creation time.
-            None means no envelope is assigned (maximally restrictive interpretation).
+            None means no envelope is assigned (maximally PERMISSIVE — no
+            constraints apply). This matches the enforced behavior:
+            envelopes.py::compute_effective_envelope documents a None result as
+            "maximally permissive" and the engine auto-approves actions when no
+            envelope resolves (the unconfigured-role = unconstrained model,
+            consistent with EATP "None role = all-access"). NOTE: this is the
+            opt-in governance default; configure a RoleEnvelope to constrain.
         clearance: The role's clearance assignment, or None if no clearance on record.
         effective_clearance_level: Posture-capped clearance level, computed as
             min(role.max_clearance, POSTURE_CEILING[posture]). None if no clearance.

--- a/src/kailash/trust/pact/explain.py
+++ b/src/kailash/trust/pact/explain.py
@@ -327,8 +327,20 @@ def explain_access(
         f"item classification={item.classification.value})"
     )
 
-    # --- Step 3: Compartment check ---
+    # --- Step 3: NDA + compartment check (SECRET and TOP_SECRET only) ---
     if item_level >= _CLEARANCE_ORDER[ConfidentialityLevel.SECRET]:
+        if not role_clearance.nda_signed:
+            lines.append(
+                "Step 3: NDA check -- FAIL "
+                "(SECRET+ access requires a signed NDA; nda_signed=False)"
+            )
+            lines.append("")
+            lines.append(
+                f"Result: DENIED at Step 3 -- NDA not signed for "
+                f"{item.classification.value} item"
+            )
+            return "\n".join(lines)
+        lines.append("Step 3: NDA check -- PASS (NDA signed)")
         if item.compartments:
             missing = item.compartments - role_clearance.compartments
             if missing:

--- a/src/kailash/trust/plane/project.py
+++ b/src/kailash/trust/plane/project.py
@@ -331,8 +331,26 @@ class TrustProject:
                 self._posture_machine.set_posture(
                     self._agent_id, TrustPosture(posture_name)
                 )
-            except (ValueError, Exception):
-                pass  # Invalid posture name — use default
+            except ValueError:
+                # Corrupted/unknown persisted posture name (legacy aliases are
+                # already handled by TrustPosture._missing_, so this is a truly
+                # unrecognized value). Fail-closed to the MOST-restrictive
+                # posture (PSEUDO) rather than silently keeping the permissive
+                # SUPERVISED default — a corrupted posture MUST NOT widen
+                # autonomy (trust-plane-security MUST-NOT-2 "no trust
+                # downgrade"; eatp.md "unknown/error states -> deny"). Surfaced
+                # LOUD, never swallowed (zero-tolerance Rule 3 / observability
+                # Rule 5). A non-ValueError (e.g. a real store error) is NOT
+                # caught here — it propagates as a genuine construction failure.
+                logger.warning(
+                    "trust_posture.invalid_persisted_posture",
+                    extra={
+                        "agent_id": self._agent_id,
+                        "posture_name": posture_name,
+                        "fallback": TrustPosture.PSEUDO.value,
+                    },
+                )
+                self._posture_machine.set_posture(self._agent_id, TrustPosture.PSEUDO)
 
     @classmethod
     async def create(
@@ -1095,7 +1113,36 @@ class TrustProject:
             stored_hash = data.get("content_hash", "")
             record = DecisionRecord.from_dict(data)
             computed_hash = record.content_hash()
-            if stored_hash and not hmac_mod.compare_digest(stored_hash, computed_hash):
+            # A decision record with NO stored content_hash is unverifiable.
+            # Treat its absence as a verification failure (fail-closed): an
+            # attacker who tampers a record AND strips its content_hash field
+            # would otherwise slip past the tamper check via the truthiness
+            # short-circuit, passing even strict verification. content_hash is a
+            # computed property (not a required from_dict field), so a record
+            # JSON with the key removed loads cleanly — the guard MUST live here.
+            if not stored_hash:
+                logger.warning(
+                    "trust_chain.hash_missing",
+                    extra={
+                        "record_id": record.decision_id,
+                        "record_type": "decision",
+                        "file": df.name,
+                    },
+                )
+                if strict:
+                    raise ChainHashMismatchError(
+                        f"decision record {record.decision_id} is missing its "
+                        f"content_hash (unverifiable)",
+                        record_id=record.decision_id,
+                        stored_hash="",
+                        computed_hash=computed_hash,
+                        record_type="decision",
+                    )
+                integrity_issues.append(
+                    f"{df.name}: missing content_hash (unverifiable)"
+                )
+                chain_valid = False
+            elif not hmac_mod.compare_digest(stored_hash, computed_hash):
                 # WARN log per observability.md Rule 5 (log triage gate) +
                 # Rule 8 (no schema-revealing field values at WARN — record_id
                 # is the identifier, not classified content).

--- a/src/kailash/trust/revocation/broadcaster.py
+++ b/src/kailash/trust/revocation/broadcaster.py
@@ -242,7 +242,9 @@ class InMemoryRevocationBroadcaster(RevocationBroadcaster):
             if len(self._history) >= _MAX_HISTORY:
                 trim_count = _MAX_HISTORY // 10  # Remove oldest 10%
                 self._history = self._history[trim_count:]
-                logger.debug(f"[BROADCASTER] Trimmed {trim_count} oldest events from history")
+                logger.debug(
+                    f"[BROADCASTER] Trimmed {trim_count} oldest events from history"
+                )
 
             # Store in history
             self._history.append(event)
@@ -261,38 +263,77 @@ class InMemoryRevocationBroadcaster(RevocationBroadcaster):
             # Call the callback
             try:
                 result = callback(event)
-                # If the callback is async, we need to run it
+                # If the callback is async, schedule it and route any later
+                # exception in the coroutine body to the dead-letter queue.
                 if asyncio.iscoroutine(result):
-                    # Run async callback in event loop if available
                     try:
-                        loop = asyncio.get_running_loop()
-                        # Schedule the coroutine to run
-                        asyncio.ensure_future(result)
+                        asyncio.get_running_loop()
+                        task = asyncio.ensure_future(result)
+                        # ensure_future schedules the coroutine DETACHED: an
+                        # exception raised inside its body after this frame exits
+                        # would otherwise surface only as an "unretrieved task
+                        # exception" warning, bypassing the dead-letter
+                        # accounting that exists to capture delivery failures
+                        # (zero-tolerance Rule 3 — no silent error hiding). The
+                        # done-callback closes that gap.
+                        task.add_done_callback(
+                            lambda t, sid=sub_id, ev=event: (
+                                self._record_async_delivery_failure(t, ev, sid)
+                            )
+                        )
                     except RuntimeError:
                         # No running event loop, run synchronously
                         asyncio.run(result)
             except Exception as e:
                 # Log error but continue with other subscribers
-                logger.error(f"Error broadcasting revocation event {event.event_id} to subscriber {sub_id}: {e}")
-                with self._lock:
-                    # Trim dead letters if at capacity (bounded collection)
-                    if len(self._dead_letters) >= _MAX_DEAD_LETTERS:
-                        trim_count = _MAX_DEAD_LETTERS // 10
-                        self._dead_letters = self._dead_letters[trim_count:]
-                        logger.debug(f"[BROADCASTER] Trimmed {trim_count} oldest dead letter entries")
-
-                    # Track in dead letter queue
-                    self._dead_letters.append(
-                        DeadLetterEntry(
-                            event=event,
-                            subscription_id=sub_id,
-                            error=str(e),
-                        )
-                    )
+                logger.error(
+                    f"Error broadcasting revocation event {event.event_id} "
+                    f"to subscriber {sub_id}: {e}"
+                )
+                self._record_dead_letter(event, sub_id, str(e))
 
         logger.debug(
             f"Broadcast revocation event {event.event_id} ({event.revocation_type.value}) for {event.target_id}"
         )
+
+    def _record_async_delivery_failure(
+        self, task: "asyncio.Future", event: RevocationEvent, sub_id: str
+    ) -> None:
+        """Route an async subscriber callback's exception to the dead-letter queue.
+
+        Invoked as a done-callback on the scheduled coroutine. A coroutine that
+        completed cleanly (or was cancelled) records nothing; one that raised is
+        logged and dead-lettered exactly like a synchronous delivery failure.
+        """
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            logger.error(
+                f"Error broadcasting revocation event {event.event_id} "
+                f"to async subscriber {sub_id}: {exc}"
+            )
+            self._record_dead_letter(event, sub_id, str(exc))
+
+    def _record_dead_letter(
+        self, event: RevocationEvent, sub_id: str, error: str
+    ) -> None:
+        """Append a dead-letter entry, trimming the bounded collection at capacity."""
+        with self._lock:
+            if len(self._dead_letters) >= _MAX_DEAD_LETTERS:
+                trim_count = _MAX_DEAD_LETTERS // 10
+                self._dead_letters = self._dead_letters[trim_count:]
+                logger.debug(
+                    f"[BROADCASTER] Trimmed {trim_count} oldest dead letter entries"
+                )
+            self._dead_letters.append(
+                DeadLetterEntry(
+                    event=event,
+                    subscription_id=sub_id,
+                    error=error,
+                )
+            )
 
     def subscribe(
         self,
@@ -530,7 +571,9 @@ class CascadeRevocationManager:
             parent_id, parent_event_id, depth = queue.pop(0)
 
             if depth >= max_depth:
-                logger.warning(f"Cascade depth limit ({max_depth}) reached for '{parent_id}' at depth {depth}")
+                logger.warning(
+                    f"Cascade depth limit ({max_depth}) reached for '{parent_id}' at depth {depth}"
+                )
                 continue
 
             delegates = self._delegation_registry.get_delegates(parent_id)
@@ -567,7 +610,9 @@ class CascadeRevocationManager:
                 # Add to queue for further processing
                 queue.append((delegate_id, cascade_event.event_id, depth + 1))
 
-        logger.info(f"Cascade revocation complete for {target_id}. Total events: {len(all_events)}")
+        logger.info(
+            f"Cascade revocation complete for {target_id}. Total events: {len(all_events)}"
+        )
 
         return all_events
 

--- a/src/kailash/trust/signing/rotation.py
+++ b/src/kailash/trust/signing/rotation.py
@@ -7,9 +7,14 @@ EATP Credential Rotation Management.
 Provides automated credential rotation for organizational authorities with:
 - Keypair rotation with grace period support
 - Audit logging for all rotation events
-- Atomic updates to prevent partial rotations (CARE-008)
+- Best-effort (non-atomic) sequential updates: the authority record is committed
+  with the new key BEFORE the trust chains are re-signed; a re-sign failure
+  raises RotationError (and emits a rotation_failed audit event) but does NOT
+  roll the authority record back (the registry exposes no transaction
+  primitive), so a partial rotation is possible and is surfaced via the raised
+  error, never silently swallowed.
 - Concurrent rotation prevention (only one rotation per authority at a time)
-- Transactional re-signing of trust chains after key rotation
+- Re-signing of trust chains after key rotation
 """
 
 import asyncio
@@ -20,19 +25,16 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from uuid import uuid4
 
-from kailash.trust.authority import (
-    AuthorityRegistryProtocol,
-    OrganizationalAuthority,
-)
+from kailash.trust.authority import AuthorityRegistryProtocol, OrganizationalAuthority
 from kailash.trust.chain import TrustLineageChain
-from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign
+from kailash.trust.chain_store import TrustStore
 from kailash.trust.exceptions import (
     AuthorityInactiveError,
     AuthorityNotFoundError,
     TrustError,
 )
 from kailash.trust.operations import TrustKeyManager
-from kailash.trust.chain_store import TrustStore
+from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign
 
 
 class RotationStatus(str, Enum):
@@ -166,12 +168,21 @@ class CredentialRotationManager:
     Manages credential rotation for organizational authorities.
 
     Provides automated key rotation with grace periods, audit logging,
-    and atomic updates to prevent partial rotations.
+    and best-effort (non-atomic) sequential updates across the authority
+    record and the re-signed trust chains.
 
     Features:
     - Grace period support (default 24 hours)
     - Audit logging for all rotation events
-    - Atomic updates to prevent partial rotations
+    - Best-effort sequential updates (NOT atomic): the authority record is
+      committed with the new key BEFORE the trust chains are re-signed. If
+      re-signing fails, ``rotate_key`` raises ``RotationError`` (and emits a
+      ``rotation_failed`` audit event), but the already-committed authority
+      record is NOT rolled back — the underlying registry exposes no
+      transaction primitive, so true atomicity is infeasible. A partial
+      rotation (the authority advertises the new key while some chains still
+      carry old-key signatures) is therefore possible and is surfaced via the
+      raised ``RotationError``, never silently swallowed.
     - Concurrent rotation prevention (only one rotation per authority at a time)
     - Automatic re-signing of trust chains after rotation
     - Scheduled rotation support
@@ -866,9 +877,13 @@ class CredentialRotationManager:
         # Remove from grace period tracking
         del self._grace_period_keys[authority_id][key_id]
 
-        # Remove from key manager (if it exists)
-        # Note: TrustKeyManager doesn't have a remove method in the current implementation,
-        # but in production this would remove the key from the HSM/KMS
+        # Invalidate the key in the key manager so it can no longer sign.
+        # Without this, revoke_old_key emitted a rotation_key_revoked audit
+        # event while the key stayed live in the manager — the audit trail
+        # asserted revocation while the "revoked" key kept signing and
+        # verifying (audit-store divergence). remove_key tombstones the
+        # private material per trust-plane-security MUST-NOT-3.
+        self.key_manager.remove_key(key_id)
 
         # Log audit event
         await self._log_rotation_event(

--- a/src/kailash/trust/vault/errors.py
+++ b/src/kailash/trust/vault/errors.py
@@ -170,7 +170,7 @@ RESTORE_GATE_ORDER: tuple[str, ...] = (
 
 # N12-FT-03 — vault_kek_recommit, 4 steps (§4.6).
 RECOMMIT_GATE_ORDER: tuple[str, ...] = (
-    "clearance-tenant-domain",  # (1) N12-CL-01/02a + cooling-off N12-CL-04
+    "clearance-tenant-domain",  # (1) vault:backup capability presence ONLY (CL-02a tenant/domain + CL-04 cooling-off NOT wired here — deferred, C3 #630)
     "generation-vault-unchanged",  # (2) → recommit-generation-altered
     "prior-commitment-exists",  # (3) → unknown-prior-commitment
     "new-commitment-binds-secret",  # (4) → recommit-binding-mismatch
@@ -178,7 +178,7 @@ RECOMMIT_GATE_ORDER: tuple[str, ...] = (
 
 # N12-FT-03 — vault_kek_retire, 4 steps (§4.6).
 RETIRE_GATE_ORDER: tuple[str, ...] = (
-    "clearance-tenant-domain",  # (1) vault:retire-alg / governance HELD
+    "clearance-tenant-domain",  # (1) vault:retire-alg capability presence ONLY (CL-02a tenant/domain NOT wired here — deferred, C3 #630; no governance-HELD action)
     "generation-vault-unchanged",  # (2) → recommit-generation-altered
     "retired-entry-exists",  # (3) → unknown-prior-commitment
     "recoverability-preserved",  # (4) live non-retired strong alg MUST remain

--- a/src/kailash/trust/vault/registry_ops.py
+++ b/src/kailash/trust/vault/registry_ops.py
@@ -433,6 +433,16 @@ def retire_vault_kek_alg(
         if gate == "clearance-tenant-domain":
             # (1) The DISTINCT vault:retire-alg capability (N12-CB-04(e)(2)) —
             # NOT the ordinary vault:restore / vault:backup capability.
+            #
+            # SCOPE (honest disclosure — matches the recommit gate's #630
+            # note): this gate enforces capability PRESENCE only. The CL-02a
+            # tenant/domain scoping + CL-04 cooling-off that the gate NAME and
+            # the spec (N12-FT-03 §4.6) imply are NOT yet wired at this surface
+            # (deferred — C3 #630; the tenant/domain + cooling-off logic exists
+            # in clearance.py but is currently invoked only on the restore
+            # path). Until #630 lands, a vault:retire-alg holder is not
+            # tenant/domain-scoped here; the recoverability-preserved gate
+            # (step 4) bounds the blast radius (the corpus cannot be stranded).
             if not clearance.has_capability(RETIRE_ALG_CAPABILITY):
                 return N12FT01Code.MISSING_CLEARANCE
             return None

--- a/tests/regression/test_redteam_trustplane_round2.py
+++ b/tests/regression/test_redteam_trustplane_round2.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests — holistic trust-plane redteam (round 2).
+
+A holistic post-multi-wave redteam of the trust-plane surface (beyond the
+2.41.1 PACT KSP/Bridge + cascade scope) surfaced ten confirmed defects.
+This file pins the SIX that changed behavior; each test fails against the
+pre-fix code and passes against the fix.
+
+| ID         | Module                              | Defect (fixed)                                          |
+| ---------- | ----------------------------------- | ------------------------------------------------------- |
+| RS-01      | trust.operations.TrustKeyManager    | revoke_old_key emitted "revoked" audit but never        |
+|            | + trust.signing.rotation            | invalidated the key (audit/store divergence)            |
+| PR-2       | trust.plane.project.verify          | tamper check skipped when content_hash stripped         |
+| PR-3       | trust.plane.project (posture load)  | corrupted posture silently downgraded to SUPERVISED     |
+| PCI-R1-01  | trust.pact.audit.AuditChain         | from_dict docstring "Raises PactError" never raised     |
+| EA-01      | trust.enforce.proximity             | NaN/Inf usage bypassed proximity escalation             |
+| RS-03      | trust.revocation.broadcaster        | async-subscriber exceptions bypassed dead-letter queue  |
+
+The remaining three findings (RS-02 rotation "atomic" over-claim, vault retire/
+recommit gate-label over-claim, PGC-03 context.py None-envelope doc
+contradiction) are documentation-accuracy corrections with NO behavioral
+delta — they are covered by the unchanged-behavior existing suites plus the
+corrected docstrings, so they carry no behavioral regression test here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# RS-01 — revoke_old_key MUST invalidate the key (audit/store divergence)
+# ---------------------------------------------------------------------------
+
+
+def test_rs01_remove_key_tombstones_material() -> None:
+    """TrustKeyManager.remove_key clears material (tombstone) and reports hit."""
+    from kailash.trust.operations import TrustKeyManager
+
+    km = TrustKeyManager()
+    km.register_key("k1", "private-material")
+    assert km.get_key("k1") == "private-material"
+
+    assert km.remove_key("k1") is True
+    # Tombstone: material cleared (falsy), distinct from None (never registered).
+    assert km.get_key("k1") == ""
+    # A second remove of an absent/already-removed key reports miss.
+    assert km.remove_key("absent") is False
+
+
+async def test_rs01_removed_key_cannot_sign() -> None:
+    """After remove_key, the key is no longer usable for signing."""
+    from kailash.trust.operations import TrustKeyManager
+
+    km = TrustKeyManager()
+    km.register_key("k1", "private-material")
+    km.remove_key("k1")
+    # sign() raises because the tombstoned material is falsy ("key not found").
+    with pytest.raises(ValueError):
+        await km.sign("payload", "k1")
+
+
+# ---------------------------------------------------------------------------
+# PR-2 — verify() MUST treat a missing content_hash as a verification failure
+# ---------------------------------------------------------------------------
+
+
+async def _project_with_one_decision(trust_dir):
+    from kailash.trust.plane.models import DecisionRecord, DecisionType
+    from kailash.trust.plane.project import TrustProject
+
+    project = await TrustProject.create(
+        trust_dir=trust_dir, project_name="RedteamR2", author="tester"
+    )
+    await project.record_decision(
+        DecisionRecord(
+            decision_type=DecisionType.SCOPE,
+            decision="d",
+            rationale="r",
+        )
+    )
+    return project
+
+
+async def test_pr2_verify_nonstrict_flags_missing_content_hash(tmp_path) -> None:
+    """A decision record stripped of content_hash fails non-strict verification."""
+    trust_dir = tmp_path / "tp"
+    project = await _project_with_one_decision(trust_dir)
+
+    dfile = next((trust_dir / "decisions").glob("*.json"))
+    data = json.loads(dfile.read_text())
+    # Tamper the decision content AND strip its content_hash — the pre-fix
+    # truthiness short-circuit (`if stored_hash and ...`) skipped the check.
+    data["decision"] = "TAMPERED"
+    del data["content_hash"]
+    dfile.write_text(json.dumps(data))
+
+    report = await project.verify(strict=False)
+    assert report["chain_valid"] is False
+    assert any("content_hash" in issue for issue in report["integrity_issues"])
+
+
+async def test_pr2_verify_strict_raises_on_missing_content_hash(tmp_path) -> None:
+    """Strict verification raises on a record missing its content_hash."""
+    from kailash.trust.plane.exceptions import ChainHashMismatchError
+
+    trust_dir = tmp_path / "tp"
+    project = await _project_with_one_decision(trust_dir)
+
+    dfile = next((trust_dir / "decisions").glob("*.json"))
+    data = json.loads(dfile.read_text())
+    data["decision"] = "TAMPERED"
+    del data["content_hash"]
+    dfile.write_text(json.dumps(data))
+
+    with pytest.raises(ChainHashMismatchError):
+        await project.verify(strict=True)
+
+
+# ---------------------------------------------------------------------------
+# PR-3 — corrupted persisted posture MUST fail-closed to PSEUDO, not downgrade
+# ---------------------------------------------------------------------------
+
+
+async def _create_then_reload_with_posture(trust_dir, posture_value):
+    from kailash.trust.plane.project import TrustProject
+
+    await TrustProject.create(
+        trust_dir=trust_dir, project_name="PostureR2", author="tester"
+    )
+    manifest_path = trust_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest.setdefault("metadata", {})["trust_posture"] = posture_value
+    manifest_path.write_text(json.dumps(manifest))
+    return await TrustProject.load(trust_dir)
+
+
+async def test_pr3_corrupt_posture_fails_closed_to_pseudo(tmp_path) -> None:
+    """An unrecognized persisted posture restores to PSEUDO (most restrictive)."""
+    from kailash.trust.posture.postures import TrustPosture
+
+    loaded = await _create_then_reload_with_posture(
+        tmp_path / "tp", "not-a-real-posture-xyz"
+    )
+    restored = loaded._posture_machine.get_posture(loaded._agent_id)
+    # Fail-closed: NOT the permissive SUPERVISED constructor default.
+    assert restored == TrustPosture.PSEUDO
+
+
+async def test_pr3_valid_posture_still_restores(tmp_path) -> None:
+    """Regression guard: a valid persisted posture still restores correctly."""
+    from kailash.trust.posture.postures import TrustPosture
+
+    loaded = await _create_then_reload_with_posture(tmp_path / "tp", "tool")
+    assert loaded._posture_machine.get_posture(loaded._agent_id) == TrustPosture.TOOL
+
+
+async def test_pr3_legacy_posture_alias_still_restores(tmp_path) -> None:
+    """A legacy posture alias (handled by _missing_) restores, not fail-closed."""
+    from kailash.trust.posture.postures import TrustPosture
+
+    loaded = await _create_then_reload_with_posture(tmp_path / "tp", "pseudo_agent")
+    assert loaded._posture_machine.get_posture(loaded._agent_id) == TrustPosture.PSEUDO
+
+
+# ---------------------------------------------------------------------------
+# PCI-R1-01 — AuditChain.from_dict MUST raise on a corrupted chain
+# ---------------------------------------------------------------------------
+
+
+def _build_chain():
+    from kailash.trust.pact.audit import AuditChain
+    from kailash.trust.pact.config import VerificationLevel
+
+    chain = AuditChain(chain_id="redteam-r2")
+    chain.append("agent-1", "act-1", VerificationLevel.AUTO_APPROVED, result="ok")
+    chain.append("agent-1", "act-2", VerificationLevel.FLAGGED, result="ok")
+    return chain
+
+
+def test_pci_r1_01_valid_chain_round_trips() -> None:
+    """A pristine chain deserializes without raising."""
+    from kailash.trust.pact.audit import AuditChain
+
+    data = _build_chain().to_dict()
+    restored = AuditChain.from_dict(data)
+    assert len(restored.anchors) == 2
+
+
+def test_pci_r1_01_corrupted_chain_raises_pacterror() -> None:
+    """A tampered anchor hash raises PactError (honors the documented contract)."""
+    from kailash.trust.pact.audit import AuditChain
+    from kailash.trust.pact.exceptions import PactError
+
+    data = _build_chain().to_dict()
+    # Tamper the genesis anchor's content_hash — breaks both its own seal
+    # verification AND the next anchor's previous_hash linkage.
+    data["anchors"][0]["content_hash"] = "0" * 64
+
+    with pytest.raises(PactError):
+        AuditChain.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# EA-01 — proximity scan MUST fail-closed on non-finite usage (NaN/Inf)
+# ---------------------------------------------------------------------------
+
+
+def _scan(used, limit):
+    from kailash.trust.constraints.dimension import ConstraintCheckResult
+    from kailash.trust.enforce.proximity import ProximityScanner
+
+    scanner = ProximityScanner()
+    return scanner.scan(
+        [ConstraintCheckResult(satisfied=True, reason="", used=used, limit=limit)],
+        "cost_limit",
+    )
+
+
+def test_ea01_nan_usage_escalates_to_held() -> None:
+    """A NaN usage value escalates to HELD instead of silently emitting no alert."""
+    from kailash.trust.enforce.strict import Verdict
+
+    alerts = _scan(float("nan"), 100.0)
+    assert len(alerts) == 1
+    assert alerts[0].escalated_verdict == Verdict.HELD
+
+
+def test_ea01_inf_usage_escalates_to_held() -> None:
+    from kailash.trust.enforce.strict import Verdict
+
+    alerts = _scan(float("inf"), 100.0)
+    assert len(alerts) == 1
+    assert alerts[0].escalated_verdict == Verdict.HELD
+
+
+def test_ea01_nonfinite_limit_is_skipped_not_crash() -> None:
+    """A non-finite limit is unmeasurable → skipped (no crash, no false alert)."""
+    assert _scan(50.0, float("nan")) == []
+
+
+def test_ea01_finite_usage_unaffected() -> None:
+    """Regression guard: finite usage behaves exactly as before the fix."""
+    from kailash.trust.enforce.strict import Verdict
+
+    assert _scan(50.0, 100.0) == []  # 0.50 < flag 0.80
+    high = _scan(99.0, 100.0)  # 0.99 >= hold 0.95
+    assert len(high) == 1 and high[0].escalated_verdict == Verdict.HELD
+
+
+# ---------------------------------------------------------------------------
+# RS-03 — async revocation-subscriber failures MUST reach the dead-letter queue
+# ---------------------------------------------------------------------------
+
+
+async def test_rs03_async_subscriber_failure_is_dead_lettered() -> None:
+    """An async subscriber that raises is recorded as a dead letter."""
+    import asyncio
+
+    from kailash.trust.revocation.broadcaster import (
+        InMemoryRevocationBroadcaster,
+        RevocationEvent,
+        RevocationType,
+    )
+
+    broadcaster = InMemoryRevocationBroadcaster()
+
+    async def failing_subscriber(event):
+        raise RuntimeError("subscriber boom")
+
+    broadcaster.subscribe(failing_subscriber)
+    broadcaster.broadcast(
+        RevocationEvent(
+            event_id="rev-r2-1",
+            revocation_type=RevocationType.AGENT_REVOKED,
+            target_id="agent-x",
+            revoked_by="admin",
+            reason="redteam r2",
+        )
+    )
+    # Let the detached coroutine run and its done-callback fire.
+    await asyncio.sleep(0.05)
+
+    dead_letters = broadcaster.get_dead_letters()
+    assert len(dead_letters) == 1
+    assert "boom" in dead_letters[0].error
+
+
+async def test_rs03_clean_async_subscriber_records_nothing() -> None:
+    """Regression guard: a clean async subscriber leaves the dead-letter queue empty."""
+    import asyncio
+
+    from kailash.trust.revocation.broadcaster import (
+        InMemoryRevocationBroadcaster,
+        RevocationEvent,
+        RevocationType,
+    )
+
+    broadcaster = InMemoryRevocationBroadcaster()
+    seen = []
+
+    async def ok_subscriber(event):
+        seen.append(event.event_id)
+
+    broadcaster.subscribe(ok_subscriber)
+    broadcaster.broadcast(
+        RevocationEvent(
+            event_id="rev-r2-2",
+            revocation_type=RevocationType.AGENT_REVOKED,
+            target_id="agent-y",
+            revoked_by="admin",
+            reason="redteam r2",
+        )
+    )
+    await asyncio.sleep(0.05)
+
+    assert seen == ["rev-r2-2"]
+    assert broadcaster.get_dead_letters() == []

--- a/tests/trust/pact/unit/test_access.py
+++ b/tests/trust/pact/unit/test_access.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+
 from kailash.trust.pact.access import (
     AccessDecision,
     KnowledgeSharePolicy,
@@ -443,6 +444,7 @@ class TestCanAccessCompartments:
                 role_address="D1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
                 compartments=frozenset({"alpha", "beta"}),
+                nda_signed=True,  # SECRET+ access requires a signed NDA
             ),
         }
         item = KnowledgeItem(
@@ -462,6 +464,39 @@ class TestCanAccessCompartments:
         )
         assert decision.allowed is True
 
+    def test_secret_item_without_nda_denied(self, simple_org: CompiledOrg) -> None:
+        """PGC-01: SECRET/TOP_SECRET access is denied without a signed NDA.
+
+        nda_signed is documented "Required for SECRET and TOP_SECRET clearance";
+        can_access enforces it fail-closed at step 3 (previously parsed/stored
+        everywhere but never consulted on the access path).
+        """
+        clearances = {
+            "D1-R1": RoleClearance(
+                role_address="D1-R1",
+                max_clearance=ConfidentialityLevel.SECRET,
+                compartments=frozenset({"alpha", "beta"}),
+                nda_signed=False,  # the governance-field-drop PGC-01 closes
+            ),
+        }
+        item = KnowledgeItem(
+            item_id="secret-item",
+            classification=ConfidentialityLevel.SECRET,
+            owning_unit_address="D1",
+            compartments=frozenset({"alpha"}),
+        )
+        decision = can_access(
+            role_address="D1-R1",
+            knowledge_item=item,
+            posture=TrustPostureLevel.DELEGATING,
+            compiled_org=simple_org,
+            clearances=clearances,
+            ksps=[],
+            bridges=[],
+        )
+        assert decision.allowed is False
+        assert decision.audit_details.get("detail") == "nda_not_signed"
+
     def test_secret_item_missing_compartment_denies(
         self, simple_org: CompiledOrg
     ) -> None:
@@ -470,6 +505,9 @@ class TestCanAccessCompartments:
                 role_address="D1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
                 compartments=frozenset({"alpha"}),
+                # NDA signed so the test reaches the compartment check (the
+                # path it targets) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(
@@ -663,6 +701,9 @@ class TestCanAccessKSP:
             "D2-R1-T1-R1": RoleClearance(
                 role_address="D2-R1-T1-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
+                # NDA signed so the test reaches the KSP classification-limit
+                # check (step 4) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(
@@ -768,6 +809,9 @@ class TestCanAccessBridge:
             "D2-R1": RoleClearance(
                 role_address="D2-R1",
                 max_clearance=ConfidentialityLevel.SECRET,
+                # NDA signed so the test reaches the bridge classification-limit
+                # check (step 4) rather than short-circuiting at the NDA gate.
+                nda_signed=True,
             ),
         }
         item = KnowledgeItem(

--- a/tests/trust/pact/unit/test_access_matrix.py
+++ b/tests/trust/pact/unit/test_access_matrix.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import pytest
+
 from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge, can_access
 from kailash.trust.pact.clearance import RoleClearance, VettingStatus
 from kailash.trust.pact.compilation import CompiledOrg, RoleDefinition, compile_org
@@ -368,6 +369,10 @@ def test_clearance_level_matrix(
         role_addr: RoleClearance(
             role_address=role_addr,
             max_clearance=role_clearance,
+            # SECRET+ access requires a signed NDA (enforced in can_access).
+            # This matrix isolates the clearance-LEVEL axis, so every cell
+            # carries a signed NDA to keep level the only varying dimension.
+            nda_signed=True,
         ),
     }
     item = KnowledgeItem(
@@ -428,6 +433,10 @@ def test_posture_capping_matrix(
         role_addr: RoleClearance(
             role_address=role_addr,
             max_clearance=ConfidentialityLevel.TOP_SECRET,
+            # SECRET+ access requires a signed NDA (enforced in can_access).
+            # This matrix isolates the POSTURE-capping axis, so the clearance
+            # carries a signed NDA to keep posture the only varying dimension.
+            nda_signed=True,
         ),
     }
     item = KnowledgeItem(

--- a/tests/trust/pact/unit/test_adversarial.py
+++ b/tests/trust/pact/unit/test_adversarial.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from dataclasses import FrozenInstanceError
 
 import pytest
+
 from kailash.trust.pact.access import (
     AccessDecision,
     KnowledgeSharePolicy,
@@ -349,6 +350,7 @@ class TestPostureGaming:
             role_addr: RoleClearance(
                 role_address=role_addr,
                 max_clearance=ConfidentialityLevel.SECRET,
+                nda_signed=True,  # SECRET+ access requires a signed NDA
             ),
         }
         item = KnowledgeItem(


### PR DESCRIPTION
## Summary

A holistic post-multi-wave redteam of the trust-plane surface (beyond the 2.41.1 PACT KSP/Bridge + cascade scope) surfaced **10 confirmed defects** across `kailash.trust.{pact,plane,operations,signing,enforce,revocation,vault}`. Each was adversarially verified against ground truth (rate-limit-immune re-verification after a workflow rate-limit), regression-tested, and gate-reviewed.

Ships as **kailash 2.42.0** (minor — the NDA-enforcement fix is a behavior change to access control).

## Findings fixed

**Changed (BREAKING)**
- **PGC-01** `pact/access.py` — `nda_signed` now ENFORCED for SECRET/TOP_SECRET access. It was documented "Required for SECRET and TOP_SECRET clearance" + parsed/stored/serialized everywhere, but **no access-decision path consulted it** → default-`False` clearances were granted SECRET+ access. `can_access` now denies (`detail="nda_not_signed"`). **Migration:** set `nda_signed=True` on SECRET+ clearances (the conformance vector + canonical fixtures already do).

**Security**
- **RS-01** `signing/rotation.py` + `operations/__init__.py` — `revoke_old_key` emitted a `rotation_key_revoked` audit event but never invalidated the key (stayed usable). `TrustKeyManager.remove_key` now tombstones the material; `revoke_old_key` calls it.
- **PR-2** `plane/project.py::verify` — tamper check was `if stored_hash and …`, so a stripped `content_hash` passed even strict verification. Missing `content_hash` is now a failure.
- **PR-3** `plane/project.py` — corrupted persisted posture was swallowed by `except (ValueError, Exception): pass` → silent downgrade to SUPERVISED. Now narrows to `ValueError`, WARNs, fails closed to PSEUDO.
- **EA-01** `enforce/proximity.py` — NaN/Inf usage bypassed every `>=` threshold check (no alert). Non-finite usage now fails closed to HELD.

**Fixed**
- **PCI-R1-01** `pact/audit.py` — `AuditChain.from_dict` promised "Raises PactError if corrupted" but only logged. Now raises.
- **RS-03** `revocation/broadcaster.py` — async-subscriber exceptions bypassed the dead-letter queue. A done-callback now records them.
- **RS-02 / vault / PGC-03 / explain** — docstring + gate-label accuracy (atomic→best-effort rotation; vault retire/recommit disclosed as capability-only with tenant/domain deferred to #630; None-envelope = permissive; explain Step-3 narration mirrors the NDA gate).

**Refuted** (documented intended design): no-envelope = permissive (EATP None=all-access); vault "silent cross-tenant retire" (known-deferred #630, recoverability-bounded — the over-claim was the real defect, fixed).

**Deferred workstream #630:** wire `vault/clearance.py` CL-02a (tenant/domain) + CL-04 (cooling-off) into the retire/recommit gates (capability-only today).

## Tests
- `tests/regression/test_redteam_trustplane_round2.py` — 15 behavioral tests; **8 fail against pre-fix code** (proven non-vacuous via `git stash`).
- PGC-01 enforcement test (`test_secret_item_without_nda_denied`) in both test trees; access/adversarial/matrix test data made conformant.
- `tests/trust/` **5953 passed**; touched-surface sweep (trust + PACT governance) **7136 passed / 35 skipped**.
- Gate reviews: **security-reviewer APPROVE** (PGC-01 gate structurally unbypassable, zero CRIT/HIGH/MED); **reviewer APPROVE** (its one same-class finding — 6 masked denial tests — fixed in-session).

## Related issues
None pre-filed — holistic redteam findings (the rule-mandated cross-shard pass). Cross-SDK parity for kailash-rs (#1393/#1394-class) remains human-gated, not auto-filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)