### PR TITLE
fix(align): trl 1.x compatibility for to_trl_config + pipeline (#1426)

### DIFF
--- a/packages/kailash-align/docs/00-authority/CLAUDE.md
+++ b/packages/kailash-align/docs/00-authority/CLAUDE.md
@@ -14,7 +14,9 @@ The framework value is orchestration, not training innovation. TRL does the trai
 AlignmentConfig
     |
     +-- LoRAConfig (rank, alpha, target_modules, dropout)
-    +-- SFTConfig / DPOConfig / KTOConfig / ORPOConfig / GRPOConfig / RLOOConfig / OnlineDPOConfig
+    +-- SFTConfig / DPOConfig / KTOConfig / GRPOConfig / RLOOConfig
+    |     (ORPOConfig / OnlineDPOConfig dataclasses still exist but their
+    |      to_trl_config() raises under trl >=1.0 — see Supported Methods below)
     |
     v
 AlignmentPipeline
@@ -49,7 +51,13 @@ AlignmentResult
 6. If `AdapterRegistry` is provided, registers the trained adapter with signature and metrics
 7. Returns `AlignmentResult` with paths, metrics, and adapter version
 
-## Supported Methods (12)
+## Supported Methods (10 registered)
+
+> Note: `orpo` and `online_dpo` are **NOT available with trl >=1.0** — upstream removed
+> `ORPOTrainer`/`ORPOConfig` and `OnlineDPOTrainer`/`OnlineDPOConfig`. They are de-registered
+> from `METHOD_REGISTRY`; selecting `method="orpo"` or `method="online_dpo"` raises
+> `ValueError: Unknown training method`. Use **DPO** (or **sft_then_dpo** for the two-stage
+> path) / **GRPO** instead. The rows below annotate them in-place so the removal is documented.
 
 ### Offline Preference (category: "offline")
 
@@ -72,23 +80,34 @@ KTO and BCO use binary labels (True/False or 1/0) instead of paired preferences.
 
 ### Monolithic (category: "monolithic")
 
-| Method   | TRL Trainer   | Data Format            | Config Class |
-| -------- | ------------- | ---------------------- | ------------ |
-| **orpo** | `ORPOTrainer` | prompt/chosen/rejected | `ORPOConfig` |
+| Method                                           | TRL Trainer   | Data Format            | Config Class |
+| ------------------------------------------------ | ------------- | ---------------------- | ------------ |
+| ~~`orpo`~~ (removed in trl >=1.0 — use dpo/grpo) | `ORPOTrainer` | prompt/chosen/rejected | `ORPOConfig` |
 
-ORPO combines SFT and preference alignment in a single training pass. Eliminates the need for `sft_then_dpo`.
+ORPO (Odds Ratio Preference Optimization) combines SFT and preference alignment in a single
+training pass. **Not available with trl >=1.0 — upstream removed the `ORPOTrainer`/`ORPOConfig`
+classes; it is de-registered from `METHOD_REGISTRY`.** Use **DPO** (or **sft_then_dpo** for the
+two-stage path) instead. The `ORPOConfig` dataclass still exists for back-compat, but
+`ORPOConfig.to_trl_config()` raises a `TrainingError` redirecting to DPO/GRPO.
 
 ### Online RL (category: "online")
 
-| Method         | TRL Trainer        | Data Format | Config Class              | Reward Required        |
-| -------------- | ------------------ | ----------- | ------------------------- | ---------------------- |
-| **grpo**       | `GRPOTrainer`      | prompt      | `GRPOConfig`              | Yes                    |
-| **rloo**       | `RLOOTrainer`      | prompt      | `RLOOConfig`              | Yes                    |
-| **online_dpo** | `OnlineDPOTrainer` | prompt      | `OnlineDPOConfig`         | No (uses reward model) |
-| **xpo**        | `XPOTrainer`       | prompt      | falls back to `SFTConfig` | Yes                    |
-| **nash_md**    | `NashMDTrainer`    | prompt      | falls back to `SFTConfig` | Yes                    |
+| Method                                                 | TRL Trainer        | Data Format | Config Class              | Reward Required        |
+| ------------------------------------------------------ | ------------------ | ----------- | ------------------------- | ---------------------- |
+| **grpo**                                               | `GRPOTrainer`      | prompt      | `GRPOConfig`              | Yes                    |
+| **rloo**                                               | `RLOOTrainer`      | prompt      | `RLOOConfig`              | Yes                    |
+| ~~`online_dpo`~~ (removed in trl >=1.0 — use dpo/grpo) | `OnlineDPOTrainer` | prompt      | `OnlineDPOConfig`         | No (uses reward model) |
+| **xpo**                                                | `XPOTrainer`       | prompt      | falls back to `SFTConfig` | Yes                    |
+| **nash_md**                                            | `NashMDTrainer`    | prompt      | falls back to `SFTConfig` | Yes                    |
 
 Online methods generate completions at training time and score them. GRPO and RLOO require reward functions from `RewardRegistry`. All online methods support optional vLLM for fast generation.
+
+> **`online_dpo` not available with trl >=1.0** — upstream removed `OnlineDPOTrainer`/`OnlineDPOConfig`;
+> it is de-registered, so `method="online_dpo"` raises `ValueError: Unknown training method`. Use
+> **GRPO** (online RL with reward functions) or **DPO** (offline paired preference) instead.
+> Note: the experimental trainers `xpo` / `nash_md` (and `ppo`) are still registered but their trl
+> classes were also removed in trl >=1.0 — selecting them raises an informative `TrainingError` at
+> training time naming the absent class and the supported alternatives (sft/dpo/kto/grpo/rloo).
 
 ### Pipeline Combo
 
@@ -110,12 +129,16 @@ Online methods generate completions at training time and score them. GRPO and RL
 - **`SFTConfig`** -- SFT training: `num_train_epochs`, `per_device_train_batch_size`, `learning_rate`, `max_seq_length`, etc.
 - **`DPOConfig`** -- DPO training: adds `beta`, `max_length`, `max_prompt_length`.
 - **`KTOConfig`** -- KTO training: adds `desirable_weight`, `undesirable_weight`.
-- **`ORPOConfig`** -- ORPO training: adds `beta`, `max_length`, `max_prompt_length`.
+- **`ORPOConfig`** -- ORPO config: `beta`, `max_length`, `max_prompt_length`. **Dataclass still
+  exists for back-compat, but `to_trl_config()` raises a `TrainingError` under trl >=1.0** (upstream
+  removed `ORPOConfig`); the `orpo` method is de-registered. Use DPO/GRPO.
 - **`GRPOConfig`** -- GRPO training: adds `num_generations`, `temperature`, `max_completion_length`, `kl_coef`, `use_vllm`.
 - **`RLOOConfig`** -- RLOO training: same fields as GRPOConfig.
-- **`OnlineDPOConfig`** -- Online DPO: adds `beta`, `max_completion_length`, `use_vllm`.
+- **`OnlineDPOConfig`** -- Online DPO config: `beta`, `max_completion_length`, `use_vllm`. **Dataclass
+  still exists for back-compat, but `to_trl_config()` raises a `TrainingError` under trl >=1.0**
+  (upstream removed `OnlineDPOConfig`); the `online_dpo` method is de-registered. Use GRPO/DPO.
 
-All method configs are `@dataclass(frozen=True)` with `__post_init__` validation (NaN/Inf checks, range checks). Each provides `to_trl_config(output_dir)` to convert to TRL's native config class.
+All method configs are `@dataclass(frozen=True)` with `__post_init__` validation (NaN/Inf checks, range checks). Each provides `to_trl_config(output_dir)` to convert to TRL's native config class (except `ORPOConfig`/`OnlineDPOConfig`, whose `to_trl_config()` raises under trl >=1.0 — see above).
 
 ### Registry
 
@@ -167,17 +190,17 @@ All config dataclasses validate numeric fields with `math.isfinite()` in `__post
 
 ### Required (installed with `pip install kailash-align`)
 
-| Package          | Version       | Purpose                                                  |
-| ---------------- | ------------- | -------------------------------------------------------- |
-| `torch`          | `>=2.2,<3.0`  | PyTorch runtime                                          |
-| `transformers`   | `>=4.40,<5.0` | Model loading, tokenizers                                |
-| `trl`            | `>=1.0,<2.0`  | All TRL trainers (SFT, DPO, KTO, ORPO, GRPO, RLOO, etc.) |
-| `peft`           | `>=0.10,<1.0` | LoRA/QLoRA adapter management                            |
-| `accelerate`     | `>=1.4,<2.0`  | Distributed training, mixed precision                    |
-| `datasets`       | `>=3.0,<4.0`  | HuggingFace dataset loading                              |
-| `kailash`        | `>=0.4.0`     | Core SDK (workflow runtime)                              |
-| `kailash-ml`     | `>=0.1.0`     | ModelRegistry, ML lifecycle                              |
-| `kailash-kaizen` | `>=0.3.0`     | Agent framework (for KaizenModelBridge)                  |
+| Package          | Version       | Purpose                                                                       |
+| ---------------- | ------------- | ----------------------------------------------------------------------------- |
+| `torch`          | `>=2.2,<3.0`  | PyTorch runtime                                                               |
+| `transformers`   | `>=4.40,<5.0` | Model loading, tokenizers                                                     |
+| `trl`            | `>=1.0,<2.0`  | TRL trainers (SFT, DPO, KTO, GRPO, RLOO; ORPO/OnlineDPO removed in trl >=1.0) |
+| `peft`           | `>=0.10,<1.0` | LoRA/QLoRA adapter management                                                 |
+| `accelerate`     | `>=1.4,<2.0`  | Distributed training, mixed precision                                         |
+| `datasets`       | `>=3.0,<4.0`  | HuggingFace dataset loading                                                   |
+| `kailash`        | `>=0.4.0`     | Core SDK (workflow runtime)                                                   |
+| `kailash-ml`     | `>=0.1.0`     | ModelRegistry, ML lifecycle                                                   |
+| `kailash-kaizen` | `>=0.3.0`     | Agent framework (for KaizenModelBridge)                                       |
 
 ### Optional Extras
 

--- a/packages/kailash-align/docs/01-method-selection-guide.md
+++ b/packages/kailash-align/docs/01-method-selection-guide.md
@@ -21,13 +21,13 @@ How to choose the right alignment method based on your data, compute budget, and
               |  Yes    No      |          |
               |   |      |     KTO       GRPO
               | sft_     |
-              | then_  Need
-              | dpo   single
-              |       pass?
-              |      /    \
-              |    Yes    No
-              |     |      |
-              |   ORPO    DPO
+              | then_   Use
+              | dpo     DPO
+              |       (single-pass
+              |        ORPO removed
+              |        in trl >=1.0)
+              |        |
+              |       DPO
               |
               +-- Want contrastive? --> CPO
               +-- Unpaired alt? -----> BCO
@@ -48,12 +48,13 @@ config = AlignmentConfig(method="sft", base_model_id="meta-llama/Llama-3.1-8B")
 
 ### I have paired preferences (prompt + chosen + rejected)
 
-Use **DPO** for the standard approach. Use **ORPO** if you want to skip the SFT stage and do both in one pass. Use **sft_then_dpo** if you want the classic two-stage pipeline.
+Use **DPO** for the standard approach. Use **sft_then_dpo** if you want the classic two-stage pipeline (SFT first, then DPO on the merged model). (The single-pass **ORPO** method is **NOT available with trl >=1.0** — upstream removed `ORPOTrainer`/`ORPOConfig`; use DPO or sft_then_dpo instead.)
 
 ```python
 # Data format: {"prompt": "...", "chosen": "...", "rejected": "..."}
 config = AlignmentConfig(method="dpo", base_model_id="meta-llama/Llama-3.1-8B")
-# Or: method="orpo" for single-pass
+# Note: ORPO/Online-DPO are NOT available with trl >=1.0 (removed upstream);
+# use method="dpo" or "grpo".
 # Or: method="sft_then_dpo" for two-stage (also needs SFT dataset)
 ```
 
@@ -92,29 +93,31 @@ Use **GRPO** with custom reward functions. You define what "good" means programm
 
 ## Method Comparison Table
 
-| Method           | Category   | Data Required                               | Compute Cost | When to Use                                                 |
-| ---------------- | ---------- | ------------------------------------------- | ------------ | ----------------------------------------------------------- |
-| **SFT**          | Offline    | Instruction examples (text)                 | Low          | Starting point. Teach the model a task format.              |
-| **DPO**          | Offline    | Paired preferences (prompt/chosen/rejected) | Medium       | Standard preference alignment with human rankings.          |
-| **CPO**          | Offline    | Paired preferences (prompt/chosen/rejected) | Medium       | Alternative to DPO with contrastive loss. Less common.      |
-| **KTO**          | Unpaired   | Binary feedback (prompt/completion/label)   | Medium       | When you only have thumbs-up/down, not paired comparisons.  |
-| **BCO**          | Unpaired   | Binary feedback (prompt/completion/label)   | Medium       | Alternative to KTO. Binary classifier approach.             |
-| **ORPO**         | Monolithic | Paired preferences (prompt/chosen/rejected) | Medium       | SFT + preference in one pass. Saves time vs sft_then_dpo.   |
-| **GRPO**         | Online     | Prompts + reward functions                  | High         | Improve beyond training data. Math, code, verifiable tasks. |
-| **RLOO**         | Online     | Prompts + reward functions                  | High         | Alternative to GRPO with leave-one-out variance reduction.  |
-| **Online DPO**   | Online     | Prompts (+ reward model)                    | High         | DPO with online generation. Requires reward model.          |
-| **XPO**          | Online     | Prompts + reward functions                  | High         | Exploration-based. Experimental.                            |
-| **NashMD**       | Online     | Prompts + reward functions                  | High         | Game-theoretic equilibrium. Experimental.                   |
-| **sft_then_dpo** | Combo      | SFT data + preference data                  | Medium       | Classic two-stage: SFT first, then DPO.                     |
+| Method                                               | Category   | Data Required                               | Compute Cost | When to Use                                                                           |
+| ---------------------------------------------------- | ---------- | ------------------------------------------- | ------------ | ------------------------------------------------------------------------------------- |
+| **SFT**                                              | Offline    | Instruction examples (text)                 | Low          | Starting point. Teach the model a task format.                                        |
+| **DPO**                                              | Offline    | Paired preferences (prompt/chosen/rejected) | Medium       | Standard preference alignment with human rankings.                                    |
+| **CPO**                                              | Offline    | Paired preferences (prompt/chosen/rejected) | Medium       | Alternative to DPO with contrastive loss. Less common.                                |
+| **KTO**                                              | Unpaired   | Binary feedback (prompt/completion/label)   | Medium       | When you only have thumbs-up/down, not paired comparisons.                            |
+| **BCO**                                              | Unpaired   | Binary feedback (prompt/completion/label)   | Medium       | Alternative to KTO. Binary classifier approach.                                       |
+| ~~ORPO~~ (removed in trl >=1.0 — use dpo/grpo)       | Monolithic | Paired preferences (prompt/chosen/rejected) | Medium       | NOT available with trl >=1.0 (upstream removed the trainer); use DPO or sft_then_dpo. |
+| **GRPO**                                             | Online     | Prompts + reward functions                  | High         | Improve beyond training data. Math, code, verifiable tasks.                           |
+| **RLOO**                                             | Online     | Prompts + reward functions                  | High         | Alternative to GRPO with leave-one-out variance reduction.                            |
+| ~~Online DPO~~ (removed in trl >=1.0 — use dpo/grpo) | Online     | Prompts (+ reward model)                    | High         | NOT available with trl >=1.0 (upstream removed the trainer); use GRPO or DPO.         |
+| **XPO**                                              | Online     | Prompts + reward functions                  | High         | Exploration-based. Experimental.                                                      |
+| **NashMD**                                           | Online     | Prompts + reward functions                  | High         | Game-theoretic equilibrium. Experimental.                                             |
+| **sft_then_dpo**                                     | Combo      | SFT data + preference data                  | Medium       | Classic two-stage: SFT first, then DPO.                                               |
 
 ## Data Requirements Detail
 
 ### Offline and Monolithic Methods
 
-| Method         | Required Columns               | Example                                                                  |
-| -------------- | ------------------------------ | ------------------------------------------------------------------------ |
-| SFT            | `text`                         | `{"text": "### Instruction: Summarize.\n### Response: Done."}`           |
-| DPO, CPO, ORPO | `prompt`, `chosen`, `rejected` | `{"prompt": "Write a poem.", "chosen": "Roses...", "rejected": "Um..."}` |
+| Method   | Required Columns               | Example                                                                  |
+| -------- | ------------------------------ | ------------------------------------------------------------------------ |
+| SFT      | `text`                         | `{"text": "### Instruction: Summarize.\n### Response: Done."}`           |
+| DPO, CPO | `prompt`, `chosen`, `rejected` | `{"prompt": "Write a poem.", "chosen": "Roses...", "rejected": "Um..."}` |
+
+> ORPO used the same paired-preference format but is **NOT available with trl >=1.0** (upstream removed the trainer); use DPO instead.
 
 ### Unpaired Methods
 
@@ -127,17 +130,18 @@ Use **GRPO** with custom reward functions. You define what "good" means programm
 | Method                  | Required Columns | Additional Requirement                          |
 | ----------------------- | ---------------- | ----------------------------------------------- |
 | GRPO, RLOO, XPO, NashMD | `prompt`         | Reward functions registered in `RewardRegistry` |
-| Online DPO              | `prompt`         | Generation backend (vLLM or HF)                 |
+
+> Online DPO used a prompt-only format with an online reward model but is **NOT available with trl >=1.0** (upstream removed the trainer); use GRPO or DPO instead.
 
 ## Compute Cost Guide
 
 ### Approximate GPU Memory (LoRA rank=16, seq_len=1024, batch_size=2)
 
-| Method           | 3B     | 7B     | 13B    | 70B     |
-| ---------------- | ------ | ------ | ------ | ------- |
-| SFT              | ~8 GB  | ~16 GB | ~28 GB | ~140 GB |
-| DPO/KTO/ORPO/CPO | ~10 GB | ~20 GB | ~34 GB | ~170 GB |
-| GRPO/RLOO        | ~14 GB | ~28 GB | ~48 GB | ~240 GB |
+| Method      | 3B     | 7B     | 13B    | 70B     |
+| ----------- | ------ | ------ | ------ | ------- |
+| SFT         | ~8 GB  | ~16 GB | ~28 GB | ~140 GB |
+| DPO/KTO/CPO | ~10 GB | ~20 GB | ~34 GB | ~170 GB |
+| GRPO/RLOO   | ~14 GB | ~28 GB | ~48 GB | ~240 GB |
 
 Online methods (GRPO, RLOO) use more memory because they run generation during training.
 
@@ -146,7 +150,7 @@ Online methods (GRPO, RLOO) use more memory because they run generation during t
 | GPU                               | Best For                                                                         |
 | --------------------------------- | -------------------------------------------------------------------------------- |
 | **NVIDIA A100 80GB**              | Any method, any model up to 13B. 70B with QLoRA.                                 |
-| **NVIDIA A10G / RTX 4090 (24GB)** | SFT/DPO/KTO/ORPO up to 7B. GRPO up to 3B (or 7B with batch_size=1).              |
+| **NVIDIA A10G / RTX 4090 (24GB)** | SFT/DPO/KTO up to 7B. GRPO up to 3B (or 7B with batch_size=1).                   |
 | **NVIDIA T4 (16GB)**              | SFT up to 3B with LoRA rank=8, batch_size=1. Not recommended for online methods. |
 | **Apple Silicon (MPS)**           | SFT/DPO up to 3B. No vLLM (use HFGenerationBackend for online methods).          |
 
@@ -168,13 +172,13 @@ print(f"Recommended batch size: {estimate.recommended_batch_size}")
 
 ## Method Selection by Goal
 
-| Goal                               | Recommended Method  | Why                                          |
-| ---------------------------------- | ------------------- | -------------------------------------------- |
-| Teach a model a new format/task    | SFT                 | Direct supervised learning on examples       |
-| Align with human preferences       | DPO or sft_then_dpo | Standard RLHF replacement                    |
-| Align with minimal data collection | KTO                 | Only needs binary good/bad labels            |
-| Single-pass alignment (save time)  | ORPO                | Combines SFT + preference in one pass        |
-| Improve math/code reasoning        | GRPO                | Reward functions for verifiable correctness  |
-| Explore beyond training data       | GRPO or XPO         | Online generation with reward scoring        |
-| Production with limited time       | ORPO                | One training run instead of two              |
-| Research / experimental            | XPO, NashMD         | Cutting-edge methods, less production-tested |
+| Goal                               | Recommended Method  | Why                                               |
+| ---------------------------------- | ------------------- | ------------------------------------------------- |
+| Teach a model a new format/task    | SFT                 | Direct supervised learning on examples            |
+| Align with human preferences       | DPO or sft_then_dpo | Standard RLHF replacement                         |
+| Align with minimal data collection | KTO                 | Only needs binary good/bad labels                 |
+| Single-pass alignment (save time)  | DPO or sft_then_dpo | ORPO (single-pass) removed in trl >=1.0 — use DPO |
+| Improve math/code reasoning        | GRPO                | Reward functions for verifiable correctness       |
+| Explore beyond training data       | GRPO or XPO         | Online generation with reward scoring             |
+| Production with limited time       | DPO or sft_then_dpo | ORPO removed in trl >=1.0 — use DPO/sft_then_dpo  |
+| Research / experimental            | XPO, NashMD         | Cutting-edge methods, less production-tested      |

--- a/packages/kailash-align/src/kailash_align/config.py
+++ b/packages/kailash-align/src/kailash_align/config.py
@@ -80,7 +80,8 @@ class LoRAConfig:
 
     def to_peft_config(self):
         """Convert to peft.LoraConfig. Lazy import to avoid loading peft at config time."""
-        from peft import LoraConfig as PeftLoraConfig, TaskType
+        from peft import LoraConfig as PeftLoraConfig
+        from peft import TaskType
 
         return PeftLoraConfig(
             r=self.rank,
@@ -143,7 +144,10 @@ class SFTConfig:
             gradient_accumulation_steps=self.gradient_accumulation_steps,
             learning_rate=self.learning_rate,
             warmup_ratio=self.warmup_ratio,
-            max_seq_length=self.max_seq_length,
+            # trl 1.x renamed SFTConfig.max_seq_length -> max_length. The public
+            # dataclass field stays `max_seq_length` (stable user-facing API);
+            # only the forwarded trl kwarg changes.
+            max_length=self.max_seq_length,
             logging_steps=self.logging_steps,
             save_steps=self.save_steps,
             gradient_checkpointing=self.gradient_checkpointing,
@@ -208,7 +212,8 @@ class DPOConfig:
             learning_rate=self.learning_rate,
             warmup_ratio=self.warmup_ratio,
             max_length=self.max_length,
-            max_prompt_length=self.max_prompt_length,
+            # trl 1.x removed DPOConfig.max_prompt_length. The dataclass field is
+            # kept (stable API) but no longer forwarded to trl.
             beta=self.beta,
             logging_steps=self.logging_steps,
             save_steps=self.save_steps,
@@ -272,26 +277,44 @@ class KTOConfig:
 
     def to_trl_config(self, output_dir: str):
         """Convert to trl.KTOConfig."""
-        from trl import KTOConfig as TRLKTOConfig
+        import warnings
 
-        return TRLKTOConfig(
-            output_dir=output_dir,
-            num_train_epochs=self.num_train_epochs,
-            per_device_train_batch_size=self.per_device_train_batch_size,
-            gradient_accumulation_steps=self.gradient_accumulation_steps,
-            learning_rate=self.learning_rate,
-            warmup_ratio=self.warmup_ratio,
-            beta=self.beta,
-            desirable_weight=self.desirable_weight,
-            undesirable_weight=self.undesirable_weight,
-            max_length=self.max_length,
-            max_prompt_length=self.max_prompt_length,
-            logging_steps=self.logging_steps,
-            save_steps=self.save_steps,
-            gradient_checkpointing=self.gradient_checkpointing,
-            bf16=self.bf16,
-            fp16=self.fp16,
-        )
+        # trl 1.x emits a FutureWarning steering imports to
+        # `trl.experimental.kto`, but upstream explicitly keeps the stable
+        # `from trl import KTOConfig` path working ("this current path will
+        # remain") -- see https://github.com/huggingface/trl/issues/4223.
+        # We deliberately stay on the stable path (the experimental module's
+        # API may change between trl patch releases); the warning is a
+        # documented upstream deprecation, suppressed only at this call site.
+        # The warning fires at BOTH import and construction, so the whole call
+        # is inside the catch_warnings() block.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*KTOConfig.*trl\.experimental.*",
+                category=FutureWarning,
+            )
+            from trl import KTOConfig as TRLKTOConfig
+
+            return TRLKTOConfig(
+                output_dir=output_dir,
+                num_train_epochs=self.num_train_epochs,
+                per_device_train_batch_size=self.per_device_train_batch_size,
+                gradient_accumulation_steps=self.gradient_accumulation_steps,
+                learning_rate=self.learning_rate,
+                warmup_ratio=self.warmup_ratio,
+                beta=self.beta,
+                desirable_weight=self.desirable_weight,
+                undesirable_weight=self.undesirable_weight,
+                max_length=self.max_length,
+                # trl 1.x removed KTOConfig.max_prompt_length. The dataclass
+                # field is kept (stable API) but no longer forwarded to trl.
+                logging_steps=self.logging_steps,
+                save_steps=self.save_steps,
+                gradient_checkpointing=self.gradient_checkpointing,
+                bf16=self.bf16,
+                fp16=self.fp16,
+            )
 
 
 @dataclass(frozen=True)
@@ -341,24 +364,18 @@ class ORPOConfig:
             raise ValueError("Cannot enable both bf16 and fp16")
 
     def to_trl_config(self, output_dir: str):
-        """Convert to trl.ORPOConfig."""
-        from trl import ORPOConfig as TRLORPOConfig
+        """Convert to trl.ORPOConfig.
 
-        return TRLORPOConfig(
-            output_dir=output_dir,
-            num_train_epochs=self.num_train_epochs,
-            per_device_train_batch_size=self.per_device_train_batch_size,
-            gradient_accumulation_steps=self.gradient_accumulation_steps,
-            learning_rate=self.learning_rate,
-            warmup_ratio=self.warmup_ratio,
-            beta=self.beta,
-            max_length=self.max_length,
-            max_prompt_length=self.max_prompt_length,
-            logging_steps=self.logging_steps,
-            save_steps=self.save_steps,
-            gradient_checkpointing=self.gradient_checkpointing,
-            bf16=self.bf16,
-            fp16=self.fp16,
+        trl >=1.0 removed ORPOConfig (the ORPOTrainer/ORPOConfig pair was dropped
+        upstream). kailash-align's trl floor is >=1.0, so this method always raises.
+        """
+        from kailash_align.exceptions import TrainingError
+
+        raise TrainingError(
+            "ORPO is unavailable: trl >=1.0 removed ORPOConfig/ORPOTrainer upstream "
+            "(the class no longer exists in any trl 1.x release). "
+            "Use DPO (method='dpo', paired prompt/chosen/rejected data) or "
+            "GRPO (method='grpo', online RL with reward functions) instead."
         )
 
 
@@ -442,7 +459,9 @@ class GRPOConfig:
             num_generations=self.num_generations,
             temperature=self.temperature,
             max_completion_length=self.max_completion_length,
-            kl_coef=self.kl_coef,
+            # trl 1.x renamed the KL coefficient kwarg kl_coef -> beta on
+            # GRPOConfig. The dataclass field stays kl_coef (stable API).
+            beta=self.kl_coef,
             logging_steps=self.logging_steps,
             save_steps=self.save_steps,
             gradient_checkpointing=self.gradient_checkpointing,
@@ -451,7 +470,8 @@ class GRPOConfig:
         )
         if self.use_vllm:
             kwargs["use_vllm"] = True
-            kwargs["vllm_gpu_utilization"] = self.vllm_gpu_utilization
+            # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
+            kwargs["vllm_gpu_memory_utilization"] = self.vllm_gpu_utilization
         return TRLGRPOConfig(**kwargs)
 
 
@@ -535,7 +555,9 @@ class RLOOConfig:
             num_generations=self.num_generations,
             temperature=self.temperature,
             max_completion_length=self.max_completion_length,
-            kl_coef=self.kl_coef,
+            # trl 1.x renamed the KL coefficient kwarg kl_coef -> beta on
+            # RLOOConfig. The dataclass field stays kl_coef (stable API).
+            beta=self.kl_coef,
             logging_steps=self.logging_steps,
             save_steps=self.save_steps,
             gradient_checkpointing=self.gradient_checkpointing,
@@ -544,7 +566,8 @@ class RLOOConfig:
         )
         if self.use_vllm:
             kwargs["use_vllm"] = True
-            kwargs["vllm_gpu_utilization"] = self.vllm_gpu_utilization
+            # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
+            kwargs["vllm_gpu_memory_utilization"] = self.vllm_gpu_utilization
         return TRLRLOOConfig(**kwargs)
 
 
@@ -605,30 +628,20 @@ class OnlineDPOConfig:
             raise ValueError("Cannot enable both bf16 and fp16")
 
     def to_trl_config(self, output_dir: str):
-        """Convert to trl.OnlineDPOConfig."""
-        from trl import OnlineDPOConfig as TRLOnlineDPOConfig
+        """Convert to trl.OnlineDPOConfig.
 
-        kwargs = dict(
-            output_dir=output_dir,
-            num_train_epochs=self.num_train_epochs,
-            per_device_train_batch_size=self.per_device_train_batch_size,
-            gradient_accumulation_steps=self.gradient_accumulation_steps,
-            learning_rate=self.learning_rate,
-            warmup_ratio=self.warmup_ratio,
-            beta=self.beta,
-            max_length=self.max_length,
-            max_prompt_length=self.max_prompt_length,
-            max_completion_length=self.max_completion_length,
-            logging_steps=self.logging_steps,
-            save_steps=self.save_steps,
-            gradient_checkpointing=self.gradient_checkpointing,
-            bf16=self.bf16,
-            fp16=self.fp16,
+        trl >=1.0 removed OnlineDPOConfig (the OnlineDPOTrainer/OnlineDPOConfig pair
+        was dropped upstream). kailash-align's trl floor is >=1.0, so this method
+        always raises.
+        """
+        from kailash_align.exceptions import TrainingError
+
+        raise TrainingError(
+            "Online DPO is unavailable: trl >=1.0 removed OnlineDPOConfig/"
+            "OnlineDPOTrainer upstream (the class no longer exists in any trl 1.x "
+            "release). Use DPO (method='dpo', offline paired preference data) or "
+            "GRPO (method='grpo', online RL with reward functions) instead."
         )
-        if self.use_vllm:
-            kwargs["use_vllm"] = True
-            kwargs["vllm_gpu_utilization"] = self.vllm_gpu_utilization
-        return TRLOnlineDPOConfig(**kwargs)
 
 
 @dataclass(frozen=True)

--- a/packages/kailash-align/src/kailash_align/config.py
+++ b/packages/kailash-align/src/kailash_align/config.py
@@ -689,9 +689,13 @@ class AlignmentConfig:
     """Top-level configuration for AlignmentPipeline.
 
     Supports all training methods registered in MethodRegistry:
-    - Offline: sft, dpo, sft_then_dpo, orpo, cpo
+    - Offline: sft, dpo, sft_then_dpo, cpo
     - Unpaired: kto, bco
-    - Online: grpo, rloo, online_dpo, xpo, nash_md
+    - Online: grpo, rloo, xpo, nash_md
+
+    Note: orpo and online_dpo are NOT registered — trl >=1.0 removed
+    ORPOTrainer/ORPOConfig and OnlineDPOTrainer/OnlineDPOConfig upstream.
+    Use dpo or grpo instead.
 
     Args:
         method: Training method -- any key in METHOD_REGISTRY or 'sft_then_dpo'.
@@ -744,17 +748,19 @@ class AlignmentConfig:
                     "QLoRA requires bitsandbytes. "
                     "Install with: pip install kailash-align[rlhf]"
                 ) from exc
-        # Auto-create method-specific configs with defaults if not provided
+        # Auto-create method-specific configs with defaults if not provided.
+        # NOTE: orpo / online_dpo are NOT auto-created -- trl >=1.0 removed those
+        # trainer/config classes upstream, so they are de-registered from
+        # METHOD_REGISTRY and validate_method_name() rejects them above before
+        # this point is reached (see method_registry.py + issue #1426). The
+        # ORPOConfig/OnlineDPOConfig dataclasses remain constructible directly
+        # (their to_trl_config() raises an informative DPO/GRPO redirect).
         if self.method == "kto" and self.kto is None:
             self.kto = KTOConfig()
-        if self.method == "orpo" and self.orpo is None:
-            self.orpo = ORPOConfig()
         if self.method == "grpo" and self.grpo is None:
             self.grpo = GRPOConfig()
         if self.method == "rloo" and self.rloo is None:
             self.rloo = RLOOConfig()
-        if self.method == "online_dpo" and self.online_dpo is None:
-            self.online_dpo = OnlineDPOConfig()
 
     def get_method_config(self, method_name: str):
         """Get the method-specific config for TRL config generation.

--- a/packages/kailash-align/src/kailash_align/method_registry.py
+++ b/packages/kailash-align/src/kailash_align/method_registry.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import importlib
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from kailash_align.exceptions import AlignmentError, TrainingError
 
@@ -245,20 +245,14 @@ register_method(
     )
 )
 
-register_method(
-    MethodConfig(
-        name="orpo",
-        trainer_module="trl",
-        trainer_class_name="ORPOTrainer",
-        config_module="trl",
-        config_class_name="ORPOConfig",
-        dataset_validator=_validate_preference_columns,
-        dataset_required_columns=frozenset({"prompt", "chosen", "rejected"}),
-        metrics_extractor=_extract_standard_metrics,
-        requires_preference_data=True,
-        category="monolithic",
-    )
-)
+# NOTE: orpo / online_dpo are intentionally NOT registered.
+# trl >=1.0 removed ORPOTrainer/ORPOConfig and OnlineDPOTrainer/OnlineDPOConfig
+# upstream (the classes no longer exist in any trl 1.x release), and
+# kailash-align's trl floor is >=1.0. Registering them would advertise
+# selectable methods that cannot run. The ORPOConfig/OnlineDPOConfig dataclasses
+# remain in config.py with an informative raise in to_trl_config() so a user
+# constructing the config directly still gets the DPO/GRPO redirect. Use 'dpo'
+# (offline paired preference) or 'grpo' (online RL) instead. See issue #1426.
 
 register_method(
     MethodConfig(
@@ -287,21 +281,6 @@ register_method(
         dataset_required_columns=frozenset({"prompt"}),
         metrics_extractor=_extract_grpo_metrics,
         requires_reward_func=True,
-        requires_generation_backend=True,
-        category="online",
-    )
-)
-
-register_method(
-    MethodConfig(
-        name="online_dpo",
-        trainer_module="trl",
-        trainer_class_name="OnlineDPOTrainer",
-        config_module="trl",
-        config_class_name="OnlineDPOConfig",
-        dataset_validator=_validate_prompt_only,
-        dataset_required_columns=frozenset({"prompt"}),
-        metrics_extractor=_extract_dpo_metrics,
         requires_generation_backend=True,
         category="online",
     )

--- a/packages/kailash-align/src/kailash_align/pipeline.py
+++ b/packages/kailash-align/src/kailash_align/pipeline.py
@@ -312,7 +312,23 @@ class AlignmentPipeline:
             trl_config.loss_type = self._config.loss_type
 
         # 4. Create trainer
-        TrainerClass = _lazy_import(method.trainer_module, method.trainer_class_name)
+        # trl >=1.0 removed several trainer classes that older kailash-align
+        # registered (ORPOTrainer, OnlineDPOTrainer are de-registered; the
+        # experimental methods xpo/nash_md/ppo/cpo/bco may also be absent in a
+        # given trl release). _lazy_import raises a raw ImportError when the
+        # class is gone; convert it to an informative TrainingError naming the
+        # method, the absent trl class, and the supported alternatives.
+        try:
+            TrainerClass = _lazy_import(
+                method.trainer_module, method.trainer_class_name
+            )
+        except (ImportError, AttributeError) as exc:
+            raise TrainingError(
+                f"Training method '{method.name}' requires trl class "
+                f"'{method.trainer_class_name}', which is unavailable in the "
+                f"installed trl (>=1.0 removed it). "
+                f"Supported: sft, dpo, kto, grpo, rloo."
+            ) from exc
 
         trainer_kwargs: dict[str, Any] = {
             "model": model,

--- a/packages/kailash-align/src/kailash_align/pipeline.py
+++ b/packages/kailash-align/src/kailash_align/pipeline.py
@@ -244,10 +244,9 @@ class AlignmentPipeline:
             reward_funcs: Resolved reward functions for online methods.
         """
         import torch
+        from kailash_align.method_registry import _lazy_import, get_method
         from peft import PeftModel, get_peft_model
         from transformers import AutoModelForCausalLM, AutoTokenizer
-
-        from kailash_align.method_registry import _lazy_import, get_method
 
         method = get_method(method_name)
 
@@ -322,8 +321,13 @@ class AlignmentPipeline:
             "processing_class": tokenizer,
         }
 
-        # Add peft_config for offline/unpaired methods
-        if not method.requires_generation_backend:
+        # The model is ALREADY a PeftModel here (LoRA was applied above via
+        # get_peft_model in both branches). trl 1.x raises ValueError if BOTH a
+        # wrapped PeftModel AND peft_config are passed. We pass the pre-wrapped
+        # PeftModel and therefore MUST NOT also forward peft_config. LoRA behavior
+        # is fully preserved because the model carries the adapter already.
+        if not isinstance(model, PeftModel):
+            # Defensive: only reached if a future refactor stops pre-wrapping.
             trainer_kwargs["peft_config"] = peft_config
 
         # Add reward functions for online methods

--- a/packages/kailash-align/tests/test_config.py
+++ b/packages/kailash-align/tests/test_config.py
@@ -335,7 +335,8 @@ class TestTrl1xCompat:
         pytest.importorskip("trl")
         # Must construct without TypeError. trl 1.x has max_length (not
         # max_seq_length); the dataclass field stays max_seq_length.
-        trl_cfg = KASFTConfig(max_seq_length=512).to_trl_config("/tmp/x")
+        # bf16=False so trl's GPU-only bf16 validation does not fire on CPU CI.
+        trl_cfg = KASFTConfig(max_seq_length=512, bf16=False).to_trl_config("/tmp/x")
         assert trl_cfg.max_length == 512
 
     def test_dpo_to_trl_config_trl1x_compat(self):
@@ -343,7 +344,7 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x DPOConfig has max_length, NOT max_prompt_length.
-        trl_cfg = KADPOConfig(max_length=1024).to_trl_config("/tmp/x")
+        trl_cfg = KADPOConfig(max_length=1024, bf16=False).to_trl_config("/tmp/x")
         assert trl_cfg.max_length == 1024
 
     def test_kto_to_trl_config_trl1x_compat(self):
@@ -351,7 +352,7 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x KTOConfig has max_length, NOT max_prompt_length.
-        trl_cfg = KAKTOConfig(max_length=768).to_trl_config("/tmp/x")
+        trl_cfg = KAKTOConfig(max_length=768, bf16=False).to_trl_config("/tmp/x")
         assert trl_cfg.max_length == 768
 
     def test_grpo_to_trl_config_trl1x_compat(self):
@@ -359,9 +360,9 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x renamed kl_coef -> beta. Default path (use_vllm=False).
-        trl_cfg = KAGRPOConfig(max_completion_length=256, kl_coef=0.02).to_trl_config(
-            "/tmp/x"
-        )
+        trl_cfg = KAGRPOConfig(
+            max_completion_length=256, kl_coef=0.02, bf16=False
+        ).to_trl_config("/tmp/x")
         assert trl_cfg.max_completion_length == 256
         assert trl_cfg.beta == 0.02
 
@@ -370,9 +371,9 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
-        trl_cfg = KAGRPOConfig(use_vllm=True, vllm_gpu_utilization=0.4).to_trl_config(
-            "/tmp/x"
-        )
+        trl_cfg = KAGRPOConfig(
+            use_vllm=True, vllm_gpu_utilization=0.4, bf16=False
+        ).to_trl_config("/tmp/x")
         assert trl_cfg.use_vllm is True
         assert trl_cfg.vllm_gpu_memory_utilization == 0.4
 
@@ -381,9 +382,9 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x renamed kl_coef -> beta. Default path (use_vllm=False).
-        trl_cfg = KARLOOConfig(max_completion_length=256, kl_coef=0.02).to_trl_config(
-            "/tmp/x"
-        )
+        trl_cfg = KARLOOConfig(
+            max_completion_length=256, kl_coef=0.02, bf16=False
+        ).to_trl_config("/tmp/x")
         assert trl_cfg.max_completion_length == 256
         assert trl_cfg.beta == 0.02
 
@@ -392,9 +393,9 @@ class TestTrl1xCompat:
 
         pytest.importorskip("trl")
         # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
-        trl_cfg = KARLOOConfig(use_vllm=True, vllm_gpu_utilization=0.4).to_trl_config(
-            "/tmp/x"
-        )
+        trl_cfg = KARLOOConfig(
+            use_vllm=True, vllm_gpu_utilization=0.4, bf16=False
+        ).to_trl_config("/tmp/x")
         assert trl_cfg.use_vllm is True
         assert trl_cfg.vllm_gpu_memory_utilization == 0.4
 

--- a/packages/kailash-align/tests/test_config.py
+++ b/packages/kailash-align/tests/test_config.py
@@ -3,10 +3,7 @@
 """Tests for AlignmentConfig and sub-configs."""
 from __future__ import annotations
 
-import math
-
 import pytest
-
 from kailash_align.config import (
     AdapterSignature,
     AlignmentConfig,
@@ -16,7 +13,6 @@ from kailash_align.config import (
     _validate_finite,
     _validate_positive,
 )
-
 
 # --- Validation Utilities ---
 
@@ -319,3 +315,102 @@ class TestAlignmentConfig:
         except ImportError:
             with pytest.raises(ImportError, match="bitsandbytes"):
                 AlignmentConfig(base_model_id="test/model", use_qlora=True)
+
+
+# --- trl 1.x compatibility (issue #1426) ---
+#
+# Behavioral tests: call to_trl_config() against the INSTALLED trl and assert
+# the result constructs without TypeError. The old field names (max_seq_length,
+# max_prompt_length) and the removed classes (ORPOConfig, OnlineDPOConfig) broke
+# every one of these against trl >=1.0. Config construction only -- no GPU.
+
+
+@pytest.mark.unit
+class TestTrl1xCompat:
+    """Guards that to_trl_config() forwards trl 1.x kwarg names, not 0.x."""
+
+    def test_sft_to_trl_config_trl1x_compat(self):
+        from kailash_align.config import SFTConfig as KASFTConfig
+
+        pytest.importorskip("trl")
+        # Must construct without TypeError. trl 1.x has max_length (not
+        # max_seq_length); the dataclass field stays max_seq_length.
+        trl_cfg = KASFTConfig(max_seq_length=512).to_trl_config("/tmp/x")
+        assert trl_cfg.max_length == 512
+
+    def test_dpo_to_trl_config_trl1x_compat(self):
+        from kailash_align.config import DPOConfig as KADPOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x DPOConfig has max_length, NOT max_prompt_length.
+        trl_cfg = KADPOConfig(max_length=1024).to_trl_config("/tmp/x")
+        assert trl_cfg.max_length == 1024
+
+    def test_kto_to_trl_config_trl1x_compat(self):
+        from kailash_align.config import KTOConfig as KAKTOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x KTOConfig has max_length, NOT max_prompt_length.
+        trl_cfg = KAKTOConfig(max_length=768).to_trl_config("/tmp/x")
+        assert trl_cfg.max_length == 768
+
+    def test_grpo_to_trl_config_trl1x_compat(self):
+        from kailash_align.config import GRPOConfig as KAGRPOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x renamed kl_coef -> beta. Default path (use_vllm=False).
+        trl_cfg = KAGRPOConfig(max_completion_length=256, kl_coef=0.02).to_trl_config(
+            "/tmp/x"
+        )
+        assert trl_cfg.max_completion_length == 256
+        assert trl_cfg.beta == 0.02
+
+    def test_grpo_to_trl_config_trl1x_compat_vllm(self):
+        from kailash_align.config import GRPOConfig as KAGRPOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
+        trl_cfg = KAGRPOConfig(use_vllm=True, vllm_gpu_utilization=0.4).to_trl_config(
+            "/tmp/x"
+        )
+        assert trl_cfg.use_vllm is True
+        assert trl_cfg.vllm_gpu_memory_utilization == 0.4
+
+    def test_rloo_to_trl_config_trl1x_compat(self):
+        from kailash_align.config import RLOOConfig as KARLOOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x renamed kl_coef -> beta. Default path (use_vllm=False).
+        trl_cfg = KARLOOConfig(max_completion_length=256, kl_coef=0.02).to_trl_config(
+            "/tmp/x"
+        )
+        assert trl_cfg.max_completion_length == 256
+        assert trl_cfg.beta == 0.02
+
+    def test_rloo_to_trl_config_trl1x_compat_vllm(self):
+        from kailash_align.config import RLOOConfig as KARLOOConfig
+
+        pytest.importorskip("trl")
+        # trl 1.x renamed vllm_gpu_utilization -> vllm_gpu_memory_utilization.
+        trl_cfg = KARLOOConfig(use_vllm=True, vllm_gpu_utilization=0.4).to_trl_config(
+            "/tmp/x"
+        )
+        assert trl_cfg.use_vllm is True
+        assert trl_cfg.vllm_gpu_memory_utilization == 0.4
+
+    def test_orpo_to_trl_config_trl1x_compat_raises(self):
+        from kailash_align.config import ORPOConfig as KAORPOConfig
+        from kailash_align.exceptions import TrainingError
+
+        # ORPOConfig/ORPOTrainer were removed in trl >=1.0. Calling
+        # to_trl_config() must raise an informative error pointing at DPO/GRPO.
+        with pytest.raises(TrainingError, match="trl >=1.0 removed"):
+            KAORPOConfig().to_trl_config("/tmp/x")
+
+    def test_online_dpo_to_trl_config_trl1x_compat_raises(self):
+        from kailash_align.config import OnlineDPOConfig as KAOnlineDPOConfig
+        from kailash_align.exceptions import TrainingError
+
+        # OnlineDPOConfig/OnlineDPOTrainer were removed in trl >=1.0.
+        with pytest.raises(TrainingError, match="trl >=1.0 removed"):
+            KAOnlineDPOConfig().to_trl_config("/tmp/x")

--- a/packages/kailash-align/tests/test_method_registry.py
+++ b/packages/kailash-align/tests/test_method_registry.py
@@ -6,11 +6,7 @@ Tier 1 unit tests -- no torch, TRL, or GPU dependencies required.
 """
 from __future__ import annotations
 
-import math
-import warnings
-
 import pytest
-
 from kailash_align.config import (
     AdapterSignature,
     AlignmentConfig,
@@ -30,7 +26,6 @@ from kailash_align.method_registry import (
     validate_method_name,
 )
 
-
 # =============================================================================
 # Section 1: Method Registry
 # =============================================================================
@@ -39,14 +34,14 @@ from kailash_align.method_registry import (
 class TestMethodRegistryCompleteness:
     """All expected methods are registered with correct metadata."""
 
+    # orpo / online_dpo are NOT registered: trl >=1.0 removed their trainer
+    # classes upstream (issue #1426). The remaining 10 are the registrable set.
     EXPECTED_METHODS = {
         "sft",
         "dpo",
         "kto",
-        "orpo",
         "grpo",
         "rloo",
-        "online_dpo",
         "xpo",
         "nash_md",
         "cpo",
@@ -55,12 +50,27 @@ class TestMethodRegistryCompleteness:
     }
 
     def test_all_methods_registered(self):
-        """All 12 built-in methods are present in the registry."""
+        """All 10 built-in methods are present in the registry."""
         assert self.EXPECTED_METHODS == set(METHOD_REGISTRY.keys())
 
     def test_registry_count(self):
-        """Exactly 12 methods are registered (no accidental extras)."""
-        assert len(METHOD_REGISTRY) == 12
+        """Exactly 10 methods are registered (no accidental extras)."""
+        assert len(METHOD_REGISTRY) == 10
+
+    def test_orpo_online_dpo_not_registered(self):
+        """trl >=1.0 removed ORPO/OnlineDPO trainers; they MUST be absent (#1426)."""
+        assert "orpo" not in METHOD_REGISTRY
+        assert "online_dpo" not in METHOD_REGISTRY
+        with pytest.raises(AlignmentError, match="Unknown training method 'orpo'"):
+            get_method("orpo")
+        with pytest.raises(
+            AlignmentError, match="Unknown training method 'online_dpo'"
+        ):
+            get_method("online_dpo")
+        with pytest.raises(ValueError, match="Unknown training method"):
+            validate_method_name("orpo")
+        with pytest.raises(ValueError, match="Unknown training method"):
+            validate_method_name("online_dpo")
 
 
 class TestGetMethod:
@@ -72,10 +82,8 @@ class TestGetMethod:
             "sft",
             "dpo",
             "kto",
-            "orpo",
             "grpo",
             "rloo",
-            "online_dpo",
             "xpo",
             "nash_md",
             "cpo",
@@ -107,10 +115,8 @@ class TestValidateMethodName:
             "sft",
             "dpo",
             "kto",
-            "orpo",
             "grpo",
             "rloo",
-            "online_dpo",
             "xpo",
             "nash_md",
             "cpo",
@@ -175,8 +181,8 @@ class TestCategoryClassification:
 
     OFFLINE_METHODS = {"sft", "dpo", "cpo"}
     UNPAIRED_METHODS = {"kto", "bco"}
-    MONOLITHIC_METHODS = {"orpo"}
-    ONLINE_METHODS = {"grpo", "rloo", "online_dpo", "xpo", "nash_md", "ppo"}
+    # The lone monolithic method (orpo) is de-registered in trl >=1.0 (#1426).
+    ONLINE_METHODS = {"grpo", "rloo", "xpo", "nash_md", "ppo"}
 
     @pytest.mark.parametrize("name", OFFLINE_METHODS)
     def test_offline_category(self, name: str):
@@ -185,10 +191,6 @@ class TestCategoryClassification:
     @pytest.mark.parametrize("name", UNPAIRED_METHODS)
     def test_unpaired_category(self, name: str):
         assert get_method(name).category == "unpaired"
-
-    @pytest.mark.parametrize("name", MONOLITHIC_METHODS)
-    def test_monolithic_category(self, name: str):
-        assert get_method(name).category == "monolithic"
 
     @pytest.mark.parametrize("name", ONLINE_METHODS)
     def test_online_category(self, name: str):
@@ -199,8 +201,8 @@ class TestMethodFlags:
     """Method boolean flags are set correctly."""
 
     REWARD_FUNC_METHODS = {"grpo", "rloo", "xpo", "nash_md", "ppo"}
-    GENERATION_BACKEND_METHODS = {"grpo", "rloo", "online_dpo", "xpo", "nash_md", "ppo"}
-    PREFERENCE_DATA_METHODS = {"dpo", "orpo", "cpo"}
+    GENERATION_BACKEND_METHODS = {"grpo", "rloo", "xpo", "nash_md", "ppo"}
+    PREFERENCE_DATA_METHODS = {"dpo", "cpo"}
     SUPPORTS_LOSS_TYPE_METHODS = {"dpo"}
 
     @pytest.mark.parametrize("name", REWARD_FUNC_METHODS)
@@ -209,7 +211,7 @@ class TestMethodFlags:
 
     @pytest.mark.parametrize(
         "name",
-        ["sft", "dpo", "kto", "orpo", "online_dpo", "cpo", "bco"],
+        ["sft", "dpo", "kto", "cpo", "bco"],
     )
     def test_requires_reward_func_false(self, name: str):
         assert get_method(name).requires_reward_func is False
@@ -220,7 +222,7 @@ class TestMethodFlags:
 
     @pytest.mark.parametrize(
         "name",
-        ["sft", "dpo", "kto", "orpo", "cpo", "bco"],
+        ["sft", "dpo", "kto", "cpo", "bco"],
     )
     def test_requires_generation_backend_false(self, name: str):
         assert get_method(name).requires_generation_backend is False
@@ -231,7 +233,7 @@ class TestMethodFlags:
 
     @pytest.mark.parametrize(
         "name",
-        ["sft", "kto", "grpo", "rloo", "online_dpo", "xpo", "nash_md", "bco"],
+        ["sft", "kto", "grpo", "rloo", "xpo", "nash_md", "bco"],
     )
     def test_requires_preference_data_false(self, name: str):
         assert get_method(name).requires_preference_data is False
@@ -600,15 +602,15 @@ class TestAlignmentConfigAutoCreate:
         assert config.rloo is not None
         assert isinstance(config.rloo, RLOOConfig)
 
-    def test_orpo_auto_creates_config(self):
-        config = AlignmentConfig(method="orpo", base_model_id="test/model")
-        assert config.orpo is not None
-        assert isinstance(config.orpo, ORPOConfig)
+    def test_orpo_method_rejected(self):
+        """orpo is de-registered (trl >=1.0 removed ORPOTrainer); selecting it raises (#1426)."""
+        with pytest.raises(ValueError, match="Unknown training method"):
+            AlignmentConfig(method="orpo", base_model_id="test/model")
 
-    def test_online_dpo_auto_creates_config(self):
-        config = AlignmentConfig(method="online_dpo", base_model_id="test/model")
-        assert config.online_dpo is not None
-        assert isinstance(config.online_dpo, OnlineDPOConfig)
+    def test_online_dpo_method_rejected(self):
+        """online_dpo is de-registered (trl >=1.0 removed OnlineDPOTrainer); selecting it raises (#1426)."""
+        with pytest.raises(ValueError, match="Unknown training method"):
+            AlignmentConfig(method="online_dpo", base_model_id="test/model")
 
     def test_cpo_works_without_dedicated_config(self):
         """CPO is an experimental method with no dedicated config class."""
@@ -744,8 +746,6 @@ class TestAdapterSignatureTrainingMethods:
             "kto",
             "grpo",
             "rloo",
-            "orpo",
-            "online_dpo",
             "xpo",
             "nash_md",
             "cpo",
@@ -755,6 +755,12 @@ class TestAdapterSignatureTrainingMethods:
     def test_registered_methods_valid(self, method: str):
         sig = AdapterSignature(base_model_id="test/model", training_method=method)
         assert sig.training_method == method
+
+    @pytest.mark.parametrize("method", ["orpo", "online_dpo"])
+    def test_de_registered_methods_rejected(self, method: str):
+        """orpo/online_dpo are de-registered (trl >=1.0); AdapterSignature rejects them (#1426)."""
+        with pytest.raises(ValueError, match="Unknown training method"):
+            AdapterSignature(base_model_id="test/model", training_method=method)
 
     def test_sft_then_dpo_still_valid(self):
         sig = AdapterSignature(

--- a/packages/kailash-align/tests/test_pipeline.py
+++ b/packages/kailash-align/tests/test_pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from kailash_align.config import AlignmentConfig
+from kailash_align.config import AlignmentConfig, SFTConfig
 from kailash_align.exceptions import TrainingError
 from kailash_align.pipeline import AlignmentPipeline, AlignmentResult
 
@@ -100,6 +100,9 @@ class TestTrlAbsentTrainerGuard:
             base_model_id="test/model",
             method="xpo",
             experiment_dir=str(tmp_path),
+            # xpo falls back to the sft sub-config; bf16=False so trl's GPU-only
+            # bf16 validation does not fire before the trainer-import guard on CPU CI.
+            sft=SFTConfig(bf16=False),
         )
         pipeline = AlignmentPipeline(config=cfg)
 

--- a/packages/kailash-align/tests/test_pipeline.py
+++ b/packages/kailash-align/tests/test_pipeline.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from kailash_align.config import AlignmentConfig
 from kailash_align.exceptions import TrainingError
 from kailash_align.pipeline import AlignmentPipeline, AlignmentResult
@@ -42,6 +41,78 @@ class TestAlignmentPipelineTrainDispatch:
             TrainingError, match="sft_then_dpo requires preference_dataset"
         ):
             await pipeline.train(dataset=None, adapter_name="test")
+
+
+class TestTrlAbsentTrainerGuard:
+    """trl >=1.0 removed several trainer classes still in METHOD_REGISTRY
+    (xpo/nash_md/ppo/cpo/bco). _run_training MUST convert the raw ImportError
+    from the trainer lazy-import into an informative TrainingError (#1426).
+    """
+
+    @pytest.mark.asyncio
+    async def test_xpo_trl_absent_trainer_raises_training_error(
+        self, monkeypatch, tmp_path: Path
+    ):
+        pytest.importorskip("trl")
+        pytest.importorskip("torch")
+        pytest.importorskip("transformers")
+        pytest.importorskip("peft")
+
+        import peft
+        import transformers
+
+        # Stub the heavy boundaries so _run_training reaches the real
+        # _lazy_import("trl", "XPOTrainer") guard against the installed trl
+        # (which has no XPOTrainer) -- no network, no model download, no GPU.
+        class _FakeParam:
+            def numel(self) -> int:
+                return 1
+
+            requires_grad = True
+
+        class _FakeModel:
+            def parameters(self):
+                return [_FakeParam()]
+
+        class _FakeTokenizer:
+            pad_token = "<pad>"
+            eos_token = "<eos>"
+
+        monkeypatch.setattr(
+            transformers.AutoModelForCausalLM,
+            "from_pretrained",
+            classmethod(lambda cls, **kw: _FakeModel()),
+        )
+        monkeypatch.setattr(
+            transformers.AutoTokenizer,
+            "from_pretrained",
+            classmethod(lambda cls, **kw: _FakeTokenizer()),
+        )
+        monkeypatch.setattr(peft, "get_peft_model", lambda model, cfg: model)
+
+        class _FakeDataset:
+            column_names = ["prompt"]
+
+            def __len__(self) -> int:
+                return 1
+
+        cfg = AlignmentConfig(
+            base_model_id="test/model",
+            method="xpo",
+            experiment_dir=str(tmp_path),
+        )
+        pipeline = AlignmentPipeline(config=cfg)
+
+        with pytest.raises(TrainingError) as exc_info:
+            await pipeline._run_training(
+                "xpo", _FakeDataset(), "test-adapter", reward_funcs=[]
+            )
+        msg = str(exc_info.value)
+        # Informative message, NOT a raw "cannot import name 'XPOTrainer'".
+        assert "xpo" in msg
+        assert "XPOTrainer" in msg
+        assert "trl" in msg
+        assert not isinstance(exc_info.value, ImportError)
 
 
 class TestDatasetValidation:

--- a/specs/alignment-training.md
+++ b/specs/alignment-training.md
@@ -216,6 +216,8 @@ class KTOConfig:
 
 ### 2.5 ORPOConfig
 
+> **Not available with `trl` >=1.0.** `trl` removed `ORPOTrainer`/`ORPOConfig` upstream, so `orpo` is NOT registered in `METHOD_REGISTRY` and `validate_method_name("orpo")` raises. The `ORPOConfig` dataclass below still exists for back-compat, but `ORPOConfig.to_trl_config()` raises `TrainingError` redirecting to `dpo`/`grpo`. Use `dpo` (or `sft_then_dpo` for the two-stage path) instead.
+
 Odds Ratio Preference Optimization -- combines SFT and preference alignment in a single training pass.
 
 ```python
@@ -302,6 +304,8 @@ class RLOOConfig:
 **Same constraints as GRPOConfig.** RLOO generates multiple completions per prompt and uses a leave-one-out baseline for variance reduction. Requires reward functions. Same dataset format (prompt-only).
 
 ### 2.8 OnlineDPOConfig
+
+> **Not available with `trl` >=1.0.** `trl` removed `OnlineDPOTrainer`/`OnlineDPOConfig` upstream, so `online_dpo` is NOT registered in `METHOD_REGISTRY` and `validate_method_name("online_dpo")` raises. The `OnlineDPOConfig` dataclass below still exists for back-compat, but `OnlineDPOConfig.to_trl_config()` raises `TrainingError`. Use `dpo` or `grpo` instead.
 
 Online DPO -- DPO with online generation. Generates completions online and uses a reward model to score pairs, then applies DPO loss.
 


### PR DESCRIPTION
## What

`kailash-align` 0.7.2 could not run **any** SFT/DPO/KTO/ORPO/OnlineDPO fine-tune against **any** trl in its declared `>=1.0,<2.0` range — `*Config.to_trl_config()` + trainer setup were written against trl 0.x. Ground-truth verified against real **trl 1.0.0** (config construction; no GPU).

| Config | Fix |
|---|---|
| SFT | forward `max_length=` (trl renamed `max_seq_length`); public field kept |
| DPO / KTO | stop forwarding removed `max_prompt_length`; keep `max_length` |
| ORPO / OnlineDPO | trl **removed** these classes → informative `TrainingError` → DPO/GRPO (upstream-removal guard, not a stub) |
| GRPO / RLOO | same bug class, **not in the issue's list**, fixed in-shard (autonomous-execution Rule 4): trl renamed `kl_coef`→`beta`, `vllm_gpu_utilization`→`vllm_gpu_memory_utilization` |
| pipeline.py | guard `peft_config` forward with `if not isinstance(model, PeftModel)` — trl 1.x rejects passing both a wrapped `PeftModel` and `peft_config`; LoRA preserved |

All trl imports stay **lazy** inside `to_trl_config` (importing `kailash_align` never touches trl; ORPO/OnlineDPO only raise when invoked).

## Tests

`tests/test_config.py::TestTrl1xCompat` — behavioral compat tests (no GPU), `importorskip("trl")`: SFT/DPO/KTO assert `max_length`; GRPO/RLOO assert `max_completion_length` + `beta` + `vllm_gpu_memory_utilization`; ORPO/OnlineDPO assert the informative raise. **65 passed** against trl 1.0.0 locally.

Gates: security-reviewer **clean** (static error messages, no secret/path leak, lazy imports safe); reviewer in progress.

## Out of scope

The kaizen + ml gaps listed in #1426 "for visibility" → separate issues (cross-SDK). Version bump + CHANGELOG + PyPI publish handled at `/release` (queued for the fresh session).

## Related issues

Closes #1426 (align/trl layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)