### PR TITLE
release(dataflow): v2.13.9 — bulk_upsert honors conflict_on (#1519)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 
-## [2.13.8] — 2026-07-03 — multi_tenant upsert binds tenant_id to the active tenant
+## [2.13.9] — 2026-07-03 — bulk_upsert honors conflict_on (SQLite/PG); 3 divergent builders reconciled
+
+### Fixed
+
+- **`bulk_upsert(conflict_on=[...])` now honors the requested conflict target instead of silently `ON CONFLICT (id) DO NOTHING` (#1519).** `db.express.bulk_upsert` and the generated `{Model}BulkUpsertNode` dropped `conflict_on` entirely and hardcoded a skip-on-`id` upsert: the target was never applied, duplicate-key rows landed, and the call returned `created/updated = 0` while rows persisted. Three divergent builders had drifted — `features/bulk.py` (the live express path) hardcoded `ON CONFLICT (id)` for **every** dialect and defaulted the express/generated path to `conflict_resolution="skip"` (→ `DO NOTHING`); `nodes/bulk_upsert.py::DataFlowBulkUpsertNode` used `INSERT OR REPLACE` on SQLite/MySQL (ignores `conflict_on`; not valid MySQL syntax) and fabricated `inserted`/`updated` counts as `rows_affected // 2`; `sql/dialects.py::build_bulk_upsert_query` honored `conflict_on` but was orphaned dead code (zero `src/` callers). Reconciled to one contract: native single-statement `INSERT ... ON CONFLICT (conflict_on) DO UPDATE ... RETURNING` (SQLite/PG) / `ON DUPLICATE KEY UPDATE` (MySQL); the express/generated path defaults to `update`; counts are derived from the write (PG `(xmax = 0)`, SQLite pre-count of existing conflict keys — no `// 2` heuristic); a non-PK/UNIQUE conflict target raises the new typed `BulkUpsertConflictTargetError` (naming the column + remediation) rather than falling back to `ON CONFLICT (id)`. The orphaned `build_bulk_upsert_query` (4 methods, ~211 LOC) was deleted (`rules/orphan-detection.md`). A batch carrying duplicate conflict-target keys is de-duplicated last-wins before the statement, so reported counts match rows written and SQLite/PG behave identically (PG previously raised "ON CONFLICT DO UPDATE command cannot affect row a second time"). Sibling of the single-record #1508; the non-unique-target error mirrors PG's #1520 behavior.
+
+### Security
+
+- **Bulk-upsert identifier validation + driver-error redaction (red-team hardening for #1519).** Every dynamically-interpolated identifier on the bulk path (`table_name`, INSERT/`DO UPDATE SET` column names) — and, closing the same class on the single-record `{Model}UpsertNode` caller — is now validated against the strict allowlist before SQL is built (`rules/dataflow-identifier-safety.md`); a crafted record key can no longer reach the statement. DB driver errors from a _different_ unique constraint (which embed column VALUES / potential PII in `DETAIL:`/`Key(...)=(...)`) are routed through a shared `sanitize_db_error` redactor at every bulk error handler (create/update/delete/upsert), and `exc_info` was dropped from those handlers so the traceback cannot re-leak the raw message.
 
 ### Fixed
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.8"
+version = "2.13.9"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.8"
+__version__ = "2.13.9"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Metadata-only release-prep for **kailash-dataflow 2.13.8 → 2.13.9**, shipping the merged #1519 fix (PR #1530): `bulk_upsert` honors `conflict_on` via native `ON CONFLICT` (SQLite/PG) / `ON DUPLICATE KEY UPDATE` (MySQL), defaults the express path to `update`, derives real counts, raises `BulkUpsertConflictTargetError` on a non-unique target, deletes the orphan `build_bulk_upsert_query`, plus red-team identifier-validation + driver-error-redaction hardening.

- `pyproject.toml` + `src/dataflow/__init__.py` → `2.13.9` (atomic, zero-tolerance Rule 5)
- `CHANGELOG.md` → `[2.13.9]` entry (Fixed + Security)

Metadata-only → PR-gate matrix auto-skips per `release/v*` convention. Tag `dataflow-v2.13.9` (→ `publish-pypi.yml`) pushed after merge.

## Related issues

Ships the fix for #1519 (closed by #1530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)