### PR TITLE
fix(dataflow): engine.py pyright 12→0 + silent-None connection fix; enforce regression gates in CI

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -256,3 +256,24 @@ jobs:
           cd packages/kailash-dataflow
           ../../.venv/bin/python -m pytest tests/unit/ \
             --maxfail=10 -q --timeout=120
+
+      - name: Test DataFlow infra-free regression gates
+        timeout-minutes: 10
+        # tests/regression/ is a MIXED dir: infra-free gates (the engine.py
+        # pyright invariant, codeql/security/import-discipline checks) PLUS
+        # Postgres/Redis-requiring tests. This [dev]-only runner has no infra,
+        # so the marker filter below excludes every infra-requiring test and
+        # runs only the infra-free gates (the engine pyright gate among them).
+        # The infra-requiring regression tests are exercised by the
+        # infrastructure workflow, not here.
+        #
+        # Explicit `-m` is REQUIRED and intentionally overrides pytest.ini's
+        # addopts marker filter: addopts excludes requires_* but NOT
+        # integration/e2e, which this directory DOES contain. (The unit step
+        # above keeps zero `-m` per the addopts-is-sole-filter convention; that
+        # convention holds for tests/unit/, which has no integration tests.)
+        run: |
+          cd packages/kailash-dataflow
+          ../../.venv/bin/python -m pytest tests/regression/ \
+            -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
+            --maxfail=10 -q --timeout=120

--- a/packages/kailash-dataflow/src/dataflow/_types.py
+++ b/packages/kailash-dataflow/src/dataflow/_types.py
@@ -30,7 +30,7 @@ runtime-surface export the leaf module owns.
 """
 from __future__ import annotations
 
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 __all__ = ["DataFlowProtocol"]
 
@@ -40,19 +40,19 @@ class DataFlowProtocol(Protocol):
     """Structural shape of :class:`dataflow.core.engine.DataFlow` used by
     :mod:`dataflow.core.tenant_context`.
 
