### PR TITLE
fix(dataflow): bulk_upsert honors conflict_on; reconcile 3 divergent builders (#1519)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -18,6 +18,7 @@ loop into a single, loud, fail-fast error at the next access.
 
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 # Re-export the public DataFlow base error so callers can `except
@@ -111,4 +112,106 @@ class DDLFailedError(DataFlowError):
         super().__init__(" — ".join(parts))
 
 
-__all__ = ["DDLFailedError", "DataFlowError"]
+class BulkUpsertConflictTargetError(DataFlowError):
+    """Raised when a bulk upsert's ``conflict_on`` target is not backed by a
+    PRIMARY KEY or UNIQUE constraint.
+
+    Native single-statement upsert (``INSERT ... ON CONFLICT (cols) DO UPDATE``
+    on PostgreSQL/SQLite, ``ON DUPLICATE KEY UPDATE`` on MySQL) requires the
+    conflict-target columns to be a PK or UNIQUE key. When they are not, the
+    database rejects the statement ("ON CONFLICT clause does not match any
+    PRIMARY KEY or UNIQUE constraint" / "there is no unique or exclusion
+    constraint matching the ON CONFLICT specification"). DataFlow converts that
+    opaque driver error into this actionable typed error rather than silently
+    falling back to ``ON CONFLICT (id)`` (which would ignore the caller's intent
+    and land duplicate rows).
+
+    Attributes:
+        conflict_on: The conflict-target columns the caller requested.
+        model_name: The model the upsert targeted (best-effort; may be None).
+        original_error: The underlying driver exception, if any.
+
+    Recovery:
+
+    1. Declare the field(s) ``unique=True`` on the model (or add a UNIQUE
+       index / constraint) so the conflict target is enforceable.
+    2. For genuinely non-unique keys, use single-record ``db.express.upsert``
+       which does a WHERE-precheck instead of a native ON CONFLICT clause —
+       bulk upsert on a non-unique key is ambiguous when the batch itself
+       contains duplicate keys.
+    """
+
+    def __init__(
+        self,
+        conflict_on: Optional[list] = None,
+        model_name: Optional[str] = None,
+        original_error: Optional[BaseException] = None,
+    ) -> None:
+        self.conflict_on = list(conflict_on or [])
+        self.model_name = model_name
+        self.original_error = original_error
+
+        cols = ", ".join(self.conflict_on) or "<none>"
+        model_part = f" on model '{model_name}'" if model_name else ""
+        super().__init__(
+            f"bulk_upsert conflict_on={self.conflict_on!r}{model_part} does not "
+            f"match any PRIMARY KEY or UNIQUE constraint. Native bulk upsert "
+            f"requires the conflict-target column(s) ({cols}) to be backed by a "
+            f"PK or UNIQUE key. Remediation: declare the field(s) unique=True "
+            f"(or add a UNIQUE index), OR — for genuinely non-unique keys — use "
+            f"single-record db.express.upsert (WHERE-precheck) instead of bulk "
+            f"upsert, which is ambiguous when a batch contains duplicate keys."
+        )
+
+
+def is_conflict_target_error(message: str) -> bool:
+    """True iff a driver error signals an unmatched ON CONFLICT target (#1519).
+
+    SQLite emits "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE
+    constraint"; PostgreSQL emits "there is no unique or exclusion constraint
+    matching the ON CONFLICT specification". Shared by the express bulk engine
+    (``features/bulk.py``) and the workflow node (``nodes/bulk_upsert.py``) so
+    both convert the opaque driver message into
+    :class:`BulkUpsertConflictTargetError` rather than a silent fallback.
+    """
+    m = (message or "").lower()
+    return (
+        "does not match any primary key or unique constraint" in m
+        or "no unique or exclusion constraint matching the on conflict" in m
+    )
+
+
+# DB driver errors embed column VALUES in "DETAIL: Key (col)=(value) already
+# exists" clauses. Those values may be user data / PII; they MUST be redacted
+# before a driver message is logged or returned to a caller. Shared by the
+# express bulk engine (``features/bulk.py``) and the workflow node
+# (``nodes/bulk_upsert.py``) so both surfaces scrub identically — one helper,
+# no drift (rules/security.md § Multi-Site Kwarg Plumbing; rules/observability.md
+# Rule 8).
+_DETAIL_RE = re.compile(r"DETAIL:[^\n]*", re.IGNORECASE)
+_KEY_VALUES_RE = re.compile(r"Key \(([^)]+)\)=\(([^)]*)\)", re.IGNORECASE)
+
+
+def sanitize_db_error(msg: str) -> str:
+    """Redact column VALUES from a DB driver error message.
+
+    Preserves the diagnostic SHAPE (the constraint/column names in
+    ``Key (col)=...`` and the presence of a ``DETAIL:`` clause) while
+    replacing the value payload with ``[REDACTED]`` so a unique-violation
+    on a column OTHER than the conflict target cannot leak user data into
+    logs or the returned error string.
+    """
+    if not isinstance(msg, str):
+        return "<non-string error>"
+    msg = _DETAIL_RE.sub("DETAIL: [REDACTED]", msg)
+    msg = _KEY_VALUES_RE.sub(r"Key (\1)=([REDACTED])", msg)
+    return msg
+
+
+__all__ = [
+    "DDLFailedError",
+    "BulkUpsertConflictTargetError",
+    "is_conflict_target_error",
+    "sanitize_db_error",
+    "DataFlowError",
+]

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -49,6 +49,9 @@ except ImportError:
     AsyncNode = Node  # type: ignore[assignment,misc]
 
 from .async_utils import async_safe_run  # Phase 6: Async-safe execution
+from .exceptions import (  # Issue #1519: typed conflict-target error propagation
+    BulkUpsertConflictTargetError,
+)
 from .logging_config import mask_sensitive_values  # Phase 7: Sensitive value masking
 
 
@@ -3389,6 +3392,27 @@ class NodeGenerator:
                         where.keys()
                     )
 
+                    # rules/dataflow-identifier-safety.md MUST-1 (redteam, #1519
+                    # sibling class on the single-record path): the dialect
+                    # builders interpolate table_name + column names (conflict
+                    # target, INSERT/UPDATE columns, WHERE-precheck keys) as bare
+                    # identifiers — drivers cannot bind identifiers. Record keys
+                    # come from user-supplied create/update payloads and are NOT
+                    # constrained to declared model fields upstream, so validate
+                    # every interpolated identifier against the strict allowlist
+                    # BEFORE the dialect builds SQL (same defense as the bulk
+                    # path in features/bulk.py::bulk_upsert).
+                    from kailash.db.dialect import _validate_identifier as _vid
+
+                    _vid(table_name)
+                    for _col in (
+                        set(conflict_columns)
+                        | set(where.keys())
+                        | set(insert_data.keys())
+                        | set(update_data.keys())
+                    ):
+                        _vid(_col)
+
                     # Get SQL dialect for database-specific query generation
                     from ..sql.dialects import SQLDialectFactory
 
@@ -4064,12 +4088,28 @@ class NodeGenerator:
                     ):
                         # Use DataFlow's bulk upsert operations
                         try:
+                            # Issue #1519: the express layer sets
+                            # ``node.conflict_columns`` as an instance attribute
+                            # (features/express.py); the workflow layer passes
+                            # ``conflict_on`` in kwargs. Resolve from either.
+                            conflict_on = kwargs_fixed.get("conflict_on") or getattr(
+                                self, "conflict_columns", None
+                            )
+                            # Issue #1519: the express/generated bulk_upsert
+                            # contract is insert-or-UPDATE. Default to "update"
+                            # (DO UPDATE), NOT "skip" (DO NOTHING) — a PK conflict
+                            # under the old "skip" default silently dropped the
+                            # row instead of updating it.
+                            conflict_resolution = (
+                                kwargs_fixed.get("conflict_resolution")
+                                or getattr(self, "conflict_resolution", None)
+                                or "update"
+                            )
                             bulk_result = await self.dataflow_instance.bulk.bulk_upsert(
                                 model_name=self.model_name,
                                 data=data,
-                                conflict_resolution=kwargs_fixed.get(
-                                    "conflict_resolution", "skip"
-                                ),
+                                conflict_resolution=conflict_resolution,
+                                conflict_on=conflict_on,
                                 batch_size=batch_size,
                                 **{
                                     k: v
@@ -4079,6 +4119,8 @@ class NodeGenerator:
                                         "data",
                                         "batch_size",
                                         "conflict_resolution",
+                                        "conflict_on",
+                                        "conflict_columns",
                                         "model_name",
                                         "db_instance",
                                     ]
@@ -4100,18 +4142,22 @@ class NodeGenerator:
                                     },
                                 )
 
+                            records_processed = bulk_result.get("records_processed", 0)
                             result = {
-                                "processed": bulk_result.get("records_processed", 0),
-                                "upserted": bulk_result.get(
-                                    "records_processed", 0
-                                ),  # Alias for compatibility
+                                "processed": records_processed,
+                                "upserted": records_processed,  # Alias for compatibility
+                                # Issue #1519: express reads ``total`` for the
+                                # user-facing count; expose it from the real
+                                # records_processed.
+                                "total": records_processed,
                                 "batch_size": batch_size,
                                 "operation": operation,
                                 "success": bulk_result.get("success", True),
                             }
 
-                            # Expose detailed upsert stats if available from underlying operation
-                            # Note: bulk_upsert is currently a STUB - these values are simulated
+                            # Issue #1519: expose the real per-row counts derived
+                            # by the bulk engine (PG xmax / SQLite pre-count /
+                            # MySQL row_count). No longer a stub.
                             if "inserted" in bulk_result:
                                 result["inserted"] = bulk_result["inserted"]
                             if "updated" in bulk_result:
@@ -4126,6 +4172,11 @@ class NodeGenerator:
                             ):
                                 result["error"] = bulk_result["error"]
                             return result
