### PR TITLE
fix(dataflow): SQLite upsert conflict_on works without a UNIQUE constraint (#1508)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -3458,14 +3458,30 @@ class NodeGenerator:
 
                         created_flag = not row_exists
 
-                    # Build upsert query using dialect abstraction
-                    upsert_query = dialect.build_upsert_query(
-                        table_name=table_name,
-                        insert_data=insert_data,
-                        update_data=update_data,
-                        conflict_columns=conflict_columns,
-                        has_updated_at=has_updated_at,
-                    )
+                    # Build upsert query using dialect abstraction.
+                    # SQLite: emit an explicit INSERT/UPDATE from the pre-check
+                    # result (row_exists) instead of INSERT ... ON CONFLICT, which
+                    # requires the conflict target to be backed by a UNIQUE
+                    # constraint. A conflict_on field that is not declared unique
+                    # would otherwise fail with "ON CONFLICT clause does not match
+                    # any PRIMARY KEY or UNIQUE constraint" (issue #1508).
+                    if database_type.lower() == "sqlite":
+                        upsert_query = dialect.build_precheck_upsert_query(
+                            table_name=table_name,
+                            insert_data=insert_data,
+                            update_data=update_data,
+                            where=where,
+                            row_exists=row_exists,
+                            has_updated_at=has_updated_at,
+                        )
+                    else:
+                        upsert_query = dialect.build_upsert_query(
+                            table_name=table_name,
+                            insert_data=insert_data,
+                            update_data=update_data,
+                            conflict_columns=conflict_columns,
+                            has_updated_at=has_updated_at,
+                        )
 
                     query = upsert_query.query
                     params = list(upsert_query.params.values())

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -3458,30 +3458,14 @@ class NodeGenerator:
 
                         created_flag = not row_exists
 
-                    # Build upsert query using dialect abstraction.
-                    # SQLite: emit an explicit INSERT/UPDATE from the pre-check
-                    # result (row_exists) instead of INSERT ... ON CONFLICT, which
-                    # requires the conflict target to be backed by a UNIQUE
-                    # constraint. A conflict_on field that is not declared unique
-                    # would otherwise fail with "ON CONFLICT clause does not match
-                    # any PRIMARY KEY or UNIQUE constraint" (issue #1508).
-                    if database_type.lower() == "sqlite":
-                        upsert_query = dialect.build_precheck_upsert_query(
-                            table_name=table_name,
-                            insert_data=insert_data,
-                            update_data=update_data,
-                            where=where,
-                            row_exists=row_exists,
-                            has_updated_at=has_updated_at,
-                        )
-                    else:
-                        upsert_query = dialect.build_upsert_query(
-                            table_name=table_name,
-                            insert_data=insert_data,
-                            update_data=update_data,
-                            conflict_columns=conflict_columns,
-                            has_updated_at=has_updated_at,
-                        )
+                    # Build upsert query using dialect abstraction
+                    upsert_query = dialect.build_upsert_query(
+                        table_name=table_name,
+                        insert_data=insert_data,
+                        update_data=update_data,
+                        conflict_columns=conflict_columns,
+                        has_updated_at=has_updated_at,
+                    )
 
                     query = upsert_query.query
                     params = list(upsert_query.params.values())

--- a/packages/kailash-dataflow/src/dataflow/sql/dialects.py
+++ b/packages/kailash-dataflow/src/dataflow/sql/dialects.py
@@ -138,6 +138,16 @@ class SQLDialect(ABC):
         # Row exists → UPDATE ... WHERE <where>. Exclude the primary key and the
         # where/identity columns from the SET clause (updating the identity would
         # move the row out from under the WHERE match).
+        if not where:
+            # Defensive: the UPDATE branch needs a non-empty WHERE to identify the
+            # row (an empty WHERE would emit invalid SQL and, worse, an unscoped
+            # UPDATE). Unreachable via the upsert node — the pre-check SELECT and
+            # upsert semantics both require a key — but guarded because this is a
+            # public base-class method.
+            raise ValueError(
+                "build_precheck_upsert_query: UPDATE branch requires a non-empty "
+                "'where' to identify the row"
+            )
         set_clauses: List[str] = []
         params: Dict[str, Any] = {}
         idx = 0

--- a/packages/kailash-dataflow/src/dataflow/sql/dialects.py
+++ b/packages/kailash-dataflow/src/dataflow/sql/dialects.py
@@ -91,6 +91,88 @@ class SQLDialect(ABC):
         """
         pass
 
+    def build_precheck_upsert_query(
+        self,
+        table_name: str,
+        insert_data: Dict[str, Any],
+        update_data: Dict[str, Any],
+        where: Dict[str, Any],
+        row_exists: bool,
+        has_updated_at: bool = False,
+    ) -> UpsertQuery:
+        """Build an upsert as an explicit INSERT or UPDATE from a caller-supplied
+        existence pre-check result, instead of ``INSERT ... ON CONFLICT``.
+
+        ``ON CONFLICT (target)`` requires the conflict target to be backed by a
+        PRIMARY KEY or UNIQUE constraint; a ``conflict_on`` field that is not
+        declared unique is rejected with "ON CONFLICT clause does not match any
+        PRIMARY KEY or UNIQUE constraint" (issue #1508). Dialects that lack
+        native INSERT/UPDATE detection (SQLite has no PostgreSQL ``xmax``) already
+        run a WHERE-based pre-check to detect INSERT vs UPDATE; that same result
+        lets us emit a plain INSERT (row absent) or UPDATE ... WHERE (row present)
+        with no reliance on a unique constraint. Values are parameter-bound; the
+        interpolated identifiers are model field names resolved from the schema.
+
+        Concrete on the base because the pattern is dialect-agnostic. It is only
+        invoked on the pre-check path (SQLite today); native-detection dialects
+        (PostgreSQL) keep ``build_upsert_query``'s atomic ``ON CONFLICT`` form.
+
+        Placeholders use the ``:p<i>`` sequence and ``params`` is built in the
+        same order, because AsyncSQLDatabaseNode rebuilds the parameter dict
+        positionally from ``list(params.values())`` — placeholder index MUST
+        match value order (see ``build_upsert_query``).
+        """
+        if not row_exists:
+            insert_columns = list(insert_data.keys())
+            placeholders = [f":p{i}" for i in range(len(insert_columns))]
+            query = (
+                f"INSERT INTO {table_name} ({', '.join(insert_columns)})\n"
+                f"            VALUES ({', '.join(placeholders)})\n"
+                f"            RETURNING *"
+            )
+            params = {f"p{i}": insert_data[col] for i, col in enumerate(insert_columns)}
+            return UpsertQuery(
+                query=query.strip(), params=params, supports_native_flag=False
+            )
+
+        # Row exists → UPDATE ... WHERE <where>. Exclude the primary key and the
+        # where/identity columns from the SET clause (updating the identity would
+        # move the row out from under the WHERE match).
+        set_clauses: List[str] = []
+        params: Dict[str, Any] = {}
+        idx = 0
+        for col in update_data.keys():
+            if col == "id" or col in where:
+                continue
+            params[f"p{idx}"] = update_data[col]
+            set_clauses.append(f"{col} = :p{idx}")
+            idx += 1
+
+        if has_updated_at:
+            set_clauses.append("updated_at = CURRENT_TIMESTAMP")
+
+        if not set_clauses:
+            # Nothing substantive to update (update payload only named id/where
+            # keys). Emit a no-op self-assignment on the first where column so the
+            # UPDATE still matches the row and RETURNING yields it.
+            first_col = next(iter(where))
+            set_clauses.append(f"{first_col} = {first_col}")
+
+        where_clauses: List[str] = []
+        for col in where.keys():
+            params[f"p{idx}"] = where[col]
+            where_clauses.append(f"{col} = :p{idx}")
+            idx += 1
+
+        query = (
+            f"UPDATE {table_name} SET {', '.join(set_clauses)}\n"
+            f"            WHERE {' AND '.join(where_clauses)}\n"
+            f"            RETURNING *"
+        )
+        return UpsertQuery(
+            query=query.strip(), params=params, supports_native_flag=False
+        )
+
 
 class PostgreSQLDialect(SQLDialect):
     """

--- a/packages/kailash-dataflow/tests/integration/test_single_upsert_conflict_fields.py
+++ b/packages/kailash-dataflow/tests/integration/test_single_upsert_conflict_fields.py
@@ -752,14 +752,6 @@ class TestUpsertConflictOnValidation:
             f"Got error: {exc_info.value}"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="conflict_on=['email'] requires a UNIQUE constraint on email that "
-        "the model/table-generation does not create → SQLite 'ON CONFLICT does not "
-        "match any UNIQUE constraint'. Pre-existing bug (independent of :memory:), "
-        "exposed by the #1502 shared-cache fix which makes the table exist so the "
-        "ON CONFLICT is now reached; see #1508. Remove when #1508 lands.",
-    )
     @pytest.mark.asyncio
     async def test_conflict_on_field_mismatch_with_where(self):
         """IT-2.1.9: Test Phase 2 behavior - conflict_on and where can differ."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1508_upsert_conflict_on_non_unique.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1508_upsert_conflict_on_non_unique.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1508 — SQLite upsert ``conflict_on`` on a field
+with no UNIQUE constraint.
+
+Before #1508, a single-record upsert with ``conflict_on=["email"]`` on a model
+whose ``email`` field was not declared unique failed with::
+
+    Database query failed: ON CONFLICT clause does not match any PRIMARY KEY
+    or UNIQUE constraint
+
+The single-record SQLite upsert path already runs a WHERE-based existence
+pre-check (SQLite lacks PostgreSQL's ``xmax``, so INSERT-vs-UPDATE is detected
+by a ``SELECT COUNT(*)``). It then needlessly emitted ``INSERT ... ON CONFLICT
+(email) ...``, which SQLite rejects unless ``email`` is backed by a UNIQUE
+constraint. The fix uses the pre-check result to emit a plain INSERT (row
+absent) or UPDATE ... WHERE (row present) via
+``SQLiteDialect.build_precheck_upsert_query`` — no ``ON CONFLICT``, so no
+reliance on a unique constraint. This matches the documented SQLite pre-check
+design intent and is independent of connection type (surfaced, not caused, by
+the #1502 ``:memory:`` shared-cache fix which made the table exist so the
+ON CONFLICT was finally reached).
+
+These are Tier-2 regression tests exercising REAL SQLite (no mocking), with
+read-backs asserting persisted state per ``rules/testing.md`` § State
+Persistence Verification.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from kailash.runtime import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
+from dataflow.sql.dialects import SQLDialectFactory
+
+
+def _uid(prefix: str = "u") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_conflict_on_non_unique_field_inserts_then_updates(tmp_path):
+    """R1: conflict_on on a non-unique field upserts (INSERT then UPDATE) on
+    file-backed SQLite — the exact #1508 repro, independent of ``:memory:``."""
+    db = DataFlow(f"sqlite:///{tmp_path / 'issue_1508.db'}")
+
+    @db.model
+    class User:
+        id: str
+        email: str  # deliberately NOT unique — this is the bug's precondition
+        name: str
+
+    runtime = AsyncLocalRuntime()
+    email = f"{_uid('alice')}@example.com"
+    uid = _uid("user")
+
+    # First upsert → INSERT (email absent). Previously raised "ON CONFLICT ...".
+    wf1 = WorkflowBuilder()
+    wf1.add_node(
+        "UserUpsertNode",
+        "upsert1",
+        {
+            "where": {"email": email},
+            "conflict_on": ["email"],
+            "update": {"name": "Alice Updated"},
+            "create": {"id": uid, "email": email, "name": "Alice New"},
+        },
+    )
+    res1, _ = await runtime.execute_workflow_async(wf1.build(), inputs={})
+    assert res1["upsert1"]["created"] is True
+    assert res1["upsert1"]["record"]["email"] == email
+    assert res1["upsert1"]["record"]["name"] == "Alice New"
+
+    # Second upsert on the same email → UPDATE (row present).
+    wf2 = WorkflowBuilder()
+    wf2.add_node(
+        "UserUpsertNode",
+        "upsert2",
+        {
+            "where": {"email": email},
+            "conflict_on": ["email"],
+            "update": {"name": "Alice Updated Again"},
+            "create": {"id": _uid("other"), "email": email, "name": "ignored"},
+        },
+    )
+    res2, _ = await runtime.execute_workflow_async(wf2.build(), inputs={})
+    assert res2["upsert2"]["created"] is False
+    assert res2["upsert2"]["record"]["name"] == "Alice Updated Again"
+
+    # Read-back: exactly one row, carrying the UPDATE payload (state persisted).
+    users = await db.express.list("User", {"email": email})
+    assert len(users) == 1
+    assert users[0]["name"] == "Alice Updated Again"
+    assert users[0]["id"] == uid  # UPDATE kept the original id, ignored the 2nd create
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_conflict_on_composite_non_unique_fields(tmp_path):
+    """R2: composite conflict_on on non-unique fields upserts correctly."""
+    db = DataFlow(f"sqlite:///{tmp_path / 'issue_1508_composite.db'}")
+
+    @db.model
+    class OrderItem:
+        id: str
+        order_id: str
+        product_id: str
+        quantity: int
+
+    runtime = AsyncLocalRuntime()
+    order_id, product_id = _uid("order"), _uid("product")
+
+    wf1 = WorkflowBuilder()
+    wf1.add_node(
+        "OrderItemUpsertNode",
+        "u1",
+        {
+            "where": {"order_id": order_id, "product_id": product_id},
+            "conflict_on": ["order_id", "product_id"],
+            "update": {"quantity": 10},
+            "create": {
+                "id": _uid("item"),
+                "order_id": order_id,
+                "product_id": product_id,
+                "quantity": 5,
+            },
+        },
+    )
+    res1, _ = await runtime.execute_workflow_async(wf1.build(), inputs={})
+    assert res1["u1"]["created"] is True
+    assert res1["u1"]["record"]["quantity"] == 5
+
+    wf2 = WorkflowBuilder()
+    wf2.add_node(
+        "OrderItemUpsertNode",
+        "u2",
+        {
+            "where": {"order_id": order_id, "product_id": product_id},
+            "conflict_on": ["order_id", "product_id"],
+            "update": {"quantity": 10},
+            "create": {
+                "id": _uid("item2"),
+                "order_id": order_id,
+                "product_id": product_id,
+                "quantity": 5,
+            },
+        },
+    )
+    res2, _ = await runtime.execute_workflow_async(wf2.build(), inputs={})
+    assert res2["u2"]["created"] is False
+    assert res2["u2"]["record"]["quantity"] == 10
+
+    items = await db.express.list("OrderItem", {"order_id": order_id})
+    assert len(items) == 1
+    assert items[0]["quantity"] == 10
+
+
+@pytest.mark.regression
+def test_precheck_upsert_query_emits_no_on_conflict():
+    """R3: unit-level structural pin — the SQLite pre-check builder emits a plain
+    INSERT / UPDATE and never ``ON CONFLICT`` (the clause that required a UNIQUE
+    constraint). Guards against a refactor re-introducing the constraint
+    dependency on the single-record SQLite path."""
+    dialect = SQLDialectFactory.get_dialect("sqlite")
+
+    insert_q = dialect.build_precheck_upsert_query(
+        table_name="users",
+        insert_data={"id": "u1", "email": "a@b.co", "name": "A"},
+        update_data={"name": "A2"},
+        where={"email": "a@b.co"},
+        row_exists=False,
+    )
+    assert "ON CONFLICT" not in insert_q.query.upper()
+    assert insert_q.query.upper().startswith("INSERT INTO")
+    assert "RETURNING *" in insert_q.query.upper()
+
+    update_q = dialect.build_precheck_upsert_query(
+        table_name="users",
+        insert_data={"id": "u1", "email": "a@b.co", "name": "A"},
+        update_data={"name": "A2"},
+        where={"email": "a@b.co"},
+        row_exists=True,
+        has_updated_at=True,
+    )
+    assert "ON CONFLICT" not in update_q.query.upper()
+    assert update_q.query.upper().startswith("UPDATE ")
+    assert "WHERE EMAIL = :" in update_q.query.upper()
+    assert "UPDATED_AT = CURRENT_TIMESTAMP" in update_q.query.upper()
+    # The identity column is never in the SET clause (would move the row).
+    assert "SET NAME" in update_q.query.upper()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1508_upsert_conflict_on_non_unique.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1508_upsert_conflict_on_non_unique.py
@@ -161,6 +161,57 @@ async def test_conflict_on_composite_non_unique_fields(tmp_path):
 
 
 @pytest.mark.regression
