### PR TITLE
release(dataflow): 2.13.7 — SQLite upsert conflict_on without a UNIQUE constraint (#1508)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.13.7] — 2026-07-03 — SQLite upsert conflict_on works without a UNIQUE constraint
+
+### Fixed
+
+- **Single-record SQLite upsert with `conflict_on` on a non-unique field now works (#1508).** An upsert with `conflict_on=["<field>"]` on a model whose field was not declared unique failed with `ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint`. The SQLite single-record upsert path already runs a `WHERE`-based existence pre-check to detect INSERT-vs-UPDATE (SQLite has no PostgreSQL `xmax`), but then still emitted `INSERT ... ON CONFLICT`, which SQLite rejects unless the conflict target is backed by a unique constraint — so the pre-check result was computed and discarded. DataFlow now uses that pre-check result to emit a plain `INSERT` (row absent) or `UPDATE ... WHERE` (row present) via `SQLDialect.build_precheck_upsert_query`, dropping the `ON CONFLICT` constraint dependency on the single-record SQLite path. Values stay parameter-bound; the identity/primary-key columns are excluded from the `SET` clause. PostgreSQL keeps its atomic `ON CONFLICT` + `xmax` form unchanged (PG genuinely requires the unique constraint for an atomic upsert — a non-unique `conflict_on` there raises a driver error tracked in #1520). Pure DML — no runtime DDL. Independent of connection type (reproduces on file-backed SQLite); surfaced, not caused, by the #1502 `:memory:` shared-cache fix which made the table exist so the `ON CONFLICT` was finally reached.
+
 ## [2.13.6] — 2026-07-03 — bare sqlite :memory: multi-connection shared-cache
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.6"
+version = "2.13.7"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.6"
+__version__ = "2.13.7"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Release: kailash-dataflow 2.13.6 → 2.13.7 (patch)

Metadata-only release-prep for the #1508 fix (merged in #1521). Version anchors + CHANGELOG only.

- `packages/kailash-dataflow/pyproject.toml` → `2.13.7`
- `packages/kailash-dataflow/src/dataflow/__init__.py::__version__` → `2.13.7`
- `packages/kailash-dataflow/CHANGELOG.md` → `[2.13.7]` entry

**Scope:** dataflow-only patch. No sibling drift (all packages at PyPI parity; zero non-dataflow src commits since `v2.45.3`). Core `kailash` unchanged — no `kailash>=` floor bump.

**Fix summary (#1508):** SQLite single-record upsert with `conflict_on` on a non-unique field now emits a plain INSERT/UPDATE from the existing pre-check result instead of `INSERT … ON CONFLICT` (which required a constraint that wasn't there). Pure DML, PostgreSQL path unchanged.

**Publish:** on merge, push lightweight tag `dataflow-v2.13.7` → `publish-pypi.yml` (Trusted Publisher/OIDC). TestPyPI skipped per the patch human-approval precedent. Clean-venv install verify follows.

## Related issues

Closes #1508 (fix merged in #1521)
Follow-ups (separate releases): #1518, #1519, #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)