### PR TITLE
test(dataflow): close leaked resources in infra-free regression suite (53 ResourceWarnings → 0)

### DIFF
--- a/packages/kailash-dataflow/pytest.ini
+++ b/packages/kailash-dataflow/pytest.ini
@@ -31,6 +31,7 @@ markers =
     bug_reproduction: Bug reproduction tests (minimal failing examples)
     bug_investigation: Bug investigation tests (hypothesis validation)
     regression: Regression tests for fixed bugs (permanent, never delete)
+    dataflow_lifecycle: Test asserts DataFlow __del__/close/GC semantics; opts out of the autouse close-fixture in tests/regression/conftest.py (F-TEST-HYGIENE)
     sqlite_memory: Test uses SQLite memory database (auto-applied by tests/unit/conftest.py)
     sqlite_file: Test uses SQLite file database (auto-applied by tests/unit/conftest.py)
     mocking: Test uses mocks/stubs (auto-applied by tests/unit/conftest.py)

--- a/packages/kailash-dataflow/tests/regression/conftest.py
+++ b/packages/kailash-dataflow/tests/regression/conftest.py
@@ -24,6 +24,9 @@ is a fixture + module-scoped pytest-importable globals.
 
 from __future__ import annotations
 
+import asyncio
+import functools
+import inspect
 import os
 import tempfile
 import uuid
@@ -32,6 +35,132 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from dataflow.trust.query_wrapper import QueryAccessResult
+
+# --- F-TEST-HYGIENE: autouse resource-close fixture (zero-tolerance Rule 1) ---
+#
+# Many infra-free regression tests construct framework resource objects
+# (``DataFlow``, ``PipelineExecutor``, ``ModelRegistry``, ``Nexus``) without
+# closing them, so each class's ``__del__`` fires
+# ``ResourceWarning: Unclosed <Class>`` when the instance is garbage collected.
+# The warnings are CORRECT SDK behaviour — the "you forgot to close" contract
+# per rules/patterns.md § "Async Resource Cleanup" — so the fix belongs in the
+# tests, not the SDK. This fixture closes any such resource a test left open,
+# at that test's teardown, so the closed-flag is set before GC runs.
+#
+# BLAST RADIUS (why the design is shaped this way): an un-closed instance is
+# freed at function-return (frame pop), firing ``__del__`` BEFORE any teardown
+# fixture runs — a teardown-only ``gc`` scan is too late to suppress the
+# warning. To *prevent* it, the fixture holds a STRONG reference from
+# construction (via one-time ``__init__`` wrappers), keeping the instance alive
+# until teardown-close. That strong reference would DEFEAT tests that rely on
+# GC firing ``__del__`` in-body (``del df; gc.collect()``) or on GC reaping
+# pool-registry entries. Such lifecycle-semantics tests carry
+# ``@pytest.mark.dataflow_lifecycle`` and OPT OUT of tracking entirely — the
+# fixture holds no reference to their instances (including resources those
+# tests construct internally, e.g. an engine-created ModelRegistry), so their
+# GC-based assertions are unaffected.
+#
+# ``ModelRegistry`` instances are created INTERNALLY by the engine (no
+# test-visible handle), so the ``__init__`` wrapper is the only mechanism that
+# can reach them. ``PipelineExecutor.close()`` is async (drains then flips the
+# flag) — driven via ``asyncio.run`` at the sync teardown (no loop is running
+# there); an idle test executor has nothing to drain, so a fresh loop is safe.
+# Every close is best-effort (try/except): the worst case is a warning persists
+# (visible), never a test failure.
+
+_tracked_resource_instances: List[Any] = []
+_resource_tracking_enabled = False
+_resource_init_installed = False
+
+
+def _make_tracking_init(orig_init: Any) -> Any:
+    @functools.wraps(orig_init)
+    def _tracking_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        if _resource_tracking_enabled:
+            _tracked_resource_instances.append(self)
+
+    return _tracking_init
+
+
+def _install_resource_init_trackers() -> None:
+    """Wrap each tracked resource class's ``__init__`` once. Imports are lazy +
+    defensive so a missing optional package never breaks conftest collection
+    for the whole regression suite. The four classes are unrelated (no
+    subclassing among them), so wrapping each independently cannot
+    double-register; ``ProtectedDataFlow`` registers once via the wrapped
+    ``DataFlow.__init__`` its ``super().__init__`` reaches."""
+    global _resource_init_installed
+    if _resource_init_installed:
+        return
+    _resource_init_installed = True
+
+    for _import in (
+        lambda: __import__("dataflow", fromlist=["DataFlow"]).DataFlow,
+        lambda: __import__(
+            "dataflow.fabric.pipeline", fromlist=["PipelineExecutor"]
+        ).PipelineExecutor,
+        lambda: __import__(
+            "dataflow.core.model_registry", fromlist=["ModelRegistry"]
+        ).ModelRegistry,
+        lambda: __import__(
+            "dataflow.cache.async_redis_adapter", fromlist=["AsyncRedisCacheAdapter"]
+        ).AsyncRedisCacheAdapter,
+        lambda: __import__("nexus", fromlist=["Nexus"]).Nexus,
+    ):
+        try:
+            cls = _import()
+        except Exception:
+            continue
+        cls.__init__ = _make_tracking_init(cls.__init__)
+
+
+@pytest.fixture(autouse=True)
+def _auto_close_resource_instances(request):
+    """Close framework resources a regression test forgot to close.
+
+    Opt out with ``@pytest.mark.dataflow_lifecycle`` for tests that assert
+    ``__del__`` / ``close`` / GC semantics and need their instances to be
+    garbage-collectable in-body.
+    """
+    global _resource_tracking_enabled
+    if request.node.get_closest_marker("dataflow_lifecycle") is not None:
+        # GC-sensitive test: hold no references; let __del__/GC behave natively.
+        yield
+        return
+    _install_resource_init_trackers()
+    _resource_tracking_enabled = True
+    start = len(_tracked_resource_instances)
+    try:
+        yield
+    finally:
+        _resource_tracking_enabled = False
+        for inst in _tracked_resource_instances[start:]:
+            try:
+                if getattr(inst, "_closed", False) is True:
+                    continue
+                # Resolve the first available close method. DataFlow exposes
+                # both sync ``close`` and async ``close_async`` — ``close`` wins
+                # (cheaper, no loop). AsyncRedisCacheAdapter exposes only
+                # ``close_async``; FabricRuntime-style resources expose ``stop``.
+                close = None
+                for _name in ("close", "close_async", "stop"):
+                    cand = getattr(inst, _name, None)
+                    if callable(cand):
+                        close = cand
+                        break
+                if close is None:
+                    continue
+                if inspect.iscoroutinefunction(close):
+                    asyncio.run(close())
+                else:
+                    close()
+            except Exception:
+                # Best-effort teardown cleanup: a close() failure here MUST NOT
+                # mask the test's own result. Acceptable per zero-tolerance
+                # Rule 3 (cleanup path, failure expected/benign).
+                pass
+        del _tracked_resource_instances[start:]
 
 
 @pytest.fixture

