### PR TITLE
docs(deploy): deployment record for kailash 2.44.0

### DIFF
--- a/deploy/deployments/2026-06-22-v2.44.0-async-sql-streaming.md
+++ b/deploy/deployments/2026-06-22-v2.44.0-async-sql-streaming.md
@@ -1,0 +1,91 @@
+# Deployment Record — kailash 2.44.0 (2026-06-22)
+
+Single-package core **minor** release `kailash 2.43.1 → 2.44.0`. Replaces the
+never-functional `FetchMode.ITERATOR` on `AsyncSQLDatabaseNode` with a real,
+memory-bounded streaming API and closes a silent-fallback bug class in the
+async-SQL fetch dispatch. Resolves the top public-reachable gaps (#1/#2) of the
+`#1406` Production/Stable stub-marker inventory.
+
+## What shipped
+
+### Added
+
+- **`AsyncSQLDatabaseNode.stream()` + adapter `stream()` — memory-bounded SQL
+  streaming** (`kailash.nodes.data.async_sql`; PR #1417). An async-context-manager
+  yielding rows lazily via server-side cursors: asyncpg cursor inside a transaction
+  (PostgreSQL), unbuffered `SSCursor` (MySQL), chunked `fetchmany` (SQLite). The
+  connection (and PostgreSQL transaction) is held open for the entire iteration and
+  released on every exit path (completion / early `break` / exception). Streamed rows
+  are byte-identical to `fetch_mode="all"`; query validation + per-row access-control
+  masking apply on the stream path. New constant `DEFAULT_STREAM_BATCH_SIZE = 1000`.
+
+### Removed (BREAKING)
+
+- **`FetchMode.ITERATOR` removed** (`kailash.nodes.data.async_sql.FetchMode`;
+  PR #1416). Never produced a working result — raised `NotImplementedError`
+  (PostgreSQL), silently returned `None` (MySQL) / `[]` (SQLite). Migration: use
+  `node.stream()` for streaming, or `fetch_mode="many"` + `fetch_size` for bounded
+  batches. No working code breaks (the member never returned usable data).
+  `fetch_mode="iterator"` now rejected at node validation.
+
+### Fixed
+
+- **Async-SQL silent-fallback** (PR #1416): an unrecognized fetch mode fell through
+  the MySQL/SQLite dispatch to `None`/`[]`; every adapter dispatch now ends in a
+  typed `ValueError("Unsupported fetch_mode: …")`.
+- **MySQL streaming connection leak** (PR #1417): an unbuffered `SSCursor` left an
+  open read transaction holding a table metadata lock (deadlocking subsequent DDL);
+  the cursor is now closed and the read transaction rolled back on every exit path
+  before the connection returns to the pool.
+
+## Convergence / gates
+
+- **#1416** — reviewer APPROVE (6/6 mechanical sweeps) + security-reviewer APPROVE
+  (no info leak; hardening; untrusted `fetch_mode` rejected at two gates). Full PR-gate
+  matrix GREEN (Python 3.11–3.14). 3 regression tests in the blocking Tier-1 lane.
+- **#1417** — security-reviewer APPROVE (per-row masking verified on the stream path —
+  no redaction bypass; access-denied blocks streaming; all queries parameterized;
+  connection/transaction released on every exit path) + reviewer APPROVE after a
+  test-fixture connection-leak fix (`ResourceWarning`/`Event loop is closed`, MED-1).
+  Deterministic memory-bound tests (batch-boundary assertion, not tracemalloc).
+  SQLite 16 (gated Tier-1) + PostgreSQL 7 + MySQL 6 = 33 streaming tests; clean under
+  `-W error::ResourceWarning`. Full PR-gate matrix GREEN.
+- Stub-marker inventory kept byte-accurate in the same commits (gaps 13→11,
+  public-reachable 6→4; the new abstractmethod sentinel inventoried; CI guard passes).
+
+## Receipts
+
+- PR #1416 (`fix/async-sql-remove-broken-iterator-mode`, merge `7e5d60669`).
+- PR #1417 (`feat/async-sql-streaming`, merge `c600e001b`).
+- Release-prep PR #1418 (`release/v2.44.0`, merge `4b5643bc3`; PR-gate matrix
+  path-skipped on `release/v*`, one benign duplicate-run cancellation; `--admin`
+  cleared REVIEW_REQUIRED).
+- Lightweight tag `v2.44.0` → publish-pypi run `27930852347` SUCCESS
+  (Determine package → Build kailash → Publish-to-PyPI → Create-GitHub-Release;
+  Publish-to-TestPyPI skipped — `workflow_dispatch`-only). TestPyPI pre-validation
+  skipped per the documented minor-release human-approval practice ("approved").
+- Clean-venv install verified live (pip `--no-cache-dir` fallback after the
+  documented uv deeper-index-cache lag): `kailash.__version__ == "2.44.0"`,
+  `FetchMode` members `['one','all','many']` (ITERATOR removed), `node.stream()`
+  present and asynccontextmanager-shaped.
+
+## Sibling drift
+
+None — all 7 sub-packages AT-PARITY with PyPI at release time (dataflow 2.12.0 /
+nexus 2.11.0 / kaizen 2.28.0 / mcp 0.2.15 / ml 2.2.1 / align 0.7.2 / pact 0.14.1).
+This session touched only `src/kailash/nodes/data/async_sql.py` (core), so only
+`kailash` needed release.
+
+## Cross-SDK
+
+The kailash-rs sibling's async-SQL equivalent may carry the same
+`FetchMode.ITERATOR`-class dead enum + silent-fallback gap (EATP-D6 parity). SURFACED
+for the operator's human-gated, scrubbed filing decision — NOT auto-filed
+(`repo-scope-discipline.md` + `upstream-issue-hygiene.md`).
+
+## Outstanding ledger
+
+- **F-STUB-GAPS — partially closed.** Gaps #1/#2 (`FetchMode.ITERATOR`) CLOSED this
+  release. Remaining public-reachable gaps from `#1406`: edge_monitoring active-count
+  bug (`nodes/edge/edge_monitoring_node.py:359`), `rest.py:433` `max_pages` no-op,
+  plus two `track`-disposition items. Each is its own focused PR + regression + redteam.


### PR DESCRIPTION
Audit-trail deployment record for the 2.44.0 release (async-SQL streaming + FetchMode.ITERATOR removal). Docs-only — no release. Release already published + verified (publish run 27930852347).

🤖 Generated with [Claude Code](https://claude.com/claude-code)