### PR TITLE
fix(dataflow): import SQLite adapter without the optional aiosqlite driver

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
@@ -20,7 +20,56 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import aiosqlite
+
+class _AiosqliteNotInstalled:
+    """Lazy stub bound when the optional ``aiosqlite`` driver is absent.
+
+    ``aiosqlite`` is an opt-in driver (``kailash-dataflow[sqlite]``), NOT a core
+    dependency. Mirroring the deferred-driver pattern the MongoDB / pgvector
+    adapters use (see ``adapters/__init__.py``), the ``SQLiteAdapter`` class
+    object MUST import cleanly so ``dataflow.adapters`` and its ``__all__``
+    resolve without the extra installed. Any runtime attribute access
+    (``aiosqlite.connect`` / ``aiosqlite.Row``) raises a descriptive
+    ``ImportError`` at connect time — the "loud failure at call site" the
+    optional-extras carve-out in ``rules/dependencies.md`` permits.
+    """
+
+    def __getattr__(self, _name: str) -> Any:
+        raise ImportError(
+            "SQLite support requires the 'aiosqlite' driver. "
+            "Install it with: pip install 'kailash-dataflow[sqlite]'"
+        )
+
+
+try:
+    import aiosqlite
+
+    _HAS_AIOSQLITE = True
+except (
+    ModuleNotFoundError
+):  # pragma: no cover - exercised only without the [sqlite] extra
+    # Narrow to ModuleNotFoundError so a genuinely-absent driver binds the stub
+    # (clean-install path) while a present-but-BROKEN aiosqlite (whose own
+    # internal import raises a plain ImportError) propagates its real diagnostic
+    # instead of the misleading "install the [sqlite] extra" hint.
+    aiosqlite = _AiosqliteNotInstalled()  # type: ignore[assignment]
+    _HAS_AIOSQLITE = False
+
+
+def _require_aiosqlite() -> None:
+    """Fail fast with a descriptive error when the SQLite driver is absent.
+
+    Called at every connect boundary so a missing optional driver surfaces
+    ONE clear ImportError up front, rather than being swallowed by the
+    connection pool's per-connection ``except`` (which is meant for transient
+    failures, not a hard missing-driver condition) and deferred to first query.
+    """
+    if not _HAS_AIOSQLITE:
+        raise ImportError(
+            "SQLite support requires the 'aiosqlite' driver. "
+            "Install it with: pip install 'kailash-dataflow[sqlite]'"
+        )
+
 
 from .base import DatabaseAdapter
 from .dialect import DialectManager
@@ -250,7 +299,10 @@ class SQLiteAdapter(DatabaseAdapter):
         )
 
         # Connection pool management
-        self._connection_pool: List[aiosqlite.Connection] = []
+        # Runtime type: aiosqlite.Connection. Typed Any (matching the MongoDB
+        # sibling adapter) because the module-level ``aiosqlite`` name is a live
+        # runtime variable (module | stub), so it cannot double as a type here.
+        self._connection_pool: List[Any] = []
         self._pool_lock = asyncio.Lock()
         self._sqlite_pool: Any = None  # AsyncSQLitePool instance (when available)
         self._active_transactions: weakref.WeakSet = weakref.WeakSet()
@@ -299,6 +351,7 @@ class SQLiteAdapter(DatabaseAdapter):
 
     async def connect(self) -> None:
         """Establish SQLite connection with enterprise features."""
+        _require_aiosqlite()
         try:
             # Initialize connection pool if enabled
             if self.enable_connection_pooling:
@@ -1061,7 +1114,9 @@ class SQLiteTransaction:
 
     def __init__(self, adapter: "SQLiteAdapter"):
         self.adapter = adapter
-        self.connection: Optional[aiosqlite.Connection] = None
+        # Runtime type: Optional[aiosqlite.Connection] (typed Any so the
+        # annotation does not require the optional aiosqlite module at import).
+        self.connection: Any = None
         self._committed = False
         self._rolled_back = False
         self._pool_cm: Any = None
@@ -1091,6 +1146,7 @@ class SQLiteTransaction:
 
     async def __aenter__(self):
         """Enter transaction context."""
+        _require_aiosqlite()
         # Prefer AsyncSQLitePool when available
         if self.adapter._sqlite_pool is not None:
             self._pool_cm = self.adapter._sqlite_pool.acquire_write()

