### PR TITLE
release(dataflow): 2.13.10 — actionable error for PG single-record upsert on non-unique conflict_on (#1520)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.13.10] — 2026-07-04 — PostgreSQL single-record upsert conflict_on gives an actionable error
+
+### Fixed
+
+- **PostgreSQL single-record upsert with `conflict_on` on a non-unique field now raises an actionable typed error instead of the raw driver message (#1520).** `db.express.upsert` / `upsert_advanced` / the generated `{Model}UpsertNode` on PostgreSQL, with `conflict_on=[field]` where the field has no backing PRIMARY KEY / UNIQUE constraint, surfaced the opaque driver text _"there is no unique or exclusion constraint matching the ON CONFLICT specification"_ — naming neither `conflict_on`, the offending field, nor the remedy. DataFlow now converts that into the typed `UpsertConflictTargetError` (single-record sibling of #1519's `BulkUpsertConflictTargetError`), naming the field(s) and the two remedies (declare the field `unique=True`, or add a UNIQUE index via a migration). The guard sits at the single-record native-`ON CONFLICT` execute — the one chokepoint every single-record upsert surface (async/sync `upsert`/`upsert_advanced`, fabric, workflow node) funnels through — and reuses the shared `is_conflict_target_error` classifier from #1519; non-matching driver errors re-raise unchanged. PostgreSQL correctly keeps its atomic `ON CONFLICT` (a WHERE-precheck would introduce a TOCTOU race under concurrency, unlike SQLite's #1508 precheck path which never reaches this error), so this is a better error, not a behavior change — no runtime DDL (blocked per `schema-migration.md`). SQLite (#1508 WHERE-precheck) and MySQL (`ON DUPLICATE KEY UPDATE`) never trip the matcher. Also corrected the now-PostgreSQL-misleading recovery note in `BulkUpsertConflictTargetError` (its "use single-record `db.express.upsert`" fallback is SQLite-only; on PostgreSQL single-record upsert also requires the unique constraint). Sibling of the single-record #1508 and the bulk #1519; the MySQL silent-upsert-on-PK variant is tracked in #1537, and a separate pre-existing `express.list` read-after-upsert-update staleness in #1538.
+
 ## [2.13.9] — 2026-07-03 — bulk_upsert honors conflict_on (SQLite/PG); 3 divergent builders reconciled
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.9"
+version = "2.13.10"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.9"
+__version__ = "2.13.10"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Metadata-only release-prep for **kailash-dataflow 2.13.10**.

- Version: `2.13.9` → `2.13.10` (`pyproject.toml` + `__init__.py::__version__`, atomic per zero-tolerance Rule 5).
- CHANGELOG: 2.13.10 entry for #1520.

The code + tests landed in #1536 (merged). PostgreSQL single-record upsert with `conflict_on` on a non-unique field now raises the typed `UpsertConflictTargetError` instead of the opaque driver message.

## Related issues

Releases the fix for #1520. Follow-ups: #1537 (MySQL), #1538 (express.list staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)