### PR TITLE
docs(sweep): 2026-06-24 repo-wide sweep + session wrapup

### DIFF
--- a/.session-notes
+++ b/.session-notes
@@ -6,14 +6,18 @@ Released **kailash-pact 0.14.2** to PyPI this session — the #1440 MCP
 rate-limiter silent-pair-GC DoS fix. Found by re-checking the live issue tracker
 (the prior session's "queue empty" reconstruction had missed #1440, filed 04:33
 the same day). Fix → PR #1443 (merge `e9fd3e936`); release → PR #1444 + tag
-`pact-v0.14.2` → publish-pypi run `28081548947` SUCCESS. Clean-venv verified
-(`pact.__version__ == "0.14.2"`, GC method present in the wheel). main == PyPI
-monorepo-wide again. The in-repo actionable queue is empty — every remaining
-forest item is gated, cross-repo, or deferred.
+`pact-v0.14.2` → publish-pypi run `28081548947` SUCCESS; deploy record + notes →
+PR #1445. Clean-venv verified (`pact.__version__ == "0.14.2"`, GC method present
+in the wheel). main == PyPI monorepo-wide.
+
+A full `/sweep` ran at session end — **clean** (`SWEEP-2026-06-24.md`). No active
+todos, no open PRs, no orphan branches, working tree clean, all 9 packages at
+PyPI parity, core unchanged since `v2.44.1`. The in-repo actionable queue is
+empty — every remaining item is gated (cross-SDK), cross-repo, or housekeeping.
 
 ## Read first
 
-1. This file's Outstanding ledger — bearings; the in-repo actionable queue is empty.
+1. This file's Outstanding ledger + `SWEEP-2026-06-24.md` — bearings.
 2. issues #1403 + #1402 — the only open in-repo-ish work (F-XSDK byte-determinism);
    gated on rs#1451 — start only once it lands.
 3. `.claude/rules/cross-sdk-inspection.md` § Rule 4b — governs #1403 (a byte-CHANGING
@@ -22,8 +26,8 @@ forest item is gated, cross-repo, or deferred.
 
 ## In-flight state
 
