### PR TITLE
chore(codify): cross-SDK serialization disciplines since 2026-06-19

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -98,3 +98,87 @@ changes:
       COC-orchestration discipline every repo running /redteam inherits; the
       failure mode (provider rate-limit -> false convergence) is CLI-neutral and
       language-neutral. Refines the global agents.md, no py-specific content.'
+
+  # ---- APPENDED 2026-06-22 codify cycle (kailash 2.43.1 / 2.44.x; since 2026-06-19) ----
+  - type: rule_update
+    artifact: trust-plane-security
+    files:
+      - .claude/rules/trust-plane-security.md
+    classification_suggestion: global
+    context: 'ADDS MUST clause 8 "Every Signing / Hash Pre-Image MUST Reject
+      NaN/Inf (allow_nan=False)" + in-clause 8-field Trust Posture Wiring.
+
+
+      Lesson: a json.dumps producing a signing/HMAC/integrity-hash/cross-SDK
+      pre-image without allow_nan=False emits RFC-8259-invalid NaN/Infinity
+      literals. Python signs them; a strict cross-SDK parser (Rust serde_json)
+      REJECTS them on parse — so a Python-signed envelope/witness/audit-anchor
+      carrying a non-finite float in free-form metadata can NEVER be re-verified
+      by the sibling SDK. Distinct from the EXISTING NaN coverage: Rule 3 +
+      MUST-NOT-5 (this file) and pact-governance.md Rule 6 guard the
+      VALUE-COMPARISON axis (NaN < limit silently passing a budget check); this
+      new clause guards the SERIALIZATION axis (NaN/Infinity literals in the
+      signed bytes). grep confirms allow_nan appeared in ZERO rules pre-this-codify.
+      The fix is byte-neutral on every finite input, so it ships WITHOUT a
+      cross-SDK lockstep; the durable guard is a module-granularity AST invariant
+      over every signing/hash root (per-function spot-checks miss sibling sites).
+
+
+      Classification rationale: GLOBAL — the failure mode is the cross-SDK
+      conformance contract both SDKs share; CLI- and language-neutral (the rs
+      sibling is the serde_json strict-parser end of the same contract). Gate-1
+      MAY also classify a kailash-rs variant note (the rs end enforces strictness
+      on parse). Origin: kailash 2.43.1 NaN/Inf trust-plane sweep, PR #1411 +
+      #1412; workspaces/cross-sdk-audit/journal/0015 + 0017.
+
+
+      rule-authoring Rule 10: trust-plane-security.md is priority:10/path-scoped
+      (NOT baseline) -> proximity-band gate does NOT fire. Grandfathered rule with
+      no prior Trust Posture Wiring; the new clause ships clause-scoped 8-field
+      wiring per the artifact-flow.md "Intake Disclosure Scrub" precedent (loom
+      Gate-1 may decide on full-rule wiring retrofit).'
+
+  - type: rule_update
+    artifact: cross-sdk-inspection
+    files:
+      - .claude/rules/cross-sdk-inspection.md
+    classification_suggestion: global
+    context:
+      'ADDS two sub-rules + in-clause 8-field Trust Posture Wiring on each.
+
+
+      Rule 4b "Byte-CHANGING Canonical-Encoder Switches Are Cross-SDK Lockstep,
+      Not Single-SDK": a canonical-encoder migration feeding a cross-SDK signing/
+      hash pre-image (e.g. default=str -> canonical_scalars) MUST be classified
+      byte-NEUTRAL vs byte-CHANGING by EMPIRICAL byte-diff (run the code, compare
+      SHAs — not by reasoning). A byte-CHANGING switch where the sibling mirrors
+      CURRENT bytes MUST NOT ship single-SDK (coordinated lockstep + pin current
+      bytes as a tripwire until lockstep lands); a byte-NEUTRAL switch (to_dict()
+      pre-normalizes) MAY ship single-SDK. Distinct from the existing Rule 4 (pin
+      >=3 parity byte-vectors): Rule 4 covers a parity-helper''s vectors; 4b covers
+      the migrate-or-not decision + the neutral/changing classification + the
+      lockstep-not-single-SDK rule. Origin: 2.43.1 canonical-encoder family sweep,
+      journal/0011 (97 default=str sites classified: audit-chain + witness-family +
+      envelope-HMAC byte-CHANGING/lockstep; envelope_hash byte-NEUTRAL/shipped);
+      specs/trust-canonical-encoders.md.
+
+
+      Rule 4c "Conformance-Vector Changes Re-Pin Their Integrity Manifest In The
+      Same Commit": changing a cross-SDK conformance vector pinned by a committed
+      *.sha256 manifest (e.g. PACT_VECTORS.sha256) MUST re-pin the manifest in the
+      SAME commit; a /redteam over canonical-vector changes MUST include an
+      integrity-manifest sweep lens (enumerate every *.sha256, shasum -a256 -c).
+      grep confirms no rule covered integrity-manifest re-pin. Origin: PR #1411
+      Gap 1 — the audit_anchor.json canonical fix omitted the PACT_VECTORS.sha256
+      re-pin -> red Cross-SDK Conformance gate a prior "converged (2 clean passes)"
+      redteam missed because no round ran shasum -c; journal/0015; closed by
+      b4929d924 + a new integrity-manifest-sweep lens.
+
+
+      Classification rationale: GLOBAL — both sub-rules govern the cross-SDK
+      conformance contract shared by kailash-py and kailash-rs; CLI- and
+      language-neutral. cross-sdk-inspection.md is priority:10/path-scoped -> Rule
+      10 proximity-band gate does NOT fire. Grandfathered (no prior wiring); both
+      sub-rules ship clause-scoped 8-field wiring.'
+
+  # ---- end 2026-06-22 append ----

