### PR TITLE
fix(dataflow): close migration ConnectionManagerAdapter runtime on DataFlow.close() (#1474)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
@@ -3211,6 +3211,17 @@ class AutoMigrationSystem:
         """
         if hasattr(self, "inspector") and self.inspector is not None:
             self.inspector.close()
+        # Issue #1474 — the ConnectionManagerAdapter built for the migration
+        # lock manager (see __init__) is constructed WITHOUT a shared runtime,
+        # so it OWNS a fresh AsyncLocalRuntime (connection_adapter.py, async
+        # branch). DataFlow.close() cascades here via self._migration_system,
+        # but without this call the adapter's owned runtime was never released
+        # and surfaced as an intermittent "Unclosed AsyncLocalRuntime
+        # (ref_count=1)" ResourceWarning at GC. The adapter's close() is
+        # idempotent and releases its runtime.
+        adapter = getattr(self, "_connection_adapter", None)
+        if adapter is not None and hasattr(adapter, "close"):
+            adapter.close()
         explicit = getattr(self, "_explicit_runtime", None)
         if explicit is not None and hasattr(explicit, "release"):
             explicit.release()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1474_migration_adapter_runtime_close.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1474_migration_adapter_runtime_close.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: DataFlow.close() releases the migration adapter's runtime.
+
+Issue #1474 — the ``ConnectionManagerAdapter`` that ``AutoMigrationSystem``
+builds for its migration lock manager is constructed WITHOUT a shared
+runtime (``auto_migration_system.py`` __init__). In an async context the
+adapter therefore OWNS a fresh ``AsyncLocalRuntime`` (``connection_adapter``
+async branch, ``_owns_runtime=True``).
+
+``DataFlow.close()`` cascades into ``self._migration_system.close()``, but
+before the fix ``AutoMigrationSystem.close()`` released only ``inspector``
+and ``_explicit_runtime`` — never ``self._connection_adapter`` — so the
+adapter's owned runtime was never released. With ``ref_count == 1`` it
+surfaced at GC as an intermittent
+
+    ResourceWarning: Unclosed AsyncLocalRuntime (ref_count=1).
+
+The warning fired during whichever later test happened to trigger
+finalization, so it never reproduced deterministically from a single test
+(GC-timing dependent). These tests trigger the adapter inside a running
+event loop and assert the runtime is released by ``close()`` — both
+structurally (adapter releases its runtime) and behaviourally (no
+``AsyncLocalRuntime`` with ``ref_count > 0`` survives a close + GC sweep).
+"""
+
+from __future__ import annotations
+
+import pytest
+from kailash.runtime.async_local import AsyncLocalRuntime
+
+from dataflow import DataFlow
+
+pytestmark = [pytest.mark.regression]
+
+
+@pytest.mark.asyncio
+async def test_issue_1474_close_releases_migration_adapter_runtime(tmp_path):
+    """Structural: the migration adapter's owned runtime is released by close()."""
+    url = f"sqlite:///{tmp_path / 'db.sqlite'}"
+    db = DataFlow(url)
+
+    # Accessing `db.express` forces `_ensure_connected()` -> migration-system
+    # init inside THIS running loop, so the ConnectionManagerAdapter detects a
+    # running loop and owns an AsyncLocalRuntime.
+    _ = db.express
+
+    mig = getattr(db, "_migration_system", None)
+    assert mig is not None, "migration system should be initialised for sqlite"
+    adapter = getattr(mig, "_connection_adapter", None)
+    assert adapter is not None, "migration lock manager adapter should exist"
+
+    if not getattr(adapter, "_owns_runtime", False):
+        # Sync-init fallback (LocalRuntime, not the leaking async branch) —
+        # the #1474 leak cannot occur on this path.
+        db.close()
+        pytest.skip("adapter did not own an async runtime on this init path")
+
+    owned = adapter._runtime
+    assert owned is not None
+
+    db.close()
+
+    assert adapter._runtime is None, (
+        "AutoMigrationSystem.close() must release the connection adapter's "
+        "owned runtime (issue #1474)"
+    )
+    if isinstance(owned, AsyncLocalRuntime):
+        assert (
+            getattr(owned, "_ref_count", 0) == 0
+        ), "the adapter's AsyncLocalRuntime ref_count must reach 0 after close()"
+
+
+@pytest.mark.asyncio
+async def test_issue_1474_owned_runtimes_released_across_instances(tmp_path):
+    """Behavioural: every migration-adapter runtime THIS test creates is released.
+
+    Tracks only the AsyncLocalRuntime objects owned by this test's own
+    DataFlow instances (NOT a global ``gc.get_objects()`` scan, which would
+    be polluted by unrelated tests' leaks and make this assertion
+    order-dependent). Deterministic: asserts ``_ref_count == 0`` after
+    ``close()`` rather than relying on GC timing.
+    """
+    owned_runtimes = []
+
+    async def _exercise(url: str) -> None:
+        db = DataFlow(url)
+        _ = db.express  # trigger migration-system + adapter within this loop
+        mig = getattr(db, "_migration_system", None)
+        adapter = getattr(mig, "_connection_adapter", None) if mig else None
+        if (
+            adapter is not None
+            and getattr(adapter, "_owns_runtime", False)
+            and isinstance(adapter._runtime, AsyncLocalRuntime)
+        ):
+            owned_runtimes.append(adapter._runtime)
+        db.close()
+
+    for i in range(4):
+        await _exercise(f"sqlite:///{tmp_path / f'db{i}.sqlite'}")
+
+    assert owned_runtimes, (
+        "expected at least one migration adapter to own an AsyncLocalRuntime "
+        "on this init path — the #1474 leak surface was not exercised"
+    )
+    unreleased = [r for r in owned_runtimes if getattr(r, "_ref_count", 0) > 0]
+    assert not unreleased, (
+        f"{len(unreleased)}/{len(owned_runtimes)} migration-adapter "
+        "AsyncLocalRuntime(s) left unreleased after DataFlow.close() — "
+        "issue #1474 (ConnectionManagerAdapter runtime leak)"
+    )


### PR DESCRIPTION
## Summary

Fixes the intermittent `Unclosed AsyncLocalRuntime (ref_count=1)` ResourceWarning tracked in #1474.

**Root cause (deterministically reproduced):** `AutoMigrationSystem.__init__` builds a `ConnectionManagerAdapter` for its migration lock manager **without** passing a shared `runtime`. In an async context the adapter therefore *owns* a fresh `AsyncLocalRuntime` (`connection_adapter.py` async branch, `_owns_runtime=True`). `DataFlow.close()` cascades into `self._migration_system.close()`, but `AutoMigrationSystem.close()` released only `inspector` + `_explicit_runtime` — never `self._connection_adapter` — so that owned runtime was never released and surfaced at GC. Because the warning fires during whichever *later* test triggers finalization, it never reproduced from a single test in isolation (matching the GC-timing note in the issue).

A `tracemalloc` allocation trace pinned the leaked runtime to `connection_adapter.py:80` ← `auto_migration_system.py` (lock-manager adapter construction).

## Fix

`AutoMigrationSystem.close()` now also calls `self._connection_adapter.close()` (idempotent; releases the owned runtime). This is consistent with the S5 "own + close" pattern and `dataflow-pool.md` Rule 5 (No Orphan Runtimes) — the adapter deliberately owns its runtime (lazy-parent S5 design dropped eager sharing), so the owner must release it on shutdown.

## Verification

- New regression test `tests/regression/test_issue_1474_migration_adapter_runtime_close.py` asserts the adapter's runtime is released by `close()` — both structurally (`adapter._runtime is None`) and via `ref_count == 0`. The structural assertion **fails without the fix** (verified by reverting) and passes with it.
- Infra-free DataFlow regression suite: **345 passed** (was 343 + the 2 new tests), no regressions. `Unclosed AsyncLocalRuntime` warnings across the suite drop **19 → 3** (the residual 3 are unrelated test fixtures that never call `db.close()` — separate test-hygiene, out of scope for #1474).
- reviewer + security-reviewer: clean (zero Critical/High/Medium/Low).

## Related issues

Fixes #1474

## Cross-SDK note

Per `cross-sdk-inspection.md` MUST-1, the equivalent migration-adapter owned-runtime lifecycle in `kailash-rs` should be checked for the same leak class (out of this repo's scope — flagged for a separate cross-sdk review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)