### PR TITLE
fix(pact): cover clearance_required in MCP monotonic-tightening (#1456)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,28 @@
 # PACT Changelog
 
+## [0.14.3] — 2026-06-25 — fix: enforce MCP tool clearance fail-closed before the cost flag and at re-registration (#1456)
+
+### Security
+
+- `pact.mcp.McpGovernanceEnforcer` now enforces a tool policy's
+  `clearance_required` as a fail-closed Layer-2 authorization gate, evaluated
+  BEFORE the cost ladder. A caller with absent, unrecognized, or insufficient
+  `caller_clearance` is BLOCKED regardless of cost band — in particular it can
+  no longer slip through the `(0.8·max_cost, max_cost]` soft-flag short-circuit.
+  `clearance_required` was previously an advertised-but-unread field (any caller
+  could invoke a `clearance_required="secret"` tool). The new
+  `McpActionContext.caller_clearance` field carries the caller's
+  `ConfidentialityLevel`; `clearance_required=None` remains a no-op (backward
+  compatible). Cross-SDK parity with kailash-rs#1492 (EATP D6).
+- `McpGovernanceEnforcer.register_tool` monotonic-tightening validation now
+  covers `clearance_required`, closing a privilege-escalation in the gate above:
+  a re-registration could previously DROP (`secret`→`None`) or LOWER
+  (`secret`→`public`) a tool's clearance bar and be accepted as "tightening",
+  silently stripping the new authorization gate. Re-registration may now only
+  KEEP or RAISE the bar; `None` is treated as the widest setting and an
+  unrecognized value as the tightest (fail-closed), exactly matching the
+  enforcement path (pact-governance Rule 2: monotonic tightening).
+
 ## [0.14.2] — 2026-06-24 — fix: evict silent (agent, tool) pairs from the MCP rate-limiter (#1440)
 
 ### Security

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.14.2"
+version = "0.14.3"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -44,6 +44,42 @@ __all__ = [
 ]
 
 
+# Confidentiality levels in ascending restrictiveness order, mirroring
+# ConfidentialityLevel's PUBLIC < RESTRICTED < CONFIDENTIAL < SECRET < TOP_SECRET.
+_CLEARANCE_LEVELS_ASCENDING = (
+    ConfidentialityLevel.PUBLIC,
+    ConfidentialityLevel.RESTRICTED,
+    ConfidentialityLevel.CONFIDENTIAL,
+    ConfidentialityLevel.SECRET,
+    ConfidentialityLevel.TOP_SECRET,
+)
+
+
+def _clearance_restrictiveness(value: str | None) -> int:
+    """Rank a policy ``clearance_required`` value by eval-time restrictiveness.
+
+    Used by monotonic-tightening validation so a re-registration can only KEEP
+    or RAISE a tool's clearance bar -- never lower or drop it (a privilege
+    escalation that would silently strip the Layer-2 authorization gate).
+
+    Ordering, widest (lowest) to tightest (highest):
+
+    - ``None`` -- no clearance requirement; any caller passes the gate -> -1.
+    - a recognized ``ConfidentialityLevel`` token -- its index in the ascending
+      order above (0..4); a higher level admits fewer callers.
+    - an unrecognized value -- fail-closed to BLOCKED-for-all at eval time (see
+      :meth:`McpGovernanceEnforcer._check_clearance`), i.e. the TIGHTEST setting
+      (no caller passes) -> ranked above every recognized level.
+    """
+    if value is None:
+        return -1
+    try:
+        level = ConfidentialityLevel(str(value).strip().lower())
+    except ValueError:
+        return len(_CLEARANCE_LEVELS_ASCENDING)
+    return _CLEARANCE_LEVELS_ASCENDING.index(level)
+
+
 @dataclass(frozen=True)
 class GovernanceDecision:
     """Result of an MCP governance check.
@@ -240,6 +276,9 @@ class McpGovernanceEnforcer:
         - rate_limit: new must be <= existing (None means "no limit" = wider)
         - allowed_args: new must be subset of existing (empty means "any" = wider)
         - denied_args: new must be superset of existing (wider deny = tighter)
+        - clearance_required: new must be equal-or-tighter than existing (None
+          means "no requirement" = widest; an unrecognized value fail-closes to
+          BLOCKED-for-all = tightest). Lowering or dropping it is widening.
 
         Raises:
             ValueError: On any widening.
@@ -300,6 +339,21 @@ class McpGovernanceEnforcer:
                     f"Monotonic tightening violation: denied_args narrowed, "
                     f"missing {missing} for tool '{new.tool_name}'"
                 )
+
+        # clearance_required: None = no requirement (widest); a recognized level
+        # is tighter as it rises; an unrecognized value fail-closes to
+        # BLOCKED-for-all (tightest). A re-registration may only KEEP or RAISE
+        # the bar -- dropping it (e.g. secret -> None) or lowering it
+        # (secret -> public) silently strips the Layer-2 clearance gate, a
+        # privilege escalation (pact-governance.md Rule 2: monotonic tightening).
+        if _clearance_restrictiveness(
+            new.clearance_required
+        ) < _clearance_restrictiveness(existing.clearance_required):
+            raise ValueError(
+                f"Monotonic tightening violation: clearance_required widened "
+                f"from {existing.clearance_required!r} to "
+                f"{new.clearance_required!r} for tool '{new.tool_name}'"
+            )
 
     def _get_policy(self, tool_name: str) -> McpToolPolicy | None:
         """Resolve the effective policy for a tool.

--- a/packages/kailash-pact/tests/regression/test_issue_1456_mcp_clearance_before_cost_flag.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1456_mcp_clearance_before_cost_flag.py
@@ -334,3 +334,95 @@ async def test_middleware_forwards_sufficient_clearance_and_executes() -> None:
     assert result.decision.allowed is True
     assert result.executed is True
     assert handler_calls == ["search"]
+
+
+# ---------------------------------------------------------------------------
+# Redteam follow-up (same bug class as #1456): register_tool monotonic
+# tightening MUST cover clearance_required. #1456 promoted clearance_required
+# from unread metadata to an enforced Layer-2 gate at the EVALUATION surface,
+# but _validate_monotonic_tightening (the RE-REGISTRATION guard) was left blind
+# to it -- so register_tool could silently drop/lower the clearance bar (a
+# privilege escalation, pact-governance.md Rule 2). These tests pin the guard.
+# ---------------------------------------------------------------------------
+
+
+def _reregister(enf: McpGovernanceEnforcer, clearance_required: str | None) -> None:
+    """Re-register tool 'search' with a new clearance_required (max_cost held)."""
+    enf.register_tool(
+        McpToolPolicy(
+            tool_name="search", max_cost=10.0, clearance_required=clearance_required
+        )
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_cannot_drop_clearance_requirement() -> None:
+    """secret -> None is a widening (drops the gate) and MUST raise; the gate
+    MUST remain enforced after the rejected attempt (no silent strip)."""
+    enf = _enforcer()  # clearance_required="secret"
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="public").level == "blocked"
+    with pytest.raises(ValueError, match="clearance_required widened"):
+        _reregister(enf, None)
+    # The gate still blocks a sub-clearance caller -- the strip did not land.
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="public").level == "blocked"
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_cannot_lower_clearance_requirement() -> None:
+    """secret -> public lowers the bar (a widening) and MUST raise."""
+    enf = _enforcer()
+    with pytest.raises(ValueError, match="clearance_required widened"):
+        _reregister(enf, "public")
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="public").level == "blocked"
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_can_raise_clearance_requirement() -> None:
+    """secret -> top_secret is a tightening and MUST be accepted; a secret
+    caller that previously passed is now blocked."""
+    enf = _enforcer()
+    _reregister(enf, "top_secret")
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="secret").level == "blocked"
+    assert (
+        _decide(enf, cost_estimate=1.0, caller_clearance="top_secret").allowed is True
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_can_add_clearance_requirement_where_none() -> None:
+    """None -> secret adds a gate where there was none (a tightening): accepted,
+    and the new gate immediately blocks an unmet caller."""
+    enf = _enforcer(clearance_required=None)
+    assert _decide(enf, cost_estimate=1.0, caller_clearance=None).allowed is True
+    _reregister(enf, "secret")
+    assert _decide(enf, cost_estimate=1.0, caller_clearance=None).level == "blocked"
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_equal_clearance_accepted() -> None:
+    """secret -> secret is equal (not a widening): accepted."""
+    enf = _enforcer()
+    _reregister(enf, "secret")  # must not raise
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="secret").allowed is True
+
+
+@pytest.mark.regression
+@pytest.mark.security
+def test_register_tool_unrecognized_clearance_is_tightest_not_widest() -> None:
+    """An unrecognized clearance fail-closes to BLOCKED-for-all (tightest), so
+    secret -> garbage is a tightening (accepted) but garbage -> secret is a
+    widening (raises). This prevents an unparseable token being treated as
+    'no requirement' and silently dropping the gate."""
+    enf = _enforcer()  # secret
+    _reregister(enf, "garbage")  # secret -> blocks-all: tightening, accepted
+    assert _decide(enf, cost_estimate=1.0, caller_clearance="top_secret").level == (
+        "blocked"
+    )  # even top_secret is now blocked -- fail-closed
+    enf2 = _enforcer(clearance_required="garbage")  # blocks-all base
+    with pytest.raises(ValueError, match="clearance_required widened"):
+        _reregister(enf2, "secret")  # blocks-all -> secret: widening


