### PR TITLE
fix(dataflow): guard @db.model fields colliding with NodeMetadata attrs (VAL-011)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/decorators.py
+++ b/packages/kailash-dataflow/src/dataflow/decorators.py
@@ -20,6 +20,7 @@ Validation Codes:
 - VAL-008: camelCase field names (should be snake_case)
 - VAL-009: SQL reserved words as field names
 - VAL-010: Missing delete cascade on relationships
+- VAL-011: Field name collides with a core NodeMetadata attribute
 """
 
 import re
@@ -188,6 +189,44 @@ AUTO_MANAGED_FIELDS = {
     "created_by": "user who created the record",
     "updated_by": "user who last updated the record",
 }
+
+
+def _node_metadata_reserved_fields() -> set:
+    """
+    Derive the VAL-011 reserved field set from ``NodeMetadata`` at runtime.
+
+    The generated CRUD/bulk node passes its construction config straight into
+    ``Node.__init__`` as ``**kwargs``; that constructor reads
+    ``kwargs.get("name")`` / ``("description")`` / ``("version")`` / ``("author")``
+    / ``("tags")`` directly into ``NodeMetadata(...)`` (see
+    ``src/kailash/nodes/base.py``). A user ``@db.model`` field whose name collides
+    with one of those attributes therefore either (a) hard-crashes node
+    construction (``tags`` is a ``set[str]`` on NodeMetadata but a ``str`` on the
+    user field -> pydantic validation error) or (b) is SILENTLY hijacked into node
+    metadata (``name`` / ``description`` / ``version`` / ``author`` are all
+    ``str`` -> the user's value overrides the node's own metadata with no error).
+
+    The set is derived from ``NodeMetadata.model_fields`` keys (NOT hardcoded) so
+    it can never drift from ``base.py``. Two keys are excluded:
+
+    - ``id``: the REQUIRED DataFlow primary-key name (VAL-003 mandates a PK named
+      ``id``). A user ``id`` field is correct usage, not a footgun, and
+      ``Node.__init__`` already namespaces it via ``_node_id`` to avoid the
+      collision. Warning on ``id`` would contradict VAL-003.
+    - any key in ``AUTO_MANAGED_FIELDS`` (e.g. ``created_at``): already owned by
+      VAL-005, which warns about auto-managed-field conflicts. Excluding it here
+      prevents a double-warning for the same field.
+
+    Returns:
+        The net VAL-011 reserved set, typically ``{name, description, version,
+        author, tags}``.
+    """
+    from kailash.nodes.base import NodeMetadata
+
+    reserved = set(NodeMetadata.model_fields.keys())
+    reserved.discard("id")  # required PK name (VAL-003) -- correct usage
+    reserved -= set(AUTO_MANAGED_FIELDS)  # owned by VAL-005 -- no double-warn
+    return reserved
 
 
 def _validate_primary_key(cls: Type, result: ValidationResult) -> None:
@@ -529,6 +568,82 @@ def _validate_naming_conventions(cls: Type, result: ValidationResult) -> None:
             pass
 
 
+def _validate_node_metadata_collisions(cls: Type, result: ValidationResult) -> None:
+    """
+    Validate NodeMetadata-attribute collisions (VAL-011).
+
+    Checks for user-defined fields whose names collide with a core
+    ``NodeMetadata`` attribute. The generated CRUD/bulk node forwards its config
+    into ``Node.__init__`` as ``**kwargs``; that constructor reads ``name`` /
+    ``description`` / ``version`` / ``author`` / ``tags`` straight into
+    ``NodeMetadata(...)``. A colliding field either crashes node construction
+    (``tags`` -> ``set[str]`` type mismatch) or is silently hijacked into node
+    metadata (``name`` / ``description`` / ``version`` / ``author``).
+
+    The reserved set is derived from ``NodeMetadata.model_fields`` at runtime via
+    ``_node_metadata_reserved_fields()`` and excludes ``id`` (the required PK,
+    VAL-003) and the auto-managed fields (VAL-005).
+
+    Args:
+        cls: SQLAlchemy model class to validate
+        result: ValidationResult to accumulate errors/warnings
+    """
+    if not HAS_SQLALCHEMY:
+        return
+
+    reserved = _node_metadata_reserved_fields()
+
+    def _suggest_rename(field: str) -> str:
+        # tags -> tag_list (matches the per-project mitigation already shipped);
+        # everything else -> <field>_value (matches the VAL-009 suggestion form).
+        return "tag_list" if field.lower() == "tags" else f"{field}_value"
+
+    def _warn(field_name: str) -> None:
+        result.add_warning(
+            "VAL-011",
+            f"Field '{field_name}' in model '{cls.__name__}' collides with a "
+            f"core NodeMetadata attribute. DataFlow forwards this field's value "
+            f"into the generated node's metadata, which either crashes node "
+            f"construction (for 'tags', a set-typed attribute) or silently "
+            f"overrides the node's own metadata (for 'name', 'description', "
+            f"'version', 'author'). Rename the field (e.g. "
+            f"'{_suggest_rename(field_name)}').",
+            field=field_name,
+        )
+
+    # First try raw class attributes
+    columns_checked = set()
+    for attr_name in dir(cls):
+        if attr_name.startswith("_"):
+            continue
+        try:
+            attr = getattr(cls, attr_name)
+            if isinstance(attr, Column):
+                columns_checked.add(attr_name)
+                if attr_name.lower() in reserved:
+                    _warn(attr_name)
+        except Exception:
+            # Non-inspectable attribute (descriptor raising, unmapped property,
+            # etc.). Skip it -- same per-attribute guard the sibling VAL-005/008/
+            # 009 validators use; a single bad attribute MUST NOT abort the whole
+            # collision scan. The mapper fallback below covers mapped columns.
+            continue
+
+    # If no raw columns found, try mapper
+    if not columns_checked:
+        try:
+            mapper = sa_inspect(cls)
+            for column in mapper.columns:
+                if column.name.lower() in reserved:
+                    _warn(column.name)
+        except Exception:
+            # Mapper not ready (decorator ran before SQLAlchemy finished mapping)
+            # -- consistent with the sibling validators, which also no-op here.
+            # The outer _run_all_validations wrapper handles the not-ready case;
+            # this guard keeps a single-model failure from aborting the scan.
+            pass
+
+
 def _validate_relationships(cls: Type, result: ValidationResult) -> None:
     """
     Validate relationship configurations (VAL-010).
