### PR TITLE
fix(core): close 3 implementable #1406 stub gaps

### DIFF
--- a/STUB-MARKER-INVENTORY.md
+++ b/STUB-MARKER-INVENTORY.md
@@ -47,13 +47,13 @@ Scoped to the `kailash` core and categorised, the real picture is:
 
 | Metric                                                  | Count |
 | ------------------------------------------------------- | ----- |
-| Files with ≥1 marker (`src/kailash`)                    | 39    |
-| Total marker lines                                      | 67    |
+| Files with ≥1 marker (`src/kailash`)                    | 36    |
+| Total marker lines                                      | 64    |
 | — false-positive (not a real marker)                    | 31    |
 | — sentinel (intentional contract)                       | 25    |
-| — gap (genuine deferred work)                           | 11    |
+| — gap (genuine deferred work)                           | 8     |
 | — tracked (deferred + issue-linked)                     | 0     |
-| **Genuine gaps reachable from a documented public API** | **4** |
+| **Genuine gaps reachable from a documented public API** | **1** |
 
 ---
 
@@ -84,34 +84,42 @@ SDK itself is complete; the `TODO`/`NotImplementedError` lives in the scaffold
 `public` = reachable from a documented public API (a stub a consumer can hit matters
 more than an internal one).
 
-| #   | Location                                         | Marker                                                                                         | public  | Disposition        | Note                                                                                                                                                                      |
-| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- | :-----: | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `nodes/edge/edge_monitoring_node.py:359`         | `# TODO: proper active check`                                                                  | **yes** | implement          | `[a for a in alerts if active_only or True]` — the `or True` makes the filter a no-op, so `active_count` **always equals the total alert count**. Latent correctness bug. |
-| 2   | `nodes/api/rest.py:433`                          | `# max_pages = ... # TODO: Implement max pages limit`                                          | **yes** | implement / remove | `max_pages` pagination cap is commented out, so the param is silently ignored — a caller passing `max_pages` gets no effect (over-fetch risk).                            |
-| 3   | `nodes/monitoring/performance_benchmark.py:2155` | `raise NotImplementedError("Anomaly detector training requires a machine learning library …")` | **yes** | track              | The anomaly-detection benchmark path raises; needs an ML dependency to implement.                                                                                         |
-| 4   | `cli/validate_imports.py:118`                    | `# TODO: Add support for include_tests flag in validator`                                      | **yes** | track              | The `--include-tests` CLI flag is parsed and printed but never passed to `validate_directory()` (`zero-tolerance` Rule 3c).                                               |
-| 5   | `nodes/monitoring/deadlock_detector.py:919`      | `# TODO: Send alerts or take automatic resolution actions`                                     |   no    | track              | Deadlocks are detected and recorded; alerting / auto-resolution is deferred (enhancement, not a broken contract).                                                         |
-| 6   | `middleware/communication/events.py:210`         | `# TODO: Replace with BatchProcessorNode for production use`                                   |   no    | track              | `EventBatch` is deprecated (emits a `DeprecationWarning`); replacement deferred.                                                                                          |
-| 7   | `middleware/communication/events.py:279`         | `# TODO: Add CacheNode when available for event history`                                       |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
-| 8   | `middleware/communication/events.py:280`         | `# TODO: Add AsyncQueueNode when available for event buffering`                                |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
-| 9   | `middleware/communication/events.py:281`         | `# TODO: Add MetricsCollectorNode when available for performance tracking`                     |   no    | track              | Depends on a node that does not yet exist.                                                                                                                                |
-| 10  | `nodes/data/bulk_operations.py:269`              | `# TODO: Implement COPY FROM for maximum performance`                                          |   no    | track              | Performance optimisation only — functionally complete via the multi-row-`INSERT` fallback directly below it.                                                              |
-| 11  | `runtime/parallel_cyclic.py:224`                 | `# TODO: Add cycle-aware parallel execution optimizations`                                     |   no    | track              | Performance optimisation; the path executes correctly without it.                                                                                                         |
+| #   | Location                                         | Marker                                                                                         | public  | Disposition | Note                                                                                                                                              |
+| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- | :-----: | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `nodes/monitoring/performance_benchmark.py:2155` | `raise NotImplementedError("Anomaly detector training requires a machine learning library …")` | **yes** | track       | The anomaly-detection benchmark path raises a clear typed error when no ML library is present; needs an ML dependency to implement the full path. |
+| 2   | `nodes/monitoring/deadlock_detector.py:919`      | `# TODO: Send alerts or take automatic resolution actions`                                     |   no    | track       | Deadlocks are detected and recorded; alerting / auto-resolution is deferred (enhancement, not a broken contract).                                |
+| 3   | `middleware/communication/events.py:210`         | `# TODO: Replace with BatchProcessorNode for production use`                                    |   no    | track       | `EventBatch` is deprecated (emits a `DeprecationWarning`); replacement deferred.                                                                 |
+| 4   | `middleware/communication/events.py:279`         | `# TODO: Add CacheNode when available for event history`                                        |   no    | track       | Depends on a node that does not yet exist.                                                                                                       |
+| 5   | `middleware/communication/events.py:280`         | `# TODO: Add AsyncQueueNode when available for event buffering`                                 |   no    | track       | Depends on a node that does not yet exist.                                                                                                       |
+| 6   | `middleware/communication/events.py:281`         | `# TODO: Add MetricsCollectorNode when available for performance tracking`                      |   no    | track       | Depends on a node that does not yet exist.                                                                                                       |
+| 7   | `nodes/data/bulk_operations.py:269`              | `# TODO: Implement COPY FROM for maximum performance`                                           |   no    | track       | Performance optimisation only — functionally complete via the multi-row-`INSERT` fallback directly below it.                                     |
+| 8   | `runtime/parallel_cyclic.py:224`                 | `# TODO: Add cycle-aware parallel execution optimizations`                                      |   no    | track       | Performance optimisation; the path executes correctly without it.                                                                                |
 
