### PR TITLE
chore(release): kailash-pact 0.14.1 — reject NaN/Inf in conformance canonical encoder

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,16 @@
 # PACT Changelog
 
+## [0.14.1] — 2026-06-21 — fix: reject NaN/Inf in the conformance canonical encoder (#1412)
+
+### Security
+
+- `pact.conformance.vectors.canonical_json_dumps` now rejects RFC-8259-invalid
+  `NaN` / `Infinity` (`allow_nan=False`), so a PACT conformance vector generated
+  with a non-finite float fails closed at serialization instead of emitting
+  invalid JSON a strict cross-SDK parser (Rust `serde_json`) cannot re-parse.
+  Byte-neutral on all finite input. Part of the trust-plane-wide NaN/Inf
+  signing/hash pre-image sweep (kailash 2.43.1, PR #1412).
+
 ## [0.14.0] — 2026-06-19 — feat: apply YAML governance specs to the runtime engine (#1386)
 
 ### Added

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.14.0"
+version = "0.14.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (


### PR DESCRIPTION
Release-prep for **kailash-pact 0.14.1** (metadata-only: version anchors + CHANGELOG; `release/*` branch auto-skips the PR-gate matrix).

Ships the stranded 1-line `allow_nan=False` hardening to `pact.conformance.vectors.canonical_json_dumps` that landed in main via PR #1412 (the trust-plane-wide NaN/Inf sweep) without a kailash-pact version bump. Byte-neutral on finite input; closes the build-repo-release-discipline Rule-5 gap so the fix reaches kailash-pact consumers.

## Related issues
Ships the kailash-pact fragment of #1412.