@@ -616,6 +731,7 @@ def _run_all_validations(
         _validate_auto_managed_fields(cls, result)
         _validate_field_types(cls, result)
         _validate_naming_conventions(cls, result)
+        _validate_node_metadata_collisions(cls, result)
         _validate_relationships(cls, result)
     except Exception:
         # Mapper not ready yet - this can happen if decorator runs before
@@ -702,9 +818,24 @@ def model(
         # Run validation
         validation_result = _run_all_validations(model_cls, effective_mode)
 
-        # Handle validation errors in STRICT mode
-        if effective_mode == ValidationMode.STRICT and validation_result.has_errors():
-            raise ModelValidationError(validation_result.errors)
+        # VAL-011 escalates to a hard error in STRICT mode. It is catalogued as
+        # a Warning (severity-consistent with its sibling field-name checks
+        # VAL-005/008/009, which surface as warnings in WARN mode) but, unlike a
+        # camelCase or SQL-reserved-word hint, a NodeMetadata-attribute collision
+        # is a GUARANTEED failure at node construction time: 'tags' crashes with
+        # a pydantic set-type error, and 'name'/'description'/'version'/'author'
+        # silently hijack the node's metadata. STRICT mode therefore promotes any
+        # VAL-011 warning into a ModelValidationError so the collision is caught
+        # at decoration time rather than at workflow-build time. WARN mode keeps
+        # the warning (handled in the warnings-emission block below).
+        if effective_mode == ValidationMode.STRICT:
+            val011_errors = [
+                ValidationError(w.code, w.message, w.field)
+                for w in validation_result.warnings
+                if w.code == "VAL-011"
+            ]
+            if validation_result.has_errors() or val011_errors:
+                raise ModelValidationError(validation_result.errors + val011_errors)
 
         # Emit warnings in both WARN and STRICT modes
         if effective_mode in (ValidationMode.WARN, ValidationMode.STRICT):

--- a/packages/kailash-dataflow/tests/unit/test_issue_dataflow_reserved_name.py
+++ b/packages/kailash-dataflow/tests/unit/test_issue_dataflow_reserved_name.py
@@ -1,0 +1,333 @@
+"""Regression: VAL-011 — @db.model field names that collide with a core
+NodeMetadata attribute (F30 / originally surfaced by #855).
+
+Bug
+---
+A user ``@db.model`` field whose name collides with a core ``NodeMetadata``
+attribute corrupts node construction. ``NodeMetadata``
+(``src/kailash/nodes/base.py``) has 7 fields:
+``id, name, description, version, author, created_at, tags``. The
+kwargs->NodeMetadata bridge in ``Node.__init__`` reads ``kwargs.get("name")``,
+``("description")``, ``("version")``, ``("author")``, ``("tags")`` straight into
+``NodeMetadata(...)``. A DataFlow-generated CRUD node forwards its construction
+config to ``Node.__init__`` as ``**kwargs`` (``DataFlowNode.__init__`` ->
+``super().__init__(**kwargs)``), so a colliding user field value reaches that
+bridge through the normal ``WorkflowBuilder.add_node(...).build()`` path. Two
+failure modes result:
+
+- ``tags`` (NodeMetadata.tags is ``set[str]``, the user field is usually
+  ``str``) -> hard crash ``NodeConfigurationError: Invalid node metadata ...
+  tags / Input should be a valid set``.
+- ``name`` / ``version`` / ``description`` / ``author`` (all ``str``) -> SILENT
+  override: the user's field value is hijacked into node metadata with no error.
+
+Before VAL-011 the only DataFlow-level field-name validator
+(``_validate_naming_conventions``, VAL-008/009) caught camelCase + SQL reserved
+words; ``name`` / ``tags`` / ``version`` / etc. are not SQL keywords, so the
+collision was caught only at node-construction time (crash) or never (silent
+override).
+
+Fix
+---
+VAL-011 (``_validate_node_metadata_collisions`` in
+``packages/kailash-dataflow/src/dataflow/decorators.py``) warns at
+decoration/validation time when a user field collides with a core
+``NodeMetadata`` attribute. The reserved set is derived from
+``NodeMetadata.model_fields`` at runtime (so it cannot drift from base.py) and
+excludes ``id`` (the required PK name, VAL-003) and the auto-managed fields
+(owned by VAL-005). Net reserved set: ``{name, description, version, author,
+tags}``. VAL-011 is a Warning in WARN mode (severity-consistent with its sibling
+field-name checks VAL-005/008/009) and escalates to a ``ModelValidationError``
+in STRICT mode, because — unlike a camelCase or SQL-reserved-word hint — a
+NodeMetadata collision is a guaranteed crash-or-silent-corruption at node
+construction.
+
+These tests exercise the REAL build-time validation path
+(``dataflow.decorators.model`` over a SQLAlchemy-mapped class — the same surface
+``@db.model(strict=True)`` / the spec §2.7 validation modes use, and the same
+surface every sibling VAL-0xx check is tested against in
+``tests/unit/test_strict_mode_model_validation.py``). They assert the guard
+FIRES with a clear message at validation time, rather than the model only
+crashing later at node construction.
+"""
+
+import warnings
+
+import pytest
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+
+from dataflow.decorators import (
+    ValidationMode,
+    ValidationResult,
+    _node_metadata_reserved_fields,
+    _validate_node_metadata_collisions,
+    model,
+)
+from dataflow.exceptions import ModelValidationError
+
+
+@pytest.fixture
+def base():
+    """Fresh declarative_base per test to avoid table-name conflicts."""
+    return declarative_base()
+
+
+def _warning_messages(record):
+    return [str(w.message) for w in record]
+
+
+# ---------------------------------------------------------------------------
+# Reserved-set derivation (runtime, not hardcoded)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_reserved_set_derived_from_node_metadata_excludes_id_and_created_at():
+    """The VAL-011 reserved set is derived from ``NodeMetadata.model_fields`` at
+    runtime and excludes ``id`` (required PK, VAL-003) and the auto-managed
+    fields (owned by VAL-005). It MUST NOT be a hardcoded list that can drift
+    from base.py.
+    """
+    from kailash.nodes.base import NodeMetadata
+
+    reserved = _node_metadata_reserved_fields()
+
+    # Derived from the live NodeMetadata schema.
+    all_meta_fields = set(NodeMetadata.model_fields.keys())
+    assert reserved <= all_meta_fields, (
+        "reserved set must be a subset of NodeMetadata.model_fields; "
+        f"got {reserved}, NodeMetadata fields {all_meta_fields}"
+    )
+
+    # id excluded (required PK name per VAL-003 — correct usage, not a footgun).
+    assert "id" not in reserved
+    # created_at excluded (owned by VAL-005 — no double-warn).
+    assert "created_at" not in reserved
+    # The collision-prone NodeMetadata str/set attributes ARE reserved.
+    assert reserved == {"name", "description", "version", "author", "tags"}
+
+
+# ---------------------------------------------------------------------------
+# Raw-attribute scan path (white-box)
+#
+# The committed @model(...) tests above exercise the SQLAlchemy *mapper*
+# fallback path: a declarative_base() subclass exposes InstrumentedAttribute
+# (not Column) for its columns, so the validator's raw `isinstance(attr, Column)`
+# scan finds nothing and falls through to `sa_inspect(cls).columns`. The raw
+# path fires for a class carrying raw `Column` class attributes (a pre-mapping
+# class). This direct call pins that branch so a future refactor that breaks
+# raw-attribute scanning fails loudly here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_raw_attribute_path_catches_collision_on_unmapped_column_class():
+    class RawColumnModel:
+        # Raw Column class attributes (NOT declarative-mapped) → the validator's
+        # `isinstance(attr, Column)` raw scan fires; mapper fallback is not reached.
+        id = Column(Integer, primary_key=True)
+        name = Column(String)  # collides with NodeMetadata.name (silent-override mode)
+        tags = Column(String)  # collides with NodeMetadata.tags (crash mode)
+        username = Column(String)  # substring-only → MUST NOT collide
+
+    result = ValidationResult()
+    _validate_node_metadata_collisions(RawColumnModel, result)
+
+    flagged = {w.field for w in result.warnings if w.code == "VAL-011"}
+    assert flagged == {"name", "tags"}, (
+        "raw-attribute path must flag exactly the colliding columns "
+        f"(name, tags); got {flagged}"
+    )
+    # id (required PK, VAL-003) and username (substring-only) MUST NOT be flagged.
+    assert "id" not in flagged
+    assert "username" not in flagged
+
+
+# ---------------------------------------------------------------------------
+# (a) tags collision is caught at validation time with a clear message
+#     (instead of only crashing at node construction)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_warns_on_tags_collision_in_warn_mode(base):
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+
+        @model(validation=ValidationMode.WARN)
+        class WidgetWithTags(base):
+            __tablename__ = "val011_widget_tags_warn"
+            id = Column(Integer, primary_key=True)
+            tags = Column(String)
+
+        assert WidgetWithTags is not None  # WARN mode does not raise
+        msgs = _warning_messages(rec)
+        assert any(
+            "VAL-011" in m and "tags" in m and "tag_list" in m for m in msgs
+        ), f"expected a VAL-011 tags warning suggesting tag_list; got {msgs}"
+
+
+@pytest.mark.regression
+def test_val011_raises_on_tags_collision_in_strict_mode(base):
+    """STRICT mode escalates the VAL-011 ``tags`` collision to a hard error at
+    DECORATION time — the clear failure the bug report wanted, instead of the
+    opaque ``NodeConfigurationError`` that previously only surfaced when the
+    generated node was constructed during ``WorkflowBuilder.build()``.
+    """
+    with pytest.raises(ModelValidationError) as exc_info:
+
+        @model(strict=True)
+        class WidgetWithTagsStrict(base):
+            __tablename__ = "val011_widget_tags_strict"
+            id = Column(Integer, primary_key=True)
+            tags = Column(String)
+
+    msg = str(exc_info.value)
+    assert "VAL-011" in msg and "tags" in msg
+
+
+# ---------------------------------------------------------------------------
+# (b) silent-override mode (a str-typed NodeMetadata attr, e.g. name) is caught
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_warns_on_name_collision_silent_override_in_warn_mode(base):
+    """``name`` collides silently at runtime (the user's value is hijacked into
+    node metadata with no error). VAL-011 surfaces it at validation time.
+    """
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+
+        @model(validation=ValidationMode.WARN)
+        class WidgetWithName(base):
+            __tablename__ = "val011_widget_name_warn"
+            id = Column(Integer, primary_key=True)
+            name = Column(String)
+
+        assert WidgetWithName is not None
+        msgs = _warning_messages(rec)
+        assert any(
+            "VAL-011" in m and "'name'" in m for m in msgs
+        ), f"expected a VAL-011 name collision warning; got {msgs}"
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("field_name", ["description", "version", "author"])
+def test_val011_warns_on_remaining_str_collisions_in_warn_mode(base, field_name):
+    """The remaining str-typed NodeMetadata attrs (description / version /
+    author) all silent-override and MUST each warn under VAL-011.
+    """
+    attrs = {
+        "__tablename__": f"val011_widget_{field_name}_warn",
+        "id": Column(Integer, primary_key=True),
+        field_name: Column(String),
+    }
+    cls = type(f"WidgetWith_{field_name}", (base,), attrs)
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        model(validation=ValidationMode.WARN)(cls)
+        msgs = _warning_messages(rec)
+        assert any(
+            "VAL-011" in m and f"'{field_name}'" in m for m in msgs
+        ), f"expected a VAL-011 {field_name} collision warning; got {msgs}"
+
+
+# ---------------------------------------------------------------------------
+# (c) a legit `id` PK field does NOT trigger VAL-011
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_does_not_fire_for_legit_id_primary_key_warn_mode(base):
+    """``id`` is the REQUIRED DataFlow primary-key name (VAL-003). A user ``id``
+    field is correct usage, not a footgun — VAL-011 MUST NOT warn on it.
+    """
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+
+        @model(validation=ValidationMode.WARN)
+        class WidgetWithIdOnly(base):
+            __tablename__ = "val011_widget_id_only"
+            id = Column(Integer, primary_key=True)
+            title = Column(String)
+
+        assert WidgetWithIdOnly is not None
+        msgs = _warning_messages(rec)
+        assert not any(
+            "VAL-011" in m for m in msgs
+        ), f"VAL-011 must not fire for the required id PK; got {msgs}"
+
+
+@pytest.mark.regression
+def test_val011_does_not_raise_for_legit_id_primary_key_strict_mode(base):
+    """Even in STRICT mode, a model whose only NodeMetadata-named field is the
+    required ``id`` PK MUST NOT raise VAL-011.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+
+        @model(strict=True)
+        class WidgetWithIdOnlyStrict(base):
+            __tablename__ = "val011_widget_id_only_strict"
+            id = Column(Integer, primary_key=True)
+            # Explicit length avoids an unrelated VAL-007 warning; this test is
+            # only concerned with the absence of a VAL-011 strict-mode raise.
+            title = Column(String(120))
+
+        # No ModelValidationError raised => the decorator returns the class.
+        assert WidgetWithIdOnlyStrict is not None
+
+
+# ---------------------------------------------------------------------------
+# (d) created_at is handled by VAL-005 only (no VAL-011 double-warn)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_created_at_is_val005_only_no_val011_double_warn(base):
+    """``created_at`` overlaps both ``NodeMetadata`` and ``AUTO_MANAGED_FIELDS``.
+    It is owned by VAL-005; VAL-011 explicitly excludes it so the same field is
+    not double-warned.
+    """
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+
+        @model(validation=ValidationMode.WARN)
+        class WidgetWithCreatedAt(base):
+            __tablename__ = "val011_widget_created_at"
+            id = Column(Integer, primary_key=True)
+            created_at = Column(String)
+
+        msgs = _warning_messages(rec)
+        # VAL-005 owns created_at.
+        assert any(
+            "VAL-005" in m and "created_at" in m for m in msgs
+        ), f"expected VAL-005 to own created_at; got {msgs}"
+        # VAL-011 MUST NOT also fire on created_at.
+        assert not any(
+            "VAL-011" in m for m in msgs
+        ), f"VAL-011 must not double-warn created_at (VAL-005 owns it); got {msgs}"
+
+
+# ---------------------------------------------------------------------------
+# OFF mode skips VAL-011 entirely (consistency with the validation-mode contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_val011_skipped_in_off_mode(base):
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+
+        @model(skip_validation=True)
+        class WidgetOff(base):
+            __tablename__ = "val011_widget_off"
+            id = Column(Integer, primary_key=True)
+            tags = Column(String)
+
+        assert WidgetOff is not None
+        msgs = _warning_messages(rec)
+        assert not any("VAL-011" in m for m in msgs)

--- a/packages/kailash-dataflow/tests/unit/test_model_validation.py
+++ b/packages/kailash-dataflow/tests/unit/test_model_validation.py
@@ -184,7 +184,10 @@ class TestPrimaryKeyValidation:
             class UserValid(Base):
                 __tablename__ = "users_valid"
                 id = Column(Integer, primary_key=True)
-                name = Column(String(100))  # Fixed: add length
+                # 'full_name', not 'name': 'name' collides with a NodeMetadata
+                # attribute (VAL-011) and would add a warning, defeating the
+                # "no warnings" happy-path assertion below.
+                full_name = Column(String(100))  # Fixed: add length
 
             # Should have no warnings
             assert len(w) == 0
@@ -666,7 +669,9 @@ class TestValidationEdgeCases:
         class PerformanceTest(Base):
             __tablename__ = "performance_test"
             id = Column(Integer, primary_key=True)
-            name = Column(String(100))
+            # 'full_name', not 'name' (VAL-011 reserved) — 'name' would escalate
+            # to a STRICT-mode error and abort this perf timing.
+            full_name = Column(String(100))
             email = Column(String(255))
             age = Column(Integer)
 

--- a/packages/kailash-dataflow/tests/unit/test_strict_mode_model_validation.py
+++ b/packages/kailash-dataflow/tests/unit/test_strict_mode_model_validation.py
@@ -89,7 +89,10 @@ def test_strict_mode_warns_about_non_id_primary_key(base):
         class User(base):
             __tablename__ = "users_pk_warn_1"
             user_id = Column(Integer, primary_key=True)
-            name = Column(String)
+            # 'full_name', not 'name': 'name' collides with a NodeMetadata
+            # attribute (VAL-011) and would escalate to an error in STRICT mode,
+            # which is not what this VAL-003 test exercises.
+            full_name = Column(String)
 
         # Should succeed (no error raised) but have warning
         assert User is not None
@@ -106,7 +109,8 @@ def test_strict_mode_allows_id_primary_key(base):
         class User(base):
             __tablename__ = "users_pk_ok_1"
             id = Column(Integer, primary_key=True)
-            name = Column(String)
+            # 'full_name', not 'name' (VAL-011 reserved) — see VAL-003 test above.
+            full_name = Column(String)
 
         assert User is not None
         # Should have no VAL-003 warnings
@@ -146,7 +150,7 @@ def test_strict_mode_warns_about_created_at_conflict(base):
         class User(base):
             __tablename__ = "users_auto_warn_1"
             id = Column(Integer, primary_key=True)
-            name = Column(String)
+            full_name = Column(String)  # 'full_name', not 'name' (VAL-011 reserved)
             created_at = Column(DateTime)
 
         assert User is not None
@@ -163,7 +167,7 @@ def test_strict_mode_warns_about_updated_at_conflict(base):
         class User(base):
             __tablename__ = "users_auto_warn_2"
             id = Column(Integer, primary_key=True)
-            name = Column(String)
+            full_name = Column(String)  # 'full_name', not 'name' (VAL-011 reserved)
             updated_at = Column(DateTime)
 
         assert User is not None
@@ -180,7 +184,7 @@ def test_strict_mode_warns_about_created_by_conflict(base):
         class User(base):
             __tablename__ = "users_auto_warn_3"
             id = Column(Integer, primary_key=True)
-            name = Column(String)
+            full_name = Column(String)  # 'full_name', not 'name' (VAL-011 reserved)
             created_by = Column(String)
 
         assert User is not None
@@ -197,7 +201,7 @@ def test_strict_mode_warns_about_updated_by_conflict(base):
         class User(base):
             __tablename__ = "users_auto_warn_4"
             id = Column(Integer, primary_key=True)
-            name = Column(String)
+            full_name = Column(String)  # 'full_name', not 'name' (VAL-011 reserved)
             updated_by = Column(String)
 
         assert User is not None
@@ -401,9 +405,9 @@ def test_warning_message_includes_code(base):
             user_id = Column(Integer, primary_key=True)
 
         warning_msgs = [str(warning.message) for warning in w]
-        assert any("VAL-003" in msg for msg in warning_msgs), (
-            "Warning should include VAL code"
-        )
+        assert any(
+            "VAL-003" in msg for msg in warning_msgs
+        ), "Warning should include VAL code"
 
 
 def test_warning_message_is_actionable(base):
@@ -512,7 +516,9 @@ def test_strict_mode_with_valid_model(base):
             __tablename__ = "users_valid_strict"
             id = Column(Integer, primary_key=True)
             email = Column(String(255))  # With length to avoid VAL-007
-            name = Column(String(100))
+            # 'full_name', not 'name': a valid model must have NO validation
+            # warnings, and 'name' would now trip VAL-011 (NodeMetadata collision).
+            full_name = Column(String(100))
 
         assert User is not None
         # Valid model should have no validation warnings

--- a/specs/dataflow-models.md
+++ b/specs/dataflow-models.md
@@ -87,6 +87,8 @@ DataFlow automatically manages these fields when present:
 
 **VAL-005**: User-defined columns with these names emit a warning about potential conflicts.
 
+**VAL-011**: User-defined columns named after a core `NodeMetadata` attribute (`name`, `description`, `version`, `author`, `tags`) emit a warning because the generated node forwards field config into `Node.__init__`, where those names are read into the node's own metadata -- a `tags` collision crashes node construction and a `name`/`description`/`version`/`author` collision silently overrides node metadata. `id` (the required primary-key name) and the auto-managed fields above (owned by VAL-005) are excluded. See §2.7 for the full catalog and the STRICT-mode escalation.
+
 ### 2.5 Table Name Mapping
 
 By default, class names are converted to snake_case table names:
@@ -140,19 +142,22 @@ from dataflow.decorators import ValidationMode
 
 **Validation codes:**
 
-| Code    | Severity | Description                                 |
-| ------- | -------- | ------------------------------------------- |
-| VAL-002 | Error    | Missing primary key                         |
-| VAL-003 | Warning  | Primary key not named `id`                  |
-| VAL-004 | Warning  | Composite primary key                       |
-| VAL-005 | Warning  | Auto-managed field conflict                 |
-| VAL-006 | Warning  | DateTime without timezone                   |
-| VAL-007 | Warning  | String without length                       |
-| VAL-008 | Warning  | camelCase field name (should be snake_case) |
-| VAL-009 | Warning  | SQL reserved word as field name             |
-| VAL-010 | Warning  | Missing cascade on foreign key              |
+| Code    | Severity | Description                                         |
+| ------- | -------- | --------------------------------------------------- |
+| VAL-002 | Error    | Missing primary key                                 |
+| VAL-003 | Warning  | Primary key not named `id`                          |
+| VAL-004 | Warning  | Composite primary key                               |
+| VAL-005 | Warning  | Auto-managed field conflict                         |
+| VAL-006 | Warning  | DateTime without timezone                           |
+| VAL-007 | Warning  | String without length                               |
+| VAL-008 | Warning  | camelCase field name (should be snake_case)         |
+| VAL-009 | Warning  | SQL reserved word as field name                     |
+| VAL-010 | Warning  | Missing cascade on foreign key                      |
+| VAL-011 | Warning  | Field name collides with a `NodeMetadata` attribute |
 
 In WARN mode (default), errors become `DataFlowValidationWarning`. In STRICT mode, errors raise `ModelValidationError`.
+
+**VAL-011** (`_validate_node_metadata_collisions`, `packages/kailash-dataflow/src/dataflow/decorators.py:571`) warns when a user field name collides with a core `NodeMetadata` attribute. A DataFlow-generated CRUD node forwards its construction config to `Node.__init__` as `**kwargs`, and that constructor reads `name` / `description` / `version` / `author` / `tags` straight into `NodeMetadata(...)`. A colliding field therefore either crashes node construction (`tags` is a `set[str]` attribute, so a `str` user field raises a pydantic set-type error) or silently overrides the node's own metadata (`name` / `description` / `version` / `author` are all `str`). The reserved set is derived from `NodeMetadata.model_fields` at runtime (`_node_metadata_reserved_fields`, `decorators.py:194`) so it cannot drift from `src/kailash/nodes/base.py`, and excludes `id` (the required primary-key name per VAL-003) and the auto-managed fields owned by VAL-005 — net reserved set `{name, description, version, author, tags}`. VAL-011 is a Warning in WARN mode (consistent with its sibling field-name checks VAL-005/008/009) but escalates to a `ModelValidationError` in STRICT mode, because a `NodeMetadata` collision is a guaranteed crash-or-silent-corruption rather than a best-practice hint.
 
 ---
 


### PR DESCRIPTION
## Summary

A user `@db.model` field whose name collides with a core `NodeMetadata` attribute (`id, name, description, version, author, created_at, tags`) corrupted node construction: the kwargs→NodeMetadata bridge in `Node.__init__` (`src/kailash/nodes/base.py:401-419`) reads the user's field value straight into node metadata. `tags` (set[str] vs str) **crashed**; `name`/`version`/`description`/`author` (all str) **silently overwrote** node metadata with no error — a data-integrity footgun whose only prior mitigation was a per-project column rename. The existing field-name validator (VAL-009) only catches SQL reserved words, which these are not.

**VAL-011** (`_validate_node_metadata_collisions`) warns at `@db.model` decoration time. The reserved set is derived from `NodeMetadata.model_fields` at runtime (cannot drift from base.py) and excludes `id` (the required PK, VAL-003) and the auto-managed fields (owned by VAL-005 — no double-warn). Net reserved set: `{name, description, version, author, tags}`. WARN mode warns with a rename suggestion; STRICT mode raises — a collision is a guaranteed crash-or-corruption, not a style hint.

## User-flow walk receipt

A user writing a colliding model now gets a clear signal at decoration time instead of a downstream crash / silent override:

```
@db.model(validation=ValidationMode.WARN)
class Article:
    id = Column(Integer, primary_key=True)
    tags = Column(String)
# → DataFlowValidationWarning: [VAL-011] Field 'tags' collides with a core
#   NodeMetadata attribute ... Consider renaming to 'tag_list'.

@db.model(strict=True)  # same model → raises ModelValidationError at decoration
```

## Tests

`packages/kailash-dataflow/tests/unit/test_issue_dataflow_reserved_name.py` (12 behavioral tests, in the **CI-run** `tests/unit/` dir): both failure modes (tags-crash, name silent-override), the raw-attribute and SQLAlchemy-mapper scan paths, the `id`/`created_at` exclusions, and OFF-mode skip. Full dataflow unit suite green (3570 passed). Gate-reviewed by `reviewer` + `security-reviewer` — both APPROVE, no CRIT/HIGH/MED.

## Deferred (intentional)

The deeper data-routing fix in core `Node.__init__` (so a legitimately-named `name`/`description` column works as data rather than being warned/blocked) is **not** in this PR — it has high blast radius (every node type) and needs its own gated change + cross-SDK lockstep. VAL-011 is the bounded defense-in-depth that makes the collision **loud** at the earliest point.

## Cross-SDK (EATP D6)

The Rust SDK likely has the equivalent NodeMetadata-attribute collision — parity item for the rs owner (I can't write to rs from here).

## Related issues

Originally surfaced by #855 (closed; the root cause was worked around there via a column rename, not fixed). No open issue tracked this; VAL-011 is the SDK-level root-cause guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)