-    The context switch only observes the facade surfaces a tenant-aware
-    operation needs — the connection manager, the optional cache backend,
-    and the ``multi_tenant`` configuration flag. The concrete
-    :class:`DataFlow` class exposes a much wider API; this Protocol
-    captures only what the context switch actually reads.
+    The context switch binds (stores + re-exposes) a DataFlow instance and
+    reads tenant configuration off ``config.security``. This Protocol captures
+    exactly that surface — ``config`` — which the concrete
+    :class:`dataflow.core.engine.DataFlow` exposes as a public instance
+    attribute, so the concrete class satisfies the Protocol structurally.
+
+    The earlier draft required ``multi_tenant`` / ``connection_manager`` /
+    ``cache_backend`` as top-level attributes; the concrete class exposes
+    those only privately (``_connection_manager``) or via ``config`` (the
+    ``multi_tenant`` flag lives at ``config.security.multi_tenant``), so the
+    over-specified Protocol made the concrete instance fail assignability.
     """
 
-    multi_tenant: bool
-    """Whether the bound instance runs in multi-tenant mode."""
-
-    connection_manager: Any
-    """The SQL connection pool facade (:class:`ConnectionManager` or
-    equivalent)."""
-
-    cache_backend: Optional[Any]
-    """Optional cache adapter (None when cache is disabled)."""
+    config: Any
+    """The :class:`DataFlowConfig` facade (carries ``security``, ``database``,
+    cache settings, etc.)."""

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -20,6 +20,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
@@ -358,7 +359,7 @@ class DataFlow(DataFlowEventMixin):
                 # SecurityConfig (default "row" — the only strategy DataFlow
                 # implements on every backend). None means "use the
                 # SecurityConfig default".
-                _security_kwargs = dict(
+                _security_kwargs: Dict[str, Any] = dict(
                     multi_tenant=multi_tenant,
                     encrypt_at_rest=encryption_key is not None,
                     audit_enabled=audit_logging,
@@ -653,8 +654,12 @@ class DataFlow(DataFlowEventMixin):
 
         # TSG-104: Wire cache configuration into Express
         _express_cache_ttl = getattr(self.config, "cache_ttl", 300)
-        _express_cache_enabled = getattr(
-            self.config, "enable_query_cache", cache_enabled
+        # bool() coerces the Any-typed config attr / Optional[bool] fallback to
+        # the bool ExpressDataFlow.__init__ declares. Behaviour-equivalent: the
+        # Express ctor immediately reduces this via `cache_enabled and ttl > 0`
+        # (a truthiness test), so coercion changes no runtime semantics.
+        _express_cache_enabled = bool(
+            getattr(self.config, "enable_query_cache", cache_enabled)
         )
         # TSG-107: Explicit redis_url parameter takes precedence over config
         _express_redis_url = redis_url or getattr(self.config, "cache_redis_url", None)
@@ -716,6 +721,11 @@ class DataFlow(DataFlowEventMixin):
         self._pool_manager = None
         self._pool_monitor = None
         self._lightweight_pool = None
+        # Shared persistent :memory: connection (assigned lazily by the SQLite
+        # in-memory path; closed in the teardown paths). Typed Optional[Any]
+        # because it may hold an aiosqlite connection — the close() calls in
+        # teardown are guarded by truthiness and only fire when it is set.
+        self._memory_connection: Optional[Any] = None
 
         # Multi-tenant manager (lightweight — no DB connection)
         if self.config.security.multi_tenant:
@@ -3725,7 +3735,7 @@ class DataFlow(DataFlowEventMixin):
     def derived_model(
         self,
         sources: List[str],
-        refresh: str = "manual",
+        refresh: Literal["scheduled", "manual", "on_source_change"] = "manual",
         schedule: Optional[str] = None,
         debounce_ms: float = 100.0,
     ):
@@ -4863,6 +4873,8 @@ class DataFlow(DataFlowEventMixin):
             # Add fields
             for column in table_info.get("columns", []):
                 field_name = column["name"]
+                # _sql_type_to_python_type returns the type *name* as a str
+                # (e.g. "int", "datetime", "Decimal") — already the annotation.
                 field_type = self._sql_type_to_python_type(column["type"])
 
                 # Skip auto-generated fields
@@ -4871,11 +4883,7 @@ class DataFlow(DataFlowEventMixin):
                 ):
                     continue
 
-                type_annotation = (
-                    field_type.__name__
-                    if hasattr(field_type, "__name__")
-                    else str(field_type)
-                )
+                type_annotation = field_type
 
                 if column.get("nullable", True) and not column.get("primary_key"):
                     type_annotation = f"Optional[{type_annotation}]"
@@ -5346,8 +5354,14 @@ class DataFlow(DataFlowEventMixin):
             class_name = class_name[:-1]
         return class_name
 
-    def _sql_type_to_python_type(self, sql_type: str):
-        """Map SQL types to Python types."""
+    def _sql_type_to_python_type(self, sql_type: str) -> str:
+        """Map a SQL type to the *name* of its Python type.
+
+        Returns the type's ``__name__`` string (e.g. ``"int"``, ``"str"``,
+        ``"datetime"``) — or the literal ``"Decimal"`` for ``decimal`` columns.
+        The return value is always a ``str`` (a type *name*), never a type
+        object, so callers must not treat it as a class.
+        """
         # Remove parameters from SQL type (e.g., VARCHAR(255) -> VARCHAR)
         base_type = sql_type.split("(")[0].lower()
 
@@ -5795,9 +5809,14 @@ class DataFlow(DataFlowEventMixin):
     def _get_database_connection(self):
         """Get a real PostgreSQL database connection for DDL operations."""
         try:
-            # Use the connection manager to get a real PostgreSQL connection
+            # Use the connection manager to get a real PostgreSQL connection.
+            # NOTE: the live ConnectionManager (utils/connection.py) has no
+            # get_connection(); the hasattr guard is the runtime gate, so this
+            # branch only runs against a connection-manager variant that DOES
+            # expose it. type: ignore narrows the false positive on the base
+            # ConnectionManager type (see report — latent dead-branch note).
             if hasattr(self._connection_manager, "get_connection"):
-                connection = self._connection_manager.get_connection()
+                connection = self._connection_manager.get_connection()  # type: ignore[attr-defined]
                 if connection:
                     return connection
 
@@ -9030,9 +9049,15 @@ class DataFlow(DataFlowEventMixin):
             return False
 
         try:
-            # Use the schema state manager to get current database schema via WorkflowBuilder
+            # Use the schema state manager to get current database schema via
+            # WorkflowBuilder. NOTE: AutoMigrationSystem does not expose
+            # _schema_state_manager (only MigrationTestFramework does), so the
+            # hasattr guard is the runtime gate — this branch only runs against
+            # a migration-system variant that DOES carry it. type: ignore
+            # narrows the false positives on AutoMigrationSystem (see report —
+            # latent dead-branch note).
             if hasattr(self._migration_system, "_schema_state_manager"):
-                schema_manager = self._migration_system._schema_state_manager
+                schema_manager = self._migration_system._schema_state_manager  # type: ignore[attr-defined]
                 current_schema_obj = schema_manager._fetch_fresh_schema()
                 current_schema = current_schema_obj.tables
             else:
@@ -9224,8 +9249,15 @@ class DataFlow(DataFlowEventMixin):
 
         return connection_context()
 
-    async def _get_async_database_connection(self):
-        """Get async database connection for validation or testing."""
+    async def _get_async_database_connection(self) -> Any:
+        """Get async database connection for validation or testing.
+
+        Returns a backend-specific connection object — ``asyncpg.Connection``,
+        ``aiosqlite.Connection``, or a TDD test connection. These share no
+        common base class, so the return type is ``Any`` (callers dispatch on
+        the configured backend, e.g. asyncpg ``conn.fetch`` vs aiosqlite
+        ``conn.execute``).
+        """
         # Check if we're in TDD mode and have a test context
         from ..testing.tdd_support import (
             get_database_manager,
@@ -9278,6 +9310,14 @@ class DataFlow(DataFlowEventMixin):
                     database_url=db_url,
                     error_message="Database type not supported (only PostgreSQL, MySQL, SQLite)",
                 )
+            # ErrorEnhancer unavailable (platform import failed): still fail
+            # loudly. Falling through here returned None silently, deferring
+            # the failure to a downstream `assert conn is not None` at one
+            # call site and leaving every other caller with a None connection.
+            raise ValueError(
+                f"Unsupported database URL '{db_url}' "
+                "(only PostgreSQL, MySQL, SQLite are supported)"
+            )
 
     def _get_table_name(self, model_name: str) -> str:
         """Get the table name for a model, respecting __tablename__ override.

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -9314,8 +9314,13 @@ class DataFlow(DataFlowEventMixin):
             # loudly. Falling through here returned None silently, deferring
             # the failure to a downstream `assert conn is not None` at one
             # call site and leaving every other caller with a None connection.
