### PR TITLE
fix(dataflow): apply every PRAGMA to each initially-pooled SQLite connection (#1497)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
@@ -863,13 +863,17 @@ class SQLiteAdapter(DatabaseAdapter):
             if self.enable_connection_pooling:
                 # Legacy list-based pool (fallback)
                 for _ in range(min(5, self.max_connections)):
+                    conn = None
                     try:
                         conn = await aiosqlite.connect(
                             self.database_path, **self._connect_kwargs
                         )
                         conn.row_factory = aiosqlite.Row
 
-                        # Apply SQLite pragmas for enterprise features
+                        # Apply SQLite pragmas for enterprise features.
+                        # The execute MUST stay inside the loop — a dedent here
+                        # applies only the LAST pragma (foreign_keys silently OFF
+                        # on pooled connections) and NameErrors on empty pragmas.
                         for pragma, value in self.pragmas.items():
                             if self.is_memory_database and pragma in (
                                 "journal_mode",
@@ -878,7 +882,10 @@ class SQLiteAdapter(DatabaseAdapter):
                             ):
                                 continue
                             safe_name, safe_value = _validate_pragma(pragma, value)
-                        await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                            cursor = await conn.execute(
+                                f"PRAGMA {safe_name} = {safe_value}"
+                            )
+                            await cursor.close()
 
                         self._connection_pool.append(conn)
                         self._pool_stats.total_connections += 1
@@ -889,6 +896,19 @@ class SQLiteAdapter(DatabaseAdapter):
                             "sqlite.failed_to_create_connection_in_pool",
                             extra={"error": str(e)},
                         )
+                        # The append above transfers ownership to the pool; a
+                        # failure before it (e.g. a pragma raising) leaves this
+                        # frame owning an open connection that _close_connection_pool
+                        # will never see. Close it here so it is not orphaned to GC
+                        # as a leaked aiosqlite Connection.
+                        if conn is not None:
+                            try:
+                                await conn.close()
+                            except Exception as close_err:  # best-effort cleanup
+                                logger.debug(
+                                    "sqlite.pool_init_cleanup_close_failed",
+                                    extra={"error": str(close_err)},
+                                )
                         break
 
                 logger.info(

--- a/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
@@ -454,7 +454,10 @@ class SQLiteAdapter(DatabaseAdapter):
                         ):
                             continue
                         safe_name, safe_value = _validate_pragma(pragma, value)
-                        await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                        cursor = await conn.execute(
+                            f"PRAGMA {safe_name} = {safe_value}"
+                        )
+                        await cursor.close()
                     self._pool_stats.total_connections += 1
                     self._pool_stats.active_connections += 1
 
@@ -492,7 +495,8 @@ class SQLiteAdapter(DatabaseAdapter):
                     ):
                         continue
                     safe_name, safe_value = _validate_pragma(pragma, value)
-                    await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                    cursor = await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                    await cursor.close()
                 yield conn
 
     async def execute_query(
@@ -936,7 +940,8 @@ class SQLiteAdapter(DatabaseAdapter):
                     ):
                         continue
                     safe_name, safe_value = _validate_pragma(pragma, value)
-                    await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                    cursor = await conn.execute(f"PRAGMA {safe_name} = {safe_value}")
+                    await cursor.close()
 
                 # Test query
                 cursor = await conn.execute("SELECT 1 as test")
@@ -1192,9 +1197,10 @@ class SQLiteTransaction:
                         ):
                             continue
                         safe_name, safe_value = _validate_pragma(pragma, value)
