### PR TITLE
release(dataflow): v2.13.1 — migration adapter runtime leak fix

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.13.1] — 2026-06-26 — Migration adapter runtime leak fix
+
+### Fixed
+
+- **Migration `ConnectionManagerAdapter` runtime now closed on `DataFlow.close()` (#1474).** `AutoMigrationSystem` builds a `ConnectionManagerAdapter` for its migration lock manager without passing a shared runtime, so in an async context the adapter owns a fresh `AsyncLocalRuntime` (`_owns_runtime=True`). `DataFlow.close()` cascades into `_migration_system.close()`, but `AutoMigrationSystem.close()` released only the inspector and `_explicit_runtime` — never `_connection_adapter` — so the adapter's owned runtime was never released and surfaced at GC as an intermittent `Unclosed AsyncLocalRuntime (ref_count=1)` `ResourceWarning`. The fix closes the adapter in `AutoMigrationSystem.close()` (idempotent; releases the owned runtime), consistent with the "own + close" pattern and `dataflow-pool.md` Rule 5 (No Orphan Runtimes). A regression test asserts the adapter's runtime is released by `close()` (structurally + `ref_count==0`).
+
 ## [2.13.0] — 2026-06-25 — Reserved-name guard + engine pyright cleanup + CI regression gates
 
 ### Added

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.0"
+version = "2.13.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.0"
+__version__ = "2.13.1"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Cuts **kailash-dataflow 2.13.1** — the sole unreleased src commit since `dataflow-v2.13.0`.

Ships **#1474** (`d408b45e2`): `AutoMigrationSystem.close()` now closes its `_connection_adapter`, releasing the `AsyncLocalRuntime` the adapter owns in async contexts. Previously this surfaced at GC as an intermittent `Unclosed AsyncLocalRuntime (ref_count=1)` `ResourceWarning`.

Metadata-only diff (version anchors + CHANGELOG) on a `release/*` branch → PR-gate matrix auto-skips per the release-prep branch convention. Both version anchors bumped atomically (`pyproject.toml` + `__init__.py`) per zero-tolerance Rule 5.

## Pre-publish verification

- Dataflow test posture green on the release base `da633d4f9` (PR #1477 CI matrix: "Test DataFlow Unit Suite (Tier 1)" + "Test DataFlow Infra Regression" both pass).
- Pre-commit gates green on commit (Black / isort / Ruff / type-annotations / Tier-1 unit / doc-style).
- README carries no hardcoded version (no doc bump needed).

## Post-merge

Tag `dataflow-v2.13.1` on the merge commit → triggers `publish-pypi.yml` OIDC publish → clean-venv install + import verification.

## Related issues

#1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)