### PR TITLE
fix(pact): re-validate persisted authorization root on deserialize (#1480)

### DIFF
--- a/src/kailash/trust/pact/__init__.py
+++ b/src/kailash/trust/pact/__init__.py
@@ -15,6 +15,7 @@ from kailash.trust.pact.addressing import (
     AddressSegment,
     GrammarError,
     NodeType,
+    parse_structural_address,
 )
 from kailash.trust.pact.agent import (
     GovernanceBlockedError,
@@ -63,7 +64,7 @@ from kailash.trust.pact.envelopes import (
     default_envelope_for_posture,
     intersect_envelopes,
 )
-from kailash.trust.pact.exceptions import PactError
+from kailash.trust.pact.exceptions import DeserializationError, PactError
 from kailash.trust.pact.explain import (
     describe_address,
     explain_access,
@@ -101,12 +102,14 @@ from kailash.trust.pact.yaml_loader import (
 __all__ = [
     # Error hierarchy (Ref-18, M5 convention compliance)
     "PactError",
+    "DeserializationError",
     # Addressing (Ref-1001)
     "Address",
     "AddressError",
     "AddressSegment",
     "GrammarError",
     "NodeType",
+    "parse_structural_address",
     # Compilation (Ref-1003, 1004, 1005)
     "CompilationError",
     "CompiledOrg",

--- a/src/kailash/trust/pact/addressing.py
+++ b/src/kailash/trust/pact/addressing.py
@@ -24,6 +24,7 @@ __all__ = [
     "NodeType",
     "AddressError",
     "GrammarError",
+    "parse_structural_address",
 ]
 
 
@@ -57,6 +58,26 @@ class AddressSegment:
 
     node_type: NodeType
     sequence: int  # 1-based within parent scope
+
+    def __post_init__(self) -> None:
+        """Validate on EVERY construction path, not just AddressSegment.parse.
+
+        The dataclass ``__init__`` (used by deserializers and any direct
+        construction) bypasses ``parse``'s string-level checks; this enforces
+        the same semantic invariants (valid node type, positive 1-based
+        sequence) so a malformed segment can never be constructed.
+        """
+        if not isinstance(self.node_type, NodeType):
+            raise AddressError(
+                f"node_type must be a NodeType, got {type(self.node_type).__name__}"
+            )
+        # bool is a subclass of int -- reject it explicitly.
+        if isinstance(self.sequence, bool) or not isinstance(self.sequence, int):
+            raise AddressError(
+                f"sequence must be an int, got {type(self.sequence).__name__}"
+            )
+        if self.sequence < 1:
+            raise AddressError(f"Sequence must be >= 1, got {self.sequence}")
 
     def __str__(self) -> str:
         return f"{self.node_type.value}{self.sequence}"
@@ -101,6 +122,25 @@ class Address:
     """
 
     segments: tuple[AddressSegment, ...]
+
+    def __post_init__(self) -> None:
+        """Validate the D/T/R adjacency grammar on EVERY construction path.
+
+        ``Address.parse`` and ``Address.from_segments`` validated grammar only
+        in their classmethods; the dataclass ``__init__`` (used by
+        deserializers and the structural ``parent``/``ancestors`` helpers)
+        bypassed it. This closes that gap so a malformed ``Address(...)``
+        raises.
+
+        The terminal-Role requirement is RELAXED here: structural prefixes
+        such as ``D1`` or ``D1-R1-T1`` name Departments and Teams and are
+        valid containment references (they cannot stand alone as complete
+        addresses, which is what ``Address.parse`` additionally enforces).
+        The adjacency grammar (every D or T immediately followed by exactly
+        one R) IS enforced, which is the invariant that both structural
+        prefixes and complete addresses share.
+        """
+        _validate_grammar(self.segments, require_terminal_role=False)
 
     def __str__(self) -> str:
         return "-".join(str(s) for s in self.segments)
@@ -250,6 +290,8 @@ class Address:
 
 def _validate_grammar(
     segments: tuple[AddressSegment, ...] | list[AddressSegment],
+    *,
+    require_terminal_role: bool = True,
 ) -> None:
     """Validate D/T/R grammar: every D or T must be immediately followed by R.
 
@@ -259,11 +301,19 @@ def _validate_grammar(
 
     Args:
         segments: The ordered sequence of address segments to validate.
+        require_terminal_role: When True (the default, used by
+            ``Address.parse`` / ``from_segments`` for complete addresses),
+            an address ending in an unmatched D or T is a violation. When
+            False (used by ``Address.__post_init__`` and
+            ``parse_structural_address`` for structural unit prefixes like
+            ``D1``), the adjacency grammar is still enforced but a trailing
+            D or T is permitted.
 
     Raises:
         AddressError: If segments is empty.
         GrammarError: If any D or T is not immediately followed by R,
-            or if the address ends with an unmatched D or T.
+            or (when ``require_terminal_role``) if the address ends with an
+            unmatched D or T.
     """
     if not segments:
         raise AddressError("Address must have at least one segment")
@@ -288,11 +338,44 @@ def _validate_grammar(
                 state = 1  # next must be R
             # R keeps us in state 0
 
-    # If we end in state 1, the last D/T has no R
-    if state == 1:
+    # If we end in state 1, the last D/T has no R. This is a violation only
+    # for complete addresses; structural unit prefixes (D1, D1-R1-T1) legally
+    # end in a D or T.
+    if require_terminal_role and state == 1:
         last = segments[-1]
         raise GrammarError(
             f"Grammar violation: address ends with {last.node_type.name} "
             f"without a head Role. Every Department or Team must be "
             f"immediately followed by a Role."
         )
+
+
+def parse_structural_address(s: str) -> Address:
+    """Parse an address that may be a structural unit prefix.
+
+    Unlike :meth:`Address.parse`, this does NOT require the address to end in
+    a Role, so it accepts unit addresses like ``D1`` or ``D1-R1-T1`` that name
+    Departments and Teams (the exact forms ``compile_org`` assigns to
+    Department and Team nodes). The D/T-must-be-immediately-followed-by-R
+    adjacency grammar IS still enforced, so a tampered address such as
+    ``D1-D2-R1`` (D followed by D) is rejected.
+
+    Args:
+        s: Hyphen-separated address string (e.g., ``D1`` or ``D1-R1-T1``).
+
+    Returns:
+        A validated Address.
+
+    Raises:
+        AddressError: If the string is empty or a segment is malformed.
+        GrammarError: If the D/T/R adjacency grammar is violated.
+    """
+    if not s or not s.strip():
+        raise AddressError("Address string is empty")
+
+    parts = s.strip().split("-")
+    segments = tuple(AddressSegment.parse(p) for p in parts)
+
+    _validate_grammar(segments, require_terminal_role=False)
+
+    return Address(segments=segments)

--- a/src/kailash/trust/pact/exceptions.py
+++ b/src/kailash/trust/pact/exceptions.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "PactError",
+    "DeserializationError",
 ]
 
 
@@ -31,3 +32,16 @@ class PactError(Exception):
     def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
         super().__init__(message)
         self.details = details or {}
+
+
+class DeserializationError(PactError):
+    """Raised when a persisted governance object fails re-validation on load.
+
+    A ``CompiledOrg`` reconstructed from stored JSON is an authorization root
+    consumed by ``pact.access.can_access``. If the persisted bytes were
+    tampered with (grammar-invalid address, node keyed by a foreign address,
+    or a node whose declared type disagrees with its address), the load MUST
+    fail closed rather than hand back an unvalidated authorization root.
+    """
+
+    pass

--- a/src/kailash/trust/pact/stores/sqlite.py
+++ b/src/kailash/trust/pact/stores/sqlite.py
@@ -289,16 +289,106 @@ class SqliteOrgStore(_SqliteBase):
 
     @staticmethod
     def _deserialize_org(data: dict[str, Any]) -> CompiledOrg:
-        """Reconstruct a CompiledOrg from serialized JSON data."""
-        from kailash.trust.pact.addressing import NodeType
+        """Reconstruct a CompiledOrg from serialized JSON data.
 
-        org = CompiledOrg(org_id=data["org_id"])
-        for addr, node_data in data.get("nodes", {}).items():
+        Security: a CompiledOrg rebuilt from persisted JSON is the
+        authorization root consumed by ``pact.access.can_access``. The stored
+        bytes are re-validated here so a tampered persisted org fails closed
+        rather than yielding an unvalidated authorization root. Every
+        reconstructed node is checked for:
+
+        1. D/T/R grammar validity of its address (``parse_structural_address``,
+           which enforces the adjacency grammar the compiler enforced at build
+           time).
+        2. Structural consistency -- the node must be keyed in the dict by its
+           own address, and the terminal segment's type must match the node's
+           declared ``node_type`` (Department node ends in D, Team in T, Role
+           in R).
+        """
+        from kailash.trust.pact.addressing import (
+            AddressError,
+            NodeType,
+            parse_structural_address,
+        )
+        from kailash.trust.pact.exceptions import DeserializationError
+
+        def _require(mapping: Any, key: str, ctx: str) -> Any:
+            # A tampered blob may drop a required key or replace a node object
+            # with a non-mapping; both must fail closed with a typed error
+            # rather than a bare KeyError/TypeError (consistent taxonomy +
+            # .details for incident triage).
+            if not isinstance(mapping, dict):
+                raise DeserializationError(
+                    f"Persisted org {ctx} is not an object",
+                    details={"context": ctx, "type": type(mapping).__name__},
+                )
+            try:
+                return mapping[key]
+            except KeyError as exc:
+                raise DeserializationError(
+                    f"Persisted org {ctx} missing required key {key!r}",
+                    details={"context": ctx, "missing_key": key},
+                ) from exc
+
+        org = CompiledOrg(org_id=_require(data, "org_id", "root"))
+
+        # "nodes" is optional (an empty org is valid), but when present it MUST
+        # be an object — a tampered non-dict fails closed rather than crashing
+        # on .items().
+        raw_nodes = data.get("nodes", {})
+        if not isinstance(raw_nodes, dict):
+            raise DeserializationError(
+                "Persisted org 'nodes' is not an object",
+                details={"context": "root", "type": type(raw_nodes).__name__},
+            )
+        for addr, node_data in raw_nodes.items():
+            node_address = _require(node_data, "address", f"node {addr!r}")
+
+            # (2) Node must be keyed by its own address.
+            if addr != node_address:
+                raise DeserializationError(
+                    f"Persisted org node key {addr!r} does not match "
+                    f"node.address {node_address!r}",
+                    details={"key": addr, "node_address": node_address},
+                )
+
+            try:
+                node_type = NodeType(_require(node_data, "node_type", f"node {addr!r}"))
+            except ValueError as exc:
+                raise DeserializationError(
+                    f"Persisted org node {node_address!r} has invalid "
+                    f"node_type {node_data.get('node_type')!r}",
+                    details={"node_address": node_address},
+                ) from exc
+
+            # (1) Address must satisfy the D/T/R grammar (fail closed).
+            try:
+                segments = parse_structural_address(node_address).segments
+            except AddressError as exc:
+                raise DeserializationError(
+                    f"Persisted org node has grammar-invalid address "
+                    f"{node_address!r}: {exc}",
+                    details={"node_address": node_address},
+                ) from exc
+
+            # (2) Terminal segment type must match the declared node type.
+            if segments[-1].node_type != node_type:
+                raise DeserializationError(
+                    f"Persisted org node {node_address!r} declares node_type "
+                    f"{node_type.value!r} but its address terminates in "
+                    f"{segments[-1].node_type.value!r}",
+                    details={
+                        "node_address": node_address,
+                        "declared_type": node_type.value,
+                        "terminal_type": segments[-1].node_type.value,
+                    },
+                )
+
             node = OrgNode(
-                address=node_data["address"],
-                node_type=NodeType(node_data["node_type"]),
-                name=node_data["name"],
-                node_id=node_data["node_id"],
+                address=node_address,
+                node_type=node_type,
+                name=_require(node_data, "name", f"node {addr!r}"),
+                node_id=_require(node_data, "node_id", f"node {addr!r}"),
                 parent_address=node_data.get("parent_address"),
                 children_addresses=tuple(node_data.get("children_addresses", [])),
                 is_vacant=node_data.get("is_vacant", False),

--- a/tests/trust/pact/unit/test_deserialize_authz_root_validation.py
+++ b/tests/trust/pact/unit/test_deserialize_authz_root_validation.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+"""Regression tests for issue #1480 -- persisted PACT authorization root re-validation.
+
+A ``CompiledOrg`` reconstructed from stored JSON is the authorization root
+consumed by ``pact.access.can_access``. Before the fix, ``_deserialize_org``
+rebuilt nodes from raw strings WITHOUT re-running the grammar/structural
+validation that ``Address.parse`` / ``compile_org`` enforce at build time --
+so a tampered persisted org became an unvalidated authorization root.
+
+Covers:
+- Address / AddressSegment ``__post_init__`` validators (every construction
+  path, including the dataclass ``__init__`` the deserializer uses).
+- ``SqliteOrgStore._deserialize_org`` fails closed on grammar-invalid AND
+  structurally-inconsistent persisted nodes.
+- A legitimate save -> load round-trip still succeeds.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kailash.trust.pact.addressing import (
+    Address,
+    AddressError,
+    AddressSegment,
+    GrammarError,
+    NodeType,
+    parse_structural_address,
+)
+from kailash.trust.pact.compilation import CompiledOrg, OrgNode
+from kailash.trust.pact.exceptions import DeserializationError, PactError
+from kailash.trust.pact.stores.sqlite import SqliteOrgStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_compiled_org(org_id: str = "authz-org") -> CompiledOrg:
+    """A minimal but grammar-valid compiled org: D1 / D1-R1 / D1-R1-T1 / -R1."""
+    org = CompiledOrg(org_id=org_id)
+    org.nodes["D1"] = OrgNode(
+        address="D1",
+        node_type=NodeType.DEPARTMENT,
+        name="Engineering",
+        node_id="eng",
+    )
+    org.nodes["D1-R1"] = OrgNode(
+        address="D1-R1",
+        node_type=NodeType.ROLE,
+        name="VP Eng",
+        node_id="vp-eng",
+        parent_address="D1",
+    )
+    org.nodes["D1-R1-T1"] = OrgNode(
+        address="D1-R1-T1",
+        node_type=NodeType.TEAM,
+        name="Backend",
+        node_id="backend",
+        parent_address="D1-R1",
+    )
+    org.nodes["D1-R1-T1-R1"] = OrgNode(
+        address="D1-R1-T1-R1",
+        node_type=NodeType.ROLE,
+        name="Backend Lead",
+        node_id="backend-lead",
+        parent_address="D1-R1-T1",
+    )
+    return org
+
+
+def _overwrite_persisted_json(store: SqliteOrgStore, org_id: str, data: dict) -> None:
+    """Test fixture: overwrite an already-saved org's compiled_json with tampered bytes.
+
+    Mirrors an attacker (or corruption) editing the persisted blob after a
+    legitimate save, which is exactly the load-path ``load_org`` exercises.
+    """
+    conn = store._get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE pact_orgs SET compiled_json = ? WHERE org_id = ?",
+            (json.dumps(data), org_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC#3 -- __post_init__ validators fire on EVERY construction path
+# ---------------------------------------------------------------------------
+
+
+class TestAddressSegmentPostInit:
+    """AddressSegment validates via __init__, not only via parse."""
+
+    def test_direct_construction_rejects_zero_sequence(self) -> None:
+        with pytest.raises(AddressError, match="Sequence must be >= 1"):
+            AddressSegment(node_type=NodeType.ROLE, sequence=0)
+
+    def test_direct_construction_rejects_negative_sequence(self) -> None:
+        with pytest.raises(AddressError, match="Sequence must be >= 1"):
+            AddressSegment(node_type=NodeType.ROLE, sequence=-3)
+
+    def test_direct_construction_rejects_non_nodetype(self) -> None:
+        with pytest.raises(AddressError, match="node_type must be a NodeType"):
+            AddressSegment(node_type="R", sequence=1)  # type: ignore[arg-type]
+
+    def test_direct_construction_rejects_bool_sequence(self) -> None:
+        # bool is a subclass of int -- must be rejected explicitly.
+        with pytest.raises(AddressError, match="sequence must be an int"):
+            AddressSegment(node_type=NodeType.ROLE, sequence=True)  # type: ignore[arg-type]
+
+    def test_valid_direct_construction_still_works(self) -> None:
+        seg = AddressSegment(node_type=NodeType.DEPARTMENT, sequence=2)
+        assert str(seg) == "D2"
+
+
+class TestAddressPostInit:
+    """Address validates the adjacency grammar via __init__, not only via parse."""
+
+    def test_direct_construction_rejects_adjacency_violation(self) -> None:
+        # D immediately followed by D -- adjacency grammar violation.
+        with pytest.raises(GrammarError, match="must be immediately followed by R"):
+            Address(
+                segments=(
+                    AddressSegment(NodeType.DEPARTMENT, 1),
+                    AddressSegment(NodeType.DEPARTMENT, 2),
+                )
+            )
+
+    def test_direct_construction_rejects_empty(self) -> None:
+        with pytest.raises(AddressError, match="at least one segment"):
+            Address(segments=())
+
+    def test_direct_construction_allows_structural_prefix(self) -> None:
+        # 'D1' is a valid structural unit reference (Department node address);
+        # it is NOT a complete address (Address.parse would reject it) but the
+        # dataflow-internal parent/ancestors helpers construct exactly this.
+        addr = Address(segments=(AddressSegment(NodeType.DEPARTMENT, 1),))
+        assert str(addr) == "D1"
+
+    def test_parent_still_builds_structural_prefix(self) -> None:
+        # Regression guard: __post_init__ must NOT break the structural parent.
+        parent = Address.parse("D1-R1").parent
+        assert parent is not None
+        assert str(parent) == "D1"
+
+
+class TestParseStructuralAddress:
+    """parse_structural_address accepts D/T-terminal unit prefixes, rejects bad grammar."""
+
+    @pytest.mark.parametrize("addr", ["D1", "T1", "D1-R1", "D1-R1-T1", "D1-R1-D2"])
+    def test_accepts_valid_unit_prefixes(self, addr: str) -> None:
+        assert str(parse_structural_address(addr)) == addr
+
+    @pytest.mark.parametrize("addr", ["D1-D2-R1", "D1-T1", "T1-T2"])
+    def test_rejects_adjacency_violations(self, addr: str) -> None:
+        with pytest.raises(GrammarError):
+            parse_structural_address(addr)
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(AddressError, match="empty"):
+            parse_structural_address("")
+
+
+# ---------------------------------------------------------------------------
+# AC#1/#2/#4 -- _deserialize_org re-validates the authorization root
+# ---------------------------------------------------------------------------
+
+
+class TestDeserializeOrgValidation:
+    """A tampered persisted org fails closed; a legitimate round-trip succeeds."""
+
+    def test_legitimate_round_trip_succeeds(self) -> None:
+        # AC#4: save -> load of a valid org still works.
+        store = SqliteOrgStore(":memory:")
+        org = _make_compiled_org("authz-org")
+        store.save_org(org)
+
+        loaded = store.load_org("authz-org")
+        assert loaded is not None
+        assert loaded.org_id == "authz-org"
+        assert len(loaded.nodes) == 4
+        assert loaded.nodes["D1"].node_type == NodeType.DEPARTMENT
+        assert loaded.nodes["D1-R1-T1-R1"].node_type == NodeType.ROLE
+
+    def test_grammar_invalid_address_fails_closed(self) -> None:
+        # AC#1/#4: a node whose address violates the D/T/R adjacency grammar
+        # (D followed by D) must reject the load.
+        tampered = {
+            "org_id": "authz-org",
+            "nodes": {
+                "D1-D2-R1": {
+                    "address": "D1-D2-R1",
+                    "node_type": "R",
+                    "name": "Injected",
+                    "node_id": "inj",
+                    "parent_address": None,
+                    "children_addresses": [],
+                    "is_vacant": False,
+                    "is_external": False,
+                }
+            },
+        }
+        with pytest.raises(DeserializationError, match="grammar-invalid address"):
+            SqliteOrgStore._deserialize_org(tampered)
+
+    def test_structurally_inconsistent_terminal_type_fails_closed(self) -> None:
+        # AC#2/#4: a node whose declared node_type disagrees with the terminal
+        # segment of its address (address ends in R but declared DEPARTMENT).
+        tampered = {
+            "org_id": "authz-org",
+            "nodes": {
+                "D1-R1": {
+                    "address": "D1-R1",
+                    "node_type": "D",  # lies: this address terminates in R
+                    "name": "Role masquerading as Dept",
+                    "node_id": "x",
+                    "parent_address": "D1",
+                    "children_addresses": [],
+                    "is_vacant": False,
+                    "is_external": False,
+                }
+            },
+        }
+        with pytest.raises(DeserializationError, match="terminates in"):
+            SqliteOrgStore._deserialize_org(tampered)
+
+    def test_node_keyed_by_foreign_address_fails_closed(self) -> None:
+        # AC#2/#4: the dict key must equal the node's own address.
+        tampered = {
+            "org_id": "authz-org",
+            "nodes": {
+                "D1-R1": {
+                    "address": "D1-R1-T1-R1",  # key != address
+                    "node_type": "R",
+                    "name": "Displaced",
+                    "node_id": "x",
+                    "parent_address": None,
+                    "children_addresses": [],
+                    "is_vacant": False,
+                    "is_external": False,
+                }
+            },
+        }
+        with pytest.raises(DeserializationError, match="does not match"):
+            SqliteOrgStore._deserialize_org(tampered)
+
+    def test_tampered_load_through_load_org_fails_closed(self) -> None:
+        # AC#4 end-to-end: save a valid org, corrupt the persisted blob, then
+        # load_org must fail closed rather than return an unvalidated root.
+        store = SqliteOrgStore(":memory:")
+        store.save_org(_make_compiled_org("authz-org"))
+
+        tampered = {
+            "org_id": "authz-org",
+            "nodes": {
+                "D1-D2-R1": {
+                    "address": "D1-D2-R1",
+                    "node_type": "R",
+                    "name": "Injected",
+                    "node_id": "inj",
+                    "parent_address": None,
+                    "children_addresses": [],
+                    "is_vacant": False,
+                    "is_external": False,
+                }
+            },
+        }
+        _overwrite_persisted_json(store, "authz-org", tampered)
+
+        with pytest.raises(DeserializationError):
+            store.load_org("authz-org")
+
+    def test_deserialization_error_is_pact_error(self) -> None:
+        # Fail-closed callers catching PactError get the deserialization failure.
+        assert issubclass(DeserializationError, PactError)
+
+
+class TestMalformedBlobFailsClosedWithTypedError:
+    """A tampered blob that DROPS a required key or replaces a mapping with a
+    non-object MUST fail closed with a typed ``DeserializationError`` (+ .details
+    for triage) -- never a bare ``KeyError``/``TypeError`` (consistent taxonomy).
+    """
+
+    @pytest.mark.parametrize(
+        "blob, detail_key, detail_val",
+        [
+            ({}, "missing_key", "org_id"),
+            ({"org_id": "o1", "nodes": [1, 2]}, "type", "list"),
+            ({"org_id": "o1", "nodes": {"D1-R1": "x"}}, "type", "str"),
+            (
+                {"org_id": "o1", "nodes": {"D1-R1": {"node_type": "R"}}},
+                "missing_key",
+                "address",
+            ),
+            (
+                {"org_id": "o1", "nodes": {"D1-R1": {"address": "D1-R1"}}},
+                "missing_key",
+                "node_type",
+            ),
+            (
+                {
+                    "org_id": "o1",
+                    "nodes": {"D1-R1": {"address": "D1-R1", "node_type": "R"}},
+                },
+                "missing_key",
+                "name",
+            ),
+            (
+                {
+                    "org_id": "o1",
+                    "nodes": {
+                        "D1-R1": {"address": "D1-R1", "node_type": "R", "name": "n"}
+                    },
+                },
+                "missing_key",
+                "node_id",
+            ),
+        ],
+    )
+    def test_malformed_blob_raises_deserialization_error(
+        self, blob: dict, detail_key: str, detail_val: str
+    ) -> None:
+        with pytest.raises(DeserializationError) as excinfo:
+            SqliteOrgStore._deserialize_org(blob)
+        assert excinfo.value.details.get(detail_key) == detail_val
+
+    def test_empty_org_with_no_nodes_key_still_loads(self) -> None:
+        # "nodes" is optional -- an empty org (no nodes key) is valid, not tampered.
+        org = SqliteOrgStore._deserialize_org({"org_id": "empty-org"})
+        assert org.org_id == "empty-org"
+        assert org.nodes == {}


### PR DESCRIPTION
## Summary
`SqliteOrgStore._deserialize_org` rebuilt a `CompiledOrg` — the authorization root `pact.access.can_access` consumes — from stored JSON without re-running the grammar/structural validation `compile_org` enforces at build time. A tampered persisted org became an unvalidated authorization root.

## Changes
- `Address`/`AddressSegment` gain `__post_init__` grammar validators (every construction path validates; adjacency grammar only, terminal-Role completeness stays `parse()`-scoped so `compile_org` still builds D/T-terminal node addresses).
- `_deserialize_org` fails closed on grammar-invalid address, node-key/address mismatch, terminal-type mismatch, dropped required keys, and non-object nodes (typed `DeserializationError` with `.details`, never bare `KeyError`).
- New `DeserializationError(PactError)`.

## Tests
New `tests/trust/pact/unit/test_deserialize_authz_root_validation.py` — grammar-invalid + structurally-inconsistent + dropped-key tamper paths all fail closed; legit round-trip succeeds. Full trust/pact unit + addressing + store suites green, 0 warnings.

## Related issues
Fixes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)