### PR TITLE
docs(deploy): record kailash-dataflow 2.13.10 release (#1520) + session notes

### DIFF
--- a/.session-notes.d/esperie.md
+++ b/.session-notes.d/esperie.md
@@ -9,33 +9,47 @@ last_reconciled_sha: c889f3fa9
 migrated_from: .session-notes
 ---
 
-# Session Notes — 2026-07-03
+# Session Notes — 2026-07-04
 
 ## Where we are
 
-Clean on `main`, 0 open PRs. This session shipped **kailash-dataflow 2.13.9** (`/autonomize` +
-`/redteam` to convergence), closing **#1519** (F-BULK — `bulk_upsert` ignored `conflict_on`,
-hardcoded `ON CONFLICT (id) DO NOTHING` → dup rows + 0 counts), and fixed a session-end log-triage
-false-positive (PR #1534, merged). Recommended next: **#1520** (F-PG, same upsert family).
+Clean on `main`, 0 open PRs. This session **shipped kailash-dataflow 2.13.10** (`/autonomize` +
+`/redteam` to convergence + full `/release`), closing **#1520** (F-PG — PG single-record upsert with
+`conflict_on` on a non-unique field raised the raw driver text; now raises typed
+`UpsertConflictTargetError` naming field + remedy; PG keeps atomic ON CONFLICT, no auto-DDL). Fix PR
+#1536, release PR #1539, tag `dataflow-v2.13.10`, publish run 28676581625 SUCCESS, clean-venv install
+verified. Also fixed 2 pre-existing PG single-upsert integration test failures (proven pre-existing).
+Filed follow-ups **#1537** (MySQL silent-upsert-on-PK) + **#1538** (`express.list` staleness).
+
+Prior: 2.13.9 closed #1519 (F-BULK). The upsert `conflict_on` family (#1508 SQLite single, #1519
+bulk, #1520 PG single) is now fully shipped.
 
 ## Read first
 
