### PR TITLE
fix(coc): correct Rust SDK repo path to esperie-enterprise/kailash-rs

### DIFF
--- a/.claude/guides/deterministic-quality/08-cross-sdk-parity.md
+++ b/.claude/guides/deterministic-quality/08-cross-sdk-parity.md
@@ -90,7 +90,7 @@ jobs:
           path: kailash-py
       - uses: actions/checkout@v4
         with:
-          repository: terrene-foundation/kailash-rs
+          repository: esperie-enterprise/kailash-rs
           path: kailash-rs
       - run: python scripts/check-api-parity.py kailash-py/ kailash-rs/
       - run: |

--- a/.claude/guides/rule-extracts/git.md
+++ b/.claude/guides/rule-extracts/git.md
@@ -89,7 +89,7 @@ Origin: 2026-04-25 kailash-rs session — PR #598 cycle of 5 sequential pushes (
 | `terrene-foundation/kailash-coc-claude-rs`    | `main` | Full (admin bypass) — legacy (archival 2026-10-22) |
 | `terrene-foundation/kailash-coc-py`           | `main` | Full (admin bypass)                                |
 | `terrene-foundation/kailash-coc-rs`           | `main` | Full (admin bypass)                                |
-| `terrene-foundation/kailash-rs`               | `main` | Full (admin bypass)                                |
+| `esperie-enterprise/kailash-rs`               | `main` | Full (admin bypass) — private Rust SDK BUILD repo  |
 | `terrene-foundation/kailash-prism`            | `main` | Full (admin bypass)                                |
 | `terrene-foundation/kailash-coc-claude-prism` | `main` | Full (admin bypass)                                |
 

--- a/.claude/rules/cross-sdk-inspection.md
+++ b/.claude/rules/cross-sdk-inspection.md
@@ -30,7 +30,7 @@ When an issue is found or fixed in ONE BUILD repo, you MUST inspect the OTHER BU
 
 - Does the Rust SDK have the same bug?
 - Does the Rust SDK need the equivalent feature?
-- File a GitHub issue on `terrene-foundation/kailash-rs` if relevant.
+- File a GitHub issue on `esperie-enterprise/kailash-rs` (the private Rust SDK BUILD repo — NOT `terrene-foundation/kailash-rs`, which does not exist) if relevant.
 
 ### 2. Cross-Reference in Issues
 
@@ -262,7 +262,7 @@ When closing any issue, verify:
 gh issue create --repo terrene-foundation/kailash-py \
   --title "feat(kaizen): per-request API key override" \
   --label "cross-sdk" \
-  --body "Cross-SDK alignment with terrene-foundation/kailash-rs#52"
+  --body "Cross-SDK alignment with esperie-enterprise/kailash-rs#52"
 ```
 
 ## Automation


### PR DESCRIPTION
## Summary
Three COC artifacts pointed cross-SDK issue filing at `terrene-foundation/kailash-rs`, which **does not exist** (`gh repo view` → 'Could not resolve to a Repository'). The real Rust SDK BUILD repo is the private **`esperie-enterprise/kailash-rs`** (per the persisted `reference-kailash-rs-repo-location` memory + `.claude/settings.local.json`).

## Corrected
- `.claude/rules/cross-sdk-inspection.md` (filing target + example body)
- `.claude/guides/rule-extracts/git.md` (protection-table row)
- `.claude/guides/deterministic-quality/08-cross-sdk-parity.md` (workflow checkout)

## Left unchanged (intentional)
- `.claude/learning/violations.jsonl` — append-only audit records (of prior sessions flagged for this exact mistake); `.claude/learning/` is not agent-editable.
- `.claude/audit-fixtures/scan-synced-disclosure/.../clean.md` — deliberate Foundation-allowlist scanner test data.
- `CHANGELOG.md:939` — released historical entry.

## ⚠️ Propagation note
These are loom-synced COC artifacts; the same defect exists upstream at loom and in sibling consumer repos. This PR fixes kailash-py only — a future `/sync-to-build` could re-overwrite it unless the correction lands at loom via `/codify` → sync. Cannot be done from this repo (repo-scope-discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)