### PR TITLE
docs(trust): accurate per-encoder serde claims on witness/envelope default=str sites (#1403)

### DIFF
--- a/src/kailash/trust/enforce/selective_disclosure.py
+++ b/src/kailash/trust/enforce/selective_disclosure.py
@@ -43,7 +43,16 @@ NON_REDACTABLE_FIELDS: FrozenSet[str] = frozenset(
 
 
 def _hash_value(value: Any) -> str:
-    """Create SHA-256 hash of a value for redaction."""
+    """Create SHA-256 hash of a value for redaction.
+
+    Serde config: ``sort_keys=True``, ``allow_nan=False``, ``default=str``
+    (NOT ``ensure_ascii``-pinned — this is a redaction digest, not a
+    cross-SDK signing pre-image). The ``default=str`` fallback stringifies
+    non-JSON-native values via Python's implementation-defined ``str()``;
+    this is the byte-CHANGING witness-family member whose current bytes are
+    pinned by ``tests/regression/test_canonical_encoder_family_conformance.py``
+    pending the cross-SDK ``canonical_scalars`` lockstep (kailash-rs#449 / #1451).
+    """
     data = json.dumps(value, sort_keys=True, allow_nan=False, default=str)
     return f"REDACTED:sha256:{hashlib.sha256(data.encode()).hexdigest()}"
 
@@ -260,12 +269,20 @@ def _compute_chain_hash(records: List[Dict[str, Any]]) -> List[str]:
     Each hash includes the previous hash, creating a tamper-evident chain.
     Uses the redacted data so witnesses can verify chain integrity.
 
-    Canonicalization (cross-SDK contract — see ``trust/pact/audit.py``
-    and kailash-rs#449): compact separators ``(",", ":")`` and
-    ``ensure_ascii=True`` so Python's ``json.dumps`` output matches
-    Rust's ``serde_json::to_string(&BTreeMap)`` byte-for-byte. Any
-    downstream verifier (same SDK or sibling) recomputes the same
-    hash from the same logical input.
+    Canonicalization config: compact separators ``(",", ":")``,
+    ``ensure_ascii=True`` (``\\uXXXX``-escaped, ASCII-only), ``allow_nan=False``,
+    ``default=str``. For JSON-native inputs this matches Rust's
+    ``serde_json::to_string(&BTreeMap)`` byte-for-byte, so a same-SDK or sibling
+    verifier recomputes the same hash. The ``default=str`` fallback, however,
+    stringifies any non-JSON-native value (Decimal / UUID / datetime / set /
+    nested dataclass) via Python's implementation-defined ``str()`` — bytes a
+    sibling SDK has no reason to reproduce. This is the byte-CHANGING member of
+    the selective-disclosure witness family: its current ``default=str`` bytes
+    are deliberately pinned (``tests/regression/test_canonical_encoder_family_conformance.py``)
+    and a switch to the ``canonical_scalars`` whitelist is a coordinated cross-SDK
+    lockstep, NOT a single-SDK change (kailash-rs#449 / #1451; see
+    ``specs/trust-canonical-encoders.md`` § "Encoder-family map" and
+    ``rules/cross-sdk-inspection.md`` Rule 4b).
     """
     hashes: List[str] = []
     prev_hash = GENESIS_HASH
@@ -327,9 +344,12 @@ def export_for_witness(
     if witness_id:
         metadata["witness_id"] = witness_id
 
-    # Sign the package — compact JSON matches the _compute_chain_hash
-    # canonicalization contract so a cross-SDK verifier can round-trip
-    # the signed payload byte-for-byte (kailash-rs#449).
+    # Sign the package — compact JSON, same config as _compute_chain_hash
+    # (ensure_ascii=True, allow_nan=False, default=str). Byte-stable cross-SDK
+    # for JSON-native payloads; the default=str fallback on typed-scalar inputs
+    # is the byte-CHANGING witness-family divergence pinned pending the
+    # cross-SDK canonical_scalars lockstep (kailash-rs#449 / #1451; see
+    # specs/trust-canonical-encoders.md § "Encoder-family map").
     sign_payload = json.dumps(
         {
             "chain_hashes": chain_hashes,

--- a/src/kailash/trust/envelope.py
+++ b/src/kailash/trust/envelope.py
@@ -1044,7 +1044,19 @@ class ConstraintEnvelope:
     def to_canonical_json(self) -> str:
         """Deterministic JSON string (sorted keys, no extra whitespace).
 
-        Suitable for cross-SDK comparison and HMAC signing payloads.
+        Serde config: ``sort_keys=True``, compact separators ``(",", ":")``,
+        ``ensure_ascii=True``, ``allow_nan=False``, ``default=str``. For
+        JSON-native payloads this is byte-stable across SDKs and serves as the
+        HMAC signing pre-image. The ``default=str`` fallback, however,
+        stringifies any non-JSON-native value in the free-form ``metadata`` dict
+        via Python's implementation-defined ``str()`` — bytes a sibling SDK has
+        no reason to reproduce. This is a byte-CHANGING site: its current
+        ``default=str`` bytes are pinned and a switch to the ``canonical_scalars``
+        whitelist is a coordinated cross-SDK lockstep, NOT a single-SDK change
+        (kailash-rs#449 / #1451; see ``specs/trust-canonical-encoders.md``
+        § "Encoder-family map" and ``rules/cross-sdk-inspection.md`` Rule 4b).
+        ``ConstraintEnvelope.envelope_hash`` is the byte-NEUTRAL sibling that
+        already routes through ``canonical_scalars`` (no ``default=str``).
         """
         return json.dumps(
             self.to_dict(),


### PR DESCRIPTION
## Summary

Closes the **AC1 doc-accuracy slice** of #1403 for the three byte-CHANGING `default=str` canonical encoders. #1403 AC1 requires each canonical encoder's docstring to state its **specific** serde configuration, not a blanket "matches `serde_json` byte-for-byte." The prior cycle (PR #1447) made `_json.py` honest but left these three siblings carrying the stale blanket claim.

The `default=str` fallback emits Python's implementation-defined `str()` for non-JSON-native values (Decimal/UUID/datetime/set/nested-dataclass) — bytes a sibling SDK has no reason to reproduce — so the old "any downstream verifier recomputes the same hash" claim was false as written on typed-scalar inputs.

## Changes (doc-only, zero byte change)

- `trust/enforce/selective_disclosure.py` — `_hash_value`, `_compute_chain_hash`, `export_for_witness`/`verify_witness_export` sign-payloads
- `trust/envelope.py` — `ConstraintEnvelope.to_canonical_json`

Each now states `ensure_ascii` + `default=str` typed-scalar policy and flags the rs#1451-blocked, conformance-pinned status, pointing at `specs/trust-canonical-encoders.md` § "Encoder-family map" + `cross-sdk-inspection.md` Rule 4b. The byte-CHANGING encoder *switch* stays correctly deferred to the cross-SDK lockstep (rs#449 / rs#1451) — this PR changes only documentation.

## Verification (user-flow walk)

```
$ .venv/bin/python -c "import kailash.trust.enforce.selective_disclosure, kailash.trust.envelope"
OK: both modules import

$ .venv/bin/python -m pytest tests/regression/test_canonical_encoder_family_conformance.py -q
11 passed in 0.93s
```

The 11 pinned-byte conformance tests passing proves **zero byte change** — the `default=str` byte-images are intact. Pre-commit (Black/isort/Ruff/type-annotations/Tier-1) all green.

## Related issues

Advances #1403 (AC1). Remaining #1403 work (the byte-CHANGING `default=str` → `canonical_scalars` switch on these same sites) stays blocked on the cross-SDK coordination item kailash-rs#1451.