-                        await self.connection.execute(
+                        cursor = await self.connection.execute(
                             f"PRAGMA {safe_name} = {safe_value}"
                         )
+                        await cursor.close()
                     self.adapter._pool_stats.total_connections += 1
                     self.adapter._pool_stats.active_connections += 1
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1497_pooled_pragma.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1497_pooled_pragma.py
@@ -1,0 +1,118 @@
+"""Regression: SQLite pooled connections apply only the LAST PRAGMA (#1497).
+
+Root cause: ``SQLiteAdapter._initialize_connection_pool`` dedented the
+``await conn.execute("PRAGMA ...")`` OUTSIDE the ``for pragma, value in
+self.pragmas.items()`` loop, so only the final pragma (``optimize``) was ever
+applied to each initially-pooled connection. ``foreign_keys`` is the *first*
+pragma in the default dict, so FK enforcement was silently OFF on every
+initial pooled connection while overflow connections (created inside
+``_get_connection``, where the execute is correctly in-loop) had it ON — an
+internally-inconsistent pool. An empty ``pragmas`` dict additionally raised
+``NameError`` on the unbound ``safe_name`` at the dedented execute.
+
+Tier-2 — NO MOCKING. Real ``SQLiteAdapter``, real ``aiosqlite``, real
+file-backed SQLite, real ``PRAGMA`` reads. Structural behavioral assertions
+(actual pragma values read back off pooled connections), not lexical source
+scanning.
+
+The coupled aiosqlite Connection-leak acceptance criterion (#1497 AC-2) is
+pinned by ``test_issue_1051_memory_connection_leak.py`` — the pragma re-indent
+keeps that suite green in the full ``-k sqlite`` slice.
+"""
+
+import pytest
+
+from dataflow.adapters.sqlite import SQLiteAdapter
+
+
+async def _read_pragma(conn, name: str):
+    cursor = await conn.execute(f"PRAGMA {name}")
+    row = await cursor.fetchone()
+    await cursor.close()
+    return row[0] if row else None
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_issue_1497_initial_pooled_conn_applies_every_pragma(sqlite_file_url):
+    """Every configured pragma reaches each initially-pooled connection.
+
+    The dedent bug applied ONLY ``optimize`` (the last pragma); foreign_keys
+    stayed at SQLite's default 0 and synchronous at the default 2 (FULL).
+    """
+    adapter = SQLiteAdapter(sqlite_file_url)
+    await adapter.connect()
+    try:
+        async with adapter._pool_lock:
+            assert adapter._connection_pool, "pool should be pre-populated"
+            conn = adapter._connection_pool[0]
+
+        # foreign_keys is the FIRST pragma in the default dict — the canonical
+        # victim of the dedent (only the LAST pragma survived).
+        assert await _read_pragma(conn, "foreign_keys") == 1, (
+            "foreign_keys OFF on an initial pooled connection — the pragma "
+            "loop's execute was dedented and only the last pragma applied"
+        )
+        # synchronous is configured NORMAL (1); the bug left it at default 2.
+        assert (
+            await _read_pragma(conn, "synchronous") == 1
+        ), "synchronous not set to configured NORMAL on a pooled connection"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_issue_1497_initial_and_overflow_conns_have_identical_pragmas(
+    sqlite_file_url,
+):
+    """Initial-pool and overflow connections apply an identical pragma set.
+
+    Overflow connections are created in ``_get_connection`` (execute already
+    in-loop); initial connections in ``_initialize_connection_pool`` (the
+    fixed site). Before the fix the two diverged (initial: FK off; overflow:
+    FK on).
+    """
+    adapter = SQLiteAdapter(sqlite_file_url)
+    await adapter.connect()
+    try:
+        # An initial pooled connection.
+        async with adapter._pool_lock:
+            initial_conn = adapter._connection_pool[0]
+        initial_fk = await _read_pragma(initial_conn, "foreign_keys")
+        initial_sync = await _read_pragma(initial_conn, "synchronous")
+
+        # Force an overflow connection: drain the pool, then acquire one more.
+        async with adapter._pool_lock:
+            drained = list(adapter._connection_pool)
+            adapter._connection_pool.clear()
+        async with adapter._get_connection() as overflow_conn:
+            overflow_fk = await _read_pragma(overflow_conn, "foreign_keys")
+            overflow_sync = await _read_pragma(overflow_conn, "synchronous")
+        # Restore drained connections so disconnect closes them all.
+        async with adapter._pool_lock:
+            adapter._connection_pool.extend(drained)
+
+        assert (
+            initial_fk == overflow_fk == 1
+        ), f"foreign_keys divergence: initial={initial_fk} overflow={overflow_fk}"
+        assert (
+            initial_sync == overflow_sync == 1
+        ), f"synchronous divergence: initial={initial_sync} overflow={overflow_sync}"
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_issue_1497_empty_pragmas_does_not_nameerror(sqlite_file_url):
+    """An empty ``pragmas`` dict must not NameError on the (formerly unbound)
+    ``safe_name`` at the dedented execute."""
+    adapter = SQLiteAdapter(sqlite_file_url, pragmas={})
+    # connect() -> _initialize_connection_pool() must not raise NameError.
+    await adapter.connect()
+    try:
+        async with adapter._pool_lock:
+            assert adapter._connection_pool, "pool should populate with empty pragmas"
+    finally:
+        await adapter.disconnect()


### PR DESCRIPTION
## Summary

`SQLiteAdapter._initialize_connection_pool` dedented the `await conn.execute("PRAGMA ...")` **outside** the `for pragma, value in self.pragmas.items()` loop, so only the **last** pragma (`optimize`) was applied to each initially-pooled connection. `foreign_keys` is the *first* pragma in the default dict, so **FK enforcement was silently OFF** on every initially-pooled connection, while overflow connections (created in `_get_connection`, execute correctly in-loop) had it ON — an internally-inconsistent pool. `synchronous`/`busy_timeout`/`cache_size`/etc. were likewise never applied to initial pooled connections. An empty `pragmas` dict additionally `NameError`'d on the unbound `safe_name`.

### Fix
- Re-indent the execute back into the loop (matching the correct sibling `_test_connection`), and close each pragma cursor.
- Close the connection in the pool-init `except` branch so a pragma failure before the ownership-transferring `append` does not orphan an open aiosqlite `Connection` to GC.
- Make all five pragma-application sites uniform (capture + close cursor) — a same-class hygiene gap surfaced by gate review (commit 2).

### On the coupled leak #1497 warned about
The issue warned the re-indent would expose an aiosqlite `Connection` leak. **It does not reproduce on current `main`** (aiosqlite 0.22.1, Python 3.13): `test_issue_1051_memory_connection_leak` passes 3/3 in isolation **and** stably across the full `-k sqlite` slice (verified 3× non-flaky) with the re-indent applied — the #1051 keystone fixes already on `main` resolved it. The pragma fix therefore lands cleanly standalone.

## Tests

`packages/kailash-dataflow/tests/regression/test_issue_1497_pooled_pragma.py` (Tier-2, real `aiosqlite`, real file-backed SQLite, no mocking) — 3 tests covering all four acceptance criteria:
- every pragma applied to a pooled connection (`foreign_keys == 1`, `synchronous == 1`)
- initial-pool / overflow pragma-set parity
- empty-pragmas path does not `NameError`

All three fail against the dedented code and pass against the fix (verified by re-introducing the bug). Full `-k sqlite` slice: the 23 pre-existing failures (tracked separately in #1498) are unchanged; the 3 new tests + `test_issue_1051` pass.

## Reviews
- **security-reviewer: SECURE** — confirmed the FK-OFF referential-integrity exposure on the default write path; validator (`_validate_pragma`) still gates every interpolation; no new surface.
- **reviewer: MERGE** — 4/4 mechanical sweeps clean; no other dedent site; no double-close/orphan.

## Follow-up (not in this PR)
Both reviewers flagged **cross-SDK inspection** (`cross-sdk-inspection.md` Rule 1): the Rust SDK's SQLite pool-init should be checked for the same dedent pattern. Cross-repo — requires separate authorization.

## Related issues
Fixes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)