### PR TITLE
chore(release): kailash-align 0.7.3 — trl 1.x compat (#1426)

### DIFF
--- a/packages/kailash-align/CHANGELOG.md
+++ b/packages/kailash-align/CHANGELOG.md
@@ -1,5 +1,40 @@
 # kailash-align Changelog
 
+## [0.7.3] — 2026-06-23 — trl 1.x compatibility for to_trl_config + pipeline (#1426)
+
+Patch release. Bug fix — 0.7.2 could not run **any** SFT/DPO/KTO/ORPO/Online-DPO
+fine-tune against **any** `trl` in its declared `>=1.0,<2.0` range (the config
+adapters + trainer setup targeted the trl 0.x API). No public dataclass-signature
+break: the user-facing `*Config` fields are unchanged.
+
+### Fixed
+
+- **`*Config.to_trl_config()` now emits trl 1.x kwargs.** `SFTConfig` forwards
+  `max_length` (was the removed `max_seq_length`); `DPOConfig`/`KTOConfig` drop
+  the removed `max_prompt_length`; `GRPOConfig`/`RLOOConfig` forward `beta`
+  (was `kl_coef`) and `vllm_gpu_memory_utilization` (was `vllm_gpu_utilization`).
+- **`pipeline.py` no longer passes both a `PeftModel` and `peft_config`** to the
+  trainer (trl 1.x raises `ValueError`); the model is pre-wrapped, so `peft_config`
+  is omitted when the model is already a `PeftModel`.
+- **Trainer lazy-import guard:** a registered method whose trl trainer class was
+  removed in trl 1.x (`xpo`/`nash_md`/`ppo`/`cpo`/`bco`) now raises an informative
+  `TrainingError` (naming the method + absent class + supported alternatives)
+  instead of a raw `ImportError`.
+
+### Changed
+
+- **`orpo` and `online_dpo` de-registered from `METHOD_REGISTRY`.** `trl` >=1.0
+  removed `ORPOTrainer`/`ORPOConfig` and `OnlineDPOTrainer`/`OnlineDPOConfig`
+  upstream, so these methods raised on every supported `trl`. `validate_method_name`
+  / `get_method` now reject them with a redirect to `dpo`/`grpo`/`sft_then_dpo`.
+  The `ORPOConfig`/`OnlineDPOConfig` dataclasses are retained for back-compat;
+  their `to_trl_config()` raises an informative `TrainingError`.
+
+### Known limitations
+
+- The `[rl-bridge]` `OnlineDPOAdapter` still references the de-registered
+  `online_dpo` method on a `kailash-ml[rl]`-gated path (tracked: #1429).
+
 ## [0.7.2] — 2026-06-08 — drop defensive `kailash-ml` cap + de-stale floor (#1183)
 
 Patch release. **No source changes** — diff is strictly `pyproject.toml` dependency-floor edits + `__version__` anchor + this CHANGELOG entry.

--- a/packages/kailash-align/pyproject.toml
+++ b/packages/kailash-align/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-align"
-version = "0.7.2"
+version = "0.7.3"
 description = "LLM fine-tuning and alignment framework for the Kailash platform"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/kailash-align/src/kailash_align/_version.py
+++ b/packages/kailash-align/src/kailash_align/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-align package."""
-__version__ = "0.7.2"
+__version__ = "0.7.3"


### PR DESCRIPTION
## What

Metadata-only release-prep for **kailash-align 0.7.3**: version anchors (`pyproject.toml` + `_version.py`) 0.7.2 → 0.7.3 + CHANGELOG entry.

The #1426 trl-1.x source fix landed in #1428 (merge `2d72dc907`) but that PR did not bump the align version — a `build-repo-release-discipline` §5 gap. This release-prep closes it so the fix reaches PyPI consumers (0.7.2 on PyPI is broken on all trl 1.x).

Patch bump — every change is a bug fix; no public dataclass-signature break (full surface in CHANGELOG `[0.7.3]`).

## Related issues

Refs #1426. Branch `release/v*` auto-skips the PR-gate matrix per git.md (metadata-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)