### PR TITLE
docs(deploy): record kailash 2.43.0 release (F-VAULT-630 vault clearance-gate wiring)

### DIFF
--- a/deploy/deployments/2026-06-20-v2.43.0-vault-630-clearance-retire-recommit.md
+++ b/deploy/deployments/2026-06-20-v2.43.0-vault-630-clearance-retire-recommit.md
@@ -1,0 +1,133 @@
+# Deployment Record — kailash 2.43.0 (2026-06-20)
+
+Single-package core minor `kailash 2.42.0 → 2.43.0` closing the deferred **CL-02a
+tenant/domain + CL-04 cooling-off clearance-gate wiring** for the two vault
+KEK-commitment registry-mutating operations (`recommit_vault_kek` /
+`retire_vault_kek_alg`) — the gate-scoping sub-part of the #630 SLIP-0039
+vault-binding follow-up that the 2.42.0 deploy record flagged as
+capability-presence-only on these two surfaces. One BREAKING signature change
+(`retire_vault_kek_alg` gains a required `resolver`) — hence the minor bump.
+
+## What shipped
+
+`recommit_vault_kek` (N12-CB-04(c)) and `retire_vault_kek_alg` (N12-CB-04(e))
+gate-1 — named `clearance-tenant-domain` — previously enforced capability
+**PRESENCE only**; the tenant/domain (N12-CL-02a) + cooling-off (N12-CL-04)
+scoping the gate name advertised was deferred (#630). This wires the existing
+`kailash.trust.vault.clearance.evaluate_clearance` gate into both, mirroring the
+proven `backup`/`restore`/`rotation` sibling pattern (cheap presence pre-check →
+resolve → full `evaluate_clearance`; the first-failing `except VaultBindingError
+as exc: return exc.code` translation preserves N12-FT-03 cross-SDK determinism —
+`missing-clearance` stays the first code).
+
+### Changed (BREAKING)
+
+- **`retire_vault_kek_alg` requires a `resolver` + enforces CL-02a tenant/domain**
+  (`kailash.trust.vault.registry_ops`). The retire gate now runs
+  `evaluate_clearance(..., "vault:retire-alg", ...)` against the vault's RESOLVED
+  tenant/domain. Because `VaultKeyHandle` carries no tenant/domain, retire grows a
+  REQUIRED keyword-only `resolver: VaultKeyResolver` (the only trusted source,
+  symmetric with `recommit_vault_kek`). The KEK is materialized solely to read the
+  trusted tenant/domain and is `zeroize()`-d in a `finally` (N12-IN-05) — it
+  crosses no return value, anchor payload, or log line. **Migration:** pass
+  `resolver=<your VaultKeyResolver>`; a cross-tenant or domain-uncovered retire
+  that previously resolved to ALLOW now resolves to DENY (`missing-clearance`).
+
+### Security
+
+- **recommit + retire enforce tenant/domain isolation; recommit honors cooling-off**
+  (`kailash.trust.vault.registry_ops`). Closes the gap where a `vault:backup`
+  (recommit) / `vault:retire-alg` (retire) token granted in tenant/domain A could
+  mutate a vault's commitment registry in tenant/domain B. `recommit_vault_kek`
+  additionally honors the N12-CL-04 7-day post-recovery cooling-off suspension
+  (it rides `vault:backup`, a cooling-off-suspended capability) via new optional
+  `posture_store` / `trust_anchored_now` / `approver_configured` parameters (absent
+  → no cooling-off check, the documented no-receipt default);
+  `retire_vault_kek_alg` is a spec-faithful cooling-off **no-op** (`vault:retire-alg`
+  is not a suspended capability). The AU-02b audit-before-mutation ordering and the
+  recoverability-preserved guard are unchanged.
+
+## Convergence
+
+3 evidence-gated redteam rounds (reviewer + security-reviewer + spec/closure-parity,
+dispatched **sequentially** under rate-limit back-off with a load-bearing `ran`
+evidence gate — an errored/empty agent never counts as a clean verdict). Code clean
+across **all** rounds; the only findings were two progressively-discovered stale
+gate-label claims (the loop-until-dry surfaced each successive sibling):
+
+- **R1** — a test-docstring "docs-only, NO behavioral delta" claim in
+  `tests/regression/test_redteam_trustplane_round2.py` (the 2.42.0 RS-02 disposition,
+  now false). Fixed.
+- **R2** — the `RECOMMIT_GATE_ORDER` / `RETIRE_GATE_ORDER` gate-1 comments in
+  `errors.py` still reading "capability presence ONLY … NOT wired here — deferred,
+  C3 #630" (the gate-order definition site; a sibling-site miss of the R1 fix).
+  Fixed + exhaustively swept (zero remaining clearance-gate stale claims; the §3.4
+  re-establishment `#630` refs are a separate, accurate gap).
+- **R3** — CLEAN across all 3 lenses.
+
+The understand workflow + the first R1 dispatch each hit a server-side rate-limit /
+session-limit producing errored agents → the evidence gate caught them as
+**zero-evidence** (never read as "0 findings"); re-run on a fresh account /
+sequentially.
+
+## Receipts
+
+- Feature PR #1408 (`feat/vault-630-clearance-retire-recommit`, merge `6f640cad8`,
+  commit `3e6bb95de`) — 8 files, +778/-154: `registry_ops.py` (wiring) +
+  `errors.py` (gate-order comments) + the two modified tests + the new regression
+  file + version + CHANGELOG. pre-commit GREEN (incl. Tier-1; one
+  `python-use-type-annotations` false positive on `# typed error` reworded to
+  `# VaultBindingError` per `git.md` pygrep-matcher guidance).
+- Tests: NEW `tests/regression/test_eatp12_vault_630_clearance_wiring.py` — 6 Tier-2
+  behavioral regression tests (real `CommitmentRegistry` + Ed25519 `AuditDispatcher`
+  - real `SQLitePostureStore` + a Protocol-satisfying deterministic resolver, no
+    mocks): cross-tenant + uncovered-domain denial (recommit + retire), recommit
+    cooling-off suspension, retire cooling-off no-op, suspended-set structural
+    invariant; each deny test asserts deny-**before**-mutation (zero anchor dispatched
+  - unchanged `live_algs`). A `git stash` prove-fail confirmed each fails against the
+    pre-fix capability-only gate. Targeted suite 45 passed; broader `-k eatp12_vault`
+    199 passed.
+- CI: full PR-gate matrix GREEN (Python 3.11–3.14 ubuntu+windows, Trust Unit, Test
+  PACT, DataFlow Tier 1, build, test-with-infrastructure, CodeQL, Analyze, Smoke).
+  The red `build` check (run `27861053682`) was a `cancel-in-progress` cancellation
+  of the duplicate push-event run (`conclusion: cancelled, event: push`), not a
+  failure.
+- TestPyPI validation (minor-release discipline): `workflow_dispatch`
+  `publish_to=testpypi` run `27862613888` SUCCESS → clean-venv verify (version
+  2.43.0 + retire `resolver` required-kw-only + recommit opt params +
+  suspended-set membership).
+- Production: tag `v2.43.0` (→ `6f640cad8`) → publish-pypi run `27862718235`
+  SUCCESS (Build → Publish-to-PyPI → Create-GitHub-Release); `pypi.org` returns
+  wheel + sdist. Clean-venv install verified live (`pip --no-cache-dir`, attempt 2
+  after index lag): `kailash.__version__ == "2.43.0"` + retire `resolver`
+  KEYWORD_ONLY required + recommit opt params + CL-04 suspended-set
+  (`vault:backup` ∈, `vault:retire-alg` ∉).
+
+## Sibling drift
+
+None. All 8 sub-packages AT-PARITY with PyPI: kailash-dataflow 2.12.0 /
+kailash-nexus 2.11.0 / kailash-kaizen 2.28.0 / kailash-mcp 0.2.15 / kailash-ml
+2.2.1 / kailash-align 0.7.2 / kailash-pact 0.14.0 / kaizen-agents 0.9.11. This
+release touched no `packages/*/src/` (core-only `src/kailash/trust/vault/`); no
+sub-package pin bump needed.
+
+## Cross-SDK
+
+The shared trust-plane (`src/kailash/trust/vault/`) means the kailash-rs sibling
+may carry the same #630 clearance-gate-scoping gap (recommit/retire
+capability-presence-only). SURFACED as a candidate EATP-D6 cross-SDK parity item
+for the operator's human-gated scrubbed filing decision (NOT auto-filed;
+`repo-scope-discipline.md` + `upstream-issue-hygiene.md`). The separate §3.4 KEK
+re-establishment / encryption-hierarchy gap (also tagged #630) is unchanged in both
+SDKs.
+
+## Outstanding ledger
+
+- **F-VAULT-630 — CLOSED** (this release). Was the prior session's recommended next
+  pick; value-anchored to `project_trustplane_day1_complete` ("no deferring gaps").
+- F-XSDK-TRUST-R2 / F-XSDK-PACT / F7 / F4 — kailash-rs cross-SDK parity items remain
+  human-gated (cross-repo; not actionable in this BUILD repo).
+- F-ATOMIC (true cross-store atomic cascade invalidation) — still deferred.
+- F-VAULT-630's §3.4 KEK re-establishment / encryption-hierarchy sibling — a
+  separate, larger architectural gap (the SDK ships a `VaultKeyResolver` Protocol,
+  not a built-in KEK-resolution hierarchy); unchanged, documented in code.


### PR DESCRIPTION
Deployment record for the `kailash 2.42.0 → 2.43.0` minor release (F-VAULT-630 — wiring CL-02a tenant/domain + CL-04 cooling-off into the vault `recommit_vault_kek` / `retire_vault_kek_alg` registry-mutating gates).

Docs-only (the deploy record is not packaged — build-repo-release-discipline §1a carve-out; no `/release` needed). Records: what shipped, the BREAKING retire `resolver` signature, 3-round evidence-gated redteam convergence, full PR-gate CI, TestPyPI + PyPI receipts (runs `27862613888` + `27862718235`), live clean-venv install verification, sibling-drift (none — all 8 sub-packages at PyPI parity), and the human-gated cross-SDK surfacing for kailash-rs.

## Related issues

Documents the release that closed the CL-02a/CL-04 clearance-gate-scoping sub-part of the #630 SLIP-0039 vault-binding follow-up (code in PR #1408, merge `6f640cad8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)