### PR TITLE
fix(async-sql)!: remove non-functional FetchMode.ITERATOR; reject unknown fetch modes

### DIFF
--- a/STUB-MARKER-INVENTORY.md
+++ b/STUB-MARKER-INVENTORY.md
@@ -47,13 +47,13 @@ Scoped to the `kailash` core and categorised, the real picture is:
 
 | Metric                                                  | Count |
 | ------------------------------------------------------- | ----- |
-| Files with ≥1 marker (`src/kailash`)                    | 39    |
-| Total marker lines                                      | 68    |
+| Files with ≥1 marker (`src/kailash`)                    | 38    |
+| Total marker lines                                      | 66    |
 | — false-positive (not a real marker)                    | 31    |
 | — sentinel (intentional contract)                       | 24    |
-| — gap (genuine deferred work)                           | 13    |
+| — gap (genuine deferred work)                           | 11    |
 | — tracked (deferred + issue-linked)                     | 0     |
-| **Genuine gaps reachable from a documented public API** | **6** |
+| **Genuine gaps reachable from a documented public API** | **4** |
 
 ---
 
@@ -84,26 +84,33 @@ SDK itself is complete; the `TODO`/`NotImplementedError` lives in the scaffold
 `public` = reachable from a documented public API (a stub a consumer can hit matters
 more than an internal one).
 
