### PR TITLE
docs(deploy): kailash-dataflow 2.13.9 release record (#1519) + session notes

### DIFF
--- a/.session-notes.d/esperie.md
+++ b/.session-notes.d/esperie.md
@@ -5,7 +5,7 @@
 
 ---
 
-last_reconciled_sha: 75015a852
+last_reconciled_sha: 3aff2a707
 migrated_from: .session-notes
 ---
 
@@ -13,35 +13,42 @@ migrated_from: .session-notes
 
 ## Where we are
 
-Clean on `main`, working tree clean, 0 open PRs. This session shipped **kailash-dataflow 2.13.8**
-(`/autonomize` + `/redteam`), closing **#1518** (multi_tenant upsert mis-mapped `tenant_id` →
-cross-tenant leak class) via an interceptor `:pN` colon-style fix. Recommended next: **#1519**
-(F-BULK, same upsert bug family).
+Clean on `main`, working tree clean, 0 open PRs. This session shipped **kailash-dataflow 2.13.9**
+(`/autonomize` + `/redteam` to convergence), closing **#1519** (F-BULK — `bulk_upsert` silently
+ignored `conflict_on`, hardcoded `ON CONFLICT (id) DO NOTHING` → dup rows + 0 counts). Fix reconciled
+3 divergent builders → native `ON CONFLICT (conflict_on) DO UPDATE ... RETURNING` (SQLite/PG) /
+`ON DUPLICATE KEY UPDATE` (MySQL), express default `update`, real counts, typed
+`BulkUpsertConflictTargetError` on a non-unique target, orphan `build_bulk_upsert_query` deleted.
+Red-team also landed identifier-validation (bulk + single-record `{Model}UpsertNode` caller) +
+driver-error PII redaction. Recommended next: **#1520** (F-PG, same upsert family).
 
 ## Read first
 