--- a/packages/kailash-dataflow/tests/regression/test_sqlite_optional_aiosqlite_import.py
+++ b/packages/kailash-dataflow/tests/regression/test_sqlite_optional_aiosqlite_import.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: the SQLite adapter MUST import without the optional
+``aiosqlite`` driver (F-AIOSQLITE).
+
+``aiosqlite`` is an OPT-IN driver declared under the ``kailash-dataflow[sqlite]``
+extra — NOT a core dependency. Before the fix, ``adapters/sqlite.py`` did a
+module-scope ``import aiosqlite`` that ``adapters/__init__.py`` eagerly pulls in
+(``from .sqlite import SQLiteAdapter``). On a clean ``pip install kailash-dataflow``
+without the ``[sqlite]`` extra, ``import dataflow.adapters`` — and any code that
+imports the public ``SQLiteAdapter`` from ``dataflow.adapters.__all__`` — raised
+``ModuleNotFoundError: No module named 'aiosqlite'``.
+
+The fix mirrors the deferred-driver pattern the MongoDB / pgvector sibling
+adapters use: the class object imports cleanly (a lazy stub is bound when the
+driver is absent), and the descriptive ``ImportError`` surfaces at the connect
+boundary via ``_require_aiosqlite()`` — the "loud failure at call site"
+``rules/dependencies.md`` permits for optional extras.
+
+Because ``aiosqlite`` IS installed in the dev/test environment, the clean-install
+condition is reproduced faithfully in a subprocess that installs a ``meta_path``
+finder rejecting the ``aiosqlite`` import — a boundary-injected fixture
+(``user-flow-validation.md`` MUST-7) rather than a mock of the import machinery.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Reproduces a clean install WITHOUT the [sqlite] extra: a meta_path finder that
+# raises ImportError for aiosqlite, exactly as a missing package would.
+_BLOCKER = textwrap.dedent(
+    """
+    import sys
+
+    class _AiosqliteBlocker:
+        def find_spec(self, name, path, target=None):
+            # A genuinely-absent module raises ModuleNotFoundError (subclass of
+            # ImportError). Match that exactly so the fixture reproduces a real
+            # clean install, not a broken-but-installed package.
+            if name == "aiosqlite" or name.startswith("aiosqlite."):
+                raise ModuleNotFoundError("No module named 'aiosqlite' (simulated clean install)")
+            return None
+
+    sys.meta_path.insert(0, _AiosqliteBlocker())
+    """
+)
+
+
+def _run(body: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCKER + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.regression
+def test_dataflow_adapters_import_without_aiosqlite():
+    """``import dataflow.adapters`` + public ``SQLiteAdapter`` import cleanly
+    when aiosqlite is absent."""
+    result = _run(
+        """
+        import dataflow.adapters
+        from dataflow.adapters import SQLiteAdapter
+        # Constructing the adapter must NOT require the driver either.
+        SQLiteAdapter("sqlite:///:memory:")
+        print("IMPORT_OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"import failed without aiosqlite:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "IMPORT_OK" in result.stdout
+
+
+@pytest.mark.regression
+def test_sqlite_connect_fails_fast_without_aiosqlite():
+    """``SQLiteAdapter.connect()`` raises a descriptive ImportError up front
+    (not a swallowed pool warning, not a deferred first-query failure) when
+    aiosqlite is absent."""
+    result = _run(
+        """
+        import asyncio
+        from dataflow.adapters import SQLiteAdapter
+
+        adapter = SQLiteAdapter("sqlite:///:memory:")
+        try:
+            asyncio.run(adapter.connect())
+        except ImportError as e:
+            assert "aiosqlite" in str(e)
+            assert "kailash-dataflow[sqlite]" in str(e)
+            print("FAILED_FAST_OK")
+        else:
+            raise AssertionError("connect() did not fail fast without aiosqlite")
+        """
+    )
+    assert result.returncode == 0, (
+        f"connect() did not fail fast as expected:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "FAILED_FAST_OK" in result.stdout


### PR DESCRIPTION
## Summary

`aiosqlite` is an opt-in driver under the `kailash-dataflow[sqlite]` extra, but `adapters/sqlite.py` imported it at **module scope**. Since `adapters/__init__.py` eagerly runs `from .sqlite import SQLiteAdapter`, a clean `pip install kailash-dataflow` **without** the extra raised `ModuleNotFoundError: No module named 'aiosqlite'` on `import dataflow.adapters` and on importing the public `SQLiteAdapter` (advertised in `__all__`).

## Fix

Mirrors the deferred-driver pattern the MongoDB / pgvector sibling adapters already use:
- Bind a lazy stub (`_AiosqliteNotInstalled`) when the driver is absent, so the class object imports cleanly.
- Surface a descriptive `ImportError` **at the connect boundary** (`connect()` / `SQLiteTransaction.__aenter__`) via `_require_aiosqlite()` — up front, not swallowed by the pool's per-connection `except` and deferred to first query.
- `except ModuleNotFoundError` (not bare `ImportError`) so a *present-but-broken* aiosqlite surfaces its real diagnostic instead of the misleading install hint.

## Verification
- With **all** optional drivers blocked, every public dataflow import surface loads; no other module-scope optional-driver import remains anywhere in the package.
- New regression tests (`tests/regression/test_sqlite_optional_aiosqlite_import.py`) reproduce a clean install via a `meta_path` finder (boundary-injected fixture, not a mock): assert `import dataflow.adapters` + `SQLiteAdapter` load, and that `connect()` fails fast with the descriptive error.
- Rigorous failing-set diff vs `main`: **0 new test failures** introduced.
- Reviewed clean by `reviewer` + `security-reviewer` (no CRITICAL/HIGH/MEDIUM).

## Related issues
Closes the F-AIOSQLITE clean-install break (kailash-dataflow[sqlite] optional-driver import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)