-| #   | Location                                         | Marker                                                                                         | public  | Disposition             | Note                                                                                                                                                                                                          |
-| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- | :-----: | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `nodes/data/async_sql.py:1268`                   | `raise NotImplementedError("Iterator mode not yet implemented")`                               | **yes** | implement / remove enum | `FetchMode.ITERATOR` is a public enum value accepted then rejected at runtime (`zero-tolerance` Rule 3c). Fix: implement a server-side-cursor iterator **or** remove the enum member via a deprecation cycle. |
-| 2   | `nodes/data/async_sql.py:1319`                   | `raise NotImplementedError("Iterator mode not yet implemented")`                               | **yes** | implement / remove enum | Second `FetchMode.ITERATOR` site (the `execute`-variant path). Must be fixed together with #1.                                                                                                                |
-| 3   | `nodes/edge/edge_monitoring_node.py:359`         | `# TODO: proper active check`                                                                  | **yes** | implement               | `[a for a in alerts if active_only or True]` — the `or True` makes the filter a no-op, so `active_count` **always equals the total alert count**. Latent correctness bug.                                     |
-| 4   | `nodes/api/rest.py:433`                          | `# max_pages = ... # TODO: Implement max pages limit`                                          | **yes** | implement / remove      | `max_pages` pagination cap is commented out, so the param is silently ignored — a caller passing `max_pages` gets no effect (over-fetch risk).                                                                |
-| 5   | `nodes/monitoring/performance_benchmark.py:2155` | `raise NotImplementedError("Anomaly detector training requires a machine learning library …")` | **yes** | track                   | The anomaly-detection benchmark path raises; needs an ML dependency to implement.                                                                                                                             |
-| 6   | `cli/validate_imports.py:118`                    | `# TODO: Add support for include_tests flag in validator`                                      | **yes** | track                   | The `--include-tests` CLI flag is parsed and printed but never passed to `validate_directory()` (`zero-tolerance` Rule 3c).                                                                                   |
-| 7   | `nodes/monitoring/deadlock_detector.py:919`      | `# TODO: Send alerts or take automatic resolution actions`                                     |   no    | track                   | Deadlocks are detected and recorded; alerting / auto-resolution is deferred (enhancement, not a broken contract).                                                                                             |
-| 8   | `middleware/communication/events.py:210`         | `# TODO: Replace with BatchProcessorNode for production use`                                   |   no    | track                   | `EventBatch` is deprecated (emits a `DeprecationWarning`); replacement deferred.                                                                                                                              |
-| 9   | `middleware/communication/events.py:279`         | `# TODO: Add CacheNode when available for event history`                                       |   no    | track                   | Depends on a node that does not yet exist.                                                                                                                                                                    |
-| 10  | `middleware/communication/events.py:280`         | `# TODO: Add AsyncQueueNode when available for event buffering`                                |   no    | track                   | Depends on a node that does not yet exist.                                                                                                                                                                    |
-| 11  | `middleware/communication/events.py:281`         | `# TODO: Add MetricsCollectorNode when available for performance tracking`                     |   no    | track                   | Depends on a node that does not yet exist.                                                                                                                                                                    |
-| 12  | `nodes/data/bulk_operations.py:269`              | `# TODO: Implement COPY FROM for maximum performance`                                          |   no    | track                   | Performance optimisation only — functionally complete via the multi-row-`INSERT` fallback directly below it.                                                                                                  |
-| 13  | `runtime/parallel_cyclic.py:224`                 | `# TODO: Add cycle-aware parallel execution optimizations`                                     |   no    | track                   | Performance optimisation; the path executes correctly without it.                                                                                                                                             |
+| #   | Location                                         | Marker                                                                                         | public  | Disposition        | Note                                                                                                                                                                      |
+| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- | :-----: | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `nodes/edge/edge_monitoring_node.py:359`         | `# TODO: proper active check`                                                                  | **yes** | implement          | `[a for a in alerts if active_only or True]` — the `or True` makes the filter a no-op, so `active_count` **always equals the total alert count**. Latent correctness bug. |
+| 2   | `nodes/api/rest.py:433`                          | `# max_pages = ... # TODO: Implement max pages limit`                                          | **yes** | implement / remove | `max_pages` pagination cap is commented out, so the param is silently ignored — a caller passing `max_pages` gets no effect (over-fetch risk).                            |
+| 3   | `nodes/monitoring/performance_benchmark.py:2155` | `raise NotImplementedError("Anomaly detector training requires a machine learning library …")` | **yes** | track              | The anomaly-detection benchmark path raises; needs an ML dependency to implement.                                                                                         |
+| 4   | `cli/validate_imports.py:118`                    | `# TODO: Add support for include_tests flag in validator`                                      | **yes** | track              | The `--include-tests` CLI flag is parsed and printed but never passed to `validate_directory()` (`zero-tolerance` Rule 3c).                                               |
+| 5   | `nodes/monitoring/deadlock_detector.py:919`      | `# TODO: Send alerts or take automatic resolution actions`                                     |   no    | track              | Deadlocks are detected and recorded; alerting / auto-resolution is deferred (enhancement, not a broken contract).                                                         |
+| 6   | `middleware/communication/events.py:210`         | `# TODO: Replace with BatchProcessorNode for production use`                                   |   no    | track              | `EventBatch` is deprecated (emits a `DeprecationWarning`); replacement deferred.                                                                                          |
+| 7   | `middleware/communication/events.py:279`         | `# TODO: Add CacheNode when available for event history`                                       |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
+| 8   | `middleware/communication/events.py:280`         | `# TODO: Add AsyncQueueNode when available for event buffering`                                |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
+| 9   | `middleware/communication/events.py:281`         | `# TODO: Add MetricsCollectorNode when available for performance tracking`                     |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
+| 10  | `nodes/data/bulk_operations.py:269`              | `# TODO: Implement COPY FROM for maximum performance`                                          |   no    | track              | Performance optimisation only — functionally complete via the multi-row-`INSERT` fallback directly below it.                                                              |
+| 11  | `runtime/parallel_cyclic.py:224`                 | `# TODO: Add cycle-aware parallel execution optimizations`                                     |   no    | track              | Performance optimisation; the path executes correctly without it.                                                                                                         |
 
-**Recommended follow-ups (highest value first):** #1+#2 (`FetchMode.ITERATOR`) and
-#3 (`edge_monitoring` active-count bug) are the only entries that alter or block
-observable behaviour on a public surface; #4 and #6 are silently-ignored public
-params; the remainder are enhancements/perf with a working code path.
+**Resolved:** the two former gaps #1/#2 (`nodes/data/async_sql.py:1268,1319` —
+`FetchMode.ITERATOR`) are closed. `FetchMode.ITERATOR` was a category error (a lazy
+async stream cannot be a materializing fetch _return value_); it never produced a
+working result (raised on PostgreSQL, returned `None`/`[]` on MySQL/SQLite). The enum
+member is removed, the silent MySQL/SQLite fallbacks now raise a typed `ValueError`,
+and a dedicated memory-bounded `stream()` API replaces the streaming use case
+(follow-up workstream). This drops the gap count 13 → 11 and the public-reachable
+gap count 6 → 4.
+
+**Recommended follow-ups (highest value first):** #1 (`edge_monitoring`
+active-count bug) is the only remaining entry that alters or blocks observable
+behaviour on a public surface; #2 and #4 are silently-ignored public params; the
+remainder are enhancements/perf with a working code path.
 
 ---
 