-1. `gh issue view 1520` — recommended next (PG upsert `conflict_on` on non-unique → cryptic driver
-   error; add an actionable up-front error mirroring #1519's `BulkUpsertConflictTargetError`, no auto-DDL).
-2. `deploy/deployments/2026-07-03-dataflow-v2.13.9-1519-bulk-upsert-conflict-on.md` — #1519 root cause + red-team.
-3. `packages/kailash-dataflow/src/dataflow/features/bulk.py` — the LIVE express bulk path (P1).
+1. `deploy/deployments/2026-07-04-dataflow-v2.13.10-1520-pg-single-upsert-conflict-on.md` — #1520 root cause + red-team + verify.
+2. `workspaces/mops-onboarding/journal/0011-*.md` — #1520 decision + redteam receipts.
+3. `gh issue view 1537` / `gh issue view 1538` — the filed follow-ups (MySQL + list-staleness).
+
+## Recommended next
+
+- **#1537** (F-MYSQL) — MySQL single-record upsert silently upserts on `id` PK ignoring `conflict_on`;
+  needs proactive `information_schema` constraint precheck (different mechanism than #1520's error-catch).
+- **#1538** (F-LISTSTALE) — root-cause the `express.list` read-after-upsert-update staleness.
+- **kailash-rs parity** for #1520 (`cross-sdk-inspection.md`) — needs a fresh read-only rs grant.
 
 ## Outstanding ledger (forest)
 
-| ID        | Item                                                                  | Value-anchor (MUST-1 source)                              | Status                                                                                  |
-| --------- | --------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| F-PG      | PG upsert `conflict_on` on non-unique field → cryptic driver error    | #1520; sibling of #1508/#1519                             | OPEN MED — actionable up-front error, mirror #1519's typed raise. **RECOMMENDED NEXT.** |
-| F-LOGSYNC | Propagate the #1534 log-triage hook fix to loom/USE templates         | cc-architect #1534 LOW-1; artifact-flow (synced hook)     | OPEN LOW — `/codify` proposal so the fix cascades downstream.                           |
-| F-COMPKEY | multi_tenant single-column `id` PK → tenants can't share natural key  | #1526; #1518 AC (user 2026-07-03)                         | OPEN design — composite `(tenant_id,id)`; fails closed today. Maintainer call.          |
-| F6        | Convert `test_production_dataflow` off mock engine (Tier-2 NO-MOCK)   | #1503; rules/testing.md §Tier 2                           | queued (#1503) — xfail-strict self-clears                                               |
-| F7        | `test_concurrent_order_processing` PG two-txn isolation fails on main | #1504 (pre-existing at HEAD)                              | queued (#1504) — separate PG-isolation shard                                            |
-| F2        | mops-onboarding cross-repo: loom issue + kailash-rs rollout           | user 2026-06-23 "roll out to kailash-rs…file 2 into loom" | GATED (receipt-gated; dedicated session)                                                |
-| F3        | ~29 prod TODO markers                                                 | user 2026-06-26 "leave as baseline"                       | DEFERRED (user)                                                                         |
+| ID          | Item                                                                                                              | Value-anchor (MUST-1 source)                              | Status                                                                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| F-PG        | PG upsert `conflict_on` on non-unique field → cryptic driver error                                                | #1520; sibling of #1508/#1519                             | **CLOSED → dataflow 2.13.10** (PR #1536 fix, #1539 release, tag `dataflow-v2.13.10`; #1520 closed). journal/0011.                   |
+| F-MYSQL     | MySQL single-record upsert silently upserts on `id` PK, ignores `conflict_on`                                     | #1537; dataflow-specialist redteam of #1520 (2026-07-04)  | OPEN MED (#1537) — pre-existing; diff mechanism (proactive `information_schema` constraint precheck, not error-catch); own shard.   |
+| F-LISTSTALE | `express.list(cache_ttl=0)` returns stale rows after an upsert-UPDATE (plain update reads fresh; raw SQL correct) | #1538; discovered while testing #1520 (2026-07-04)        | OPEN (#1538) — pre-existing PG read-snapshot/pool gap (likely the #1519-notes "single-upsert pool gap"); separate class from #1520. |
+| F-LOGSYNC   | Propagate the #1534 log-triage hook fix to loom/USE templates                                                     | cc-architect #1534 LOW-1; artifact-flow (synced hook)     | OPEN LOW — `/codify` proposal so the fix cascades downstream.                                                                       |
+| F-COMPKEY   | multi_tenant single-column `id` PK → tenants can't share natural key                                              | #1526; #1518 AC (user 2026-07-03)                         | OPEN design — composite `(tenant_id,id)`; fails closed today. Maintainer call.                                                      |
+| F6          | Convert `test_production_dataflow` off mock engine (Tier-2 NO-MOCK)                                               | #1503; rules/testing.md §Tier 2                           | queued (#1503) — xfail-strict self-clears                                                                                           |
+| F7          | `test_concurrent_order_processing` PG two-txn isolation fails on main                                             | #1504 (pre-existing at HEAD)                              | queued (#1504) — separate PG-isolation shard                                                                                        |
+| F2          | mops-onboarding cross-repo: loom issue + kailash-rs rollout                                                       | user 2026-06-23 "roll out to kailash-rs…file 2 into loom" | GATED (receipt-gated; dedicated session)                                                                                            |
+| F3          | ~29 prod TODO markers                                                                                             | user 2026-06-26 "leave as baseline"                       | DEFERRED (user)                                                                                                                     |
 
 Closed this session: `F-BULK` → `dataflow-v2.13.9` (PR #1530 fix, #1531 release, tag `dataflow-v2.13.9`; #1519 closed). Log-triage audit-log false-positive → PR #1534 (F-LOGSYNC opened for its loom propagation).
 

--- a/deploy/deployments/2026-07-04-dataflow-v2.13.10-1520-pg-single-upsert-conflict-on.md
+++ b/deploy/deployments/2026-07-04-dataflow-v2.13.10-1520-pg-single-upsert-conflict-on.md
@@ -1,0 +1,68 @@
+# Deployment Record — kailash-dataflow 2.13.10 (#1520)
+
+**Date:** 2026-07-04
+**Package:** kailash-dataflow `2.13.9 → 2.13.10` (patch, dataflow-only)
+**Issue:** #1520 — PostgreSQL single-record upsert `conflict_on` on a non-unique field raises the raw driver message instead of an actionable error
+**Fix PR:** #1536 · **Release-prep PR:** #1539 · **Tag:** `dataflow-v2.13.10` · **Publish run:** `28676581625` (SUCCESS)
+
+## What shipped
+
+On PostgreSQL, a single-record upsert (`db.express.upsert` / `upsert_advanced` / the generated
+`{Model}UpsertNode`) with `conflict_on=[field]` where the field has **no backing PK/UNIQUE
+constraint** surfaced the opaque driver text _"there is no unique or exclusion constraint matching
+the ON CONFLICT specification"_ — naming neither `conflict_on`, the offending field, nor the remedy.
+
+DataFlow now converts that into the typed **`UpsertConflictTargetError`** (single-record sibling of
+#1519's `BulkUpsertConflictTargetError`), naming the field(s) + the two remedies (declare the field
+`unique=True`, or add a UNIQUE index via a migration). The guard sits at the single-record
+native-`ON CONFLICT` execute — the **one chokepoint** every single-record upsert surface
+(async/sync `upsert`/`upsert_advanced`, fabric, workflow node) funnels through — and reuses the
+shared `is_conflict_target_error` classifier from #1519; non-matching driver errors re-raise
+unchanged.
+
+PostgreSQL correctly keeps its **atomic** `ON CONFLICT` (a WHERE-precheck would introduce a TOCTOU
+race under concurrency, unlike SQLite's #1508 precheck path which never reaches this error) — so this
+is a **better error, not a behavior change**; no runtime DDL (blocked per `schema-migration.md`).
+SQLite (#1508 WHERE-precheck) and MySQL (`ON DUPLICATE KEY UPDATE`) never trip the matcher. Also
+corrected the now-PG-misleading recovery note in `BulkUpsertConflictTargetError` (its WHERE-precheck
+fallback is SQLite-only).
+
+Sibling of the single-record #1508 and the bulk #1519.
+
+## Also fixed (same surface, pre-existing)
+
+2 pre-existing PG failures in `tests/integration/test_single_upsert_conflict_fields.py::TestPostgreSQLUpsertConflictOn`
+(proven pre-existing via `git stash`): missing `auto_migrate` + no table cleanup let a persistent
+table accumulate duplicate rows, so `CREATE UNIQUE INDEX` failed on the dup data. Drop-first +
+`auto_migrate` → deterministic across re-runs.
+
+## Verification
+
+- **Red-team CONVERGED (round 1 clean, 3 independent parallel reviewers).** security-reviewer
+  **SECURE** (the 42P10 conflict-target error carries no column VALUES; the typed message never
+  interpolates driver text; `original_error` handling identical to the bulk sibling — no new leak,
+  no injection). reviewer **CLEAN / ship-ready** (all 5 mechanical sweeps pass: single guarded
+  chokepoint, both entry points reach the guard, `__all__` parity, operands in scope, tests green).
+  dataflow-specialist **CLEAN** (guard complete + correctly placed; SQLite #1508 and MySQL
+  behavior undisturbed; tenancy/multi-tenant route through the same guard). Post-review: corrected
+  the guard comment (SQLite reaches the execute but never trips the matcher; MySQL emits
+  `ON DUPLICATE KEY UPDATE`), re-verified green.
+- **Tests:** new `tests/regression/test_issue_1520_pg_single_upsert_conflict_target.py` — 6 tests:
+  Tier-2 PG error-path (raise + no row lands + actionable message) + no-regression happy path
+  (real-infra read-back via `get_connection`), cross-dialect SQLite non-raise pin, 3 structural
+  pins. Upsert family: **75 passed / 1 xfailed**; #1520 + single-upsert integration: **14 passed /
+  1 xfailed** on real PostgreSQL:5434.
+- **CI:** Fix PR #1536 full matrix GREEN (20 pass / 4 skip). Release-prep PR #1539
+  (`release/v2.13.10-dataflow`, `--admin`, matrix path-skipped).
+- **PyPI install verify:** clean-venv `uv pip install --refresh kailash-dataflow==2.13.10` +
+  `import dataflow; dataflow.__version__ == "2.13.10"` + `from dataflow.core.exceptions import
+UpsertConflictTargetError` — PASS.
+
+## Follow-ups (out of scope, separate class — filed)
+
+- **#1537** — MySQL single-record upsert silently upserts on the `id` PK, ignoring `conflict_on`
+  (needs proactive `information_schema` constraint introspection — different mechanism).
+- **#1538** — `express.list(cache_ttl=0)` read-after-upsert-update staleness (pre-existing PG
+  read-snapshot/pool gap).
+- **Cross-SDK (kailash-rs) parity** per `cross-sdk-inspection.md` Rule 1 — user-owned; a filing on
+  rs needs a separate explicit gate.

--- a/workspaces/mops-onboarding/journal/0011-DECISION-issue-1520-pg-single-upsert-conflict-error.md
+++ b/workspaces/mops-onboarding/journal/0011-DECISION-issue-1520-pg-single-upsert-conflict-error.md
@@ -1,0 +1,86 @@
+---
+type: DECISION
+date: 2026-07-04
+display_id: esperie
+project: dataflow-upsert-1508
+topic: "#1520 F-PG — PostgreSQL single-record upsert conflict_on actionable error"
+phase: redteam
+---
+
+# DECISION — #1520 (F-PG): typed error for PG single-record upsert on a non-unique conflict target
+
+## What & why
+
+Continuation of the upsert `conflict_on` family (#1508 SQLite single-record precheck,
+#1519 bulk). On PostgreSQL a single-record upsert (`db.express.upsert` /
+`upsert_advanced` / workflow `{Model}UpsertNode`) with `conflict_on=[field]` where the
+field lacks a PK/UNIQUE constraint surfaced the raw driver text *"there is no unique or
+exclusion constraint matching the ON CONFLICT specification"* — never naming the field
+or the fix. PG's `ON CONFLICT` is atomic and genuinely requires the constraint (a
+WHERE-precheck would be a TOCTOU race, unlike SQLite #1508) → the fix is a better error,
+not a behavior change.
+
+## Change (working tree, uncommitted — BUILD repo, commit is the user's)
+
+- `core/exceptions.py` — new `UpsertConflictTargetError` (single-record sibling of
+  `BulkUpsertConflictTargetError`); added to `__all__`; corrected the now-PG-misleading
+  recovery note #2 in `BulkUpsertConflictTargetError` (WHERE-precheck fallback is
+  SQLite-only; PG single-record also requires the unique constraint).
+- `core/nodes.py` — try/except around the single-record native-ON-CONFLICT execute
+  (~:3529), catching the shared `is_conflict_target_error` classifier → raises the typed
+  error naming `conflict_on` + remedy; non-matching errors re-raise unchanged (no swallow).
+  Verified the SINGLE chokepoint: every single-record surface (express.upsert /
+  upsert_advanced / sync variants / fabric / workflow node) funnels through this execute;
+  `build_upsert_query` has exactly one production caller (this site).
+- NEW `tests/regression/test_issue_1520_pg_single_upsert_conflict_target.py` — 6 tests:
+  Tier-2 PG error-path (raise + no row lands + actionable msg) + no-regression happy path
+  (real-infra read-back via `get_connection`), cross-dialect SQLite non-raise pin, 3 unit
+  pins (message actionable, classifier PG+SQLite match, distinct-but-parallel types).
+- `tests/integration/test_single_upsert_conflict_fields.py` — fixed 2 **pre-existing**
+  PG failures (proven pre-existing via `git stash`): missing `auto_migrate=True` + no
+  table cleanup → persistent dup-data broke `CREATE UNIQUE INDEX`. Drop-first + auto_migrate;
+  deterministic across re-runs.
+
+## Redteam — CONVERGED (round 1 clean, 3 independent parallel reviewers)
+
+Receipts (background agent verdicts, 2026-07-04):
+- **security-reviewer** (`a362945e6917fe4df`) → **SECURE**: 42P10 conflict-target error
+  carries no column VALUES; typed message never interpolates driver text; `original_error`
+  handling identical to the bulk sibling — no new leak, no injection.
+- **reviewer** (`a6dfb14d2196511a2`) → **CLEAN / ship-ready**: all 5 mechanical sweeps pass
+  (single chokepoint, both entry points reach guard, `__all__` parity, operands in scope,
+  14+1xfail green). 3 minor advisories (cosmetic message-dialect wording, deep-import
+  ergonomics = sibling parity, cross-SDK checklist).
+- **dataflow-specialist** (`a7e0c9db3076f7faa`) → **CLEAN on core fix**: guard correctly
+  placed + complete; SQLite (#1508) and MySQL behavior undisturbed; tenancy/multi-tenant
+  route through the same guard.
+
+Applied post-review: corrected the guard comment (SQLite reaches the execute but never
+trips the matcher; MySQL emits ON DUPLICATE KEY UPDATE). Kept the PG-specific error
+message (only PostgreSQL reaches this raise today; the divergence-pin test guards a future
+SQLite-via-ON-CONFLICT refactor). Re-verified green.
+
+Test tally: upsert family **75 passed / 1 xfailed**; #1520 + single-upsert integration
+**14 passed / 1 xfailed** on real PG:5434.
+
+## Out-of-scope follow-ups (exceed this shard; surfaced for user)
+
+1. **MySQL non-unique conflict target silently upserts on the PK** (specialist finding).
+   `ON DUPLICATE KEY UPDATE` ignores `conflict_on` and matches the `id` PK → silent INSERT
+   instead of upsert-on-field. Pre-existing; NOT introduced by #1520; different mechanism
+   (needs proactive `information_schema` constraint precheck, not reactive error-catch) →
+   own shard. Recommend a follow-up issue.
+2. **`express.list` read-after-upsert-UPDATE staleness** (discovered while testing).
+   `db.express.list(cache_ttl=0)` returns stale data after an upsert-UPDATE specifically
+   (a plain `update` reads fresh; raw SQL confirms the DB row is correct). Repro standalone
+   (no test fixture). Pre-existing (the #1520 guard is transparent on the success path);
+   likely the same "PG single-upsert pool gap" the #1519 session notes flagged. Separate
+   class from #1520.
+3. **Cross-SDK (kailash-rs) parity** for #1520 per `cross-sdk-inspection.md` Rule 1 —
+   user-owned; a filing on rs needs a separate explicit gate (`upstream-issue-hygiene.md`).
+
+## Next
+
+Recommend proceeding to `/release` (dataflow patch, mirroring #1519 → 2.13.9): version
+bump + CHANGELOG + regression `git add` + PR + admin-merge + PyPI + tag. Awaiting user go
+(BUILD-repo shared-state/irreversible steps require confirmation per autonomize Prudence).


### PR DESCRIPTION
Post-release documentation for **kailash-dataflow 2.13.10** (#1520 — PG single-record upsert `conflict_on` actionable error).

- `deploy/deployments/2026-07-04-dataflow-v2.13.10-1520-pg-single-upsert-conflict-on.md` — deployment record (root cause, red-team, PyPI verify).
- `.session-notes.d/esperie.md` — forest ledger updated (F-PG CLOSED; follow-ups #1537/#1538 filed).
- `workspaces/mops-onboarding/journal/0011-*.md` — #1520 decision + redteam receipts.

Docs/workspace-only (no source change; release carve-out per `build-repo-release-discipline.md` Rule 1a).

## Related issues

Documents the #1520 release. Follow-ups: #1537, #1538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)