### PR TITLE
release(dataflow): 2.13.8 — multi_tenant upsert tenant_id fix (#1518)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.13.8] — 2026-07-03 — multi_tenant upsert binds tenant_id to the active tenant
+
+### Fixed
+
+- **`multi_tenant=True` upsert now persists the active tenant in `tenant_id` (#1518, cross-tenant leak class).** A single-record upsert on a multi-tenant DataFlow persisted the **wrong** value in `tenant_id` — it received the row's `id` value instead of the active tenant, so write-path tenant scoping was silently built against a bogus `tenant_id` (`rules/tenant-isolation.md`). Root cause: the SQLite precheck-upsert builder (`build_precheck_upsert_query`, #1508) emits named `:pN` placeholders; the tenant `QueryInterceptor` appends `tenant_id` when the INSERT column list omits it (the upsert `insert_data = {**where, **create}` never carries `tenant_id`), but `_detect_placeholder_style` did not recognise the `:pN` style and defaulted to `qmark`, appending a lone `?` into a `:pN` query. Downstream `_convert_to_named_parameters` renumbered that `?` to `:p0` (its counter restarts at 0), colliding with the existing `:p0`, so `tenant_id` bound to the first value. The same `:pN`-blindness also corrupted the existing-row `UPDATE` branch. The interceptor now recognises the `:pN` (`colon`) style across the INSERT, UPDATE/DELETE, and SELECT injection paths, so the injected query is pure `:pN` — structurally identical to the already-correct non-tenant upsert. `:pN` is emitted by every upsert/bulk dialect builder, so the machinery-level fix covers all of them. A caller-supplied `tenant_id` in `create` is overwritten to the active tenant (no spoofing). Pre-existing on `main`; surfaced while red-teaming #1508. The separate "two tenants sharing one natural key" case (single-column `id` PK) is tracked in #1526.
+
 ## [2.13.7] — 2026-07-03 — SQLite upsert conflict_on works without a UNIQUE constraint
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.7"
+version = "2.13.8"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.7"
+__version__ = "2.13.8"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Release: kailash-dataflow 2.13.7 → 2.13.8 (patch, dataflow-only)

Version anchors + CHANGELOG for the **#1518** fix (merged to main via PR #1525, redteam-converged, CI-green).

### What ships
`multi_tenant=True` single-record upsert now binds `tenant_id` to the **active tenant** instead of the row's `id` value — closing a cross-tenant leak class on the write path (`rules/tenant-isolation.md`). The tenant `QueryInterceptor` now recognises the `:pN` named-placeholder style across INSERT / UPDATE / SELECT injection paths.

### Scope
- Dataflow-only patch. **Security** (cross-tenant leak class), pre-existing on `main`, surfaced red-teaming #1508.
- No sibling drift; core `kailash` unchanged (no `kailash>=` floor bump).
- 11 Tier-2 + structural regression tests; full tenancy + upsert suites green.

### Related
Fixes #1518 (via PR #1525). Composite-key follow-up: #1526. Siblings: #1519, #1520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)