### PR TITLE
fix(ml): numba>=0.61 floor — fix Python 3.12+ fresh-install (#1430)

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,20 @@
 # kailash-ml Changelog
 
+## [2.2.2] — 2026-06-23 — numba floor fixes Python 3.12+ fresh-install (#1430)
+
+Patch release. Dependency-constraint fix — no public API change.
+
+### Fixed
+
+- **`numba>=0.61` floor added** so a fresh `pip install kailash-ml` on Python
+  3.12/3.13/3.14 no longer backtracks to `numba 0.53.1` → `llvmlite 0.36.0`
+  (which has no wheel for those Pythons and fails to build from source with
+  `RuntimeError: Cannot install on Python version 3.x`). `numba` is pulled
+  transitively by `umap-learn`/`pynndescent` for `UMAPTrainable`; the floor
+  forces `llvmlite>=0.44` (wheels for all supported Pythons). Minimum version
+  floor per `rules/dependencies.md` (NOT a cap). Verified: 3.12/3.13/3.14
+  fresh-resolve → `llvmlite 0.47.0`, real install + import OK. (#1430)
+
 ## [2.2.1] — 2026-06-13 — URL credential masking consolidated onto core helper
 
 Patch release. Internal refactor — no public API change. Replaces three

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "2.2.1"
+version = "2.2.2"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -58,6 +58,14 @@ dependencies = [
     # HDBSCAN (already in scikit-learn>=1.5). Phase 2 roadmap: torch-native
     # UMAP across MPS/ROCm/XPU.
     "umap-learn>=0.5",
+    # numba floor (#1430): umap-learn/pynndescent pull `numba` -> `llvmlite`.
+    # A fresh (lock-ignoring) resolve on Python 3.12+ backtracks to numba 0.53.1
+    # -> llvmlite 0.36.0, which has no cp312/313/314 wheel and fails to build
+    # from source ("Cannot install on Python version 3.x"). numba>=0.61 forces
+    # llvmlite>=0.44 (wheels for all supported Pythons). Minimum version floor
+    # per rules/dependencies.md (NOT a cap); numba is transitively load-bearing
+    # for UMAPTrainable. Verified: 3.12/3.13/3.14 fresh-resolve -> llvmlite 0.47.0.
+    "numba>=0.61",
     # Lightning is the training spine for every family per ml-engines.md
     # §3 MUST 2 — every training call routes through pytorch_lightning.Trainer.
     # We depend on the standalone `pytorch-lightning` distribution rather than

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "2.2.1"
+__version__ = "2.2.2"


### PR DESCRIPTION
## What

A fresh (lock-ignoring) `pip install kailash-ml` / `uv pip install -e packages/kailash-ml` on **Python 3.12/3.13/3.14** backtracks to `numba 0.53.1` → `llvmlite 0.36.0`, which has no wheel for those Pythons and fails to build from source (`RuntimeError: Cannot install on Python version 3.x`). `numba` is pulled transitively by `umap-learn`/`pynndescent` (UMAPTrainable).

**Fix:** `numba>=0.61` floor in kailash-ml deps → forces `llvmlite>=0.44` (wheels for all supported Pythons). Minimum version floor per `rules/dependencies.md` (not a cap). Patch bump 2.2.1 → 2.2.2.

## Verification

Fresh resolve on 3.12/3.13/3.14 → `llvmlite 0.47.0` + `numba 0.65.1`; real install + `import numba, llvmlite` OK on 3.14 (`cuda avail: False`).

## Surfaced by

#1426's align CI: `test-kailash-align.yml`'s `uv pip install -e packages/kailash-ml` failed at the **install** step on every Python except 3.11 (lock-ignoring install — uv.lock already pins llvmlite 0.44.0, but the fresh resolve never consulted it). This fix unblocks that workflow AND fixes the same failure for end-users.

## Note on uv.lock

Not updated here — main's lock is independently stale post-loom-2.45.0 sync (`uv lock --check` fails on clean main), and a full `uv lock` reconciles unrelated packages (anthropic / rfc3161ng / core-version bumps). That reconciliation is a separate chore; no active workflow enforces the lock.

## Related issues

Closes #1430. Unblocks #1428 (#1426 align trl 1.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)