### PR TITLE
fix(dataflow-tests): make engine-pyright + fabric-endpoint regression gates actually enforce in CI (#1472)

### DIFF
--- a/packages/kailash-dataflow/tests/regression/test_engine_pyright_invariant.py
+++ b/packages/kailash-dataflow/tests/regression/test_engine_pyright_invariant.py
@@ -17,6 +17,7 @@ Silent threshold relaxation is BLOCKED.
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -39,27 +40,59 @@ ENGINE_PATH = (
 )
 
 
+def _resolve_pyright() -> list[str] | None:
+    """Resolve an invocable pyright command, or None if none is installed.
+
+    Issue #1472: the gate previously invoked ``uv run pyright``, which resolves
+    uv's *project* environment — NOT the ``.venv`` the CI job installs into. In
+    the ``test-dataflow`` job that env has no pyright, so ``uv run pyright``
+    failed to spawn and the gate silently skipped (enforcing nothing).
+
+    Resolution order:
+      1. pyright installed alongside the running interpreter. CI runs pytest
+         under ``.venv/bin/python`` and ``kailash-dataflow[dev]`` installs
+         pyright==1.1.371 into that same ``.venv/bin`` — so the gate ENFORCES
+         there.
+      2. pyright on PATH (local dev outside a venv-adjacent install).
+      3. ``uv run pyright`` (resolves a synced uv project env, e.g. plain
+         ``uv run pytest`` locally where pyright is a project dep).
+    """
+    venv_pyright = Path(sys.executable).parent / "pyright"
+    if venv_pyright.exists():
+        return [str(venv_pyright)]
+    on_path = shutil.which("pyright")
+    if on_path is not None:
+        return [on_path]
+    if shutil.which("uv") is not None:
+        return ["uv", "run", "pyright"]
+    return None
+
+
 def _run_pyright() -> tuple[int, int, str]:
     """Invoke pyright on engine.py; return (errors, warnings, raw_output)."""
-    if shutil.which("uv") is None:
-        pytest.skip("uv not available — gate cannot resolve pyright")
+    cmd = _resolve_pyright()
+    if cmd is None:
+        # GENUINELY cannot execute (no pyright installed anywhere) — an
+        # acceptable "cannot execute" skip per test-skip-discipline. CI installs
+        # pyright via kailash-dataflow[dev], so this branch is local-only.
+        pytest.skip(
+            "pyright is not installed in this environment — the engine pyright "
+            "gate cannot execute here. CI installs it via kailash-dataflow[dev]."
+        )
     result = subprocess.run(
-        ["uv", "run", "pyright", str(ENGINE_PATH)],
+        [*cmd, str(ENGINE_PATH)],
         capture_output=True,
         text=True,
     )
     output = result.stdout + result.stderr
-    # When pyright cannot actually be spawned in this environment (e.g. the
-    # node-based launcher is not invocable via `uv run` in CI), the gate cannot
-    # enforce. Skip-when-unavailable rather than fail — the gap is tracked at
-    # issue #1472 (engine pyright CI gate does not enforce). See test-skip
-    # discipline: an acceptable skip is "cannot execute", not "system broken".
+    # A resolved pyright that still fails to spawn (or emits nothing) is a BROKEN
+    # gate, not an absent one — fail loudly rather than skip. Silent-skip here
+    # was the exact #1472 failure mode (the gate enforced nothing while green).
     if "Failed to spawn" in output or not output.strip():
-        pytest.skip(
-            "pyright is not invocable in this environment "
-            "(`uv run pyright` failed to spawn) — the engine pyright gate does "
-            "not enforce here; see issue #1472. "
-            f"Captured output: {output[:300]!r}"
+        pytest.fail(
+            f"pyright resolved to {cmd!r} but failed to spawn or emitted no "
+            f"output — the engine pyright gate could not execute. "
+            f"Captured output: {output[:500]!r}"
         )
     # Summary line shape: "N errors, M warnings, K informations"
     match = re.search(
@@ -74,18 +107,23 @@ def _run_pyright() -> tuple[int, int, str]:
 @pytest.mark.regression
 def test_engine_pyright_version_pinned() -> None:
     """Running pyright must match the pinned version (calibration baseline)."""
-    if shutil.which("uv") is None:
-        pytest.skip("uv not available — version pin cannot be verified")
+    cmd = _resolve_pyright()
+    if cmd is None:
+        pytest.skip(
+            "pyright is not installed in this environment — the version pin "
+            "cannot be verified here. CI installs it via kailash-dataflow[dev]."
+        )
     result = subprocess.run(
-        ["uv", "run", "pyright", "--version"],
+        [*cmd, "--version"],
         capture_output=True,
         text=True,
     )
     running = result.stdout.strip()
     if not running or "Failed to spawn" in (result.stdout + result.stderr):
-        pytest.skip(
-            "pyright is not invocable in this environment — the engine pyright "
-            "version pin cannot be verified here; see issue #1472."
+        pytest.fail(
+            f"pyright resolved to {cmd!r} but failed to report a version — the "
+            f"engine pyright version pin could not be verified. "
+            f"Captured: {(result.stdout + result.stderr)[:500]!r}"
         )
     assert PINNED_PYRIGHT_VERSION in running, (
         f"pyright version mismatch: running {running!r}, "

--- a/packages/kailash-dataflow/tests/regression/test_phase_5_8_fabric_endpoints_registered.py
+++ b/packages/kailash-dataflow/tests/regression/test_phase_5_8_fabric_endpoints_registered.py
@@ -36,14 +36,18 @@ from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi.responses import JSONResponse, StreamingResponse
 
-# dataflow.fabric.* requires the [fabric] extra (janus et al.), absent in a
-# [dev]-only venv. Skip the whole module when janus is missing — otherwise the
-# unconditional dataflow.fabric import below raises ModuleNotFoundError in a
-# fabric-less environment (per testing.md skip-discipline + dependencies.md
-# "Declared = Imported"; see tests/CLAUDE.md § fabric tier note).
-pytest.importorskip("janus")
+# The fabric HTTP adapter (dataflow.fabric.nexus_adapter / .runtime) requires
+# only fastapi — NOT janus. janus is a thread-safe sync/async queue pulled in by
+# kailash-nexus, and is NOT imported anywhere under dataflow.fabric. The prior
+# `importorskip("janus")` guard therefore SKIPPED this gate in the [dev]-only CI
+# job (janus absent) even though fastapi — its real dependency — is present, so
+# the fabric endpoint-registration invariant enforced nothing in CI. Guard the
+# actual dependency, before importing it (testing.md skip-discipline +
+# dependencies.md "Declared = Imported"; see tests/CLAUDE.md § fabric tier note).
+pytest.importorskip("fastapi")
+
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from dataflow.fabric.nexus_adapter import (
     fabric_handler_to_fastapi,
@@ -84,7 +88,10 @@ class _StubNexus:
 
 def test_nexus_register_endpoint_exists_pre_start():
     """``Nexus.register_endpoint`` is callable before the gateway starts."""
-    from nexus import Nexus
+    # These two tests construct a REAL Nexus, which transitively imports janus
+    # (nexus.events). Skip them individually when kailash-nexus is unavailable —
+    # the other 12 tests use a MagicMock stub Nexus and need only fastapi.
+    Nexus = pytest.importorskip("nexus").Nexus
 
     n = Nexus(api_port=18081)
 
@@ -96,7 +103,10 @@ def test_nexus_register_endpoint_exists_pre_start():
 
 
 def test_nexus_register_endpoint_rejects_empty_methods():
-    from nexus import Nexus
+    # These two tests construct a REAL Nexus, which transitively imports janus
+    # (nexus.events). Skip them individually when kailash-nexus is unavailable —
+    # the other 12 tests use a MagicMock stub Nexus and need only fastapi.
+    Nexus = pytest.importorskip("nexus").Nexus
 
     n = Nexus(api_port=18082)
 

--- a/packages/kailash-dataflow/uv.lock
+++ b/packages/kailash-dataflow/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.21.0"
+version = "2.44.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1207,9 +1207,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/fb/6fa2f5cb598a8264355cacea0e1c8cb48b240a3eee8c69b447c4635f8dde/kailash-2.21.0.tar.gz", hash = "sha256:676dce665aaa20b68a151e5982a4c5fadffee10871b117808d09244676404a4d", size = 2641131, upload-time = "2026-05-13T10:23:21.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/d2/f153a5c448732b824334ec5edc81c4a9d0d9bfabfe969d5cfb28cf00dd27/kailash-2.44.1.tar.gz", hash = "sha256:0000f9064cf1d95314189f8602783c9dc7b47d8cd7090e6100336c0eab1d5dba", size = 2986960, upload-time = "2026-06-22T06:43:47.791Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/d2/e70833d340e7ebb88ee0aaba14418c25cfc556a0383166536bdf21202883/kailash-2.21.0-py3-none-any.whl", hash = "sha256:7d1ac53fecdd757b3aefd01c946e55ea62b3321f442e60a8b7da16bd1a34142a", size = 3047625, upload-time = "2026-05-13T10:23:19.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/8aa427cc0135b60c2378c1f6892949c7bc8723ec927f8449b203082976f8/kailash-2.44.1-py3-none-any.whl", hash = "sha256:fc41267c1a3452289f2f7ad50a569198b0d81054deb78622baab9379090be174", size = 3412356, upload-time = "2026-06-22T06:43:45.452Z" },
 ]
 
 [package.optional-dependencies]
@@ -1229,7 +1229,7 @@ server = [
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.9.9"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -1356,7 +1356,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'cloud'", specifier = ">=2.18" },
     { name = "httpx", marker = "extra == 'fabric'", specifier = ">=0.27" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "kailash", specifier = ">=2.18.0" },
+    { name = "kailash", specifier = ">=2.28.0" },
     { name = "kailash", extras = ["server"], marker = "extra == 'dev'" },
     { name = "kailash-dataflow", extras = ["fabric", "cloud", "excel", "parquet", "streaming"], marker = "extra == 'fabric-all'" },
     { name = "kailash-dataflow", extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", "security", "monitoring", "templates", "fabric-all"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

Two dataflow regression gates were silently **skipping in CI** — enforcing nothing while reporting green — plus a stale lockfile. Same failure class across both gates: a `pytest.importorskip` / `uv run` resolved against the wrong environment in CI's dev-only `test-dataflow` job, so the gate skipped instead of enforcing.

### 1. Engine pyright gate now enforces in CI (`Fixes #1472`)
`test_engine_pyright_invariant.py` invoked `uv run pyright`, which resolves uv's *project* env — not the `.venv` the CI job installs pyright into. There pyright failed to spawn and the gate silently skipped (since #1465). Now resolves pyright adjacent to the running interpreter (CI runs pytest under `.venv/bin/python` where `kailash-dataflow[dev]` installs pyright==1.1.371), then PATH, then `uv run`. A resolved-but-unspawnable pyright now **fails loudly** rather than skipping.

### 2. Fabric endpoint gate guards fastapi, not janus
`test_phase_5_8_fabric_endpoints_registered.py` guarded the whole module with `importorskip("janus")` — but `dataflow.fabric.*` imports only **fastapi**, never janus (janus is a kailash-nexus queue dep). In the dev-only job (fastapi present, janus absent) that skipped all 14 tests. Now: module-level `importorskip("fastapi")` (12 stub-Nexus tests enforce); the 2 real-Nexus tests guard themselves with `importorskip("nexus")`.

### 3. uv.lock refresh
Committed lock pinned kailash 2.21.0 / dataflow 2.9.9 with a stale `kailash>=2.18.0` requires-dist; committed pyproject already declares `kailash>=2.28.0` / 2.13.0. `uv lock --check` resolves cleanly against the refreshed lock.

## User-flow walk receipts

Clean dev-only venv mirroring CI (`uv venv` + `uv pip install -e .` + `-e "packages/kailash-dataflow[dev]"`):

```
$ .venv/bin/python -m pytest tests/regression/test_engine_pyright_invariant.py -v
  test_engine_pyright_version_pinned PASSED
  test_engine_pyright_zero_errors PASSED
  test_engine_pyright_warnings_under_ceiling PASSED
  test_engine_pyright_suppressions_documented PASSED
  4 passed   (was: 3 skipped before — gate now enforces)

$ <devonly>/bin/python -m pytest tests/regression/test_phase_5_8_fabric_endpoints_registered.py -rs
  12 passed, 2 skipped   (was: 0 enforcing — all 14 skipped on janus)
  SKIPPED ... could not import 'nexus': No module named 'janus'   (honest cannot-execute)

$ ../../.venv/bin/python -m pytest <fabric test>   # full-stack venv (nexus+janus present)
  14 passed

$ <devonly>/bin/python -m pytest tests/regression/ -m "not (requires_* or integration or e2e)"
  332 passed, 5 skipped, 66 deselected   (full test-dataflow regression step, green)
```

## Known pre-existing finding (not in this PR's scope)
The full regression run surfaces one `PytestUnraisableExceptionWarning`: `Unclosed AsyncLocalRuntime` from core `kailash/runtime/async_local.py:2104` `__del__`, in unmodified `test_issue_1051_memory_connection_leak.py` (the #1010/#1016 AsyncLocalRuntime-teardown lineage). Pre-existing, core-runtime-deep, non-fatal (CI green with it). Flagged for separate disposition.

## Related issues
Fixes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
