### PR TITLE
feat(roster): bootstrap multi-operator genesis owner (esperie)

### DIFF
--- a/.claude/operators.roster.json
+++ b/.claude/operators.roster.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://terrene.foundation/schemas/operators.roster.schema.json",
+  "genesis": {
+    "repo_owner": "terrene-foundation",
+    "repo_owner_kind": "org",
+    "root_commit": "166c5eab84c39822b6e06ac47954cb3230de1d8c",
+    "genesis_generation": 0
+  },
+  "persons": {
+    "pid-esperie-2b8cb994": {
+      "display_id": "esperie",
+      "role": "owner",
+      "github_login": "esperie",
+      "host_role": "human",
+      "keys": [
+        {
+          "type": "ssh",
+          "fingerprint": "SHA256:ZJJ4BzXTDOS2WMGbNmesXb5K2VGzSvk3O30DmKacml0",
+          "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC8QXej8+gMWK04XapFrSV9fgzWlyssT+0aAIIwSXT27"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Bootstraps the kailash-py multi-operator coordination substrate (currently installed but unenrolled).

## What this lands
`.claude/operators.roster.json` — the trust-root roster:
- **genesis**: `terrene-foundation` / `org` / root `166c5eab…` / generation 0
- **owner**: `esperie` (sole genesis owner, `role: owner`, `host_role: human`), SSH key `id_ed25519` (`SHA256:ZJJ4Bz…`)

Schema-validated clean via `roster-schema-validate.js`.

## Next (separate, operator-run)
`/whoami --enroll-genesis` anchors the signed genesis record — fail-closed; uses the issue-#358 org-owned-admin attestation path (esperie is a verified active terrene-foundation admin; root commit is unsigned, which the org-admin relaxation accepts).

## Merge note
N=1 genesis bootstrap: a *first* owner has no second owner to co-sign. This is the documented genesis exception (genesis-ceremony.js N=1 path), distinct from a steady-state owner-add (which forbids self-attesting admin-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)