### PR TITLE
fix(hooks): exclude audit-log files from log-triage WARN+ scan (Rule 5a)

### DIFF
--- a/.claude/audit-fixtures/log-triage-gate/run.mjs
+++ b/.claude/audit-fixtures/log-triage-gate/run.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Audit fixture for log-triage-gate.js EXCLUDED_FILES predicate
+// (observability.md Rule 5a — audit-log files excluded by filename).
+//
+// Contract: the session-end WARN+ scanner MUST NOT flag a structured
+// append-only AUDIT log (whose payload verbatim-quotes commit subjects that
+// may contain "WARNING"/"ERROR"), but MUST still flag a genuine runtime *.log.
+//
+// This drives the REAL hook end-to-end (spawns it with a Stop payload and
+// asserts on the emitted systemMessage) so it locks the ACTUAL find
+// expression + the EXCLUDED_FILES predicate's placement within the
+// `\( -type d ... -prune \) -o -type f ...` branch — not a reconstruction.
+//
+// Run: node .claude/audit-fixtures/log-triage-gate/run.mjs   (exit 0 = pass)
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOK = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "hooks",
+  "log-triage-gate.js",
+);
+
+const dir = mkdtempSync(join(tmpdir(), "log-triage-fixture-"));
+// (a) an AUDIT log whose content contains a WARN+ token — MUST NOT flag
+writeFileSync(
+  join(dir, ".journal-skipped.log"),
+  '2026-07-02T15:36:20Z <journal-skip>commit=abc reason=fix-routine subject="fix(fabric): remove exc_info from ChangeDetector poll-loop WARNING log"</journal-skip>\n',
+);
+// (b) a genuine runtime log with a WARN line — MUST flag
+writeFileSync(
+  join(dir, "runtime.log"),
+  "2026-07-02T15:36:20Z WARN pool exhausted, degrading\n",
+);
+
+const res = spawnSync("node", [HOOK], {
+  input: JSON.stringify({ cwd: dir }),
+  encoding: "utf8",
+  timeout: 10000,
+});
+
+let systemMessage = "";
+try {
+  systemMessage = JSON.parse(res.stdout || "{}").systemMessage || "";
+} catch {
+  console.error("FAIL: hook did not emit valid JSON:", res.stdout, res.stderr);
+  process.exit(1);
+}
+
+const flaggedAudit = systemMessage.includes(".journal-skipped.log");
+const flaggedRuntime = systemMessage.includes("runtime.log");
+
+let ok = true;
+if (flaggedAudit) {
+  console.error("FAIL: .journal-skipped.log was flagged (must be excluded)");
+  ok = false;
+}
+if (!flaggedRuntime) {
+  console.error(
+    "FAIL: runtime.log was NOT flagged (real WARN must still surface)",
+  );
+  ok = false;
+}
+if (ok)
+  console.log(
+    "PASS: real hook excludes .journal-skipped.log; runtime WARN still surfaced",
+  );
+process.exit(ok ? 0 : 1);

--- a/.claude/hooks/log-triage-gate.js
+++ b/.claude/hooks/log-triage-gate.js
@@ -90,6 +90,17 @@ const EXCLUDED_DIRS = [
   "benchmarks", // perf measurement output (FAIL means "missed perf target", not session-actionable)
 ];
 
+// Structured append-only AUDIT-log files, excluded by FILENAME per
+// observability.md Rule 5a. These record machine-readable events (classifier
+// decisions, journal-skip reasons) whose payload verbatim-quotes commit
+// subjects — a subject like "remove exc_info from ... WARNING log" matches a
+// WARN+ scanner as a guaranteed false positive. Filename-keyed exclusion is
+// the only structural fix that closes the class; per-finding regex suppression
+// is BLOCKED. Composes with EXCLUDED_DIRS above.
+const EXCLUDED_FILES = [
+  ".journal-skipped.log", // journal-classifier audit log (commit subjects verbatim)
+];
+
 function triageLogs(cwd) {
   const messages = [];
 
@@ -180,11 +191,16 @@ function scanRecentLogs(cwd) {
     const prune = pathClauses
       ? `${nameClauses} -o ${pathClauses}`
       : nameClauses;
+    // Exclude audit-log files by FILENAME (observability.md Rule 5a), composed
+    // as `! -name '<f>'` predicates on the -type f branch.
+    const fileExcl = EXCLUDED_FILES.map(
+      (f) => `! -name '${f.replace(/'/g, "'\\''")}'`,
+    ).join(" ");
     // find: prune tool cache dirs + nested git checkouts, then match *.log
-    // modified in last 120 min.
+    // (minus excluded audit-log filenames) modified in last 120 min.
     const cmd =
       `find "${cwd}" \\( -type d \\( ${prune} \\) -prune \\) -o ` +
-      `-type f -name '*.log' -mmin -120 -print 2>/dev/null ` +
+      `-type f -name '*.log' ${fileExcl} -mmin -120 -print 2>/dev/null ` +
       `| head -20 | xargs -I{} grep -HnE 'WARN|ERROR|FAIL' {} 2>/dev/null ` +
       `| head -200`;
     const out = execSync(cmd, { encoding: "utf8", timeout: 3000 });


### PR DESCRIPTION
## Summary

The session-end `log-triage-gate.js` scanner greps recent `*.log` for `WARN|ERROR|FAIL` but had only `EXCLUDED_DIRS` (directory pruning), no filename allowlist. Structured append-only **audit logs** — `workspaces/<name>/.journal-skipped.log` (26+ instances, outside every pruned dir) — record commit subjects verbatim, so a subject like `"...remove exc_info from ChangeDetector poll-loop WARNING log"` matched the scanner as a **phantom WARN+ at every session end**.

`observability.md` Rule 5a mandates exactly this fix: a filename-keyed `EXCLUDED_FILES` allowlist (it names `.journal-skipped.log` as the canonical case); per-finding regex suppression is BLOCKED.

## Change
- `EXCLUDED_FILES = [".journal-skipped.log"]` constant, composed with `EXCLUDED_DIRS` via `! -name '<f>'` predicates (POSIX single-quote-escaped) on the `-type f` branch of the find expression.
- Committed audit fixture (`cc-artifacts` Rule 9) that **spawns the real hook** with a Stop payload and asserts the audit log is excluded while a genuine runtime `WARN` still surfaces — locking the actual `find` expression + predicate placement, not a reconstruction.

## Review
cc-architect: **MERGE-WITH-FIXES** — core fix confirmed correct + Rule-5a-structural, empirically verified on BSD + GNU `find` (precedence, dotfile match, `EXCLUDED_DIRS` composition). MED-1 (fixture drives the real hook) addressed in this PR. Follow-ups: originate a `/codify` proposal so the hook fix propagates to USE templates (LOW-1); record the audit-fixtures boundary disposition at codify time (MED-2).

Advisory Stop-event scanner (`severity: "warn"`, never blocks) — not on the self-referential-codify firing allowlist, so the full multi-agent gate is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)