@@ -173,14 +180,14 @@ Documented so the count is complete and the guard's raw hits are explained.
 {
   "scope": "src/kailash",
   "regex": "\\b(TODO|FIXME|HACK|STUB|XXX)\\b|NotImplementedError",
-  "total": 68,
+  "total": 66,
   "category_tally": {
     "false_positive": 31,
     "sentinel": 24,
-    "gap": 13,
+    "gap": 11,
     "tracked": 0
   },
-  "public_reachable_gaps": 6,
+  "public_reachable_gaps": 4,
   "per_file": {
     "src/kailash/channels/mcp/base.py": 5,
     "src/kailash/channels/mcp/http.py": 2,
@@ -195,7 +202,6 @@ Documented so the count is complete and the guard's raw hits are explained.
     "src/kailash/nodes/base_async.py": 4,
     "src/kailash/nodes/base_with_acl.py": 2,
     "src/kailash/nodes/compliance/gdpr.py": 1,
-    "src/kailash/nodes/data/async_sql.py": 2,
     "src/kailash/nodes/data/bulk_operations.py": 1,
     "src/kailash/nodes/edge/edge_data.py": 2,
     "src/kailash/nodes/edge/edge_monitoring_node.py": 1,

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -18,7 +18,7 @@ Key Features:
 - Connection pooling with configurable limits
 - Support for PostgreSQL (asyncpg), MySQL (aiomysql), SQLite (aiosqlite)
 - Parameterized queries to prevent SQL injection
-- Multiple fetch modes (one, all, many, iterator)
+- Multiple fetch modes (one, all, many)
 - Transaction management
 - Timeout handling
 - Retry logic with exponential backoff
@@ -224,7 +224,6 @@ class FetchMode(Enum):
     ONE = "one"  # Fetch single row
     ALL = "all"  # Fetch all rows
     MANY = "many"  # Fetch specific number of rows
-    ITERATOR = "iterator"  # Return async iterator
 
 
 @dataclass
@@ -1264,8 +1263,8 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 else:
                     rows = await conn.fetch(query, *params)
                 return [self._convert_row(dict(row)) for row in rows[:fetch_size]]
-            elif fetch_mode == FetchMode.ITERATOR:
-                raise NotImplementedError("Iterator mode not yet implemented")
+            else:
+                raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
         else:
             # Use pool connection
             async with self._pool.acquire() as conn:
@@ -1315,8 +1314,8 @@ class PostgreSQLAdapter(DatabaseAdapter):
                     else:
                         rows = await conn.fetch(query, *params)
                     return [self._convert_row(dict(row)) for row in rows[:fetch_size]]
-                elif fetch_mode == FetchMode.ITERATOR:
-                    raise NotImplementedError("Iterator mode not yet implemented")
+                else:
+                    raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
 
     async def execute_many(
         self,
@@ -1484,6 +1483,8 @@ class MySQLAdapter(DatabaseAdapter):
                             self._convert_row(dict(zip(columns, row))) for row in rows
                         ]
                     return []
+                else:
+                    raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
         else:
             async with self._pool.acquire() as conn:
                 async with conn.cursor() as cursor:
@@ -1527,6 +1528,8 @@ class MySQLAdapter(DatabaseAdapter):
                                 for row in rows
                             ]
                         return []
+                    else:
+                        raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
 
     async def execute_many(
         self,
@@ -1772,7 +1775,7 @@ class SQLiteAdapter(DatabaseAdapter):
                     rows = await cursor.fetchmany(fetch_size)
                     result = [self._convert_row(dict(row)) for row in rows]
                 else:
-                    result = []
+                    raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
 
                 # Check if this was an INSERT and capture lastrowid for SQLite
                 if query_type == "INSERT" and (
@@ -1844,7 +1847,7 @@ class SQLiteAdapter(DatabaseAdapter):
             rows = await cursor.fetchmany(fetch_size)
             result = [self._convert_row(dict(row)) for row in rows]
         else:
-            result = []
+            raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
 
         if query_type == "INSERT" and (not result or result == []):
             lastrowid = cursor.lastrowid if hasattr(cursor, "lastrowid") else None
@@ -4249,10 +4252,9 @@ class AsyncSQLDatabaseNode(AsyncNode):
 
         # Validate fetch mode
         fetch_mode = self.config.get("fetch_mode", "all").lower()
-        if fetch_mode not in ["one", "all", "many", "iterator"]:
+        if fetch_mode not in ["one", "all", "many"]:
             raise NodeValidationError(
-                f"Invalid fetch_mode: {fetch_mode}. "
-                "Must be one of: one, all, many, iterator"
+                f"Invalid fetch_mode: {fetch_mode}. " "Must be one of: one, all, many"
             )
 
         if fetch_mode == "many" and not self.config.get("fetch_size"):

--- a/tests/integration/nodes/test_async_sql_feature_parity_integration.py
+++ b/tests/integration/nodes/test_async_sql_feature_parity_integration.py
@@ -508,8 +508,9 @@ class TestAsyncSQLFeatureParity:
 
     def test_fetch_mode_parameter_handling(self):
         """Test fetch mode parameter handling."""
-        # Test all valid fetch modes
-        valid_modes = ["one", "all", "many", "iterator"]
+        # Test all valid fetch modes (iterator removed — see
+        # tests/unit/nodes/test_async_sql_fetchmode_iterator_removal.py)
+        valid_modes = ["one", "all", "many"]
 
         for mode in valid_modes:
             if mode == "many":

--- a/tests/unit/nodes/test_async_sql_fetchmode_iterator_removal.py
+++ b/tests/unit/nodes/test_async_sql_fetchmode_iterator_removal.py
@@ -1,0 +1,88 @@
+"""Regression: FetchMode.ITERATOR removed; adapters reject unknown modes loudly.
+
+The ``iterator`` fetch mode was a category error — a lazily-yielding async stream
+cannot be a materializing fetch *return value* (ONE/ALL/MANY all return a value).
+It was never implemented: it raised ``NotImplementedError`` on PostgreSQL and
+silently returned ``None`` (MySQL) / ``[]`` (SQLite). It is removed in favour of a
+dedicated streaming API (``stream()``); the per-adapter fetch dispatch now raises a
+typed ``ValueError`` for any unrecognized mode instead of falling through silently
+(``zero-tolerance.md`` Rule 3 — no silent fallbacks).
+
+Guards against (a) the dead enum member returning, (b) the node silently accepting
+``fetch_mode="iterator"`` again, and (c) the adapter silent-fallback behaviour
+(``None``/``[]``) re-appearing.
+
+Lives under ``tests/unit/nodes/`` (alongside the other ``async_sql`` unit tests,
+which also exercise real in-memory SQLite) so it runs in the blocking Tier-1 CI
+lane; ``tests/regression/`` is not currently executed by the core CI workflow.
+
+Inventory: ``STUB-MARKER-INVENTORY.md`` gaps #1/#2 (issue #1406 follow-up).
+"""
+
+from typing import cast
+
+import pytest
+
+from kailash.nodes.base import NodeConfigurationError
+from kailash.nodes.data.async_sql import (
+    AsyncSQLDatabaseNode,
+    DatabaseConfig,
+    DatabaseType,
+    FetchMode,
+    SQLiteAdapter,
+)
+
+
+@pytest.mark.regression
+def test_fetchmode_has_no_iterator_member():
+    """FetchMode is exactly {one, all, many} — the dead ITERATOR member is gone."""
+    assert [m.value for m in FetchMode] == ["one", "all", "many"]
+    assert not hasattr(FetchMode, "ITERATOR")
+
+
+@pytest.mark.regression
+def test_iterator_fetch_mode_rejected_at_node_validation():
+    """Constructing a node with fetch_mode='iterator' fails loudly, not silently."""
+    with pytest.raises(NodeConfigurationError, match="Invalid fetch_mode: iterator"):
+        AsyncSQLDatabaseNode(
+            name="iterator_removed",
+            database_type="postgresql",
+            host="localhost",
+            database="d",
+            user="u",
+            password="p",
+            fetch_mode="iterator",
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_adapter_raises_on_unknown_fetch_mode_no_silent_fallback():
+    """An unrecognized fetch mode raises ValueError instead of returning None/[].
+
+    Pre-fix, an unhandled mode fell through the SQLite dispatch to ``result = []``
+    (and ``None`` on MySQL), masking the unimplemented path as an empty result.
+    The terminal ``else`` now raises, so a future unhandled mode can never silently
+    return a wrong-but-plausible value. Exercised against real in-memory SQLite.
+    """
+    adapter = SQLiteAdapter(
+        DatabaseConfig(type=DatabaseType.SQLITE, database=":memory:")
+    )
+    await adapter.connect()
+    try:
+        await adapter.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        await adapter.execute("INSERT INTO t (name) VALUES ('alice')")
+
+        # ALL is a normal materializing read (sanity that the table is populated).
+        rows = await adapter.execute("SELECT * FROM t", fetch_mode=FetchMode.ALL)
+        assert rows == [{"id": 1, "name": "alice"}]
+
+        # A mode the dispatch does not handle MUST raise, not silently return [].
+        # cast() passes a deliberately-invalid value past the type checker to
+        # exercise the runtime defensive guard (the whole point of the test).
+        with pytest.raises(ValueError, match="Unsupported fetch_mode"):
+            await adapter.execute(
+                "SELECT * FROM t", fetch_mode=cast(FetchMode, "iterator")
+            )
+    finally:
+        await adapter.disconnect()


### PR DESCRIPTION
## Summary

`FetchMode.ITERATOR` was a **category error**: a lazily-yielding async stream cannot be a materializing fetch *return value* the way `ONE`/`ALL`/`MANY` are. It was never implemented and produced three different broken behaviours by dialect:

| Dialect | Pre-change behaviour for `fetch_mode="iterator"` |
| --- | --- |
| PostgreSQL | `raise NotImplementedError("Iterator mode not yet implemented")` |
| MySQL | fell through the `if/elif` chain → **silently returned `None`** |
| SQLite | hit `else: result = []` → **silently returned `[]`** |

The MySQL/SQLite silent fallthrough is itself a `zero-tolerance.md` Rule 3 violation the stub-marker regex couldn't see (no marker — just a missing branch).

This PR:
- Removes the `FetchMode.ITERATOR` enum member and the two PostgreSQL `NotImplementedError` branches.
- Rejects `fetch_mode="iterator"` at node validation (`["one","all","many"]`).
- Replaces the silent per-dialect fallthrough with a terminal `else: raise ValueError("Unsupported fetch_mode: …")` at **all 6** adapter dispatch sites, so an unhandled mode can never again return a wrong-but-plausible empty result.
- Updates `STUB-MARKER-INVENTORY.md` in the same commit (gaps #1/#2 resolved; total 68→66, gap 13→11, public-reachable 6→4; per-file CI guard stays in sync).
- Adds Tier-1 regression tests (`tests/unit/nodes/test_async_sql_fetchmode_iterator_removal.py`).

**Breaking change** (`!`): the public enum member is removed. No *working* caller breaks — it never produced a usable result on any dialect, so per `zero-tolerance.md` Rule 6a no deprecation shim is warranted (nothing functional to deprecate).

The streaming use case it gestured at is delivered separately as a dedicated memory-bounded `stream()` async-context-manager API (follow-up PR in the same workstream); no release will be cut between the two.

## User-flow walk receipts

`fetch_mode="iterator"` (the new loud rejection):
```
$ AsyncSQLDatabaseNode(..., fetch_mode="iterator")
NodeConfigurationError: Failed to initialize node 'AsyncSQLDatabaseNode': Invalid fetch_mode: iterator. Must be one of: one, all, many
```
Disposition: clear, actionable error at construction — replaces the prior NotImplementedError / silent wrong result.

Normal `fetch_mode="all"` query through the node (real SQLite, end-to-end):
```
$ node.async_run(query="SELECT * FROM users ORDER BY id")
{'result': {'data': [{'id': 1, 'name': 'alice'}, {'id': 2, 'name': 'bob'}], 'row_count': 2, ...}}
```
Disposition: the materializing path (one/all/many) is intact.

## Verification

- `tests/unit/nodes/test_async_sql_fetchmode_iterator_removal.py` — 3 regression tests (enum membership, node-boundary rejection, adapter silent-fallback closure against real in-memory SQLite). Lives in the **blocking Tier-1 CI lane**.
- Stub-marker inventory guard (`tests/unit/test_stub_marker_inventory.py`) — passes against ground truth.
- Full pre-commit suite (Black/isort/ruff/Tier-1 unit) — green.
- Gate review: reviewer **APPROVE** (6/6 mechanical sweeps), security-reviewer **APPROVE** (no info leak; hardening; untrusted `fetch_mode` rejected at two gates before the adapter; parameterization untouched).

## Related issues

Related: #1406 (stub-marker inventory — `FetchMode.ITERATOR` was gaps #1/#2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)