### PR TITLE
docs(deploy): record kailash 2.42.0 release (trust-plane redteam round-2)

### DIFF
--- a/deploy/deployments/2026-06-20-v2.42.0-trust-plane-redteam-round2.md
+++ b/deploy/deployments/2026-06-20-v2.42.0-trust-plane-redteam-round2.md
@@ -1,0 +1,116 @@
+# Deployment Record — kailash 2.42.0 (2026-06-20)
+
+Single-package core minor `kailash 2.41.1 → 2.42.0` shipping ten trust-plane
+correctness/security fixes surfaced by a **holistic post-multi-wave redteam of
+the broader trust-plane surface** (beyond the 2.41.1 PACT KSP/Bridge + cascade
+scope). Nine are non-breaking; one (`nda_signed` enforcement) is a behavior
+change to knowledge-access control — hence the minor bump.
+
+## Convergence
+
+A redteam workflow swept six trust-critical clusters; its first run hit a
+server-side rate-limit that produced a FALSE "2 dry rounds / 0 confirmed"
+convergence (every verifier + the round-2 finders errored → read as "0
+findings"). The evidence gate caught it: the round was re-verified
+**sequentially, against ground-truth code** (rate-limit-immune). Result: 14
+candidates → **10 confirmed, 3 refuted, 1 deferred workstream**.
+
+## What shipped (10 confirmed fixes)
+
+### Changed (BREAKING)
+
+- **PGC-01 (`kailash.trust.pact.access`)** — `nda_signed` is now ENFORCED for
+  SECRET/TOP_SECRET knowledge access. It was documented "Required for SECRET and
+  TOP_SECRET clearance" and parsed/stored/serialized across the YAML loader,
+  SQLite store, and backup paths, but **no access-decision path consulted it** —
+  a default-`False` clearance was granted SECRET+ access. `can_access` now denies
+  (`detail="nda_not_signed"`). Migration: set `nda_signed=True` on SECRET+
+  clearances (the value the conformance vector + canonical fixtures already use).
+
+### Security
+
+- **RS-01 (`signing/rotation` + `operations`)** — `revoke_old_key` emitted a
+  `rotation_key_revoked` audit event but never invalidated the key (it stayed
+  usable for signing). `TrustKeyManager.remove_key` now tombstones the material;
+  `revoke_old_key` calls it (closes the audit/store divergence).
+- **PR-2 (`plane/project.verify`)** — the tamper check was guarded by
+  `if stored_hash and …`, so a decision record with `content_hash` stripped
+  passed even `strict=True`. Missing/empty `content_hash` is now a failure.
+- **PR-3 (`plane/project`)** — a corrupted persisted `trust_posture` was
+  swallowed by `except (ValueError, Exception): pass` → silent downgrade to
+  SUPERVISED. Now narrows to `ValueError`, WARNs, fails closed to PSEUDO.
+- **EA-01 (`enforce/proximity`)** — a NaN/Inf usage value bypassed every `>=`
+  threshold (no alert). Non-finite usage now fails closed to HELD.
+
+### Fixed
+
+- **PCI-R1-01 (`pact/audit`)** — `AuditChain.from_dict` promised "Raises
+  PactError if corrupted" but only logged. Now raises.
+- **RS-03 (`revocation/broadcaster`)** — async-subscriber exceptions bypassed
+  the dead-letter queue; a done-callback now records them.
+- **RS-02 / vault / PGC-03 / explain** — docstring + gate-label accuracy
+  (atomic→best-effort rotation; vault retire/recommit gates disclosed as
+  capability-only with tenant/domain deferred to #630; None-envelope =
+  permissive; explain Step-3 narration mirrors the NDA gate).
+
+### Refuted (documented intended design)
+
+- No-envelope = permissive (`project.check` / `engine.verify_action`) — matches
+  `eatp` "None role = all-access" + `compute_effective_envelope` docstring.
+- Vault "silent cross-tenant retire" — the tenant/domain check is a known,
+  in-code-disclosed deferral (#630); `clearance.py` CL-02a/CL-04 exist but are
+  wired only on the restore path, and the recoverability gate bounds blast
+  radius. The over-claim (gate labels) was the real defect — fixed.
+
+### Deferred workstream
+
+- **#630** — wire `vault/clearance.py` CL-02a (tenant/domain) + CL-04
+  (cooling-off) into the retire/recommit gates (capability-only today). Exceeds
+  one shard; value-anchored to trust-plane-day-1-complete ("no deferring gaps").
+
+## Receipts
+
+- Fix PR #1398 (`fix/holistic-redteam-trustplane-round2`, merge `ac0d94f04`) —
+  2 commits: `0e18e9e14` (10 fixes + tests + CHANGELOG + version), `3d5aa0a65`
+  (#1375 ksp-deny-observability helper NDA conformance — the one CI Test PACT
+  red, fixed in-session).
+- Gate reviews: **security-reviewer APPROVE** (PGC-01 NDA gate structurally
+  unbypassable; zero CRIT/HIGH/MED; 2 LOW same-class gaps — module-docstring +
+  explain narration — fixed in-session). **reviewer APPROVE** (its one Important
+  finding — 6 NDA-masked compartment/KSP/bridge denial tests across both trees —
+  fixed in-session).
+- Tests: `tests/regression/test_redteam_trustplane_round2.py` (15 behavioral, 8
+  proven to fail pre-fix via `git stash`) + a PGC-01 enforcement test in both
+  trees; access/adversarial/matrix + #1375 test data made conformant
+  (`nda_signed=True` on SECRET+ clearances). `tests/trust/` 5953 passed;
+  touched-surface sweep 7136 passed / 35 skipped.
+- CI: full PR-gate matrix GREEN (Test 3.11–3.14 ubuntu+windows, Trust Unit,
+  Test PACT, PACT N6 Conformance, DataFlow Tier 1, CodeQL, Analyze,
+  test-with-infrastructure). The red `build` check was a `cancel-in-progress`
+  cancellation of the duplicate push-event run (`conclusion: cancelled`), not a
+  failure.
+- TestPyPI validation (minor-release discipline): `workflow_dispatch`
+  publish_to=testpypi run `27859118268` SUCCESS → clean-venv verify (version +
+  RS-01 tombstone + PCI-R1-01 raise + EA-01 NaN→HELD + PGC-01 NDA gate).
+- Production: tag `v2.42.0` (→ `ac0d94f04`) → publish-pypi run `27859172305`
+  SUCCESS (Build → Publish-to-PyPI → Create-GitHub-Release); `pypi.org` returns
+  wheel + sdist. Clean-venv install verified (`pip --no-cache-dir`, attempt 2
+  after cache lag): `kailash.__version__ == "2.42.0"` + RS-01 + EA-01 + PGC-01
+  confirmed live.
+
+## Sibling drift
+
+None. All 7 sub-packages AT-PARITY with PyPI: kailash-dataflow 2.12.0 /
+kailash-nexus 2.11.0 / kailash-kaizen 2.28.0 / kailash-mcp 0.2.15 /
+kailash-ml 2.2.1 / kailash-align 0.7.2 / kailash-pact 0.14.0. This release
+touched no `packages/*/src/` (the kailash-pact change was test-data-only →
+test-only carve-out; its `kailash>=` floor is satisfied by 2.42.0).
+
+## Cross-SDK
+
+The shared trust-plane (`src/kailash/trust/`) means the kailash-rs sibling may
+carry the same defect classes (NDA-unenforced, fake key revocation, tamper-check
+short-circuit, NaN proximity bypass, audit from_dict over-claim). SURFACED as
+candidate EATP-D6 cross-SDK parity items for the operator's human-gated scrubbed
+filing decision (NOT auto-filed; `repo-scope-discipline.md` +
+`upstream-issue-hygiene.md`).


### PR DESCRIPTION
Deployment record for kailash 2.42.0 (trust-plane redteam round-2). Docs-only; release verified live on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)