### PR TITLE
chore(release): kailash 2.44.0 — SQL streaming API; remove FetchMode.ITERATOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.44.0] - 2026-06-22
+
+Replaces the never-functional `FetchMode.ITERATOR` on `AsyncSQLDatabaseNode` with a
+real, memory-bounded streaming API and closes a silent-fallback bug class in the
+async-SQL fetch dispatch (PR #1416, #1417). Resolves the top public-reachable gaps
+(#1/#2) of the Production/Stable stub-marker inventory (#1406).
+
+### Added
+
+- **Memory-bounded SQL streaming — `AsyncSQLDatabaseNode.stream()` (+ adapter
+  `stream()`)** (`kailash.nodes.data.async_sql`; PR #1417). An async-context-manager
+  that pulls rows lazily via server-side cursors — asyncpg cursor inside a
+  transaction (PostgreSQL), unbuffered `SSCursor` (MySQL), chunked `fetchmany`
+  (SQLite) — so large result sets do not materialize in memory:
+
+  ```python
+  async with node.stream(query="SELECT * FROM big_table", batch_size=1000) as cursor:
+      async for row in cursor:        # peak memory bounded by batch_size
+          process(row)                # each row already converted, masked if access-controlled
+  ```
+
+  The connection (and, for PostgreSQL, its transaction) is held open for the entire
+  iteration and released on every exit path (completion, early `break`, exception).
+  Streamed rows are byte-identical to `fetch_mode="all"` rows; access-control masking
+  and query validation apply on the stream path exactly as on the materialized path.
+  New module constant `DEFAULT_STREAM_BATCH_SIZE = 1000` (distinct from `fetch_size`).
+
+### Removed
+
+- **BREAKING — `FetchMode.ITERATOR` removed** (`kailash.nodes.data.async_sql.FetchMode`;
+  PR #1416). The member never produced a working result on any dialect — it raised
+  `NotImplementedError` on PostgreSQL and silently returned `None` (MySQL) / `[]`
+  (SQLite). A lazily-yielding stream cannot be a materializing fetch _return value_
+  the way `ONE`/`ALL`/`MANY` are, so it was a category error. **Migration:** for
+  streaming, use the new `node.stream()` async-context-manager (see Added); for
+  bounded batches, use `fetch_mode="many"` with `fetch_size`. No working code breaks —
+  the member never returned usable data. `fetch_mode="iterator"` is now rejected at
+  node validation with `Invalid fetch_mode: iterator. Must be one of: one, all, many`.
+
+### Fixed
+
+- **Silent-fallback in async-SQL fetch dispatch** (`kailash.nodes.data.async_sql`;
+  PR #1416). An unrecognized fetch mode previously fell through the MySQL/SQLite
+  dispatch to `None`/`[]` instead of raising; every adapter dispatch now ends in a
+  typed `ValueError("Unsupported fetch_mode: …")` so a wrong-but-plausible empty
+  result can never again be returned silently.
+- **MySQL streaming connection leak** (`kailash.nodes.data.async_sql`; PR #1417).
+  An unbuffered `SSCursor` left an open read transaction holding a table metadata
+  lock, deadlocking subsequent DDL; the cursor is now closed and the read
+  transaction rolled back on every exit path before the connection returns to the
+  pool.
+
 ## [2.43.1] - 2026-06-21
 
 Cross-SDK canonical-encoder conformance plus a trust-plane-wide NaN/Inf signing

--- a/docs/core/nodes.rst
+++ b/docs/core/nodes.rst
@@ -49,6 +49,27 @@ For reading and writing data:
        "parameter_types": ["BOOLEAN"]
    })
 
+For large result sets, ``AsyncSQLDatabaseNode.stream()`` returns an async context
+manager that yields rows lazily from a server-side cursor (PostgreSQL, MySQL) or a
+chunked fetch (SQLite), so peak memory is bounded by ``batch_size`` rather than the
+full result. The connection is held open for the duration of iteration and released
+on every exit path — normal completion, early ``break``, or exception. Streamed rows
+are identical to ``fetch_mode="all"`` rows, and query validation plus access-control
+masking apply on the stream path exactly as on the materialized path:
+
+.. code-block:: python
+
+   node = AsyncSQLDatabaseNode(
+       database_type="postgresql",
+       connection_string=os.environ.get("DATABASE_URL"),
+   )
+
+   async with node.stream(
+       query="SELECT * FROM events ORDER BY id", batch_size=1000
+   ) as cursor:
+       async for row in cursor:
+           process(row)
+
 AI / LLM Nodes
 ---------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.43.1"
+version = "2.44.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.43.1"
+__version__ = "2.44.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Release: kailash 2.44.0

Minor release bundling two merged PRs that resolve the top public-reachable gaps (#1/#2) of the #1406 stub-marker inventory:

- **#1416** — removed the non-functional `FetchMode.ITERATOR` (never worked: raised on Postgres, silently returned `None`/`[]` on MySQL/SQLite) and closed the async-SQL silent-fallback bug class with typed errors.
- **#1417** — added a memory-bounded `AsyncSQLDatabaseNode.stream()` / adapter `stream()` API (server-side cursors across PostgreSQL/MySQL/SQLite), with per-row access-control masking and correct connection lifetime on every exit path.

### Why minor
`stream()` is a new public API (Added → minor). The `FetchMode.ITERATOR` removal is breaking but marked inline with migration guidance — it never produced a working result, so no working code breaks. Consistent with the repo's stay-in-2.x, mark-breaking-inline convention (e.g. 2.43.1 shipped a BREAKING byte-shape change as a patch).

### Diff (metadata-only — release-prep)
- `pyproject.toml` + `src/kailash/__init__.py` → `2.44.0` (atomic)
- `CHANGELOG.md` → 2.44.0 section (Added `stream()`, Removed **BREAKING** `FetchMode.ITERATOR` + migration, Fixed silent fallbacks + MySQL leak)
- `docs/core/nodes.rst` → `stream()` API section

### Gates
- The code (both PRs) was security-reviewed (security-reviewer APPROVE on each) and passed the full CI matrix (Python 3.11–3.14) on main.
- No sibling-package drift — all sub-packages at PyPI parity.
- TestPyPI: skippable for this minor per the repo's documented minor-release practice (post-publish clean-venv install is the installability gate).

## Related issues

Resolves the FetchMode.ITERATOR gaps (#1/#2) of #1406 via #1416 + #1417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)