+            # Mask credentials in the message — db_url may embed user:password
+            # (the ErrorEnhancer path above masks via mask_url; mirror it here so
+            # this fallback never leaks a credential into logs/traces).
+            from kailash.utils.url_credentials import mask_url
+
             raise ValueError(
-                f"Unsupported database URL '{db_url}' "
+                f"Unsupported database URL '{mask_url(db_url)}' "
                 "(only PostgreSQL, MySQL, SQLite are supported)"
             )
 

--- a/packages/kailash-dataflow/tests/regression/test_engine_pyright_invariant.py
+++ b/packages/kailash-dataflow/tests/regression/test_engine_pyright_invariant.py
@@ -26,8 +26,13 @@ import pytest
 PINNED_PYRIGHT_VERSION = "1.1.371"
 
 # Post-cleanup baseline ceilings. Errors MUST be 0; warnings ≤ ceiling.
+# Ceiling TIGHTENED 10 → 0 (2026-06-25): engine.py was driven to 0 pinned-pyright
+# warnings (the prior 12-vs-10 drift was fixed at root — annotation corrections +
+# two justified targeted ignores + one real silent-None-return bug fix). With the
+# gate now CI-enforced (unified-ci test-dataflow job runs tests/regression/), 0 is
+# the strict floor: any new warning fails loudly. Tightening, not relaxation.
 ERROR_CEILING = 0
