### PR TITLE
chore(release): kailash 2.43.1 — cross-SDK canonical conformance + NaN/Inf sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.43.1] - 2026-06-21
+
+Cross-SDK canonical-encoder conformance plus a trust-plane-wide NaN/Inf signing
+pre-image sweep. Brings Python's audit-chain canonical hash into lockstep with the
+Rust SDK (kailash-rs v4.12.0, rs#1448) and closes an RFC-8259 cross-SDK
+re-verification hazard at every trust-plane signing/hash pre-image (PR #1411, #1412).
+
+### Changed
+
+- **BREAKING (audit-chain byte-shape) — audit-chain canonical hash now uses fixed
+  6-digit microseconds for cross-SDK conformance** (`kailash.trust` audit-chain
+  canonical encoder; issue #1400 via PR #1411). The Python audit-chain canonical
+  pre-image now matches the Rust SDK (kailash-rs v4.12.0) so a Python-anchored audit
+  chain re-verifies under Rust `serde_json` and vice-versa. **Migration:** audit
+  anchors created under ≤2.43.0 whose timestamps differ in microsecond representation
+  (e.g. whole-second timestamps, previously emitted without a trailing `.000000`)
+  recompute to a different integrity hash under 2.43.1 — re-anchor persisted chains
+  after upgrade. This is a byte-shape change to the canonical pre-image, not a
+  public-API change.
+
+### Security
+
+- **Reject NaN/Inf at every trust-plane signing / hash / cross-SDK pre-image**
+  (`allow_nan=False`; PR #1411, #1412). A `json.dumps` over a signing or
+  integrity-hash pre-image that omitted `allow_nan=False` emitted RFC-8259-invalid
+  `NaN` / `Infinity` literals: Python signs and hashes them, but a strict cross-SDK
+  parser (Rust `serde_json`) rejects them, so a Python-signed artifact whose
+  pre-image carried a non-finite float could not be re-verified cross-SDK. Every
+  pre-image now rejects NaN/Inf at serialization (fail-closed), and the change is
+  byte-neutral on all finite input. Covers: envelope HMAC, audit-chain Merkle digest,
+  selective-disclosure witness export/verify, A2A JWT, interop tokens
+  (Biscuit / SD-JWT / UCAN), delegation execution-context state hash,
+  multi-signature, verification-bundle + archive integrity, PACT SQLite audit/policy,
+  and the cross-SDK delegate-conformance digest. A durable AST-invariant regression
+  guard now locks every signing/hash pre-image module to carry `allow_nan=False`.
+
 ## [2.43.0] - 2026-06-20
 
 Wires the binding-owned CL-02a tenant/domain scoping and CL-04 cooling-off

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.43.0"
+version = "2.43.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.43.0"
+__version__ = "2.43.1"
 
 __all__ = [
     # Core workflow components

--- a/workspaces/cross-sdk-audit/journal/0016-DECISION-cross-repo-authorized-kailash-rs-1448-release-state-verify.md
+++ b/workspaces/cross-sdk-audit/journal/0016-DECISION-cross-repo-authorized-kailash-rs-1448-release-state-verify.md
@@ -1,0 +1,50 @@
+# DECISION — Cross-repo authorization: verify kailash-rs #1448 RELEASE state (py 2.43.1 lockstep gate)
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+- **Requester:** the user (technical leader, manages both SDK teams), genuine user turn.
+- **Target repo:** `esperie-enterprise/kailash-rs` (private; Rust SDK sibling BUILD repo —
+  NOT `terrene-foundation/kailash-rs`, per the standing reference correction).
+- **Timestamp:** 2026-06-21T10:47:28Z
+- **Verbatim instruction:** "approved" — approving the prior message's two-part request:
+  (a) explicit authorization to verify rs#1448's release state on `esperie-enterprise/kailash-rs`,
+  and (b) confirmation to proceed with the py 2.43.1 PyPI publish of the NaN/Inf sweep.
+- **Bounded action authorized (READ-ONLY against kailash-rs; ALL py-side writes are in-repo):**
+  1. READ rs#1448 issue + its closing PR state
+     (`gh issue view 1448 --repo esperie-enterprise/kailash-rs`; the closing PR rs#1450 per 0014).
+  2. READ kailash-rs RELEASE state (`gh release list/view --repo esperie-enterprise/kailash-rs`)
+     to determine whether the #1448 audit-chain-canonical content has been cut into a released
+     crate version — the py 2.43.1 lockstep gate (does py ship the cross-SDK-conformance content
+     ahead of rs, or is rs already released?).
+- **Scope fence (condition 5):** ONLY the reads above against the named repo — rs#1448 issue/PR
+  state + rs release-list/version state. NO broad rs source spidering, NO writes/PRs/comments
+  against kailash-rs. py-side edits (version bump, CHANGELOG, journal amendment) are in-repo and
+  ride the `release/v2.43.1` PR. Any rs read beyond #1448 + release state requires its own
+  authorization + receipt.
+- **Context:** Follows journal/0014 (rs#1448 audit-chain LANDED + 0-divergence verified;
+  closing PR rs#1450 MERGED 2026-06-20T11:40:42Z) + 0015 (PR #1411 converged). PR #1412
+  (trust-plane-wide NaN/Inf sweep) MERGED 2026-06-21 (py merge `b2f265ce8`); its surfaces are
+  OUTSIDE Family-B (byte-neutral, no pinned cross-SDK vector changed — needs no rs lockstep per
+  the convergence redteam). This authorization confirms the rs RELEASE state (not merely landed)
+  before the irreversible py 2.43.1 PyPI publish.
+
+---
+
+## OUTCOME (verify, 2026-06-21)
+
+Read scope honored: only rs#1448 issue state, the rs release list, and rs release `v4.12.0`
+notes (to confirm #1448 inclusion). No broad rs source spidering; no writes against kailash-rs.
+
+### rs#1448 — RELEASED (lockstep gate CLEARED)
+
+- rs#1448 **CLOSED/COMPLETED** 2026-06-20T11:40:43Z (closing PR rs#1450, per journal/0014).
+- kailash-rs releases since: **v4.12.0** (2026-06-20T17:43:51Z), v4.12.1 (2026-06-21T08:53:00Z).
+  v4.11.0 (06-20T10:08Z) predates the #1448 close, so the first release CARRYING #1448 is v4.12.0.
+- rs **v4.12.0** release notes confirm it verbatim: _"fix(audit): align audit-chain canonical
+  timestamp to fixed 6-digit microseconds (#1448, cross-SDK lockstep) … PR #1450"_.
+- **Disposition:** rs has already RELEASED the #1448 audit-chain-canonical content (v4.12.0+).
+  py 2.43.1 (audit-chain re-pin from #1411 + the trust-plane-wide NaN/Inf sweep from #1412)
+  therefore FOLLOWS rs — it does not ship cross-SDK-conformance content ahead of the Rust SDK.
+  The #1412 NaN/Inf surfaces are additionally out-of-Family-B / byte-neutral / need no rs
+  lockstep at all (per the convergence redteam, run `wf_157fb9c6-3e8`). **py 2.43.1 is clear
+  to release.**

--- a/workspaces/cross-sdk-audit/journal/0017-DECISION-naninf-bug-class-closure-convergence-and-2.43.1-release.md
+++ b/workspaces/cross-sdk-audit/journal/0017-DECISION-naninf-bug-class-closure-convergence-and-2.43.1-release.md
@@ -1,0 +1,69 @@
+# DECISION — NaN/Inf signing-pre-image bug class CLOSED + convergence receipt + 2.43.1 release
+
+relates_to: 0015 (PR #1411 convergence), 0016 (rs#1448 release-state verify)
+
+## What closed
+
+The trust-plane-WIDE **NaN/Inf-in-signing-pre-image** bug class is fully closed and
+on `main`. A `json.dumps` over a signing / integrity-hash pre-image that omitted
+`allow_nan=False` emitted RFC-8259-invalid `NaN` / `Infinity` literals — Python
+signs/hashes them, a strict cross-SDK parser (Rust `serde_json`) rejects them, so a
+Python-signed artifact whose pre-image carried a non-finite float could not be
+re-verified cross-SDK. The sweep added `allow_nan=False` at EVERY signing/hash/
+cross-SDK pre-image (byte-neutral on all finite input).
+
+- **PR #1412** (`fix/witness-family-nan-inf-allow-nan`, 6 commits f888ee65e..ece16e9dd
+  - pin test 5c9abdf51) — MERGED 2026-06-21, merge commit **`b2f265ce8`**. Extends the
+    PR #1411 envelope/audit-chain NaN/Inf start to the full trust plane + PACT + the
+    cross-SDK delegate-conformance digest.
+- **Durable guard:** `tests/regression/test_trust_signing_preimage_rejects_nan_inf.py`
+  — a module-granularity AST invariant (`test_trust_plane_signing_preimages_all_carry_allow_nan`)
+  over roots `src/kailash/trust`, `packages/kailash-pact/src`, `src/kailash/delegate/conformance`,
+  plus behavioral tests. EXCLUDED-by-design (encoded in the guard): `pact/audit.py`
+  legacy/prefix forensic byte-reproducers + `enforce/decorators.py` `_hash_*` local
+  memoization caches.
+
+## Convergence receipt (the gate before merge)
+
+A final convergence `/redteam` ran on current HEAD (post-delegate-fix) as a Workflow —
+**run `wf_157fb9c6-3e8`**, output `tasks/w75gk4ivy.output`. Three independent lenses per
+round (exhaustive multi-site sweep / fix-adversarial / byte-neutral full-suite), evidence-
+gated with serial fallback on this machine's rate-limit throttle.
+
+- **Result: CONVERGED — 2 consecutive clean rounds**, all 6 lens-agents ran with verbatim
+  command evidence, 0 CRIT/HIGH/MED.
+- Independent AST sweep (149 `json.dumps` across trust + pact + delegate + diagnostics)
+  found EXACTLY the 4 documented EXCLUDED sites — **no missed sibling**. The guard's
+  cross-file blind spot was manually traced: every central canonical helper
+  (`_json.canonical_json_dumps`, `pact.conformance.vectors.canonical_json_dumps`,
+  `diagnostics._canonical_json`, `crypto.serialize_for_signing`) carries `allow_nan=False`.
+- The prior-round blocking **MED** (`delegate/conformance/schema.py:448 _canonical_json_bytes`)
+  verified CLOSED (allow_nan added + guard root extended + behavioral test).
+
+## LOW disposition (the only residual)
+
+`verify_witness_export` raises an uncaught `ValueError` (rather than returning `valid=False`)
+on a **hand-forged** NaN-bearing `ExportPackage`. This is **fail-closed** (verify can never
+return `valid=True` for it) and unreachable via any legitimate or cross-SDK flow (the
+producer + Rust `serde_json` both reject NaN). Disposition: **pinned the intended fail-closed
+contract with a behavioral regression test** (`test_verify_witness_export_rejects_nan_inf_fail_closed`,
+commit `5c9abdf51`) — NOT wrapped to return a verdict (a forged adversarial input deserves a
+loud raise). This also filled the witness-family behavioral coverage gap (the family the
+sweep originated from, f888ee65e).
+
+## Release — 2.43.1 (core kailash)
+
+- **Lockstep gate CLEARED** (journal/0016): rs#1448 RELEASED in kailash-rs **v4.12.0**
+  (2026-06-20). py 2.43.1 FOLLOWS rs; the #1412 NaN/Inf surfaces are additionally
+  out-of-Family-B / byte-neutral / need no rs lockstep.
+- **Version:** 2.43.0 → **2.43.1** (patch; per project convention behavior/conformance
+  fixes ship as patch, minor reserved for API-signature breaks). Combined release ships
+  PR #1411 (audit-chain canonical 6-digit conformance — byte-CHANGING, see CHANGELOG
+  migration note) + PR #1412 (NaN/Inf sweep — byte-neutral).
+- **Scope:** core kailash only. Sibling-drift enumeration clean (all other packages
+  main == PyPI). Residual: a 1-line byte-neutral `allow_nan` hardening to
+  `packages/kailash-pact/src/pact/conformance/vectors.py` is stranded (pact main == PyPI
+  0.14.0) — a Rule-5 gap from #1412; surfaced for a separate kailash-pact 0.14.1 decision.
+
+Human gates honored: convergence + CI-green preceded merge (approval ≠ convergence bypass);
+the merge and the 2.43.1 publish were each explicitly user-authorized this session.


### PR DESCRIPTION
Release-prep for **kailash 2.43.1** (metadata-only: version anchors + CHANGELOG + release journal; `release/v*` branch auto-skips the PR-gate matrix).

Ships two already-merged, CI-green workstreams to PyPI:
- **PR #1411** — audit-chain canonical 6-digit microseconds (issue #1400). **Byte-changing**: aligns the Python audit-chain canonical pre-image to kailash-rs v4.12.0 (rs#1448). CHANGELOG carries the persisted-chain re-anchor migration note.
- **PR #1412** — trust-plane-wide NaN/Inf signing-pre-image sweep. Byte-neutral on finite input.

Lockstep rs#1448 RELEASE-state confirmed at kailash-rs v4.12.0 (workspaces/cross-sdk-audit/journal/0016). Convergence receipt: workflow `wf_157fb9c6-3e8` — 2 consecutive clean redteam rounds (journal/0017).

## Related issues
Ships #1400, #1411, #1412.