-1. `gh issue view 1519` — recommended next (bulk_upsert ignores `conflict_on` on SQLite).
-2. `deploy/deployments/2026-07-03-dataflow-v2.13.8-1518-multi-tenant-upsert-tenant-id.md` — #1518 root cause.
-3. `packages/kailash-dataflow/src/dataflow/sql/dialects.py` — the 3 divergent bulk builders (#1519 core).
-4. `packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py` — the `:pN` machinery just fixed.
+1. `gh issue view 1520` — recommended next (PG upsert `conflict_on` on a non-unique field → cryptic
+   driver error; add an actionable up-front error, no auto-DDL — mirrors #1519's raise).
+2. `deploy/deployments/2026-07-03-dataflow-v2.13.9-1519-bulk-upsert-conflict-on.md` — #1519 root cause + red-team.
+3. `packages/kailash-dataflow/src/dataflow/features/bulk.py` — the LIVE express bulk path (P1);
+   `bulk_upsert` + `_build_{postgresql,sqlite,mysql}_upsert` + `_count_existing_conflicts`.
+4. `packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py` — the workflow/gateway node (P2).
 
 ## Outstanding ledger (forest)
 
-| ID        | Item                                                                   | Value-anchor (MUST-1 source)                              | Status                                                                                                        |
-| --------- | ---------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| F-BULK    | bulk_upsert ignores `conflict_on` on SQLite (hardcodes ON CONFLICT id) | #1519; surfaced by #1508 redteam                          | OPEN HIGH — dup rows + 0 counts; 3 divergent builders + orphaned methods. Design shard. **RECOMMENDED NEXT.** |
-| F-PG      | PG upsert `conflict_on` on non-unique field → cryptic driver error     | #1520; sibling of #1508                                   | OPEN MED — add actionable up-front error (no auto-DDL).                                                       |
-| F-COMPKEY | multi_tenant single-column `id` PK → tenants can't share a natural key | #1526; #1518 AC (user-flagged 2026-07-03)                 | OPEN design — needs composite `(tenant_id,id)` uniqueness. Fails closed today (safe). Maintainer call.        |
-| F6        | Convert `test_production_dataflow` off mock engine (Tier-2 NO-MOCK)    | #1503; rules/testing.md §Tier 2                           | queued (#1503) — xfail-strict self-clears                                                                     |
-| F7        | `test_concurrent_order_processing` PG two-txn isolation fails on main  | #1504 (pre-existing at HEAD)                              | queued (#1504) — separate PG-isolation shard                                                                  |
-| F2        | mops-onboarding cross-repo: loom issue + kailash-rs rollout            | user 2026-06-23 "roll out to kailash-rs…file 2 into loom" | GATED (receipt-gated; dedicated session)                                                                      |
-| F3        | ~29 prod TODO markers                                                  | user 2026-06-26 "leave as baseline"                       | DEFERRED (user)                                                                                               |
+| ID        | Item                                                                   | Value-anchor (MUST-1 source)                              | Status                                                                                                                        |
+| --------- | ---------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| F-PG      | PG upsert `conflict_on` on non-unique field → cryptic driver error     | #1520; sibling of #1508/#1519                             | OPEN MED — add actionable up-front error (no auto-DDL); mirror #1519's `BulkUpsertConflictTargetError`. **RECOMMENDED NEXT.** |
+| F-COMPKEY | multi_tenant single-column `id` PK → tenants can't share a natural key | #1526; #1518 AC (user-flagged 2026-07-03)                 | OPEN design — needs composite `(tenant_id,id)` uniqueness. Fails closed today (safe). Maintainer call.                        |
+| F6        | Convert `test_production_dataflow` off mock engine (Tier-2 NO-MOCK)    | #1503; rules/testing.md §Tier 2                           | queued (#1503) — xfail-strict self-clears                                                                                     |
+| F7        | `test_concurrent_order_processing` PG two-txn isolation fails on main  | #1504 (pre-existing at HEAD)                              | queued (#1504) — separate PG-isolation shard                                                                                  |
+| F2        | mops-onboarding cross-repo: loom issue + kailash-rs rollout            | user 2026-06-23 "roll out to kailash-rs…file 2 into loom" | GATED (receipt-gated; dedicated session)                                                                                      |
+| F3        | ~29 prod TODO markers                                                  | user 2026-06-26 "leave as baseline"                       | DEFERRED (user)                                                                                                               |
 
-Closed this session: `F-TENANT` → `dataflow-v2.13.8` (PR #1525 fix, #1527 release; #1518 closed).
+Closed this session: `F-BULK` → `dataflow-v2.13.9` (PR #1530 fix, #1531 release, tag `dataflow-v2.13.9` publish run 28663196213; #1519 closed).
 
 ## Traps
 
 - Test env: `.venv/bin/python -m pytest` (NOT `uv run`); SQLite tests need `aiosqlite`; real PG on 5434.
-- PG upsert integration tests (`test_single_upsert_*`) fail on `main` with `relation "order_items" does not exist` — pre-existing PG-fixture gap, NOT a regression (proven via stash). Don't chase as new.
-- `:pN` (colon) placeholders come from EVERY upsert/bulk dialect builder, not only the SQLite precheck — relevant to #1519's builder reconciliation.
-- PyPI/uv index lag on release-verify: `uv pip install --refresh`, retry ~3×/60s.
+- **Live express bulk path = `features/bulk.py` (P1), NOT `nodes/bulk_upsert.py` (P2) nor `sql/dialects.py`.** `db.express.bulk_upsert` → generated `{Model}BulkUpsertNode` → `core/nodes.py` generic bulk handler → `self.bulk.bulk_upsert`. P2 (`DataFlowBulkUpsertNode`) is the separate `workflow.add_node(...)` / gateway path. `sql/dialects.py::build_bulk_upsert_query` was orphan dead code — deleted in #1519.
+- PG upsert integration tests (`test_single_upsert_*::TestPostgreSQL*`) fail on `main` (`could not create unique index "user_email_unique"` / `relation "order_items" does not exist`) — pre-existing PG-fixture-isolation gap, NOT a regression (proven via stash). Don't chase as new.
+- `test_bulk_upsert_comprehensive.py` HANGS (pytest-timeout) on `main` too — pre-existing pool/ordering issue; exclude from sweeps, don't chase.
+- Bulk/single-record upsert `conflict_on` MUST reference a PK/UNIQUE key → else `BulkUpsertConflictTargetError` (bulk) / driver error (#1520, single-record PG). SQLite single-record tolerates non-unique via the #1508 WHERE-precheck; bulk requires unique (batch-internal-dup ambiguity).
+- PyPI/uv index lag on release-verify: `uv pip install --refresh` (uv venv has no pip — don't `python -m pip`); PyPI json endpoint confirms publish before the index reflects it.

--- a/deploy/deployments/2026-07-03-dataflow-v2.13.9-1519-bulk-upsert-conflict-on.md
+++ b/deploy/deployments/2026-07-03-dataflow-v2.13.9-1519-bulk-upsert-conflict-on.md
@@ -1,0 +1,81 @@
+# Deployment Record — kailash-dataflow 2.13.9 (#1519)
+
+**Date:** 2026-07-03
+**Package:** kailash-dataflow `2.13.8 → 2.13.9` (patch, dataflow-only)
+**Issue:** #1519 — `bulk_upsert` silently ignores `conflict_on` (hardcodes `ON CONFLICT (id) DO NOTHING`) → dup rows + 0 counts
+**Fix PR:** #1530 · **Release-prep PR:** #1531 · **Tag:** `dataflow-v2.13.9` · **Publish run:** `28663196213` (SUCCESS)
+
+## What shipped
+
+`db.express.bulk_upsert(model, records, conflict_on=[...])` and the generated `{Model}BulkUpsertNode`
+**silently ignored `conflict_on`** and hardcoded `INSERT ... ON CONFLICT (id) DO NOTHING`: the
+requested conflict target was never applied, duplicate-key rows landed, and the call returned
+`created/updated = 0` while rows persisted (`zero-tolerance.md` Rule 3c — documented kwarg with zero
+effect, + silent data duplication + wrong counts).
+
+Root cause — three divergent bulk-upsert builders had drifted apart:
+
+1. `features/bulk.py` (the LIVE express path: `db.express.bulk_upsert` → generated
+   `{Model}BulkUpsertNode` → `core/nodes.py` generic bulk handler → `self.bulk.bulk_upsert`) —
+   `bulk_upsert()` dropped `conflict_on` in `**kwargs`; the three dialect builders hardcoded
+   `ON CONFLICT (id)`; the generic handler defaulted `conflict_resolution="skip"` (→ `DO NOTHING`).
+2. `nodes/bulk_upsert.py::DataFlowBulkUpsertNode` (workflow / gateway path) — SQLite/MySQL used
+   `INSERT OR REPLACE` (ignores `conflict_on`; not valid MySQL syntax) and fabricated
+   `inserted`/`updated` as `rows_affected // 2`.
+3. `sql/dialects.py::build_bulk_upsert_query` — honored `conflict_on` but was **orphaned dead code**
+   (zero `src/` callers; would be #1508-vulnerable if wired).
+
+Fix — reconciled to one contract: honor `conflict_on` via native single-statement
+`INSERT ... ON CONFLICT (conflict_on) DO UPDATE ... RETURNING` (SQLite/PG) / `ON DUPLICATE KEY UPDATE`
+(MySQL); the express/generated path defaults to `update`; counts are derived from the write (PG
+`(xmax = 0)`; SQLite pre-count of existing conflict keys — no `// 2`); a non-PK/UNIQUE conflict target
+raises the new typed `BulkUpsertConflictTargetError` (naming the column + remediation) rather than
+falling back to `ON CONFLICT (id)`. The orphaned `build_bulk_upsert_query` (4 methods, ~211 LOC) was
+deleted (`orphan-detection.md`). A batch carrying duplicate conflict-target keys is de-duplicated
+last-wins before the statement, so reported counts match rows written and SQLite/PG behave
+identically (PG previously raised "ON CONFLICT DO UPDATE command cannot affect row a second time").
+Sibling of the single-record #1508; the non-unique-target error mirrors PG's #1520 behavior.
+
+## Verification
+
+- **Red-team CONVERGED (2 rounds, parallel `reviewer` + `security-reviewer` + empirical
+  dataflow closure).** Round 1: reviewer MERGE-WITH-FIXES (HIGH — internal-duplicate-batch
+  over-count on the live express path; PG hard-errors on the same input) + M1 (non-atomic pre-count,
+  documented); security SECURE-WITH-FIXES (CRITICAL — `features/bulk.py` validated only the
+  conflict columns, leaving `table_name` + the INSERT/`DO UPDATE SET` column list unvalidated;
+  MEDIUM — raw `str(e)` driver errors could leak column VALUES / PII). All fixed in-session per
+  `autonomous-execution.md` Rule 4: batch dedup (last-wins), `_validate_identifier` on every
+  interpolated identifier (bulk path AND the same-class single-record `{Model}UpsertNode` caller),
+  shared `sanitize_db_error` at every bulk error handler + `exc_info` dropped so tracebacks cannot
+  re-leak. Round 2: reviewer CLOSED-MERGE (routing corrected — the live path IS `features/bulk.py`
+  P1; dedup placement + cross-chunk counts verified); security SECURE-WITH-FIXES (both findings
+  closed on the #1519 path; the pre-existing single-record dialect gap was fixed same-session).
+- **Tests:** 13 Tier-2 regression tests (`test_issue_1519_bulk_upsert_conflict_on.py`, real SQLite +
+  real PG on 5434) — `conflict_on` honored / updates-not-duplicates; unique-target honored;
+  non-unique raises with no rows landed; internal-dup dedup counts (both dialects); P2 node
+  SQLite/MySQL SQL-shape + non-fabricated counts; crafted-key injection rejected (bulk +
+  single-record); driver-error redaction. Broader gate: 894 passed across
+  `tests/unit/{features,core}` + bulk delegation/node integration + #1252 + #1508 unregressed.
+- **CI:** Fix PR #1530 full matrix GREEN (20 pass / 4 skip). Release-prep PR #1531
+  (`release/v2.13.9-dataflow`, `--admin`, matrix path-skipped).
+- **Clean-venv (Python 3.12, published wheel + `aiosqlite`, after the documented uv index-cache lag —
+  `uv pip install --refresh`):** `dataflow.__version__ == "2.13.9"`; #1519 repro (bulk_upsert
+  `conflict_on=["id"]`) → `created=2` then `created=1/updated=1`, existing row updated (`A`→`A2`),
+  non-unique `conflict_on=["email"]` → `BulkUpsertConflictTargetError`. PASS. TestPyPI skipped per
+  the patch human-approval precedent (user "Publish to PyPI now").
+
+## Scope / drift
+
+Dataflow-only patch. Sibling enumeration at release-time — all 7 siblings at PyPI parity
+(kailash 2.45.3, nexus 2.11.0, kaizen 2.28.0, mcp 0.2.15, ml 2.2.2, align 0.7.4, pact 0.14.3 all ==
+PyPI); no sibling drift. Core `kailash` unchanged — no `kailash>=` floor bump (the fix is entirely
+within the dataflow bulk/upsert builders + the single-record upsert caller identifier guard).
+
+## Cross-SDK (cross-sdk-inspection.md)
+
+#1519 is the **bulk** sibling of #1508 (single-record SQLite upsert `conflict_on`). The Rust SDK's
+DataFlow-equivalent likely carries the same class (bulk-upsert `conflict_on` handling). Per
+`repo-scope-discipline.md`, cross-repo inspection was NOT self-authorized this session (the prior
+read-only rs grant, journal 0010, was scoped to #1508/#1518 in a different session). Recommend a
+re-confirmed read-only grant to inspect the Rust SDK for the bulk variant; deferred to a
+dedicated / separately-gated session.


### PR DESCRIPTION
Post-release docs for **kailash-dataflow 2.13.9** (#1519 — bulk_upsert honors conflict_on): deployment record + forest-ledger session-notes refresh (F-BULK closed → 2.13.9; F-PG/#1520 next). Docs/session-only diff — no `/release` needed per build-repo-release-discipline carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)