### PR TITLE
fix(dataflow): actionable typed error for PG single-record upsert on non-unique conflict_on (#1520)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -135,10 +135,14 @@ class BulkUpsertConflictTargetError(DataFlowError):
 
     1. Declare the field(s) ``unique=True`` on the model (or add a UNIQUE
        index / constraint) so the conflict target is enforceable.
-    2. For genuinely non-unique keys, use single-record ``db.express.upsert``
-       which does a WHERE-precheck instead of a native ON CONFLICT clause —
-       bulk upsert on a non-unique key is ambiguous when the batch itself
-       contains duplicate keys.
+    2. On **SQLite only**, for genuinely non-unique keys, use single-record
+       ``db.express.upsert`` which does a WHERE-precheck instead of a native
+       ON CONFLICT clause (issue #1508) — bulk upsert on a non-unique key is
+       ambiguous when the batch itself contains duplicate keys. This fallback
+       does NOT exist on PostgreSQL: PG's single-record upsert also uses an
+       atomic ON CONFLICT and raises :class:`UpsertConflictTargetError` on a
+       non-unique target (issue #1520), so the conflict target MUST be a
+       PK/UNIQUE key there.
     """
 
     def __init__(
@@ -158,9 +162,69 @@ class BulkUpsertConflictTargetError(DataFlowError):
             f"match any PRIMARY KEY or UNIQUE constraint. Native bulk upsert "
             f"requires the conflict-target column(s) ({cols}) to be backed by a "
             f"PK or UNIQUE key. Remediation: declare the field(s) unique=True "
-            f"(or add a UNIQUE index), OR — for genuinely non-unique keys — use "
-            f"single-record db.express.upsert (WHERE-precheck) instead of bulk "
-            f"upsert, which is ambiguous when a batch contains duplicate keys."
+            f"(or add a UNIQUE index), OR — on SQLite, for genuinely non-unique "
+            f"keys — use single-record db.express.upsert (WHERE-precheck) "
+            f"instead of bulk upsert, which is ambiguous when a batch contains "
+            f"duplicate keys. (On PostgreSQL single-record upsert also requires "
+            f"the unique constraint — see UpsertConflictTargetError / #1520.)"
+        )
+
+
+class UpsertConflictTargetError(DataFlowError):
+    """Raised when a single-record upsert's ``conflict_on`` target is not backed
+    by a PRIMARY KEY or UNIQUE constraint (issue #1520).
+
+    On PostgreSQL a native ``INSERT ... ON CONFLICT (cols) DO UPDATE`` requires
+    the conflict-target columns to be a PK or UNIQUE key, and the statement is
+    atomic — DataFlow cannot substitute a WHERE-precheck without a TOCTOU race
+    under concurrency (unlike SQLite, whose single-record upsert path #1508 DOES
+    use a precheck and therefore never reaches this error). When the target is
+    not unique, PostgreSQL rejects the statement with the opaque driver message
+    "there is no unique or exclusion constraint matching the ON CONFLICT
+    specification". DataFlow converts that into this actionable typed error
+    rather than surfacing the raw driver text (which never names ``conflict_on``,
+    the offending field, or the remedy).
+
+    This is the single-record sibling of :class:`BulkUpsertConflictTargetError`.
+
+    Attributes:
+        conflict_on: The conflict-target columns the caller requested.
+        model_name: The model the upsert targeted (best-effort; may be None).
+        original_error: The underlying driver exception, if any.
+
+    Recovery (PostgreSQL — the conflict target MUST be enforceable):
+
+    1. Declare the field(s) ``unique=True`` on the model so DataFlow's migration
+       creates the backing UNIQUE constraint.
+    2. Or add a UNIQUE index / constraint via a migration
+       (``CREATE UNIQUE INDEX ... ON {table} ({cols})``).
+
+    DataFlow does NOT auto-create the index at runtime: runtime DDL is blocked
+    per ``schema-migration.md`` Rule 1, and it would fail anyway on a column that
+    already holds duplicate values.
+    """
+
+    def __init__(
+        self,
+        conflict_on: Optional[list] = None,
+        model_name: Optional[str] = None,
+        original_error: Optional[BaseException] = None,
+    ) -> None:
+        self.conflict_on = list(conflict_on or [])
+        self.model_name = model_name
+        self.original_error = original_error
+
+        cols = ", ".join(self.conflict_on) or "<none>"
+        model_part = f" on model '{model_name}'" if model_name else ""
+        super().__init__(
+            f"upsert conflict_on={self.conflict_on!r}{model_part} does not match "
+            f"any PRIMARY KEY or UNIQUE constraint. Native PostgreSQL upsert "
+            f"(INSERT ... ON CONFLICT) requires the conflict-target column(s) "
+            f"({cols}) to be backed by a PK or UNIQUE key. Remediation: declare "
+            f"the field(s) unique=True on the model (or add a UNIQUE index via a "
+            f"migration). DataFlow does not auto-create the index (blocked by "
+            f"schema-migration policy; it would also fail on existing duplicate "
+            f"values)."
         )
 
 
@@ -211,6 +275,7 @@ def sanitize_db_error(msg: str) -> str:
 __all__ = [
     "DDLFailedError",
     "BulkUpsertConflictTargetError",
+    "UpsertConflictTargetError",
     "is_conflict_target_error",
     "sanitize_db_error",
     "DataFlowError",

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -49,9 +49,11 @@ except ImportError:
     AsyncNode = Node  # type: ignore[assignment,misc]
 
 from .async_utils import async_safe_run  # Phase 6: Async-safe execution
-from .exceptions import (  # Issue #1519: typed conflict-target error propagation
+from .exceptions import (  # Issue #1519/#1520: typed conflict-target error propagation
     BulkUpsertConflictTargetError,
+    UpsertConflictTargetError,
 )
+from .exceptions import is_conflict_target_error as _is_conflict_target_error
 from .logging_config import mask_sensitive_values  # Phase 7: Sensitive value masking
 
 
@@ -3524,13 +3526,36 @@ class NodeGenerator:
                         )
                     # For SQLite, sql_node was already created during pre-check
 
-                    result = await sql_node.async_run(
-                        query=query,
-                        params=params,
-                        fetch_mode="one",
-                        validate_queries=False,
-                        transaction_mode="auto",
-                    )
+                    try:
+                        result = await sql_node.async_run(
+                            query=query,
+                            params=params,
+                            fetch_mode="one",
+                            validate_queries=False,
+                            transaction_mode="auto",
+                        )
+                    except Exception as exec_err:
+                        # Issue #1520: on the native ON CONFLICT path, a conflict
+                        # target that is not a PK/UNIQUE key is a caller error,
+                        # not a transient DB failure. PostgreSQL raises the opaque
+                        # "there is no unique or exclusion constraint matching the
+                        # ON CONFLICT specification"; convert it into the
+                        # actionable typed error naming conflict_on + the remedy,
+                        # mirroring the bulk path (#1519). In practice only the
+                        # PostgreSQL builder reaches this matcher: SQLite's
+                        # single-record upsert enters this same execute but runs
+                        # the WHERE-precheck INSERT/UPDATE (#1508) — never an
+                        # ON CONFLICT clause — so it cannot emit the trigger
+                        # string; MySQL emits ON DUPLICATE KEY UPDATE (no
+                        # ON-CONFLICT-target error). Non-matching errors re-raise
+                        # unchanged below.
+                        if _is_conflict_target_error(str(exec_err)):
+                            raise UpsertConflictTargetError(
+                                conflict_on=conflict_columns,
+                                model_name=self.model_name,
+                                original_error=exec_err,
+                            ) from exec_err
+                        raise
 
                     # Parse result to determine if INSERT or UPDATE occurred
                     if result and "result" in result and "data" in result["result"]:

--- a/packages/kailash-dataflow/tests/integration/test_single_upsert_conflict_fields.py
+++ b/packages/kailash-dataflow/tests/integration/test_single_upsert_conflict_fields.py
@@ -65,7 +65,7 @@ class TestPostgreSQLUpsertConflictOn:
     async def test_postgresql_upsert_email_conflict(self, postgresql_db_url):
         """IT-2.1.1: Test PostgreSQL upsert with conflict_on=['email'] (custom single field)."""
         # Arrange: Create DataFlow with PostgreSQL
-        db = DataFlow(postgresql_db_url)
+        db = DataFlow(postgresql_db_url, auto_migrate=True)
 
         @db.model
         class User:
@@ -75,8 +75,20 @@ class TestPostgreSQLUpsertConflictOn:
 
         runtime = AsyncLocalRuntime()
 
-        # Create unique index on email for ON CONFLICT to work
+        # Clean slate + unique index for ON CONFLICT (email) to work. The
+        # postgresql_db_url fixture does NOT truncate between runs, so a
+        # persistent `users` table accumulates duplicate-email rows across
+        # runs and CREATE UNIQUE INDEX then fails on the dup data. Drop it,
+        # let auto_migrate recreate it empty, then add the UNIQUE index
+        # (mirrors this file's null-values test which drops first).
         import asyncpg
+
+        conn = await asyncpg.connect(postgresql_db_url)
+        try:
+            await conn.execute("DROP TABLE IF EXISTS users CASCADE")
+        finally:
+            await conn.close()
+        db._ensure_connected()  # auto_migrate recreates the empty table
 
         conn = await asyncpg.connect(postgresql_db_url)
         try:
@@ -152,7 +164,7 @@ class TestPostgreSQLUpsertConflictOn:
     async def test_postgresql_upsert_composite_conflict(self, postgresql_db_url):
         """IT-2.1.2: Test PostgreSQL upsert with conflict_on=['order_id', 'product_id'] (composite keys)."""
         # Arrange: Create DataFlow with PostgreSQL
-        db = DataFlow(postgresql_db_url)
+        db = DataFlow(postgresql_db_url, auto_migrate=True)
 
         @db.model
         class OrderItem:
@@ -164,8 +176,19 @@ class TestPostgreSQLUpsertConflictOn:
 
         runtime = AsyncLocalRuntime()
 
-        # Create composite unique index for ON CONFLICT to work
+        # Clean slate + composite unique index for ON CONFLICT to work. The
+        # persistent `order_items` table accumulates rows across runs (the
+        # fixture does not truncate), so CREATE UNIQUE INDEX on the composite
+        # key fails on leftover dup data. Drop it, let auto_migrate recreate it
+        # empty, then add the composite UNIQUE index.
         import asyncpg
+
+        conn = await asyncpg.connect(postgresql_db_url)
+        try:
+            await conn.execute("DROP TABLE IF EXISTS order_items CASCADE")
+        finally:
+            await conn.close()
+        db._ensure_connected()  # auto_migrate recreates the empty table
 
         conn = await asyncpg.connect(postgresql_db_url)
         try:
@@ -265,7 +288,7 @@ class TestPostgreSQLUpsertConflictOn:
     async def test_postgresql_conflict_on_with_null_values(self, postgresql_db_url):
         """IT-2.1.6: Test conflict_on with NULL values (should always INSERT per SQL standard)."""
         # Arrange: Create DataFlow with PostgreSQL
-        db = DataFlow(postgresql_db_url)
+        db = DataFlow(postgresql_db_url, auto_migrate=True)
 
         @db.model
         class Document:

--- a/packages/kailash-dataflow/tests/regression/test_issue_1520_pg_single_upsert_conflict_target.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1520_pg_single_upsert_conflict_target.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1520 — PostgreSQL single-record upsert with
+``conflict_on`` on a field that has no backing PRIMARY KEY / UNIQUE constraint.
+
+Before #1520, a single-record upsert (``db.express.upsert`` / the generated
+``{Model}UpsertNode``) with ``conflict_on=["field"]`` where ``field`` is not
+unique surfaced the raw PostgreSQL driver message::
+
+    Database query failed: there is no unique or exclusion constraint matching
+    the ON CONFLICT specification
+
+The message never named ``conflict_on``, the offending field, or the remedy.
+
+Why PG differs from the SQLite fix (#1508): SQLite's single-record upsert path
+emits a WHERE-precheck INSERT/UPDATE (no ``ON CONFLICT``) and therefore never
+reaches this error. PostgreSQL's ``ON CONFLICT`` is atomic and genuinely
+requires the unique constraint — emulating via pre-check+branch would introduce
+a TOCTOU race under PG concurrency. So PG correctly keeps ``ON CONFLICT``; the
+fix converts the opaque driver error into the actionable typed
+:class:`UpsertConflictTargetError` (naming the field + the two remedies),
+mirroring the bulk path's :class:`BulkUpsertConflictTargetError` (#1519). No
+runtime DDL — auto-creating the index is BLOCKED per ``schema-migration.md``
+Rule 1 and would fail on existing duplicate data.
+
+The single-record catch lives at the native-ON-CONFLICT execute site in
+``dataflow/core/nodes.py``; the shared classifier is
+``exceptions.is_conflict_target_error`` (also used by #1519's bulk path).
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.exceptions import (
+    BulkUpsertConflictTargetError,
+    UpsertConflictTargetError,
+    is_conflict_target_error,
+)
+
+
+def _uid(prefix: str = "u") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: PostgreSQL — the live #1520 path (real PG on port 5434)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+async def pg_suite():
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+async def _drop_table(url, table):
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=url,
+        database_type="postgresql",
+        query=f"DROP TABLE IF EXISTS {table} CASCADE",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_single_upsert_non_unique_conflict_target_raises(pg_suite):
+    """AC1: PostgreSQL single-record ``db.express.upsert`` with ``conflict_on``
+    on a non-unique field raises the typed :class:`UpsertConflictTargetError`
+    (naming the field + remedy), NOT the raw driver message — and no row lands
+    (ON CONFLICT is atomic; the statement aborts wholesale)."""
+    url = pg_suite.config.url
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1520PgNonuniq:
+        tag: str  # deliberately NOT unique — the bug's precondition
+        body: str
+
+    table = db._models["Issue1520PgNonuniq"]["table_name"]
+    await _drop_table(url, table)
+    db._ensure_connected()
+
+    try:
+        with pytest.raises(UpsertConflictTargetError) as excinfo:
+            await db.express.upsert(
+                "Issue1520PgNonuniq",
+                {"tag": "t", "body": "one"},
+                conflict_on=["tag"],
+            )
+
+        # The typed error names conflict_on + the field + the remedy, and does
+        # NOT leak the raw driver text.
+        msg = str(excinfo.value)
+        assert "tag" in msg
+        assert "unique" in msg.lower()
+        assert "unique=True" in msg or "UNIQUE index" in msg
+        assert "no unique or exclusion constraint" not in msg.lower()
+        assert excinfo.value.conflict_on == ["tag"]
+        assert excinfo.value.model_name == "Issue1520PgNonuniq"
+
+        # No row landed on the raise (atomic ON CONFLICT statement aborted).
+        assert await db.express.count("Issue1520PgNonuniq") == 0
+    finally:
+        await _drop_table(url, table)
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_single_upsert_unique_conflict_target_still_works(pg_suite):
+    """AC2 (no-regression): PostgreSQL single-record upsert on a UNIQUE
+    ``conflict_on`` field still works end-to-end (INSERT then UPDATE) — the new
+    guard must NOT break the happy path."""
+    url = pg_suite.config.url
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1520PgUniq:
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    table = db._models["Issue1520PgUniq"]["table_name"]
+    await _drop_table(url, table)
+    db._ensure_connected()
+
+    email = f"{_uid('alice')}@example.com"
+    try:
+        # First upsert → INSERT (email absent). The return is the executed
+        # statement's RETURNING row (ground truth of what the SQL did).
+        r1 = await db.express.upsert(
+            "Issue1520PgUniq",
+            {"email": email, "name": "Alice New"},
+            conflict_on=["email"],
+        )
+        assert r1["name"] == "Alice New"
+        original_id = r1["id"]
+
+        # Second upsert on the same email → UPDATE (row present), same id.
+        r2 = await db.express.upsert(
+            "Issue1520PgUniq",
+            {"email": email, "name": "Alice Updated"},
+            conflict_on=["email"],
+        )
+        assert r2["name"] == "Alice Updated"
+        assert r2["id"] == original_id  # UPDATE in place, NOT a second INSERT
+
+        # Ground-truth read-back on a fresh pooled connection (real infra,
+        # committed state) — exactly one row carrying the UPDATE payload. This
+        # asserts persistence independent of the express read-cache layer.
+        async with pg_suite.get_connection() as conn:
+            db_rows = await conn.fetch(
+                f"SELECT id, name FROM {table} WHERE email = $1", email
+            )
+        assert len(db_rows) == 1, db_rows
+        assert db_rows[0]["name"] == "Alice Updated"
+        assert db_rows[0]["id"] == original_id
+    finally:
+        await _drop_table(url, table)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: cross-dialect divergence pin — SQLite single-record upsert on a
+# non-unique conflict_on field does NOT raise (uses the #1508 WHERE-precheck).
+# Locks the guard as PG-path-only; a refactor that routed SQLite through
+# ON CONFLICT (regressing #1508) would flip this test.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sqlite_single_upsert_non_unique_conflict_target_does_not_raise(tmp_path):
+    """SQLite's single-record upsert on a non-unique conflict_on field upserts
+    via the #1508 precheck (INSERT then UPDATE) — it MUST NOT raise
+    :class:`UpsertConflictTargetError`; that error is PG-path-specific."""
+    db = DataFlow(f"sqlite:///{tmp_path / 'issue_1520_sqlite.db'}", auto_migrate=True)
+
+    @db.model
+    class Note:
+        id: str
+        tag: str  # NOT unique
+        body: str
+
+    db._ensure_connected()
+    tag = _uid("tag")
+    nid = _uid("note")
+
+    # INSERT then UPDATE on a non-unique conflict target — no raise on SQLite.
+    await db.express.upsert(
+        "Note", {"id": nid, "tag": tag, "body": "one"}, conflict_on=["tag"]
+    )
+    await db.express.upsert(
+        "Note", {"id": nid, "tag": tag, "body": "two"}, conflict_on=["tag"]
+    )
+
+    rows = await db.express.list("Note", {"tag": tag})
+    assert len(rows) == 1
+    assert rows[0]["body"] == "two"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier-1: structural pins on the typed error + shared classifier (no DB)
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+def test_upsert_conflict_target_error_message_is_actionable():
+    """The typed error names conflict_on, the offending field(s), and the
+    remedy — and never echoes the opaque driver text."""
+    e = UpsertConflictTargetError(conflict_on=["tag"], model_name="Note")
+    msg = str(e)
+    assert "conflict_on" in msg
+    assert "tag" in msg
+    assert "unique=True" in msg  # the actionable remedy
+    assert "PostgreSQL" in msg
+    # Never surface the raw driver message the fix replaces.
+    assert "no unique or exclusion constraint" not in msg.lower()
+    # Structural: carries the caller's request for programmatic handling.
+    assert e.conflict_on == ["tag"]
+    assert e.model_name == "Note"
+
+
+@pytest.mark.regression
+def test_is_conflict_target_error_matches_pg_and_sqlite_messages():
+    """The shared classifier (also used by #1519's bulk path) matches both the
+    PostgreSQL and SQLite unmatched-ON-CONFLICT driver messages, and rejects
+    unrelated errors."""
+    pg = (
+        "Database query failed: there is no unique or exclusion constraint "
+        "matching the ON CONFLICT specification"
+    )
+    sqlite = "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
+    assert is_conflict_target_error(pg) is True
+    assert is_conflict_target_error(sqlite) is True
+    # An unrelated unique-violation on a DIFFERENT column must NOT be reclassified.
+    assert (
+        is_conflict_target_error(
+            'duplicate key value violates unique constraint "users_email_key"'
+        )
+        is False
+    )
+    assert is_conflict_target_error("") is False
+
+
+@pytest.mark.regression
+def test_upsert_and_bulk_conflict_errors_are_distinct_types():
+    """Single-record (#1520) and bulk (#1519) conflict-target errors are
+    distinct types so callers can ``try/except`` one without catching the
+    other — but both derive from DataFlowError."""
+    from dataflow.core.exceptions import DataFlowError
+
+    assert not issubclass(UpsertConflictTargetError, BulkUpsertConflictTargetError)
+    assert not issubclass(BulkUpsertConflictTargetError, UpsertConflictTargetError)
+    assert issubclass(UpsertConflictTargetError, DataFlowError)
+    assert issubclass(BulkUpsertConflictTargetError, DataFlowError)


### PR DESCRIPTION
## Summary

On PostgreSQL, a single-record upsert (`db.express.upsert` / `upsert_advanced` / workflow `{Model}UpsertNode`) with `conflict_on=[field]` where the field has **no backing PK/UNIQUE constraint** surfaced the raw driver message *"there is no unique or exclusion constraint matching the ON CONFLICT specification"* — naming neither the field nor the remedy.

This adds the typed **`UpsertConflictTargetError`** (single-record sibling of #1519's `BulkUpsertConflictTargetError`), raised at the single-record native-`ON CONFLICT` execute chokepoint via the shared `is_conflict_target_error` classifier. Non-matching driver errors re-raise unchanged.

PostgreSQL correctly keeps its atomic `ON CONFLICT` (a WHERE-precheck would be a TOCTOU race under concurrency, unlike SQLite's #1508 precheck) — the fix is a **better error, not a behavior change**. No runtime DDL (blocked per `schema-migration.md`).

## Why it's complete

- Every single-record upsert surface (`express.upsert`/`upsert_advanced`, sync variants, fabric, workflow node) funnels through the one guarded execute; `build_upsert_query` has exactly one production caller (this site).
- SQLite (#1508 WHERE-precheck) and MySQL (`ON DUPLICATE KEY UPDATE`) never trip the matcher — verified.
- Corrected the now-PG-misleading recovery note in `BulkUpsertConflictTargetError` (the WHERE-precheck fallback is SQLite-only).

## Also fixed (same surface, pre-existing)

2 pre-existing PG failures in `test_single_upsert_conflict_fields.py` (proven pre-existing via `git stash`): missing `auto_migrate` + no table cleanup let a persistent table accumulate duplicate rows so `CREATE UNIQUE INDEX` failed. Drop-first + `auto_migrate` → deterministic.

## Tests

- New `tests/regression/test_issue_1520_pg_single_upsert_conflict_target.py` — 6 tests: Tier-2 PG error-path (raise + no row lands + actionable message) + no-regression happy path (real-infra read-back), cross-dialect SQLite non-raise pin, 3 structural pins.
- Upsert family: **75 passed / 1 xfailed**; #1520 + single-upsert integration: **14 passed / 1 xfailed** on real PostgreSQL:5434.

## Red team

3 independent reviewers converged: security-reviewer **SECURE** (no PII leak — the 42P10 error carries no column values; typed message never interpolates driver text), reviewer **CLEAN** (all mechanical sweeps pass), dataflow-specialist **CLEAN** (single chokepoint, SQLite/MySQL undisturbed).

## Related issues

Fixes #1520. Sibling of #1508 (SQLite single-record) and #1519 (bulk).

## Follow-ups (out of scope, separate class)

- MySQL single-record upsert silently upserts on the `id` PK ignoring `conflict_on` (needs proactive constraint introspection — different mechanism).
- `express.list(cache_ttl=0)` read-after-upsert-update staleness (pre-existing PG read-snapshot gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)