### PR TITLE
fix(pact): evict silent (agent, tool) pairs from MCP rate-limiter (#1440)

### DIFF
--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -120,6 +120,10 @@ class McpGovernanceEnforcer:
         self._policy_overlay: dict[str, McpToolPolicy] = {}
         # Rate tracking: "agent_id:tool_name" -> deque of timestamps
         self._rate_tracker: dict[str, deque[datetime]] = {}
+        # Observed-time high-water of the last window-expiry GC sweep. None until
+        # the first rate-limited check. Amortizes the O(n) silent-pair sweep so
+        # the hot path stays O(1) between sweeps (see _gc_expired_rate_entries).
+        self._last_rate_gc_ts: float | None = None
 
     @property
     def config(self) -> McpGovernanceConfig:
@@ -182,6 +186,16 @@ class McpGovernanceEnforcer:
 
         return decision
 
+    # Sliding-window width for rate limiting (seconds). Single source of truth
+    # for both the per-key prune cutoff and the silent-pair GC cutoff.
+    _RATE_LIMIT_WINDOW_SECONDS = 60.0
+    # Amortization cadence for the window-expiry GC sweep (seconds of observed
+    # time). The map is reclaimed at most once per interval so the hot path
+    # stays O(1) between sweeps; the size cap is the within-burst backstop.
+    _RATE_GC_INTERVAL_SECONDS = 60.0
+    # Hard backstop: max distinct (agent, tool) pairs retained. Only reached
+    # when more than this many pairs are simultaneously ACTIVE within one
+    # window (GC cannot reclaim active pairs); bounds memory under that extreme.
     _MAX_RATE_TRACKER_ENTRIES = 10_000
 
     def register_tool(self, policy: McpToolPolicy) -> None:
@@ -458,18 +472,24 @@ class McpGovernanceEnforcer:
             A BLOCKED GovernanceDecision if rate limit exceeded, None otherwise.
         """
         key = f"{agent_id}:{tool_name}"
+        cutoff = now.timestamp() - self._RATE_LIMIT_WINDOW_SECONDS
         with self._lock:
+            # Window-expiry GC: reclaim "silent" pairs whose sliding window has
+            # fully expired so the map tracks CURRENTLY-ACTIVE pairs, not every
+            # pair ever seen. Amortized; never evicts an in-window (active) pair.
+            self._gc_expired_rate_entries(cutoff, now)
+
             if key not in self._rate_tracker:
-                # Evict oldest entries if dict exceeds max size
+                # Hard backstop: if STILL at the cap after GC (more than the cap
+                # of simultaneously-active pairs), evict to bound memory.
                 if len(self._rate_tracker) >= self._MAX_RATE_TRACKER_ENTRIES:
-                    self._evict_oldest_rate_entries()
+                    self._evict_oldest_rate_entries(cutoff)
                 # Bounded deque for rate tracking
                 self._rate_tracker[key] = deque(maxlen=rate_limit + 1)
 
             tracker = self._rate_tracker[key]
 
-            # Prune entries older than 60 seconds
-            cutoff = now.timestamp() - 60.0
+            # Prune entries older than the rate-limit window
             while tracker and tracker[0].timestamp() < cutoff:
                 tracker.popleft()
 
@@ -479,7 +499,8 @@ class McpGovernanceEnforcer:
                     tool_name=tool_name,
                     agent_id=agent_id,
                     reason=(
-                        f"Rate limit exceeded: {len(tracker)} calls in last 60s "
+                        f"Rate limit exceeded: {len(tracker)} calls in last "
+                        f"{int(self._RATE_LIMIT_WINDOW_SECONDS)}s "
                         f"(limit: {rate_limit}/min) for tool '{tool_name}'"
                     ),
                     timestamp=now,
@@ -490,15 +511,83 @@ class McpGovernanceEnforcer:
 
         return None
 
-    def _evict_oldest_rate_entries(self) -> None:
-        """Evict the oldest 10% of rate tracker entries by last-access timestamp.
+    def _gc_expired_rate_entries(self, cutoff: float, now: datetime) -> None:
+        """Evict rate-tracker entries whose sliding window has fully expired.
+
+        A "silent" pair is one whose most-recent invocation is older than the
+        rate-limit window: pruning its deque would empty it, so it contributes
+        nothing to enforcement (re-creating the deque on the next call yields
+        identical behavior) yet retains memory until the size cap forces
+        eviction. This proactive sweep keeps the map sized to CURRENTLY-ACTIVE
+        pairs -- bounded by active load, not by the total number of distinct
+        pairs ever seen -- closing the silent-pair accumulation surface
+        (issue #1440 / cross-SDK parity with kailash-rs#1491).
+
+        Window-expiry eviction NEVER removes an active pair (one whose last
+        invocation is within the window), so enforcement fidelity is preserved.
+
+        Amortized: runs at most once per ``_RATE_GC_INTERVAL_SECONDS`` of
+        observed time so the hot path stays O(1) between sweeps. Out-of-order
+        (earlier) timestamps simply skip the sweep; the size cap remains the
+        within-burst backstop.
+
+        Must be called while holding self._lock.
+        """
+        now_ts = now.timestamp()
+        last = self._last_rate_gc_ts
+        if last is not None and (now_ts - last) < self._RATE_GC_INTERVAL_SECONDS:
+            return
+        self._last_rate_gc_ts = now_ts
+
+        expired = [
+            k
+            for k, dq in self._rate_tracker.items()
+            if not dq or dq[-1].timestamp() < cutoff
+        ]
+        for k in expired:
+            del self._rate_tracker[k]
+
+        if expired:
+            # Schema-safe: log the COUNT only -- never the (agent_id, tool) keys
+            # (PII-adjacent per observability.md Rule 8). DEBUG so an amortized
+            # sweep cannot flood aggregators.
+            logger.debug(
+                "McpGovernanceEnforcer: rate-tracker GC evicted %d silent "
+                "pair(s); %d active pair(s) remain",
+                len(expired),
+                len(self._rate_tracker),
+            )
+
+    def _evict_oldest_rate_entries(self, cutoff: float) -> None:
+        """Hard-cap backstop: bound the rate tracker at the size cap.
+
+        Frees ~10% of entries. Evicts expired-window entries FIRST (safe -- they
+        hold no active rate state); only if that does not free enough does it
+        fall back to evicting the least-recently-active entries. Reaching the
+        LRU fallback means more than ``_MAX_RATE_TRACKER_ENTRIES`` pairs are
+        simultaneously ACTIVE within one window -- an overload in which memory
+        protection takes precedence over per-pair enforcement fidelity (a
+        deliberate DoS bound).
 
         Must be called while holding self._lock.
         """
         if not self._rate_tracker:
             return
 
-        # Sort keys by the most recent (last) timestamp in their deque.
+        target = max(1, len(self._rate_tracker) // 10)
+
+        # 1) Expired-window entries first -- safe, they hold no active state.
+        expired = [
+            k
+            for k, dq in self._rate_tracker.items()
+            if not dq or dq[-1].timestamp() < cutoff
+        ]
+        for k in expired:
+            del self._rate_tracker[k]
+        if len(expired) >= target:
+            return
+
+        # 2) Still over budget -> evict least-recently-active as a last resort.
         # Empty deques sort to epoch so they are evicted first.
         epoch = datetime.min.replace(tzinfo=UTC)
 
@@ -506,7 +595,7 @@ class McpGovernanceEnforcer:
             dq = self._rate_tracker[k]
             return dq[-1] if dq else epoch
 
+        remaining = target - len(expired)
         sorted_keys = sorted(self._rate_tracker.keys(), key=_last_ts)
-        evict_count = max(1, len(sorted_keys) // 10)
-        for k in sorted_keys[:evict_count]:
+        for k in sorted_keys[:remaining]:
             del self._rate_tracker[k]

--- a/packages/kailash-pact/tests/regression/test_issue_1440_mcp_rate_limit_silent_pair_gc.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1440_mcp_rate_limit_silent_pair_gc.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1440 -- MCP Layer-5 rate-limit silent-pair GC.
+
+The MCP governance enforcer's per-(agent_id, tool_name) rate-limit map MUST
+evict pairs whose sliding window has fully expired ("silent" pairs), so the map
+tracks CURRENTLY-ACTIVE pairs rather than every pair ever seen. Without it, a
+caller rotating ``agent_id`` per request accumulates rate-state entries -- a
+memory-exhaustion DoS surface against any rate-limited MCP tool (the very layer
+meant to bound abuse).
+
+Acceptance criteria (issue #1440):
+  1. The map evicts entries whose sliding window has fully expired.
+  2. Driving N distinct silent pairs keeps the map bounded (not ~linear in N).
+  3. Eviction never weakens enforcement for active pairs (a pair still inside
+     its window is never evicted).
+
+Cross-SDK parity: kailash-rs#1491 (kailash-rs v4.16.1) fixed the same enforcer
+with the same window-expiry GC. EATP D6 -- independent implementation, matching
+semantics.
+
+These are white-box tests: a memory-bound invariant is asserted against the
+enforcer's internal ``_rate_tracker`` map size, exactly as criterion 2 requires.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pact.mcp.enforcer import McpGovernanceEnforcer
+from pact.mcp.types import McpActionContext, McpGovernanceConfig, McpToolPolicy
+
+# Fixed base instant so every test is fully deterministic (no wall-clock).
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _enforcer(rate_limit: int = 5) -> McpGovernanceEnforcer:
+    return McpGovernanceEnforcer(
+        McpGovernanceConfig(
+            tool_policies={
+                "search": McpToolPolicy(tool_name="search", rate_limit=rate_limit)
+            },
+            audit_enabled=False,
+        )
+    )
+
+
+def _call(enf: McpGovernanceEnforcer, agent_id: str, at: datetime):
+    return enf.check_tool_call(
+        McpActionContext(tool_name="search", agent_id=agent_id, timestamp=at)
+    )
+
+
+@pytest.mark.regression
+def test_issue_1440_silent_pair_evicted_after_window_expiry() -> None:
+    """Criterion 1: a pair whose window fully expired is GC'd, not retained."""
+    enf = _enforcer()
+    _call(enf, "agent-silent", _T0)
+    assert "agent-silent:search" in enf._rate_tracker
+
+    # Advance past one window + one GC interval, then drive an unrelated pair to
+    # trigger the amortized sweep.
+    later = _T0 + timedelta(
+        seconds=enf._RATE_LIMIT_WINDOW_SECONDS + enf._RATE_GC_INTERVAL_SECONDS + 1
+    )
+    _call(enf, "agent-other", later)
+
+    assert "agent-silent:search" not in enf._rate_tracker, (
+        "a silent pair past its window must be evicted, not retained until the "
+        "size cap forces it out"
+    )
+
+
+@pytest.mark.regression
+def test_issue_1440_map_bounded_under_many_silent_pairs() -> None:
+    """Criterion 2: map size stays bounded; it does NOT grow ~linearly with N.
+
+    Models the rotating-agent DoS: N distinct pairs that each call once and then
+    go silent. With window-expiry GC the map tracks only the active-window worth
+    of pairs, far below N.
+    """
+    enf = _enforcer()
+    n = 2_000
+    for i in range(n):
+        _call(enf, f"agent-{i}", _T0 + timedelta(seconds=i))
+
+    size = len(enf._rate_tracker)
+    # The active-window worth is ~window + GC-interval pairs (~120 at 1 call/s);
+    # generous headroom, but nowhere near linear in N.
+    assert size < n // 4, f"map grew to {size} for {n} silent pairs -- not bounded"
+    assert size <= 250, f"map size {size} exceeds the active-window bound"
+
+
+@pytest.mark.regression
+def test_issue_1440_window_gc_preserves_active_pairs() -> None:
+    """Criterion 3 (direct): window-expiry GC evicts ONLY expired pairs.
+
+    Seeds one active pair (last call within the window) and one silent pair
+    (last call past the window), then runs the sweep and asserts the active
+    pair survives untouched while only the silent pair is reclaimed.
+    """
+    enf = _enforcer()
+    now = _T0 + timedelta(seconds=1_000)
+    cutoff = now.timestamp() - enf._RATE_LIMIT_WINDOW_SECONDS
+
+    active_last = now - timedelta(seconds=10)  # inside the 60s window
+    silent_last = now - timedelta(seconds=120)  # well past the window
+    enf._rate_tracker["active:search"] = deque([active_last])
+    enf._rate_tracker["silent:search"] = deque([silent_last])
+    enf._last_rate_gc_ts = None  # force the amortized sweep to run
+
+    enf._gc_expired_rate_entries(cutoff, now)
+
+    assert "active:search" in enf._rate_tracker, "active pair must survive GC"
+    assert "silent:search" not in enf._rate_tracker, "expired pair must be GC'd"
+    # State preserved -- GC did not delete-and-recreate the active pair.
+    assert list(enf._rate_tracker["active:search"]) == [active_last]
+
+
+@pytest.mark.regression
+def test_issue_1440_active_pair_survives_gc_churn_end_to_end() -> None:
+    """Criterion 3 (end-to-end): a continuously-active pair survives repeated GC
+    sweeps triggered by churning silent pairs AND keeps enforcing its limit."""
+    enf = _enforcer(rate_limit=5)
+    t = _T0
+    for rnd in range(6):
+        decision = _call(enf, "vip", t)  # active pair, ~once per 30s (under limit)
+        assert decision.allowed
+        assert "vip:search" in enf._rate_tracker, "active pair must never be GC'd"
+        for j in range(15):  # churn distinct silent pairs to advance time + GC
+            _call(enf, f"noise-{rnd}-{j}", t)
+            t += timedelta(seconds=2)
+
+    # The active pair is still present and still enforces: burst past its limit
+    # within a single window and confirm enforcement bites (GC did not reset it).
+    burst_blocked = any(
+        not _call(enf, "vip", t + timedelta(seconds=k)).allowed for k in range(7)
+    )
+    assert burst_blocked, (
+        "GC must not weaken enforcement -- the active pair must still be "
+        "rate-limited after surviving the GC churn"
+    )
+
+
+@pytest.mark.regression
+def test_issue_1440_size_cap_bounds_simultaneous_burst(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backstop: a same-instant burst of >cap distinct pairs (GC cannot reclaim
+    active pairs within one instant) is bounded by the hard size cap."""
+    # Shrink the cap to keep the test fast; the eviction logic under test is
+    # identical at the shipped 10_000 cap.
+    cap = 50
+    monkeypatch.setattr(McpGovernanceEnforcer, "_MAX_RATE_TRACKER_ENTRIES", cap)
+    enf = _enforcer()
+
+    # All at the SAME timestamp -> no observed-time advance -> GC never fires,
+    # so the size cap is the only bound. Drive well past the cap.
+    for i in range(cap + 200):
+        _call(enf, f"burst-{i}", _T0)
+
+    assert (
+        len(enf._rate_tracker) <= cap
+    ), f"size cap breached: {len(enf._rate_tracker)} > {cap}"


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity unbounded-memory DoS (#1440) in the PACT MCP governance
rate-limiter. The enforcer's per-`(agent_id, tool_name)` Layer-5 rate-limit map
only reclaimed entries at a 10k size cap via LRU; pairs whose 60s sliding window
had fully expired ("silent" pairs) were retained until that cap forced eviction.
A caller rotating `agent_id` per request accumulated rate-state toward the cap,
and the LRU backstop could evict a still-active pair and reset its counter (a
rate-limit weakening under memory pressure).

## What changed

- **`_gc_expired_rate_entries`** — amortized window-expiry GC reclaims silent
  pairs whose window has fully expired, so the map tracks currently-active pairs
  (bounded by active load, not by total pairs ever seen). Runs at most once per
  `_RATE_GC_INTERVAL_SECONDS` of observed time → the hot path stays O(1) between
  sweeps. It never evicts an in-window pair, so enforcement fidelity is preserved.
- **`_evict_oldest_rate_entries(cutoff)`** — the hard size-cap backstop now
  evicts expired entries first, falling back to LRU only under genuine
  >cap-simultaneously-active overload (a documented memory-vs-enforcement bound).
- Window width extracted to a single named constant `_RATE_LIMIT_WINDOW_SECONDS`.

In production, `McpActionContext.timestamp` is set server-side by the middleware
(`middleware.py` `timestamp=now`), so the GC cadence is not attacker-controlled;
and even if it were, the size cap bounds memory under every timestamp pattern.

## Cross-SDK parity (EATP D6)

Python equivalent of kailash-rs#1491 (kailash-rs v4.16.1) — independent
implementation, matching semantics.

## Tests

5 regression tests in `tests/regression/test_issue_1440_*.py` cover all three
issue acceptance criteria + the size-cap backstop (silent-pair eviction; map
bounded under 2,000 distinct silent pairs, asserts ≤ 250; active pairs never
evicted by window GC — direct + end-to-end enforcement-still-bites; same-instant
burst bounded by the cap).

Verification receipts (this session):
- `pytest tests/regression/test_issue_1440_*.py tests/unit/mcp/test_enforcer.py` → **43 passed**
- full pact MCP + regression suite → **168 passed**, no Resource/Runtime warnings
- `pytest --collect-only` (whole pact package) → **1654 collected**, exit 0
- `ruff check` clean; `black --line-length=88 --check` clean

## Review gates

- **reviewer**: APPROVE — 5 mechanical sweeps green (lock discipline; no PII in
  logs; collect-only; targeted run), cutoff `<` boundary logic correct, all three
  criteria behaviorally covered (not source-grep).
- **security-reviewer**: APPROVE — all 5 security invariants pass; original DoS
  **fully closed** (memory bounded `O(cap × max_rate_limit)` under every timestamp
  pattern, including adversarial same-timestamp / out-of-order); no enforcement
  weakening by window GC; thread-safe under the existing lock (no re-entrant
  acquisition); GC log emits integer counts only; fail-closed preserved.

## Related issues

Fixes #1440
