### PR TITLE
docs(sweep): repo sweep 2026-06-22 (post-2.44.1)

### DIFF
--- a/SWEEP-2026-06-22.md
+++ b/SWEEP-2026-06-22.md
@@ -1,0 +1,100 @@
+# Repo Sweep — kailash-py — 2026-06-22
+
+Run after shipping kailash 2.44.1 (#1406 implementable stub gaps). Repo-scoped
+(this repo only). Overall: **CLEAN** — no in-repo actionable gaps; all outstanding
+items belong to other (human-gated) workstreams.
+
+## Findings
+
+### [LOW] [Sweep 1] No active workspace todos
+
+`workspaces/*/todos/active/` — empty. Nothing queued. No action.
+
+### [MED] [Sweep 2] 10 pending journal entries await promotion (other workstreams)
+
+Location:
+
+- `workspaces/cross-sdk-audit/journal/.pending/` — 4 (2 DECISION + 2 RISK)
+- `workspaces/issue-1337-masking-callables-py/.../.pending/` — 1 DECISION
+- `workspaces/issue-1339-distributed-lock/.../.pending/` — 1 DECISION
+- `workspaces/issue-1356-jwt-revocation/.../.pending/` — 1 DISCOVERY
+- `workspaces/issue-855-kaizen-agents-pyright/.../.pending/` — 3 (2 RISK + 1 DISCOVERY)
+
+Disposition: **DEFER-WITH-REASON** — all predate this session (none from the #1406
+work) and belong to their respective workstreams. Per `rules/journal.md` each needs
+promote (high-value commit body) or discard (bare-merge / already-codified) by that
+workstream's owner. None are >14d (no stale-`.pending` finding). NOT auto-discarded
+— RISK/DISCOVERY entries can carry real signal. Why it matters: unpromoted entries
+are institutional knowledge sitting un-indexed; low urgency but should not accrete.
+
+### [MED] [Sweep 3] 6 open issues — all the canonical-encoder hardening cluster
+
+`#1401`–`#1405`, `#1407` (all updated 2026-06-20, before this session):
+audit-chain / canonical-JSON / `AuditAnchor` byte-determinism + tz-validation +
+divergent-encoder consolidation.
+
+Disposition: **queued-with-value-rank (genuinely-actionable, human-gated)** — value
+anchor: the cross-sdk-audit / EATP-D6 byte-determinism workstream (`.session-notes`
+ledger `F-XSDK-1451`, marked "DEFERRED — byte-changing; no live divergence"). Several
+are byte-changing (invalidate on-disk HMAC envelopes) and cross-SDK, so they are
+correctly human-gated, NOT stale-for-closure. No `deferred` label present → not a
+Rule-1b 4-condition check. NOT mine to action this session. Recommend the next
+cross-sdk-audit session triage them as one cluster.
+
+`#1406` itself is **CLOSED** — the auditable `STUB-MARKER-INVENTORY.md` was its
+resolution; this session's 2.44.1 work further reduced it (public-reachable 4→1).
+PRs referenced it as "Part of #1406" (historical pointer), not auto-close.
+
+### [LOW] [Sweep 4] No open PRs, no orphan branches
+
+0 open PRs; no unmerged remote branches. This session's branches (#1420/#1421/#1422)
+all merged + deleted. No action.
+
+### [N/A] [Sweep 5] Redteam — orchestration mode (no per-workspace specs)
+
+<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->
+
+Pre-condition: `workspaces/*/specs/` dirs = 0; `tools/sweep-redteam.py` present.
+EITHER-absent → structural N/A (no proxy substituted). The active workspaces are
+issue-tracking/audit workspaces without materialized per-workspace specs.
+
+### [LOW] [Sweep 6] One stale `.session-notes`; no orphan worktrees
+
+- `workspaces/kaizen-rag-node-coverage/.session-notes` >30d — archive candidate.
+- `git worktree list`: only the main checkout (no orphan/zero-commit worktrees).
+- No `.pending` >14d.
+  Disposition: DEFER — archival hygiene, no urgency.
+
+### [LOW] [Sweep 7] Clean working tree; in sync with origin
+
+- Uncommitted: only `.session-notes` (the session-continuity file — normal).
+- `origin/main...HEAD` = `0 0` (in sync).
+- 36 src/kailash files carry markers = the **inventoried baseline**
+  (`STUB-MARKER-INVENTORY.md`: 64 markers, all categorised; CI guard green). No NEW
+  stubs introduced. NOT a finding.
+
+### [LOW] [Sweep 8] No unreleased shippable work
+
+Latest stable tag `v2.44.1` == `pyproject.toml` version. Shippable diff
+(`src/` + `packages/*/src`) since `v2.44.1` is EMPTY. Nothing to release.
+
+## Cross-cutting observations
+
+- The repo is at a clean convergence point: 2.44.1 shipped + verified, nothing in
+  flight, main == origin == PyPI.
+- The only standing in-repo backlog is the **canonical-encoder cluster** (6 issues +
+  4 cross-sdk-audit `.pending` entries) — a single coherent workstream, human-gated
+  because it is byte-changing / cross-SDK. It is NOT decaying-by-neglect; it is
+  deliberately deferred per the ledger.
+
+## Recommended next-session items (ranked — human decides)
+
+1. **Canonical-encoder cluster triage** (`#1401`–`#1405`, `#1407`) — one focused
+   cross-sdk-audit session to disposition the 6 issues + promote/discard the 4
+   cross-sdk-audit `.pending` journals. Human-gated (byte-changing). Highest-value
+   standing in-repo backlog.
+2. **Pending-journal hygiene** across issue-1337/1339/1356/855 workspaces — promote
+   high-value entries, discard bare-merge ones (cheap, per-workspace).
+3. **Archive** `workspaces/kaizen-rag-node-coverage/` stale session-notes (LOW).
+
+Nothing requires action before a fresh session starts.


### PR DESCRIPTION
8-sweep repo-wide audit after kailash 2.44.1. CLEAN — no in-repo actionable gaps. Standing backlog = human-gated canonical-encoder cluster + cross-workstream pending journals. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)