### PR TITLE
release(dataflow): kailash-dataflow 2.13.0

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [2.13.0] — 2026-06-25 — Reserved-name guard + engine pyright cleanup + CI regression gates
+
+### Added
+
+- **VAL-011 `@db.model` reserved-name guard (#1464).** `@db.model` now warns at decoration time when a user field name collides with a core `NodeMetadata` attribute (`name` / `description` / `version` / `author` / `tags`). Previously such a field either crashed at node construction (`tags`, a `set[str]` field, vs a `str` value) or **silently overwrote** node metadata (`name` / `version` / `description` / `author`) with no error. The reserved set is derived from `NodeMetadata.model_fields` at runtime (so it cannot drift from the core model) and excludes `id` (the required primary-key name, VAL-003) and the auto-managed fields (owned by VAL-005). WARN mode emits a warning with a rename suggestion; STRICT mode raises `ModelValidationError` at decoration.
+
+### Fixed
+
+- **Unsupported-database-URL connection no longer returns `None` silently (#1465).** `DataFlow._get_async_database_connection` previously raised only when the platform `ErrorEnhancer` was importable; when it was not (its import is `try/except ImportError -> None`), an unsupported URL fell through and returned `None`, deferring the failure to a downstream dereference. It now raises `ValueError` unconditionally, with credentials masked via `mask_url` so a connection string's password never leaks into the error message.
+
+### Changed
+
+- **`core/engine.py` pyright cleanup to zero (#1465).** Driven from 12 to 0 pinned-pyright (1.1.371) warnings via root annotation corrections plus a `DataFlowProtocol` relaxation (type-only, no runtime change); the engine pyright regression-gate ceiling was tightened from 10 to 0.
+
+### Internal
+
+- **DataFlow `tests/regression/` infra-free gates now run in CI (#1465).** The `test-dataflow` CI job now exercises the infra-free regression gates (including the engine pyright invariant) in addition to `tests/unit/`; the Postgres / Redis / integration-marked regression tests continue to run in the infrastructure workflow.
+
 ## [2.12.0] — 2026-06-16 — Standalone callable masking + record-agnostic redaction (#1337)
 
 ### Added

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.12.0"
+version = "2.13.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.12.0"
+__version__ = "2.13.0"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Metadata-only release-prep for **kailash-dataflow 2.13.0** (version anchors + CHANGELOG; `release/v*` branch auto-skips the PR-gate matrix per ci-runners.md §8).

Bundles two already-merged source PRs:
- **#1464 (F30):** VAL-011 `@db.model` reserved-name guard.
- **#1465:** engine.py pyright 12→0, silent-`None` connection fix (credentials masked), CI regression-gate enforcement.

Both gate-reviewed (reviewer + security-reviewer); main verified healthy (full dataflow `tests/unit/` = 3574 passed). After merge: TestPyPI validation → `dataflow-v2.13.0` tag → publish.

## Related issues
Follows #1464, #1465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)