### PR TITLE
release: kailash 2.45.3 + kailash-dataflow 2.13.6 (#1502 :memory: shared-cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.45.3] - 2026-07-03
+
+### Fixed
+
+- **SQLite shared-cache `:memory:` cross-thread support for `SQLDatabaseNode` (#1502).** For a SQLite **memory** connection string only, `SQLDatabaseNode` now uses `StaticPool` + `check_same_thread=False` (and normalizes a `file:` shared-cache URI to `sqlite:///file:...&uri=true`) so the sync model-registry path executed in a thread pool no longer raises `sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread`. File-backed SQLite, PostgreSQL, and MySQL keep `QueuePool` byte-for-byte (the branch is guarded on `mode=memory`/`:memory:`).
+- **Added `SQLDatabaseNode.dispose_pools_for(connection_string)`** — a targeted, per-connection-string pool dispose (vs the global `cleanup_pools`) so a caller can release exactly its own shared pools at teardown without disturbing other live instances (used by DataFlow's `:memory:` teardown to prevent a leaked shared-cache DB + `id()`-reuse cross-instance aliasing).
+
 ## [2.45.2] - 2026-07-03
 
 ### Fixed

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.13.6] — 2026-07-03 — bare sqlite :memory: multi-connection shared-cache
+
+### Fixed
+
+- **Bare `sqlite :memory:` multi-connection now works end-to-end (#1502).** Each consumer of a bare-`:memory:` DataFlow (Express CRUD node, the 5 `SyncDDLExecutor` sites, the migration system, `migration_connection_manager`, `migration_test_framework`, the model registry, the schema-state manager, and the `_get_async_sql_connection` fallback DDL path) previously turned `:memory:` into its **own private** in-memory database, so migrations created tables in one DB while CRUD/registry read another → `no such table`. DataFlow now computes **one shared-cache URI per instance** (`file:df_mem_<id>?mode=memory&cache=shared`, stored as `_memory_db_uri`) and injects it at every SQLite connection-construction site, plus keeps a **lifetime anchor connection** open so the shared-cache DB survives per-node pool churn and event-loop-driven node recreation. `close()`/`close_async()` dispose the registry's `StaticPool` for the instance's URI (preventing a leaked in-memory DB and `id()`-reuse cross-instance aliasing). `config.database.url` is left as the literal `:memory:`, so all dialect-detection is unchanged; the rewrite fires **only** for bare `:memory:` — file-backed SQLite / PostgreSQL / MySQL are byte-for-byte unaffected. The cross-thread registry `sqlite3.ProgrammingError` is fixed in `kailash` 2.45.3 (`SQLDatabaseNode` StaticPool), hence the floor bump.
+
+### Requires
+
+- `kailash>=2.45.3` (the `SQLDatabaseNode` shared-cache-memory StaticPool + `dispose_pools_for` the registry cross-thread path depends on).
+
 ## [2.13.5] — 2026-07-03 — SQLite/PostgreSQL upsert returns the upserted row and applies update values
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.5"
+version = "2.13.6"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.45.2",
+    "kailash>=2.45.3",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.5"
+__version__ = "2.13.6"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.2"
+version = "2.45.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.2"
+__version__ = "2.45.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release prep for the #1502 bare-`:memory:` shared-cache fix merged in #1509.

- **kailash 2.45.2 → 2.45.3** — SQLDatabaseNode shared-cache-memory StaticPool (cross-thread) + `dispose_pools_for`.
- **kailash-dataflow 2.13.5 → 2.13.6** — one shared-cache `:memory:` URI per instance + lifetime anchor threaded through all SQLite connection sites; `kailash>=` floor 2.45.2 → 2.45.3.

Publish order: core first (`v2.45.3`), then dataflow (`dataflow-v2.13.6`).

Refs #1502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)