### PR TITLE
fix(deps): regenerate uv.lock to match committed workspace + extras state

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.111.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/8a/9afc7305a2ce4b52b30e137f83cd2a6a90b918b3997073db11bb5a1de55a/anthropic-0.111.0.tar.gz", hash = "sha256:39cbda0ac17a6d423e5bf609811bd69b26eddf6299d7a468126e05bc711ce826", size = 934001, upload-time = "2026-06-18T17:31:44.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/bb/09e82a81885d787f350fb55ca9df865b63140dd28b3b5b3104c4ae261657/anthropic-0.111.0-py3-none-any.whl", hash = "sha256:c14edb36ed80da9099acbd26b5cec810d76606c31f32a0d56a4cf9d4fa9e25ae", size = 929774, upload-time = "2026-06-18T17:31:43.116Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,6 +1046,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1772,7 +1800,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.29.3"
+version = "2.44.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1820,6 +1848,7 @@ all = [
     { name = "qrcode" },
     { name = "redis" },
     { name = "requests" },
+    { name = "rfc3161ng" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1920,6 +1949,9 @@ pact = [
 redis = [
     { name = "redis" },
 ]
+rfc3161 = [
+    { name = "rfc3161ng" },
+]
 scheduler = [
     { name = "apscheduler" },
 ]
@@ -1984,7 +2016,7 @@ requires-dist = [
     { name = "hvac", marker = "extra == 'vault'", specifier = ">=2.1.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "jsonschema", specifier = ">=4.24.0" },
-    { name = "kailash", extras = ["server", "http-client", "db-postgres", "db-mysql", "db-sqlite", "redis", "trust", "auth", "auth-azure", "monitoring", "telemetry", "scheduler", "mcp", "data"], marker = "extra == 'all'" },
+    { name = "kailash", extras = ["server", "http-client", "db-postgres", "db-mysql", "db-sqlite", "redis", "trust", "auth", "auth-azure", "monitoring", "telemetry", "scheduler", "mcp", "data", "rfc3161"], marker = "extra == 'all'" },
     { name = "kailash-align", marker = "extra == 'align'", editable = "packages/kailash-align" },
     { name = "kailash-align", marker = "extra == 'all'", editable = "packages/kailash-align" },
     { name = "kailash-dataflow", marker = "extra == 'dataflow'", editable = "packages/kailash-dataflow" },
@@ -2033,6 +2065,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'", specifier = ">=6.2.0" },
     { name = "requests", marker = "extra == 'http-client'", specifier = ">=2.32.3" },
     { name = "requests", marker = "extra == 'server'", specifier = ">=2.32.3" },
+    { name = "rfc3161ng", marker = "extra == 'rfc3161'", specifier = ">=2.1.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.12" },
     { name = "shamir-mnemonic", marker = "extra == 'shamir'", specifier = ">=0.3" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.2.3" },
@@ -2048,11 +2081,11 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.31.0" },
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
 ]
-provides-extras = ["server", "http-client", "db-postgres", "db-mysql", "db-sqlite", "redis", "trust", "auth", "auth-azure", "monitoring", "telemetry", "scheduler", "mcp", "data", "dataflow", "nexus", "kaizen", "pact", "ml", "align", "shamir", "vault", "aws-secrets", "azure-secrets", "ldap", "dev", "docs", "all"]
+provides-extras = ["server", "http-client", "db-postgres", "db-mysql", "db-sqlite", "redis", "trust", "auth", "auth-azure", "monitoring", "telemetry", "scheduler", "mcp", "data", "dataflow", "nexus", "kaizen", "pact", "ml", "align", "shamir", "rfc3161", "vault", "aws-secrets", "azure-secrets", "ldap", "dev", "docs", "all"]
 
 [[package]]
 name = "kailash-align"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "packages/kailash-align" }
 dependencies = [
     { name = "accelerate" },
@@ -2097,7 +2130,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "rl-bridge", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.11.3"
+version = "2.12.0"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "asyncpg" },
@@ -2165,7 +2198,7 @@ provides-extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", 
 
 [[package]]
 name = "kailash-kaizen"
-version = "2.24.5"
+version = "2.28.0"
 source = { editable = "packages/kailash-kaizen" }
 dependencies = [
     { name = "aiohttp" },
@@ -2243,6 +2276,7 @@ requires-dist = [
     { name = "prometheus-client", marker = "extra == 'observability'", specifier = ">=0.19.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pymongo", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "pypdf", marker = "extra == 'research'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -2268,7 +2302,7 @@ provides-extras = ["providers-azure", "providers-google", "providers-tokens", "p
 
 [[package]]
 name = "kailash-mcp"
-version = "0.2.14"
+version = "0.2.15"
 source = { editable = "packages/kailash-mcp" }
 dependencies = [
     { name = "aiohttp" },
@@ -2305,7 +2339,7 @@ provides-extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server
 
 [[package]]
 name = "kailash-ml"
-version = "2.0.1"
+version = "2.2.2"
 source = { editable = "packages/kailash-ml" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2314,6 +2348,7 @@ dependencies = [
     { name = "kailash-dataflow" },
     { name = "kailash-nexus" },
     { name = "lightgbm" },
+    { name = "numba" },
     { name = "numpy" },
     { name = "onnxmltools" },
     { name = "onnxruntime" },
@@ -2343,9 +2378,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
     { name = "imbalanced-learn", marker = "extra == 'imbalance'", specifier = ">=0.12" },
-    { name = "kailash", specifier = ">=2.16.0" },
+    { name = "kailash", specifier = ">=2.31.0" },
     { name = "kailash-align", marker = "extra == 'alignment'", specifier = ">=0.6" },
-    { name = "kailash-dataflow", specifier = ">=2.0.11" },
+    { name = "kailash-dataflow", specifier = ">=2.11.3" },
     { name = "kailash-kaizen", marker = "extra == 'agents'", specifier = ">=2.7.5" },
     { name = "kailash-kaizen", marker = "extra == 'kaizen-judges'", specifier = ">=2.7.5" },
     { name = "kailash-kaizen", marker = "extra == 'kaizen-observability'", specifier = ">=2.7.5" },
@@ -2359,6 +2394,7 @@ requires-dist = [
     { name = "kailash-nexus", specifier = ">=2.1.0" },
     { name = "lightgbm", specifier = ">=4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "numba", specifier = ">=0.61" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnxmltools", specifier = ">=1.12" },
     { name = "onnxruntime", specifier = ">=1.17" },
@@ -2380,6 +2416,8 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'mlflow'", specifier = ">=6.0" },
     { name = "ragas", marker = "extra == 'rag'", specifier = ">=0.1" },
     { name = "ray", extras = ["rllib"], marker = "extra == 'rl-distributed'", specifier = ">=2.30" },
+    { name = "redis", marker = "extra == 'dev'", specifier = ">=6.2.0" },
+    { name = "redis", marker = "extra == 'online-store'", specifier = ">=6.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "sb3-contrib", marker = "extra == 'rl'", specifier = ">=2.3" },
     { name = "scikit-learn", specifier = ">=1.5" },
@@ -2402,11 +2440,11 @@ requires-dist = [
     { name = "xgboost", specifier = ">=2.0" },
     { name = "xgboost", marker = "extra == 'xgb'", specifier = ">=2.0" },
 ]
-provides-extras = ["dl", "dl-gpu", "rl", "rl-offline", "rl-envpool", "rl-distributed", "grpc", "automl-bayes", "agents", "alignment", "kaizen-judges", "kaizen-observability", "explain", "imbalance", "rag", "xgb", "catboost", "stats", "hpo", "mlflow", "huggingface", "dashboard", "interop", "all", "all-gpu", "dev"]
+provides-extras = ["dl", "dl-gpu", "rl", "rl-offline", "rl-envpool", "rl-distributed", "grpc", "automl-bayes", "agents", "alignment", "kaizen-judges", "kaizen-observability", "explain", "imbalance", "online-store", "rag", "xgb", "catboost", "stats", "hpo", "mlflow", "huggingface", "dashboard", "interop", "all", "all-gpu", "dev"]
 
 [[package]]
 name = "kailash-nexus"
-version = "2.9.0"
+version = "2.11.0"
 source = { editable = "packages/kailash-nexus" }
 dependencies = [
     { name = "aiofiles" },
@@ -2458,7 +2496,7 @@ provides-extras = ["metrics", "dev"]
 
 [[package]]
 name = "kailash-pact"
-version = "0.12.0"
+version = "0.14.1"
 source = { editable = "packages/kailash-pact" }
 dependencies = [
     { name = "click" },
@@ -2481,7 +2519,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.109" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
-    { name = "kailash", specifier = ">=2.16.0" },
+    { name = "kailash", specifier = ">=2.41.0" },
     { name = "kailash-kaizen", marker = "extra == 'execution'", specifier = ">=2.7.5" },
     { name = "kailash-pact", extras = ["api", "execution"], marker = "extra == 'all'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
@@ -2496,9 +2534,11 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.9.8"
+version = "0.9.11"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
+    { name = "anthropic" },
+    { name = "google-genai" },
     { name = "httpx" },
     { name = "kailash" },
     { name = "kailash-kaizen" },
@@ -2507,10 +2547,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "kailash", specifier = ">=2.14.0" },
-    { name = "kailash-kaizen", specifier = ">=2.18.1" },
+    { name = "kailash-kaizen", specifier = ">=2.25.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.0" },
@@ -4839,6 +4881,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/e6/eefcad2228f4124f17e01064428fbcd0ade06a274f3063ce3a126a569d6b/restructuredtext_lint-2.0.2.tar.gz", hash = "sha256:dd25209b9e0b726929d8306339faf723734a3137db382bcf27294fa18a6bc52b", size = 17494, upload-time = "2025-11-23T08:05:18.585Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/63/ac52b32b33ae62f2076ed5c4f6b00e065e3ccbb2063e9a2e813b2bfc95bf/restructuredtext_lint-2.0.2-py3-none-any.whl", hash = "sha256:374c0d3e7e0867b2335146a145343ac619400623716b211b9a010c94426bbed7", size = 14198, upload-time = "2025-11-23T08:05:23.267Z" },
+]
+
+[[package]]
+name = "rfc3161ng"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1" },
+    { name = "pyasn1-modules" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/ab/7b1cc11019fb63d9420093ed9ff339ea544d0158141ac0daf33961a200cf/rfc3161ng-2.1.3.tar.gz", hash = "sha256:1e88614da61b22abd591577f9dd39d3a030335f9e8a12d8bc001149c17d0a01e", size = 22418, upload-time = "2020-10-30T14:38:29.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/66/cf13725b4ad06527ca482c99202a683ca3b35586eec9bad5f9e19efb43b9/rfc3161ng-2.1.3-py2.py3-none-any.whl", hash = "sha256:81fe7e4488f523c758b1206bf5e72ba2066b78f2812107b1b7bb16a7596e524b", size = 9949, upload-time = "2020-10-30T14:38:26.277Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`uv lock --check` failed on a clean `main` ("The lockfile at \`uv.lock\` needs to be updated"), leaving every PR's frozen-install gate drifting from committed `pyproject.toml` state. The lock had never been regenerated after a run of pyproject changes landed.

## Change set (all verified against ground-truth `pyproject.toml`)

**9 workspace-editable member version catch-ups:**
- `kailash` (root) 2.29.3 → 2.44.1
- `kailash-align` 0.7.2 → 0.7.3
- `kailash-dataflow` 2.11.3 → 2.12.0
- `kailash-kaizen` 2.24.5 → 2.28.0
- `kailash-mcp` 0.2.14 → 0.2.15
- `kailash-ml` 2.0.1 → 2.2.2
- `kailash-nexus` 2.9.0 → 2.11.0
- `kailash-pact` 0.12.0 → 0.14.1
- `kaizen-agents` 0.9.8 → 0.9.11

**3 newly-locked deps (all from committed declarations):**
- `rfc3161ng 2.1.3` — new `rfc3161` extra (`rfc3161ng>=2.1.3`, EATP timestamping) in root `pyproject.toml`
- `anthropic 0.111.0` — declared by `packages/kaizen-agents/pyproject.toml` (`anthropic>=0.40.0`)
- `docstring-parser 0.18.0` — transitive of `anthropic`

**Zero external PyPI upgrades or downgrades** — purely a catch-up to committed workspace + extras state.

## Verification

- `uv lock --check` now passes (`Resolved 282 packages`, no update needed)
- `pre-commit run --files uv.lock` clean, incl. the Tier-1 unit-test hook
- All 9 locked workspace versions cross-checked against their `pyproject.toml`

## Related issues

Surfaced during the #1430 (CLOSED) align-CI investigation; no dedicated issue.