### PR TITLE
fix(eatp): bind reviewed disclosure into hold resolution signature (#1483)

### DIFF
--- a/src/kailash/trust/plane/holds.py
+++ b/src/kailash/trust/plane/holds.py
@@ -4,20 +4,29 @@
 """Hold/Approve workflow for HELD actions.
 
 When trust_check returns HELD, a HoldRecord is created. The human
-resolves it via CLI (approve/deny), creating an audit anchor.
+resolves it via CLI (approve/deny). Every resolution is Ed25519-signed
+over a canonical payload that binds the reviewed hold's decision-relevant
+disclosure (action, resource, reason, context — the last carries the
+submitter/caller, capability, and agent identity) together with the
+decision itself (approved/denied, resolver, resolution reason). The
+signature is recomputed from the *queued* hold at verification time, so a
+resolution signed over a disclosure that differs from the stored hold
+fails verification (see :meth:`HoldManager.verify_resolution`).
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import secrets
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kailash.trust._locking import file_lock
+from kailash.trust._locking import file_lock, safe_read_text
+from kailash.trust.signing.crypto import generate_keypair, sign, verify_signature
 
 if TYPE_CHECKING:
     from kailash.trust.plane.store import TrustPlaneStore
@@ -39,6 +48,11 @@ class HoldRecord:
     resolved_at: datetime | None = None
     resolved_by: str | None = None
     resolution_reason: str | None = None
+    # Ed25519 signature (base64) binding the reviewed disclosure + decision,
+    # and the base64 public key it verifies against. Populated on resolution;
+    # ``None`` while the hold is pending. See HoldManager.verify_resolution.
+    resolution_signature: str | None = None
+    signing_pubkey: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -52,6 +66,8 @@ class HoldRecord:
             "resolved_at": self.resolved_at.isoformat() if self.resolved_at else None,
             "resolved_by": self.resolved_by,
             "resolution_reason": self.resolution_reason,
+            "resolution_signature": self.resolution_signature,
+            "signing_pubkey": self.signing_pubkey,
         }
 
     @classmethod
@@ -71,6 +87,8 @@ class HoldRecord:
             ),
             resolved_by=data.get("resolved_by"),
             resolution_reason=data.get("resolution_reason"),
+            resolution_signature=data.get("resolution_signature"),
+            signing_pubkey=data.get("signing_pubkey"),
         )
 
 
@@ -80,6 +98,71 @@ def generate_hold_id(action: str, resource: str) -> str:
     nonce = secrets.token_hex(4)
     content = f"hold:{action}:{resource}:{now}:{nonce}"
     return f"hold-{hashlib.sha256(content.encode()).hexdigest()[:12]}"
+
+
+def _resolution_signing_payload(hold: "HoldRecord") -> dict:
+    """Canonical payload a resolution signature binds.
+
+    Folds the reviewed hold's decision-relevant disclosure — ``action``,
+    ``resource``, ``reason``, and the ``context`` dict (which carries the
+    submitter/caller, requested capability, and agent identity) — together
+    with the decision (status, resolver, resolution reason, timestamp). Both
+    the signer (:meth:`HoldManager.resolve`) and the verifier
+    (:meth:`HoldManager.verify_resolution`) build this from the *queued* hold,
+    so a resolution signed over a disclosure that differs from the stored hold
+    fails verification. The signature fields themselves are excluded (they are
+    the output, not the input).
+    """
+    return {
+        "hold_id": hold.hold_id,
+        "action": hold.action,
+        "resource": hold.resource,
+        "reason": hold.reason,
+        "context": hold.context,
+        "status": hold.status,
+        "resolved_by": hold.resolved_by,
+        "resolution_reason": hold.resolution_reason,
+        "resolved_at": hold.resolved_at.isoformat() if hold.resolved_at else None,
+    }
+
+
+def _load_or_create_signing_keys(keys_dir: Path) -> tuple[str, str]:
+    """Load the trust-plane keypair, generating and persisting one if absent.
+
+    Reuses the same ``keys/private.key`` / ``keys/public.key`` layout the
+    plane project writes, so a HoldManager attached to an initialized project
+    signs with that project's authority key. The private key is written with
+    ``0o600`` and ``O_NOFOLLOW`` (no symlink redirection), matching the
+    trust-plane key-at-rest contract.
+    """
+    priv_path = keys_dir / "private.key"
+    pub_path = keys_dir / "public.key"
+
+    if priv_path.exists() and pub_path.exists():
+        return safe_read_text(priv_path), safe_read_text(pub_path)
+
+    private_key, public_key = generate_keypair()
+    keys_dir.mkdir(parents=True, exist_ok=True)
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(priv_path), flags, 0o600)
+    try:
+        os.write(fd, private_key.encode())
+    finally:
+        os.close(fd)
+
+    pub_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        pub_flags |= os.O_NOFOLLOW
+    pub_fd = os.open(str(pub_path), pub_flags, 0o644)
+    try:
+        os.write(pub_fd, public_key.encode())
+    finally:
+        os.close(pub_fd)
+
+    return private_key, public_key
 
 
 class HoldManager:
@@ -106,6 +189,16 @@ class HoldManager:
         self._holds_dir = trust_dir / "holds"
         self._holds_dir.mkdir(parents=True, exist_ok=True)
         self._lock_path = self._holds_dir / ".lock"
+        self._keys_dir = trust_dir / "keys"
+        # Signing keys are loaded lazily on first resolution so read-only
+        # operations (list/get) never create key material as a side effect.
+        self._signing_keys: tuple[str, str] | None = None
+
+    def _get_signing_keys(self) -> tuple[str, str]:
+        """Return (private_key, public_key), loading/generating on first use."""
+        if self._signing_keys is None:
+            self._signing_keys = _load_or_create_signing_keys(self._keys_dir)
+        return self._signing_keys
 
     def create_hold(
         self, action: str, resource: str, reason: str, context: dict | None = None
@@ -138,9 +231,47 @@ class HoldManager:
             hold.resolved_at = datetime.now(timezone.utc)
             hold.resolved_by = resolved_by
             hold.resolution_reason = reason
+
+            # Sign the reviewed disclosure + decision BEFORE the durable write.
+            # If signing raises, the store is never updated and the hold stays
+            # pending (fail-closed — no half-resolved, unsigned record persists).
+            private_key, public_key = self._get_signing_keys()
+            payload = _resolution_signing_payload(hold)
+            hold.resolution_signature = sign(payload, private_key)
+            hold.signing_pubkey = public_key
+
             self._store.update_hold(hold)
         logger.info("Resolved hold %s: %s by %s", hold_id, hold.status, resolved_by)
         return hold
+
+    def verify_resolution(self, hold_id: str) -> bool:
+        """Verify a resolved hold's signature against its *queued* disclosure.
+
+        Recomputes the canonical resolution payload from the stored hold's
+        current fields and verifies the stored Ed25519 signature. A resolution
+        signed over a disclosure that differs from the stored hold — e.g. the
+        reviewed action, resource, reason, or context (submitter/caller,
+        capability, agent identity) was altered after the human decided —
+        fails verification. Fail-closed: a pending or unsigned hold returns
+        ``False``. This method never mutates or deletes the hold, so a hold
+        that fails verification survives for a correct decision.
+        """
+        hold = self.get(hold_id)
+        if (
+            hold.status == "pending"
+            or not hold.resolution_signature
+            or not hold.signing_pubkey
+        ):
+            return False
+        payload = _resolution_signing_payload(hold)
+        try:
+            return verify_signature(
+                payload, hold.resolution_signature, hold.signing_pubkey
+            )
+        except Exception:
+            # Any verification error (malformed signature/key, decode failure)
+            # is a failed verification, never an exception to the caller.
+            return False
 
     def get(self, hold_id: str) -> HoldRecord:
         """Get a hold by ID."""

--- a/tests/trust/plane/integration/test_holds.py
+++ b/tests/trust/plane/integration/test_holds.py
@@ -123,3 +123,100 @@ class TestHoldManager:
         retrieved = manager2.get(hold.hold_id)
         assert retrieved.status == "approved"
         assert retrieved.resolved_by == "Carol"
+
+
+class TestHoldResolutionSignature:
+    """Resolution signatures bind the reviewed hold's disclosure.
+
+    Cross-SDK parity with kailash-rs#1562: the signer and verifier both fold
+    the reviewed hold's decision-relevant disclosure into the signed payload,
+    recomputed from the queued hold at verification time. A resolution signed
+    over a disclosure differing from the queued hold fails verification.
+    """
+
+    def test_approve_populates_signature_fields(self, manager):
+        hold = manager.create_hold(
+            action="publish",
+            resource="paper.md",
+            reason="review",
+            context={"submitted_by": "agent-7", "capability": "publish_docs"},
+        )
+        resolved = manager.resolve(hold.hold_id, True, "Alice", "ok")
+        assert resolved.resolution_signature is not None
+        assert resolved.signing_pubkey is not None
+
+    def test_approve_resolution_verifies(self, manager):
+        hold = manager.create_hold(
+            action="publish",
+            resource="paper.md",
+            reason="review",
+            context={"submitted_by": "agent-7", "capability": "publish_docs"},
+        )
+        manager.resolve(hold.hold_id, True, "Alice", "reviewed and approved")
+        assert manager.verify_resolution(hold.hold_id) is True
+
+    def test_deny_resolution_verifies(self, manager):
+        hold = manager.create_hold(
+            action="delete",
+            resource="keys/",
+            reason="dangerous",
+            context={"submitted_by": "agent-9", "capability": "delete_keys"},
+        )
+        manager.resolve(hold.hold_id, False, "Bob", "not appropriate")
+        assert manager.verify_resolution(hold.hold_id) is True
+
+    def test_pending_hold_not_verified(self, manager):
+        hold = manager.create_hold(action="a", resource="r", reason="r")
+        # Unresolved hold has no signature — fail-closed.
+        assert manager.verify_resolution(hold.hold_id) is False
+
+    def test_tampered_disclosure_approve_fails_verification(self, manager):
+        hold = manager.create_hold(
+            action="publish",
+            resource="paper.md",
+            reason="review",
+            context={"submitted_by": "agent-7", "capability": "publish_docs"},
+        )
+        manager.resolve(hold.hold_id, True, "Alice", "approved")
+        assert manager.verify_resolution(hold.hold_id) is True
+
+        # Tamper the reviewed disclosure AFTER signing: the stored hold now
+        # presents a capability the approver never reviewed. Keep the original
+        # signature (as an attacker would). The signature was computed over the
+        # original disclosure; verification recomputes from the tampered hold.
+        stored = manager.get(hold.hold_id)
+        stored.context = {"submitted_by": "agent-7", "capability": "delete_keys"}
+        manager._store.update_hold(stored)
+
+        assert manager.verify_resolution(hold.hold_id) is False
+        # Hold survives — not consumed/destroyed — so a correct decision remains
+        # possible; the tampered approval is simply not trusted.
+        survivor = manager.get(hold.hold_id)
+        assert survivor.status == "approved"
+
+    def test_tampered_disclosure_deny_fails_verification(self, manager):
+        hold = manager.create_hold(
+            action="wire_transfer",
+            resource="account/123",
+            reason="fraud check",
+            context={"submitted_by": "agent-3", "amount": 500},
+        )
+        manager.resolve(hold.hold_id, False, "Bob", "rejected")
+        assert manager.verify_resolution(hold.hold_id) is True
+
+        # Tamper the reviewed action after the rejection was signed.
+        stored = manager.get(hold.hold_id)
+        stored.action = "read_balance"
+        manager._store.update_hold(stored)
+
+        assert manager.verify_resolution(hold.hold_id) is False
+        survivor = manager.get(hold.hold_id)
+        assert survivor.status == "denied"
+
+    def test_signature_verifies_across_reload(self, manager, holds_dir):
+        hold = manager.create_hold(action="publish", resource="p.md", reason="r")
+        manager.resolve(hold.hold_id, True, "Carol", "approved")
+
+        # A fresh manager loads keys + record from disk and still verifies.
+        manager2 = HoldManager(holds_dir)
+        assert manager2.verify_resolution(hold.hold_id) is True


### PR DESCRIPTION
## Summary
Python-side parity of terrene-foundation/kailash-rs#1562 (semantic parity per EATP D6). `HoldManager.resolve()` set status/resolution_reason with **no signature at all** — the human-approval gate (compensating control for the MCP confused-deputy class) attested to nothing. Deeper than the Rust gap, which at least signed hold_id + approver metadata.

## Changes
- `resolve()` signs an Ed25519 payload **before** the durable write (fail-closed: signing failure leaves the hold pending, never half-resolved).
- Payload folds the reviewed hold's disclosure (action, resource, reason, context → submitter/caller, capability, agent id) + the decision.
- `verify_resolution()` recomputes the payload from the **stored** hold → an approval/rejection signed over a differing disclosure fails verification; the hold **survives** for a correct decision (never mutated/consumed on failed verify).
- Signing key at `<trust_dir>/keys` with `0o600` + `O_NOFOLLOW`, reusing `signing/crypto.py` (no hand-rolled Ed25519).

## Tests
`TestHoldResolutionSignature` — approve+deny verify; tampered-disclosure (context escalation + action swap) → verify False + hold survives; pending → fail-closed; verifies across reload. Store-conformance + trust-plane suites green.

## Related issues
Fixes #1483 · cross-SDK of terrene-foundation/kailash-rs#1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)