--- a/packages/kailash-dataflow/tests/regression/test_dataflow_del_no_async_cleanup.py
+++ b/packages/kailash-dataflow/tests/regression/test_dataflow_del_no_async_cleanup.py
@@ -46,7 +46,10 @@ import pytest
 
 from dataflow import DataFlow
 
-pytestmark = [pytest.mark.regression]
+# dataflow_lifecycle: asserts __del__/ResourceWarning via in-body del+gc.collect;
+# opts out of the autouse close-fixture (conftest.py F-TEST-HYGIENE) whose strong
+# reference would prevent the GC these tests depend on.
+pytestmark = [pytest.mark.regression, pytest.mark.dataflow_lifecycle]
 
 
 @pytest.mark.asyncio

--- a/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
@@ -90,6 +90,18 @@ def _drive_persistent_loop(runtime: ProtectedDataFlowRuntime) -> None:
         pass
 
 
+# ``_drive_persistent_loop`` runs a CreateNode workflow through the protected
+# runtime, allocating an AsyncSQLDatabaseNode on the runtime's persistent event
+# loop. These tests then DELIBERATELY close that loop (the #1045 fix under test).
+# After the loop is gone the orphaned node cannot be disconnected (no loop to
+# await on), so its ``_connected`` flag stays True and ``__del__`` emits a
+# benign "GC'd while still connected" ResourceWarning — the underlying
+# connection is already dead with the closed loop. Scoped-ignore that one
+# message so the deliberate-loop-closure scenario stays warning-clean
+# (F-TEST-HYGIENE); every other ResourceWarning still surfaces.
+@pytest.mark.filterwarnings(
+    "ignore:AsyncSQLDatabaseNode GC.d while still connected:ResourceWarning"
+)
 @pytest.mark.regression
 class TestIssue1045ProtectedRuntimeClose:
     """ProtectedDataFlow.close()/close_async() drain protected runtimes."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
@@ -38,6 +38,11 @@ import pytest
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
 
+# dataflow_lifecycle: asserts no ResourceWarning via in-body del+gc.collect under
+# simplefilter("error", ResourceWarning); opts out of the autouse close-fixture
+# (conftest.py F-TEST-HYGIENE) whose strong reference would prevent the in-body GC.
+pytestmark = pytest.mark.dataflow_lifecycle
+
 
 def _live_aiosqlite_connections():
     """Structural probe: live aiosqlite Connection objects."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_352_fastapi_startup.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_352_fastapi_startup.py
@@ -46,6 +46,38 @@ from dataflow.core.model_registry import ModelRegistry, _normalize_runtime_resul
 pytestmark = pytest.mark.regression
 
 