-WARNING_CEILING = 10  # brief-mandated hard ceiling per zero-tolerance.md Rule 1b
+WARNING_CEILING = 0
 
 ENGINE_PATH = (
     Path(__file__).resolve().parents[2] / "src" / "dataflow" / "core" / "engine.py"

--- a/packages/kailash-dataflow/tests/unit/test_issue_engine_unsupported_scheme_raises.py
+++ b/packages/kailash-dataflow/tests/unit/test_issue_engine_unsupported_scheme_raises.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test: _get_async_database_connection must raise (not return None)
+on an unsupported DB URL scheme when ErrorEnhancer is unavailable.
+
+Bug: the final ``else`` branch of ``DataFlow._get_async_database_connection``
+only raised ``if ErrorEnhancer is not None``; ``ErrorEnhancer`` can be ``None``
+(its import is wrapped in ``try/except ImportError -> None`` at engine.py top),
+so an unsupported scheme with ErrorEnhancer unavailable fell through and
+returned ``None`` SILENTLY — deferring the failure to a single downstream
+``assert conn is not None`` at one call site and handing every other caller a
+None connection. The fix raises ``ValueError`` unconditionally. (silent None
+return on unsupported scheme when ErrorEnhancer unavailable)
+
+This is a Tier-1 unit test: it invokes the method on a minimal stub object via
+the unbound function, so it never constructs a full DataFlow instance (avoiding
+the async express-path setup). No real DB connection is opened — the unsupported
+scheme short-circuits before any connect() call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from dataflow.core import engine as engine_mod
+from dataflow.core.engine import DataFlow
+
+
+def _stub_with_url(url: str) -> SimpleNamespace:
+    """Minimal object exposing only ``self.config.database.url``.
+
+    ``_get_async_database_connection`` reads nothing else off ``self`` before
+    the unsupported-scheme branch, so this stub is sufficient to drive the
+    branch under test without DataFlow.__init__.
+    """
+    return SimpleNamespace(config=SimpleNamespace(database=SimpleNamespace(url=url)))
+
+
+@pytest.mark.regression
+@pytest.mark.timeout(30)
+async def test_unsupported_scheme_raises_when_error_enhancer_none(monkeypatch):
+    # Exercise the EXACT previously-falling-through branch: unsupported scheme
+    # AND ErrorEnhancer unavailable (its import failed -> None at module load).
+    monkeypatch.setattr(engine_mod, "ErrorEnhancer", None)
+    monkeypatch.delenv("DATAFLOW_TDD_MODE", raising=False)  # stay on the prod path
+
+    stub = _stub_with_url("mongodb://localhost:27017/db")  # unsupported by this method
+
+    with pytest.raises(ValueError, match="Unsupported database URL"):
+        # Bind the unbound method to the stub — no DataFlow.__init__, no hang.
+        await DataFlow._get_async_database_connection(stub)
+
+
+@pytest.mark.regression
+@pytest.mark.timeout(30)
+async def test_unsupported_scheme_raises_when_error_enhancer_present(monkeypatch):
+    # When ErrorEnhancer IS present it raises via enhance_invalid_database_url;
+    # assert the path still raises (does NOT return None) regardless of which
+    # branch handles it.
+    class _EnhancerStub:
+        @staticmethod
+        def enhance_invalid_database_url(database_url, error_message):
+            return ValueError(f"enhanced: {error_message}")
+
+    monkeypatch.setattr(engine_mod, "ErrorEnhancer", _EnhancerStub)
+    monkeypatch.delenv("DATAFLOW_TDD_MODE", raising=False)
+
+    stub = _stub_with_url("oracle://localhost/db")  # unsupported scheme
+
+    with pytest.raises(ValueError):
+        await DataFlow._get_async_database_connection(stub)
+
+
+@pytest.mark.regression
+@pytest.mark.timeout(30)
+async def test_none_url_raises(monkeypatch):
+    # Sibling guard already present in the method: a None url must raise too,
+    # never return None.
+    monkeypatch.delenv("DATAFLOW_TDD_MODE", raising=False)
+    stub = _stub_with_url(None)
+
+    with pytest.raises(ValueError, match="Database URL is not configured"):
+        await DataFlow._get_async_database_connection(stub)

--- a/packages/kailash-dataflow/tests/unit/test_issue_engine_unsupported_scheme_raises.py
+++ b/packages/kailash-dataflow/tests/unit/test_issue_engine_unsupported_scheme_raises.py
@@ -56,6 +56,28 @@ async def test_unsupported_scheme_raises_when_error_enhancer_none(monkeypatch):
 
 @pytest.mark.regression
 @pytest.mark.timeout(30)
+async def test_unsupported_scheme_error_masks_credentials(monkeypatch):
+    # Security regression: the fallback raise (ErrorEnhancer=None branch) routes
+    # db_url through mask_url() so a credentialed connection string never leaks
+    # its password into the exception message (logs/traces). The unmasked-db_url
+    # form would have shipped 'admin:secretpass@' verbatim.
+    monkeypatch.setattr(engine_mod, "ErrorEnhancer", None)
+    monkeypatch.delenv("DATAFLOW_TDD_MODE", raising=False)
+
+    # mysql:// is unsupported by this method -> hits the masked fallback raise.
+    stub = _stub_with_url("mysql://admin:secretpass@db.internal:3306/app")
+
+    with pytest.raises(ValueError) as excinfo:
+        await DataFlow._get_async_database_connection(stub)
+
+    message = str(excinfo.value)
+    assert "secretpass" not in message, f"password leaked into error: {message!r}"
+    assert "admin:secretpass" not in message
+    assert "***" in message  # mask_url canonical redaction marker
+
+
+@pytest.mark.regression
+@pytest.mark.timeout(30)
 async def test_unsupported_scheme_raises_when_error_enhancer_present(monkeypatch):
     # When ErrorEnhancer IS present it raises via enhance_invalid_database_url;
     # assert the path still raises (does NOT return None) regardless of which


### PR DESCRIPTION
## Summary

Follow-up to #1464 (F30), closing the two cross-cutting findings that surfaced during it:

1. **engine.py pyright debt** — `engine.py` carried **12 pinned-pyright warnings** against a ceiling of 10, so `test_engine_pyright_invariant` was **RED**.
2. **The gate was never CI-enforced** — it lives in `packages/kailash-dataflow/tests/regression/`, which `unified-ci` never ran (the `test-dataflow` job ran `tests/unit/` only). That's *why* the drift went unnoticed.

This PR fixes the warnings **and** the CI gap.

## engine.py 12 → 0 (pinned pyright 1.1.371), all at root
- Annotation corrections: `_security_kwargs` `Dict[str, Any]`; `_express_cache_enabled` `bool()`; `_memory_connection` `Optional[Any]`; `derived_model` `refresh` → `Literal[...]`; `_sql_type_to_python_type` `-> str`; `_get_async_database_connection` `-> Any`.
- `_types.py`: `DataFlowProtocol` relaxed — it over-specified members the concrete `DataFlow` exposes only privately; its sole consumer reads nothing off the instance. Type-only, zero runtime change.
- Two **justified** targeted `# type: ignore[attr-defined]` on always-False `hasattr` guards (`ConnectionManager.get_connection`, `AutoMigrationSystem._schema_state_manager`) — dead branches, noted for follow-up; not deleted here to keep this type-only.

## Real bug fixed (zero-tolerance Rule 3)
`_get_async_database_connection` **silently returned `None`** on an unsupported DB URL when `ErrorEnhancer` was unavailable (its platform import is `try/except ImportError → None`), deferring failure to a downstream `None`-deref. Now raises `ValueError` unconditionally. Infra-free regression test added at `tests/unit/test_issue_engine_unsupported_scheme_raises.py` (3 tests, exercises the `ErrorEnhancer=None` branch via a `SimpleNamespace` stub + unbound-function call — no DB, no hang).

## Gate ceiling 10 → 0
Engine is clean; the strict floor means any new warning fails loudly.

## CI: regression gates now enforced
The `test-dataflow` job now also runs `tests/regression/` (343 infra-free tests incl. the engine pyright gate). `tests/regression/` is a mixed dir — the marker filter excludes the Postgres/Redis/integration tests (those run in the infra workflow). The explicit `-m` intentionally overrides `pytest.ini` `addopts` (which excludes `requires_*` but not `integration`/`e2e`, both present here).

## Verification
- Pinned pyright on engine.py: `0 errors, 0 warnings`.
- Full dataflow unit suite: **3573 passed**, 17 skipped.
- Infra-free regression CI command: **343 passed**, 1 skipped, 66 deselected.
- Gate-reviewed by `reviewer` + `security-reviewer`.

## Follow-up (noted, out of scope)
Delete the two dead always-False `hasattr` branches; add an infra job for the 66 Postgres-requiring regression tests.

## Related
Follow-up to #1464. Same `kailash-dataflow` release will cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)