--- a/.claude/rules/cross-sdk-inspection.md
+++ b/.claude/rules/cross-sdk-inspection.md
@@ -164,6 +164,85 @@ $ git add bindings/kailash-rs/test-vectors/trace-event-canonical.json
 
 Origin: kailash-rs PR #761 (merged 8286775f, 2026-05-02) — vendored `test-vectors/trace-event-canonical.json` from `terrene-foundation/kailash-py:main`. Pre-vendor: rs-side fixture had `id`/`input` shape with V1-V3 inputs cosmetically different from py-side; V4-V5 fingerprints already matched (Unicode coverage tests aligned, V1-V3 weren't). Post-vendor: all 5 V1-V5 fingerprints reproduce byte-for-byte through both Rust `compute_trace_event_fingerprint` AND Python binding `serialize_canonical_json`. Same-shard sibling consumer fix per `autonomous-execution.md` Rule 4 (Python binding test orphaned at first push, CI surfaced it, fix-immediately landed in same PR commit `10274a5d`). Codified GLOBAL via /sync rs Gate 1 (2026-05-02 second cycle).
 
+### 4b. Byte-CHANGING Canonical-Encoder Switches Are Cross-SDK Lockstep, Not Single-SDK
+
+When migrating a canonical-encoder / serialization helper that feeds a cross-SDK signing or hash pre-image (e.g. `json.dumps(..., default=str)` → a stricter `canonical_scalars`), you MUST first classify the switch as **byte-NEUTRAL** or **byte-CHANGING** by EMPIRICALLY byte-diffing production output on fixed inputs — NOT by reasoning about it. A byte-CHANGING switch where the sibling SDK mirrors this SDK's CURRENT bytes MUST NOT ship single-SDK; it is a coordinated cross-SDK lockstep (one re-pin event in both repos) and the current bytes MUST be pinned in a regression test as a loud tripwire until the lockstep lands. A byte-NEUTRAL switch (the `to_dict()` / normalization layer already pre-normalizes every divergent type, so the swap changes zero currently-emitted bytes) MAY ship single-SDK.
+
+```python
+# DO — empirically classify, then pin current bytes for the byte-CHANGING site
+@pytest.mark.regression
+def test_witness_sign_payload_pins_current_default_str_bytes():
+    # CROSS_SDK_BLOCKED: AuditAnchor reaches the encoder un-normalized; default=str
+    # stringifies the dataclass repr, canonical_scalars asdict-expands it → different SHA.
+    # kailash-rs mirrors these CURRENT bytes; a py-only switch diverges the two SDKs.
+    assert _sign_payload(fixture) == "edfdf52b…"   # tripwire until rs#NNNN lockstep
+# (the byte-NEUTRAL sibling — envelope_hash, where to_dict() pre-normalizes — SHIPPED py-only)
+
+# DO NOT — switch a byte-CHANGING signing encoder single-SDK
+def to_canonical_json(self):
+    return json.dumps(self._hashable_dict(), default=canonical_scalars)  # was default=str
+    # ↑ silently diverges every on-disk signed artifact from the sibling SDK's bytes;
+    #   no test pins the old bytes, so the cross-SDK break is invisible until a verify fails.
+```
+
+**BLOCKED rationalizations:**
+
+- "canonical_scalars is stricter / more correct, so switching is an improvement"
+- "I reasoned through the types; it can't change the bytes" (reason is not a byte-diff)
+- "The sibling SDK will catch up on its next release"
+- "It's one encoder; the lockstep ceremony is overkill"
+- "Pinning the OLD bytes blocks the migration I'm trying to do"
+
+**Why:** A canonical signing encoder is a byte-for-byte cross-SDK contract (Rule 4); switching it single-SDK silently diverges every artifact the sibling SDK must re-verify, and the break surfaces only when a cross-SDK verify fails in production. Empirical byte-diff (run the code, compare SHAs) is the only sound classifier — "I reasoned the types are equivalent" is exactly how the audit-chain / witness-family / envelope-HMAC sites were each almost switched py-only. Pinning the current bytes converts the deferred lockstep from an un-tracked memory into a test that fails loudly the moment someone switches one side.
+
+**Trust Posture Wiring (byte-changing cross-SDK lockstep):**
+
+- **Severity:** `halt-and-report` at gate-review (reviewer + security-reviewer at `/implement` confirm any canonical-encoder switch on a signing/hash site is classified byte-neutral-vs-byte-changing with an empirical byte-diff, and byte-changing switches carry a pinned-bytes tripwire + cross-SDK issue); `advisory` at hook layer.
+- **Grace period:** 7 days from rule landing.
+- **Cumulative posture impact:** same-class violations (a byte-changing canonical switch shipped single-SDK, or unclassified) contribute per `trust-posture.md` MUST-4 (3× same-rule / 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** trigger key `cross_sdk_canonical_single_sdk_switch` fires emergency downgrade (1 step) per `trust-posture.md` MUST-4.
+- **Receipt requirement:** SessionStart `[ack: cross-sdk-inspection]` IFF `posture.json::pending_verification` includes this rule_id (soft-gate).
+- **Detection mechanism:** Phase 1 — gate-level reviewer at `/implement`: for any diff touching a canonical-encoder/serialization helper on a signing/hash path, demand the empirical byte-diff classification + (for byte-changing) the pinned-current-bytes regression test + the cross-SDK lockstep issue. Phase 2 (deferred): a regression-suite invariant enumerating signing-site encoders and asserting each pinned.
+- **Violation scope:** this clause (canonical-encoder switches on cross-SDK signing/hash pre-images). Every violation row names the encoder site + the missing classification or tripwire.
+- **Origin:** kailash 2.43.1 cross-SDK canonical-encoder family sweep (2026-06-20) — `workspaces/cross-sdk-audit/journal/0011` (byte-diff classification of 97 `default=str` sites: audit-chain + witness-family + envelope-HMAC byte-CHANGING/lockstep, envelope_hash byte-NEUTRAL/shipped); `specs/trust-canonical-encoders.md`.
+
+### 4c. Conformance-Vector Changes Re-Pin Their Integrity Manifest In The Same Commit
+
+When a commit changes a cross-SDK conformance vector / test-fixture file pinned by a committed integrity manifest (`*.sha256`, e.g. `PACT_VECTORS.sha256`), the manifest MUST be re-pinned in the SAME commit. A `/redteam` over any canonical-vector change MUST include an **integrity-manifest sweep** lens: enumerate every `*.sha256` and run `shasum -a256 -c` on each.
+
+```bash
+# DO — re-pin the manifest in the same commit that changes the vector
+$ edit tests/trust/pact/conformance/vectors/audit_anchor.json   # the canonical fix
+$ shasum -a256 tests/trust/.../audit_anchor.json                 # recompute
+$ edit PACT_VECTORS.sha256                                       # re-pin in SAME commit
+$ shasum -a256 -c PACT_VECTORS.sha256                            # verify green before push
+
+# DO NOT — change the vector, leave the manifest stale
+$ edit tests/trust/.../audit_anchor.json && git commit           # manifest unchanged
+# ↑ remote `Verify vector integrity` (shasum -c) goes RED ("audit_anchor.json: FAILED");
+#   a "converged" redteam that never ran shasum -c declares clean over a red CI gate.
+```
+
+**BLOCKED rationalizations:**
+
+- "The vector change is correct; the manifest is a separate concern"
+- "CI will catch the manifest if it's stale" (catching it red ≠ shipping it green)
+- "The redteam already converged" (a convergence claim over a red remote gate is false — `verify-resource-existence.md` MUST-4)
+- "shasum -c isn't part of the canonical-conformance lens-set"
+
+**Why:** An integrity manifest exists to make silent tampering of a pinned vector loud; a vector change that omits the re-pin either reds the CI gate (best case) or — if the manifest also drifts — silently no-ops the integrity check for that file until a future real tamper goes undetected. The redteam integrity-manifest sweep is the lens that makes a "converged" claim cite `shasum -c` evidence rather than assume it; without it a round can declare 2-clean-rounds while the remote conformance gate is red. Evidence: PR #1411 (2026-06-20) shipped the correct `audit_anchor.json` canonical fix but omitted the `PACT_VECTORS.sha256` re-pin → red `Cross-SDK Conformance` gate that a prior "converged (2 clean passes)" redteam missed because no round ran `shasum -c`.
+
+**Trust Posture Wiring (conformance-vector integrity-manifest re-pin):**
+
+- **Severity:** `halt-and-report` at gate-review (reviewer at `/implement` + release-specialist at `/release` confirm any conformance-vector diff re-pins its `*.sha256`); `block` at the structural CI gate (`shasum -a256 -c` is a structural exit-code signal per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing.
+- **Cumulative posture impact:** same-class violations (vector changed without manifest re-pin) contribute per `trust-posture.md` MUST-4 (3× same-rule / 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** trigger key `integrity_manifest_not_repinned` fires emergency downgrade (1 step) per `trust-posture.md` MUST-4.
+- **Receipt requirement:** SessionStart `[ack: cross-sdk-inspection]` IFF `posture.json::pending_verification` includes this rule_id (soft-gate; shared with Rule 4b).
+- **Detection mechanism:** Phase 1 — the CI `Verify vector integrity` step (`shasum -a256 -c *.sha256`) is the structural detector; the canonical-vector `/redteam` integrity-manifest-sweep lens enumerates every `*.sha256` and runs the check. Phase 2 (deferred): a pre-commit hook asserting that a changed `*.json` under a vectors dir co-changes its manifest.
+- **Violation scope:** this clause (conformance-vector integrity-manifest re-pin). Every violation row names the vector file + its stale manifest.
+- **Origin:** PR #1411 Gap 1 (2026-06-20) — `workspaces/cross-sdk-audit/journal/0015` (the `PACT_VECTORS.sha256` re-pin omission a "converged" redteam missed because no round ran `shasum -c`; closed by commit `b4929d924` + a new integrity-manifest-sweep lens).
+
 ### 5. Inspection Checklist
 
 When closing any issue, verify:

--- a/.claude/rules/trust-plane-security.md
+++ b/.claude/rules/trust-plane-security.md
@@ -7,7 +7,6 @@ paths:
 
 # Trust-Plane Security Rules
 
-
 <!-- slot:neutral-body -->
 
 ### 1. No Bare `open()` or `Path.read_text()` for Record Files
@@ -173,5 +172,37 @@ norm = os.path.normpath(user_path)  # Platform-dependent, Windows backslashes
 ```
 
 **Why:** `os.path.normpath` produces platform-dependent results (backslashes on Windows), causing constraint patterns that match on Linux to silently fail on other platforms.
+
+### 8. Every Signing / Hash Pre-Image MUST Reject NaN/Inf (`allow_nan=False`)
+
+Every `json.dumps` that produces a SIGNING, HMAC, integrity-hash, or cross-SDK-conformance pre-image MUST pass `allow_nan=False` (and `ensure_ascii=True` to match the wire-format common config). A free-form `metadata` / `dict[str, Any]` field that reaches the pre-image is the un-guarded ingress; financial / constraint numerics are guarded by `math.isfinite()` (Rule 3 / MUST-NOT-5) but free-form metadata is NOT. This is distinct from Rule 3 / MUST-NOT-5, which guard the VALUE-COMPARISON axis (a `NaN` cost silently passing `> limit`); this clause guards the SERIALIZATION axis (a `NaN`/`Infinity` literal in the signed bytes).
+
+```python
+# DO — every signing/hash pre-image rejects non-finite floats
+def to_canonical_json(self) -> str:
+    return json.dumps(self._hashable_dict(), sort_keys=True,
+                      default=str, allow_nan=False, ensure_ascii=True)
+    # NaN/Inf in metadata → raises ValueError at sign time (fail-closed)
+
+# DO NOT — permissive json.dumps over a signed pre-image
+def to_canonical_json(self) -> str:
+    return json.dumps(self._hashable_dict(), sort_keys=True, default=str)
+    # NaN/Inf → emits "NaN"/"Infinity" literals; Python signs them, but a
+    # strict cross-SDK parser (Rust serde_json) REJECTS them → the
+    # Python-signed artifact cannot be HMAC/signature-re-verified cross-SDK.
+```
+
+**Why:** `NaN`/`Infinity` are RFC-8259-invalid JSON; Python's permissive `json.dumps` emits and signs them, but a strict cross-SDK verifier (Rust `serde_json`) rejects them on parse — so a Python-signed envelope/witness/audit-anchor carrying a non-finite float in free-form metadata can never be re-verified by the sibling SDK, the exact cross-SDK parity hazard the trust plane exists to close. The fix is byte-neutral on every finite input (the `allow_nan` kwarg changes zero currently-emitted bytes for valid data), so it ships without a cross-SDK lockstep — unlike a `default=str` → `canonical_scalars` migration (see `cross-sdk-inspection.md` Rule 4b). A module-granularity AST sweep over every signing/hash root is the durable guard; per-function spot-checks miss sibling pre-images (the 2026-06-21 sweep found 4 deliberately-excluded forensic/memoization sites and 0 missed signing sites only after the per-function pass was widened to module-granularity).
+
+**Trust Posture Wiring (NaN/Inf signing pre-image):**
+
+- **Severity:** `halt-and-report` at gate-review (security-reviewer at `/implement` + `/release` confirms every `json.dumps` over a signing/hash pre-image in the diff carries `allow_nan=False`); `advisory` at any hook layer (a lexical `json.dumps`-without-`allow_nan` scan cannot carry `block` per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing.
+- **Cumulative posture impact:** same-class violations (a signing/hash pre-image shipped without `allow_nan=False`) contribute per `trust-posture.md` MUST-4 (3× same-rule / 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** trigger key `nan_inf_signing_preimage` fires emergency downgrade (1 step) per `trust-posture.md` MUST-4.
+- **Receipt requirement:** SessionStart `[ack: trust-plane-security]` IFF `posture.json::pending_verification` includes this rule_id (soft-gate).
+- **Detection mechanism:** Phase 1 — the module-granularity AST invariant test `tests/regression/test_trust_signing_preimage_rejects_nan_inf.py::test_trust_plane_signing_preimages_all_carry_allow_nan` over roots `src/kailash/trust`, `packages/kailash-pact/src`, `src/kailash/delegate/conformance` (excludes documented forensic/memoization sites); plus security-reviewer gate-review at `/implement` + `/release`. Phase 2 (deferred): a `PostToolUse(Edit|Write)` lexical advisory on trust-plane paths.
+- **Violation scope:** this clause (signing/hash/conformance pre-image serialization). Every violation row names the file + the un-guarded `json.dumps` site.
+- **Origin:** kailash 2.43.1 (2026-06-21) trust-plane-wide NaN/Inf signing-pre-image sweep — PR #1411 (envelope/audit-chain start) + PR #1412 (full trust plane + PACT + delegate-conformance digest); workspace receipt `workspaces/cross-sdk-audit/journal/0015` + `0017`.
 
 <!-- /slot:neutral-body -->

--- a/workspaces/cross-sdk-audit/journal/0019-DECISION-codify-since-last-codification-2026-06-22.md
+++ b/workspaces/cross-sdk-audit/journal/0019-DECISION-codify-since-last-codification-2026-06-22.md
@@ -1,0 +1,75 @@
+---
+type: DECISION
+date: 2026-06-22
+author: agent
+project: cross-sdk-audit
+topic: /codify cycle since the 2026-06-19 codification — 3 cross-SDK/trust-plane rule clauses authored, appended to the pending BUILD->loom proposal
+phase: codify
+tags:
+  [
+    codify,
+    cross-sdk,
+    trust-plane,
+    nan-inf,
+    canonical-encoder,
+    integrity-manifest,
+    build-to-loom-proposal,
+  ]
+relates_to: 0011-DISCOVERY-canonical-encoder-family-sweep-broadens-cross-sdk-lockstep, 0015-DECISION-fresh-redteam-caught-two-gaps-pr1411-converged, 0017-DECISION-naninf-bug-class-closure-convergence-and-2.43.1-release
+---
+
+# DECISION — /codify since the last codification (2026-06-19 → 2026-06-22)
+
+User directive: "please /codify, not just the last session, but since the last codification."
+
+Last codification was **2026-06-19** (`learning-codified.json::last_codified`); a `pending_review`
+BUILD→loom proposal from that date carries the `agents.md` redteam-dispatch clause. This cycle
+codifies the genuinely-new pattern-level learnings from the **2.43.1 / 2.44.x** work since then
+(NaN/Inf trust-plane sweep, async-SQL streaming, #1406 stub-gap closure, canonical-encoder
+cross-SDK lockstep, JWT revocation parity) and APPENDS them to the same proposal.
+
+## What was authored (3 clauses across 2 path-scoped rules)
+
+1. **`trust-plane-security.md` MUST clause 8 — Signing/Hash Pre-Images MUST Reject NaN/Inf
+   (`allow_nan=False`).** The SERIALIZATION-axis NaN/Inf failure mode. Verified against ground
+   truth: `grep "allow_nan"` across `.claude/rules/` returned ZERO hits pre-cycle. DISTINCT from
+   the existing value-comparison NaN guards (this file's Rule 3 + MUST-NOT-5; `pact-governance.md`
+   Rule 6). Origin: 2.43.1 sweep (PR #1411 + #1412; journal/0015 + 0017).
+
+2. **`cross-sdk-inspection.md` Rule 4b — Byte-CHANGING Canonical-Encoder Switches Are Cross-SDK
+   Lockstep, Not Single-SDK.** Classify a canonical-encoder migration byte-NEUTRAL vs
+   byte-CHANGING by EMPIRICAL byte-diff; byte-CHANGING where the sibling mirrors current bytes →
+   lockstep + pin-current-bytes tripwire; byte-NEUTRAL → may ship single-SDK. Distinct from the
+   existing Rule 4 (parity byte-vectors). Origin: journal/0011 (97-site classification) +
+   `specs/trust-canonical-encoders.md`.
+
+3. **`cross-sdk-inspection.md` Rule 4c — Conformance-Vector Changes Re-Pin Their Integrity
+   Manifest In The Same Commit** (+ `/redteam` integrity-manifest-sweep lens). `grep` confirmed
+   no rule covered manifest re-pin. Origin: PR #1411 Gap 1 (the `PACT_VECTORS.sha256` re-pin
+   omission a "converged" redteam missed because no round ran `shasum -c`; journal/0015).
+
+Each new clause ships clause-scoped 8-field Trust Posture Wiring (both rules grandfathered with no
+prior wiring; clause-scoped wiring per the `artifact-flow.md` "Intake Disclosure Scrub" precedent).
+
+## Process / gates honored
+
+- **Repo class = BUILD** → `/codify` writes the rule clauses locally for immediate use AND appends
+  to `.claude/.proposals/latest.yaml` (status stays `pending_review`; 3 changes total) for loom
+  Gate-1 classification (all suggested GLOBAL — the failure modes are the cross-SDK conformance
+  contract both SDKs share). No cross-repo sync from this BUILD session (repo-scope-discipline).
+- **Self-referential gate:** neither `trust-plane-security.md` nor `cross-sdk-inspection.md` is on
+  the `self-referential-codify.md` Rule 2 allowlist → the MANDATORY multi-agent redteam-with-tests
+  round does NOT fire. Both rules are `priority:10/path-scoped` → `rule-authoring.md` Rule 10
+  proximity-band gate does NOT fire.
+- **Branch:** `codify/esperie-2026-06-22` (integrity-guard requires `.claude/` writes off a
+  `codify/*` branch). PR + admin-merge per `coc-sync-landing.md` MUST-3.
+
+## What was NOT codified (and why)
+
+- The stale `journal/.pending/` auto-captures (NaN/Inf sweep, reseal_only test, vault gates) are
+  SessionEnd captures of already-merged commits, several CWD-misrouted DUPLICATES — the exact
+  failure the 2026-06-19 journal-hygiene candidate (#1086 candidate 2+4) targets; the real remedy
+  is the loom-side dedup-by-source_commit hook (#1086 candidate 3). Left for that fix.
+- reseal_only multi-anchor test pin / JWT-revocation rs parity / canonical-spec LOW citation fixes
+  are INSTANCES of already-codified patterns (testing.md regression; cross-sdk-inspection Rule 1;
+  zero-tolerance 3e) — no new rule.

--- a/workspaces/cross-sdk-audit/journal/0020-DISCOVERY-cross-sdk-serialization-disciplines-extracted.md
+++ b/workspaces/cross-sdk-audit/journal/0020-DISCOVERY-cross-sdk-serialization-disciplines-extracted.md
@@ -1,0 +1,62 @@
+---
+type: DISCOVERY
+date: 2026-06-22
+author: agent
+project: cross-sdk-audit
+topic: Three cross-SDK serialization disciplines distilled from the 2.43.x canonical-encoder + NaN/Inf work — the next session inherits them as rules, not session-notes memory
+phase: codify
+tags:
+  [
+    cross-sdk,
+    serialization,
+    nan-inf,
+    canonical-encoder,
+    byte-determinism,
+    integrity-manifest,
+  ]
+relates_to: 0019-DECISION-codify-since-last-codification-2026-06-22
+---
+
+# DISCOVERY — Cross-SDK serialization has three distinct, separately-codifiable disciplines
+
+The 2.43.x trust-plane work surfaced that "make the signing bytes cross-SDK-safe" is NOT one
+concern but THREE orthogonal ones, each with its own failure mode and its own structural defense.
+Prior sessions held these only in `.session-notes` "Traps"; they are now rules the next session
+loads automatically.
+
+## 1. The serialization axis of NaN/Inf is distinct from the value-comparison axis
+
+The codebase already guarded NaN on the VALUE axis (`math.isfinite()` on cost/constraint fields,
+so `NaN < limit` can't silently pass a budget check). The 2.43.1 sweep found a SECOND axis: a
+`json.dumps` over a SIGNED pre-image without `allow_nan=False` emits `NaN`/`Infinity` literals
+that Python signs but Rust `serde_json` rejects on parse — breaking cross-SDK re-verification
+even though no comparison is ever fooled. The two axes need two separate guards; closing one
+leaves the other open. (→ `trust-plane-security.md` clause 8.)
+
+## 2. "Should we switch this encoder?" is decided by EMPIRICAL byte-diff, not reasoning
+
+The audit byte-diffed all 97 `default=str` sites against the conformant `canonical_scalars` rather
+than reasoning about them — and the empirical result split them three ways: byte-NEUTRAL (the
+`to_dict()` layer already normalizes → safe to switch single-SDK, e.g. `envelope_hash`),
+byte-CHANGING + cross-SDK-contracted (witness family, envelope HMAC, audit chain → lockstep only,
+pin current bytes as a tripwire), and no-cross-SDK-contract (local dedup/memo hashes → leave).
+The decisive lesson: a canonical signing encoder is a byte-for-byte cross-SDK contract, and "I
+reasoned the types are equivalent" is exactly how each of those sites was almost switched py-only.
+(→ `cross-sdk-inspection.md` Rule 4b.)
+
+## 3. An integrity manifest is a second artifact that drifts independently of the vector
+
+PR #1411 shipped the CORRECT canonical vector fix but omitted re-pinning `PACT_VECTORS.sha256` →
+red CI that a "converged (2 clean passes)" redteam missed because no round ran `shasum -c`. The
+manifest and the vector are two files under one contract; changing one without the other either
+reds CI (best case) or silently no-ops the integrity check. The durable defense is two-fold: re-pin
+in the SAME commit, AND a redteam integrity-manifest-sweep lens that enumerates every `*.sha256`.
+(→ `cross-sdk-inspection.md` Rule 4c.)
+
+## Cross-cutting meta-lesson (already codified 2026-06-19, reinforced here)
+
+All three surfaced during redteam rounds where a prior round had declared "converged." The
+recurring remedy — every reviewer/lens must return a `ran`/evidence signal, errored/empty ≠ clean,
+and a convergence claim must cite a durable receipt + cross-check remote CI — is the
+2026-06-19 `agents.md` redteam-dispatch clause + `verify-resource-existence.md` MUST-4. The three
+new serialization rules are the WHAT; that clause is the HOW the WHAT keeps getting found.


### PR DESCRIPTION
## What

`/codify` of the pattern-level learnings since the **2026-06-19** codification — the 2.43.1 NaN/Inf trust-plane sweep + the 2.44.x canonical-encoder cross-SDK lockstep / integrity-manifest cycle. Three new MUST clauses across two **path-scoped** rules, appended to the pending BUILD→loom proposal for loom Gate-1.

| Rule (clause) | Pattern | Origin |
| --- | --- | --- |
| `trust-plane-security.md` cl. 8 | Signing/hash pre-images MUST reject NaN/Inf (`allow_nan=False`) — the **serialization** axis (Python signs RFC-8259-invalid literals that Rust `serde_json` rejects → cross-SDK re-verify breaks). Distinct from existing value-comparison NaN guards. | PR #1411/#1412 (2.43.1) |
| `cross-sdk-inspection.md` 4b | Byte-CHANGING canonical-encoder switches are cross-SDK **lockstep**, not single-SDK (classify by empirical byte-diff; pin current bytes as a tripwire). Byte-NEUTRAL may ship single-SDK. | journal/0011 |
| `cross-sdk-inspection.md` 4c | Conformance-vector changes re-pin their `*.sha256` integrity manifest in the **same commit**; `/redteam` adds a `shasum -c` sweep lens. | PR #1411 Gap 1 |

## Why these (and not others)

`grep` confirmed `allow_nan` and integrity-manifest re-pin appeared in **zero** rules pre-cycle; 4b is distinct from the existing parity-vector Rule 4. Skipped as already-codified instances: reseal_only test pin (testing.md), JWT-revocation rs parity (cross-sdk Rule 1), spec LOW citation fixes (zero-tolerance 3e). Stale `.pending/` auto-captures left for the loom-side #1086 dedup hook.

## Gates

- Both rules `priority:10/path-scoped` → `rule-authoring.md` Rule-10 proximity-band gate N/A.
- Neither on the `self-referential-codify.md` allowlist → no mandatory multi-agent redteam round.
- New clauses ship clause-scoped 8-field Trust Posture Wiring (both rules grandfathered).
- Proposal stays `pending_review` (append-never-overwrite); 3 changes total, all suggested GLOBAL.
- `.claude/learning/learning-codified.json` updated locally (gitignored per-repo state, not synced).

## Related issues

Receipts: `workspaces/cross-sdk-audit/journal/0019` (DECISION) + `0020` (DISCOVERY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)