-**Resolved:** the two former gaps #1/#2 (`nodes/data/async_sql.py:1268,1319` —
-`FetchMode.ITERATOR`) are closed. `FetchMode.ITERATOR` was a category error (a lazy
-async stream cannot be a materializing fetch _return value_); it never produced a
-working result (raised on PostgreSQL, returned `None`/`[]` on MySQL/SQLite). The enum
-member is removed, the silent MySQL/SQLite fallbacks now raise a typed `ValueError`,
-and a dedicated memory-bounded `stream()` API replaces the streaming use case
-(follow-up workstream). This drops the gap count 13 → 11 and the public-reachable
-gap count 6 → 4.
+**Resolved this cycle (3 of the 4 former public-reachable gaps):**
 
-**Recommended follow-ups (highest value first):** #1 (`edge_monitoring`
-active-count bug) is the only remaining entry that alters or blocks observable
-behaviour on a public surface; #2 and #4 are silently-ignored public params; the
-remainder are enhancements/perf with a working code path.
+- **`edge_monitoring_node.py` active-count no-op (former gap #1)** — `[a for a in
+  alerts if active_only or True]` made `active_count` always equal the total alert
+  count. Fixed by extracting `EdgeMonitor.is_alert_active()` (the cooldown-window
+  predicate, previously inline in `get_alerts`) and computing `active_count` from
+  it. The marker line is removed.
+- **`rest.py` `max_pages` (former gap #2)** — the prior inventory called this
+  "silently ignored". Ground truth contradicts that: `max_pages` **is** read and
+  enforced in the remaining-pages fetch loop (`max_pages = int(...)` →
+  `while pages_fetched < max_pages`). The only defect was a stale, misleading
+  commented-out line (`# max_pages = ... # TODO`) earlier in the method; it is
+  removed and a regression test pins the cap behaviour.
+- **`cli/validate_imports.py` `--include-tests` (former gap #4)** — the flag was
+  parsed but never passed to `validate_directory()` (`zero-tolerance` Rule 3c —
+  documented kwarg with no effect). `validate_directory` now takes
+  `include_tests: bool = False`; the CLI forwards `args.include_tests`.
 
+Earlier cycle (`FetchMode.ITERATOR`, `nodes/data/async_sql.py`) dropped the
+public-reachable count 6 → 4; this cycle drops it 4 → 1. The one remaining
+public-reachable gap (#1) needs an ML dependency and stays `track`.
+
+**Recommended follow-ups:** the remaining entries are all `track` — #1 needs an ML
+dependency; #2–#8 are enhancements/perf with a working code path. None alters or
+blocks observable behaviour on a public surface today.
 ---
 
 ## Sentinels (category `sentinel`) — intentional, no action
@@ -181,24 +189,22 @@ Documented so the count is complete and the guard's raw hits are explained.
 {
   "scope": "src/kailash",
   "regex": "\\b(TODO|FIXME|HACK|STUB|XXX)\\b|NotImplementedError",
-  "total": 67,
+  "total": 64,
   "category_tally": {
     "false_positive": 31,
     "sentinel": 25,
-    "gap": 11,
+    "gap": 8,
     "tracked": 0
   },
-  "public_reachable_gaps": 4,
+  "public_reachable_gaps": 1,
   "per_file": {
     "src/kailash/channels/mcp/base.py": 5,
     "src/kailash/channels/mcp/http.py": 2,
-    "src/kailash/cli/validate_imports.py": 1,
     "src/kailash/delegate/dispatch.py": 2,
     "src/kailash/delegate/trust.py": 1,
     "src/kailash/edge/consistency.py": 2,
     "src/kailash/edge/prediction/predictive_warmer.py": 1,
     "src/kailash/middleware/communication/events.py": 4,
-    "src/kailash/nodes/api/rest.py": 1,
     "src/kailash/nodes/base.py": 2,
     "src/kailash/nodes/base_async.py": 4,
     "src/kailash/nodes/base_with_acl.py": 2,
@@ -206,7 +212,6 @@ Documented so the count is complete and the guard's raw hits are explained.
     "src/kailash/nodes/data/async_sql.py": 1,
     "src/kailash/nodes/data/bulk_operations.py": 1,
     "src/kailash/nodes/edge/edge_data.py": 2,
-    "src/kailash/nodes/edge/edge_monitoring_node.py": 1,
     "src/kailash/nodes/edge/edge_state.py": 1,
     "src/kailash/nodes/edge/edge_warming_node.py": 1,
     "src/kailash/nodes/monitoring/deadlock_detector.py": 1,

--- a/src/kailash/cli/validate_imports.py
+++ b/src/kailash/cli/validate_imports.py
@@ -115,9 +115,10 @@ For more info, see: .claude/skills/17-gold-standards/gold-absolute-imports.md
             print(f"Include tests: {args.include_tests}")
             print()
 
-        # TODO: Add support for include_tests flag in validator
         issues = validator.validate_directory(
-            str(path), recursive=not args.no_recursive
+            str(path),
+            recursive=not args.no_recursive,
+            include_tests=args.include_tests,
         )
 
     # Handle results

--- a/src/kailash/edge/monitoring/edge_monitor.py
+++ b/src/kailash/edge/monitoring/edge_monitor.py
@@ -11,7 +11,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional
 
 
 class MetricType(Enum):
@@ -336,18 +336,32 @@ class EdgeMonitor:
                 continue
 
             # Active filter
-            if active_only:
-                # Check if alert is still active (within cooldown)
-                key = f"{alert.edge_node}:{alert.metric_type.value}"
-                if key in self.alert_history:
-                    if (
-                        datetime.now() - self.alert_history[key]
-                    ).total_seconds() > self.alert_cooldown:
-                        continue
+            if active_only and not self.is_alert_active(alert):
+                continue
 
             results.append(alert)
 
         return sorted(results, key=lambda a: a.timestamp, reverse=True)
+
+    def is_alert_active(self, alert: EdgeAlert) -> bool:
+        """Return True if an alert is still active (within its cooldown window).
+
+        An alert is "active" when its issue key (``edge_node:metric_type``) has a
+        recorded last-fire time AND that fire happened no longer ago than
+        ``alert_cooldown`` seconds. An alert whose key has no history entry is
+        treated as inactive — there is no live cooldown keeping it open.
+
+        Args:
+            alert: The alert to evaluate.
+
+        Returns:
+            True if the alert is within its cooldown window, else False.
+        """
+        key = f"{alert.edge_node}:{alert.metric_type.value}"
+        last_fired = self.alert_history.get(key)
+        if last_fired is None:
+            return False
+        return (datetime.now() - last_fired).total_seconds() <= self.alert_cooldown
 
     def get_analytics(self, edge_node: str) -> Dict[str, Any]:
         """Get analytics for an edge node.

--- a/src/kailash/nodes/api/rest.py
+++ b/src/kailash/nodes/api/rest.py
@@ -430,7 +430,8 @@ class RESTClientNode(Node):
 
         pagination_type = pagination_params.get("type", "page")
         items_path = pagination_params.get("items_path", "data")
-        # max_pages = pagination_params.get("max_pages", 10)  # TODO: Implement max pages limit
+        # The max_pages cap is read and enforced in the remaining-pages fetch
+        # loop below (see `while pages_fetched < max_pages`).
 
         # Extract items from initial response
         all_items = self._get_nested_value(initial_response, items_path, [])

--- a/src/kailash/nodes/edge/edge_monitoring_node.py
+++ b/src/kailash/nodes/edge/edge_monitoring_node.py
@@ -4,15 +4,13 @@ This node integrates edge monitoring capabilities into workflows,
 providing metrics collection, health monitoring, alerting, and analytics.
 """
 
-import asyncio
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 from kailash.edge.monitoring.edge_monitor import (
     AlertSeverity,
     EdgeMetric,
     EdgeMonitor,
-    HealthStatus,
     MetricType,
 )
 from kailash.nodes.base import NodeParameter, register_node
@@ -354,9 +352,7 @@ class EdgeMonitoringNode(AsyncNode):
             "status": "success",
             "alerts": [a.to_dict() for a in alerts],
             "count": len(alerts),
-            "active_count": len(
-                [a for a in alerts if active_only or True]
-            ),  # TODO: proper active check
+            "active_count": sum(1 for a in alerts if self.monitor.is_alert_active(a)),
         }
 
     async def _get_analytics(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/kailash/runtime/validation/import_validator.py
+++ b/src/kailash/runtime/validation/import_validator.py
@@ -9,12 +9,10 @@ Based on Gold Standard: .claude/skills/17-gold-standards/gold-absolute-imports.m
 
 import ast
 import logging
-import os
-import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -325,7 +323,10 @@ class ImportPathValidator:
             return f"from {suggested_module} import ..."
 
     def validate_directory(
-        self, directory: str | Path, recursive: bool = True
+        self,
+        directory: str | Path,
+        recursive: bool = True,
+        include_tests: bool = False,
     ) -> List[ImportIssue]:
         """
         Validate all Python files in a directory.
@@ -333,6 +334,8 @@ class ImportPathValidator:
         Args:
             directory: Directory path to validate
             recursive: Whether to scan subdirectories
+            include_tests: When True, also validate test files (files whose
+                name contains ``test``). Defaults to False, which skips them.
 
         Returns:
             List of all import issues found
@@ -345,8 +348,10 @@ class ImportPathValidator:
 
         pattern = "**/*.py" if recursive else "*.py"
         for py_file in dir_path.glob(pattern):
-            # Skip test files by default (can be configured)
-            if "test" in py_file.name or "__pycache__" in str(py_file):
+            if "__pycache__" in str(py_file):
+                continue
+            # Skip test files unless explicitly included.
+            if not include_tests and "test" in py_file.name:
                 continue
 
             issues = self.validate_file(py_file)

--- a/tests/unit/edge/test_edge_monitoring_active_count.py
+++ b/tests/unit/edge/test_edge_monitoring_active_count.py
@@ -80,6 +80,36 @@ async def test_active_count_excludes_inactive_alerts():
 
 
 @pytest.mark.regression
+async def test_get_alerts_active_only_uses_is_alert_active():
+    """Pin the unified `active` semantic on the public `get_alerts(active_only=True)`
+    path: `is_alert_active` is the single predicate for both `get_alerts` filtering
+    and the node's `active_count`. An alert with a live cooldown entry is returned;
+    a stale-cooldown alert and a no-history alert are both excluded.
+
+    Note: the no-history case is the one deliberate change from the pre-extraction
+    `get_alerts` (which kept no-history alerts via a `key in alert_history` guard).
+    Unifying on `is_alert_active` makes filtering and counting agree. The live path
+    is unaffected — every generated alert records its cooldown entry at creation
+    (`EdgeMonitor._check_thresholds`).
+    """
+    monitor = EdgeMonitor(alert_cooldown=300)
+    active = _alert("n1", MetricType.LATENCY, "active")
+    stale = _alert("n2", MetricType.ERROR_RATE, "stale")
+    no_history = _alert("n3", MetricType.THROUGHPUT, "nohist")
+    monitor.alerts = [active, stale, no_history]
+    monitor.alert_history["n1:latency"] = datetime.now()
+    monitor.alert_history["n2:error_rate"] = datetime.now() - timedelta(seconds=600)
+    # n3 has no alert_history entry.
+
+    returned = await monitor.get_alerts(active_only=True)
+    returned_ids = {a.alert_id for a in returned}
+    assert returned_ids == {"active"}
+
+    # active_only=False returns everything (filtering unchanged on that path).
+    assert len(await monitor.get_alerts(active_only=False)) == 3
+
+
+@pytest.mark.regression
 async def test_active_count_zero_when_no_history():
     """When no alert has a live cooldown entry, active_count is 0 even though
     alerts are returned — the no-op filter would have reported the full count."""

--- a/tests/unit/edge/test_edge_monitoring_active_count.py
+++ b/tests/unit/edge/test_edge_monitoring_active_count.py
@@ -1,0 +1,95 @@
+"""Regression tests for issue #1406 gap #1 — edge monitoring active_count.
+
+The ``_get_alerts`` handler used ``len([a for a in alerts if active_only or True])``
+to compute ``active_count``. The ``or True`` made the comprehension a no-op, so
+``active_count`` always equalled the total alert count regardless of which alerts
+were actually active. The fix introduces ``EdgeMonitor.is_alert_active`` (the
+cooldown-window predicate, previously inline in ``get_alerts``) and computes
+``active_count`` from it.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from kailash.edge.monitoring.edge_monitor import (
+    AlertSeverity,
+    EdgeAlert,
+    EdgeMonitor,
+    MetricType,
+)
+from kailash.nodes.edge.edge_monitoring_node import EdgeMonitoringNode
+
+
+def _alert(edge_node: str, metric_type: MetricType, alert_id: str) -> EdgeAlert:
+    return EdgeAlert(
+        alert_id=alert_id,
+        timestamp=datetime.now(),
+        edge_node=edge_node,
+        severity=AlertSeverity.WARNING,
+        metric_type=metric_type,
+        message="threshold exceeded",
+        current_value=1.0,
+        threshold=0.5,
+    )
+
+
+def test_is_alert_active_true_within_cooldown():
+    monitor = EdgeMonitor(alert_cooldown=300)
+    alert = _alert("n1", MetricType.LATENCY, "a1")
+    monitor.alert_history["n1:latency"] = datetime.now()
+    assert monitor.is_alert_active(alert) is True
+
+
+def test_is_alert_active_false_outside_cooldown():
+    monitor = EdgeMonitor(alert_cooldown=300)
+    alert = _alert("n1", MetricType.LATENCY, "a1")
+    monitor.alert_history["n1:latency"] = datetime.now() - timedelta(seconds=600)
+    assert monitor.is_alert_active(alert) is False
+
+
+def test_is_alert_active_false_without_history():
+    monitor = EdgeMonitor(alert_cooldown=300)
+    alert = _alert("n1", MetricType.LATENCY, "a1")
+    # No alert_history entry for this key → not active.
+    assert monitor.is_alert_active(alert) is False
+
+
+@pytest.mark.regression
+async def test_active_count_excludes_inactive_alerts():
+    """active_count must count ONLY active alerts, not every alert.
+
+    The pre-fix `or True` short-circuit made active_count == count
+    unconditionally. With one active and one inactive alert returned,
+    active_count MUST be 1, not 2.
+    """
+    node = EdgeMonitoringNode()
+
+    active = _alert("n1", MetricType.LATENCY, "active")
+    inactive = _alert("n2", MetricType.ERROR_RATE, "inactive")
+    node.monitor.alerts = [active, inactive]
+    node.monitor.alert_history["n1:latency"] = datetime.now()
+    node.monitor.alert_history["n2:error_rate"] = datetime.now() - timedelta(
+        seconds=10_000
+    )
+
+    result = await node._get_alerts({"active_only": False})
+
+    assert result["count"] == 2
+    assert result["active_count"] == 1
+
+
+@pytest.mark.regression
+async def test_active_count_zero_when_no_history():
+    """When no alert has a live cooldown entry, active_count is 0 even though
+    alerts are returned — the no-op filter would have reported the full count."""
+    node = EdgeMonitoringNode()
+    node.monitor.alerts = [
+        _alert("n1", MetricType.LATENCY, "a1"),
+        _alert("n2", MetricType.THROUGHPUT, "a2"),
+    ]
+
+    result = await node._get_alerts({"active_only": False})
+
+    assert result["count"] == 2
+    assert result["active_count"] == 0

--- a/tests/unit/nodes/test_rest_pagination_max_pages.py
+++ b/tests/unit/nodes/test_rest_pagination_max_pages.py
@@ -1,0 +1,61 @@
+"""Regression test for issue #1406 gap #2 — REST pagination max_pages cap.
+
+The stub inventory flagged ``rest.py`` as "max_pages silently ignored" because
+of a commented-out ``# max_pages = ... # TODO`` line. Ground truth: the cap IS
+read and enforced in the remaining-pages fetch loop (``while pages_fetched <
+max_pages``). This test pins that behaviour so the cap cannot regress, and the
+misleading comment was removed in the same change.
+"""
+
+from unittest.mock import Mock
+
+from kailash.nodes.api.rest import RESTClientNode
+
+
+def test_max_pages_caps_fetch_loop():
+    """With pages that never run dry, only ``max_pages`` is the stop condition;
+    the loop MUST fetch at most ``max_pages - 1`` additional pages."""
+    node = RESTClientNode()
+
+    # Every follow-up request returns a non-empty page, so the ONLY thing that
+    # can stop the loop is the max_pages cap.
+    node.http_node.execute = Mock(  # type: ignore[method-assign]
+        return_value={"success": True, "response": {"content": {"data": [3, 4]}}}
+    )
+
+    initial_response = {"data": [1, 2]}
+    query_params = {"page": "1", "per_page": "2"}
+    pagination_params = {
+        "type": "page",
+        "items_path": "data",
+        "page_param": "page",
+        "limit_param": "per_page",
+        # no total_path → no early total-based exit; max_pages is the gate
+        "max_pages": 3,
+    }
+
+    all_items = node._handle_pagination(
+        initial_response, query_params, pagination_params
+    )
+
+    # pages_fetched starts at 1 (the initial page), loop runs while < 3 → 2 fetches.
+    assert node.http_node.execute.call_count == 2
+    # initial [1, 2] + two fetched pages [3, 4] each
+    assert all_items == [1, 2, 3, 4, 3, 4]
+
+
+def test_max_pages_one_disables_followup_fetches():
+    """max_pages=1 means only the initial page is kept; no follow-up fetch."""
+    node = RESTClientNode()
+    node.http_node.execute = Mock(  # type: ignore[method-assign]
+        return_value={"success": True, "response": {"content": {"data": [9]}}}
+    )
+
+    all_items = node._handle_pagination(
+        {"data": [1, 2]},
+        {"page": "1", "per_page": "2"},
+        {"type": "page", "items_path": "data", "max_pages": 1},
+    )
+
+    assert node.http_node.execute.call_count == 0
+    assert all_items == [1, 2]

--- a/tests/unit/runtime/test_import_validator.py
+++ b/tests/unit/runtime/test_import_validator.py
@@ -223,6 +223,29 @@ class TestImportPathValidator:
 
         assert len(issues) == 0  # Test files should be skipped
 
+    def test_include_tests_flag_validates_test_files(self):
+        """Regression (#1406 gap #4): the --include-tests flag was parsed by the
+        CLI but never reached validate_directory, so test files were always
+        skipped. With include_tests=True their import issues MUST be reported."""
+        self._create_test_file(
+            "src/mymodule/test_processor.py", "from .processor import process"
+        )
+        self._create_test_file(
+            "src/mymodule/processor_test.py", "from .processor import process"
+        )
+
+        module_dir = Path(self.temp_dir) / "src" / "mymodule"
+
+        # Default: test files skipped.
+        assert self.validator.validate_directory(module_dir) == []
+
+        # include_tests=True: both test files are validated and their relative
+        # imports flagged.
+        included = self.validator.validate_directory(module_dir, include_tests=True)
+        assert len(included) == 2
+        assert any("test_processor.py" in issue.file_path for issue in included)
+        assert any("processor_test.py" in issue.file_path for issue in included)
+
     def test_generate_report(self):
         """Test report generation."""
         # Create files with different issue types

--- a/workspaces/cross-sdk-audit/journal/0018-DECISION-cross-repo-authorized-kailash-rs-async-sql-streaming-parity.md
+++ b/workspaces/cross-sdk-audit/journal/0018-DECISION-cross-repo-authorized-kailash-rs-async-sql-streaming-parity.md
@@ -36,3 +36,10 @@ cross-repo-authorized: esperie-enterprise/kailash-rs
 4. Journaled before acting — THIS entry, written before `gh issue create` runs. ✓
 5. Scoped exactly — only this one issue against only this repo; no incidental reads,
    no scope creep. ✓
+
+## Result
+
+- **Filed:** `esperie-enterprise/kailash-rs#1465` (labels: `cross-sdk`, `enhancement`)
+  — https://github.com/esperie-enterprise/kailash-rs/issues/1465
+- Body filed verbatim as approved; no labels-fallback needed (both labels existed).
+- Ledger: `F-XSDK-STREAMING` → FILED (rs#1465), awaiting rs maintainer.

--- a/workspaces/cross-sdk-audit/journal/0018-DECISION-cross-repo-authorized-kailash-rs-async-sql-streaming-parity.md
+++ b/workspaces/cross-sdk-audit/journal/0018-DECISION-cross-repo-authorized-kailash-rs-async-sql-streaming-parity.md
@@ -1,0 +1,38 @@
+# 0018 — DECISION: cross-repo authorized — kailash-rs async-SQL streaming parity issue
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+- **Timestamp:** 2026-06-22T05:31:45Z
+- **Requester:** jack.hong (co-owner; in-session)
+- **Target repo:** `esperie-enterprise/kailash-rs` (private Rust SDK)
+- **Action (bounded, exact):** file ONE scrubbed cross-SDK parity issue via
+  `gh issue create --repo esperie-enterprise/kailash-rs`, labels `cross-sdk` +
+  `enhancement`, with the verbatim title + body reviewed and approved in-session.
+  The issue requests the rs maintainer check for (a) an equivalent non-functional
+  `FetchMode::Iterator`-class dead enum + silent-fallback in the Rust async-SQL
+  surface and (b) a memory-bounded server-side-cursor `stream()` parity API —
+  cross-referencing the Python work (terrene-foundation/kailash-py#1416 + #1417,
+  shipped in kailash 2.44.0).
+- **NO incidental reads** of kailash-rs source/specs/tests; the issue is authored
+  from the known py-side finding only (cross-sdk-inspection pattern), letting the rs
+  maintainer scope it with their own repro. Body scrubbed per
+  `upstream-issue-hygiene.md` MUST-2/3 (no session/workspace/downstream context, no
+  finding tags, minimal SDK-API-only repro shape).
+
+## Verbatim authorization
+
+1. Decision-packet selection: **"File a scrubbed rs issue now"** (Rust SDK parity
+   question, this session).
+2. On the presented verbatim issue title + body + target + labels: **"yes"** (file
+   it verbatim against `esperie-enterprise/kailash-rs`).
+
+## Conditions (repo-scope-discipline.md User-Authorized Exception — all five hold)
+
+1. User-initiated — genuine user turns (the selection + the "yes"). ✓
+2. Explicit + specific — names `esperie-enterprise/kailash-rs` + the exact bounded
+   filing action + the verbatim body. ✓
+3. Confirmed — agent restated action + target + verbatim body; user confirmed "yes"
+   before execution. ✓
+4. Journaled before acting — THIS entry, written before `gh issue create` runs. ✓
+5. Scoped exactly — only this one issue against only this repo; no incidental reads,
+   no scope creep. ✓


### PR DESCRIPTION
## Summary

Closes the three **implementable** public-reachable gaps from the `#1406` stub-marker inventory. Each was a documented feature the code did not perform (the `zero-tolerance` Rule 3c class). The fourth public-reachable gap (anomaly-detector benchmark) genuinely needs an ML dependency and stays `track`.

| Former gap | File | What was wrong | Fix |
| --- | --- | --- | --- |
| #1 active_count no-op | `nodes/edge/edge_monitoring_node.py` + `edge/monitoring/edge_monitor.py` | `[a for a in alerts if active_only or True]` — the `or True` made the filter a no-op, so `active_count` **always equalled the total alert count** | Extract `EdgeMonitor.is_alert_active()` (the cooldown-window predicate, previously inline in `get_alerts`) and compute `active_count` from it |
| #2 max_pages "ignored" | `nodes/api/rest.py` | The inventory called `max_pages` "silently ignored" — **ground truth contradicts that**: the cap IS read and enforced at `while pages_fetched < max_pages`. The only defect was a stale, misleading commented-out `# max_pages = ... # TODO` line | Remove the dead comment; regression test pins the cap |
| #4 `--include-tests` dropped | `cli/validate_imports.py` + `runtime/validation/import_validator.py` | The CLI flag was parsed but never passed to `validate_directory()`, so test files were always skipped | Add `include_tests: bool = False`; CLI forwards `args.include_tests` |

Also updates `STUB-MARKER-INVENTORY.md` + its machine-readable baseline **in the same commit** (per the inventory's own CI guard): `67→64` markers, `gap 11→8`, public-reachable `4→1`; and removes pre-existing unused imports surfaced by the touched files.

## Tests (all in `tests/unit/` — the gated CI path)

- `tests/unit/edge/test_edge_monitoring_active_count.py` — `is_alert_active` predicate, node `active_count` (mixed/no-history), and `get_alerts(active_only=True)` semantic pin.
- `tests/unit/runtime/test_import_validator.py::test_include_tests_flag_validates_test_files` — flag now reaches the validator.
- `tests/unit/nodes/test_rest_pagination_max_pages.py` — `max_pages` cap is enforced.
- `tests/unit/test_stub_marker_inventory.py` — baseline guard green against the updated inventory.

## Gate review

A `reviewer` pass ran mechanical sweeps + judgment. It surfaced one MED: the `get_alerts` refactor flipped the **no-history** branch of `active_only=True` (KEPT→SKIPPED) — unreachable in production (every generated alert records its cooldown entry at creation, `edge_monitor.py:490`), but a deliberate unification of `get_alerts` filtering and `active_count` on a single predicate. Fixed-immediately (commit `f731281ea`): added a `get_alerts(active_only=True)` pinning test and corrected the over-broad "behaviour-preserving" claim.

## User-flow walk receipt (`--include-tests`)

```
$ python -m kailash.cli.validate_imports <dir>            # default — test files skipped
✅ No import issues found! All imports are production-ready.

$ python -m kailash.cli.validate_imports <dir> --include-tests
File: .../test_feature.py
Line 1: from .helper import thing
Issue: Relative import will fail in production deployment
Fix: from src.your_module.helper import thing
```
Disposition: flag now actionable (was a no-op); default unchanged.

## Known pre-existing items (out of scope — NOT introduced here)

- `nodes/api/rest.py:~1353-1367` — pre-existing pyright `reportOptionalSubscript` in `process_response` (different method; non-blocking pyright; untouched by the comment-only edit here).
- `runtime/validation/import_validator.py:175` — pre-existing unused `content` parameter of `_check_import` (signature change with caller impact; left as-is).

## Related issues

Part of #1406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)