### PR TITLE
release(dataflow): 2.13.3 — SQLite adapter imports without optional aiosqlite [AUTHORIZATION PENDING]

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.13.3] — 2026-07-03 — SQLite adapter imports without the optional aiosqlite driver
+
+### Fixed
+
+- **`import dataflow.adapters` no longer requires the optional `aiosqlite` driver (F-AIOSQLITE).** `aiosqlite` is an opt-in driver under the `kailash-dataflow[sqlite]` extra, but `adapters/sqlite.py` imported it at module scope. Because `adapters/__init__.py` eagerly runs `from .sqlite import SQLiteAdapter`, a clean `pip install kailash-dataflow` without the extra raised `ModuleNotFoundError: No module named 'aiosqlite'` on `import dataflow.adapters` and on importing the public `SQLiteAdapter` (advertised in `__all__`). The adapter now mirrors the deferred-driver pattern the MongoDB / pgvector sibling adapters use: a lazy stub is bound when the driver is absent so the class object imports cleanly, and a descriptive `ImportError` (naming the `[sqlite]` extra) is raised up front at the connect boundary (`connect()` / `SQLiteTransaction.__aenter__`) rather than being swallowed by the pool's per-connection error handler and deferred to first query. `except ModuleNotFoundError` (not bare `ImportError`) lets a present-but-broken `aiosqlite` surface its real diagnostic. Regression tests reproduce a clean install via a `meta_path` finder.
+
 ## [2.13.1] — 2026-06-26 — Migration adapter runtime leak fix
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.2"
+version = "2.13.3"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.2"
+__version__ = "2.13.3"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## ⚠️ Release authorization pending — do NOT merge/tag/publish without owner go

Metadata-only release-prep for **kailash-dataflow 2.13.3**, bundling the F-AIOSQLITE fix already merged to `main` (PR #1495). Prepared to the edge of the irreversible step; the **PyPI publish + `dataflow-v2.13.3` tag are intentionally NOT performed** by the autonomous session (owner-authorized step).

## Contents (metadata-only)
- `pyproject.toml`: `2.13.2` → `2.13.3`
- `src/dataflow/__init__.py`: `__version__` `2.13.2` → `2.13.3` (atomic with pyproject, zero-tolerance Rule 5)
- `CHANGELOG.md`: `## [2.13.3]` entry for the aiosqlite optional-import fix

## To finish the release (owner)
1. Merge this PR to `main`.
2. `git tag dataflow-v2.13.3 && git push origin dataflow-v2.13.3` → triggers the sub-package publish workflow.

## Notes
- Branch uses the `release/v*` convention so the PR-gate matrix auto-skips (metadata-only diff).
- Pre-existing CHANGELOG gap: `2.13.2` has no entry (landed last session without one); not reconstructed here to avoid fabricating unverified release notes.

## Related
Delivers PR #1495 (F-AIOSQLITE) to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)