### PR TITLE
chore(release): kailash-align 0.7.4

### DIFF
--- a/packages/kailash-align/CHANGELOG.md
+++ b/packages/kailash-align/CHANGELOG.md
@@ -1,5 +1,28 @@
 # kailash-align Changelog
 
+## [0.7.4] — 2026-06-24 — OnlineDPOAdapter.build raises an informative TrainingError (#1429)
+
+Patch release. Bug fix — no public dataclass-signature break; the `online_dpo`
+method remains de-registered (as of 0.7.3 / #1426, since trl >=1.0 removed
+`OnlineDPOTrainer`/`OnlineDPOConfig` upstream).
+
+### Fixed
+
+- **`OnlineDPOAdapter.build()` now raises an informative `TrainingError`**
+  instead of the opaque `AlignmentError: Unknown training method 'online_dpo'`.
+  0.7.3 (#1426) de-registered `online_dpo` from the method registry, but
+  `OnlineDPOAdapter.build()` still called `get_method("online_dpo")` outside its
+  guard, surfacing a registry-miss error that told the user nothing about WHY
+  Online-DPO is unavailable or what to use instead. `build()` now raises the
+  SAME message `OnlineDPOConfig.to_trl_config()` already raises in `config.py`
+  ("Online DPO is unavailable: trl >=1.0 removed … use `dpo` or `grpo`"). A
+  parity regression test pins the two messages byte-identical so a future edit
+  to one without the other fails loudly.
+- **`OnlineDPOAdapter.learn()` surfaces the same informative error.** `learn()`
+  builds the trainer first, so it now hits the same `TrainingError`; the
+  unreachable post-build trainer-construction body (which constructed a trl
+  trainer that can never exist) was dead code and is removed.
+
 ## [0.7.3] — 2026-06-23 — trl 1.x compatibility for to_trl_config + pipeline (#1426)
 
 Patch release. Bug fix — 0.7.2 could not run **any** SFT/DPO/KTO/ORPO/Online-DPO

--- a/packages/kailash-align/pyproject.toml
+++ b/packages/kailash-align/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-align"
-version = "0.7.3"
+version = "0.7.4"
 description = "LLM fine-tuning and alignment framework for the Kailash platform"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/kailash-align/src/kailash_align/_version.py
+++ b/packages/kailash-align/src/kailash_align/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-align package."""
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
## Summary

Release-prep for **kailash-align 0.7.3 → 0.7.4** (patch). Ships the #1429 fix
(merged in #1439, commit `de5863f3e`) to PyPI — it is the only unreleased
kailash-align src commit since `align-v0.7.3`, so downstream consumers see only
0.7.3 until this tag cuts.

The fix: `OnlineDPOAdapter.build()` now raises an informative `TrainingError`
("Online DPO is unavailable: trl >=1.0 removed … use `dpo` or `grpo`") instead
of the opaque `AlignmentError: Unknown training method 'online_dpo'`. `learn()`
builds-first so it surfaces the same error; the unreachable post-build
trainer-construction body is removed. A parity test pins the adapter message
byte-identical to `OnlineDPOConfig.to_trl_config()`.

## Diff

Metadata-only (version anchors + CHANGELOG):
- `packages/kailash-align/pyproject.toml` — `0.7.3` → `0.7.4`
- `packages/kailash-align/src/kailash_align/_version.py` — `0.7.4`
- `packages/kailash-align/CHANGELOG.md` — `[0.7.4]` entry

(The source change itself already landed in #1439.)

## Pre-release gate receipts

- **Tests:** `pytest packages/kailash-align/tests/unit/rl_bridge/ -q` → **40 passed**.
- **security-reviewer:** APPROVE — no findings (no secrets/eval/injection; no new
  v0 public API; fail-closed posture intact; byte-identical parity confirmed).
- **reviewer:** APPROVE — no findings (version anchors consistent per
  zero-tolerance Rule 5; collection clean; no residual dead-symbol refs;
  registry claim accurate; Python-only, no cross-SDK surface).
- **TestPyPI:** skipped per the patch human-approval exception (`deployment.md`).

## Related issues

Releases the fix for #1429 (already closed by #1439). No new issue closure.