### PR TITLE
fix(dataflow): multi_tenant upsert binds tenant_id to the active tenant (#1518)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
+++ b/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
@@ -843,7 +843,6 @@ class QueryInterceptor:
         # must be type bigint, not type text``). For ``$N`` we emit a sentinel
         # token and renumber the whole query left-to-right after insertion.
         style = self._detect_placeholder_style(modified_query)
-        tenant_ph = self._tenant_placeholder_for_style(style)
 
         # Issue #1249: build the tenant-column reference once. When a genuine
         # alias / explicit table qualifier is needed (multi-table / JOIN
@@ -853,6 +852,53 @@ class QueryInterceptor:
         # FROM clause — a qualifier-vs-FROM quoting mismatch. Bare column avoids
         # that entirely and is unambiguous for the single-table case.
         has_join = len(tenant_tables) > 1 or parsed.has_joins
+
+        # Issue #1518: named ``:pN`` binds by index downstream, position-
+        # independent in the query text, so each tenant value is APPENDED and
+        # referenced as ``:p{len(params)}`` at append time — never insert-at-
+        # index + ``$N`` renumber (that positional path is wrong for ``:pN``,
+        # and ``_count_placeholders_before``'s ``_PLACEHOLDER_RE`` does not even
+        # match ``:pN``). No DataFlow SELECT builder emits ``:pN`` today (only
+        # the upsert builders do), so this branch is defense-in-depth keeping the
+        # read path symmetric with the write path against a future named-param
+        # SELECT builder silently reopening the #1518 mixed-placeholder leak.
+        if style == "colon":
+            tables = tenant_tables if has_join else tenant_tables[:1]
+
+            def _colon_conditions() -> str:
+                parts = []
+                for table in tables:
+                    ph = f":p{len(modified_params)}"
+                    parts.append(
+                        self._build_tenant_condition(
+                            modified_query, table, qualify=has_join, placeholder=ph
+                        )
+                    )
+                    modified_params.append(self.tenant_id)
+                return " AND ".join(parts)
+
+            if "WHERE" in modified_query.upper():
+                where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
+                conditions = _colon_conditions()
+                modified_query = (
+                    modified_query[: where_match.end()]
+                    + f"{conditions} AND "
+                    + modified_query[where_match.end() :]
+                )
+            else:
+                insertion_point = self._find_insertion_point(modified_query)
+                where_clause = f" WHERE {_colon_conditions()}"
+                if insertion_point:
+                    modified_query = (
+                        modified_query[:insertion_point]
+                        + where_clause
+                        + modified_query[insertion_point:]
+                    )
+                else:
+                    modified_query += where_clause
+            return modified_query, modified_params
+
+        tenant_ph = self._tenant_placeholder_for_style(style)
 
         # Add tenant conditions to WHERE clause.
         # Issue #1249: the tenant VALUE is inserted into ``modified_params`` at
@@ -976,9 +1022,13 @@ class QueryInterceptor:
         Returns one of:
             ``"dollar"``  — PostgreSQL / asyncpg ``$1, $2, ...`` (ordinal).
             ``"percent"`` — psycopg / MySQL ``%s`` (positional).
-            ``"colon"``   — named ``:p0, :p1, ...`` emitted by the SQLite
-                            precheck-upsert builder (issue #1508's
-                            ``build_precheck_upsert_query``). Bound by NAME
+            ``"colon"``   — named ``:p0, :p1, ...`` emitted by the DataFlow
+                            upsert builders generally: the SQLite precheck path
+                            (``build_precheck_upsert_query``, issue #1508) AND
+                            the native ``ON CONFLICT`` builders for every dialect
+                            (``build_upsert_query`` on PG/SQLite/MySQL) plus
+                            ``build_bulk_upsert_query`` (``sql/dialects.py``).
+                            Bound by NAME
                             downstream (``_convert_to_named_parameters`` maps the
                             positional params list to ``{p0, p1, ...}`` by index),
                             so a colon placeholder is position-independent in the
@@ -1008,11 +1058,26 @@ class QueryInterceptor:
         (``_renumber_dollar_placeholders``) assigns the correct ``$N`` once the
         full query is assembled. For ``percent`` / ``qmark`` the placeholder is
         positional, so the literal text is final.
+
+        Issue #1518: ``colon`` (``:pN``) has NO fixed literal — the placeholder
+        index is ``:p{len(params)}`` (the appended value's future index), which
+        only the caller knows. Callers MUST branch on ``colon`` and compute the
+        placeholder inline (see ``_inject_insert_conditions`` /
+        ``_inject_where_predicate`` / ``_inject_select_conditions``). Reaching
+        this helper with ``colon`` is a caller bug — fail LOUD rather than
+        silently return ``?`` (a ``?`` in a ``:pN`` query renumbers to ``:p0``
+        downstream and mis-binds the tenant column — the exact #1518 defect).
         """
         if style == "dollar":
             return cls._TENANT_PLACEHOLDER_TOKEN
         if style == "percent":
             return "%s"
+        if style == "colon":
+            raise ValueError(
+                "colon (:pN) tenant placeholder is index-dependent; the caller "
+                "must emit ':p{len(params)}' inline, not via "
+                "_tenant_placeholder_for_style"
+            )
         return "?"
 
     @classmethod
@@ -1115,9 +1180,11 @@ class QueryInterceptor:
                 elif style == "percent":
                     value_ph = "%s"
                 elif style == "colon":
-                    # Issue #1518: the SQLite precheck-upsert INSERT (issue #1508)
-                    # emits named ``:pN`` placeholders bound positionally by list
-                    # index in ``_convert_to_named_parameters`` (``{p{i}: params[i]}``).
+                    # Issue #1518: the DataFlow upsert builders (the SQLite
+                    # precheck path #1508 + the native ON CONFLICT builders on
+                    # every dialect + bulk) emit named ``:pN`` placeholders bound
+                    # positionally by list index in ``_convert_to_named_parameters``
+                    # (``{p{i}: params[i]}``).
                     # The tenant value is appended to the END of the params list
                     # below, so its placeholder MUST be ``:p{len(params)}`` (its
                     # future index) — NOT a ``?``. A ``?`` here would be renumbered
@@ -1197,7 +1264,8 @@ class QueryInterceptor:
         # unrenumbered after the insertion shifted positions.
         style = self._detect_placeholder_style(modified_query)
 
-        # Issue #1518: named ``:pN`` (SQLite precheck-upsert UPDATE, issue #1508)
+        # Issue #1518: named ``:pN`` (emitted by the DataFlow upsert builders —
+        # the SQLite precheck-upsert UPDATE #1508 + native ON CONFLICT builders)
         # binds by NAME downstream, not by textual position, so the tenant value
         # is APPENDED to the params list and referenced as ``:p{len(params)}``
         # (its future index) regardless of where the predicate text lands. The

--- a/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
+++ b/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
@@ -976,6 +976,14 @@ class QueryInterceptor:
         Returns one of:
             ``"dollar"``  — PostgreSQL / asyncpg ``$1, $2, ...`` (ordinal).
             ``"percent"`` — psycopg / MySQL ``%s`` (positional).
+            ``"colon"``   — named ``:p0, :p1, ...`` emitted by the SQLite
+                            precheck-upsert builder (issue #1508's
+                            ``build_precheck_upsert_query``). Bound by NAME
+                            downstream (``_convert_to_named_parameters`` maps the
+                            positional params list to ``{p0, p1, ...}`` by index),
+                            so a colon placeholder is position-independent in the
+                            query text but its ``:pN`` index MUST equal the value's
+                            index in the params list.
             ``"qmark"``   — SQLite / generic ``?`` (positional). Also the default
                             when the query carries no placeholders at all.
         """
@@ -983,6 +991,13 @@ class QueryInterceptor:
             return "dollar"
         if "%s" in query:
             return "percent"
+        # Issue #1518: the ``:pN`` named style must be detected BEFORE falling
+        # back to qmark. Appending a ``?`` into a ``:pN`` query produced a mixed
+        # statement whose lone ``?`` was renumbered to ``:p0`` downstream
+        # (counter restarts at 0), colliding with the existing ``:p0`` — the
+        # tenant column then bound to the first value instead of the tenant id.
+        if re.search(r":p\d+", query):
+            return "colon"
         return "qmark"
 
     @classmethod
@@ -1099,6 +1114,16 @@ class QueryInterceptor:
                     value_ph = f"${existing + 1}"
                 elif style == "percent":
                     value_ph = "%s"
+                elif style == "colon":
+                    # Issue #1518: the SQLite precheck-upsert INSERT (issue #1508)
+                    # emits named ``:pN`` placeholders bound positionally by list
+                    # index in ``_convert_to_named_parameters`` (``{p{i}: params[i]}``).
+                    # The tenant value is appended to the END of the params list
+                    # below, so its placeholder MUST be ``:p{len(params)}`` (its
+                    # future index) — NOT a ``?``. A ``?`` here would be renumbered
+                    # to ``:p0`` downstream (counter restarts at 0) and collide with
+                    # the existing ``:p0``, binding tenant_id to the first value.
+                    value_ph = f":p{len(modified_params)}"
                 else:
                     value_ph = "?"
                 new_columns = f"{columns}, {self.tenant_column}"
@@ -1171,6 +1196,28 @@ class QueryInterceptor:
         # mixed dialects on PostgreSQL (``$N``) and left existing ``$N``
         # unrenumbered after the insertion shifted positions.
         style = self._detect_placeholder_style(modified_query)
+
+        # Issue #1518: named ``:pN`` (SQLite precheck-upsert UPDATE, issue #1508)
+        # binds by NAME downstream, not by textual position, so the tenant value
+        # is APPENDED to the params list and referenced as ``:p{len(params)}``
+        # (its future index) regardless of where the predicate text lands. The
+        # positional path below (insert-at-index + $N renumber) is WRONG for
+        # ``:pN`` — inserting mid-list would shift every existing ``:pN`` binding.
+        if style == "colon":
+            tenant_ph = f":p{len(modified_params)}"
+            predicate = f"{self.tenant_column} = {tenant_ph}"
+            if "WHERE" in modified_query.upper():
+                where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
+                modified_query = (
+                    modified_query[: where_match.end()]
+                    + f"{predicate} AND "
+                    + modified_query[where_match.end() :]
+                )
+            else:
+                modified_query += f" WHERE {predicate}"
+            modified_params.append(self.tenant_id)
+            return modified_query, modified_params
+
         tenant_ph = self._tenant_placeholder_for_style(style)
         predicate = f"{self.tenant_column} = {tenant_ph}"
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
@@ -337,6 +337,26 @@ def test_issue_1518_select_colon_injection_is_defense_in_depth_pure_colon():
     assert out_p.index("tenant-a") == 1
 
 
+def test_issue_1518_select_colon_no_where_inserts_before_limit():
+    """Defense-in-depth (no-WHERE colon SELECT, insert-before-clause sub-branch):
+    the injected tenant predicate must land BEFORE ``LIMIT`` as a fresh ``:p{len}``
+    so the LIMIT value keeps its own placeholder/index — never a ``?``."""
+    interceptor = QueryInterceptor(
+        tenant_id="tenant-a",
+        tenant_tables=["tenant_docs"],
+        tenant_column="tenant_id",
+    )
+    query = "SELECT id, tenant_id FROM tenant_docs LIMIT :p0"
+    params = [10]
+    out_q, out_p = interceptor.inject_tenant_conditions(query, params)
+
+    assert "?" not in out_q, f"mixed placeholder on no-WHERE SELECT: {out_q!r}"
+    assert "WHERE tenant_id = :p1" in out_q, out_q
+    # WHERE must precede LIMIT; the LIMIT value keeps :p0, tenant gets :p1
+    assert out_q.index("WHERE") < out_q.index("LIMIT"), out_q
+    assert out_p == [10, "tenant-a"], out_p
+
+
 def test_issue_1518_tenant_placeholder_for_style_rejects_colon():
     """``_tenant_placeholder_for_style`` must FAIL LOUD on colon rather than
     silently return ``?`` (a ``?`` in a ``:pN`` query is the #1518 defect). This

--- a/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
@@ -236,7 +236,9 @@ async def test_issue_1518_cross_tenant_upsert_cannot_corrupt_other_tenant_row():
         # single-tenant PK on ``id`` rejects the second row) and MUST NOT mutate
         # tenant-a's existing row.
         with db.tenant_context.switch("tenant-b"):
-            with pytest.raises(Exception):
+            # Pinned to the PK-collision fail-closed path — a future regression
+            # that threw for an unrelated reason must not keep this green.
+            with pytest.raises(Exception, match="(?i)UNIQUE constraint"):
                 await _upsert(runtime, "doc-a", "HACKED", "hack@example.com")
 
         after = {
@@ -291,3 +293,107 @@ def test_issue_1518_insert_injection_emits_pure_colon_no_qmark():
     assert out_p[-1] == "tenant-a"
     # the tenant value's :pN index must equal its position in the params list
     assert out_p.index("tenant-a") == 3
+
+
+def test_issue_1518_update_where_predicate_colon_emits_indexed_placeholder():
+    """Symmetric structural lock for the UPDATE/WHERE colon branch: the injected
+    tenant predicate on a ``:pN`` UPDATE must be ``:p{len}`` (pure named), never
+    a ``?``, with the value's index == its params position."""
+    interceptor = QueryInterceptor(
+        tenant_id="tenant-a",
+        tenant_tables=["tenant_docs"],
+        tenant_column="tenant_id",
+    )
+    query = (
+        "UPDATE tenant_docs SET title = :p0\n"
+        "            WHERE id = :p1\n"
+        "            RETURNING *"
+    )
+    params = ["A2", "doc-a"]
+    out_q, out_p = interceptor.inject_tenant_conditions(query, params)
+
+    assert "tenant_id = :p2" in out_q, out_q
+    assert "?" not in out_q, f"mixed placeholder regressed: {out_q!r}"
+    assert out_p[-1] == "tenant-a"
+    assert out_p.index("tenant-a") == 2
+
+
+def test_issue_1518_select_colon_injection_is_defense_in_depth_pure_colon():
+    """Defense-in-depth: a (currently-unemitted) ``:pN`` SELECT injected by the
+    interceptor must also be pure ``:pN`` — the read-path symmetry that stops a
+    future named-param SELECT builder silently reopening the #1518 leak."""
+    interceptor = QueryInterceptor(
+        tenant_id="tenant-a",
+        tenant_tables=["tenant_docs"],
+        tenant_column="tenant_id",
+    )
+    query = "SELECT id, tenant_id, title FROM tenant_docs WHERE id = :p0"
+    params = ["doc-a"]
+    out_q, out_p = interceptor.inject_tenant_conditions(query, params)
+
+    assert "tenant_id = :p1" in out_q, out_q
+    assert "?" not in out_q, f"mixed placeholder on SELECT read path: {out_q!r}"
+    assert out_p[-1] == "tenant-a"
+    assert out_p.index("tenant-a") == 1
+
+
+def test_issue_1518_tenant_placeholder_for_style_rejects_colon():
+    """``_tenant_placeholder_for_style`` must FAIL LOUD on colon rather than
+    silently return ``?`` (a ``?`` in a ``:pN`` query is the #1518 defect). This
+    locks the fail-closed guard against a future caller forgetting the inline
+    colon branch."""
+    with pytest.raises(ValueError, match="(?i)colon"):
+        QueryInterceptor._tenant_placeholder_for_style("colon")
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+@pytest.mark.asyncio
+async def test_issue_1518_tenant_id_in_create_is_overwritten_to_active_tenant():
+    """The 'tenant column already present' interceptor branch: when ``create``
+    supplies a WRONG ``tenant_id``, the interceptor MUST overwrite it with the
+    active tenant (never persist the caller-supplied value). Locks the
+    style-agnostic overwrite branch for colon-style upserts."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1518_present.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    runtime = AsyncLocalRuntime()
+    try:
+        doc_id = _uid()
+        wf = WorkflowBuilder()
+        wf.add_node(
+            "TenantDocUpsertNode",
+            "u",
+            {
+                "where": {"id": doc_id},
+                "conflict_on": ["id"],
+                "update": {"title": "A1"},
+                # caller supplies a spoofed tenant_id — must be overwritten.
+                "create": {
+                    "id": doc_id,
+                    "tenant_id": "tenant-EVIL",
+                    "email": "a@example.com",
+                    "title": "A1",
+                },
+            },
+        )
+        with db.tenant_context.switch("tenant-a"):
+            await runtime.execute_workflow_async(wf.build(), inputs={})
+
+        row = _raw_rows(path, "tenant_docs")[0]
+        assert (
+            row["tenant_id"] == "tenant-a"
+        ), f"spoofed tenant_id not overwritten: stored {row['tenant_id']!r}"
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1518_multi_tenant_upsert_tenant_id.py
@@ -1,0 +1,293 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1518 — multi_tenant upsert mis-maps ``tenant_id``.
+
+On a ``multi_tenant=True`` DataFlow, a single-record upsert persisted the WRONG
+value in the ``tenant_id`` column: it received another column's value (the
+row's ``id``) instead of the active tenant. Tenant scoping on the write path was
+therefore built against a bogus ``tenant_id`` — a cross-tenant leak class.
+
+Root cause (traced end-to-end): the SQLite precheck-upsert builder
+(``build_precheck_upsert_query``, issue #1508) emits *named* ``:pN``
+placeholders. The tenant ``QueryInterceptor`` appends ``tenant_id`` when the
+INSERT column list omits it (``insert_data = {**where, **create}`` never carries
+``tenant_id``), but ``_detect_placeholder_style`` did not recognise the ``:pN``
+style and defaulted to ``qmark`` — appending a lone ``?`` into a ``:pN`` query.
+Downstream ``_convert_to_named_parameters`` renumbered that ``?`` to ``:p0``
+(its counter restarts at 0), colliding with the existing ``:p0`` so ``tenant_id``
+bound to the first value. The fix teaches the interceptor the ``:pN`` (``colon``)
+style so the injected query is pure ``:pN`` — structurally identical to the
+already-correct non-tenant upsert.
+
+These are Tier-2 regression tests exercising REAL SQLite (no mocking) with raw
+``sqlite3`` read-backs asserting the persisted ``tenant_id`` value — the mis-map
+is about the stored value, so the ground-truth read is raw, not framework-read.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import time
+
+import pytest
+from kailash.runtime import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
+from dataflow.tenancy.interceptor import QueryInterceptor
+
+
+def _uid(prefix: str = "doc") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+def _raw_rows(db_path: str, table: str):
+    """Ground-truth read straight from the file — bypasses every framework
+    read-path transform so the persisted ``tenant_id`` value is asserted as
+    stored on disk."""
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        cur = con.execute(
+            f"SELECT id, tenant_id, email, title FROM {table} ORDER BY id, tenant_id"
+        )
+        return [dict(r) for r in cur.fetchall()]
+    finally:
+        con.close()
+
+
+async def _upsert(runtime, doc_id, title, email):
+    wf = WorkflowBuilder()
+    wf.add_node(
+        "TenantDocUpsertNode",
+        "u",
+        {
+            "where": {"id": doc_id},
+            "conflict_on": ["id"],
+            "update": {"title": title},
+            # deliberately omit tenant_id from create — the exact #1518 path where
+            # the interceptor must APPEND it (insert_data never carries tenant_id).
+            "create": {"id": doc_id, "email": email, "title": title},
+        },
+    )
+    return await runtime.execute_workflow_async(wf.build(), inputs={})
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+@pytest.mark.asyncio
+async def test_issue_1518_new_row_upsert_persists_active_tenant():
+    """R1 (the reported bug): a new-row multi_tenant upsert persists
+    ``tenant_id == active tenant`` — NOT the row's ``id`` value."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1518.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    runtime = AsyncLocalRuntime()
+    try:
+        doc_id = _uid()
+        with db.tenant_context.switch("tenant-a"):
+            await _upsert(runtime, doc_id, "A1", "a@example.com")
+
+        rows = _raw_rows(path, "tenant_docs")
+        assert len(rows) == 1, rows
+        row = rows[0]
+        # Pre-fix this was ``row["id"]`` (the mis-map): tenant_id == doc_id.
+        assert row["tenant_id"] == "tenant-a", (
+            f"tenant_id mis-map: stored {row['tenant_id']!r}, expected 'tenant-a' "
+            f"(row={row})"
+        )
+        # Payload columns must be intact (the mixed-placeholder bug also risked
+        # binding payload columns to the wrong values).
+        assert row["id"] == doc_id and row["email"] == "a@example.com"
+        assert row["title"] == "A1"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+@pytest.mark.asyncio
+async def test_issue_1518_tenant_id_correct_regardless_of_create_column_order():
+    """R1b (AC: 'regardless of the payload column order'): reordering the
+    ``create`` dict must not change which column ``tenant_id`` binds to."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1518_order.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    runtime = AsyncLocalRuntime()
+    try:
+        doc_id = _uid()
+        # create dict with columns in a non-schema order
+        wf = WorkflowBuilder()
+        wf.add_node(
+            "TenantDocUpsertNode",
+            "u",
+            {
+                "where": {"id": doc_id},
+                "conflict_on": ["id"],
+                "update": {"title": "Z9"},
+                "create": {"title": "Z9", "email": "z@example.com", "id": doc_id},
+            },
+        )
+        with db.tenant_context.switch("tenant-a"):
+            await runtime.execute_workflow_async(wf.build(), inputs={})
+
+        row = _raw_rows(path, "tenant_docs")[0]
+        assert row["tenant_id"] == "tenant-a", row
+        assert row["title"] == "Z9" and row["email"] == "z@example.com"
+        assert row["id"] == doc_id
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+@pytest.mark.asyncio
+async def test_issue_1518_existing_row_upsert_update_stays_tenant_scoped():
+    """R2: the existing-row UPDATE branch of the upsert (also ``:pN``, injected
+    via ``_inject_where_predicate``) keeps ``tenant_id`` correct and applies the
+    update to the right row."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1518_update.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    runtime = AsyncLocalRuntime()
+    try:
+        doc_id = _uid()
+        with db.tenant_context.switch("tenant-a"):
+            await _upsert(runtime, doc_id, "A1", "a@example.com")  # INSERT
+            await _upsert(runtime, doc_id, "A2", "a@example.com")  # UPDATE
+
+        rows = _raw_rows(path, "tenant_docs")
+        assert len(rows) == 1, rows
+        row = rows[0]
+        assert row["tenant_id"] == "tenant-a", row
+        assert row["title"] == "A2", f"UPDATE did not apply: {row}"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+@pytest.mark.asyncio
+async def test_issue_1518_cross_tenant_upsert_cannot_corrupt_other_tenant_row():
+    """R3 (the security invariant): a second tenant upserting another tenant's
+    natural key MUST NOT modify the first tenant's row. Two tenants each keep a
+    correctly-scoped row; one tenant's write never touches the other's."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1518_iso.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class TenantDoc:
+        id: str
+        tenant_id: str
+        email: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+    runtime = AsyncLocalRuntime()
+    try:
+        with db.tenant_context.switch("tenant-a"):
+            await _upsert(runtime, "doc-a", "A1", "a@example.com")
+        with db.tenant_context.switch("tenant-b"):
+            await _upsert(runtime, "doc-b", "B1", "b@example.com")
+
+        before = {r["id"]: dict(r) for r in _raw_rows(path, "tenant_docs")}
+        assert before["doc-a"]["tenant_id"] == "tenant-a"
+        assert before["doc-b"]["tenant_id"] == "tenant-b"
+
+        # tenant-b attempts to write tenant-a's key. It MUST fail closed (the
+        # single-tenant PK on ``id`` rejects the second row) and MUST NOT mutate
+        # tenant-a's existing row.
+        with db.tenant_context.switch("tenant-b"):
+            with pytest.raises(Exception):
+                await _upsert(runtime, "doc-a", "HACKED", "hack@example.com")
+
+        after = {
+            (r["tenant_id"], r["id"]): dict(r) for r in _raw_rows(path, "tenant_docs")
+        }
+        a_row = after[("tenant-a", "doc-a")]
+        assert a_row == before["doc-a"], (
+            f"cross-tenant write leak: tenant-a's row changed: {a_row} != "
+            f"{before['doc-a']}"
+        )
+        # tenant-b never planted a row under doc-a with tenant-a's data.
+        assert ("tenant-b", "doc-a") not in after
+    finally:
+        db.close()
+
+
+# --- Structural unit tests: lock the root-cause fix (no DB) --------------------
+
+
+def test_issue_1518_detect_placeholder_style_recognizes_colon():
+    """The ``:pN`` named style emitted by ``build_precheck_upsert_query`` MUST be
+    detected as ``colon`` — the classification the whole fix hinges on."""
+    q = "INSERT INTO t (id, email) VALUES (:p0, :p1) RETURNING *"
+    assert QueryInterceptor._detect_placeholder_style(q) == "colon"
+    # regressions of the other styles must still classify correctly
+    assert QueryInterceptor._detect_placeholder_style("... $1 ...") == "dollar"
+    assert QueryInterceptor._detect_placeholder_style("... %s ...") == "percent"
+    assert QueryInterceptor._detect_placeholder_style("... ? ...") == "qmark"
+
+
+def test_issue_1518_insert_injection_emits_pure_colon_no_qmark():
+    """The INSERT append-branch on a ``:pN`` query MUST emit a ``:p{N}`` tenant
+    placeholder (pure named), never a ``?`` — a mixed statement collides at
+    ``:p0`` downstream."""
+    interceptor = QueryInterceptor(
+        tenant_id="tenant-a",
+        tenant_tables=["tenant_docs"],
+        tenant_column="tenant_id",
+    )
+    query = (
+        "INSERT INTO tenant_docs (id, email, title)\n"
+        "            VALUES (:p0, :p1, :p2)\n"
+        "            RETURNING *"
+    )
+    params = ["doc-a", "a@example.com", "A1"]
+    out_q, out_p = interceptor.inject_tenant_conditions(query, params)
+
+    assert "tenant_id" in out_q
+    assert "?" not in out_q, f"mixed placeholder regressed: {out_q!r}"
+    # tenant value appended at index 3 → placeholder must be :p3
+    assert ":p3" in out_q, out_q
+    assert out_p[-1] == "tenant-a"
+    # the tenant value's :pN index must equal its position in the params list
+    assert out_p.index("tenant-a") == 3


### PR DESCRIPTION
## Summary

On a `multi_tenant=True` DataFlow, a single-record upsert persisted the **wrong** value in `tenant_id` — it received the row's `id` value instead of the active tenant, so write-path tenant scoping was built against a bogus `tenant_id` (**cross-tenant leak class**, `rules/tenant-isolation.md`). Pre-existing on `main`; surfaced while red-teaming #1508.

## Root cause (traced end-to-end)

1. `nodes.py` — `insert_data = {**where, **create}` never carries `tenant_id`.
2. `dialects.py` — `build_precheck_upsert_query` (the #1508 fix) emits **named** `:pN` placeholders.
3. `interceptor.py` — `_detect_placeholder_style` didn't recognise `:pN` → defaulted to `qmark` → appended a lone `?` into a `:pN` query.
4. `async_sql.py` — `_convert_to_named_parameters` renumbered that `?` to `:p0` (counter restarts at 0), colliding with the existing `:p0`; `tenant_id` bound to the first value. The same `:pN`-blindness also corrupted the existing-row **UPDATE** branch via `_inject_where_predicate`.

## Fix

Teach the interceptor the `:pN` (`colon`) style — a named placeholder binds by index downstream, so the injected query becomes **pure `:pN`**, structurally identical to the already-correct non-tenant upsert. Covers both the INSERT append-branch and the WHERE-predicate injection. `:pN` is emitted by every upsert/bulk builder, so the machinery-level fix covers all of them.

## Walk receipt (real SQLite, raw `sqlite3` read-back)

```
# BEFORE (main):
INSERT OUT: (id, email, title, tenant_id) VALUES (:p0, :p1, :p2, ?)   # mixed
stored row: tenant_id='doc-a'   ← the id value (MIS-MAP)

# AFTER (this PR):
INSERT OUT: (id, email, title, tenant_id) VALUES (:p0, :p1, :p2, :p3)  # pure :pN
after INSERT: tenant_id='tenant-a'
after UPDATE: tenant_id='tenant-a', title='A2'
cross-tenant: tenant-b same-key upsert fails closed; tenant-a row unchanged
```

## Tests

Tier-2 regression (`test_issue_1518_multi_tenant_upsert_tenant_id.py`, real SQLite): new-row INSERT persists active tenant regardless of create-dict column order; existing-row UPDATE stays tenant-scoped; a second tenant's same-key upsert fails closed and cannot corrupt the first tenant's row; + structural unit tests locking colon detection and pure-`:pN` injection. **All 6 fail without the fix, pass with it.** Full local gate: 102 passed / 9 skipped (PG-infra) / 0 fail across tenancy + upsert suites; #1249/#1252/#1508/#1498 unregressed.

## Scope

Sibling-audit (AC #3): `CreateNode` does not use the `:pN` append path; bulk tenant isolation is covered by #1252. The "two tenants share one natural key → separate rows" AC needs composite `(tenant_id, id)` uniqueness — a separate schema-generation concern, to be filed separately.

## Related issues

Fixes #1518. Surfaced by the #1508 red-team. Siblings: #1519 (bulk conflict_on), #1520 (PG error DX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)