### PR TITLE
chore(release): kailash-pact 0.14.1 → 0.14.2 (#1440 MCP rate-limiter DoS fix)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,20 @@
 # PACT Changelog
 
+## [0.14.2] — 2026-06-24 — fix: evict silent (agent, tool) pairs from the MCP rate-limiter (#1440)
+
+### Security
+
+- `pact.mcp.McpGovernanceEnforcer` now evicts "silent" `(agent_id, tool_name)`
+  pairs whose Layer-5 rate-limit sliding window has fully expired, instead of
+  retaining them until the 10k size cap forces LRU eviction. A caller rotating
+  `agent_id` per request previously accumulated rate-state toward the cap (a
+  memory-exhaustion DoS surface against any rate-limited MCP tool), and the LRU
+  backstop could evict a still-active pair and reset its counter (weakening
+  enforcement under memory pressure). Window-expiry GC is amortized (the hot
+  path stays O(1) between sweeps), never evicts an in-window pair, and the size
+  cap remains the within-burst hard backstop — so memory is bounded under every
+  timestamp pattern. Cross-SDK parity with kailash-rs#1491 (EATP D6).
+
 ## [0.14.1] — 2026-06-21 — fix: reject NaN/Inf in the conformance canonical encoder (#1412)
 
 ### Security

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.14.1"
+version = "0.14.2"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (


### PR DESCRIPTION
## Release: kailash-pact 0.14.1 → 0.14.2

Patch release shipping the **#1440** MCP rate-limiter silent-pair GC DoS fix
(merged to main via PR #1443, commit `c379b38a9`) to PyPI.

### Diff (metadata-only)
- `packages/kailash-pact/pyproject.toml` — version 0.14.1 → 0.14.2
- `packages/kailash-pact/src/pact/__init__.py` — `__version__` 0.14.1 → 0.14.2
- `packages/kailash-pact/CHANGELOG.md` — 0.14.2 entry (### Security)

### Pre-release checklist
- Source fix already on main (PR #1443), full CI matrix green (Python 3.11–3.14, PACT, DataFlow, CodeQL, infra).
- Security review: APPROVE (DoS fully closed). Code review: APPROVE.
- Version anchors consistent (pyproject + __init__ both 0.14.2).
- Sibling-drift sweep: all 8 other packages at PyPI-parity; pact is the only release.
- Patch release — TestPyPI may be skipped per `deployment.md` (with human approval).

## Related issues
Fixes #1440 (released to PyPI)