+# ``_build_registry`` constructs ModelRegistry via ``__new__`` (bypassing
+# __init__), so the conftest autouse close-fixture — which tracks via an
+# __init__ wrapper — cannot reach these instances. Setting ``registry.runtime``
+# routes through the ``runtime`` setter (`_explicit_runtime = value`), so each
+# leaks ``ResourceWarning: Unclosed ModelRegistry`` at GC unless closed. This
+# module-local list + autouse fixture closes them at teardown (the append holds
+# the instance alive past frame-pop so the close lands before __del__). See
+# F-TEST-HYGIENE in tests/regression/conftest.py.
+_built_registries: list = []
+
+
+@pytest.fixture(autouse=True)
+def _close_built_registries():
+    yield
+    while _built_registries:
+        registry = _built_registries.pop()
+        try:
+            registry.close()
+        except Exception:
+            # A fake runtime's release() can raise (the fakes skip the real
+            # __init__), so close() may abort before clearing the override.
+            pass
+        # Guarantee __del__ stays quiet: it warns only when _explicit_runtime
+        # is not None (model_registry.py:1849). Clear it directly — the same
+        # final state close() reaches on its happy path (model_registry.py:1832)
+        # — since the test owns this __new__-built registry entirely.
+        try:
+            registry._explicit_runtime = None
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # _normalize_runtime_result
 # ---------------------------------------------------------------------------
@@ -169,6 +201,7 @@ def _build_registry(runtime: Any, is_async: bool) -> ModelRegistry:
     registry = ModelRegistry.__new__(ModelRegistry)
     registry.runtime = runtime
     registry._is_async = is_async
+    _built_registries.append(registry)  # closed at teardown (F-TEST-HYGIENE)
     return registry
 
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_835_transaction_cross_loop.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_835_transaction_cross_loop.py
@@ -37,7 +37,14 @@ from dataflow import DataFlow
 from dataflow.features.transactions import TransactionScope
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
-pytestmark = [pytest.mark.regression, pytest.mark.integration]
+# dataflow_lifecycle: asserts GC reaping of pool-registry entries across closed
+# loops; opts out of the autouse close-fixture (conftest.py F-TEST-HYGIENE) whose
+# strong reference would keep pools alive and break the registry-cap assertions.
+pytestmark = [
+    pytest.mark.regression,
+    pytest.mark.integration,
+    pytest.mark.dataflow_lifecycle,
+]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The infra-free DataFlow regression suite emitted **53 `ResourceWarning`s** — `DataFlow` / `PipelineExecutor` / `ModelRegistry` / `Nexus` / `AsyncRedisCacheAdapter` instances constructed by tests but never closed, firing each class's `__del__` "you forgot to close" contract at GC. Per `rules/zero-tolerance.md` Rule 1, a warning is an error the framework chose to run through; the warnings are correct SDK behaviour (`rules/patterns.md` § Async Resource Cleanup), so the fix belongs in the **tests**.

**Result: 345 passed, 1 skipped, 0 warnings — deterministic across runs.**

## How

- **Autouse conftest fixture** (`tests/regression/conftest.py`) holds a strong reference to each tracked resource from construction (one-time `__init__` wrappers) and closes any still-open instance at teardown, so the closed-flag is set before GC. The strong-ref-from-construction shape is load-bearing: an unclosed instance is freed at frame-pop, firing `__del__` *before* a teardown-only scan could run. Close dispatch tries `close` / `close_async` / `stop` (async-aware via `asyncio.run`), all best-effort (worst case: a warning persists, never a test failure).
- **New `@pytest.mark.dataflow_lifecycle` marker** (registered in `pytest.ini`): tests that rely on GC firing `__del__` in-body (`del df; gc.collect()`) or on GC reaping pool-registry entries opt out of tracking, so their GC-based assertions are unaffected — `test_dataflow_del_no_async_cleanup`, `test_issue_1051_memory_connection_leak`, `test_issue_835_transaction_cross_loop`.
- **`test_issue_352`**: `_build_registry` constructs `ModelRegistry` via `__new__` (bypassing the `__init__` wrapper), so a module-local fixture registers + closes those.
- **`test_issue_1045`**: deliberately closes a protected runtime's persistent loop, orphaning an `AsyncSQLDatabaseNode` whose connection is already dead with the loop (no close method, loop gone by design); its stale `_connected` flag is scoped-ignored via a documented `filterwarnings` marker.

## Verification

- `345 passed, 1 skipped, 0 warnings` (infra-free selection), deterministic across 3 runs.
- The 5 lifecycle/marked test files pass with their GC/close-semantics assertions intact.
- `pytest --collect-only` clean (408/412, 4 deselected) — no collection breakage.
- All changes are test-only (`pytest.ini` + `tests/regression/`); no `src/` behaviour change.

## Related issues

F-TEST-HYGIENE (sweep `SWEEP-2026-06-26.md` finding #12; `rules/zero-tolerance.md` Rule 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)