### PR TITLE
chore(sweep): repo-wide sweep 2026-06-22 pm — clean convergence

### DIFF
--- a/SWEEP-2026-06-22-pm.md
+++ b/SWEEP-2026-06-22-pm.md
@@ -1,0 +1,80 @@
+# Sweep — 2026-06-22 (pm)
+
+Repo-wide outstanding-work audit. kailash-py (BUILD repo). Follow-up to the
+morning `SWEEP-2026-06-22.md`; this pm pass re-ran after the #1403 canonical-encoder
+re-audit. **Result: clean convergence — no in-scope actionable code work.**
+
+## Findings by sweep
+
+### Sweep 1 — Active todos
+
+- **None.** Zero files under `workspaces/*/todos/active/`. ✅
+
+### Sweep 2 — Pending journal entries (LOW)
+
+- 10 `.pending/` entries across 6 dormant workspaces (cross-sdk-audit ×4,
+  issue-855-kaizen-agents-pyright ×3, issue-1337/1339/1356 ×1 each).
+- **Disposition: DEFER** — promotion/discard belongs in each entry's owning
+  workspace context, all of which are dormant (stale ≥21d per root `.session-notes`).
+  None are >14d by mtime (Sweep-6 stale-pending check empty). Not blocking;
+  not value-bearing forest items.
+
+### Sweep 3 — Open GitHub issues (current repo)
+
+- `#1403` [hardening] canonical-JSON encoders — **cross-SDK-blocked**, annotated
+  this session ([comment](https://github.com/terrene-foundation/kailash-py/issues/1403#issuecomment-4768226941)).
+  Concrete hazard (fingerprint + audit-chain `default=str`) already fixed; AC3
+  (pinning tests) + AC4 (`specs/trust-canonical-encoders.md`) DONE; witness-export
+  remainder is byte-CHANGING + gated on **kailash-rs#1451** (alignment direction
+  open; rs on inverse encoder). NOT closeable py-only.
+- `#1402` [hardening] cross-impl byte-equality — **cross-SDK-blocked**, needs an
+  independently-rs-produced digest (kailash-rs#449 lockstep). NOT closeable py-only.
+- **Disposition: both DEFER — cross-SDK coordination (rs#1451). No py-only action.**
+
+### Sweep 4 — Open PRs / stale branches
+
+- **None.** No open PRs, no unmerged remote branches. ✅
+
+### Sweep 5 — Redteam gaps vs specs
+
+- `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`
+- spec_count=0 (no `workspaces/*/specs/` present); `tools/sweep-redteam.py` present
+  but no per-workspace specs to verify against. Structural N/A — no proxy run.
+
+### Sweep 6 — Workspace / worktree hygiene (LOW)
+
+- 1 stale `.session-notes` >30d: `workspaces/kaizen-rag-node-coverage/` — archive candidate.
+- No orphan worktrees (single checkout at HEAD). ✅
+- **Disposition: DEFER** — cosmetic; archive in a future cleanup pass.
+
+### Sweep 7 — Process hygiene
+
+- Working tree clean except `.session-notes` (normal). 0 ahead / 0 behind origin/main. ✅
+- No new stub markers introduced this session (no src edits made).
+
+### Sweep 8 — Release readiness
+
+- LATEST stable tag `v2.44.1`. HEAD 4 commits ahead but **zero shippable diff**
+  (`git diff --stat v2.44.1..HEAD -- src/ packages/` empty — docs/sweep merges only).
+- Version anchor `2.44.1` == tag == PyPI. **No release finding.** ✅
+
+## Cross-cutting observations
+
+- Repo is at a genuine convergence point. The only open issues (#1402, #1403) are
+  both **cross-SDK-blocked on kailash-rs#1451** — not deferral-by-neglect, genuine
+  coordination gating. Neither has a safe py-only code change.
+- This session's value: prevented an uncoordinated py-only cross-SDK byte change
+  to the selective-disclosure witness family that a committed regression test
+  (`test_canonical_encoder_family_conformance.py`) explicitly forbids and would
+  have broken loudly. Net code change: none (correct outcome).
+
+## Recommended next-session items (ranked)
+
+1. **Cross-SDK coordination on rs#1451** (when rs side is ready) — settles the
+   canonical-encoder alignment direction; unblocks BOTH #1402 and #1403 witness/
+   envelope remainder in lockstep. Human/cross-repo gated; not py-only.
+2. **Low-priority housekeeping** (no urgency): promote/discard the 10 dormant
+   `.pending/` journal entries within their workspaces; archive the
+   `kaizen-rag-node-coverage` stale workspace.
+
+No FIX-NOW items. No new issues filed (nothing actionable to file).


### PR DESCRIPTION
Repo-wide `/sweep` (pm) after the #1403 canonical-encoder re-audit.

## Result: clean convergence
- Sweep 1 (todos): none
- Sweep 3 (issues): #1402 + #1403 both cross-SDK-blocked on kailash-rs#1451 — no py-only action
- Sweep 4 (PRs/branches): none
- Sweep 5 (specs): N/A (orchestration mode, no per-workspace specs)
- Sweep 8 (release): no shippable diff since v2.44.1

Key outcome: the #1403 witness-export `canonical_scalars` migration was correctly **not** applied — `test_canonical_encoder_family_conformance.py` forbids the uncoordinated py-only byte change (gated on kailash-rs#1451).

## Related issues
Refs #1402, #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)