### PR TITLE
feat(async-sql): memory-bounded SQL streaming API (stream()) for AsyncSQLDatabaseNode

### DIFF
--- a/STUB-MARKER-INVENTORY.md
+++ b/STUB-MARKER-INVENTORY.md
@@ -47,10 +47,10 @@ Scoped to the `kailash` core and categorised, the real picture is:
 
 | Metric                                                  | Count |
 | ------------------------------------------------------- | ----- |
-| Files with ≥1 marker (`src/kailash`)                    | 38    |
-| Total marker lines                                      | 66    |
+| Files with ≥1 marker (`src/kailash`)                    | 39    |
+| Total marker lines                                      | 67    |
 | — false-positive (not a real marker)                    | 31    |
-| — sentinel (intentional contract)                       | 24    |
+| — sentinel (intentional contract)                       | 25    |
 | — gap (genuine deferred work)                           | 11    |
 | — tracked (deferred + issue-linked)                     | 0     |
 | **Genuine gaps reachable from a documented public API** | **4** |
@@ -121,26 +121,27 @@ These raise `NotImplementedError` **by contract** (abstract method / typed-node 
 a base without implementing the required method, or by calling a deliberately
 unsupported operation, and the error message names the fix.
 
-| Location                                   | Contract                                                                               |
-| ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `nodes/base_async.py:190`, `:210`          | `AsyncNode.run()` guard — async nodes must implement `async_run()`.                    |
-| `nodes/base.py:2056`                       | `AsyncTypedNode.run()` guard — must implement `async_run()`.                           |
-| `nodes/base_with_acl.py:147`, `:258`       | Access-controlled node must implement `_execute()`.                                    |
-| `runtime/base.py:940`                      | `BaseRuntime.execute()` — implemented by `LocalRuntime` / `AsyncLocalRuntime`.         |
-| `delegate/dispatch.py:643`                 | Abstract connector primitive (`# pragma: no cover (abstract)`).                        |
-| `delegate/dispatch.py:769`                 | Guard for legacy `invoke()`-only connectors — directs to `connector.invoke(...)`.      |
-| `utils/migrations/models.py:196`           | Abstract template method — "Override in subclasses".                                   |
-| `nodes/edge/edge_data.py:564`, `:574`      | Strong-consistency / primary-refresh need an inter-edge transport (subclass supplies). |
-| `nodes/edge/edge_warming_node.py:348`      | Edge warming needs infrastructure integration (subclass supplies).                     |
-| `nodes/edge/edge_state.py:622`             | State replication needs an edge transport (subclass supplies).                         |
-| `edge/consistency.py:214`, `:241`          | 2PC prepare / abort need a replica transport (subclass supplies).                      |
-| `edge/prediction/predictive_warmer.py:524` | Edge warming needs infrastructure integration (subclass supplies).                     |
-| `workflow/convergence.py:28`               | Abstract `ConvergenceCondition.should_terminate()`.                                    |
-| `trust/audit_service.py:488`               | Guard — `get_unattested_reasoning()` requires a store with `list_records()`.           |
-| `trust/plane/conformance/__init__.py:602`  | Dispatch guard for a conformance test name with no `_test_<name>` method.              |
-| `trust/pact/stores/sqlite.py:176`          | Abstract `_create_tables()` — "Override in subclasses".                                |
-| `channels/mcp/http.py:130`                 | `HttpTransport.receive()` — HTTP is request/response only (documented design).         |
-| `channels/mcp/base.py:80`, `:99`, `:108`   | Abstract `Transport` base — `send` / `receive` / `close`.                              |
+| Location                                   | Contract                                                                                                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `nodes/base_async.py:190`, `:210`          | `AsyncNode.run()` guard — async nodes must implement `async_run()`.                                                                                    |
+| `nodes/base.py:2056`                       | `AsyncTypedNode.run()` guard — must implement `async_run()`.                                                                                           |
+| `nodes/data/async_sql.py:1103`             | Abstract `DatabaseAdapter.stream()` (`# pragma: no cover - abstract`) — each dialect adapter supplies the server-side-cursor streaming implementation. |
+| `nodes/base_with_acl.py:147`, `:258`       | Access-controlled node must implement `_execute()`.                                                                                                    |
+| `runtime/base.py:940`                      | `BaseRuntime.execute()` — implemented by `LocalRuntime` / `AsyncLocalRuntime`.                                                                         |
+| `delegate/dispatch.py:643`                 | Abstract connector primitive (`# pragma: no cover (abstract)`).                                                                                        |
+| `delegate/dispatch.py:769`                 | Guard for legacy `invoke()`-only connectors — directs to `connector.invoke(...)`.                                                                      |
+| `utils/migrations/models.py:196`           | Abstract template method — "Override in subclasses".                                                                                                   |
+| `nodes/edge/edge_data.py:564`, `:574`      | Strong-consistency / primary-refresh need an inter-edge transport (subclass supplies).                                                                 |
+| `nodes/edge/edge_warming_node.py:348`      | Edge warming needs infrastructure integration (subclass supplies).                                                                                     |
+| `nodes/edge/edge_state.py:622`             | State replication needs an edge transport (subclass supplies).                                                                                         |
+| `edge/consistency.py:214`, `:241`          | 2PC prepare / abort need a replica transport (subclass supplies).                                                                                      |
+| `edge/prediction/predictive_warmer.py:524` | Edge warming needs infrastructure integration (subclass supplies).                                                                                     |
+| `workflow/convergence.py:28`               | Abstract `ConvergenceCondition.should_terminate()`.                                                                                                    |
+| `trust/audit_service.py:488`               | Guard — `get_unattested_reasoning()` requires a store with `list_records()`.                                                                           |
+| `trust/plane/conformance/__init__.py:602`  | Dispatch guard for a conformance test name with no `_test_<name>` method.                                                                              |
+| `trust/pact/stores/sqlite.py:176`          | Abstract `_create_tables()` — "Override in subclasses".                                                                                                |
+| `channels/mcp/http.py:130`                 | `HttpTransport.receive()` — HTTP is request/response only (documented design).                                                                         |
+| `channels/mcp/base.py:80`, `:99`, `:108`   | Abstract `Transport` base — `send` / `receive` / `close`.                                                                                              |
 
 ---
 
@@ -180,10 +181,10 @@ Documented so the count is complete and the guard's raw hits are explained.
 {
   "scope": "src/kailash",
   "regex": "\\b(TODO|FIXME|HACK|STUB|XXX)\\b|NotImplementedError",
-  "total": 66,
+  "total": 67,
   "category_tally": {
     "false_positive": 31,
-    "sentinel": 24,
+    "sentinel": 25,
     "gap": 11,
     "tracked": 0
   },
@@ -202,6 +203,7 @@ Documented so the count is complete and the guard's raw hits are explained.
     "src/kailash/nodes/base_async.py": 4,
     "src/kailash/nodes/base_with_acl.py": 2,
     "src/kailash/nodes/compliance/gdpr.py": 1,
+    "src/kailash/nodes/data/async_sql.py": 1,
     "src/kailash/nodes/data/bulk_operations.py": 1,
     "src/kailash/nodes/edge/edge_data.py": 2,
     "src/kailash/nodes/edge/edge_monitoring_node.py": 1,

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -36,6 +36,7 @@ import sys
 import threading
 import time
 import traceback
+import uuid
 import warnings
 import weakref
 from abc import ABC, abstractmethod
@@ -2027,44 +2028,61 @@ class SQLiteAdapter(DatabaseAdapter):
         SQLite has no true server-side cursor; ``fetchmany(batch_size)`` bounds
         peak Python-object memory by pulling at most ``batch_size`` rows per
         round trip. The connection is reused from the pool / shared-memory
-        helper / inline-file path (mirroring ``execute``); the cursor is closed
-        in a ``finally``. The shared ``:memory:`` connection is NEVER closed
+        helper / inline-file path (mirroring ``execute``).
+
+        Cursor + connection lifecycle ORDER is load-bearing: the cursor MUST
+        be closed BEFORE its connection is released, on every exit path
+        (normal completion, early ``break``, exception unwind). The cursor is
+        therefore opened and closed in THIS context-manager body — not inside
+        the row-yielding inner generator — so the explicit ``await
+        cursor.close()`` sequences strictly before the connection's
+        ``__aexit__`` runs. The shared ``:memory:`` connection is NEVER closed
         here — ``disconnect()`` owns that connection's lifecycle (issue #1051).
         """
         assert self._aiosqlite is not None
 
-        async def _iter_rows(db):
-            cursor = await db.execute(query, params or [])
-            try:
-                while True:
-                    batch = await cursor.fetchmany(batch_size)
-                    if not batch:
-                        break
-                    for row in batch:
-                        yield self._convert_row(dict(row))
-            finally:
-                await cursor.close()
+        async def _iter_rows(cursor):
+            while True:
+                batch = await cursor.fetchmany(batch_size)
+                if not batch:
+                    break
+                for row in batch:
+                    yield self._convert_row(dict(row))
 
         if self._pool is not None:
             # Pool path: hold the acquired connection open for the whole
             # iteration. ``acquire`` keeps the connection checked out until
             # the ``async with`` block exits (i.e. __aexit__).
             async with self._pool.acquire(query) as db:
-                yield _iter_rows(db)
+                cursor = await db.execute(query, params or [])
+                try:
+                    yield _iter_rows(cursor)
+                finally:
+                    await cursor.close()
         elif self._is_memory_db:
             # Shared :memory: connection — owned by disconnect(); do NOT close.
             db = await self._get_connection()
-            yield _iter_rows(db)
+            cursor = await db.execute(query, params or [])
+            try:
+                yield _iter_rows(cursor)
+            finally:
+                await cursor.close()
         else:
             # File DB with no pool — own the connection for the iteration's
             # lifetime; the ``async with aiosqlite.connect`` closes it on
-            # __aexit__ (normal completion, break, or exception unwind).
+            # __aexit__. The cursor is closed FIRST (the explicit finally
+            # below), then the connection, so an early break never closes a
+            # connection out from under a still-open cursor.
             async with self._aiosqlite.connect(
                 self._db_path, **self._connect_kwargs
             ) as db:
                 db.row_factory = self._aiosqlite.Row
                 await self._configure_connection(db)
-                yield _iter_rows(db)
+                cursor = await db.execute(query, params or [])
+                try:
+                    yield _iter_rows(cursor)
+                finally:
+                    await cursor.close()
 
     async def execute_many(
         self,
@@ -4929,6 +4947,140 @@ class AsyncSQLDatabaseNode(AsyncNode):
     async def process(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Async process method for middleware compatibility."""
         return await self.async_run(**inputs)
+
+    @contextlib.asynccontextmanager
+    async def stream(
+        self,
+        query: Optional[str] = None,
+        params: Optional[Union[tuple, dict, list]] = None,
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+        user_context: Any | None = None,
+    ):
+        """Stream query results lazily via a server-side cursor.
+
+        Public streaming surface — the replacement for the removed
+        ``FetchMode.ITERATOR``. Use it for result sets too large to
+        materialize:
+
+            async with node.stream(query=q, params=p, batch_size=1000) as cursor:
+                async for row in cursor:        # row is a dict, _convert_row-converted
+                    ...
+
+        LIFETIME CONTRACT: the underlying connection (and PostgreSQL
+        transaction) stay open for the whole iteration and are released on
+        ``__aexit__`` — normal completion, early ``break``, or exception
+        unwind. The connection cannot be returned from a call and iterated
+        later; it MUST be consumed inside the ``async with`` block.
+
+        RETRY: streaming does NOT use ``_execute_with_retry``. A transient
+        failure may be retried only during the connect + cursor-open phase
+        (before the first row); once iteration has begun, errors propagate to
+        the caller (re-driving mid-iteration would double-yield rows). The
+        connect/cursor-open phase is covered by the adapter pool's own
+        connection acquisition.
+
+        ACCESS CONTROL: when ``access_control_manager`` + ``user_context`` are
+        set, EXECUTE access is checked before streaming and ``apply_data_masking``
+        is applied PER ROW (the materialized path masks per row too — streaming
+        MUST NOT silently bypass masking).
+
+        Args:
+            query: SQL query (falls back to the node's configured ``query``).
+            params: Query parameters (tuple/list positional or dict named).
+            batch_size: Rows pulled per server round trip.
+            user_context: Access-control context for the EXECUTE check + masking.
+        """
+        # Pre-flight mirrors async_run: resolve query/params, convert param
+        # style, validate, check access — all BEFORE opening the cursor.
+        query = query if query is not None else self.config.get("query")
+        if params is None:
+            params = self.config.get("params")
+        if not query:
+            raise NodeExecutionError("No query provided")
+
+        db_type = self.config.get("database_type", "").lower()
+
+        if params is not None:
+            if db_type == "mysql":
+                if isinstance(params, dict):
+                    pass  # aiomysql handles dict params directly
+                elif isinstance(params, (list, tuple)):
+                    params = tuple(params) if isinstance(params, list) else params
+                else:
+                    params = (params,)
+            else:
+                # PostgreSQL/SQLite: convert positional → named (:p0, :p1 ...);
+                # the adapter then re-converts named → dialect-positional.
+                if isinstance(params, (list, tuple)):
+                    query, params = self._convert_to_named_parameters(query, params)
+                elif not isinstance(params, dict):
+                    query, params = self._convert_to_named_parameters(query, [params])
+
+        # Validate query for security (same gate as async_run).
+        if self._validate_queries:
+            try:
+                QueryValidator.validate_query(query, allow_admin=self._allow_admin)
+            except NodeValidationError as e:
+                raise NodeExecutionError(
+                    f"Query validation failed: {e}. "
+                    "Set validate_queries=False to bypass (not recommended)."
+                )
+
+        # Access-control EXECUTE check (same gate as async_run).
+        if self.access_control_manager and user_context:
+            from kailash.access_control import NodePermission
+
+            decision = self.access_control_manager.check_node_access(
+                user_context, self.metadata.name, NodePermission.EXECUTE
+            )
+            if not decision.allowed:
+                raise NodeExecutionError(f"Access denied: {decision.reason}")
+
+        adapter = await self._get_adapter()
+
+        correlation_id = uuid.uuid4().hex
+        start_time = time.monotonic()
+        rows_yielded = 0
+        # Observability: structured log at stream OPEN (intent + batch_size +
+        # correlation id). Do NOT log per row (hot-loop spam).
+        logger.info(
+            "async_sql.stream.open",
+            extra={
+                "node_id": self.id,
+                "correlation_id": correlation_id,
+                "database_type": db_type,
+                "batch_size": batch_size,
+                "has_masking": bool(self.access_control_manager and user_context),
+            },
+        )
+
+        async def _masked_rows(raw_cursor):
+            nonlocal rows_yielded
+            apply_mask = bool(self.access_control_manager and user_context)
+            async for row in raw_cursor:
+                if apply_mask:
+                    # Per-row masking — streaming MUST NOT bypass the
+                    # masking the materialized path applies (security gap).
+                    row = self.access_control_manager.apply_data_masking(
+                        user_context, self.metadata.name, row
+                    )
+                rows_yielded += 1
+                yield row
+
+        try:
+            async with adapter.stream(query, params, batch_size=batch_size) as cursor:
+                yield _masked_rows(cursor)
+        finally:
+            # Observability: structured log at stream CLOSE (rows + duration).
+            logger.info(
+                "async_sql.stream.close",
+                extra={
+                    "node_id": self.id,
+                    "correlation_id": correlation_id,
+                    "rows_yielded": rows_yielded,
+                    "duration_ms": round((time.monotonic() - start_time) * 1000, 2),
+                },
+            )
 
     async def execute_many_async(
         self, query: str, params_list: list[dict[str, Any]]

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -25,6 +25,7 @@ Key Features:
 """
 
 import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -224,6 +225,14 @@ class FetchMode(Enum):
     ONE = "one"  # Fetch single row
     ALL = "all"  # Fetch all rows
     MANY = "many"  # Fetch specific number of rows
+
+
+# Default number of rows pulled per server-side-cursor round trip for
+# ``stream()``. This is SEPARATE from ``fetch_size`` (which selects how many
+# rows ``FetchMode.MANY`` materializes in a single ``execute()`` call); a
+# streaming cursor keeps its connection open and pulls rows lazily in batches
+# of this size so peak memory stays bounded regardless of result-set size.
+DEFAULT_STREAM_BATCH_SIZE = 1000
 
 
 @dataclass
@@ -1052,6 +1061,48 @@ class DatabaseAdapter(ABC):
         pass
 
     @abstractmethod
+    def stream(
+        self,
+        query: str,
+        params: Optional[Union[tuple, dict]] = None,
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    ) -> "contextlib.AbstractAsyncContextManager":
+        """Stream query results lazily via a server-side cursor.
+
+        Returns an async context manager whose ``__aenter__`` yields an async
+        iterator of rows. Each yielded row is a ``dict`` already passed through
+        ``self._convert_row`` — byte-identical to a row materialized by
+        ``execute(..., fetch_mode=FetchMode.ALL)``.
+
+        LIFETIME CONTRACT (load-bearing): the underlying connection (and, for
+        PostgreSQL, the wrapping transaction) MUST stay OPEN for the entire
+        duration of iteration. The connection/transaction are owned by the
+        context-manager body and are NOT released until ``__aexit__`` — which
+        MUST release them on normal completion, early ``break``, AND exception
+        unwind. This is exactly why streaming cannot be a value returned from
+        ``execute()``: a returned cursor would outlive its connection scope.
+
+        Streaming does NOT use the node's retry logic: a transient failure may
+        be retried only during the connect + cursor-open phase (before the
+        first row is yielded). Once the first row has been yielded, errors
+        propagate to the caller — re-driving the query mid-iteration would
+        double-yield already-consumed rows.
+
+        Args:
+            query: SQL query to stream. Parameters arrive positionally by the
+                time they reach the adapter (the node converts dict→named→
+                positional), mirroring ``execute``.
+            params: Query parameters (tuple/list positional, or dict for the
+                PostgreSQL ``:name`` style mirrored from ``execute``).
+            batch_size: Rows pulled per server-round-trip / ``fetchmany`` chunk
+                (prefetch for asyncpg). Bounds peak memory.
+
+        Yields:
+            dict: One converted row at a time.
+        """
+        raise NotImplementedError  # pragma: no cover - abstract
+
+    @abstractmethod
     async def execute_many(
         self,
         query: str,
@@ -1317,6 +1368,78 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 else:
                     raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
 
+    @contextlib.asynccontextmanager
+    async def stream(
+        self,
+        query: str,
+        params: Optional[Union[tuple, dict]] = None,
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    ):
+        """Stream PostgreSQL rows via an asyncpg server-side cursor.
+
+        asyncpg's ``connection.cursor()`` requires an explicit transaction —
+        the transaction + acquired connection are held open by THIS context
+        manager for the full duration of iteration and released on
+        ``__aexit__`` (normal completion, early ``break``, or exception
+        unwind). ``prefetch`` bounds how many rows asyncpg buffers per
+        server round trip.
+
+        Dict params are converted to positional ``$N`` placeholders mirroring
+        ``execute`` (asyncpg has no native named-parameter support).
+        """
+        # Mirror execute()'s dict→positional ($N) conversion so a streamed
+        # query accepts the same param shapes the materialized path does.
+        if isinstance(params, dict):
+            query, positional = self._convert_named_to_positional(query, params)
+            params = positional
+        elif params is None:
+            params = ()
+        elif not isinstance(params, (list, tuple)):
+            params = (params,)
+
+        async def _iter_rows(conn):
+            # asyncpg server-side cursor — REQUIRES an open transaction.
+            async with conn.transaction():
+                cur = conn.cursor(query, *params, prefetch=batch_size)
+                async for record in cur:
+                    yield self._convert_row(dict(record))
+
+        async with self._pool.acquire() as conn:
+            yield _iter_rows(conn)
+
+    def _convert_named_to_positional(
+        self, query: str, params: dict
+    ) -> tuple[str, tuple]:
+        """Convert a ``:name`` dict-param query to asyncpg ``$N`` positional.
+
+        Mirrors the dict-handling half of ``execute`` (longest-key-first
+        replacement to avoid prefix collisions, bool/int explicit casts to
+        avoid asyncpg type-inference ambiguity), but returns the rewritten
+        query + positional tuple instead of executing.
+        """
+        original_items = list(params.items())
+        query_params = []
+        for _key, value in original_items:
+            if isinstance(value, dict):
+                value = json.dumps(value)
+            query_params.append(value)
+
+        # Replace longer keys first so ":userid" isn't clobbered by ":user".
+        keys_by_length = sorted(params.keys(), key=len, reverse=True)
+        for key in keys_by_length:
+            position = (
+                next(i for i, (k, _v) in enumerate(original_items) if k == key) + 1
+            )
+            value = original_items[position - 1][1]
+            if isinstance(value, bool):
+                query = query.replace(f":{key}", f"${position}::boolean")
+            elif isinstance(value, int):
+                query = query.replace(f":{key}", f"${position}::integer")
+            else:
+                query = query.replace(f":{key}", f"${position}")
+
+        return query, tuple(query_params)
+
     async def execute_many(
         self,
         query: str,
@@ -1530,6 +1653,40 @@ class MySQLAdapter(DatabaseAdapter):
                         return []
                     else:
                         raise ValueError(f"Unsupported fetch_mode: {fetch_mode}")
+
+    @contextlib.asynccontextmanager
+    async def stream(
+        self,
+        query: str,
+        params: Optional[Union[tuple, dict]] = None,
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    ):
+        """Stream MySQL rows via an UNBUFFERED ``aiomysql.SSCursor``.
+
+        ``SSCursor`` does not buffer the whole result set client-side — rows
+        are pulled from the server in ``batch_size`` chunks via
+        ``fetchmany``. The cursor holds the result set, so it MUST be fully
+        drained/closed before the connection is released; the
+        ``async with conn.cursor(SSCursor)`` block guarantees that on
+        ``__aexit__`` (normal completion, early ``break``, or exception
+        unwind). The acquired connection is likewise held open by THIS
+        context manager for the full iteration and released on exit.
+        """
+        import aiomysql
+
+        async def _iter_rows(conn):
+            async with conn.cursor(aiomysql.SSCursor) as cursor:
+                await cursor.execute(query, params)
+                columns = [d[0] for d in cursor.description]
+                while True:
+                    batch = await cursor.fetchmany(batch_size)
+                    if not batch:
+                        break
+                    for row in batch:
+                        yield self._convert_row(dict(zip(columns, row)))
+
+        async with self._pool.acquire() as conn:
+            yield _iter_rows(conn)
 
     async def execute_many(
         self,
@@ -1857,6 +2014,57 @@ class SQLiteAdapter(DatabaseAdapter):
 
         await db.commit()
         return result
+
+    @contextlib.asynccontextmanager
+    async def stream(
+        self,
+        query: str,
+        params: Optional[Union[tuple, dict]] = None,
+        batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    ):
+        """Stream SQLite rows via a chunked ``fetchmany`` loop.
+
+        SQLite has no true server-side cursor; ``fetchmany(batch_size)`` bounds
+        peak Python-object memory by pulling at most ``batch_size`` rows per
+        round trip. The connection is reused from the pool / shared-memory
+        helper / inline-file path (mirroring ``execute``); the cursor is closed
+        in a ``finally``. The shared ``:memory:`` connection is NEVER closed
+        here — ``disconnect()`` owns that connection's lifecycle (issue #1051).
+        """
+        assert self._aiosqlite is not None
+
+        async def _iter_rows(db):
+            cursor = await db.execute(query, params or [])
+            try:
+                while True:
+                    batch = await cursor.fetchmany(batch_size)
+                    if not batch:
+                        break
+                    for row in batch:
+                        yield self._convert_row(dict(row))
+            finally:
+                await cursor.close()
+
+        if self._pool is not None:
+            # Pool path: hold the acquired connection open for the whole
+            # iteration. ``acquire`` keeps the connection checked out until
+            # the ``async with`` block exits (i.e. __aexit__).
+            async with self._pool.acquire(query) as db:
+                yield _iter_rows(db)
+        elif self._is_memory_db:
+            # Shared :memory: connection — owned by disconnect(); do NOT close.
+            db = await self._get_connection()
+            yield _iter_rows(db)
+        else:
+            # File DB with no pool — own the connection for the iteration's
+            # lifetime; the ``async with aiosqlite.connect`` closes it on
+            # __aexit__ (normal completion, break, or exception unwind).
+            async with self._aiosqlite.connect(
+                self._db_path, **self._connect_kwargs
+            ) as db:
+                db.row_factory = self._aiosqlite.Row
+                await self._configure_connection(db)
+                yield _iter_rows(db)
 
     async def execute_many(
         self,

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -1665,29 +1665,56 @@ class MySQLAdapter(DatabaseAdapter):
         """Stream MySQL rows via an UNBUFFERED ``aiomysql.SSCursor``.
 
         ``SSCursor`` does not buffer the whole result set client-side — rows
-        are pulled from the server in ``batch_size`` chunks via
-        ``fetchmany``. The cursor holds the result set, so it MUST be fully
-        drained/closed before the connection is released; the
-        ``async with conn.cursor(SSCursor)`` block guarantees that on
-        ``__aexit__`` (normal completion, early ``break``, or exception
-        unwind). The acquired connection is likewise held open by THIS
-        context manager for the full iteration and released on exit.
+        are pulled from the server in ``batch_size`` chunks via ``fetchmany``.
+        The cursor holds the server-side result set, so the lifecycle ORDER is
+        load-bearing on every exit path (completion / early ``break`` /
+        exception unwind):
+
+        1. the SSCursor is opened and closed in THIS context-manager body (not
+           the inner row generator) so ``cursor.close()`` sequences strictly
+           before the connection is released;
+        2. the read transaction is rolled back before the connection returns
+           to the pool — the pool runs ``autocommit=False``, so a streamed
+           SELECT leaves an open read transaction; returning the connection
+           dirty makes the NEXT query (especially DDL, which implicitly
+           commits) block on the prior open transaction.
+
+        Closing the SSCursor before draining (early break) also discards the
+        remaining server-side rows so the connection is not left mid-result.
+        The acquired connection is held open by this CM for the whole
+        iteration and released on exit.
         """
         import aiomysql
 
-        async def _iter_rows(conn):
-            async with conn.cursor(aiomysql.SSCursor) as cursor:
-                await cursor.execute(query, params)
-                columns = [d[0] for d in cursor.description]
-                while True:
-                    batch = await cursor.fetchmany(batch_size)
-                    if not batch:
-                        break
-                    for row in batch:
-                        yield self._convert_row(dict(zip(columns, row)))
+        async def _iter_rows(cursor, columns):
+            while True:
+                batch = await cursor.fetchmany(batch_size)
+                if not batch:
+                    break
+                for row in batch:
+                    yield self._convert_row(dict(zip(columns, row)))
 
         async with self._pool.acquire() as conn:
-            yield _iter_rows(conn)
+            cursor = await conn.cursor(aiomysql.SSCursor)
+            try:
+                await cursor.execute(query, params)
+                columns = [d[0] for d in cursor.description]
+                yield _iter_rows(cursor, columns)
+            finally:
+                # Close the SSCursor FIRST (discards any unread server-side
+                # rows on an early break), THEN clear the read transaction so
+                # the connection returns to the pool clean.
+                await cursor.close()
+                try:
+                    await conn.rollback()
+                except Exception:  # noqa: BLE001 - best-effort txn reset
+                    # A rollback failure here must not mask the real exception
+                    # being unwound; the connection will be recycled by the
+                    # pool's own health check. Logged for triage.
+                    logger.warning(
+                        "async_sql.mysql_stream.rollback_failed",
+                        exc_info=True,
+                    )
 
     async def execute_many(
         self,

--- a/tests/integration/nodes/test_async_sql_streaming_integration.py
+++ b/tests/integration/nodes/test_async_sql_streaming_integration.py
@@ -30,6 +30,13 @@ from tests.utils.docker_config import (
     get_postgres_connection_string,
 )
 
+# `DROP TABLE IF EXISTS <t>` against a not-yet-created table emits a benign MySQL
+# NOTE (1051 "Unknown table") that aiomysql surfaces as a base `Warning` — the
+# `IF EXISTS` is doing exactly its job. Accept it explicitly, message-scoped so it
+# cannot mask any real warning (zero-tolerance.md Rule 1 — documented third-party
+# note suppression). PostgreSQL tests never emit this message.
+pytestmark = pytest.mark.filterwarnings("ignore:Unknown table:Warning")
+
 # ===========================================================================
 # PostgreSQL
 # ===========================================================================
@@ -74,6 +81,7 @@ async def pg_node():
                 "ssn": f"{i:03d}-00-0000",
             },
         )
+    await setup.cleanup()
 
     node = AsyncSQLDatabaseNode(
         name="pg_stream_node",
@@ -83,6 +91,7 @@ async def pg_node():
         share_pool=False,
     )
     yield node
+    await node.cleanup()
 
     teardown = AsyncSQLDatabaseNode(
         name="pg_stream_teardown",
@@ -92,6 +101,7 @@ async def pg_node():
         share_pool=False,
     )
     await teardown.async_run(query=f"DROP TABLE IF EXISTS {PG_TABLE}")
+    await teardown.cleanup()
 
 
 @pytest.mark.integration
@@ -482,6 +492,7 @@ async def mysql_node():
                 f"{i:03d}-00-0000",
             ),
         )
+    await setup.cleanup()
 
     node = AsyncSQLDatabaseNode(
         name="mysql_stream_node",
@@ -491,6 +502,7 @@ async def mysql_node():
         share_pool=False,
     )
     yield node
+    await node.cleanup()
 
     teardown = AsyncSQLDatabaseNode(
         name="mysql_stream_teardown",
@@ -500,6 +512,7 @@ async def mysql_node():
         share_pool=False,
     )
     await teardown.async_run(query=f"DROP TABLE IF EXISTS {MYSQL_TABLE}")
+    await teardown.cleanup()
 
 
 @pytest.mark.integration

--- a/tests/integration/nodes/test_async_sql_streaming_integration.py
+++ b/tests/integration/nodes/test_async_sql_streaming_integration.py
@@ -1,0 +1,776 @@
+"""Tier-2 integration tests for SQL streaming — PostgreSQL + MySQL.
+
+Real infrastructure, NO mocking (per testing.md Tier-2). PostgreSQL runs on
+localhost:5434 and MySQL on localhost:3307 (see tests/utils/docker_config.py).
+These markers (requires_postgres / requires_mysql) are EXCLUDED by the gating
+CI lane; run them locally against the live containers.
+
+Coverage per dialect:
+* round-trip correctness vs fetch_mode=ALL over mixed types;
+* memory-bounded proof — instrument the driver fetch path to assert ≤
+  batch_size rows are pulled when the consumer has processed only the first
+  row (a deterministic batch-boundary assertion, NOT a tracemalloc heuristic);
+* lifetime/cleanup — early break + exception unwind release the connection
+  back to the pool (pool free-count restored; for PostgreSQL, no
+  idle_in_transaction leak);
+* retry contract — open-phase transient failure retries; mid-iteration failure
+  propagates without re-yielding;
+* access-control masking applied per streamed row.
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from kailash.nodes.data.async_sql import DEFAULT_STREAM_BATCH_SIZE, AsyncSQLDatabaseNode
+from kailash.sdk_exceptions import NodeExecutionError
+from tests.utils.docker_config import (
+    get_mysql_connection_string,
+    get_postgres_connection_string,
+)
+
+# ===========================================================================
+# PostgreSQL
+# ===========================================================================
+
+PG_TABLE = "_stream_it_pg"
+
+
+@pytest_asyncio.fixture
+async def pg_node():
+    """AsyncSQLDatabaseNode against the live PostgreSQL, table seeded."""
+    conn = get_postgres_connection_string()
+    setup = AsyncSQLDatabaseNode(
+        name="pg_stream_setup",
+        database_type="postgresql",
+        connection_string=conn,
+        validate_queries=False,  # DDL setup
+        share_pool=False,
+    )
+    await setup.async_run(query=f"DROP TABLE IF EXISTS {PG_TABLE}")
+    await setup.async_run(
+        query=(
+            f"CREATE TABLE {PG_TABLE} ("
+            "  id INTEGER PRIMARY KEY,"
+            "  name TEXT,"
+            "  score DOUBLE PRECISION,"
+            "  active BOOLEAN,"
+            "  ssn TEXT"
+            ")"
+        )
+    )
+    for i in range(1, 26):
+        await setup.async_run(
+            query=(
+                f"INSERT INTO {PG_TABLE} (id, name, score, active, ssn) "
+                "VALUES (:id, :name, :score, :active, :ssn)"
+            ),
+            params={
+                "id": i,
+                "name": None if i == 7 else f"name-{i}",
+                "score": None if i == 11 else float(i) + 0.5,
+                "active": (i % 2 == 0),
+                "ssn": f"{i:03d}-00-0000",
+            },
+        )
+
+    node = AsyncSQLDatabaseNode(
+        name="pg_stream_node",
+        database_type="postgresql",
+        connection_string=conn,
+        validate_queries=True,
+        share_pool=False,
+    )
+    yield node
+
+    teardown = AsyncSQLDatabaseNode(
+        name="pg_stream_teardown",
+        database_type="postgresql",
+        connection_string=conn,
+        validate_queries=False,
+        share_pool=False,
+    )
+    await teardown.async_run(query=f"DROP TABLE IF EXISTS {PG_TABLE}")
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_round_trip_vs_fetch_all(pg_node):
+    """Streamed PG rows are byte-identical to fetch_mode=ALL."""
+    materialized = await pg_node.async_run(
+        query=f"SELECT id, name, score, active, ssn FROM {PG_TABLE} ORDER BY id"
+    )
+    expected = materialized["result"]["data"]
+
+    streamed = []
+    async with pg_node.stream(
+        query=f"SELECT id, name, score, active, ssn FROM {PG_TABLE} ORDER BY id",
+        batch_size=10,
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    assert streamed == expected
+    assert len(streamed) == 25
+    assert streamed[6]["name"] is None  # NULL survived
+    assert streamed[10]["score"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_memory_bounded(pg_node):
+    """asyncpg prefetch MUST bound rows pulled before the consumer advances.
+
+    We instrument the asyncpg connection's cursor() factory to count rows the
+    cursor buffers. After consuming exactly ONE row, no more than batch_size
+    rows have been read from the server — proof of bounded, lazy pulls.
+    """
+    batch_size = 5
+    adapter = await pg_node._get_adapter()
+    real_pool = adapter._pool
+    pulled = {"n": 0}
+
+    # asyncpg's Pool.acquire is read-only, so we swap adapter._pool (a plain,
+    # writable attribute) for a thin wrapper that counts rows as asyncpg's
+    # server-side cursor yields them. asyncpg buffers `prefetch` rows per round
+    # trip; counting at the async-for boundary measures rows pulled from the
+    # server.
+    class _CountingConnWrapper:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def cursor(self, query, *args, **kwargs):
+            real_cursor = self._conn.cursor(query, *args, **kwargs)
+
+            class _CountingCursor:
+                def __aiter__(self):
+                    self._it = real_cursor.__aiter__()
+                    return self
+
+                async def __anext__(self):
+                    rec = await self._it.__anext__()
+                    pulled["n"] += 1
+                    return rec
+
+            return _CountingCursor()
+
+    class _AcquireCM:
+        def __init__(self):
+            self._cm = real_pool.acquire()
+
+        async def __aenter__(self):
+            conn = await self._cm.__aenter__()
+            return _CountingConnWrapper(conn)
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    class _PoolWrapper:
+        def __getattr__(self, name):
+            return getattr(real_pool, name)
+
+        def acquire(self, *a, **kw):
+            return _AcquireCM()
+
+    adapter._pool = _PoolWrapper()
+    try:
+        async with pg_node.stream(
+            query=f"SELECT id FROM {PG_TABLE} ORDER BY id", batch_size=batch_size
+        ) as cursor:
+            agen = cursor.__aiter__()
+            first = await agen.__anext__()
+            assert first["id"] == 1
+            # After consuming exactly one row, asyncpg has buffered at most one
+            # prefetch window (batch_size) — never the whole 25-row set.
+            assert pulled["n"] <= batch_size, (
+                f"pulled {pulled['n']} rows after consuming 1 "
+                f"(batch_size={batch_size}); streaming is not memory-bounded"
+            )
+            # Drain so the CM exits cleanly.
+            async for _ in agen:
+                pass
+    finally:
+        adapter._pool = real_pool
+
+    assert pulled["n"] == 25  # all rows eventually streamed
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_early_break_releases_to_pool(pg_node):
+    """Early break releases the connection + closes the txn (no idle leak)."""
+    adapter = await pg_node._get_adapter()
+    pool = adapter._pool
+    free_before = pool.get_idle_size()
+
+    seen = []
+    async with pg_node.stream(
+        query=f"SELECT id FROM {PG_TABLE} ORDER BY id", batch_size=5
+    ) as cursor:
+        async for row in cursor:
+            seen.append(row["id"])
+            if len(seen) == 3:
+                break
+    assert seen == [1, 2, 3]
+
+    # Connection returned to the pool.
+    assert pool.get_idle_size() == free_before
+
+    # No idle_in_transaction backend left behind (the txn was closed on exit).
+    check = await pg_node.async_run(
+        query=(
+            "SELECT COUNT(*) AS c FROM pg_stat_activity "
+            "WHERE state = 'idle in transaction'"
+        )
+    )
+    assert check["result"]["data"][0]["c"] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_exception_unwind_releases_to_pool(pg_node):
+    """An exception mid-iteration releases the connection + closes the txn."""
+    adapter = await pg_node._get_adapter()
+    pool = adapter._pool
+    free_before = pool.get_idle_size()
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        async with pg_node.stream(
+            query=f"SELECT id FROM {PG_TABLE} ORDER BY id", batch_size=5
+        ) as cursor:
+            async for row in cursor:
+                if row["id"] == 4:
+                    raise Boom("consumer failure mid-stream")
+
+    assert pool.get_idle_size() == free_before
+    check = await pg_node.async_run(
+        query=(
+            "SELECT COUNT(*) AS c FROM pg_stat_activity "
+            "WHERE state = 'idle in transaction'"
+        )
+    )
+    assert check["result"]["data"][0]["c"] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_mid_iteration_failure_propagates_no_reyield(pg_node):
+    """A failure AFTER the first row propagates and does NOT re-drive/re-yield.
+
+    We force the asyncpg cursor to raise on the 4th fetched record and assert
+    (a) the exception propagates, (b) exactly the first 3 rows were yielded
+    (no retry re-yielded rows 1-3).
+    """
+    adapter = await pg_node._get_adapter()
+    real_pool = adapter._pool
+
+    class InjectedError(RuntimeError):
+        pass
+
+    class _FailingConnWrapper:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def cursor(self, query, *args, **kwargs):
+            real_cursor = self._conn.cursor(query, *args, **kwargs)
+
+            class _FailingCursor:
+                def __aiter__(self):
+                    self._it = real_cursor.__aiter__()
+                    self._n = 0
+                    return self
+
+                async def __anext__(self):
+                    rec = await self._it.__anext__()
+                    self._n += 1
+                    if self._n == 4:
+                        raise InjectedError("driver blew up mid-stream")
+                    return rec
+
+            return _FailingCursor()
+
+    class _AcquireCM:
+        def __init__(self):
+            self._cm = real_pool.acquire()
+
+        async def __aenter__(self):
+            conn = await self._cm.__aenter__()
+            return _FailingConnWrapper(conn)
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    class _PoolWrapper:
+        def __getattr__(self, name):
+            return getattr(real_pool, name)
+
+        def acquire(self, *a, **kw):
+            return _AcquireCM()
+
+    adapter._pool = _PoolWrapper()
+    seen = []
+    try:
+        with pytest.raises(InjectedError):
+            async with pg_node.stream(
+                query=f"SELECT id FROM {PG_TABLE} ORDER BY id", batch_size=10
+            ) as cursor:
+                async for row in cursor:
+                    seen.append(row["id"])
+    finally:
+        adapter._pool = real_pool
+
+    # Exactly 3 rows yielded; no retry re-yielded rows 1-3 (no double-yield).
+    assert seen == [1, 2, 3]
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_open_phase_transient_retry(pg_node):
+    """A transient failure at connection-acquire (open phase) is recoverable.
+
+    The open phase (pool.acquire) is retried by the pool's own acquisition;
+    here we make the FIRST acquire raise a transient error, then succeed, and
+    assert the stream still yields all rows. (Once the first row is yielded,
+    no retry applies — that is the mid-iteration test above.)
+    """
+    adapter = await pg_node._get_adapter()
+    real_pool = adapter._pool
+    state = {"calls": 0}
+
+    class _FlakyAcquireCM:
+        def __init__(self):
+            state["calls"] += 1
+            self._fail = state["calls"] == 1
+            self._cm = None if self._fail else real_pool.acquire()
+
+        async def __aenter__(self):
+            if self._fail:
+                raise ConnectionError("server closed the connection (transient)")
+            return await self._cm.__aenter__()
+
+        async def __aexit__(self, *exc):
+            if self._cm is not None:
+                return await self._cm.__aexit__(*exc)
+            return False
+
+    class _FlakyPoolWrapper:
+        def __getattr__(self, name):
+            return getattr(real_pool, name)
+
+        def acquire(self, *a, **kw):
+            return _FlakyAcquireCM()
+
+    adapter._pool = _FlakyPoolWrapper()
+    try:
+        # The adapter's stream opens the connection inside __aenter__; the
+        # first acquire fails. We retry the OPEN ourselves (the caller's
+        # responsibility per the documented retry contract: open-phase only).
+        streamed = []
+        last_err = None
+        for _attempt in range(3):
+            try:
+                async with pg_node.stream(
+                    query=f"SELECT id FROM {PG_TABLE} ORDER BY id", batch_size=10
+                ) as cursor:
+                    async for row in cursor:
+                        streamed.append(row["id"])
+                break
+            except ConnectionError as e:
+                last_err = e
+                streamed.clear()
+                continue
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"open never succeeded: {last_err}")
+    finally:
+        adapter._pool = real_pool
+
+    assert streamed == list(range(1, 26))
+    assert state["calls"] >= 2  # first failed, second (or later) succeeded
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.asyncio
+async def test_pg_stream_masking_per_row(pg_node):
+    """Access-control masking is applied to every streamed PG row."""
+
+    class _MaskMgr:
+        class _D:
+            allowed = True
+            reason = "ok"
+
+        def check_node_access(self, *a, **k):
+            return self._D()
+
+        def apply_data_masking(self, user_context, node_name, row):
+            r = dict(row)
+            if r.get("ssn"):
+                r["ssn"] = "***-**-****"
+            return r
+
+    pg_node.access_control_manager = _MaskMgr()
+    rows = []
+    async with pg_node.stream(
+        query=f"SELECT id, ssn FROM {PG_TABLE} ORDER BY id",
+        user_context={"user_id": "u1"},
+        batch_size=10,
+    ) as cursor:
+        async for row in cursor:
+            rows.append(row)
+
+    assert len(rows) == 25
+    assert all(r["ssn"] == "***-**-****" for r in rows), rows[:3]
+
+
+# ===========================================================================
+# MySQL
+# ===========================================================================
+
+MYSQL_TABLE = "_stream_it_mysql"
+
+
+@pytest_asyncio.fixture
+async def mysql_node():
+    """AsyncSQLDatabaseNode against the live MySQL, table seeded."""
+    conn = get_mysql_connection_string()
+    setup = AsyncSQLDatabaseNode(
+        name="mysql_stream_setup",
+        database_type="mysql",
+        connection_string=conn,
+        validate_queries=False,
+        share_pool=False,
+    )
+    await setup.async_run(query=f"DROP TABLE IF EXISTS {MYSQL_TABLE}")
+    await setup.async_run(
+        query=(
+            f"CREATE TABLE {MYSQL_TABLE} ("
+            "  id INT PRIMARY KEY,"
+            "  name VARCHAR(64),"
+            "  score DOUBLE,"
+            "  active TINYINT,"
+            "  ssn VARCHAR(32)"
+            ")"
+        )
+    )
+    for i in range(1, 26):
+        await setup.async_run(
+            query=(
+                f"INSERT INTO {MYSQL_TABLE} (id, name, score, active, ssn) "
+                "VALUES (%s, %s, %s, %s, %s)"
+            ),
+            params=(
+                i,
+                None if i == 7 else f"name-{i}",
+                None if i == 11 else float(i) + 0.5,
+                1 if i % 2 == 0 else 0,
+                f"{i:03d}-00-0000",
+            ),
+        )
+
+    node = AsyncSQLDatabaseNode(
+        name="mysql_stream_node",
+        database_type="mysql",
+        connection_string=conn,
+        validate_queries=True,
+        share_pool=False,
+    )
+    yield node
+
+    teardown = AsyncSQLDatabaseNode(
+        name="mysql_stream_teardown",
+        database_type="mysql",
+        connection_string=conn,
+        validate_queries=False,
+        share_pool=False,
+    )
+    await teardown.async_run(query=f"DROP TABLE IF EXISTS {MYSQL_TABLE}")
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_round_trip_vs_fetch_all(mysql_node):
+    """Streamed MySQL rows are byte-identical to fetch_mode=ALL."""
+    materialized = await mysql_node.async_run(
+        query=(f"SELECT id, name, score, active, ssn FROM {MYSQL_TABLE} ORDER BY id"),
+        params=(),
+    )
+    expected = materialized["result"]["data"]
+
+    streamed = []
+    async with mysql_node.stream(
+        query=(f"SELECT id, name, score, active, ssn FROM {MYSQL_TABLE} ORDER BY id"),
+        batch_size=10,
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    assert streamed == expected
+    assert len(streamed) == 25
+    assert streamed[6]["name"] is None
+    assert streamed[10]["score"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_memory_bounded(mysql_node):
+    """SSCursor.fetchmany MUST pull ≤ batch_size rows before consumer advances.
+
+    Instrument the SSCursor's fetchmany to count rows pulled; after consuming
+    exactly ONE row only the first batch (batch_size) has been pulled.
+    """
+    batch_size = 5
+    adapter = await mysql_node._get_adapter()
+    real_pool = adapter._pool
+    pulled = {"n": 0}
+
+    # The adapter opens the SSCursor via ``await conn.cursor(SSCursor)``, so the
+    # wrapper's cursor() MUST return an awaitable yielding the (instrumented)
+    # cursor — not an async context manager.
+    class _CountingConnWrapper:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def cursor(self, *args, **kwargs):
+            real_awaitable = self._conn.cursor(*args, **kwargs)
+
+            async def _await_and_wrap():
+                cur = await real_awaitable
+                real_fetchmany = cur.fetchmany
+
+                async def counting_fetchmany(size):
+                    batch = await real_fetchmany(size)
+                    pulled["n"] += len(batch)
+                    return batch
+
+                cur.fetchmany = counting_fetchmany
+                return cur
+
+            return _await_and_wrap()
+
+    class _AcquireCM:
+        def __init__(self):
+            self._cm = real_pool.acquire()
+
+        async def __aenter__(self):
+            conn = await self._cm.__aenter__()
+            return _CountingConnWrapper(conn)
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    class _PoolWrapper:
+        def __getattr__(self, name):
+            return getattr(real_pool, name)
+
+        def acquire(self, *a, **kw):
+            return _AcquireCM()
+
+    adapter._pool = _PoolWrapper()
+    try:
+        async with mysql_node.stream(
+            query=f"SELECT id FROM {MYSQL_TABLE} ORDER BY id", batch_size=batch_size
+        ) as cursor:
+            agen = cursor.__aiter__()
+            first = await agen.__anext__()
+            assert first["id"] == 1
+            assert pulled["n"] <= batch_size, (
+                f"pulled {pulled['n']} after consuming 1 "
+                f"(batch_size={batch_size}); not memory-bounded"
+            )
+            async for _ in agen:
+                pass
+    finally:
+        adapter._pool = real_pool
+
+    assert pulled["n"] == 25
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_early_break_releases_to_pool(mysql_node):
+    """Early break drains+closes the SSCursor and returns the connection."""
+    adapter = await mysql_node._get_adapter()
+    pool = adapter._pool
+    free_before = pool.freesize
+
+    seen = []
+    async with mysql_node.stream(
+        query=f"SELECT id FROM {MYSQL_TABLE} ORDER BY id", batch_size=5
+    ) as cursor:
+        async for row in cursor:
+            seen.append(row["id"])
+            if len(seen) == 3:
+                break
+    assert seen == [1, 2, 3]
+
+    # Allow the pool to reclaim the connection, then assert it is back.
+    await asyncio.sleep(0)
+    assert pool.freesize == free_before
+
+    # The connection is usable again (SSCursor fully drained on exit).
+    after = await mysql_node.async_run(
+        query=f"SELECT COUNT(*) AS c FROM {MYSQL_TABLE}", params=()
+    )
+    assert after["result"]["data"][0]["c"] == 25
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_exception_unwind_releases_to_pool(mysql_node):
+    """An exception mid-iteration drains the SSCursor + releases the conn."""
+    adapter = await mysql_node._get_adapter()
+    pool = adapter._pool
+    free_before = pool.freesize
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        async with mysql_node.stream(
+            query=f"SELECT id FROM {MYSQL_TABLE} ORDER BY id", batch_size=5
+        ) as cursor:
+            async for row in cursor:
+                if row["id"] == 4:
+                    raise Boom("consumer failure mid-stream")
+
+    await asyncio.sleep(0)
+    assert pool.freesize == free_before
+    after = await mysql_node.async_run(
+        query=f"SELECT COUNT(*) AS c FROM {MYSQL_TABLE}", params=()
+    )
+    assert after["result"]["data"][0]["c"] == 25
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_mid_iteration_failure_propagates_no_reyield(
+    mysql_node,
+):
+    """A failure after the first row propagates without re-yielding rows."""
+    adapter = await mysql_node._get_adapter()
+    real_pool = adapter._pool
+
+    class InjectedError(RuntimeError):
+        pass
+
+    class _FailingConnWrapper:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def cursor(self, *args, **kwargs):
+            real_awaitable = self._conn.cursor(*args, **kwargs)
+
+            async def _await_and_wrap():
+                cur = await real_awaitable
+                real_fetchmany = cur.fetchmany
+                calls = {"n": 0}
+
+                async def failing_fetchmany(size):
+                    calls["n"] += 1
+                    if calls["n"] == 2:
+                        raise InjectedError("driver blew up mid-stream")
+                    return await real_fetchmany(size)
+
+                cur.fetchmany = failing_fetchmany
+                return cur
+
+            return _await_and_wrap()
+
+    class _AcquireCM:
+        def __init__(self):
+            self._cm = real_pool.acquire()
+
+        async def __aenter__(self):
+            conn = await self._cm.__aenter__()
+            return _FailingConnWrapper(conn)
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    class _PoolWrapper:
+        def __getattr__(self, name):
+            return getattr(real_pool, name)
+
+        def acquire(self, *a, **kw):
+            return _AcquireCM()
+
+    adapter._pool = _PoolWrapper()
+    seen = []
+    try:
+        with pytest.raises(InjectedError):
+            async with mysql_node.stream(
+                query=f"SELECT id FROM {MYSQL_TABLE} ORDER BY id", batch_size=3
+            ) as cursor:
+                async for row in cursor:
+                    seen.append(row["id"])
+    finally:
+        adapter._pool = real_pool
+
+    # First batch of 3 yielded; the 2nd fetchmany raised → no re-yield.
+    assert seen == [1, 2, 3]
+
+
+@pytest.mark.integration
+@pytest.mark.requires_mysql
+@pytest.mark.asyncio
+async def test_mysql_stream_masking_per_row(mysql_node):
+    """Access-control masking is applied to every streamed MySQL row."""
+
+    class _MaskMgr:
+        class _D:
+            allowed = True
+            reason = "ok"
+
+        def check_node_access(self, *a, **k):
+            return self._D()
+
+        def apply_data_masking(self, user_context, node_name, row):
+            r = dict(row)
+            if r.get("ssn"):
+                r["ssn"] = "***-**-****"
+            return r
+
+    mysql_node.access_control_manager = _MaskMgr()
+    rows = []
+    async with mysql_node.stream(
+        query=f"SELECT id, ssn FROM {MYSQL_TABLE} ORDER BY id",
+        user_context={"user_id": "u1"},
+        batch_size=10,
+    ) as cursor:
+        async for row in cursor:
+            rows.append(row)
+
+    assert len(rows) == 25
+    assert all(r["ssn"] == "***-**-****" for r in rows), rows[:3]
+
+
+def test_default_stream_batch_size_is_1000():
+    """Sanity: the documented default batch size constant."""
+    assert DEFAULT_STREAM_BATCH_SIZE == 1000

--- a/tests/unit/nodes/test_async_sql_streaming.py
+++ b/tests/unit/nodes/test_async_sql_streaming.py
@@ -1,0 +1,381 @@
+"""Tier-1 unit tests for SQL streaming (server-side cursor) — SQLite lane.
+
+SQLite needs no Docker, so this lane is the BLOCKING Tier-1 CI gate for the
+streaming API. It covers, against a real on-disk SQLite database:
+
+* round-trip correctness — streamed rows are byte-identical to a
+  ``fetch_mode=ALL`` materialization over mixed types (NULL / int / str /
+  float / bool);
+* the context-manager lifetime contract — early ``break`` AND exception
+  unwind both release the connection;
+* batch-boundary behaviour — rows are pulled in ``batch_size`` chunks via
+  ``fetchmany``, not all up front.
+
+The PostgreSQL + MySQL lanes (server-side cursors / SSCursor, memory-bounded
+proofs, retry contract, masking) live under ``tests/integration/nodes/`` and
+run against the live containers.
+"""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from kailash.nodes.data.async_sql import (
+    DEFAULT_STREAM_BATCH_SIZE,
+    DatabaseConfig,
+    DatabaseType,
+    FetchMode,
+    SQLiteAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_db_path():
+    """A real on-disk SQLite database file (NOT :memory:).
+
+    Using a file DB exercises the inline-connection ``stream`` path where the
+    context-manager owns the connection and MUST close it on every exit.
+    """
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        yield path
+    finally:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        # aiosqlite WAL sidecar files
+        for sidecar in (f"{path}-wal", f"{path}-shm"):
+            try:
+                os.remove(sidecar)
+            except FileNotFoundError:
+                pass
+
+
+@pytest.fixture
+async def seeded_adapter(sqlite_db_path):
+    """SQLiteAdapter connected to a file DB seeded with mixed-type rows."""
+    config = DatabaseConfig(
+        type=DatabaseType.SQLITE,
+        database=sqlite_db_path,
+    )
+    adapter = SQLiteAdapter(config)
+    await adapter.connect()
+
+    # Mixed types incl. NULL/int/str/float/bool. SQLite stores bool as int.
+    await adapter.execute(
+        "CREATE TABLE items ("
+        "  id INTEGER PRIMARY KEY,"
+        "  name TEXT,"
+        "  score REAL,"
+        "  active INTEGER,"
+        "  note TEXT"
+        ")"
+    )
+    rows = [
+        (1, "alpha", 1.5, 1, "first"),
+        (2, "beta", 2.0, 0, None),  # NULL note
+        (3, None, 3.25, 1, "third"),  # NULL name
+        (4, "delta", None, 0, "fourth"),  # NULL score
+        (5, "epsilon", 5.0, 1, "fifth"),
+    ]
+    for r in rows:
+        await adapter.execute(
+            "INSERT INTO items (id, name, score, active, note) "
+            "VALUES (?, ?, ?, ?, ?)",
+            r,
+        )
+
+    try:
+        yield adapter
+    finally:
+        await adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_rows_byte_identical_to_fetch_all(seeded_adapter):
+    """Streamed rows MUST equal the materialized (fetch_mode=ALL) rows."""
+    materialized = await seeded_adapter.execute(
+        "SELECT id, name, score, active, note FROM items ORDER BY id",
+        fetch_mode=FetchMode.ALL,
+    )
+
+    streamed = []
+    async with seeded_adapter.stream(
+        "SELECT id, name, score, active, note FROM items ORDER BY id"
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    assert streamed == materialized
+    # Sanity: NULLs survived as None, not as a sentinel.
+    assert streamed[1]["note"] is None
+    assert streamed[2]["name"] is None
+    assert streamed[3]["score"] is None
+    # Each row is a plain dict.
+    assert all(isinstance(r, dict) for r in streamed)
+
+
+@pytest.mark.asyncio
+async def test_stream_with_positional_params(seeded_adapter):
+    """Parameterized streaming returns only matching rows, converted."""
+    streamed = []
+    async with seeded_adapter.stream(
+        "SELECT id, name FROM items WHERE active = ? ORDER BY id", (1,)
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    assert [r["id"] for r in streamed] == [1, 3, 5]
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_result_set(seeded_adapter):
+    """An empty result set yields zero rows and still releases cleanly."""
+    streamed = []
+    async with seeded_adapter.stream("SELECT id FROM items WHERE id > 9999") as cursor:
+        async for row in cursor:
+            streamed.append(row)
+    assert streamed == []
+
+
+# ---------------------------------------------------------------------------
+# Context-manager lifetime: early break + exception unwind release the conn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_early_break_releases_connection(seeded_adapter):
+    """Breaking out of iteration MUST exit the CM and release the connection.
+
+    After an early break, the SAME adapter must be able to run a fresh query —
+    proof the connection/cursor were released, not leaked open.
+    """
+    seen = []
+    async with seeded_adapter.stream("SELECT id FROM items ORDER BY id") as cursor:
+        async for row in cursor:
+            seen.append(row["id"])
+            if len(seen) == 2:
+                break  # early exit mid-stream
+
+    assert seen == [1, 2]
+
+    # The connection is released — a follow-up query succeeds.
+    after = await seeded_adapter.execute(
+        "SELECT COUNT(*) AS c FROM items", fetch_mode=FetchMode.ONE
+    )
+    assert after["c"] == 5
+
+
+@pytest.mark.asyncio
+async def test_stream_exception_unwind_releases_connection(seeded_adapter):
+    """An exception raised inside the iteration body MUST still release.
+
+    The exception propagates (not swallowed), AND the adapter is reusable
+    afterward — proof __aexit__ ran the cleanup on the exception path.
+    """
+
+    class Boom(RuntimeError):
+        pass
+
+    seen = []
+    with pytest.raises(Boom):
+        async with seeded_adapter.stream("SELECT id FROM items ORDER BY id") as cursor:
+            async for row in cursor:
+                seen.append(row["id"])
+                if row["id"] == 3:
+                    raise Boom("consumer blew up mid-stream")
+
+    assert seen == [1, 2, 3]
+
+    # Connection released despite the exception — follow-up query works.
+    after = await seeded_adapter.execute(
+        "SELECT COUNT(*) AS c FROM items", fetch_mode=FetchMode.ONE
+    )
+    assert after["c"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Batch boundary: fetchmany pulls in batch_size chunks, not all up front
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_pulls_in_batch_size_chunks(seeded_adapter, monkeypatch):
+    """With batch_size=2, fetchmany MUST be called with size 2 each round.
+
+    We instrument the cursor's fetchmany to record the requested chunk size
+    and the number of round trips — a deterministic batch-boundary assertion
+    rather than a memory heuristic.
+    """
+    recorded_sizes = []
+    real_get_conn = seeded_adapter._get_connection
+
+    async def instrumented_get_conn():
+        db = await real_get_conn()
+        real_execute = db.execute
+
+        async def execute_wrapping_cursor(sql, params=None):
+            cursor = await real_execute(sql, params)
+            real_fetchmany = cursor.fetchmany
+
+            async def recording_fetchmany(size):
+                recorded_sizes.append(size)
+                return await real_fetchmany(size)
+
+            cursor.fetchmany = recording_fetchmany
+            return cursor
+
+        db.execute = execute_wrapping_cursor
+        return db
+
+    # File-DB stream path uses aiosqlite.connect inline, so patch that to
+    # wrap the cursor's fetchmany. We monkeypatch the adapter's aiosqlite
+    # connect to return a connection whose execute wraps fetchmany.
+    import aiosqlite
+
+    real_connect = aiosqlite.connect
+
+    class _ConnectWrapper:
+        def __init__(self, *args, **kwargs):
+            self._cm = real_connect(*args, **kwargs)
+
+        async def __aenter__(self):
+            db = await self._cm.__aenter__()
+            real_execute = db.execute
+
+            async def execute_wrapping_cursor(sql, params=None):
+                cursor = await real_execute(sql, params)
+                real_fetchmany = cursor.fetchmany
+
+                async def recording_fetchmany(size):
+                    recorded_sizes.append(size)
+                    return await real_fetchmany(size)
+
+                cursor.fetchmany = recording_fetchmany
+                return cursor
+
+            db.execute = execute_wrapping_cursor
+            return db
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    monkeypatch.setattr(seeded_adapter._aiosqlite, "connect", _ConnectWrapper)
+
+    streamed = []
+    async with seeded_adapter.stream(
+        "SELECT id FROM items ORDER BY id", batch_size=2
+    ) as cursor:
+        async for row in streamed_consume(cursor, streamed):
+            pass
+
+    assert [r["id"] for r in streamed] == [1, 2, 3, 4, 5]
+    # Every fetchmany call requested exactly batch_size=2.
+    assert recorded_sizes, "fetchmany was never called"
+    assert all(size == 2 for size in recorded_sizes), recorded_sizes
+    # 5 rows / chunk of 2 => 3 chunks with data + 1 empty terminator.
+    assert len(recorded_sizes) == 4, recorded_sizes
+
+
+async def streamed_consume(cursor, sink):
+    """Helper: drain a stream cursor into ``sink`` and yield each row."""
+    async for row in cursor:
+        sink.append(row)
+        yield row
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_pull_remaining_rows_before_consumed(
+    seeded_adapter,
+):
+    """Before the consumer has processed past the first batch, only the first
+    batch_size rows have been pulled — proof of lazy, bounded pulls.
+
+    With batch_size=2, after pulling exactly ONE row from the iterator (which
+    triggers the first fetchmany of 2), at most 2 rows have been read from the
+    driver — never all 5.
+    """
+    fetched_total = 0
+
+    import aiosqlite
+
+    real_connect = aiosqlite.connect
+
+    class _ConnectWrapper:
+        def __init__(self, *args, **kwargs):
+            self._cm = real_connect(*args, **kwargs)
+
+        async def __aenter__(self):
+            db = await self._cm.__aenter__()
+            real_execute = db.execute
+
+            async def execute_wrapping(sql, params=None):
+                cursor = await real_execute(sql, params)
+                real_fetchmany = cursor.fetchmany
+
+                async def counting_fetchmany(size):
+                    nonlocal fetched_total
+                    batch = await real_fetchmany(size)
+                    fetched_total += len(batch)
+                    return batch
+
+                cursor.fetchmany = counting_fetchmany
+                return cursor
+
+            db.execute = execute_wrapping
+            return db
+
+        async def __aexit__(self, *exc):
+            return await self._cm.__aexit__(*exc)
+
+    seeded_adapter._aiosqlite.connect = _ConnectWrapper
+    try:
+        async with seeded_adapter.stream(
+            "SELECT id FROM items ORDER BY id", batch_size=2
+        ) as cursor:
+            agen = cursor.__aiter__()
+            first = await agen.__anext__()
+            assert first["id"] == 1
+            # Only the first batch (2 rows) should have been pulled so far.
+            assert fetched_total <= 2, (
+                f"pulled {fetched_total} rows after consuming 1; "
+                "streaming is not bounded"
+            )
+            # Drain the rest so the CM exits cleanly.
+            async for _ in agen:
+                pass
+    finally:
+        seeded_adapter._aiosqlite.connect = real_connect
+
+    assert fetched_total == 5
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant + API surface
+# ---------------------------------------------------------------------------
+
+
+def test_default_stream_batch_size_constant():
+    """The documented default batch size is exposed as a module constant."""
+    assert DEFAULT_STREAM_BATCH_SIZE == 1000
+
+
+def test_stream_uses_default_batch_size_signature():
+    """adapter.stream defaults batch_size to DEFAULT_STREAM_BATCH_SIZE."""
+    import inspect
+
+    sig = inspect.signature(SQLiteAdapter.stream)
+    assert sig.parameters["batch_size"].default == DEFAULT_STREAM_BATCH_SIZE

--- a/tests/unit/nodes/test_async_sql_streaming.py
+++ b/tests/unit/nodes/test_async_sql_streaming.py
@@ -379,3 +379,191 @@ def test_stream_uses_default_batch_size_signature():
 
     sig = inspect.signature(SQLiteAdapter.stream)
     assert sig.parameters["batch_size"].default == DEFAULT_STREAM_BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Node-layer stream() — public surface (node.stream), masking, lifetime
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def seeded_node(sqlite_db_path):
+    """An AsyncSQLDatabaseNode over a seeded file-backed SQLite DB."""
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        name="stream_test_node",
+        database_type="sqlite",
+        database=sqlite_db_path,
+        validate_queries=True,
+        allow_admin=True,  # needed only to seed the schema below
+        share_pool=False,
+    )
+    await node.async_run(
+        query="CREATE TABLE people (id INTEGER PRIMARY KEY, name TEXT, ssn TEXT)"
+    )
+    for i, name, ssn in [
+        (1, "Alice", "111-11-1111"),
+        (2, "Bob", "222-22-2222"),
+        (3, "Carol", "333-33-3333"),
+    ]:
+        await node.async_run(
+            query="INSERT INTO people (id, name, ssn) VALUES (:id, :name, :ssn)",
+            params={"id": i, "name": name, "ssn": ssn},
+        )
+    return node
+
+
+@pytest.mark.asyncio
+async def test_node_stream_round_trip_matches_async_run(seeded_node):
+    """node.stream rows equal the node's materialized async_run data."""
+    materialized = await seeded_node.async_run(
+        query="SELECT id, name FROM people ORDER BY id"
+    )
+    expected = materialized["result"]["data"]
+
+    streamed = []
+    async with seeded_node.stream(
+        query="SELECT id, name FROM people ORDER BY id", batch_size=2
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    assert streamed == expected
+    assert [r["id"] for r in streamed] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_node_stream_positional_params(seeded_node):
+    """Positional params are converted (node→named→adapter→positional)."""
+    streamed = []
+    async with seeded_node.stream(
+        query="SELECT id FROM people WHERE id > ? ORDER BY id", params=[1]
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row["id"])
+    assert streamed == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_node_stream_early_break_then_reuse(seeded_node):
+    """Early break releases the connection; the node is reusable after."""
+    seen = []
+    async with seeded_node.stream(query="SELECT id FROM people ORDER BY id") as cursor:
+        async for row in cursor:
+            seen.append(row["id"])
+            break
+    assert seen == [1]
+
+    after = await seeded_node.async_run(query="SELECT COUNT(*) AS c FROM people")
+    assert after["result"]["data"][0]["c"] == 3
+
+
+@pytest.mark.asyncio
+async def test_node_stream_validates_query(seeded_node):
+    """Streaming honors the same query validation gate as async_run.
+
+    A UNION-based injection pattern is rejected regardless of allow_admin,
+    proving the validation gate fires on the streaming path too.
+    """
+    from kailash.sdk_exceptions import NodeExecutionError
+
+    with pytest.raises(NodeExecutionError, match="Query validation failed"):
+        async with seeded_node.stream(
+            query="SELECT id FROM people UNION SELECT ssn FROM people"
+        ):
+            pass
+
+
+class _MaskingAccessControlManager:
+    """Deterministic access-control manager (Protocol-satisfying, NOT a mock).
+
+    Allows EXECUTE and masks the ``ssn`` field per row. Deterministic output
+    over deterministic input — per testing.md § "Protocol Adapters", this is a
+    real adapter, not a mock.
+    """
+
+    class _Decision:
+        allowed = True
+        reason = "ok"
+
+    def check_node_access(self, user_context, node_name, permission):
+        return self._Decision()
+
+    def apply_data_masking(self, user_context, node_name, row):
+        masked = dict(row)
+        if "ssn" in masked and masked["ssn"] is not None:
+            masked["ssn"] = "***-**-****"
+        return masked
+
+
+@pytest.mark.asyncio
+async def test_node_stream_applies_masking_per_row(seeded_node):
+    """Per-row masking MUST be applied to streamed rows (no silent bypass).
+
+    The materialized path masks per row; streaming MUST do the same, or
+    streaming becomes a masking-bypass security gap.
+    """
+    seeded_node.access_control_manager = _MaskingAccessControlManager()
+    user_context = {"user_id": "u1"}
+
+    streamed = []
+    async with seeded_node.stream(
+        query="SELECT id, name, ssn FROM people ORDER BY id",
+        user_context=user_context,
+    ) as cursor:
+        async for row in cursor:
+            streamed.append(row)
+
+    # Every streamed row has the ssn masked, names intact.
+    assert [r["name"] for r in streamed] == ["Alice", "Bob", "Carol"]
+    assert all(r["ssn"] == "***-**-****" for r in streamed), streamed
+    # No raw SSN leaked through the stream.
+    assert all("111-11-1111" != r["ssn"] for r in streamed)
+
+
+@pytest.mark.asyncio
+async def test_node_stream_no_masking_when_no_user_context(seeded_node):
+    """With a manager set but no user_context, masking is NOT applied.
+
+    Mirrors async_run: masking requires BOTH the manager AND a user_context.
+    """
+    seeded_node.access_control_manager = _MaskingAccessControlManager()
+
+    streamed = []
+    async with seeded_node.stream(
+        query="SELECT id, ssn FROM people ORDER BY id"
+    ) as cursor:  # no user_context
+        async for row in cursor:
+            streamed.append(row)
+
+    # Unmasked — the raw SSNs come through (no user_context → no masking).
+    assert [r["ssn"] for r in streamed] == [
+        "111-11-1111",
+        "222-22-2222",
+        "333-33-3333",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_node_stream_access_denied_blocks(seeded_node):
+    """A denying access-control manager blocks streaming before it opens."""
+    from kailash.sdk_exceptions import NodeExecutionError
+
+    class _DenyManager:
+        class _Decision:
+            allowed = False
+            reason = "no access"
+
+        def check_node_access(self, user_context, node_name, permission):
+            return self._Decision()
+
+        def apply_data_masking(self, user_context, node_name, row):
+            return row
+
+    seeded_node.access_control_manager = _DenyManager()
+    with pytest.raises(NodeExecutionError, match="Access denied"):
+        async with seeded_node.stream(
+            query="SELECT id FROM people", user_context={"user_id": "u1"}
+        ):
+            pass

--- a/tests/unit/nodes/test_async_sql_streaming.py
+++ b/tests/unit/nodes/test_async_sql_streaming.py
@@ -411,7 +411,8 @@ async def seeded_node(sqlite_db_path):
             query="INSERT INTO people (id, name, ssn) VALUES (:id, :name, :ssn)",
             params={"id": i, "name": name, "ssn": ssn},
         )
-    return node
+    yield node
+    await node.cleanup()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a real, **memory-bounded SQL streaming API** to `AsyncSQLDatabaseNode` and its adapters — the proper replacement for the removed `FetchMode.ITERATOR` (#1416). Streaming is its own control-flow (server-side cursors held open across iteration), so it is an **async context manager**, NOT a fetch_mode return value:

```python
async with node.stream(query="SELECT * FROM big_table", batch_size=1000) as cursor:
    async for row in cursor:        # rows pulled in batches; peak memory bounded
        process(row)                # each row already _convert_row-converted
```

### What's added
- `DatabaseAdapter.stream()` — `@abstractmethod` returning an async context manager.
- Per-dialect server-side cursors: **PostgreSQL** (asyncpg cursor inside `conn.transaction()`, `prefetch=batch_size`), **MySQL** (aiomysql unbuffered `SSCursor`), **SQLite** (chunked `fetchmany`). Each applies `_convert_row` per row, so a streamed row is byte-identical to a `fetch_mode=ALL` row.
- The three `Production*Adapter` wrappers inherit `stream()` (the node instantiates these — streaming runs through the production path).
- `AsyncSQLDatabaseNode.stream()` — public surface: query validation + param conversion + access-control check + **per-row data masking** + open/close observability logs.
- Module constant `DEFAULT_STREAM_BATCH_SIZE = 1000` (separate from `fetch_size`).

### Load-bearing invariant — connection lifetime
The connection (and, for PostgreSQL, its transaction) stays **open for the entire iteration**; the `@asynccontextmanager` releases it on **all** exit paths — normal completion, early `break`, and exception unwind. This is why streaming cannot be a value returned from `execute()`.

### Bugs found + fixed during implementation
- **MySQL `SSCursor` connection leak**: an unbuffered streamed `SELECT` left an open read transaction holding a table **metadata lock** (next DDL deadlocked on `Waiting for table metadata lock`). Fixed: the cursor is closed then the read txn `rollback()`ed on every exit path before the connection returns to the pool.
- **SQLite cursor/connection ordering**: cursor now closes strictly before connection release on every sub-path (pool / shared-`:memory:` / inline-file).

### Retry contract
Streaming does **not** use the node's retry wrapper (re-driving mid-iteration would double-yield). Retry covers only the connect + cursor-open phase; after the first row, errors propagate to the caller.

## User-flow walk receipt
```
$ async with node.stream(query="SELECT * FROM events ORDER BY id", batch_size=50) as cursor:
      async for row in cursor: ...; break after 10
rows processed before early break: 10
first row: {'id': 1, 'msg': 'event-1'}
follow-up query after stream works: [{'n': 250}]   # connection released cleanly
```

## Verification
- **SQLite streaming** → `tests/unit/nodes/test_async_sql_streaming.py` (16 tests) — runs in the **blocking Tier-1 CI lane** (no Docker). Round-trip vs `fetch_mode=ALL`, early-break + exception-unwind release, batch-boundary, per-row masking (applies + access-denied-blocks + no-mask-without-user_context).
- **PostgreSQL + MySQL streaming** → `tests/integration/nodes/test_async_sql_streaming_integration.py` (`requires_postgres` / `requires_mysql`; excluded from gating CI, run locally against the live containers): **7 PG + 6 MySQL passed**. Memory-bounded proof is a **deterministic batch-boundary assertion** (instrument the driver fetch, assert ≤ batch_size pulled after 1 row consumed), not a tracemalloc heuristic; PG asserts `idle in transaction == 0` after break/exception; both assert pool free-count restored.
- Full suite (SQLite unit + PG + MySQL): **33 passed**, clean under `-W error::ResourceWarning -W error::PytestUnraisableExceptionWarning`.
- Stub-marker inventory updated (the new abstractmethod sentinel; guard passes).

## Gate review
- **security-reviewer: APPROVE** — per-row masking verified on the stream path (no redaction bypass; access-denied blocks streaming), all queries parameterized (no interpolation), connection/transaction released on every exit path in all 3 dialects, no secret/row leak in logs, no silent fallback.
- **reviewer: APPROVE** (after the fixture-cleanup fix) — load-bearing lifetime invariant verified on all paths; the MySQL leak fix and SQLite ordering confirmed correct; deterministic memory-bound tests confirmed; Production-wrapper wiring confirmed (no orphan).

### Known non-blocking note
pyright reports a false-positive "Cannot instantiate abstract class SQLiteAdapter" — the concrete `@asynccontextmanager async def stream` overrides the `@abstractmethod def stream -> AbstractAsyncContextManager`; Python's ABC only checks the name is overridden (runtime + all 33 tests prove instantiation works). pyright is non-blocking in CI.

## Related issues

Follow-up to #1416 (removal of the non-functional `FetchMode.ITERATOR`); together these resolve gaps #1/#2 of #1406. No release is cut between the two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)