### PR DESCRIPTION
## Summary

`/redteam` over the unreleased #1456 clearance gate (merged in PR #1458) surfaced a **privilege-escalation** the fix itself introduced: #1456 promoted `McpToolPolicy.clearance_required` from advertised-but-unread metadata to an enforced fail-closed Layer-2 gate at the evaluation surface (`_check_clearance` / Step 3.5), but left `register_tool`'s `_validate_monotonic_tightening` blind to it. A re-registration could DROP (`secret`→`None`) or LOWER (`secret`→`public`) a tool's clearance bar and be accepted as "tightening" — silently stripping the new gate (`pact-governance` Rule 2: monotonic tightening).

Fix: a fail-closed clearance dimension in the validator via a module-level `_clearance_restrictiveness` rank (`None` = widest, an unrecognized value = tightest), exactly mirroring `_check_clearance`'s own parse. Re-registration may now only KEEP or RAISE the bar. Ships as **kailash-pact 0.14.3** alongside the #1456 gate.

## Affected API

`pact.mcp.McpGovernanceEnforcer.register_tool` / `_validate_monotonic_tightening`

## Reproduction (before fix)

```python
from pact.mcp.enforcer import McpGovernanceEnforcer as E
from pact.mcp.types import McpGovernanceConfig as C, McpToolPolicy as P
enf = E(C(tool_policies={"t": P(tool_name="t", max_cost=100.0, clearance_required="secret")}, audit_enabled=False))
# public caller is correctly BLOCKED ... then:
enf.register_tool(P(tool_name="t", max_cost=100.0, clearance_required=None))  # accepted as "tightening"
# public caller now AUTO_APPROVED — gate stripped
```

