### PR TITLE
feat(trust)!: wire CL-02a tenant/domain + CL-04 cooling-off into vault retire/recommit gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.43.0] - 2026-06-20
+
+Wires the binding-owned CL-02a tenant/domain scoping and CL-04 cooling-off
+suspension (the existing `kailash.trust.vault.clearance.evaluate_clearance` gate)
+into the two KEK-commitment registry-mutating operations — `recommit_vault_kek`
+and `retire_vault_kek_alg`. This closes the clearance-gate-scoping sub-part of the
+SLIP-0039 vault-binding follow-up (#630) that the 2.42.0 deploy record flagged as
+capability-presence-only on these two surfaces (the separate §3.4 KEK
+re-establishment / encryption-hierarchy gap is unchanged). `retire_vault_kek_alg`
+gains a required `resolver` parameter — hence the minor bump.
+
+### Changed
+
+- **BREAKING — `retire_vault_kek_alg` now requires a `resolver` and enforces
+  CL-02a tenant/domain scoping** (`kailash.trust.vault.registry_ops`). The retire
+  gate named `clearance-tenant-domain` previously checked the `vault:retire-alg`
+  capability PRESENCE only; it now runs the full `evaluate_clearance` gate
+  (tenant → domain → token, fail-closed order) against the vault's RESOLVED
+  tenant/domain. Because `VaultKeyHandle` carries no tenant/domain, the operation
+  gains a REQUIRED keyword-only `resolver: VaultKeyResolver` (the only trusted
+  source), making it symmetric with `recommit_vault_kek`. The resolved KEK is
+  materialized solely to read the trusted tenant/domain and is `zeroize()`-d in a
+  `finally` (N12-IN-05) — it crosses no return value, anchor payload, or log line.
+  **Migration:** pass `resolver=<your VaultKeyResolver>` to `retire_vault_kek_alg`.
+  A retire whose clearance tenant/domain does not match/cover the vault's — and
+  that previously resolved to ALLOW — now resolves to DENY (`missing-clearance`);
+  same-tenant, covered-domain retires are unaffected.
+
+### Security
+
+- **`recommit_vault_kek` + `retire_vault_kek_alg` enforce tenant/domain isolation
+  and (recommit) post-recovery cooling-off** (`kailash.trust.vault.registry_ops`).
+  Both registry-mutating operations now perform the binding-owned CL-02a
+  tenant/domain scoping the gate label always advertised, closing the gap where a
+  `vault:backup` (recommit) or `vault:retire-alg` (retire) token granted in
+  tenant/domain A could mutate a vault's commitment registry in tenant/domain B.
+  `recommit_vault_kek` additionally honors the N12-CL-04 7-day post-recovery
+  cooling-off suspension (it rides `vault:backup`, a cooling-off-suspended
+  capability) via new optional `posture_store` / `trust_anchored_now` /
+  `approver_configured` parameters (absent → no cooling-off check, the documented
+  no-receipt default); `retire_vault_kek_alg` is a spec-faithful cooling-off no-op
+  (`vault:retire-alg` is not a suspended capability). The audit-before-mutation
+  (AU-02b) ordering and the recoverability-preserved guard are unchanged.
+
 ## [2.42.0] - 2026-06-20
 
 A holistic post-multi-wave redteam of the trust-plane surface (beyond the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.42.0"
+version = "2.43.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.42.0"
+__version__ = "2.43.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/trust/vault/errors.py
+++ b/src/kailash/trust/vault/errors.py
@@ -170,7 +170,7 @@ RESTORE_GATE_ORDER: tuple[str, ...] = (
 
 # N12-FT-03 — vault_kek_recommit, 4 steps (§4.6).
 RECOMMIT_GATE_ORDER: tuple[str, ...] = (
-    "clearance-tenant-domain",  # (1) vault:backup capability presence ONLY (CL-02a tenant/domain + CL-04 cooling-off NOT wired here — deferred, C3 #630)
+    "clearance-tenant-domain",  # (1) N12-CL-01/02a tenant→domain→token + N12-CL-04 cooling-off — full evaluate_clearance gate wired in registry_ops.py::recommit_vault_kek (F-VAULT-630; vault:backup IS cooling-off-suspended)
     "generation-vault-unchanged",  # (2) → recommit-generation-altered
     "prior-commitment-exists",  # (3) → unknown-prior-commitment
     "new-commitment-binds-secret",  # (4) → recommit-binding-mismatch
@@ -178,7 +178,7 @@ RECOMMIT_GATE_ORDER: tuple[str, ...] = (
 
 # N12-FT-03 — vault_kek_retire, 4 steps (§4.6).
 RETIRE_GATE_ORDER: tuple[str, ...] = (
-    "clearance-tenant-domain",  # (1) vault:retire-alg capability presence ONLY (CL-02a tenant/domain NOT wired here — deferred, C3 #630; no governance-HELD action)
+    "clearance-tenant-domain",  # (1) N12-CL-01/02a tenant→domain→token — full evaluate_clearance gate wired in registry_ops.py::retire_vault_kek_alg (F-VAULT-630; CL-04 cooling-off no-op: vault:retire-alg not in the suspended set)
     "generation-vault-unchanged",  # (2) → recommit-generation-altered
     "retired-entry-exists",  # (3) → unknown-prior-commitment
     "recoverability-preserved",  # (4) live non-retired strong alg MUST remain

--- a/src/kailash/trust/vault/registry_ops.py
+++ b/src/kailash/trust/vault/registry_ops.py
@@ -19,11 +19,13 @@ top of the C2a additive commitment registry
   specific ``(kek_commitment_alg -> kek_identity_commitment)`` registry entry
   ``retired=True`` (producing a NEW frozen :class:`CommitmentEntry` — registry
   entries are additive/immutable). Requires the distinct ``vault:retire-alg``
-  capability (NOT ordinary ``vault:restore`` / ``vault:backup``); enforces the
-  **recoverability guard** (a live, non-retired strong-alg commitment ``C_Y`` for
-  the same ``(vault_id, kek_generation)`` MUST already exist so retirement never
-  strands the corpus); and dispatches a ``vault_kek_retire`` OUTCOME anchor (D2,
-  ``recovery`` tier, AU-02b).
+  capability (NOT ordinary ``vault:restore`` / ``vault:backup``), scoped by the
+  full §4.2 clearance gate (CL-02a tenant/domain against the RESOLVED vault
+  tenant/domain — the handle carries none, so the resolver is the trusted-module
+  source); enforces the **recoverability guard** (a live, non-retired strong-alg
+  commitment ``C_Y`` for the same ``(vault_id, kek_generation)`` MUST already
+  exist so retirement never strands the corpus); and dispatches a
+  ``vault_kek_retire`` OUTCOME anchor (D2, ``recovery`` tier, AU-02b).
 
 Both operations drive their checks through the canonical first-failing gate
 orders (:data:`~kailash.trust.vault.errors.RECOMMIT_GATE_ORDER` /
@@ -39,22 +41,27 @@ does (register only after the anchor lands).
 
 The reconstructed secret is supplied by the same injected
 :class:`~kailash.trust.vault.input_gates.VaultKeyResolver` boundary the
-backup/restore surface uses; it is consumed for the binding-mismatch check and
-``del``-ed in a ``finally`` (N12-IN-05). No plaintext crosses any return value,
-anchor payload, or log line.
+backup/restore surface uses; it is consumed for the recommit binding-mismatch
+recompute AND to source the trusted vault tenant/domain the retire CL-02a gate
+scopes against (the handle carries no tenant/domain), then ``zeroize()``-d in a
+``finally`` (N12-IN-05). No plaintext crosses any return value, anchor payload,
+or log line.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Optional
 
 from kailash.delegate.types import DelegateIdentity
+from kailash.trust.posture.postures import PostureStore
 from kailash.trust.vault.anchors import (
     build_kek_recommit_anchor,
     build_kek_retire_anchor,
 )
 from kailash.trust.vault.backup import AnchorSigner, _sign_and_dispatch
+from kailash.trust.vault.clearance import evaluate_clearance
 from kailash.trust.vault.commitment import verify_commitment
 from kailash.trust.vault.dispatch import AuditDispatcher, AuditTier
 from kailash.trust.vault.errors import (
@@ -64,7 +71,12 @@ from kailash.trust.vault.errors import (
     VaultBindingError,
     first_failing,
 )
-from kailash.trust.vault.input_gates import ResolvedKek, VaultKeyResolver
+from kailash.trust.vault.input_gates import (
+    BACKUP_CAPABILITY,
+    ResolvedKek,
+    VaultKeyResolver,
+    require_clearance,
+)
 from kailash.trust.vault.registry import (
     CommitmentEntry,
     CommitmentRegistry,
@@ -103,6 +115,9 @@ def recommit_vault_kek(
     timestamp: Optional[str] = None,
     time_attested: bool = False,
     principal: Optional[str] = None,
+    posture_store: Optional[PostureStore] = None,
+    trust_anchored_now: Optional[datetime] = None,
+    approver_configured: bool = False,
 ) -> CommitmentEntry:
     """ADDITIVELY recommit a KEK commitment under a new algorithm (N12-CB-04(c)).
 
@@ -115,9 +130,18 @@ def recommit_vault_kek(
 
     FT-03 gate order (``RECOMMIT_GATE_ORDER``, fail-closed first-failing):
 
-    1. ``clearance-tenant-domain`` — ``clearance.has_capability("vault:backup")``
-       (the recommit capability; a cooling-off check is C3's) else
-       ``missing-clearance``;
+    1. ``clearance-tenant-domain`` — the FULL §4.2 clearance gate
+       (:func:`~kailash.trust.vault.clearance.evaluate_clearance`) for the
+       recommit capability ``vault:backup``: the binding-OWNED CL-02a
+       tenant→domain→token fail-closed scoping against the RESOLVED vault
+       tenant/domain (the substrate gate is domain-blind) PLUS the N12-CL-04
+       cooling-off suspension — ``vault:backup`` is a cooling-off-suspended
+       capability, so a principal inside the 7-day post-recovery window cannot
+       recommit without a verified governance-approver. Any failure →
+       ``missing-clearance``. A cheap presence-only check
+       (:func:`~kailash.trust.vault.input_gates.require_clearance`) runs BEFORE
+       resolution so a token-less caller is denied without materializing the
+       secret (same ``missing-clearance`` code).
     2. ``generation-vault-unchanged`` — the recommit MUST NOT alter
        ``kek_generation`` or ``vault_id`` (it operates on the resolved handle's
        own generation/vault) else ``recommit-generation-altered``;
@@ -152,6 +176,13 @@ def recommit_vault_kek(
             default when omitted.
         timestamp / time_attested: N12-AU-04a two-state grammar.
         principal: The acting principal; defaults to ``clearance.principal``.
+        posture_store: The PostureStore the CL-04 cooling-off read consults
+            (``None`` → no-receipt conservative default: not suspended).
+        trust_anchored_now: The trust-anchored clock the CL-04 window is
+            evaluated against (NEVER a locally-mutable wall clock).
+        approver_configured: The X1 CL-03 seam — recorded on a cooling-off
+            denial for audit; a configured-but-unexercised approver does NOT by
+            itself lift the suspension.
 
     Returns:
         The newly-registered live :class:`CommitmentEntry` for
@@ -180,8 +211,14 @@ def recommit_vault_kek(
         },
     )
 
+    # Gate 1 (cheap presence-only) — vault:backup token check BEFORE resolution
+    # (mirror the backup/rotation gate-1-cheap): a token-less caller is denied
+    # without materializing the KEK secret. Same missing-clearance code as the
+    # full gate below, so the first-failing determinism is preserved.
+    require_clearance(clearance, BACKUP_CAPABILITY)
+
     # Resolve the KEK inside the trusted module; consumed for the binding check
-    # and del-ed in the finally (N12-IN-05).
+    # and the CL-02a tenant/domain read, then del-ed in the finally (N12-IN-05).
     resolved = resolver.resolve_kek(key_handle)
     if not isinstance(resolved, ResolvedKek):
         raise VaultBindingError(
@@ -197,10 +234,27 @@ def recommit_vault_kek(
         def check(gate: str) -> Optional[N12FT01Code]:
             """The FT-03 recommit per-gate predicate (steps 1-4)."""
             if gate == "clearance-tenant-domain":
-                # (1) The recommit rides the ordinary vault:backup capability
-                # (a distinct cooling-off / tenant-domain check is C3's #630).
-                if not clearance.has_capability("vault:backup"):
-                    return N12FT01Code.MISSING_CLEARANCE
+                # (1) The FULL §4.2 clearance gate for the recommit capability
+                # vault:backup: binding-OWNED CL-02a tenant→domain→token
+                # fail-closed scoping against the RESOLVED vault tenant/domain
+                # (the substrate gate is domain-blind) + N12-CL-04 cooling-off
+                # suspension (vault:backup IS a suspended capability, so a
+                # principal inside the 7-day post-recovery window is suspended).
+                # A vault:backup granted in tenant/domain A fails against this
+                # vault in tenant/domain B. evaluate_clearance raises on failure;
+                # translate to the typed code for first_failing (preserves the
+                # missing-clearance first-failing determinism, N12-FT-03).
+                try:
+                    evaluate_clearance(
+                        clearance,
+                        resolved,
+                        BACKUP_CAPABILITY,
+                        posture_store=posture_store,
+                        now=trust_anchored_now,
+                        approver_configured=approver_configured,
+                    )
+                except VaultBindingError as exc:
+                    return exc.code
                 return None
             if gate == "generation-vault-unchanged":
                 # (2) The recommit MUST NOT alter kek_generation / vault_id. We
@@ -347,6 +401,7 @@ def retire_vault_kek_alg(
     key_handle: VaultKeyHandle,
     clearance: ClearanceContext,
     *,
+    resolver: VaultKeyResolver,
     dispatcher: AuditDispatcher,
     signer: AnchorSigner,
     signer_identity: DelegateIdentity,
@@ -357,6 +412,9 @@ def retire_vault_kek_alg(
     timestamp: Optional[str] = None,
     time_attested: bool = False,
     principal: Optional[str] = None,
+    posture_store: Optional[PostureStore] = None,
+    trust_anchored_now: Optional[datetime] = None,
+    approver_configured: bool = False,
 ) -> CommitmentEntry:
     """Retire a specific commitment-registry entry as non-verifiable (N12-CB-04(e)).
 
@@ -370,9 +428,21 @@ def retire_vault_kek_alg(
 
     FT-03 gate order (``RETIRE_GATE_ORDER``, fail-closed first-failing):
 
-    1. ``clearance-tenant-domain`` — ``clearance.has_capability("vault:retire-alg")``
-       (the DISTINCT high-consequence capability; NOT ``vault:restore`` /
-       ``vault:backup``) else ``missing-clearance``;
+    1. ``clearance-tenant-domain`` — the FULL §4.2 clearance gate
+       (:func:`~kailash.trust.vault.clearance.evaluate_clearance`) for the
+       DISTINCT high-consequence ``vault:retire-alg`` capability (NOT
+       ``vault:restore`` / ``vault:backup``): the binding-OWNED CL-02a
+       tenant→domain→token fail-closed scoping against the RESOLVED vault
+       tenant/domain (the handle carries no tenant/domain — the resolver is the
+       only trusted-module source). N12-CL-04 cooling-off is a structural no-op
+       here: ``vault:retire-alg`` is NOT in
+       :data:`~kailash.trust.vault.clearance.COOLING_OFF_SUSPENDED_CAPABILITIES`,
+       so a retire is never suspended by the post-recovery window (spec-faithful;
+       retire is not a materializing-restore-class op). Any failure →
+       ``missing-clearance``. A cheap presence-only check
+       (:func:`~kailash.trust.vault.input_gates.require_clearance`) runs BEFORE
+       resolution so a token-less caller is denied without materializing the
+       secret (same ``missing-clearance`` code).
     2. ``generation-vault-unchanged`` — the retire MUST NOT alter
        ``kek_generation`` or ``vault_id`` else ``recommit-generation-altered``;
     3. ``retired-entry-exists`` — a LIVE (non-retired) registry entry MUST exist
@@ -386,12 +456,24 @@ def retire_vault_kek_alg(
 
     AU-02b: the ``vault_kek_retire`` anchor is dispatched to the ``recovery``
     tier BEFORE the registry entry is replaced. A dispatch failure RAISES and
-    the entry stays live.
+    the entry stays live. The resolve + gate machinery + AU-02b dispatch +
+    registry mutation are wrapped in a ``try`` / ``finally`` that ``zeroize()``-s
+    the resolved KEK on EVERY exit (N12-IN-05), preserving the anchor-before-
+    mutation ordering.
 
     Args:
-        key_handle: The target KEK handle (vault_id + generation). NO resolver
-            is needed — retire touches no secret (it marks an existing entry).
+        key_handle: The target KEK handle (vault_id + generation). Retire
+            resolves it via ``resolver`` to source the trusted vault
+            tenant/domain for the CL-02a clearance scoping — the handle itself
+            carries no tenant/domain (``VaultKeyHandle`` has only key_id /
+            vault_id / kek_generation), so the resolver is the ONLY trusted-
+            module source. The materialized secret is consumed only to read the
+            trusted tenant/domain and ``zeroize()``-d in the ``finally``; it
+            never crosses a return value, anchor payload, or log line (N12-IN-05).
         clearance: MUST carry ``vault:retire-alg`` (N12-CB-04(e)(2)).
+        resolver: The injected trusted-module resolver — the trusted source of
+            the vault's tenant/domain for the CL-02a scoping (consume-and-
+            ``zeroize``).
         dispatcher: The named-tier audit dispatcher (D1).
         signer / signer_identity: The anchor signer + identity.
         alg_id: The deployment SLIP-0039 algorithm id (rides
@@ -402,6 +484,13 @@ def retire_vault_kek_alg(
             omitted.
         timestamp / time_attested: N12-AU-04a two-state grammar.
         principal: The acting principal; defaults to ``clearance.principal``.
+        posture_store: The PostureStore the CL-04 cooling-off read consults
+            (``None`` → no-receipt conservative default). CL-04 is a structural
+            no-op for ``vault:retire-alg`` (not a suspended capability) — this
+            is threaded for signature symmetry with recommit + future-proofing.
+        trust_anchored_now: The trust-anchored clock for the CL-04 window
+            (NEVER a locally-mutable wall clock).
+        approver_configured: The X1 CL-03 seam (recorded on a denial for audit).
 
     Returns:
         The new retired :class:`CommitmentEntry` (``retired=True``).
@@ -428,137 +517,183 @@ def retire_vault_kek_alg(
         },
     )
 
-    def check(gate: str) -> Optional[N12FT01Code]:
-        """The FT-03 retire per-gate predicate (steps 1-4)."""
-        if gate == "clearance-tenant-domain":
-            # (1) The DISTINCT vault:retire-alg capability (N12-CB-04(e)(2)) —
-            # NOT the ordinary vault:restore / vault:backup capability.
-            #
-            # SCOPE (honest disclosure — matches the recommit gate's #630
-            # note): this gate enforces capability PRESENCE only. The CL-02a
-            # tenant/domain scoping + CL-04 cooling-off that the gate NAME and
-            # the spec (N12-FT-03 §4.6) imply are NOT yet wired at this surface
-            # (deferred — C3 #630; the tenant/domain + cooling-off logic exists
-            # in clearance.py but is currently invoked only on the restore
-            # path). Until #630 lands, a vault:retire-alg holder is not
-            # tenant/domain-scoped here; the recoverability-preserved gate
-            # (step 4) bounds the blast radius (the corpus cannot be stranded).
-            if not clearance.has_capability(RETIRE_ALG_CAPABILITY):
-                return N12FT01Code.MISSING_CLEARANCE
-            return None
-        if gate == "generation-vault-unchanged":
-            # (2) Retire MUST NOT alter generation/vault. The handle carries the
-            # captured generation; a negative generation would have been rejected
-            # at VaultKeyHandle construction, so this gate is structurally a
-            # no-op on a well-formed handle, BUT it stays in the order so the
-            # first-failing sequence matches the recommit path + the spec FT-03
-            # ordering. (A later C3 ordinal-generation surface may strengthen it.)
-            if kek_generation != key_handle.kek_generation:  # pragma: no cover
-                return N12FT01Code.RECOMMIT_GENERATION_ALTERED
-            return None
-        if gate == "retired-entry-exists":
-            # (3) A LIVE entry MUST exist under retired_kek_commitment_alg whose
-            # commitment equals retired_kek_identity_commitment.
-            lookup = active_registry.lookup(
-                vault_id=vault_id,
-                kek_generation=kek_generation,
-                kek_commitment_alg=retired_kek_commitment_alg,
-            )
-            target_entry = lookup.entry
-            if (
-                target_entry is None
-                or target_entry.retired
-                or target_entry.commitment != retired_kek_identity_commitment
-            ):
-                return N12FT01Code.UNKNOWN_PRIOR_COMMITMENT
-            return None
-        if gate == "recoverability-preserved":
-            # (4) Recoverability guard (N12-CB-04(e)(4)): a LIVE non-retired
-            # commitment C_Y for the SAME (vault_id, gen) under a DIFFERENT alg
-            # MUST already exist, so the retire does NOT strand the corpus. The
-            # live_algs() growth metric is the source of truth: after removing
-            # the alg about to be retired, at least one OTHER live alg MUST
-            # remain. Refused with a missing-clearance-class typed error (the
-            # spec's "missing-clearance-class rejection, never stranding
-            # recoverability").
-            live = set(
-                active_registry.live_algs(
-                    vault_id=vault_id, kek_generation=kek_generation
-                )
-            )
-            live.discard(retired_kek_commitment_alg)
-            if not live:
-                return N12FT01Code.MISSING_CLEARANCE
-            return None
+    # Gate 1 (cheap presence-only) — vault:retire-alg token check BEFORE
+    # resolution: a token-less caller is denied without materializing the KEK
+    # secret. Same missing-clearance code as the full gate below, so the
+    # first-failing determinism is preserved.
+    require_clearance(clearance, RETIRE_ALG_CAPABILITY)
+
+    # Resolve the KEK inside the trusted module — the ONLY trusted-module source
+    # of the vault's tenant/domain for the CL-02a scoping (the handle carries
+    # none). The secret is materialized solely to read the trusted tenant/domain
+    # and zeroize()-d in the finally on EVERY exit (N12-IN-05); it never crosses
+    # a return value, anchor payload, or log line.
+    resolved = resolver.resolve_kek(key_handle)
+    if not isinstance(resolved, ResolvedKek):
         raise VaultBindingError(
-            N12FT01Code.PARAMETER_MISMATCH,
-            f"retire gate {gate!r} is not a recognized FT-03 gate "
-            f"(closed order: {list(RETIRE_GATE_ORDER)})",
-            details={"gate": gate},
+            N12FT01Code.NOT_A_KEK,
+            "resolver.resolve_kek MUST return a ResolvedKek; got "
+            f"{type(resolved).__name__}",
+            details={"returned_type": type(resolved).__name__},
         )
 
-    first = first_failing(RETIRE_GATE_ORDER, check)
-    if first is not None:
-        logger.warning(
-            "vault.retire.gate_failed",
+    try:
+
+        def check(gate: str) -> Optional[N12FT01Code]:
+            """The FT-03 retire per-gate predicate (steps 1-4)."""
+            if gate == "clearance-tenant-domain":
+                # (1) The FULL §4.2 clearance gate for the DISTINCT
+                # vault:retire-alg capability (N12-CB-04(e)(2)) — NOT the
+                # ordinary vault:restore / vault:backup capability. Runs the
+                # binding-OWNED CL-02a tenant→domain→token fail-closed scoping
+                # against the RESOLVED vault tenant/domain (the resolver is the
+                # only trusted-module source; the handle carries no
+                # tenant/domain). A vault:retire-alg holder in tenant/domain A
+                # is denied against this vault in tenant/domain B even with a
+                # live recoverability sibling alg present.
+                #
+                # CL-04 cooling-off is a STRUCTURAL no-op here: vault:retire-alg
+                # is NOT in COOLING_OFF_SUSPENDED_CAPABILITIES (it is not a
+                # materializing-restore-class op), so is_in_cooling_off is never
+                # consulted for it — a principal inside the 7-day post-recovery
+                # window is NOT suspended for a retire. This is spec-faithful;
+                # we do NOT force-suspend retire.
+                #
+                # evaluate_clearance raises on failure; translate to the typed
+                # code for first_failing (preserves the missing-clearance
+                # first-failing determinism, N12-FT-03).
+                try:
+                    evaluate_clearance(
+                        clearance,
+                        resolved,
+                        RETIRE_ALG_CAPABILITY,
+                        posture_store=posture_store,
+                        now=trust_anchored_now,
+                        approver_configured=approver_configured,
+                    )
+                except VaultBindingError as exc:
+                    return exc.code
+                return None
+            if gate == "generation-vault-unchanged":
+                # (2) Retire MUST NOT alter generation/vault. The handle carries
+                # the captured generation; a negative generation would have been
+                # rejected at VaultKeyHandle construction, so this gate is
+                # structurally a no-op on a well-formed handle, BUT it stays in
+                # the order so the first-failing sequence matches the recommit
+                # path + the spec FT-03 ordering. (A later C3 ordinal-generation
+                # surface may strengthen it.)
+                if kek_generation != key_handle.kek_generation:  # pragma: no cover
+                    return N12FT01Code.RECOMMIT_GENERATION_ALTERED
+                return None
+            if gate == "retired-entry-exists":
+                # (3) A LIVE entry MUST exist under retired_kek_commitment_alg
+                # whose commitment equals retired_kek_identity_commitment.
+                lookup = active_registry.lookup(
+                    vault_id=vault_id,
+                    kek_generation=kek_generation,
+                    kek_commitment_alg=retired_kek_commitment_alg,
+                )
+                target_entry = lookup.entry
+                if (
+                    target_entry is None
+                    or target_entry.retired
+                    or target_entry.commitment != retired_kek_identity_commitment
+                ):
+                    return N12FT01Code.UNKNOWN_PRIOR_COMMITMENT
+                return None
+            if gate == "recoverability-preserved":
+                # (4) Recoverability guard (N12-CB-04(e)(4)): a LIVE non-retired
+                # commitment C_Y for the SAME (vault_id, gen) under a DIFFERENT
+                # alg MUST already exist, so the retire does NOT strand the
+                # corpus. The live_algs() growth metric is the source of truth:
+                # after removing the alg about to be retired, at least one OTHER
+                # live alg MUST remain. Refused with a missing-clearance-class
+                # VaultBindingError (the spec's "missing-clearance-class rejection,
+                # never stranding recoverability"). UNCHANGED by #630.
+                live = set(
+                    active_registry.live_algs(
+                        vault_id=vault_id, kek_generation=kek_generation
+                    )
+                )
+                live.discard(retired_kek_commitment_alg)
+                if not live:
+                    return N12FT01Code.MISSING_CLEARANCE
+                return None
+            raise VaultBindingError(
+                N12FT01Code.PARAMETER_MISMATCH,
+                f"retire gate {gate!r} is not a recognized FT-03 gate "
+                f"(closed order: {list(RETIRE_GATE_ORDER)})",
+                details={"gate": gate},
+            )
+
+        first = first_failing(RETIRE_GATE_ORDER, check)
+        if first is not None:
+            logger.warning(
+                "vault.retire.gate_failed",
+                extra={
+                    "vault_id": vault_id,
+                    "kek_generation": kek_generation,
+                    "gate_code": first.value,
+                },
+            )
+            raise VaultBindingError(
+                first,
+                f"retire gate failed: {first.value} (vault_id={vault_id})",
+                details={"gate_code": first.value, "vault_id": vault_id},
+            )
+
+        ts = timestamp if (time_attested and timestamp is not None) else "unverified"
+        payload = build_kek_retire_anchor(
+            alg_id=alg_id,
+            vault_id=vault_id,
+            kek_generation=kek_generation,
+            retired_kek_commitment_alg=retired_kek_commitment_alg,
+            retired_kek_identity_commitment=retired_kek_identity_commitment,
+            principal=acting_principal,
+            timestamp=ts,
+            time_attested=time_attested,
+        )
+
+        # AU-02b: dispatch the OUTCOME anchor to the recovery tier BEFORE
+        # replacing the registry entry. A dispatch failure RAISES (no receipt)
+        # and the entry stays live — the registry mirrors the audited recovery-
+        # tier chain. The resolve/zeroize try/finally WRAPS this dispatch +
+        # mutation so the anchor-before-mutation ordering is preserved and the
+        # secret is always zeroized on every exit (N12-IN-05).
+        _sign_and_dispatch(
+            dispatcher=dispatcher,
+            signer=signer,
+            signer_identity=signer_identity,
+            event_payload=payload,
+            tier=AuditTier.RECOVERY,
+        )
+
+        # Replace the entry with a new frozen retired one (entries are immutable
+        # — the retire produces a NEW CommitmentEntry, never mutates in place).
+        # The commitment + key_id carry through verbatim; only `retired` flips.
+        retired_entry = _mark_entry_retired(
+            active_registry,
+            vault_id=vault_id,
+            kek_generation=kek_generation,
+            kek_commitment_alg=retired_kek_commitment_alg,
+        )
+        logger.info(
+            "vault.retire.ok",
             extra={
                 "vault_id": vault_id,
                 "kek_generation": kek_generation,
-                "gate_code": first.value,
+                "retired_kek_commitment_alg": retired_kek_commitment_alg,
+                "live_algs": list(
+                    active_registry.live_algs(
+                        vault_id=vault_id, kek_generation=kek_generation
+                    )
+                ),
             },
         )
-        raise VaultBindingError(
-            first,
-            f"retire gate failed: {first.value} (vault_id={vault_id})",
-            details={"gate_code": first.value, "vault_id": vault_id},
-        )
-
-    ts = timestamp if (time_attested and timestamp is not None) else "unverified"
-    payload = build_kek_retire_anchor(
-        alg_id=alg_id,
-        vault_id=vault_id,
-        kek_generation=kek_generation,
-        retired_kek_commitment_alg=retired_kek_commitment_alg,
-        retired_kek_identity_commitment=retired_kek_identity_commitment,
-        principal=acting_principal,
-        timestamp=ts,
-        time_attested=time_attested,
-    )
-
-    # AU-02b: dispatch the OUTCOME anchor to the recovery tier BEFORE replacing
-    # the registry entry. A dispatch failure RAISES (no receipt) and the entry
-    # stays live — the registry mirrors the audited recovery-tier chain.
-    _sign_and_dispatch(
-        dispatcher=dispatcher,
-        signer=signer,
-        signer_identity=signer_identity,
-        event_payload=payload,
-        tier=AuditTier.RECOVERY,
-    )
-
-    # Replace the entry with a new frozen retired one (entries are immutable —
-    # the retire produces a NEW CommitmentEntry, never mutates in place). The
-    # commitment + key_id carry through verbatim; only `retired` flips True.
-    retired_entry = _mark_entry_retired(
-        active_registry,
-        vault_id=vault_id,
-        kek_generation=kek_generation,
-        kek_commitment_alg=retired_kek_commitment_alg,
-    )
-    logger.info(
-        "vault.retire.ok",
-        extra={
-            "vault_id": vault_id,
-            "kek_generation": kek_generation,
-            "retired_kek_commitment_alg": retired_kek_commitment_alg,
-            "live_algs": list(
-                active_registry.live_algs(
-                    vault_id=vault_id, kek_generation=kek_generation
-                )
-            ),
-        },
-    )
-    return retired_entry
+        return retired_entry
+    finally:
+        # N12-IN-05: consume-and-zeroize the resolved KEK material on every exit.
+        resolved.zeroize()
 
 
 def _mark_entry_retired(

--- a/tests/integration/test_eatp12_vault_recommit_retire_wiring.py
+++ b/tests/integration/test_eatp12_vault_recommit_retire_wiring.py
@@ -331,6 +331,7 @@ def test_retire_old_alg_then_restore_fails_retired_commitment_alg():
     retired_entry = retire_vault_kek_alg(
         _handle(),
         _clearance("vault:retire-alg"),
+        resolver=resolver,
         dispatcher=dispatcher,
         signer=signer,
         signer_identity=identity,
@@ -393,6 +394,7 @@ def test_retire_only_live_entry_is_refused_recoverability_guard():
         retire_vault_kek_alg(
             _handle(),
             _clearance("vault:retire-alg"),
+            resolver=_DeterministicResolver(),
             dispatcher=dispatcher,
             signer=signer,
             signer_identity=identity,
@@ -547,6 +549,7 @@ def test_retire_missing_retire_alg_capability():
         retire_vault_kek_alg(
             _handle(),
             _clearance("vault:backup", "vault:restore"),
+            resolver=resolver,
             dispatcher=dispatcher,
             signer=signer,
             signer_identity=identity,
@@ -626,6 +629,7 @@ def test_retire_au02b_failing_dispatch_aborts_entry_stays_live():
         retire_vault_kek_alg(
             _handle(),
             _clearance("vault:retire-alg"),
+            resolver=resolver,
             dispatcher=wrong_dispatcher,
             signer=signer,
             signer_identity=signer_identity,

--- a/tests/regression/test_eatp12_vault_630_clearance_wiring.py
+++ b/tests/regression/test_eatp12_vault_630_clearance_wiring.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression — F-VAULT-630: recommit + retire enforce CL-02a tenant/domain + CL-04.
+
+Closes the #630 gap. Before this fix, the ``clearance-tenant-domain`` gate of
+``recommit_vault_kek`` (N12-CB-04(c)) and ``retire_vault_kek_alg``
+(N12-CB-04(e)) was NAMED for tenant/domain scoping but enforced capability
+PRESENCE only (``clearance.has_capability(...)``) — the CL-02a tenant→domain
+scoping (N12-CL-02a) and the CL-04 cooling-off (N12-CL-04) the gate name + spec
+imply were deferred (the honest-disclosure comment at registry_ops.py + the
+``test_redteam_trustplane_round2.py`` "gate-label over-claim, NO behavioral
+delta" note). This fix wires the full ``evaluate_clearance`` gate into both
+surfaces, mirroring the proven backup/restore/rotation sibling pattern.
+
+Each test below FAILS against the pre-fix capability-only gate and PASSES against
+the wired gate — verified by the git-stash prove-fail receipt in the F-VAULT-630
+session report. NO mocks (``rules/testing.md`` Tier-2): a real
+:class:`~kailash.trust.vault.registry.CommitmentRegistry`, a real per-tier
+:class:`AuditDispatcher` with an Ed25519 signer + verifier, a real
+:class:`~kailash.trust.posture.posture_store.SQLitePostureStore`, and the
+deployment-supplied trusted resolver (a Protocol-satisfying deterministic
+adapter, NOT a mock) exercised through the real binding code path.
+
+Coverage:
+
+* recommit — a vault:backup holder whose clearance tenant/domain does NOT match
+  the vault's (resolved) tenant/domain is DENIED missing-clearance even with all
+  other gates satisfiable (CL-02a, both the tenant axis and the domain axis).
+* retire — a vault:retire-alg holder in tenant/domain A is DENIED
+  missing-clearance against a vault in tenant/domain B even with a live
+  recoverability sibling alg present (CL-02a).
+* recommit cooling-off — a principal inside the 7-day post-recovery window is
+  SUSPENDED for recommit (vault:backup IS a cooling-off-suspended capability) →
+  missing-clearance, when no approver path (CL-04).
+* retire cooling-off no-op — a principal inside the window is NOT suspended for
+  retire (vault:retire-alg is NOT in COOLING_OFF_SUSPENDED_CAPABILITIES) → the
+  retire still passes the clearance gate (spec-faithful no-op, CL-04).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from kailash.delegate.types import DelegateIdentity, PrincipalDirectory
+from kailash.delegate.verifier import Ed25519Verifier
+from kailash.trust.key_manager import KeyClass
+from kailash.trust.posture.posture_store import SQLitePostureStore
+from kailash.trust.vault.clearance import COOLING_OFF_SUSPENDED_CAPABILITIES
+from kailash.trust.vault.commitment import kek_identity_commitment
+from kailash.trust.vault.dispatch import AuditDispatcher, AuditTier
+from kailash.trust.vault.errors import N12FT01Code, VaultBindingError
+from kailash.trust.vault.input_gates import ResolvedKek
+from kailash.trust.vault.registry import CommitmentRegistry
+from kailash.trust.vault.registry_ops import recommit_vault_kek, retire_vault_kek_alg
+from kailash.trust.vault.stale_guard import trigger_d6_posture_downgrade
+from kailash.trust.vault.types import ClearanceContext, VaultKeyHandle
+
+pytestmark = pytest.mark.regression
+
+_KNOWN_KEK = bytes.fromhex(
+    "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+)
+_KEK_GENERATION = 7
+_KEY_ID = "kek-handle-630"
+_VAULT_ID = "vault-630"
+_PROVENANCE = "vault-derived:v1"
+_ALG_V1 = "eatp-v1"
+_ALG_V11 = "eatp-v1.1"
+#: The principal acting in the regression tests (also the cooling-off subject).
+_PRINCIPAL = "agent-630"
+#: The vault's TRUSTED tenant/domain (resolved from the handle by the resolver).
+_VAULT_TENANT = "tenant-A"
+_VAULT_DOMAIN = "domain-A"
+
+
+class _Resolver:
+    """Deployment-supplied trusted resolver returning the known KEK (NOT a mock).
+
+    Resolves the vault's bound ``vault_tenant`` / ``vault_domain`` — the CL-02a
+    trusted-module source the clearance gate compares the ClearanceContext
+    against. The handle carries no tenant/domain; the resolver is authoritative.
+    """
+
+    def __init__(
+        self,
+        *,
+        vault_tenant: str = _VAULT_TENANT,
+        vault_domain: str = _VAULT_DOMAIN,
+    ) -> None:
+        self._tenant = vault_tenant
+        self._domain = vault_domain
+
+    def resolve_kek(self, handle: VaultKeyHandle) -> ResolvedKek:
+        return ResolvedKek(
+            master_secret=_KNOWN_KEK,
+            key_class=KeyClass.KEK,
+            kek_generation=_KEK_GENERATION,
+            key_id=_KEY_ID,
+            passphrase_provenance=_PROVENANCE,
+            vault_tenant=self._tenant,
+            vault_domain=self._domain,
+        )
+
+
+def _build_signer() -> tuple[DelegateIdentity, Ed25519Verifier, Callable[[bytes], str]]:
+    priv = Ed25519PrivateKey.generate()
+    pub_bytes = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    identity = DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-vault-binding",
+        role_binding_ref="rb-vault-binding",
+        genesis_ref="gen-vault-binding",
+    )
+    directory = PrincipalDirectory(
+        identities=(identity,),
+        verification_keys={identity.delegate_id: pub_bytes},
+    )
+    verifier = Ed25519Verifier(directory=directory)
+
+    def signer(canonical_bytes: bytes) -> str:
+        return priv.sign(canonical_bytes).hex()
+
+    return identity, verifier, signer
+
+
+def _handle() -> VaultKeyHandle:
+    return VaultKeyHandle(
+        key_id=_KEY_ID, vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION
+    )
+
+
+def _clearance(*caps: str, tenant: str = _VAULT_TENANT, domain: str = _VAULT_DOMAIN):
+    return ClearanceContext(
+        principal=_PRINCIPAL, tenant=tenant, domain=domain, capabilities=tuple(caps)
+    )
+
+
+def _commitment(alg: str) -> str:
+    return kek_identity_commitment(
+        vault_id=_VAULT_ID,
+        kek_generation=_KEK_GENERATION,
+        master_secret=_KNOWN_KEK,
+        passphrase_provenance=_PROVENANCE,
+        alg=alg,
+    )
+
+
+def _seed_v1(registry: CommitmentRegistry) -> str:
+    """Register the initial ``eatp-v1`` commitment (models a prior backup)."""
+    commitment = _commitment(_ALG_V1)
+    registry.register(
+        vault_id=_VAULT_ID,
+        kek_generation=_KEK_GENERATION,
+        kek_commitment_alg=_ALG_V1,
+        commitment=commitment,
+        key_id=_KEY_ID,
+    )
+    return commitment
+
+
+def _seed_v11(registry: CommitmentRegistry) -> str:
+    """Register a LIVE eatp-v1.1 sibling (recoverability guard satisfiable)."""
+    commitment = _commitment(_ALG_V11)
+    registry.register(
+        vault_id=_VAULT_ID,
+        kek_generation=_KEK_GENERATION,
+        kek_commitment_alg=_ALG_V11,
+        commitment=commitment,
+        key_id=_KEY_ID,
+    )
+    return commitment
+
+
+@pytest.fixture
+def posture_store():
+    """A REAL SQLitePostureStore against a temp DB (Tier-2, NO mock)."""
+    fd, path = tempfile.mkstemp(suffix="-630-postures.db")
+    os.close(fd)
+    os.unlink(path)
+    store = SQLitePostureStore(path)
+    try:
+        yield store
+    finally:
+        store.close()
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# CL-02a — recommit tenant/domain scoping (the #630 gap, recommit surface)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_recommit_wrong_tenant_denied_missing_clearance():
+    """recommit — a vault:backup holder in the WRONG tenant is DENIED.
+
+    All other recommit gates are satisfiable (the resolver's generation matches,
+    a live prior eatp-v1 exists, the bind recomputes), yet a tenant mismatch on
+    the CL-02a axis denies missing-clearance. Pre-fix (capability-PRESENCE only)
+    this passed and recommitted.
+    """
+    identity, verifier, signer = _build_signer()
+    dispatcher = AuditDispatcher.for_named_tiers(verifier)
+    registry = CommitmentRegistry()
+    c_x = _seed_v1(registry)
+
+    with pytest.raises(VaultBindingError) as exc:
+        recommit_vault_kek(
+            _handle(),
+            _clearance("vault:backup", tenant="tenant-B"),  # wrong tenant
+            resolver=_Resolver(),  # vault tenant is tenant-A
+            dispatcher=dispatcher,
+            signer=signer,
+            signer_identity=identity,
+            alg_id=_ALG_V1,
+            prior_kek_commitment_alg=_ALG_V1,
+            prior_kek_identity_commitment=c_x,
+            new_kek_commitment_alg=_ALG_V11,
+            registry=registry,
+        )
+    assert exc.value.code is N12FT01Code.MISSING_CLEARANCE
+    # No anchor dispatched + the new alg was NEVER registered (denied at gate 1).
+    assert dispatcher.sequence_length(AuditTier.RECOVERY.value) == 0
+    assert registry.live_algs(vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION) == (
+        _ALG_V1,
+    )
+
+
+@pytest.mark.regression
+def test_recommit_uncovered_domain_denied_missing_clearance():
+    """recommit — a vault:backup holder whose domain does NOT cover the vault's
+    domain is DENIED (CL-02a(b), domain axis)."""
+    identity, verifier, signer = _build_signer()
+    dispatcher = AuditDispatcher.for_named_tiers(verifier)
+    registry = CommitmentRegistry()
+    c_x = _seed_v1(registry)
+
+    with pytest.raises(VaultBindingError) as exc:
+        recommit_vault_kek(
+            _handle(),
+            # Right tenant, but a SIBLING domain that does not cover domain-A.
+            _clearance("vault:backup", domain="domain-B"),
+            resolver=_Resolver(),  # vault domain is domain-A
+            dispatcher=dispatcher,
+            signer=signer,
+            signer_identity=identity,
+            alg_id=_ALG_V1,
+            prior_kek_commitment_alg=_ALG_V1,
+            prior_kek_identity_commitment=c_x,
+            new_kek_commitment_alg=_ALG_V11,
+            registry=registry,
+        )
+    assert exc.value.code is N12FT01Code.MISSING_CLEARANCE
+    assert dispatcher.sequence_length(AuditTier.RECOVERY.value) == 0
+    assert registry.live_algs(vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION) == (
+        _ALG_V1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CL-02a — retire tenant/domain scoping (the #630 gap, retire surface)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_retire_wrong_tenant_denied_even_with_live_recoverability_sibling():
+    """retire — a vault:retire-alg holder in tenant/domain A is DENIED against a
+    vault in tenant/domain B even with a live recoverability sibling alg present.
+
+    The recoverability-preserved gate (step 4) is SATISFIABLE (a live eatp-v1.1
+    sibling exists), so the only thing denying the retire is the CL-02a
+    tenant/domain scoping at gate 1. Pre-fix (capability-PRESENCE only) the
+    retire was authorized regardless of tenant/domain.
+    """
+    identity, verifier, signer = _build_signer()
+    dispatcher = AuditDispatcher.for_named_tiers(verifier)
+    registry = CommitmentRegistry()
+    c_x = _seed_v1(registry)
+    _seed_v11(registry)  # live recoverability sibling — guard would PASS
+
+    with pytest.raises(VaultBindingError) as exc:
+        retire_vault_kek_alg(
+            _handle(),
+            # Holder in tenant/domain B; the vault is tenant/domain A.
+            _clearance("vault:retire-alg", tenant="tenant-B", domain="domain-B"),
+            resolver=_Resolver(),  # vault is tenant-A / domain-A
+            dispatcher=dispatcher,
+            signer=signer,
+            signer_identity=identity,
+            alg_id=_ALG_V1,
+            retired_kek_commitment_alg=_ALG_V1,
+            retired_kek_identity_commitment=c_x,
+            registry=registry,
+        )
+    assert exc.value.code is N12FT01Code.MISSING_CLEARANCE
+    # No anchor dispatched; BOTH algs stay live (retire denied at gate 1).
+    assert dispatcher.sequence_length(AuditTier.RECOVERY.value) == 0
+    assert set(
+        registry.live_algs(vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION)
+    ) == {_ALG_V1, _ALG_V11}
+
+
+# ---------------------------------------------------------------------------
+# CL-04 — recommit cooling-off suspension (vault:backup IS suspended)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_recommit_cooling_off_suspends_principal_in_window(posture_store):
+    """recommit — a principal inside the 7-day post-recovery window is SUSPENDED.
+
+    vault:backup IS in COOLING_OFF_SUSPENDED_CAPABILITIES, so a recommit by a
+    principal whose cooling-off receipt is present (and inside the window per the
+    trust-anchored clock) is denied missing-clearance when no approver is
+    configured. Pre-fix the cooling-off check never ran on the recommit surface.
+    """
+    identity, verifier, signer = _build_signer()
+    dispatcher = AuditDispatcher.for_named_tiers(verifier)
+    registry = CommitmentRegistry()
+    c_x = _seed_v1(registry)
+
+    # Fire the RT-05 D6 trigger with an INJECTED trust-anchored start (records
+    # the cooling-off receipt the CL-04 gate reads) for our principal.
+    start = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    trigger_d6_posture_downgrade(
+        posture_store, principal=_PRINCIPAL, forced_stale=False, now=start
+    )
+
+    # A recommit 3 days into the window (trust-anchored now), same principal.
+    now_in_window = start + timedelta(days=3)
+    with pytest.raises(VaultBindingError) as exc:
+        recommit_vault_kek(
+            _handle(),
+            _clearance("vault:backup"),  # correct tenant/domain
+            resolver=_Resolver(),
+            dispatcher=dispatcher,
+            signer=signer,
+            signer_identity=identity,
+            alg_id=_ALG_V1,
+            prior_kek_commitment_alg=_ALG_V1,
+            prior_kek_identity_commitment=c_x,
+            new_kek_commitment_alg=_ALG_V11,
+            registry=registry,
+            posture_store=posture_store,
+            trust_anchored_now=now_in_window,
+        )
+    assert exc.value.code is N12FT01Code.MISSING_CLEARANCE
+    # Suspended before any anchor / registry mutation.
+    assert dispatcher.sequence_length(AuditTier.RECOVERY.value) == 0
+    assert registry.live_algs(vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION) == (
+        _ALG_V1,
+    )
+
+
+@pytest.mark.regression
+def test_vault_backup_is_a_cooling_off_suspended_capability():
+    """Structural invariant — vault:backup IS suspended, vault:retire-alg is NOT.
+
+    Pins the membership the two cooling-off regression tests depend on. If the
+    suspended set ever changes, this fails loudly and forces a re-audit of the
+    recommit (suspended) vs retire (no-op) cooling-off behavior.
+    """
+    assert "vault:backup" in COOLING_OFF_SUSPENDED_CAPABILITIES
+    assert "vault:retire-alg" not in COOLING_OFF_SUSPENDED_CAPABILITIES
+
+
+# ---------------------------------------------------------------------------
+# CL-04 — retire cooling-off NO-OP (vault:retire-alg is NOT suspended)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_retire_cooling_off_is_a_noop_principal_in_window_still_passes(posture_store):
+    """retire — a principal inside the window is NOT suspended for retire.
+
+    vault:retire-alg is NOT in COOLING_OFF_SUSPENDED_CAPABILITIES, so the CL-04
+    cooling-off is a structural no-op: a principal with a present cooling-off
+    receipt (inside the window) still passes the retire clearance gate. This
+    proves the SPEC-FAITHFUL no-op — we do NOT force-suspend retire — and the
+    retire completes (a live eatp-v1.1 sibling satisfies recoverability).
+
+    Pre-fix this test ALSO passed (the gate was capability-only, so cooling-off
+    never ran for retire either) — but it now passes for the RIGHT reason: the
+    full clearance gate runs and correctly declines to suspend a non-suspended
+    capability. It is the paired counterpart to the recommit-suspended test:
+    together they prove the suspended-set membership drives behavior.
+    """
+    identity, verifier, signer = _build_signer()
+    dispatcher = AuditDispatcher.for_named_tiers(verifier)
+    registry = CommitmentRegistry()
+    c_x = _seed_v1(registry)
+    _seed_v11(registry)  # live recoverability sibling so the retire can complete
+
+    # Same principal, same in-window cooling-off receipt as the recommit test.
+    start = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    trigger_d6_posture_downgrade(
+        posture_store, principal=_PRINCIPAL, forced_stale=False, now=start
+    )
+    now_in_window = start + timedelta(days=3)
+
+    # The retire PASSES the clearance gate (no suspension) and completes.
+    retired_entry = retire_vault_kek_alg(
+        _handle(),
+        _clearance("vault:retire-alg"),  # correct tenant/domain
+        resolver=_Resolver(),
+        dispatcher=dispatcher,
+        signer=signer,
+        signer_identity=identity,
+        alg_id=_ALG_V1,
+        retired_kek_commitment_alg=_ALG_V1,
+        retired_kek_identity_commitment=c_x,
+        registry=registry,
+        posture_store=posture_store,
+        trust_anchored_now=now_in_window,
+    )
+    assert retired_entry.retired is True
+    # eatp-v1 retired; eatp-v1.1 remains the live recoverability sibling.
+    assert registry.live_algs(vault_id=_VAULT_ID, kek_generation=_KEK_GENERATION) == (
+        _ALG_V11,
+    )
+    # A vault_kek_retire anchor DID land (the retire was authorized).
+    rec = dispatcher._engines[AuditTier.RECOVERY.value].entries
+    assert any(e.event_payload["subtype"] == "vault_kek_retire" for e in rec)

--- a/tests/regression/test_redteam_trustplane_round2.py
+++ b/tests/regression/test_redteam_trustplane_round2.py
@@ -18,11 +18,16 @@ pre-fix code and passes against the fix.
 | EA-01      | trust.enforce.proximity             | NaN/Inf usage bypassed proximity escalation             |
 | RS-03      | trust.revocation.broadcaster        | async-subscriber exceptions bypassed dead-letter queue  |
 
-The remaining three findings (RS-02 rotation "atomic" over-claim, vault retire/
-recommit gate-label over-claim, PGC-03 context.py None-envelope doc
-contradiction) are documentation-accuracy corrections with NO behavioral
-delta — they are covered by the unchanged-behavior existing suites plus the
-corrected docstrings, so they carry no behavioral regression test here.
+Of the remaining three findings, two (RS-02 rotation "atomic" over-claim, PGC-03
+context.py None-envelope doc contradiction) are documentation-accuracy
+corrections with NO behavioral delta — covered by the unchanged-behavior existing
+suites plus the corrected docstrings, so they carry no behavioral regression test
+here. The third (the vault retire/recommit "clearance-tenant-domain" gate-label
+over-claim) was a docs-only correction AT 2.42.0, but was SUBSEQUENTLY CLOSED
+behaviorally by F-VAULT-630 — which wires the full CL-02a tenant/domain + CL-04
+cooling-off ``evaluate_clearance`` gate into both surfaces, so the gate label is
+now accurate by behavior rather than by walked-back docstring. Its behavioral
+coverage lives in ``tests/regression/test_eatp12_vault_630_clearance_wiring.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Wires the binding-owned **CL-02a tenant/domain scoping** + **CL-04 cooling-off suspension** (the existing `kailash.trust.vault.clearance.evaluate_clearance` gate) into the two vault KEK-commitment registry-mutating operations — `recommit_vault_kek` and `retire_vault_kek_alg`. Their gate-1 (named `clearance-tenant-domain`) previously enforced capability **PRESENCE only**; the tenant/domain + cooling-off scoping the gate name advertised was deferred (the #630 SLIP-0039 vault-binding follow-up's gate-scoping sub-part, flagged capability-only in the 2.42.0 deploy record). Mirrors the proven `backup`/`restore`/`rotation` sibling pattern.

## Breaking change (minor bump 2.42.0 → 2.43.0)

`retire_vault_kek_alg` gains a **required** keyword-only `resolver: VaultKeyResolver` — the only trusted source of the vault's tenant/domain (`VaultKeyHandle` carries none), making it symmetric with `recommit_vault_kek`. **Migration:** pass `resolver=<your VaultKeyResolver>`. A cross-tenant / domain-uncovered retire/recommit that previously resolved to ALLOW now resolves to DENY (`missing-clearance`); same-tenant / covered-domain operations are unaffected. (Same minor-bump-with-BREAKING convention 2.42.0 used for the PGC-01 NDA change.)

## What changed

- **`recommit_vault_kek`** — gate-1 now runs `evaluate_clearance(..., "vault:backup", ...)`; new optional `posture_store` / `trust_anchored_now` / `approver_configured` thread CL-04 cooling-off (vault:backup IS a suspended capability). Backwards-compatible signature.
- **`retire_vault_kek_alg`** — grows the required `resolver`; resolves + `zeroize()`s in a `finally` (N12-IN-05 — the secret is materialized only to read trusted tenant/domain and crosses no return value, anchor payload, or log line); gate-1 runs `evaluate_clearance(..., "vault:retire-alg", ...)`. CL-04 is a spec-faithful **no-op** (vault:retire-alg is not a suspended capability).
- **`errors.py`** — `RECOMMIT_GATE_ORDER` / `RETIRE_GATE_ORDER` gate-1 comments updated to describe the wired gate (the gate-order tuples are byte-identical).
- AU-02b audit-before-mutation ordering + the recoverability-preserved guard are **unchanged**.

## Tests

- **New** `tests/regression/test_eatp12_vault_630_clearance_wiring.py` — 6 Tier-2 behavioral regression tests (real `CommitmentRegistry` + Ed25519 `AuditDispatcher` + real `SQLitePostureStore` + a Protocol-satisfying deterministic resolver — no mocks): cross-tenant + uncovered-domain denial (recommit + retire), recommit cooling-off suspension, retire cooling-off no-op, and a suspended-set structural invariant. Each deny test asserts deny-**before**-mutation (zero anchor dispatched + unchanged `live_algs`). A `git stash` prove-fail confirmed each fails against the pre-fix capability-only gate.
- `tests/integration/test_eatp12_vault_recommit_retire_wiring.py` — retire call sites threaded with `resolver=`.
- `tests/regression/test_redteam_trustplane_round2.py` — docstring updated to record this behavioral closure.
- Targeted suite: **45 passed**; broader `-k eatp12_vault`: **199 passed**.

## Redteam convergence

3 evidence-gated rounds (reviewer + security-reviewer + spec/closure-parity, dispatched sequentially with an evidence gate so an errored/empty agent can never read as clean). Code clean across **all** rounds; the only findings were two progressively-discovered stale gate-label claims (test docstring → `errors.py` gate-order comments), both fixed + exhaustively swept. Round 3 **clean across all 3 lenses**.

## Related issues

Closes the **CL-02a/CL-04 clearance-gate-scoping sub-part** of the #630 SLIP-0039 vault-binding follow-up (the deferral the 2.42.0 deploy record flagged as capability-only). The **separate** §3.4 KEK re-establishment / encryption-hierarchy gap (also tagged #630) is unchanged. Issue #630 itself is already closed; referenced descriptively, not via an auto-close keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)