### PR TITLE
docs(coc): public-artifact disclosure clause + cross-SDK codify

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -449,3 +449,43 @@ changes:
       pass ran on the proposed text. Cross-SDK sibling: kailash-rs uses the same gh-CLI
       PR flow; the clause applies identically (the existing git.md § "Pre-FIRST-Push
       CI Parity Discipline" already carries the rs cargo-command set).
+  - type: rule_update
+    artifact: cross-sdk-inspection
+    files:
+      - .claude/rules/cross-sdk-inspection.md
+      - .claude/guides/rule-extracts/git.md
+      - .claude/guides/deterministic-quality/08-cross-sdk-parity.md
+    classification_suggestion: global
+    context: |
+      APPEND 2026-07-02 (session-continuation codify). TWO changes, BOTH global.
+
+      (1) REPO-PATH CORRECTION (landed BUILD-side, PR #1487): cross-sdk-inspection.md
+      pointed cross-SDK issue filing at `terrene-foundation/kailash-rs`, which DOES NOT
+      EXIST (`gh repo view` → "Could not resolve to a Repository"). Corrected to the real
+      private `esperie-enterprise/kailash-rs` (Rule 1 filing target + the Example body).
+      Sibling artifacts fixed same PR: the git.md protection-table row + the
+      08-cross-sdk-parity workflow checkout.
+      LOOM GATE-1 ACTION: this defect exists UPSTREAM at loom + every consumer repo (these
+      are synced artifacts); distribute the correction fleet-wide, else a /sync-to-build
+      re-overwrites the local fix with the still-wrong path.
+
+      (2) NEW MUST Rule 6 — "Cross-SDK References In Public-Published Artifacts Are
+      BLOCKED": public/published artifacts (CHANGELOG, README, docs, package metadata)
+      MUST NOT name the private Rust SDK repo/org/versions/issues/crate-paths/architecture
+      (disclosure + Foundation Independence, Directive 0). Ships WITH a canonical 8-field
+      Trust Posture Wiring block (trigger key `public_artifact_private_repo_disclosure`).
+
+      SAME-SESSION SAME-CLASS FIXES (autonomous-execution Rule 4), landed BUILD-side:
+      CHANGELOG.md — 27 rs references removed/genericized (PR #1488); README.md (the PyPI
+      long_description) — 3 bare kailash-rs refs genericized (the codify PR).
+
+      REDTEAM: reviewer + security-reviewer + cc-architect (parallel) → MERGE-WITH-FIXES;
+      all fixes applied (README scrub + removed a leaked private seed-org token `rrps-mtu`
+      from the clause's own detection grep). NOT a self-referential-codify Rule-1 round —
+      cross-sdk-inspection.md is NOT on that allowlist; clause deliberately NOT added to it
+      (public-artifact hygiene is code-behavior governance, like security.md).
+
+      CLASSIFICATION: GLOBAL. Disclosure + Foundation-Independence discipline is CLI-neutral
+      and applies to every public-published repo; the repo-path correction is a factual fix
+      every consumer needs. The DO/DO-NOT examples are illustrative markdown (no per-CLI
+      delegation primitive), so the clause emits globally with no cross-cli slot partitioning.

--- a/.claude/rules/cross-sdk-inspection.md
+++ b/.claude/rules/cross-sdk-inspection.md
@@ -254,6 +254,38 @@ When closing any issue, verify:
 
 **Why:** Closing without cross-SDK verification is the primary cause of feature drift — the checklist is the last gate before an issue is forgotten.
 
+### 6. Cross-SDK References In Public-Published Artifacts Are BLOCKED
+
+The Rust SDK BUILD repo (`esperie-enterprise/kailash-rs`) is **PRIVATE**. Cross-SDK references — the sibling repo/org name, its version numbers, its issue numbers, its crate paths, its internal architecture — MUST NOT appear in any PUBLIC-PUBLISHED artifact of this (public, PyPI-published) repo: `CHANGELOG.md`, `README.md`, rendered docs, published package metadata, or public source/comments. Cross-SDK parity tracking lives in INTERNAL issues (filed on `esperie-enterprise/kailash-rs` itself) and journals — never in the public changelog. Genericize to "cross-SDK" / "cross-implementation" without naming the private repo.
+
+```markdown
+# DO — public CHANGELOG genericizes; the parity link lives in an internal issue
+
+- **Tenant-scoped event bus (#1338, cross-SDK parity)**: ...
+
+# DO NOT — public CHANGELOG names the private repo/org/version/issue
+
+- **Tenant-scoped event bus (#1338, cross-SDK parity with esperie-enterprise/kailash-rs #1352)**: ...
+- ... "mirrors kailash-rs v4.12.0 (rs#1448)" / "kailash-rs uses axum + tokio" ...
+```
+
+**BLOCKED rationalizations:** "it's just a cross-reference" / "the parity note is useful context for users" / "the repo name is already known internally" / "it's only the version number, not the code" / "the CHANGELOG is developer-facing, not really public".
+
+**Why:** A public artifact naming the private repo leaks its existence, its org, and its internals to every PyPI consumer — and couples the Foundation-independent Python SDK to a private sibling in violation of `CLAUDE.md` Directive 0 (Foundation Independence — "Kailash Python IS the product, not a derivative of anything"). Cross-SDK visibility belongs in internal tracking, where it informs parity without disclosing the private repo to the world.
+
+**Note (broader surface, flagged not closed):** synced COC governance artifacts (`.claude/rules/`, `.claude/skills/`) that reference `kailash-rs` for cross-SDK PROCEDURE are internal governance, distinct from public-published artifacts — but if a downstream USE template is public, those references become public too. That exposure is a separate, larger audit (out of this clause's scope); this clause governs the PyPI-published artifact surface (CHANGELOG/README/docs/package-metadata/public-source).
+
+**Trust Posture Wiring:**
+
+- **Severity:** `halt-and-report` at gate-review (reviewer at `/implement` + release-specialist at `/release` confirm no public-published artifact in the diff names the private Rust SDK repo/org/version/issue); `advisory` at any hook layer (a lexical `kailash-rs|esperie` scan of public artifacts cannot carry `block` per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing.
+- **Cumulative posture impact:** same-class violations (a private-repo reference shipped in a public-published artifact) contribute per `trust-posture.md` MUST-4 (3× same-rule / 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** trigger key `public_artifact_private_repo_disclosure` fires emergency downgrade (1 step) per `trust-posture.md` MUST-4.
+- **Receipt requirement:** SessionStart `[ack: cross-sdk-inspection]` IFF `posture.json::pending_verification` includes this rule_id (soft-gate; shared with Rules 4b/4c).
+- **Detection mechanism:** Phase 1 — gate-level reviewer at `/implement` + `/release`: for any diff touching `CHANGELOG.md` / `README.md` / `docs/` / package metadata, grep `kailash-rs|esperie` and halt on a hit. Phase 2 (deferred): a `PostToolUse(Edit|Write)` advisory scanning public-artifact paths.
+- **Violation scope:** this clause (private-repo references in public-published artifacts). Every violation row names the artifact + the leaked reference.
+- **Origin:** 2026-07-02 — a `/codify` session found 27 references to the private `esperie-enterprise/kailash-rs` (incl. the private org names + rs versions/issues/crate-paths/architecture) in the public, PyPI-published `CHANGELOG.md`; scrubbed in kailash-py PR #1488. User directive: "why will CHANGELOG record kailash-rs? There is NO REASON TO!" This clause generalizes the fix to all public-published artifacts.
+
 ## Examples
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **Scale-out ready** -- Distributed circuit breaker (Redis-backed with Lua atomic transitions), multi-worker task queue architecture, resource quotas with semaphore-based concurrency control, coordinated graceful shutdown, Kubernetes deployment manifests.
 - **Progressive infrastructure** -- Start with zero config (SQLite), scale to multi-worker PostgreSQL/MySQL by changing environment variables. Dialect-portable SQL via QueryDialect strategy pattern. SQL task queue with `SKIP LOCKED`, worker heartbeat registry, exactly-once idempotent execution. No code changes between Level 0 (dev) and Level 2 (production).
 - **Infrastructure-agnostic** -- `LocalRuntime` runs entirely in-process. No server cluster, no external database, no message broker. Deploy anywhere: any cloud, any region, on-prem, edge, air-gapped. Zero vendor lock-in.
-- **Unified engine APIs** -- `DataFlowEngine.builder("sqlite:///app.db").build()` and `NexusEngine.builder().preset(Preset.SAAS).build()` provide fluent builder patterns with validation layers, data classification, query monitoring, and enterprise middleware. Cross-SDK parity with kailash-rs.
+- **Unified engine APIs** -- `DataFlowEngine.builder("sqlite:///app.db").build()` and `NexusEngine.builder().preset(Preset.SAAS).build()` provide fluent builder patterns with validation layers, data classification, query monitoring, and enterprise middleware. Cross-SDK parity.
 - **Field-level validation and data classification** -- Declarative `@field_validator` and `@classify` decorators on DataFlow models. Built-in validators for email, URL, UUID, phone, length, range, pattern. Classification levels (PII, internal, public) with retention policies and masking strategies.
 - **Organizational governance (PACT)** -- D/T/R accountability grammar, operating envelopes with monotonic tightening, knowledge clearance levels, verification gradient, and MCP tool governance. Governs AI agent organizations with fail-closed decisions and anti-self-modification defense.
 - **Foundation for four application frameworks** -- [Kaizen](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-kaizen) (AI agents with trust), [Nexus](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-nexus) (multi-channel deploy), [DataFlow](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-dataflow) (zero-config database), and [PACT](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-pact) (organizational governance) are all built on this Core SDK.
@@ -157,13 +157,13 @@ schema, model_spec, eval_spec = kailash_ml.from_brief(
 
 The five `from_brief()` surfaces are NOT named inconsistently by accident. The verb form reflects what each call returns:
 
-| Surface       | Entry point                          | Returns                                | Verb form         | Why                                                                |
-| ------------- | ------------------------------------ | -------------------------------------- | ----------------- | ------------------------------------------------------------------ |
-| Workflow      | `Workflow.from_brief(brief)`         | `Workflow` instance                    | classmethod       | result IS a Workflow — `cls(...)` is the natural constructor       |
-| DataFlow      | `DataFlow.from_brief(brief, conn)`   | `DataFlow` instance                    | classmethod       | result IS a DataFlow — same naming convention                      |
-| Kaizen        | `Kaizen.signature_from_brief(brief)` | `Signature` SUBCLASS (not a Kaizen)    | classmethod (suffix verb) | result is a Signature, NOT a Kaizen — the `signature_` suffix tells you what you got back |
-| Bootstrap     | `kailash.bootstrap(brief, profile)`  | `Config` dataclass                     | module-level      | result is a Config, NOT a kailash module — module-level is the honest verb         |
-| ML            | `kailash_ml.from_brief(brief, df)`   | `(FeatureSchema, ModelSpec, EvalSpec)` | module-level      | result is a triple of three independent dataclasses — module-level for the same reason |
+| Surface   | Entry point                          | Returns                                | Verb form                 | Why                                                                                       |
+| --------- | ------------------------------------ | -------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------- |
+| Workflow  | `Workflow.from_brief(brief)`         | `Workflow` instance                    | classmethod               | result IS a Workflow — `cls(...)` is the natural constructor                              |
+| DataFlow  | `DataFlow.from_brief(brief, conn)`   | `DataFlow` instance                    | classmethod               | result IS a DataFlow — same naming convention                                             |
+| Kaizen    | `Kaizen.signature_from_brief(brief)` | `Signature` SUBCLASS (not a Kaizen)    | classmethod (suffix verb) | result is a Signature, NOT a Kaizen — the `signature_` suffix tells you what you got back |
+| Bootstrap | `kailash.bootstrap(brief, profile)`  | `Config` dataclass                     | module-level              | result is a Config, NOT a kailash module — module-level is the honest verb                |
+| ML        | `kailash_ml.from_brief(brief, df)`   | `(FeatureSchema, ModelSpec, EvalSpec)` | module-level              | result is a triple of three independent dataclasses — module-level for the same reason    |
 
 Rule of thumb: if the call returns an instance of the host class, it's a classmethod. If the call returns something else, the verb lives at module level so callers don't import-then-call something whose name lies about its return type.
 
@@ -467,7 +467,7 @@ Structural invariants — re-validated on every dispatch + execute path:
 Cross-implementation receipt evidence:
 
 - 5 conformance vectors pinned in `tests/fixtures/delegate-conformance/canonical.json` (DV-3-001, DV-5-001, DV-7-001, DV-9-001, DV-10-001).
-- 2 vectors (DV-5-001, DV-10-001) vendored byte-for-byte from kailash-rs canonical per `cross-sdk-inspection.md` Rule 4a.
+- 2 vectors (DV-5-001, DV-10-001) vendored byte-for-byte from the cross-SDK canonical per `cross-sdk-inspection.md` Rule 4a.
 - `receipts_agree(rs, py)` cross-impl comparator with default timestamp-exclusion (`terminated_at`, `executed_at`, `started_at`, `signed_at`) and ordered comparison for chained data (`audit_chain_entries`, TAOD `transitions`).
 - Vector tamper-detection on load — `ConformanceVectorIntegrityError` raises on hash-drift between the fixture's stored `digest` and a re-computed digest.
 
@@ -506,7 +506,7 @@ print(f"{len(vectors)} vectors: {[v.vector_id for v in vectors]}")
 
 ### Status: pre-pledge
 
-The primitive is **pre-pledge**: structurally complete, byte-shape-pinned against kailash-rs, deferral set disclosed. Not yet attested to PACT D/T/R compliance or third-party security audit. The post-pledge state requires:
+The primitive is **pre-pledge**: structurally complete, byte-shape-pinned against the cross-SDK canonical, deferral set disclosed. Not yet attested to PACT D/T/R compliance or third-party security audit. The post-pledge state requires:
 
 - §10 G1 closure ([issue #1143](https://github.com/terrene-foundation/kailash-py/issues/1143))
 - Independent PACT-class audit

--- a/workspaces/mops-onboarding/journal/0006-AUTHORIZATION-cross-repo-esperie-kailash-rs-filing.md
+++ b/workspaces/mops-onboarding/journal/0006-AUTHORIZATION-cross-repo-esperie-kailash-rs-filing.md
@@ -1,0 +1,56 @@
+---
+type: AUTHORIZATION
+date: 2026-07-02T08:51:12Z
+requester: Jack Hong <jack@integrum.global>
+target: esperie-enterprise/kailash-rs
+---
+
+# Cross-Repo Authorization — file/comment on esperie-enterprise/kailash-rs
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Requester
+
+Jack Hong (jack@integrum.global) — user, in-session.
+
+## Verbatim instruction
+
+Turn 1: "i approve the filing"
+Turn 2 (after corrected-scope recommendation): "approved"
+
+The corrected scope was explicitly presented to and approved by the user:
+comment the merged kailash-py PR #1486 cross-reference onto the EXISTING
+rs issue #1551 (do NOT file a duplicate ConsentAttestation issue), and
+file ONE new disclosure-trace issue (cross-SDK of kailash-py #1482) IF a
+re-check confirms none exists.
+
+## Target
+
+`esperie-enterprise/kailash-rs` (private Rust SDK BUILD repo; verified to
+exist — `gh repo view` → private=true, issues=true).
+
+## Exact bounded action (scoped)
+
+1. `gh issue comment 1551` on esperie-enterprise/kailash-rs — add a
+   cross-SDK transparency comment linking merged kailash-py PR #1486
+   (ConsentAttestation, cross-SDK of py #1481). No new issue for #1481.
+2. `gh issue list`/`view` on esperie-enterprise/kailash-rs — dedup re-check
+   for an existing disclosure-trace issue.
+3. `gh issue create` on esperie-enterprise/kailash-rs — ONE issue:
+   per-recipient disclosure-trace tokens (cross-SDK of kailash-py #1482),
+   ONLY if step 2 finds no existing equivalent.
+
+No other repo, no other action, no incidental writes. Purpose: EATP-D6
+spec-parity transparency (specs drive both SDKs; the issue is a
+transparency signal, not a command).
+
+## Timestamp
+
+Authorized + receipt landed: 2026-07-02T08:51:12Z (BEFORE any rs command
+in the corrected-scope execution).
+
+## Process note
+
+An earlier pre-flight existence/dup/label read against rs ran BEFORE this
+receipt (repo-scope-discipline MUST-NOT-1 hook halt, 2026-07-02). This
+receipt corrects the ordering; all further rs commands run AFTER it.

--- a/workspaces/mops-onboarding/journal/0007-DECISION-cross-sdk-disclosure-hygiene-codify.md
+++ b/workspaces/mops-onboarding/journal/0007-DECISION-cross-sdk-disclosure-hygiene-codify.md
@@ -1,0 +1,29 @@
+---
+type: DECISION
+date: 2026-07-02
+display_id: esperie
+---
+
+# DECISION — cross-SDK disclosure-hygiene codify (2026-07-02)
+
+## What was updated and why
+
+**Rule change (global, proposed for loom):** `.claude/rules/cross-sdk-inspection.md`
+
+- **Repo-path correction** (PR #1487): the rule filed cross-SDK issues at `terrene-foundation/kailash-rs`, which does not exist. Corrected to the real private `esperie-enterprise/kailash-rs` (Rule 1 + Example). Sibling fixes: `guides/rule-extracts/git.md` protection table + `guides/deterministic-quality/08-cross-sdk-parity.md` workflow. Root cause: I parroted the wrong path from the rule's own examples + issue #1483's body, ignoring my persisted `reference-kailash-rs-repo-location` memory which already carried the correction.
+- **New MUST Rule 6** — public-published artifacts (CHANGELOG/README/docs/package-metadata) MUST NOT name the private Rust SDK repo/org/versions/issues/crate-paths/architecture (disclosure + Foundation Independence, Directive 0). 8-field trust-posture wiring, trigger `public_artifact_private_repo_disclosure`.
+
+**Same-class fixes (autonomous-execution Rule 4), landed BUILD-side:**
+
+- `CHANGELOG.md` — 27 private-Rust-SDK references removed/genericized (PR #1488).
+- `README.md` (PyPI long_description) — 3 bare `kailash-rs` refs genericized (codify PR).
+
+**Feature work merged this session (issues #1480/#1481/#1482/#1483):** PACT authz-root re-validation (#1480, PR #1484), hold-resolution disclosure-binding (#1483, PR #1485), ConsentAttestation + disclosure-trace primitives (#1481/#1482, PR #1486). Cross-SDK transparency filed on `esperie-enterprise/kailash-rs`: comment on #1551 (ConsentAttestation), new #1592 (disclosure-trace), under journaled authorization (0006).
+
+## Redteam
+
+reviewer + security-reviewer + cc-architect (parallel) on Rule 6 → MERGE-WITH-FIXES; all applied. Corrected a false "self-referential" premise (cross-sdk-inspection.md is NOT on the allowlist; my earlier `grep | head && echo` check was a shell-logic false positive).
+
+## Anchor
+
+`learning-codified.json::last_codified` advanced to 2026-07-02. The 287 telemetry observations in the backlog are auto-captured test-pattern noise, not codified.

--- a/workspaces/mops-onboarding/journal/0008-DISCOVERY-public-artifact-private-repo-leak.md
+++ b/workspaces/mops-onboarding/journal/0008-DISCOVERY-public-artifact-private-repo-leak.md
@@ -1,0 +1,20 @@
+---
+type: DISCOVERY
+date: 2026-07-02
+display_id: esperie
+---
+
+# DISCOVERY — public artifacts silently accrue private-repo disclosure
+
+## Pattern (inherit next session)
+
+**Public-published artifacts leak the private sibling SDK over time.** The public, PyPI-published `CHANGELOG.md` had accumulated **27** references to the private `esperie-enterprise/kailash-rs` — org names, versions, issue numbers, crate paths, even internal architecture ("axum + tokio") — one cross-SDK parity note at a time across many releases. Each looked harmless; the aggregate is a standing disclosure + a Foundation-Independence (Directive 0) violation. README (the PyPI long_description) carried 3 more. Now codified as `cross-sdk-inspection.md` Rule 6.
+
+**Cross-repo target resolution: trust reference-memory + `settings.local.json`, NOT rule-doc examples or issue bodies.** I recommended filing at `terrene-foundation/kailash-rs` (nonexistent) because both the rule's own examples AND issue #1483's body carried that wrong path — while my persisted `reference-kailash-rs-repo-location` memory already said the real repo is the private `esperie-enterprise/kailash-rs`. The synced doc was wrong; the memory was right; I trusted the doc. Memory updated with a CRITICAL "do not trust rule-doc/issue-body for this path" warning.
+
+**specs drive both SDKs (EATP D6).** Neither SDK drives the other. A cross-SDK issue is a TRANSPARENCY signal to maintain spec parity, not a command. Filing on the sibling repo requires the repo-scope-discipline User-Authorized Exception: journaled `cross-repo-authorized:` receipt BEFORE any command touches the sibling — I ran pre-flight reads before the receipt this session and the hook correctly halted me; corrected by landing the receipt (0006) first.
+
+## Process lessons
+
+- `grep pattern file | head -1 && echo X` fires the echo unconditionally (`head` always exits 0) — a false-positive detector I used to (wrongly) conclude a file was allowlisted. Use `grep -q` and check its exit, not a piped `head && echo`.
+- A private seed-org token (`rrps-mtu`) from memory leaked into the very rule meant to prevent leaks; redteam caught it. Private scan tokens belong in gitignored operator-local config, never a synced rule.


### PR DESCRIPTION
## Summary
`/codify` cycle capturing this session's cross-SDK disclosure-hygiene learnings.

- **New `cross-sdk-inspection.md` Rule 6** — public-published artifacts (CHANGELOG/README/docs/package-metadata) MUST NOT name the private Rust SDK repo/org/versions/issues/crate-paths/architecture (disclosure + Foundation Independence, Directive 0). 8-field trust-posture wiring.
- **README.md scrub** — 3 bare `kailash-rs` refs (the PyPI long_description) genericized; same-class same-session fix per autonomous-execution Rule 4.
- **Proposal append** (`latest.yaml`) — the repo-path correction (PR #1487) + Rule 6, both suggested GLOBAL, for loom fleet-wide distribution (⚠️ the wrong path exists upstream at loom + all consumers; a `/sync-to-build` would re-overwrite the local fix otherwise).
- **Journal** 0006/0007/0008 (authorization receipt / DECISION / DISCOVERY).

## Redteam
reviewer + security-reviewer + cc-architect (parallel) → MERGE-WITH-FIXES; all applied (README scrub + removed a leaked `rrps-mtu` seed-org token from the clause's grep). Corrected a false self-referential premise (cross-sdk-inspection.md is NOT on the allowlist; clause deliberately kept off it — public-artifact hygiene is code-behavior governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)