+def test_precheck_update_shape_is_tenant_scoped():
+    """R4: the NEW bare ``UPDATE ... WHERE ... RETURNING`` shape this fix
+    introduces on the single-record SQLite upsert path MUST flow through the
+    tenant interceptor and get ``tenant_id`` injected into its WHERE (the
+    cross-tenant leak class per ``tenant-isolation.md``).
+
+    Deterministic query-transformation test (mirrors the tenancy-wiring suite's
+    ``test_tenant_context_injects_conditions``): build the exact UPDATE query
+    ``build_precheck_upsert_query`` emits, run it through the node's
+    ``_apply_tenant_isolation`` under a tenant switch, and assert the tenant
+    predicate is injected while ``RETURNING *`` is preserved. This locks the
+    integration point the fix newly exercises without depending on the
+    (separately-tracked) multi-tenant INSERT-injection machinery.
+    """
+    db = DataFlow("sqlite:///:memory:", multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str  # NOT unique — the #1508 precondition
+        title: str
+
+    ctx = db.tenant_context
+    ctx.register_tenant("tenant-x", "Tenant X")
+
+    # The exact UPDATE query the fix emits for a row-exists upsert.
+    uq = SQLDialectFactory.get_dialect("sqlite").build_precheck_upsert_query(
+        table_name="tenant_docs",
+        insert_data={"id": "d1", "email": "a@e.co", "title": "T"},
+        update_data={"title": "T2"},
+        where={"email": "a@e.co"},
+        row_exists=True,
+    )
+    assert uq.query.upper().startswith("UPDATE ")
+
+    node_class = db._nodes.get("TenantDocUpsertNode")
+    assert node_class is not None
+    node = node_class(node_id="t")
+
+    with ctx.switch("tenant-x"):
+        scoped_query, scoped_params = node._apply_tenant_isolation(
+            uq.query, list(uq.params.values())
+        )
+
+    assert "tenant_id" in scoped_query, "tenant predicate not injected into UPDATE"
+    assert "tenant-x" in scoped_params, "tenant value not bound"
+    assert "RETURNING" in scoped_query.upper(), "RETURNING clause dropped by injection"
+
+
+@pytest.mark.regression
 def test_precheck_upsert_query_emits_no_on_conflict():
     """R3: unit-level structural pin — the SQLite pre-check builder emits a plain
     INSERT / UPDATE and never ``ON CONFLICT`` (the clause that required a UNIQUE


### PR DESCRIPTION
## Summary

A single-record upsert with `conflict_on=["email"]` on a model whose field is **not declared unique** failed with:

```
Database query failed: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint
```

The SQLite single-record upsert path already runs a `WHERE`-based existence pre-check to detect INSERT-vs-UPDATE (SQLite has no PostgreSQL `xmax`), then **threw that result away** and emitted `INSERT … ON CONFLICT`, which SQLite rejects unless the conflict target is backed by a unique constraint.

**Fix:** use the pre-check `row_exists` to emit a plain `INSERT` (row absent) or `UPDATE … WHERE` (row present) via a new dialect-agnostic `SQLDialect.build_precheck_upsert_query`, dropping the `ON CONFLICT` constraint dependency on the single-record SQLite path. Values stay parameter-bound; identity/PK columns are excluded from `SET`. PostgreSQL keeps its atomic `ON CONFLICT` + `xmax` form unchanged. **Pure DML — no runtime DDL** (matches the documented SQLite pre-check design intent).

Independent of connection type (reproduces on file-backed SQLite); surfaced — not caused — by the #1502 `:memory:` shared-cache fix, which made the table exist so the `ON CONFLICT` was finally reached.

## Changes

- `sql/dialects.py`: new concrete `SQLDialect.build_precheck_upsert_query` (INSERT / `UPDATE … WHERE` / `RETURNING *`, `:p{i}` params) + defensive empty-`where` guard.
- `core/nodes.py`: single-record UpsertNode SQLite branch calls the pre-check builder using the existing `row_exists`; PostgreSQL path untouched.
- Removed the `xfail(strict=True)` marker on the repro (self-clears per `testing.md`).
- `tests/regression/test_issue_1508_*`: R1 (Tier-2 INSERT→UPDATE on file SQLite), R2 (composite conflict_on), R3 (structural pin: pre-check builder never emits `ON CONFLICT`), R4 (deterministic: the new UPDATE shape is tenant-scoped by the interceptor).

## Verification

- **Tier-2 integration** `test_single_upsert_conflict_fields.py`: 6/6 (previously-xfail `test_conflict_on_field_mismatch_with_where` now passes).
- **Tier-2 regression + Tier-1 structural** `test_issue_1508_*`: 4/4.
- **Regression siblings** (#1498/#1502/#1058 SQLite upsert) + all dialect/upsert unit tests: 56 pass, 1 skip.
- Collection gate across the dataflow package: 6474 collected, exit 0. Pre-commit (Black/isort/Ruff/type-annotations/Tier-1): clean.

## Red-team (converged — 3 parallel reviewers, all with live evidence)

- **security-reviewer: SECURE** — no new injection surface (identifier interpolation identical to the baseline `build_upsert_query`; DML not DDL), tenant isolation and redaction paths unchanged.
- **dataflow-specialist: CORRECT + COMPLETE** — semantic equivalence verified live (INSERT byte-identical; UPDATE equivalent-or-more-correct); TOCTOU window is pre-existing/inherent and strictly better than the prior always-fail.
- **reviewer: MERGE** (after the in-shard tenant regression test + empty-`where` guard applied) — mechanical sweeps all pass (zero DDL added, param-ordering correct).

## Out-of-scope defects surfaced by red-team (filed separately; NOT introduced here)

- #1518 — **multi_tenant upsert mis-maps `tenant_id`** (INSERT injection writes another column's value; proven pre-existing on `main` via file-swap). HIGH / tenant-isolation.
- #1519 — bulk_upsert silently ignores `conflict_on` on SQLite (hardcodes `ON CONFLICT (id)`, duplicates rows, 0 counts). HIGH.
- #1520 — PG `conflict_on` on a non-unique field raises a cryptic driver error; add an actionable error. MEDIUM.

## Related issues

Closes #1508
Follow-ups: #1518, #1519, #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)