### PR TITLE
chore: wrapup #1508 + kailash-rs cross-SDK inspection (not applicable)

### DIFF
--- a/.session-notes.d/esperie.md
+++ b/.session-notes.d/esperie.md
@@ -44,6 +44,21 @@ closing **#1508** (the F8 item the prior session approved as next work).
 Closed this session: **#1508** (PR #1521 fix, #1522 release → `dataflow-v2.13.7`).
 Filed this session: **#1518**, **#1519**, **#1520** (all pre-existing, surfaced by #1508 red-team).
 
+## Cross-SDK (kailash-rs) — #1508 NOT applicable
+
+User-authorized READ-ONLY inspection (journal `0010`, `cross-repo-authorized: esperie-enterprise/kailash-rs`).
+Finding: the Rust DataFlow upsert primitive `QueryDialect::upsert_conflict_clause(pk: &str, update_columns)`
+(`crates/kailash-dataflow/src/dialect.rs`, called `upsert_conflict_clause(pk, …)` in `query.rs`) conflicts on
+a **single primary key** (`ON CONFLICT({pk})`) — ALWAYS PK-constraint-backed. It does NOT expose an arbitrary
+non-unique `conflict_on`/`conflict_keys` field, so the #1508 bug class (SQLite ON CONFLICT on a non-unique
+target) is **structurally unreachable** in rs. Legitimate EATP-D6 API divergence (same shape as kailash-py's
+own pk-only bulk path). **No rs fix or issue needed for #1508.** (rs `excluded.col` SET is correct for its
+single-payload upsert — no #1498 divergence: #1498 was py's separate create-vs-update-dict bug.)
+**#1518 (tenant mis-map) NOT assessed in rs** — py-implementation-specific (interceptor INSERT column/param
+misalignment); rs has an independent Rust tenant impl. If rs cross-check for #1518 is wanted, do it from a
+DEDICATED kailash-rs session (its own scope), not cross-repo from here. NO issue filed on rs (scope-fenced;
+filing needs a separate gate per upstream-issue-hygiene MUST-1).
+
 ## Bug-origin context (user asked "why so many issues suddenly?")
 
 NOT new regressions — pre-existing test-coverage debt in the DataFlow upsert/SQLite/multi-tenant

--- a/workspaces/mops-onboarding/journal/0010-AUTHORIZATION-cross-repo-kailash-rs-1508-inspection.md
+++ b/workspaces/mops-onboarding/journal/0010-AUTHORIZATION-cross-repo-kailash-rs-1508-inspection.md
@@ -1,0 +1,31 @@
+---
+type: DECISION
+date: 2026-07-03
+author: human
+display_id: esperie
+project: dataflow-upsert-1508
+topic: cross-repo authorization — read-only kailash-rs inspection for the #1508 bug class
+phase: redteam
+---
+
+# AUTHORIZATION — read-only kailash-rs inspection for the #1508 upsert bug class
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Grant (repo-scope-discipline.md User-Authorized Exception)
+
+- **Requester:** esperie (user), genuine user turn (2026-07-03).
+- **Verbatim instruction:** _"approved, /wrapup for fresh session. also check if kailash-rs needs the same bug resolution"_
+- **Target repo:** `esperie-enterprise/kailash-rs` (private; the Rust SDK — per `reference_kailash_rs_repo_location` memory, NOT `terrene-foundation/kailash-rs`).
+- **Bounded action:** READ-ONLY inspection — determine whether the Rust SDK's DataFlow-equivalent has the same bug class as kailash-py #1508 (SQLite upsert `conflict_on` on a non-UNIQUE field emits `ON CONFLICT` that requires a constraint) and, opportunistically, #1518 (multi-tenant INSERT tenant-injection mis-map).
+- **Timestamp:** 2026-07-03 (this session).
+
+## Scope fence
+
+- READ-ONLY. NO writes, NO branches, NO issue/PR filing against kailash-rs. Filing a cross-SDK issue on rs (per `cross-sdk-inspection.md`) would require a SEPARATE explicit user gate per `upstream-issue-hygiene.md` MUST-1 — NOT covered by this receipt.
+- Only the named inspection against only the named repo (condition 5). No incidental writes.
+- If rs is not locally accessible, inspection is via `gh` read APIs against `esperie-enterprise/kailash-rs` only.
+
+## Disposition
+
+Findings recorded in the session wrap-up + surfaced to the user. Any rs remediation (fix or issue) is deferred to a dedicated kailash-rs session or a separately-gated filing.


### PR DESCRIPTION
Session wrap-up for a fresh start.

- `workspaces/mops-onboarding/journal/0010` — journaled `cross-repo-authorized:` receipt for the READ-ONLY kailash-rs inspection.
- `.session-notes.d/esperie.md` — refreshed notes: #1508 shipped (`kailash-dataflow 2.13.7`), #1518 recommended next, bug-origin trace, cross-SDK finding.

**Cross-SDK result:** kailash-rs upsert is pk-only (`ON CONFLICT({pk})`, always constraint-backed) — no arbitrary `conflict_on`, so the #1508 bug class is structurally unreachable there. No rs fix/issue needed (EATP-D6 divergence). #1518 deferred to a dedicated rs session.

Docs/notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)