### PR TITLE
release: kailash 2.45.2 + kailash-dataflow 2.13.5 (#1498 SQLite/PG upsert fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.45.2] - 2026-07-03
+
+### Fixed
+
+- **SQLite adapter no longer discards `RETURNING` rows (#1498).** `AsyncSQLDatabaseNode`'s SQLite path short-circuited every `INSERT`/`UPDATE`/`DELETE` to `[{"rows_affected": N}]` on a leading-keyword check, never fetching the `RETURNING` result set — so a `... RETURNING *` insert/update came back as a row-count summary with the returned columns silently dropped (surfaced as DataFlow SQLite upsert returning `{"record": {"rows_affected": 0}}`). Added a `"RETURNING" not in query` guard to both SQLite DML short-circuits so RETURNING queries fall through to the fetch, matching the guard the PostgreSQL adapter already had. Non-RETURNING DML is unchanged.
+
 ## [2.45.0] - 2026-07-02
 
 Trust-plane hardening plus two new trust primitives.

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.13.5] — 2026-07-03 — SQLite/PostgreSQL upsert returns the upserted row and applies update values
+
+### Fixed
+
+- **Single-record upsert now returns the upserted row instead of a DML summary (#1498).** The generated `<Model>UpsertNode` emits `... ON CONFLICT ... RETURNING *`, but the core SQLite adapter discarded the returned rows (fixed in `kailash` 2.45.2 — hence the `kailash>=2.45.2` floor bump), so an upsert came back as `{"created": true, "record": {"rows_affected": 0}, "action": "created"}` and callers reading `record["<field>"]` raised `KeyError`. With the core fix, `record` now carries the upserted row.
+- **Upsert applies the `update` payload's values on conflict (#1498).** `build_upsert_query` (SQLite **and** PostgreSQL) built the `DO UPDATE SET` clause as `col = EXCLUDED.col`, but `EXCLUDED` references the value proposed for INSERT (the `create` payload), not the caller's separate `update` payload. On a conflict the row was therefore set to the `create` values, silently ignoring `update`. The clause now binds the `update` values as parameters (continuing the `:p<i>` sequence so the node's positional→named param rebuild stays aligned). This also fixes two pre-existing PostgreSQL upsert failures, verified against real Postgres.
+
+### Requires
+
+- `kailash>=2.45.2` (the SQLite `RETURNING` fix the upsert row-return depends on).
+
 ## [2.13.4] — 2026-07-03 — SQLite pooled-connection PRAGMA fix + model-registry runtime resolution
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.4"
+version = "2.13.5"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.28.0",
+    "kailash>=2.45.2",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.4"
+__version__ = "2.13.5"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.1"
+version = "2.45.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.1"
+__version__ = "2.45.2"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release prep for the #1498 fixes merged in #1505.

- **kailash 2.45.1 → 2.45.2** — core SQLite adapter RETURNING guard.
- **kailash-dataflow 2.13.4 → 2.13.5** — upsert dialect update-value binding; `kailash>=` floor 2.28.0 → 2.45.2.

Publish order: core first (tag `v2.45.2`), then dataflow (tag `dataflow-v2.13.5`) so the floor resolves.

Refs #1498. Follow-ups: #1502, #1503, #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)