### PR TITLE
docs(pact): clarify PactBridge is strictly pairwise, not N-party (#1460)

### DIFF
--- a/specs/pact-envelopes.md
+++ b/specs/pact-envelopes.md
@@ -284,6 +284,8 @@ class PactBridge:
 
 Bridges grant role-level access paths. Bridges are NOT inherited by descendant roles -- if VP Admin has a bridge, Finance Director does NOT inherit that access (descendant access is governed by KSPs).
 
+**Strictly pairwise, not N-party.** Every bridge connects EXACTLY TWO roles (`role_a_address` + `role_b_address`), regardless of `bridge_type`. `bridge_type` (`"standing"` / `"scoped"` / `"ad_hoc"`) classifies the bridge's nature, NOT the number of participants -- a `"scoped"` bridge is still a two-role bridge, not a participant group of N roles. `bridge_type` is descriptive metadata only (surfaced in the access-decision audit trail); it drives no enforcement branching. Model a multi-party scoped collaboration among N roles as the C(N,2) pairwise bridges between every pair of roles.
+
 **Bridge approval (Section 4.4):** Before creating a cross-functional bridge, the Lowest Common Ancestor (LCA) of the two roles in the D/T/R tree must approve. Approvals have 24h TTL. Optional bilateral consent when `require_bilateral_consent=True`.
 
 ### 6.7 Pre-Retrieval Filtering

--- a/src/kailash/trust/pact/access.py
+++ b/src/kailash/trust/pact/access.py
@@ -246,15 +246,26 @@ class PactBridge:
     a Scoped bridge is limited to specific operations, and an Ad-Hoc bridge
     is temporary.
 
+    Strictly pairwise -- NOT N-party. Every bridge, regardless of
+    ``bridge_type``, connects EXACTLY TWO roles (``role_a_address`` +
+    ``role_b_address``). ``bridge_type`` classifies the bridge's nature, NOT
+    the number of participants; in particular a "scoped" bridge is still a
+    two-role bridge, not a participant group of N roles. To model a
+    multi-party collaboration among N roles, create the C(N, 2) pairwise
+    bridges between every pair of roles (3 roles -> 3 bridges; 4 roles -> 6).
+
     When bilateral=True, both roles can access each other's unit data.
     When bilateral=False, only role_a can access role_b's unit data
     (unilateral: A reads B, but B cannot read A).
 
     Attributes:
         id: Unique bridge identifier.
-        role_a_address: First role in the bridge.
-        role_b_address: Second role in the bridge.
-        bridge_type: One of "standing", "scoped", "ad_hoc".
+        role_a_address: First of the bridge's exactly two endpoint roles.
+        role_b_address: Second of the bridge's exactly two endpoint roles.
+        bridge_type: Descriptive nature classification -- one of "standing",
+            "scoped", "ad_hoc". Does NOT affect participant count (every
+            bridge is pairwise); "scoped" labels the bridge's nature, it is
+            not an N-party participant set.
         max_classification: Maximum classification accessible via this bridge.
         operational_scope: Limit bridge to specific operations (empty = all).
         bilateral: Whether both roles have mutual access.

--- a/tests/regression/test_issue_1460_pactbridge_pairwise.py
+++ b/tests/regression/test_issue_1460_pactbridge_pairwise.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+"""Regression: PactBridge is strictly pairwise; bridge_type is a descriptive
+``str``, not a ``BridgeType`` enum (issue #1460, cross-SDK twin of
+``terrene-foundation/kailash-rs#1409``).
+
+Issue #1460 clarified the docs that a "scoped" bridge is role-PAIRWISE, not an
+N-party participant group. Per ``cross-sdk-inspection.md`` Rule 3a (structural
+API-divergence disposition), these structural-invariant tests pin the contract
+the doc clarification now asserts so a future refactor toward the sibling SDK's
+shape -- an N-party participant list, OR a ``BridgeType`` enum -- fails loudly
+and forces a docstring + ``specs/pact-envelopes.md`` §6.6 + cross-SDK re-audit.
+
+This is a documentation-clarity issue at a partially-divergent surface: the
+``BridgeType`` enum named in the issue's precondition does NOT exist on
+kailash-py (``bridge_type`` is a plain ``str``), so the only durable guard is
+the structural invariant, not a behavioral repro.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import kailash.trust.pact.access as access_mod
+from kailash.trust.pact.access import PactBridge
+
+
+@pytest.mark.regression
+def test_issue_1460_pactbridge_has_exactly_two_role_endpoints() -> None:
+    """PactBridge connects exactly two roles -- ``role_a_address`` +
+    ``role_b_address`` -- with no N-party participant-list field."""
+    field_names = {f.name for f in dataclasses.fields(PactBridge)}
+    assert "role_a_address" in field_names
+    assert "role_b_address" in field_names
+
+    # No participant-list / N-party-shaped field: a bridge is strictly pairwise.
+    nparty_markers = ("participant", "member", "roles", "addresses", "endpoints")
+    nparty_fields = sorted(
+        n for n in field_names if any(m in n.lower() for m in nparty_markers)
+    )
+    assert nparty_fields == [], (
+        f"PactBridge grew an N-party-shaped field {nparty_fields}; bridges are "
+        f"strictly pairwise (issue #1460). If multi-party support is intended, "
+        f"re-audit the PactBridge docstring + specs/pact-envelopes.md §6.6 + "
+        f"cross-SDK parity with kailash-rs#1409 before adding it."
+    )
+
+
+@pytest.mark.regression
+def test_issue_1460_bridge_type_is_descriptive_str_not_enum() -> None:
+    """``bridge_type`` is a plain ``str`` on kailash-py (no ``BridgeType``
+    enum) -- the documented cross-SDK divergence from kailash-rs's enum."""
+    bridge_type_field = {f.name: f for f in dataclasses.fields(PactBridge)}[
+        "bridge_type"
+    ]
+    # ``from __future__ import annotations`` makes the annotation a string;
+    # accept both the str type and the "str" forward-ref for robustness.
+    assert bridge_type_field.type in (str, "str"), (
+        f"bridge_type annotation drifted to {bridge_type_field.type!r}; "
+        f"kailash-py models it as a descriptive str (issue #1460)."
+    )
+
+    # No BridgeType enum is exported from the access module. The Rust SDK
+    # exposes a BridgeType enum; kailash-py deliberately uses a str field, and
+    # issue #1460's precondition ("if kailash-py exposes a BridgeType enum")
+    # resolved to N/A precisely because none exists.
+    assert not hasattr(access_mod, "BridgeType"), (
+        "A BridgeType enum appeared on kailash-py's pact.access module; issue "
+        "#1460's no-enum precondition no longer holds -- re-audit cross-SDK "
+        "parity with kailash-rs#1409 and the PactBridge docstring."
+    )


### PR DESCRIPTION
## Summary

Clarifies that a PACT **Cross-Functional Bridge** is **strictly pairwise** — a `"scoped"` bridge could read as implying an N-party participant group, but every `PactBridge` connects **exactly two roles** (`role_a_address` + `role_b_address`) regardless of `bridge_type`. `bridge_type` is descriptive metadata (surfaced only in the access-decision audit trail) and drives **no access-enforcement branching** (verified in `_check_bridges` — `bridge_type` is read only in the audit reason string / `audit_details`).

Changes:
- `src/kailash/trust/pact/access.py` — `PactBridge` class docstring + `bridge_type` attribute doc.
- `specs/pact-envelopes.md` §6.6 — "Strictly pairwise, not N-party" clarification (describes today's behavior; no gap/phase framing).
- `tests/regression/test_issue_1460_pactbridge_pairwise.py` — **new** structural-invariant test (`cross-sdk-inspection` Rule 3a) pinning the pairwise contract + the no-`BridgeType`-enum divergence.

To model a multi-party collaboration among N roles: create the C(N,2) pairwise bridges between every pair (3 roles → 3 bridges; 4 roles → 6).

## Cross-SDK

Python twin of `terrene-foundation/kailash-rs#1409` (semantics match per EATP D6). kailash-py exposes **no** `BridgeType` enum (`bridge_type` is a `str` field), so the issue's enum precondition is N/A — the fix targets the docstring + spec. The new test pins this divergence so a future refactor toward the Rust shape (enum or N-party list) fails loudly.

## Verification

User-flow walk (`PactBridge.__doc__`): now renders "Strictly pairwise -- NOT N-party … C(N, 2) pairwise bridges between every pair of roles" — the #1460 ambiguity is resolved at the exact surface a developer reads.

- New regression test: 2/2 pass; `test_access.py`: 38/38 pass (no behavioral regression).
- Pre-commit (Black/isort/Ruff/type-anno/spec-drift/Tier-1/doc-style): green.
- Multi-lens redteam to convergence — **0 findings**: doc-accuracy/cross-SDK (independent agent, ran clean) + structural-test + security/disclosure + completeness-sweep (first-party deterministic command output; mechanical lenses verified by exact execution rather than LLM judge).

## Related issues

Fixes #1460