## Expected vs actual

- **Expected:** dropping/lowering `clearance_required` is a widening → rejected.
- **Actual (before fix):** accepted; the Layer-2 authorization gate is silently removed.

## Severity

MEDIUM–HIGH — privilege-escalation, but reachable only via the `register_tool` config-plane (agents receive `GovernanceContext(frozen=True)`, never the enforcer; `pact-governance` Rule 1).

## User-flow walk receipts

```
$ .venv/bin/python repro_clearance_widen.py   # before fix
before re-register, public caller -> blocked
register_tool(clearance_required=None): ACCEPTED
after  re-register, public caller -> auto_approved      # exploit confirmed

$ .venv/bin/python repro_clearance_widen.py   # after fix
register_tool raised: Monotonic tightening violation: clearance_required widened from 'secret' to None
after  re-register, public caller -> blocked            # gate holds

$ pytest tests/ -k "1456 or clearance or mcp" -q
299 passed
```

Truth table verified: `secret→None` / `secret→public` / `top_secret→secret` / `garbage→secret` RAISE; `None→secret` / `public→secret` / `secret→secret` / `secret→top_secret` / `secret→garbage` accepted. mypy / ruff / black / isort clean.

## Acceptance criteria

- [x] `register_tool` rejects any re-registration that drops or lowers `clearance_required`.
- [x] Legitimate tightening (add/raise) still accepted; unrecognized value treated as tightest (fail-closed), consistent with the eval path.
- [x] 6 behavioral regression tests in `tests/regression/test_issue_1456_mcp_clearance_before_cost_flag.py`.
- [x] Version bumped to 0.14.3 (pyproject.toml + `__init__.py`) + CHANGELOG entry.

## Related issues

Redteam follow-up to #1456 (merged via PR #1458). Cross-SDK sibling of kailash-rs#1492 — the same monotonic-tightening gap should be audited in the Rust enforcer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