-- None. Working tree carries only this file + the deploy record (pending the
-  post-release records PR). All release artifacts committed (PRs #1443 + #1444).
+- None. Working tree clean; in sync with origin/main. All this-session artifacts
+  landed (PRs #1443 + #1444 + #1445).
 
 ## Outstanding ledger (forest)
 
@@ -34,10 +38,12 @@ forest item is gated, cross-repo, or deferred.
 | F-XSDK-RS-FILED | rs parity (rs issues #1465 / #1442 / #1420) | EATP D6 | FILED — awaiting rs |
 | F-LOOM-INDEP | loom 2.45.0 obsoleted independence.md + terrene-naming.md | PR #1427 flag | SURFACED — loom-side |
 | F-TRUST-DEFER | F-VAULT-S34 (#630 KEK) + F-ATOMIC cross-store cascade | project_trustplane_day1 | DEFERRED |
+| F-HK-JOURNALS | Triage 10 `.pending` journal entries across 5 workspaces (cross-sdk-audit, issue-855/1337/1339/1356) | journal.md promote/discard | HOUSEKEEPING — all <14d, not yet stale |
+| F-HK-ARCHIVE | Archive `workspaces/kaizen-rag-node-coverage/` (.session-notes 34d) | worktree-isolation hygiene | HOUSEKEEPING — LOW |
 
 Closed this session: **#1440** (MCP rate-limiter silent-pair GC DoS) → fix PR #1443
 → release kailash-pact 0.14.1 → 0.14.2 (PR #1444, tag `pact-v0.14.2`, publish run
-28081548947) → clean-venv verified → deploy record. Issue auto-closed via Fixes #1440.
+28081548947) → clean-venv verified → deploy record (PR #1445). Issue auto-closed.
 
 ## Unreleased packages
 
@@ -47,8 +53,8 @@ Closed this session: **#1440** (MCP rate-limiter silent-pair GC DoS) → fix PR 
 
 - **pact formats with Black `--line-length=88`** (pre-commit hook), NOT `ruff format`.
   `ruff format` discovers pact's `[tool.ruff] line-length = 100` and UN-wraps lines
-  Black-88 had wrapped → the pre-commit Black hook then re-wraps → "files modified by
-  hook" → commit aborts. For pact (and likely other packages) use
+  Black-88 had wrapped → the pre-commit Black hook re-wraps → "files modified by hook"
+  → commit aborts. For pact (and likely other packages) run
   `.venv/bin/black --line-length=88 <file>` before staging; ruff is lint-only here.
 - F-XSDK #1403: do NOT switch the `default=str` signing-path encoder unilaterally in
   py — byte-CHANGING cross-SDK contract; coordinate with rs (cross-sdk Rule 4b).

--- a/SWEEP-2026-06-24.md
+++ b/SWEEP-2026-06-24.md
@@ -1,0 +1,81 @@
+# Sweep — 2026-06-24
+
+Repo-wide outstanding-work audit (kailash-py BUILD repo). Run after shipping
+kailash-pact 0.14.2 (#1440 MCP rate-limiter DoS fix → PyPI). **Result: clean.**
+This session's work is fully landed, released, verified, and recorded; all
+findings are pre-existing housekeeping in other workstreams, none blocking, none
+introduced this session.
+
+## Findings
+
+### [LOW] [Sweep 2] 10 pending journal entries across 5 workspaces awaiting triage
+
+- **Location:** `cross-sdk-audit` (4), `issue-855-kaizen-agents-pyright` (3),
+  `issue-1337-masking-callables-py` (1), `issue-1339-distributed-lock` (1),
+  `issue-1356-jwt-revocation` (1) — all under `journal/.pending/`.
+- **Evidence:** `find workspaces/*/journal/.pending/` → 10 files; timestamps
+  2026-06-16 … 2026-06-20 (all < 14d, so NOT yet stale per Sweep 6).
+- **Disposition:** DEFER-WITH-REASON — these belong to prior workstreams, not
+  this session. Per `journal.md`, each needs read-and-classify (promote
+  high-value → `journal/`, discard bare-merge / already-codified). Recent
+  (< 14d), so no urgency.
+- **Why it matters:** `.pending` entries are auto-generated knowledge awaiting
+  promotion; left untriaged > 14d they become stale-knowledge debt.
+
+### [INFO/DEFER] [Sweep 3] 2 open issues — both gated cross-SDK, not actionable from this repo
+
+- **Location:** #1402 + #1403 (`[hardening]` canonical-JSON byte-determinism).
+- **Disposition:** DEFER — gated on **rs#1451** (cross-SDK lockstep per
+  `cross-sdk-inspection.md` Rule 4b). Genuinely actionable work, but cannot
+  proceed unilaterally in py (#1403 trap: do NOT switch the `default=str`
+  signing-path encoder single-SDK). Not closeable (real work, blocked).
+- **Note:** #1440 is now CLOSED/COMPLETED (released this session) — absent from
+  the open list, as expected.
+
+### [LOW] [Sweep 6] One workspace with `.session-notes` > 30d
+
+- **Location:** `workspaces/kaizen-rag-node-coverage/.session-notes` (34d).
+- **Disposition:** archive candidate (LOW). Recommend moving to
+  `workspaces/_archive/` per `worktree-isolation.md` workspace hygiene.
+- **Why it matters:** stale workspace notes accrete and obscure the active set.
+
+### [INFO] [Sweep 7] Pre-existing stub-marker baseline (not a session finding)
+
+- **Evidence:** ~198 `TODO/FIXME/HACK/XXX/NotImplementedError` markers across
+  `src/kailash` + `packages/*/src` (repo-wide baseline; includes iterative
+  issue-linked TODOs permitted per `zero-tolerance.md` Rule 6).
+- **Disposition:** baseline — **this session introduced zero** new stubs (the
+  pact fix passed the "No untracked TODO-NNN markers" pre-commit gate +
+  reviewer + security-reviewer). Full per-marker triage is a separate,
+  out-of-scope effort, not a finding of this sweep.
+
+## Clean sweeps
+
+- **Sweep 1** (active todos): none.
+- **Sweep 4** (open PRs / orphan branches): none — this session's 3 PRs (#1443,
+  #1444, #1445) all merged + branches deleted; no unmerged remote branches.
+- **Sweep 5** (redteam vs specs): **N/A** — `<!-- sweep-redteam:v1:N/A
+reason=orchestration-mode no_specs=true no_tool=false -->` (no
+  `workspaces/*/specs/` dirs present; `tools/sweep-redteam.py` exists but has no
+  per-workspace specs to scan).
+- **Sweep 7** (process hygiene): working tree clean; in sync with origin/main
+  (0 ahead / 0 behind); only the main worktree (no orphans).
+- **Sweep 8** (release readiness): **all 9 packages AT-PARITY with PyPI.** Core
+  `src/kailash` has zero commits since `v2.44.1` (== PyPI). The
+  `v2.44.1..HEAD` package commits (pact, align, ml) are all released under their
+  own package tags — verified `c379b38a9` (the pact fix) IS an ancestor of
+  `pact-v0.14.2`. No unreleased shippable work.
+
+## Recommended next-session items (ranked)
+
+1. **(gated — start only when rs#1451 lands)** #1402/#1403 canonical-JSON
+   byte-determinism. Cross-SDK lockstep; needs the Rust side first. Highest
+   user-value open item, but blocked outside this repo.
+2. **(housekeeping)** Triage the 10 `.pending` journal entries across 5
+   workspaces — promote high-value DECISION/RISK/DISCOVERY, discard the rest.
+3. **(housekeeping)** Archive `workspaces/kaizen-rag-node-coverage/` (notes 34d
+   stale).
+
+The in-repo actionable queue remains empty: items 2–3 are housekeeping, item 1
+is cross-repo-gated. Nothing blocks; nothing was deferred from this session's own
+work (it shipped end-to-end).


### PR DESCRIPTION
Post-release `/sweep` (clean) + refreshed `.session-notes` for a fresh session. This session shipped #1440 end-to-end (kailash-pact 0.14.2 → PyPI). Remaining items are cross-SDK-gated (#1402/#1403 on rs#1451) or housekeeping. Docs-only.