### PR TITLE
release: kailash 2.45.1 + kailash-dataflow 2.13.2

### DIFF
--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.1"
+version = "2.13.2"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.1"
+__version__ = "2.13.2"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.0"
+version = "2.45.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.0"
+__version__ = "2.45.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Changes

- **fix(fabric):** Prevent ChangeDetector startup poll storm; expose max_concurrent (#1492, ce4f6dab2)
- **fix(fabric):** Remove exc_info from ChangeDetector poll-loop WARNING log (c53308b86)

## Version bumps

- kailash 2.45.0 → 2.45.1
- kailash-dataflow 2.13.1 → 2.13.2

## Related issues

Fixes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)