+                        except BulkUpsertConflictTargetError:
+                            # Issue #1519: caller-actionable conflict-target error
+                            # MUST propagate as a typed raise, not flatten into a
+                            # {"success": False} dict the express layer ignores.
+                            raise
                         except Exception as e:
                             logger.error(
                                 "nodes.bulk_upsert_operation_failed",

--- a/packages/kailash-dataflow/src/dataflow/features/bulk.py
+++ b/packages/kailash-dataflow/src/dataflow/features/bulk.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, List, Optional
 
 from kailash.utils.url_credentials import mask_url
 
+from ..core.exceptions import BulkUpsertConflictTargetError
+from ..core.exceptions import is_conflict_target_error as _is_conflict_target_error
+from ..core.exceptions import sanitize_db_error as _sanitize_db_error
 from ..core.tenant_context import get_current_tenant_id
 from ..nodes.bulk_result_processor import BulkCreateResultProcessor
 
@@ -520,13 +523,21 @@ class BulkOperations:
             return success_result
 
         except Exception as e:
+            # Redteam MEDIUM (scanner-surface symmetry): scrub driver-error
+            # column VALUES (potential PII) before log/return — same shared
+            # redactor as bulk_upsert / the workflow node.
+            safe_error = _sanitize_db_error(str(e))
             error_result = {
                 "success": False,
-                "error": f"Bulk create operation failed: {str(e)}",
+                "error": f"Bulk create operation failed: {safe_error}",
                 "records_processed": 0,
             }
             logger.error(
-                "bulk.bulk_create_exception", extra={"error": str(e)}, exc_info=True
+                # exc_info dropped: the traceback's terminal frame re-emits the
+                # raw driver message (potential PII) the sanitizer just scrubbed
+                # (redteam LOW). Match the P2 node's no-exc_info bulk-error log.
+                "bulk.bulk_create_exception",
+                extra={"error": safe_error},
             )
             logger.error(
                 "bulk.bulk_create_error_result", extra={"error_result": error_result}
@@ -727,13 +738,19 @@ class BulkOperations:
                 )
                 return success_result
             except Exception as e:
+                # Redteam MEDIUM (scanner-surface symmetry): scrub driver-error
+                # column VALUES (potential PII) before log/return.
+                safe_error = _sanitize_db_error(str(e))
                 error_result = {
                     "success": False,
-                    "error": f"Bulk update operation failed: {str(e)}",
+                    "error": f"Bulk update operation failed: {safe_error}",
                     "records_processed": 0,
                 }
                 logger.error(
-                    "bulk.bulk_update_exception", extra={"error": str(e)}, exc_info=True
+                    # exc_info dropped: traceback re-leaks raw driver PII the
+                    # sanitizer scrubbed (redteam LOW).
+                    "bulk.bulk_update_exception",
+                    extra={"error": safe_error},
                 )
                 logger.error(
                     "bulk.bulk_update_error_result",
@@ -915,13 +932,19 @@ class BulkOperations:
                 )
                 return success_result
             except Exception as e:
+                # Redteam MEDIUM (scanner-surface symmetry): scrub driver-error
+                # column VALUES (potential PII) before log/return.
+                safe_error = _sanitize_db_error(str(e))
                 error_result = {
                     "success": False,
-                    "error": f"Bulk update operation failed: {str(e)}",
+                    "error": f"Bulk update operation failed: {safe_error}",
                     "records_processed": 0,
                 }
                 logger.error(
-                    "bulk.bulk_update_exception", extra={"error": str(e)}, exc_info=True
+                    # exc_info dropped: traceback re-leaks raw driver PII the
+                    # sanitizer scrubbed (redteam LOW).
+                    "bulk.bulk_update_exception",
+                    extra={"error": safe_error},
                 )
                 logger.error(
                     "bulk.bulk_update_error_result",
@@ -1093,13 +1116,19 @@ class BulkOperations:
                 )
                 return success_result
             except Exception as e:
+                # Redteam MEDIUM (scanner-surface symmetry): scrub driver-error
+                # column VALUES (potential PII) before log/return.
+                safe_error = _sanitize_db_error(str(e))
                 error_result = {
                     "success": False,
-                    "error": f"Bulk delete operation failed: {str(e)}",
+                    "error": f"Bulk delete operation failed: {safe_error}",
                     "records_processed": 0,
                 }
                 logger.error(
-                    "bulk.bulk_delete_exception", extra={"error": str(e)}, exc_info=True
+                    # exc_info dropped: traceback re-leaks raw driver PII the
+                    # sanitizer scrubbed (redteam LOW).
+                    "bulk.bulk_delete_exception",
+                    extra={"error": safe_error},
                 )
                 logger.error(
                     "bulk.bulk_delete_error_result",
@@ -1124,6 +1153,7 @@ class BulkOperations:
         data: List[Dict[str, Any]],
         conflict_resolution: str = "update",
         batch_size: int = 1000,
+        conflict_on: Optional[List[str]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Perform bulk upsert (insert or update) operation.
@@ -1133,10 +1163,31 @@ class BulkOperations:
             data: List of dictionaries with record data (must include 'id' field)
             conflict_resolution: Strategy for conflicts - "update" or "skip"/"ignore"
             batch_size: Number of records per batch
+            conflict_on: Columns that define the conflict target (issue #1519).
+                Defaults to ``["id"]``. MUST reference a PRIMARY KEY or UNIQUE
+                constraint — a non-unique target raises
+                ``BulkUpsertConflictTargetError`` (native ON CONFLICT cannot
+                target a non-unique column). Backward-compatible aliases
+                ``conflict_columns`` / ``conflict_fields`` are accepted via
+                ``kwargs``.
 
         Returns:
             Dict with records_processed, inserted, updated, skipped, success
+
+        Raises:
+            BulkUpsertConflictTargetError: when ``conflict_on`` does not match a
+                PK or UNIQUE constraint.
         """
+        # Issue #1519: resolve conflict target. Accept legacy aliases that
+        # callers / the generated node forward through kwargs.
+        if conflict_on is None:
+            conflict_on = kwargs.pop("conflict_columns", None) or kwargs.pop(
+                "conflict_fields", None
+            )
+        else:
+            kwargs.pop("conflict_columns", None)
+            kwargs.pop("conflict_fields", None)
+        conflict_columns = list(conflict_on) if conflict_on else ["id"]
         import logging
 
         logger = logging.getLogger(__name__)
@@ -1171,25 +1222,38 @@ class BulkOperations:
                 "Must be 'update', 'skip', or 'ignore'.",
             }
 
-        # Validate all records have 'id' field
-        for i, record in enumerate(data):
-            if "id" not in record:
-                return {
-                    "success": False,
-                    "error": f"Record at index {i} missing required 'id' field. "
-                    "All records must have an 'id' for upsert operations.",
-                }
-
         # Issue #1252 — stamp tenant_id from the contextvar source (the one
         # tenant_context.switch() actually sets), NOT the stale legacy
         # self.dataflow._tenant_context dict. Fails closed under multi_tenant
         # with no bound tenant. tenant_id rides in the column list, so the
-        # ON CONFLICT (id) target stays valid (id is the PK; tenant_id is just
-        # another INSERT/EXCLUDED column). See _resolve_bulk_tenant.
+        # ON CONFLICT target stays valid (tenant_id is just another
+        # INSERT/EXCLUDED column). See _resolve_bulk_tenant.
         bound_tenant = self._resolve_bulk_tenant(model_name)
         if bound_tenant is not None:
             for record in data:
                 record["tenant_id"] = bound_tenant
+
+        # Issue #1519: validate every record carries the conflict-target
+        # columns, NOT a hardcoded 'id'. With ``conflict_on=["email"]`` and an
+        # auto-generated SERIAL id, records legitimately omit 'id' — the old
+        # hardcoded 'id' check rejected them, the same conflict_on-ignoring bug.
+        # Runs AFTER tenant stamping so a tenant_id conflict target (e.g.
+        # conflict_on=["email", "tenant_id"]) is present when checked.
+        for i, record in enumerate(data):
+            missing = [col for col in conflict_columns if col not in record]
+            if missing:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Record at index {i} is missing conflict-target "
+                        f"column(s) {missing}. Every record MUST supply the "
+                        f"conflict_on columns {conflict_columns} for upsert."
+                    ),
+                    "records_processed": 0,
+                    "inserted": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                }
 
         # Auto-convert ISO datetime strings to datetime objects for each record
         from ..core.nodes import convert_datetime_fields
@@ -1216,7 +1280,27 @@ class BulkOperations:
         except TypeError as e:
             return {"success": False, "error": str(e)}
 
+        # Issue #1519 (redteam H1): collapse duplicate conflict-target keys
+        # WITHIN the input to the LAST occurrence BEFORE building the single
+        # INSERT ... ON CONFLICT statement. A batch carrying two rows with the
+        # same conflict key (e.g. two records id="x") is ambiguous: SQLite
+        # applies last-wins in-statement but OVER-COUNTS (RETURNING yields one
+        # row per VALUES tuple, not per physical row → created was reported as 2
+        # when 1 row landed), while PostgreSQL fails loud ("ON CONFLICT DO
+        # UPDATE command cannot affect row a second time"). De-duping last-wins
+        # makes the reported counts match rows actually written AND makes both
+        # dialects behave identically. Order is preserved by the last index.
+        if len(data) > 1:
+            _seen: Dict[tuple, int] = {}
+            for _i, _rec in enumerate(data):
+                _seen[tuple(_rec.get(_c) for _c in conflict_columns)] = _i
+            if len(_seen) != len(data):
+                data = [data[_i] for _i in sorted(_seen.values())]
+
         # Perform actual database upsert
+        import time
+
+        _upsert_start = time.perf_counter()
         try:
             connection_string = self.dataflow.config.database.get_connection_url(
                 self.dataflow.config.environment
@@ -1239,6 +1323,33 @@ class BulkOperations:
             columns = list(data[0].keys())
             column_names = ", ".join(columns)
 
+            # Issue #1519 + rules/dataflow-identifier-safety.md MUST-1: the
+            # conflict-target columns are interpolated into ``ON CONFLICT (...)``
+            # (drivers cannot bind identifiers), so every one MUST pass the
+            # strict allowlist validator before interpolation. A conflict-target
+            # column absent from the record set is a caller error.
+            from kailash.db.dialect import _validate_identifier
+
+            # rules/dataflow-identifier-safety.md MUST-1 (redteam CRITICAL):
+            # table_name AND every column name are interpolated as bare
+            # identifiers into INSERT INTO {table} ({columns}) ... ON CONFLICT
+            # (...) DO UPDATE SET {col} = excluded.{col} — drivers cannot bind
+            # identifiers. TypeAwareFieldProcessor does NOT constrain record
+            # keys to declared model fields, so a crafted record key would
+            # otherwise reach the SET/INSERT clause as raw SQL. Validate ALL of
+            # them against the strict allowlist BEFORE interpolation, mirroring
+            # the workflow node (nodes/bulk_upsert.py).
+            _validate_identifier(table_name)
+            for col in columns:
+                _validate_identifier(col)
+
+            for col in conflict_columns:
+                if col not in columns:
+                    raise ValueError(
+                        f"bulk_upsert: conflict_on column '{col}' is not present "
+                        f"in the record data (columns: {columns})."
+                    )
+
             # Build upsert query based on database type
             total_inserted = 0
             total_updated = 0
@@ -1251,22 +1362,37 @@ class BulkOperations:
 
                 # Build database-specific upsert query
                 if database_type.lower() == "postgresql":
-                    # PostgreSQL: INSERT ... ON CONFLICT (id) DO UPDATE SET ...
+                    # PostgreSQL: INSERT ... ON CONFLICT (<conflict_on>) DO UPDATE
                     query, params = self._build_postgresql_upsert(
-                        table_name, columns, batch, conflict_resolution, model_name
+                        table_name,
+                        columns,
+                        batch,
+                        conflict_resolution,
+                        model_name,
+                        conflict_columns,
                     )
                 elif database_type.lower() == "mysql":
                     # MySQL: INSERT ... ON DUPLICATE KEY UPDATE ...
                     query, params = self._build_mysql_upsert(
-                        table_name, columns, batch, conflict_resolution, model_name
+                        table_name,
+                        columns,
+                        batch,
+                        conflict_resolution,
+                        model_name,
+                        conflict_columns,
                     )
                 else:  # sqlite
-                    # SQLite: INSERT ... ON CONFLICT (id) DO UPDATE SET ...
+                    # SQLite: INSERT ... ON CONFLICT (<conflict_on>) DO UPDATE
                     query, params = self._build_sqlite_upsert(
-                        table_name, columns, batch, conflict_resolution, model_name
+                        table_name,
+                        columns,
+                        batch,
+                        conflict_resolution,
+                        model_name,
+                        conflict_columns,
                     )
 
-                logger.warning(
+                logger.debug(
                     f"BULK_UPSERT: Executing batch {batches_processed + 1}, "
                     f"query='{query[:200]}...', param_count={len(params)}"
                 )
@@ -1276,22 +1402,51 @@ class BulkOperations:
                 # This ensures connection pooling and data visibility across operations
                 sql_node = self.dataflow._get_or_create_async_sql_node(database_type)
 
-                result = await sql_node.async_run(
-                    query=query,
-                    params=params,
-                    fetch_mode="all",
-                    validate_queries=False,
-                    transaction_mode="auto",
-                )
+                # Issue #1519: SQLite RETURNING cannot flag insert-vs-update per
+                # row (no xmax), so derive real ``updated`` from a pre-count of
+                # existing conflict-target keys. PG uses ``(xmax = 0)`` inline.
+                preexisting = None
+                if database_type.lower() == "sqlite" and conflict_resolution not in (
+                    "skip",
+                    "ignore",
+                ):
+                    preexisting = await self._count_existing_conflicts(
+                        sql_node, table_name, conflict_columns, batch
+                    )
 
-                logger.warning("bulk.bulk_upsert_sql_result", extra={"result": result})
+                try:
+                    result = await sql_node.async_run(
+                        query=query,
+                        params=params,
+                        fetch_mode="all",
+                        validate_queries=False,
+                        transaction_mode="auto",
+                    )
+                except Exception as exec_err:
+                    # Issue #1519: a conflict target that is not a PK/UNIQUE key
+                    # is a caller error, not a transient DB failure. Convert the
+                    # opaque driver message into the actionable typed error
+                    # instead of silently falling back to ON CONFLICT (id).
+                    if _is_conflict_target_error(str(exec_err)):
+                        raise BulkUpsertConflictTargetError(
+                            conflict_on=conflict_columns,
+                            model_name=model_name,
+                            original_error=exec_err,
+                        ) from exec_err
+                    raise
+
+                logger.debug("bulk.bulk_upsert_sql_result", extra={"result": result})
 
                 # Extract operation counts from result
                 # For UPSERT operations, we need to parse the result to determine
                 # inserted vs updated vs skipped counts
                 batch_inserted, batch_updated, batch_skipped = (
                     self._parse_upsert_result(
-                        result, database_type, len(batch), conflict_resolution
+                        result,
+                        database_type,
+                        len(batch),
+                        conflict_resolution,
+                        preexisting_count=preexisting,
                     )
                 )
 
@@ -1301,6 +1456,7 @@ class BulkOperations:
                 batches_processed += 1
 
             records_processed = total_inserted + total_updated + total_skipped
+            elapsed = time.perf_counter() - _upsert_start
             success_result = {
                 "records_processed": records_processed,
                 "inserted": total_inserted,
@@ -1310,28 +1466,63 @@ class BulkOperations:
                 "batch_size": batch_size,
                 "conflict_resolution": conflict_resolution,
                 "success": True,
+                "performance_metrics": {
+                    "elapsed_seconds": elapsed,
+                    "execution_time_seconds": elapsed,
+                    "records_per_second": (
+                        records_processed / elapsed if elapsed > 0 else 0
+                    ),
+                    "batches_processed": batches_processed,
+                },
             }
             logger.warning(
                 "bulk.bulk_upsert_success", extra={"success_result": success_result}
             )
             return success_result
 
+        except BulkUpsertConflictTargetError:
+            # Issue #1519: caller-actionable conflict-target error MUST propagate
+            # as a typed raise, not be flattened into a {"success": False} dict.
+            raise
         except Exception as e:
+            # Redteam MEDIUM: a driver error from a DIFFERENT unique constraint
+            # (e.g. "DETAIL: Key (username)=(alice) already exists") embeds
+            # column VALUES that may be PII. Scrub them before the message is
+            # logged (log aggregators have broader access than the DB) or
+            # returned to the caller — same shared redactor as the workflow node
+            # (rules/observability.md Rule 8; rules/security.md § No secrets in
+            # logs).
+            safe_error = _sanitize_db_error(str(e))
             error_result = {
                 "success": False,
-                "error": f"Bulk upsert operation failed: {str(e)}",
+                "error": f"Bulk upsert operation failed: {safe_error}",
                 "records_processed": 0,
                 "inserted": 0,
                 "updated": 0,
                 "skipped": 0,
             }
             logger.error(
-                "bulk.bulk_upsert_exception", extra={"error": str(e)}, exc_info=True
+                # exc_info dropped: see bulk_create — the traceback re-leaks the
+                # raw driver message the sanitizer scrubbed (redteam LOW).
+                "bulk.bulk_upsert_exception",
+                extra={"error": safe_error},
             )
             logger.error(
                 "bulk.bulk_upsert_error_result", extra={"error_result": error_result}
             )
             return error_result
+
+    @staticmethod
+    def _upsert_update_columns(
+        columns: List[str], conflict_columns: List[str]
+    ) -> List[str]:
+        """Columns eligible for the DO UPDATE SET clause (issue #1519).
+
+        Excludes every conflict-target column (updating the conflict key is a
+        no-op / error) plus the immutable ``id`` and ``created_at`` columns.
+        """
+        excluded = set(conflict_columns) | {"id", "created_at"}
+        return [col for col in columns if col not in excluded]
 
     def _build_postgresql_upsert(
         self,
@@ -1340,6 +1531,7 @@ class BulkOperations:
         batch: List[Dict[str, Any]],
         conflict_resolution: str,
         model_name: str,
+        conflict_columns: List[str],
     ) -> tuple:
         """Build PostgreSQL upsert query with ON CONFLICT clause."""
         column_names = ", ".join(columns)
@@ -1358,28 +1550,28 @@ class BulkOperations:
             params.extend(record_params)
 
         values_clause = ", ".join(values_placeholders)
+        conflict_target = ", ".join(conflict_columns)
 
-        # Build ON CONFLICT clause with RETURNING to distinguish INSERT vs UPDATE
+        # Build ON CONFLICT clause with RETURNING to distinguish INSERT vs UPDATE.
+        # xmax = 0 → INSERT, xmax > 0 → UPDATE (exact per-row flag).
         if conflict_resolution in ["skip", "ignore"]:
-            # Skip conflicts - do nothing
-            # Use xmax to detect if row was updated: xmax = 0 means INSERT, xmax > 0 means UPDATE (skipped)
             conflict_clause = (
-                "ON CONFLICT (id) DO NOTHING RETURNING id, (xmax = 0) AS inserted"
+                f"ON CONFLICT ({conflict_target}) DO NOTHING "
+                f"RETURNING id, (xmax = 0) AS inserted"
             )
         else:  # update
-            # Update all columns except 'id' on conflict
-            update_columns = [col for col in columns if col != "id"]
+            update_columns = self._upsert_update_columns(columns, conflict_columns)
             if update_columns:
                 set_parts = [f"{col} = EXCLUDED.{col}" for col in update_columns]
-                # Use xmax to detect if row was updated: xmax = 0 means INSERT, xmax > 0 means UPDATE
                 conflict_clause = (
-                    f"ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)} "
-                    f"RETURNING id, (xmax = 0) AS inserted"
+                    f"ON CONFLICT ({conflict_target}) DO UPDATE SET "
+                    f"{', '.join(set_parts)} RETURNING id, (xmax = 0) AS inserted"
                 )
             else:
-                # Only 'id' column - skip on conflict
+                # Nothing to update (all non-conflict columns are immutable).
                 conflict_clause = (
-                    "ON CONFLICT (id) DO NOTHING RETURNING id, (xmax = 0) AS inserted"
+                    f"ON CONFLICT ({conflict_target}) DO NOTHING "
+                    f"RETURNING id, (xmax = 0) AS inserted"
                 )
 
         query = f"INSERT INTO {table_name} ({column_names}) VALUES {values_clause} {conflict_clause}"
@@ -1392,8 +1584,14 @@ class BulkOperations:
         batch: List[Dict[str, Any]],
         conflict_resolution: str,
         model_name: str,
+        conflict_columns: List[str],
     ) -> tuple:
-        """Build MySQL upsert query with ON DUPLICATE KEY UPDATE clause."""
+        """Build MySQL upsert query with ON DUPLICATE KEY UPDATE clause.
+
+        MySQL auto-detects the violated UNIQUE/PRIMARY key, so ``conflict_on``
+        does not appear in the clause itself — it only governs which columns are
+        excluded from the update set.
+        """
         column_names = ", ".join(columns)
         values_placeholders = []
         params = []
@@ -1411,18 +1609,18 @@ class BulkOperations:
 
         # Build ON DUPLICATE KEY UPDATE clause
         if conflict_resolution in ["skip", "ignore"]:
-            # MySQL doesn't support DO NOTHING in ON DUPLICATE KEY
-            # Workaround: update id to itself (no actual change)
-            duplicate_clause = "ON DUPLICATE KEY UPDATE id = id"
+            # MySQL has no DO NOTHING; a no-op self-assignment of the first
+            # conflict column keeps existing rows unchanged.
+            noop_col = conflict_columns[0] if conflict_columns else "id"
+            duplicate_clause = f"ON DUPLICATE KEY UPDATE {noop_col} = {noop_col}"
         else:  # update
-            # Update all columns except 'id' on duplicate
-            update_columns = [col for col in columns if col != "id"]
+            update_columns = self._upsert_update_columns(columns, conflict_columns)
             if update_columns:
                 set_parts = [f"{col} = VALUES({col})" for col in update_columns]
                 duplicate_clause = f"ON DUPLICATE KEY UPDATE {', '.join(set_parts)}"
             else:
-                # Only 'id' column - no update needed
-                duplicate_clause = "ON DUPLICATE KEY UPDATE id = id"
+                noop_col = conflict_columns[0] if conflict_columns else "id"
+                duplicate_clause = f"ON DUPLICATE KEY UPDATE {noop_col} = {noop_col}"
 
         query = f"INSERT INTO {table_name} ({column_names}) VALUES {values_clause} {duplicate_clause}"
         return query, params
@@ -1434,8 +1632,15 @@ class BulkOperations:
         batch: List[Dict[str, Any]],
         conflict_resolution: str,
         model_name: str,
+        conflict_columns: List[str],
     ) -> tuple:
-        """Build SQLite upsert query with ON CONFLICT clause."""
+        """Build SQLite upsert query with ON CONFLICT clause.
+
+        SQLite RETURNING cannot flag insert-vs-update per row (no xmax); the
+        caller derives real counts via a pre-count of existing conflict keys
+        (see ``_count_existing_conflicts``). RETURNING id lets the caller count
+        how many rows the statement actually affected.
+        """
         column_names = ", ".join(columns)
         values_placeholders = []
         params = []
@@ -1450,32 +1655,86 @@ class BulkOperations:
             params.extend(record_params)
 
         values_clause = ", ".join(values_placeholders)
+        conflict_target = ", ".join(conflict_columns)
 
-        # Build ON CONFLICT clause with RETURNING to distinguish INSERT vs UPDATE
-        # SQLite 3.35+ supports RETURNING
+        # SQLite 3.35+ supports RETURNING.
         if conflict_resolution in ["skip", "ignore"]:
-            # Skip conflicts - do nothing
-            # For SQLite, we can't use xmax but we can check if columns changed
-            conflict_clause = "ON CONFLICT (id) DO NOTHING RETURNING id, 1 AS inserted"
+            # DO NOTHING returns only the inserted rows.
+            conflict_clause = f"ON CONFLICT ({conflict_target}) DO NOTHING RETURNING id"
         else:  # update
-            # Update all columns except 'id' on conflict
-            update_columns = [col for col in columns if col != "id"]
+            update_columns = self._upsert_update_columns(columns, conflict_columns)
             if update_columns:
                 set_parts = [f"{col} = excluded.{col}" for col in update_columns]
-                # For SQLite, mark as inserted=0 when it's an update (simplified approach)
-                # We use a CASE to detect: if old value != new value, it's an update
                 conflict_clause = (
-                    f"ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)} "
-                    f"RETURNING id, 0 AS inserted"
+                    f"ON CONFLICT ({conflict_target}) DO UPDATE SET "
+                    f"{', '.join(set_parts)} RETURNING id"
                 )
             else:
-                # Only 'id' column - skip on conflict
                 conflict_clause = (
-                    "ON CONFLICT (id) DO NOTHING RETURNING id, 1 AS inserted"
+                    f"ON CONFLICT ({conflict_target}) DO NOTHING RETURNING id"
                 )
 
         query = f"INSERT INTO {table_name} ({column_names}) VALUES {values_clause} {conflict_clause}"
         return query, params
+
+    async def _count_existing_conflicts(
+        self,
+        sql_node,
+        table_name: str,
+        conflict_columns: List[str],
+        batch: List[Dict[str, Any]],
+    ) -> int:
+        """Count rows already present matching the batch's conflict-target keys.
+
+        Issue #1519: SQLite's RETURNING gives no insert-vs-update signal, so the
+        number of pre-existing conflict keys IS the number of UPDATEs the upsert
+        will perform. Uses OR-of-AND equality (dialect-agnostic, avoids
+        row-value IN quirks) with ``?`` placeholders bound positionally. NULL
+        conflict values never match a UNIQUE target and are skipped.
+
+        Concurrency contract (redteam M1): this COUNT and the subsequent upsert
+        run as two ``transaction_mode="auto"`` statements, so under a CONCURRENT
+        writer inserting a conflicting key between them the insert-vs-update
+        split can be off by the number of racing rows. The persisted DATA stays
+        correct (the upsert is atomic); only the reported ``inserted``/``updated``
+        breakdown is best-effort under concurrency. Within a single call the
+        input is de-duplicated on the conflict target upstream, so a batch can
+        no longer self-conflict.
+        """
+        clauses: List[str] = []
+        params: List[Any] = []
+        for record in batch:
+            vals = [record.get(col) for col in conflict_columns]
+            if any(v is None for v in vals):
+                continue
+            conds = " AND ".join(f"{col} = ?" for col in conflict_columns)
+            clauses.append(f"({conds})")
+            params.extend(vals)
+
+        if not clauses:
+            return 0
+
+        where = " OR ".join(clauses)
+        query = f"SELECT COUNT(*) AS match_count FROM {table_name} WHERE {where}"
+        result = await sql_node.async_run(
+            query=query,
+            params=params,
+            fetch_mode="all",
+            validate_queries=False,
+            transaction_mode="auto",
+        )
+        rows = []
+        if result and "result" in result:
+            rows = result["result"].get("data", []) or []
+        if rows and isinstance(rows[0], dict):
+            value = (
+                rows[0].get("match_count")
+                or rows[0].get("COUNT(*)")
+                or rows[0].get("count")
+                or 0
+            )
+            return int(value)
+        return 0
 
     def _parse_upsert_result(
         self,
@@ -1483,37 +1742,53 @@ class BulkOperations:
         database_type: str,
         batch_size: int,
         conflict_resolution: str,
+        preexisting_count: Optional[int] = None,
     ) -> tuple:
         """Parse upsert result to extract inserted, updated, and skipped counts.
+
+        Issue #1519: counts are derived from real signals — PostgreSQL uses the
+        per-row ``(xmax = 0)`` RETURNING flag; SQLite uses ``preexisting_count``
+        (rows whose conflict key already existed = UPDATEs); MySQL derives from
+        the ``row_count`` (1 per insert, 2 per update). No fabricated ``// 2``.
 
         Returns:
             tuple: (inserted, updated, skipped)
         """
-        # For PostgreSQL and SQLite with RETURNING clause:
-        # - The 'data' field contains rows with 'inserted' boolean column
-        # - inserted=true means INSERT, inserted=false means UPDATE
-
+        returned_rows: List[Any] = []
         if result and "result" in result:
             result_data = result["result"]
-
-            # Check if we have RETURNING data (PostgreSQL/SQLite with RETURNING)
-            if "data" in result_data and len(result_data["data"]) > 0:
+            if isinstance(result_data.get("data"), list):
                 returned_rows = result_data["data"]
 
-                # For PostgreSQL/SQLite with RETURNING clause
-                # Each row has 'inserted' field: True for INSERT, False for UPDATE
-                if isinstance(returned_rows, list) and len(returned_rows) > 0:
-                    first_row = returned_rows[0]
-                    if isinstance(first_row, dict) and "inserted" in first_row:
-                        # Count inserts and updates from RETURNING data
-                        inserted = sum(
-                            1 for row in returned_rows if row.get("inserted") is True
-                        )
-                        updated = sum(
-                            1 for row in returned_rows if row.get("inserted") is False
-                        )
-                        skipped = batch_size - len(returned_rows)
-                        return (inserted, updated, skipped)
+        dbt = database_type.lower()
+
+        # PostgreSQL: exact per-row flag from RETURNING id, (xmax = 0) AS inserted.
+        if (
+            dbt == "postgresql"
+            and returned_rows
+            and isinstance(returned_rows[0], dict)
+            and "inserted" in returned_rows[0]
+        ):
+            inserted = sum(1 for row in returned_rows if row.get("inserted") is True)
+            updated = sum(1 for row in returned_rows if row.get("inserted") is False)
+            skipped = batch_size - len(returned_rows)
+            return (inserted, updated, skipped)
+
+        # SQLite: RETURNING id gives the affected-row count; the pre-count of
+        # existing conflict keys gives the UPDATE count.
+        if dbt == "sqlite":
+            affected = len(returned_rows)
+            if conflict_resolution in ["skip", "ignore"]:
+                # DO NOTHING returns only inserted rows.
+                inserted = affected
+                updated = 0
+                skipped = batch_size - affected
+            else:
+                pre = preexisting_count or 0
+                updated = min(pre, affected)
+                inserted = affected - updated
+                skipped = batch_size - affected
+            return (inserted, updated, skipped)
 
         # Fallback: Extract row_count from result (for MySQL or when RETURNING not available)
         rows_affected = 0

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import re
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -12,23 +11,17 @@ from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
 
-# #499 finding 5 — PG/MySQL drivers embed raw column values in DETAIL /
+# #499 finding 5 / #1519 — PG/MySQL drivers embed raw column values in DETAIL /
 # Key(...)=(…) clauses. Strip them before any log or return-value echo so
 # PII / SECRET column values cannot leak through the observability layer.
-# The surrounding error text (class of failure, table, constraint name)
-# stays so operators retain triage signal.
-_DETAIL_RE = re.compile(r"DETAIL:[^\n]*", re.IGNORECASE)
-_KEY_VALUES_RE = re.compile(r"Key \(([^)]+)\)=\(([^)]*)\)", re.IGNORECASE)
-
-
-def _sanitize_db_error(msg: str) -> str:
-    """Redact column values from DB driver error messages."""
-    if not isinstance(msg, str):
-        return "<non-string error>"
-    msg = _DETAIL_RE.sub("DETAIL: [REDACTED]", msg)
-    msg = _KEY_VALUES_RE.sub(r"Key (\1)=([REDACTED])", msg)
-    return msg
-
+# The redactor is a single shared helper in ``core.exceptions`` so this node
+# and the express bulk engine (``features/bulk.py``) scrub identically — one
+# implementation, no drift (rules/security.md § Multi-Site Kwarg Plumbing).
+from ..core.exceptions import (  # Issue #1519: typed conflict-target error
+    BulkUpsertConflictTargetError,
+    is_conflict_target_error,
+)
+from ..core.exceptions import sanitize_db_error as _sanitize_db_error
 
 # Allowlist of supported dialects. Unknown values (typos like "postgres",
 # "pg") MUST raise loudly rather than fall through to SQLite REPLACE
@@ -218,10 +211,12 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                     **kwargs_copy,
                 )
             else:
-                # Dry run or fallback mock
+                # Dry run: nothing is written, so no honest insert/update split
+                # exists (issue #1519 — no fabricated `// 2`). ``would_upsert``
+                # below reports the row count that WOULD be affected.
                 rows_affected = len(data)
-                inserted_count = len(data) // 2  # Mock estimation
-                updated_count = len(data) - inserted_count
+                inserted_count = 0
+                updated_count = 0
                 upserted_records = []
                 duplicates_removed = 0  # No deduplication in dry run
 
@@ -289,8 +284,11 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
             return result
 
-        except (ValueError, NodeValidationError):
-            # Let validation errors propagate for proper test handling
+        except (ValueError, NodeValidationError, BulkUpsertConflictTargetError):
+            # Issue #1519: a conflict-target error is a caller error, not a
+            # transient DB failure — surface it as a typed raise (like ValueError
+            # / NodeValidationError) instead of flattening it into a
+            # {"success": False} dict a caller might treat as a soft outcome.
             raise
         except Exception as e:
             return {"success": False, "error": str(e), "rows_affected": 0}
@@ -365,11 +363,24 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
                 # Execute batch using connection pool if available, otherwise fallback
                 try:
+                    # Issue #1519: derive REAL insert/update counts from a
+                    # pre-count of existing conflict-target keys (no fabricated
+                    # `// 2`). The batch is already deduped on conflict_on, so
+                    # each matching pre-existing key is exactly one UPDATE.
+                    preexisting = await self._count_existing_conflicts(
+                        batch, conflict_on, **kwargs
+                    )
                     result = await self._execute_query(query, params=params, **kwargs)
 
                     # Process result to count upserts and get records
                     batch_rows, batch_inserted, batch_updated, batch_records = (
-                        self._process_upsert_result(result, len(batch), return_records)
+                        self._process_upsert_result(
+                            result,
+                            len(batch),
+                            return_records,
+                            merge_strategy,
+                            preexisting,
+                        )
                     )
                     total_rows_affected += batch_rows
                     total_inserted += batch_inserted
@@ -378,7 +389,18 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                     if return_records and batch_records:
                         all_upserted_records.extend(batch_records)
 
+                except BulkUpsertConflictTargetError:
+                    # Issue #1519: an unmatched ON CONFLICT target is a caller
+                    # error affecting EVERY batch — fail fast, don't accumulate
+                    # it as a per-batch partial failure.
+                    raise
                 except Exception as batch_error:
+                    if is_conflict_target_error(str(batch_error)):
+                        raise BulkUpsertConflictTargetError(
+                            conflict_on=conflict_on,
+                            model_name=self.table_name,
+                            original_error=batch_error,
+                        ) from batch_error
                     # rules/observability.md Rule 7 — bulk partial-failure WARN
                     # MUST include the error message so operators can triage.
                     # rules/security.md + #499 finding 5: DB drivers often
@@ -414,6 +436,10 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                 duplicates_removed,
             )
 
+        except BulkUpsertConflictTargetError:
+            # Issue #1519: caller-actionable typed error MUST propagate as-is,
+            # not be re-wrapped in a generic NodeExecutionError.
+            raise
         except Exception as e:
             raise NodeExecutionError(f"Database upsert error: {str(e)}")
 
@@ -535,94 +561,195 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
             f"VALUES {', '.join(value_rows)}"
         )
 
-        if dialect == "postgresql":
-            conflict_columns_str = ", ".join(conflict_on)
+        conflict_columns_str = ", ".join(conflict_on)
 
+        if dialect == "postgresql":
             if merge_strategy == "ignore":
                 query = f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
             else:  # update strategy
-                update_clauses = []
-                for col in columns:
-                    if col not in conflict_on and col not in [
-                        "id",
-                        "created_at",
-                    ]:
-                        if col == self.version_field and self.version_control:
-                            update_clauses.append(
-                                f"{col} = {self.table_name}.{col} + 1"
-                            )
-                        elif col == "updated_at" and self.auto_timestamps:
-                            update_clauses.append(f"{col} = CURRENT_TIMESTAMP")
-                        else:
-                            update_clauses.append(f"{col} = EXCLUDED.{col}")
-
+                update_clauses = self._build_update_clauses(columns, conflict_on)
                 if update_clauses:
-                    update_clause = ", ".join(update_clauses)
                     query = (
                         f"{base_query} ON CONFLICT ({conflict_columns_str}) "
-                        f"DO UPDATE SET {update_clause}"
+                        f"DO UPDATE SET {', '.join(update_clauses)}"
                     )
                 else:
                     query = (
                         f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
                     )
-        else:
-            # SQLite/MySQL fallback uses INSERT OR REPLACE semantics.
-            query = base_query.replace("INSERT INTO", "INSERT OR REPLACE INTO")
-
-        if dialect == "postgresql" and return_records:
-            query += " RETURNING *"
+            if return_records:
+                query += " RETURNING *"
+        elif dialect == "sqlite":
+            # Issue #1519: SQLite honors conflict_on via native ON CONFLICT
+            # (NOT INSERT OR REPLACE, which ignores conflict_on and replaces the
+            # whole row, discarding un-supplied columns + firing FK cascades).
+            if merge_strategy == "ignore":
+                query = f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
+            else:
+                update_clauses = self._build_update_clauses(
+                    columns, conflict_on, sqlite=True
+                )
+                if update_clauses:
+                    query = (
+                        f"{base_query} ON CONFLICT ({conflict_columns_str}) "
+                        f"DO UPDATE SET {', '.join(update_clauses)}"
+                    )
+                else:
+                    query = (
+                        f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
+                    )
+            if return_records:
+                query += " RETURNING *"
+        else:  # mysql
+            # Issue #1519: MySQL uses ON DUPLICATE KEY UPDATE (INSERT OR REPLACE
+            # is not valid MySQL syntax). MySQL auto-detects the violated unique
+            # key, so conflict_on governs only which columns are excluded.
+            if merge_strategy == "ignore":
+                noop = conflict_on[0] if conflict_on else "id"
+                query = f"{base_query} ON DUPLICATE KEY UPDATE {noop} = {noop}"
+            else:
+                update_clauses = self._build_update_clauses(
+                    columns, conflict_on, mysql=True
+                )
+                if update_clauses:
+                    query = (
+                        f"{base_query} ON DUPLICATE KEY UPDATE "
+                        f"{', '.join(update_clauses)}"
+                    )
+                else:
+                    noop = conflict_on[0] if conflict_on else "id"
+                    query = f"{base_query} ON DUPLICATE KEY UPDATE {noop} = {noop}"
 
         return query, params
 
+    def _build_update_clauses(
+        self,
+        columns: List[str],
+        conflict_on: List[str],
+        *,
+        sqlite: bool = False,
+        mysql: bool = False,
+    ) -> List[str]:
+        """Build the SET clauses for a DO UPDATE / ON DUPLICATE KEY UPDATE.
+
+        Excludes conflict-target columns and the immutable ``id`` / ``created_at``
+        columns. ``version_field`` increments; ``updated_at`` uses
+        ``CURRENT_TIMESTAMP``; everything else copies the incoming value with the
+        dialect-appropriate reference (``EXCLUDED.col`` on PG/SQLite,
+        ``VALUES(col)`` on MySQL).
+        """
+        clauses: List[str] = []
+        for col in columns:
+            if col in conflict_on or col in ("id", "created_at"):
+                continue
+            if col == self.version_field and self.version_control:
+                clauses.append(f"{col} = {self.table_name}.{col} + 1")
+            elif col == "updated_at" and self.auto_timestamps:
+                clauses.append(f"{col} = CURRENT_TIMESTAMP")
+            elif mysql:
+                clauses.append(f"{col} = VALUES({col})")
+            else:  # postgresql / sqlite both use excluded/EXCLUDED
+                ref = "excluded" if sqlite else "EXCLUDED"
+                clauses.append(f"{col} = {ref}.{col}")
+        return clauses
+
     def _process_upsert_result(
-        self, result: Dict[str, Any], batch_size: int, return_records: bool = False
+        self,
+        result: Dict[str, Any],
+        batch_size: int,
+        return_records: bool,
+        merge_strategy: str,
+        preexisting_count: int,
     ) -> tuple[int, int, int, List[Dict[str, Any]]]:
-        """Process AsyncSQLDatabaseNode result to extract counts and records."""
-        rows_affected = 0
-        inserted_count = 0
-        updated_count = 0
-        upserted_records = []
+        """Process AsyncSQLDatabaseNode result to extract counts and records.
 
-        if "result" in result and result["result"]:
+        Issue #1519: counts are DERIVED, not fabricated. The batch is deduped on
+        conflict_on, so ``preexisting_count`` (rows whose conflict key already
+        exists) IS the number of UPDATEs. There is no ``// 2`` heuristic.
+
+        - ``update`` strategy: every batch row is inserted OR updated →
+          updated = preexisting, inserted = batch_size - preexisting,
+          rows_affected = batch_size.
+        - ``ignore`` strategy: only new rows land →
+          inserted = batch_size - preexisting, updated = 0,
+          rows_affected = inserted.
+        """
+        upserted_records: List[Dict[str, Any]] = []
+        if return_records and "result" in result and result["result"]:
             result_data = result["result"]
+            data = result_data.get("data")
+            if (
+                isinstance(data, list)
+                and data
+                and isinstance(data[0], dict)
+                and ("id" in data[0] or len(data[0]) > 1)
+            ):
+                upserted_records = data
 
-            if "data" in result_data and isinstance(result_data["data"], list):
-                data = result_data["data"]
-
-                if data and isinstance(data[0], dict):
-                    if "id" in data[0]:
-                        # RETURNING clause results
-                        upserted_records = data
-                        rows_affected = len(upserted_records)
-                        # For now, assume half are inserts and half are updates (could be improved)
-                        inserted_count = rows_affected // 2
-                        updated_count = rows_affected - inserted_count
-                    elif "rows_affected" in data[0] and len(data[0]) == 1:
-                        # Metadata response - use batch_size
-                        rows_affected = batch_size
-                        inserted_count = batch_size // 2
-                        updated_count = batch_size - inserted_count
-                    else:
-                        # Other data - count the records
-                        rows_affected = len(data)
-                        inserted_count = rows_affected // 2
-                        updated_count = rows_affected - inserted_count
-            elif "row_count" in result_data:
-                # For UPSERT operations without RETURNING
-                rows_affected = batch_size
-                inserted_count = batch_size // 2
-                updated_count = batch_size - inserted_count
-            else:
-                rows_affected = batch_size  # Assume success for UPSERT
-                inserted_count = batch_size // 2
-                updated_count = batch_size - inserted_count
-        else:
-            rows_affected = batch_size  # Assume success if no specific result
-            inserted_count = batch_size // 2
-            updated_count = batch_size - inserted_count
+        preexisting = max(0, min(preexisting_count, batch_size))
+        if merge_strategy == "ignore":
+            inserted_count = batch_size - preexisting
+            updated_count = 0
+            rows_affected = inserted_count
+        else:  # update
+            updated_count = preexisting
+            inserted_count = batch_size - preexisting
+            rows_affected = batch_size
 
         return rows_affected, inserted_count, updated_count, upserted_records
+
+    async def _count_existing_conflicts(
+        self, batch: List[Dict[str, Any]], conflict_on: List[str], **kwargs
+    ) -> int:
+        """Count rows already present matching the batch's conflict-target keys.
+
+        Issue #1519: gives the real UPDATE count without relying on a per-row
+        insert/update flag (which SQLite's RETURNING cannot provide). Uses
+        OR-of-AND equality with dialect-appropriate placeholders. NULL conflict
+        values never match a UNIQUE target and are skipped. Every conflict
+        column is validated (``_validate_identifier``) before interpolation.
+        """
+        dialect = (self.database_type or "postgresql").lower()
+        for col in conflict_on:
+            _validate_identifier(col)
+
+        clauses: List[str] = []
+        params: List[Any] = []
+        for record in batch:
+            vals = [record.get(col) for col in conflict_on]
+            if any(v is None for v in vals):
+                continue
+            conds = []
+            for col in conflict_on:
+                if dialect == "postgresql":
+                    conds.append(f"{col} = ${len(params) + 1}")
+                elif dialect == "mysql":
+                    conds.append(f"{col} = %s")
+                else:  # sqlite
+                    conds.append(f"{col} = ?")
+                params.append(record.get(col))
+            clauses.append(f"({' AND '.join(conds)})")
+
+        if not clauses:
+            return 0
+
+        query = (
+            f"SELECT COUNT(*) AS match_count FROM {self.table_name} "
+            f"WHERE {' OR '.join(clauses)}"
+        )
+        result = await self._execute_query(query, params=params, **kwargs)
+        rows = []
+        if result and "result" in result and result["result"]:
+            rows = result["result"].get("data", []) or []
+        if rows and isinstance(rows[0], dict):
+            value = (
+                rows[0].get("match_count")
+                or rows[0].get("COUNT(*)")
+                or rows[0].get("count")
+                or 0
+            )
+            return int(value)
+        return 0
 
     async def _execute_query(
         self,

--- a/packages/kailash-dataflow/src/dataflow/sql/dialects.py
+++ b/packages/kailash-dataflow/src/dataflow/sql/dialects.py
@@ -67,30 +67,6 @@ class SQLDialect(ABC):
         """
         pass
 
-    @abstractmethod
-    def build_bulk_upsert_query(
-        self,
-        table_name: str,
-        records: List[Dict[str, Any]],
-        conflict_columns: List[str],
-        update_fields: List[str],
-        has_updated_at: bool = False,
-    ) -> UpsertQuery:
-        """
-        Build database-specific bulk upsert query.
-
-        Args:
-            table_name: Name of the table
-            records: List of records to upsert
-            conflict_columns: Columns that define uniqueness for conflict detection
-            update_fields: Fields to update on conflict
-            has_updated_at: Whether the model has an updated_at timestamp field
-
-        Returns:
-            UpsertQuery with query string, parameters, and native flag support info
-        """
-        pass
-
     def build_precheck_upsert_query(
         self,
         table_name: str,
@@ -255,70 +231,6 @@ class PostgreSQLDialect(SQLDialect):
             supports_native_flag=True,  # PostgreSQL has xmax
         )
 
-    def build_bulk_upsert_query(
-        self,
-        table_name: str,
-        records: List[Dict[str, Any]],
-        conflict_columns: List[str],
-        update_fields: List[str],
-        has_updated_at: bool = False,
-    ) -> UpsertQuery:
-        """Build PostgreSQL bulk upsert with xmax detection."""
-
-        if not records:
-            raise ValueError("Cannot build bulk upsert query with empty records list")
-
-        # Get columns from first record
-        columns = list(records[0].keys())
-
-        # Build VALUES clause with placeholders
-        values_clauses = []
-        params = {}
-        param_idx = 0
-
-        for record in records:
-            placeholders = []
-            for col in columns:
-                param_key = f"p{param_idx}"
-                placeholders.append(f":{param_key}")
-                params[param_key] = record[col]
-                param_idx += 1
-            values_clauses.append(f"({', '.join(placeholders)})")
-
-        values_str = ",\n            ".join(values_clauses)
-
-        # Build ON CONFLICT clause
-        conflict_cols_str = ", ".join(conflict_columns)
-
-        # Build UPDATE clause
-        update_clauses = []
-        for field in update_fields:
-            if field not in conflict_columns and field != "id":
-                update_clauses.append(f"{field} = EXCLUDED.{field}")
-
-        if has_updated_at:
-            update_clauses.append("updated_at = CURRENT_TIMESTAMP")
-
-        update_clause_str = (
-            ", ".join(update_clauses) if update_clauses else "id = EXCLUDED.id"
-        )
-
-        # Build complete query
-        query = f"""
-            INSERT INTO {table_name} ({", ".join(columns)})
-            VALUES
-            {values_str}
-            ON CONFLICT ({conflict_cols_str})
-            DO UPDATE SET {update_clause_str}
-            RETURNING id, (xmax = 0) AS inserted
-        """
-
-        return UpsertQuery(
-            query=query.strip(),
-            params=params,
-            supports_native_flag=True,  # PostgreSQL has xmax
-        )
-
 
 class SQLiteDialect(SQLDialect):
     """
@@ -392,70 +304,6 @@ class SQLiteDialect(SQLDialect):
             supports_native_flag=False,  # SQLite needs pre-check for INSERT/UPDATE detection
         )
 
-    def build_bulk_upsert_query(
-        self,
-        table_name: str,
-        records: List[Dict[str, Any]],
-        conflict_columns: List[str],
-        update_fields: List[str],
-        has_updated_at: bool = False,
-    ) -> UpsertQuery:
-        """Build SQLite bulk upsert without xmax detection."""
-
-        if not records:
-            raise ValueError("Cannot build bulk upsert query with empty records list")
-
-        # Get columns from first record
-        columns = list(records[0].keys())
-
-        # Build VALUES clause with placeholders
-        values_clauses = []
-        params = {}
-        param_idx = 0
-
-        for record in records:
-            placeholders = []
-            for col in columns:
-                param_key = f"p{param_idx}"
-                placeholders.append(f":{param_key}")
-                params[param_key] = record[col]
-                param_idx += 1
-            values_clauses.append(f"({', '.join(placeholders)})")
-
-        values_str = ",\n            ".join(values_clauses)
-
-        # Build ON CONFLICT clause
-        conflict_cols_str = ", ".join(conflict_columns)
-
-        # Build UPDATE clause
-        update_clauses = []
-        for field in update_fields:
-            if field not in conflict_columns and field != "id":
-                update_clauses.append(f"{field} = EXCLUDED.{field}")
-
-        if has_updated_at:
-            update_clauses.append("updated_at = CURRENT_TIMESTAMP")
-
-        update_clause_str = (
-            ", ".join(update_clauses) if update_clauses else "id = EXCLUDED.id"
-        )
-
-        # Build complete query WITHOUT xmax flag (use constant 1 as placeholder)
-        query = f"""
-            INSERT INTO {table_name} ({", ".join(columns)})
-            VALUES
-            {values_str}
-            ON CONFLICT ({conflict_cols_str})
-            DO UPDATE SET {update_clause_str}
-            RETURNING id, 1 AS inserted
-        """
-
-        return UpsertQuery(
-            query=query.strip(),
-            params=params,
-            supports_native_flag=False,  # SQLite needs pre-check
-        )
-
 
 class MySQLDialect(SQLDialect):
     """
@@ -503,65 +351,6 @@ class MySQLDialect(SQLDialect):
 
         # Build parameters
         params = {f"p{i}": insert_data[col] for i, col in enumerate(insert_columns)}
-
-        return UpsertQuery(
-            query=query.strip(),
-            params=params,
-            supports_native_flag=False,  # MySQL needs ROW_COUNT() check
-        )
-
-    def build_bulk_upsert_query(
-        self,
-        table_name: str,
-        records: List[Dict[str, Any]],
-        conflict_columns: List[str],
-        update_fields: List[str],
-        has_updated_at: bool = False,
-    ) -> UpsertQuery:
-        """Build MySQL bulk upsert with ON DUPLICATE KEY UPDATE."""
-
-        if not records:
-            raise ValueError("Cannot build bulk upsert query with empty records list")
-
-        # Get columns from first record
-        columns = list(records[0].keys())
-
-        # Build VALUES clause with placeholders
-        values_clauses = []
-        params = {}
-        param_idx = 0
-
-        for record in records:
-            placeholders = []
-            for col in columns:
-                param_key = f"p{param_idx}"
-                placeholders.append(f":{param_key}")
-                params[param_key] = record[col]
-                param_idx += 1
-            values_clauses.append(f"({', '.join(placeholders)})")
-
-        values_str = ",\n            ".join(values_clauses)
-
-        # Build UPDATE clause
-        update_clauses = []
-        for field in update_fields:
-            if field not in conflict_columns and field != "id":
-                update_clauses.append(f"{field} = VALUES({field})")
-
-        if has_updated_at:
-            update_clauses.append("updated_at = CURRENT_TIMESTAMP")
-
-        update_clause_str = (
-            ", ".join(update_clauses) if update_clauses else "id = VALUES(id)"
-        )
-
-        # Build complete query
-        query = f"""
-            INSERT INTO {table_name} ({", ".join(columns)})
-            VALUES
-            {values_str}
-            ON DUPLICATE KEY UPDATE {update_clause_str}
-        """
 
         return UpsertQuery(
             query=query.strip(),

--- a/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
+++ b/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
@@ -1026,8 +1026,7 @@ class QueryInterceptor:
                             upsert builders generally: the SQLite precheck path
                             (``build_precheck_upsert_query``, issue #1508) AND
                             the native ``ON CONFLICT`` builders for every dialect
-                            (``build_upsert_query`` on PG/SQLite/MySQL) plus
-                            ``build_bulk_upsert_query`` (``sql/dialects.py``).
+                            (``build_upsert_query`` on PG/SQLite/MySQL).
                             Bound by NAME
                             downstream (``_convert_to_named_parameters`` maps the
                             positional params list to ``{p0, p1, ...}`` by index),

--- a/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_delegation_integration.py
+++ b/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_delegation_integration.py
@@ -358,22 +358,33 @@ class TestBulkUpsertDelegationIntegration:
         """Test multi-tenant support in bulk_upsert delegation."""
         connection_string = setup_test_table
 
-        # Add tenant_id column and update constraint
-        alter_node = AsyncSQLDatabaseNode(
+        # Add tenant_id column and update constraint. asyncpg cannot execute
+        # multiple commands in one prepared statement, so run each ALTER
+        # separately.
+        drop_constraint_node = AsyncSQLDatabaseNode(
             connection_string=connection_string,
             database_type="postgresql",
-            query="""
-            ALTER TABLE test_upsert_delegations
-            DROP CONSTRAINT IF EXISTS test_upsert_delegations_email_key;
-
-            ALTER TABLE test_upsert_delegations
-            ADD CONSTRAINT test_upsert_delegations_email_tenant_key
-            UNIQUE (email, tenant_id);
-            """,
+            query=(
+                "ALTER TABLE test_upsert_delegations "
+                "DROP CONSTRAINT IF EXISTS test_upsert_delegations_email_key"
+            ),
             validate_queries=False,
         )
-        await alter_node.async_run()
-        await alter_node.cleanup()
+        await drop_constraint_node.async_run()
+        await drop_constraint_node.cleanup()
+
+        add_constraint_node = AsyncSQLDatabaseNode(
+            connection_string=connection_string,
+            database_type="postgresql",
+            query=(
+                "ALTER TABLE test_upsert_delegations "
+                "ADD CONSTRAINT test_upsert_delegations_email_tenant_key "
+                "UNIQUE (email, tenant_id)"
+            ),
+            validate_queries=False,
+        )
+        await add_constraint_node.async_run()
+        await add_constraint_node.cleanup()
 
         # Create DataFlow with multi-tenant enabled
         db = DataFlow(connection_string, auto_migrate=False)
@@ -407,6 +418,7 @@ class TestBulkUpsertDelegationIntegration:
                     },
                 ],
                 conflict_resolution="update",
+                conflict_columns=["email", "tenant_id"],
             )
 
         assert result1["success"] is True
@@ -424,6 +436,7 @@ class TestBulkUpsertDelegationIntegration:
                     },
                 ],
                 conflict_resolution="update",
+                conflict_columns=["email", "tenant_id"],
             )
 
         assert result2["success"] is True
@@ -506,7 +519,7 @@ class TestBulkUpsertDelegationIntegration:
         count_before_node = AsyncSQLDatabaseNode(
             connection_string=connection_string,
             database_type="postgresql",
-            query="SELECT COUNT(*) as count FROM test_upsert_delegation",
+            query="SELECT COUNT(*) as count FROM test_upsert_delegations",
             validate_queries=False,
         )
         before_result = await count_before_node.async_run()
@@ -529,7 +542,7 @@ class TestBulkUpsertDelegationIntegration:
         count_after_node = AsyncSQLDatabaseNode(
             connection_string=connection_string,
             database_type="postgresql",
-            query="SELECT COUNT(*) as count FROM test_upsert_delegation",
+            query="SELECT COUNT(*) as count FROM test_upsert_delegations",
             validate_queries=False,
         )
         after_result = await count_after_node.async_run()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1519_bulk_upsert_conflict_on.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1519_bulk_upsert_conflict_on.py
@@ -1,0 +1,515 @@
+"""Regression tests for issue #1519 — bulk_upsert silently ignored conflict_on.
+
+Before the fix, ``db.express.bulk_upsert(model, records, conflict_on=[...])`` and
+the generated ``{Model}BulkUpsertNode`` hardcoded ``ON CONFLICT (id) DO NOTHING``:
+
+- ``conflict_on`` was fully ignored (dropped in ``**kwargs`` on the way to
+  ``features/bulk.py::bulk_upsert``; the three dialect builders hardcoded
+  ``ON CONFLICT (id)``);
+- the generated/express path defaulted to ``conflict_resolution="skip"`` →
+  ``DO NOTHING`` instead of the documented insert-or-UPDATE contract;
+- returned counts were fabricated / zero while rows persisted.
+
+The DataFlowBulkUpsertNode (P2) SQLite/MySQL branch used ``INSERT OR REPLACE``
+(ignores conflict_on, invalid MySQL syntax) and fabricated counts via ``// 2``.
+
+The fix honors ``conflict_on`` via native single-statement
+``INSERT ... ON CONFLICT (conflict_on) DO UPDATE ... RETURNING`` (SQLite/PG) /
+``ON DUPLICATE KEY UPDATE`` (MySQL), defaults the express/generated path to
+``update``, derives real counts (PG ``(xmax = 0)`` / SQLite pre-count of existing
+conflict keys), and raises :class:`BulkUpsertConflictTargetError` when the
+conflict target is not a PK/UNIQUE key (instead of silently falling back).
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+import sqlite3
+import tempfile
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.exceptions import BulkUpsertConflictTargetError
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: express bulk_upsert over real file-backed SQLite (the live path)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def sqlite_db():
+    """Single-tenant DataFlow over file-backed SQLite. Yields (db, tmpdir)."""
+    tmpdir = tempfile.mkdtemp()
+    db = DataFlow(f"sqlite:///{tmpdir}/df.db", auto_migrate=True)
+
+    @db.model
+    class Widget:
+        id: str
+        name: str
+        qty: int
+
+    @db.model
+    class Person:
+        id: str
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    @db.model
+    class Note:
+        id: str
+        tag: str  # deliberately NOT unique
+        body: str
+
+    db._ensure_connected()
+    try:
+        yield db, tmpdir
+    finally:
+        db.close()
+
+
+def _rows(tmpdir, sql):
+    con = sqlite3.connect(f"{tmpdir}/df.db")
+    try:
+        return con.execute(sql).fetchall()
+    finally:
+        con.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_conflict_on_id_overlapping_updates_not_duplicates(sqlite_db):
+    """AC1/AC4: conflict_on=['id'] with overlapping ids updates, not duplicates,
+    and created/updated counts reflect the real rows written."""
+    db, tmpdir = sqlite_db
+
+    r1 = await db.express.bulk_upsert(
+        "Widget",
+        [{"id": "w1", "name": "A", "qty": 1}, {"id": "w2", "name": "B", "qty": 2}],
+        conflict_on=["id"],
+    )
+    assert r1["created"] == 2 and r1["updated"] == 0 and r1["total"] == 2
+
+    r2 = await db.express.bulk_upsert(
+        "Widget",
+        [
+            {"id": "w1", "name": "A-upd", "qty": 10},  # UPDATE existing id
+            {"id": "w3", "name": "C", "qty": 3},  # INSERT new id
+        ],
+        conflict_on=["id"],
+    )
+    # DO UPDATE (not DO NOTHING); counts split correctly.
+    assert r2["created"] == 1, r2
+    assert r2["updated"] == 1, r2
+    assert r2["total"] == 2, r2
+
+    rows = _rows(tmpdir, "SELECT id, name, qty FROM widgets ORDER BY id")
+    assert rows == [("w1", "A-upd", 10), ("w2", "B", 2), ("w3", "C", 3)], rows
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_conflict_on_unique_field_is_honored(sqlite_db):
+    """AC2: conflict_on on a field declared unique targets that constraint."""
+    db, tmpdir = sqlite_db
+
+    await db.express.bulk_upsert(
+        "Person",
+        [{"id": "p1", "email": "x@e.com", "name": "X1"}],
+        conflict_on=["email"],
+    )
+    r = await db.express.bulk_upsert(
+        "Person",
+        # Same email, DIFFERENT id -> conflict resolves on email, row updates.
+        [{"id": "p2", "email": "x@e.com", "name": "X2"}],
+        conflict_on=["email"],
+    )
+    assert r["updated"] == 1 and r["created"] == 0, r
+
+    rows = _rows(tmpdir, "SELECT email, name FROM people ORDER BY email")
+    assert rows == [("x@e.com", "X2")], rows  # single row, updated in place
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_conflict_on_non_unique_field_raises_actionable_error(sqlite_db):
+    """AC3: conflict_on on a non-unique column raises an actionable typed error
+    naming the column + remediation, and does NOT silently insert duplicates."""
+    db, tmpdir = sqlite_db
+
+    with pytest.raises(BulkUpsertConflictTargetError) as exc:
+        await db.express.bulk_upsert(
+            "Note",
+            [
+                {"id": "n1", "tag": "t", "body": "one"},
+                {"id": "n2", "tag": "t", "body": "two"},
+            ],
+            conflict_on=["tag"],
+        )
+    msg = str(exc.value)
+    assert "tag" in msg
+    assert "unique" in msg.lower()
+    assert "db.express.upsert" in msg  # remediation guidance
+
+    # No rows landed on the raise (not a silent duplicate-insert).
+    assert _rows(tmpdir, "SELECT COUNT(*) FROM notes")[0][0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: DataFlowBulkUpsertNode (P2 — the workflow/gateway node path)
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_node_sqlite_honors_conflict_on_no_insert_or_replace():
+    """P2: the SQLite branch uses native ON CONFLICT (NOT INSERT OR REPLACE) and
+    derives real counts."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/n.db"
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, email TEXT UNIQUE, name TEXT)")
+    con.execute("INSERT INTO t (id, email, name) VALUES (1, 'a@e.com', 'A')")
+    con.commit()
+    con.close()
+
+    node = DataFlowBulkUpsertNode(
+        table_name="t",
+        connection_string=f"sqlite:///{path}",
+        database_type="sqlite",
+        conflict_columns=["email"],
+        auto_timestamps=False,
+    )
+
+    # The generated SQL must NOT be INSERT OR REPLACE.
+    sql, _ = node._build_upsert_query(
+        [{"email": "z@e.com", "name": "Z"}],
+        ["email", "name"],
+        "email, name",
+        False,
+        "update",
+        ["email"],
+    )
+    assert "INSERT OR REPLACE" not in sql
+    assert "ON CONFLICT (email)" in sql and "DO UPDATE SET" in sql
+
+    res = await node.async_run(
+        data=[
+            {"email": "a@e.com", "name": "A-upd"},  # update by email
+            {"email": "b@e.com", "name": "B"},  # insert
+        ],
+        conflict_on=["email"],
+        merge_strategy="update",
+    )
+    assert res["success"] is True
+    assert res["inserted"] == 1 and res["updated"] == 1, res  # real, not // 2
+
+    con = sqlite3.connect(path)
+    rows = con.execute("SELECT email, name FROM t ORDER BY email").fetchall()
+    con.close()
+    assert dict(rows) == {"a@e.com": "A-upd", "b@e.com": "B"}, rows
+
+
+@pytest.mark.regression
+async def test_node_mysql_uses_on_duplicate_key_update():
+    """P2: the MySQL branch emits ON DUPLICATE KEY UPDATE (INSERT OR REPLACE is
+    invalid MySQL syntax). SQL-shape assertion, no MySQL server needed."""
+    node = DataFlowBulkUpsertNode(
+        table_name="t",
+        connection_string="mysql://x/y",
+        database_type="mysql",
+        conflict_columns=["email"],
+        auto_timestamps=False,
+    )
+    sql, _ = node._build_upsert_query(
+        [{"email": "z@e.com", "name": "Z"}],
+        ["email", "name"],
+        "email, name",
+        False,
+        "update",
+        ["email"],
+    )
+    assert "INSERT OR REPLACE" not in sql
+    assert "ON DUPLICATE KEY UPDATE" in sql
+    assert "name = VALUES(name)" in sql
+    # conflict-target column is excluded from the update set.
+    assert "email = VALUES(email)" not in sql
+
+
+@pytest.mark.regression
+async def test_node_dry_run_does_not_fabricate_counts():
+    """P2: dry-run reports would_upsert without a fabricated inserted/updated
+    split (issue #1519 — the `// 2` mock estimate is gone)."""
+    node = DataFlowBulkUpsertNode(
+        table_name="t",
+        connection_string="postgresql://x/y",
+        database_type="postgresql",
+        conflict_columns=["email"],
+    )
+    res = await node.async_run(
+        data=[
+            {"email": "a@e.com", "name": "A"},
+            {"email": "b@e.com", "name": "B"},
+            {"email": "c@e.com", "name": "C"},
+        ],
+        dry_run=True,
+        conflict_on=["email"],
+    )
+    assert res["dry_run"] is True
+    assert res["would_upsert"] == 3
+    assert res["inserted"] == 0 and res["updated"] == 0  # no // 2 fabrication
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: PostgreSQL parity (AC5) — real PG on port 5434
+# ---------------------------------------------------------------------------
+@pytest.fixture
+async def pg_suite():
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+async def _drop_table(url, table):
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=url,
+        database_type="postgresql",
+        query=f"DROP TABLE IF EXISTS {table} CASCADE",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_postgres_conflict_on_honored_with_real_counts(pg_suite):
+    """AC5: PostgreSQL equivalent — conflict_on honored + accurate created/updated
+    counts derived from the (xmax = 0) RETURNING flag."""
+    url = pg_suite.config.url
+    # auto_migrate creates the table (with the UNIQUE(email) index) so the
+    # table name matches DataFlow's own pluralization.
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1519Pg:
+        email: str
+        name: str
+        score: int
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    table = db._models["Issue1519Pg"]["table_name"]
+    await _drop_table(url, table)
+    db._ensure_connected()
+
+    try:
+        # First upsert: 2 inserts.
+        r1 = await db.bulk.bulk_upsert(
+            model_name="Issue1519Pg",
+            data=[
+                {"email": "a@e.com", "name": "A", "score": 1},
+                {"email": "b@e.com", "name": "B", "score": 2},
+            ],
+            conflict_resolution="update",
+            conflict_on=["email"],
+        )
+        assert r1["success"] is True
+        assert r1["inserted"] == 2 and r1["updated"] == 0, r1
+
+        # Second upsert: 1 update (a@e.com) + 1 insert (c@e.com), by EMAIL not id.
+        r2 = await db.bulk.bulk_upsert(
+            model_name="Issue1519Pg",
+            data=[
+                {"email": "a@e.com", "name": "A2", "score": 11},
+                {"email": "c@e.com", "name": "C", "score": 3},
+            ],
+            conflict_resolution="update",
+            conflict_on=["email"],
+        )
+        assert r2["success"] is True
+        assert r2["inserted"] == 1, r2
+        assert r2["updated"] == 1, r2
+
+        rows = await db.express.list("Issue1519Pg", order_by="email")
+        by_email = {r["email"]: (r["name"], r["score"]) for r in rows}
+        assert len(by_email) == 3, rows
+        assert by_email["a@e.com"] == ("A2", 11)  # updated in place
+        assert by_email["c@e.com"] == ("C", 3)
+    finally:
+        await _drop_table(url, table)
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_postgres_non_unique_conflict_target_raises(pg_suite):
+    """AC5/AC3 parity: PostgreSQL non-unique conflict target raises the typed
+    error instead of silently landing duplicates."""
+    url = pg_suite.config.url
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1519PgNonuniq:
+        tag: str  # NOT unique
+        body: str
+
+    table = db._models["Issue1519PgNonuniq"]["table_name"]
+    await _drop_table(url, table)
+    db._ensure_connected()
+
+    try:
+        with pytest.raises(BulkUpsertConflictTargetError):
+            await db.bulk.bulk_upsert(
+                model_name="Issue1519PgNonuniq",
+                data=[{"tag": "t", "body": "one"}, {"tag": "t", "body": "two"}],
+                conflict_resolution="update",
+                conflict_on=["tag"],
+            )
+        # No rows landed on the raise.
+        assert await db.express.count("Issue1519PgNonuniq") == 0
+    finally:
+        await _drop_table(url, table)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Redteam H1: internal-duplicate conflict keys within one batch
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_internal_duplicate_conflict_keys_dedup_last_wins(sqlite_db):
+    """Redteam H1: a single bulk_upsert call carrying TWO records with the same
+    conflict-target key must (a) collapse to last-wins, (b) write exactly one
+    row, and (c) report counts that MATCH the rows actually written — never the
+    pre-fix over-count (created=2 while 1 row landed). Guards against the SQLite
+    over-count AND the PostgreSQL "ON CONFLICT DO UPDATE cannot affect row a
+    second time" hard-error by making both dialects dedup-consistent."""
+    db, tmpdir = sqlite_db
+
+    r = await db.express.bulk_upsert(
+        "Widget",
+        [
+            {"id": "x", "name": "first", "qty": 1},
+            {"id": "x", "name": "second", "qty": 2},  # same id — last wins
+            {"id": "y", "name": "Y", "qty": 9},
+        ],
+        conflict_on=["id"],
+    )
+    # Two distinct keys → two rows; counts MUST equal rows written.
+    assert r["created"] + r["updated"] == 2, r
+    assert r["created"] == 2 and r["updated"] == 0, r
+
+    rows = _rows(tmpdir, "SELECT id, name, qty FROM widgets ORDER BY id")
+    assert rows == [("x", "second", 2), ("y", "Y", 9)], rows  # last-wins on x
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_internal_dup_then_update_reports_real_counts(sqlite_db):
+    """Second call whose batch re-conflicts an existing key AND self-duplicates:
+    the deduped single UPDATE must report updated=1 (not the pre-fix over-count),
+    and the persisted value is the last occurrence."""
+    db, tmpdir = sqlite_db
+    await db.express.bulk_upsert(
+        "Widget", [{"id": "k", "name": "orig", "qty": 0}], conflict_on=["id"]
+    )
+    r = await db.express.bulk_upsert(
+        "Widget",
+        [
+            {"id": "k", "name": "up-a", "qty": 1},
+            {"id": "k", "name": "up-b", "qty": 2},  # dup of k in same batch
+        ],
+        conflict_on=["id"],
+    )
+    assert r["created"] == 0 and r["updated"] == 1, r
+    rows = _rows(tmpdir, "SELECT id, name, qty FROM widgets ORDER BY id")
+    assert rows == [("k", "up-b", 2)], rows
+
+
+# ---------------------------------------------------------------------------
+# Redteam MEDIUM (security): shared driver-error redactor scrubs column values
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+def test_sanitize_db_error_redacts_column_values():
+    """Redteam MEDIUM: a unique-violation from a DIFFERENT constraint embeds
+    column VALUES (potential PII) in the driver message. The shared redactor
+    (used by features/bulk.py AND nodes/bulk_upsert.py) MUST strip the value
+    payload while preserving the diagnostic shape; non-DB messages pass
+    through unchanged."""
+    from dataflow.core.exceptions import sanitize_db_error
+
+    # PostgreSQL form: value rides in a DETAIL: line → whole line redacted.
+    leaked_pg = (
+        'duplicate key value violates unique constraint "users_username_key"\n'
+        "DETAIL:  Key (username)=(alice@example.com) already exists."
+    )
+    scrubbed_pg = sanitize_db_error(leaked_pg)
+    assert "alice@example.com" not in scrubbed_pg  # the security property
+    assert "DETAIL: [REDACTED]" in scrubbed_pg  # shape preserved
+    assert "users_username_key" in scrubbed_pg  # constraint name (triage) kept
+
+    # Main-line Key(...)=(...) form (no DETAIL: prefix) → value payload redacted,
+    # column name retained.
+    leaked_key = "ERROR: Key (email)=(bob@corp.example) already exists"
+    scrubbed_key = sanitize_db_error(leaked_key)
+    assert "bob@corp.example" not in scrubbed_key
+    assert "Key (email)=([REDACTED])" in scrubbed_key
+
+    # Non-DB message passes through untouched (no false redaction).
+    assert sanitize_db_error("Bulk upsert operation failed: timeout") == (
+        "Bulk upsert operation failed: timeout"
+    )
+    # Non-string input fails closed to a sentinel, never raises.
+    assert sanitize_db_error(None) == "<non-string error>"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Redteam CRITICAL (security): dynamic identifiers are validated before
+# interpolation on the express bulk path (dataflow-identifier-safety.md MUST-1)
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_crafted_column_key_rejected_no_injection(sqlite_db):
+    """Redteam CRITICAL: a crafted record KEY (column names are interpolated as
+    bare identifiers into INSERT/ON CONFLICT/DO UPDATE — drivers cannot bind
+    identifiers) MUST be rejected by _validate_identifier BEFORE any SQL is
+    emitted. The express bulk path (features/bulk.py) previously validated only
+    the conflict-target columns, leaving the INSERT/SET column list unguarded."""
+    db, tmpdir = sqlite_db
+
+    res = await db.bulk.bulk_upsert(
+        "Widget",
+        [{"id": "a", "name": "x", "evil) ; DROP TABLE widgets;--": "z"}],
+        conflict_on=["id"],
+    )
+    # Rejected as a failure — not a silent success — and NO injection executed.
+    assert res.get("success") is False, res
+    # The fingerprinted validator message must NOT echo the raw payload.
+    assert "DROP TABLE" not in str(res.get("error", "")), res
+    # The table still exists (the injection never ran).
+    assert _rows(tmpdir, "SELECT count(*) FROM widgets") == [(0,)]
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_single_record_upsert_crafted_key_rejected(sqlite_db):
+    """Redteam sibling (same identifier-injection class on the single-record
+    {Model}UpsertNode path): a crafted record KEY in the create payload MUST be
+    rejected by _validate_identifier before the dialect builds SQL — no
+    injection, table intact. Guards the core/nodes.py single-record upsert
+    caller-side validation added alongside the #1519 bulk fix."""
+    db, tmpdir = sqlite_db
+
+    with pytest.raises(Exception) as exc:
+        await db.express.upsert(
+            "Widget",
+            {"id": "z", "name": "x", "evil) ; DROP TABLE widgets;--": "q"},
+            {"name": "y"},
+        )
+    # Fingerprinted identifier error — must NOT echo the raw payload.
+    assert "DROP TABLE" not in str(exc.value)
+    assert "identifier" in str(exc.value).lower()
+    # The injection never executed — table still present with 0 rows.
+    assert _rows(tmpdir, "SELECT COUNT(*) FROM widgets") == [(0,)]

--- a/packages/kailash-dataflow/tests/unit/features/test_bulk_upsert_delegation.py
+++ b/packages/kailash-dataflow/tests/unit/features/test_bulk_upsert_delegation.py
@@ -322,7 +322,10 @@ class TestBulkUpsertDelegation:
 
         bulk_ops = BulkOperations(mock_dataflow)
 
-        # Test 1: Missing 'id' field returns error (validation before SQL execution)
+        # Test 1: Missing conflict-target column returns error before SQL exec.
+        # Issue #1519: with the default conflict_on=["id"], a record without an
+        # 'id' is missing the conflict target — the validation now names the
+        # conflict-target column(s) rather than a hardcoded 'id'.
         result = await bulk_ops.bulk_upsert(
             model_name="User",
             data=[{"email": "test@example.com", "name": "Test"}],  # Missing 'id'
@@ -331,7 +334,8 @@ class TestBulkUpsertDelegation:
 
         assert result["success"] is False
         assert "error" in result
-        assert "missing required 'id' field" in result["error"]
+        assert "missing conflict-target column(s) ['id']" in result["error"]
+        assert result["records_processed"] == 0
 
         # Test 2: SQL node raises exception
         mock_sql_node = AsyncMock()


### PR DESCRIPTION
## Summary

`db.express.bulk_upsert(model, records, conflict_on=[...])` and the generated `{Model}BulkUpsertNode` **silently ignored `conflict_on`** and hardcoded `INSERT ... ON CONFLICT (id) DO NOTHING`: the requested conflict target was never applied, duplicate-key rows landed, and the call returned `created/updated=0` while rows persisted.

Root cause was three divergent bulk-upsert builders that had drifted apart:
1. `features/bulk.py` (the live `db.express` path) — hardcoded `ON CONFLICT (id)` for **all** dialects; `conflict_on` dropped in `**kwargs`.
2. `nodes/bulk_upsert.py::DataFlowBulkUpsertNode` — SQLite/MySQL used `INSERT OR REPLACE` (ignores `conflict_on`, invalid MySQL syntax); counts fabricated via `// 2`.
3. `sql/dialects.py::build_bulk_upsert_query` — honored `conflict_on` but was **orphaned dead code** (zero `src/` callers).

## What changed

- **Honor `conflict_on`** via native single-statement `INSERT ... ON CONFLICT (conflict_on) DO UPDATE ... RETURNING` (SQLite/PG) / `ON DUPLICATE KEY UPDATE` (MySQL).
- **Default the express/generated path to `conflict_resolution="update"`** (was `"skip"` → the erroneous `DO NOTHING`).
- **Real counts** — PG `(xmax=0)`, SQLite pre-count of existing conflict keys. No fabricated `// 2`.
- **Actionable error** — a non-PK/UNIQUE conflict target raises the new typed `BulkUpsertConflictTargetError` (naming the column + remediation) instead of silently falling back to `ON CONFLICT (id)`.
- **Deleted the orphan** `build_bulk_upsert_query` (4 methods, ~211 LOC) + its interceptor doc ref (orphan-detection Rule 3).

## Redteam findings (reviewer + security-reviewer, 2 rounds — all closed)

- **Batch de-duplication** on the conflict target (last-wins) before the statement: an internal-duplicate batch previously over-counted on SQLite (`created=2` for 1 row) and hard-errored on PG; dedup makes counts match reality and both dialects consistent.
- **Identifier safety** (`dataflow-identifier-safety.md` MUST-1): validate `table_name` + every interpolated column name on the bulk path **and** the single-record `{Model}UpsertNode` caller (same injection class, reachable via user-supplied record keys) before any SQL is built.
- **Driver-error PII**: shared `sanitize_db_error` scrubs column VALUES from `DETAIL:`/`Key(...)` driver messages at every bulk error handler; `exc_info` dropped so the traceback cannot re-leak them.

## Tests

13 Tier-2 regression tests in `tests/regression/test_issue_1519_bulk_upsert_conflict_on.py` (real SQLite + real PG): `conflict_on` honored/updates-not-duplicates, unique-target honored, non-unique raises, internal-dup dedup counts, P2 node SQLite/MySQL SQL-shape + real counts, crafted-key injection rejected (bulk + single-record), driver-error redaction. Broad sweep: 894 passed.

Pre-existing/out-of-scope (proven via stash, per session notes): 2 PG single-record fixture failures (`user_email_unique` index) and the `test_bulk_upsert_comprehensive.py` hang — both reproduce on `main`.

## Related issues

Fixes #1519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)