### PR TITLE
fix(dataflow): actionable MySQL upsert conflict-target + PG express.list stale-read (#1537, #1538)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
@@ -262,6 +262,28 @@ class ListNodeCacheIntegration:
             invalidates=[f"{prefix}:{{model}}:*"],
         )
 
+        # Issue #1538: upsert / bulk_upsert MUST register invalidation
+        # patterns too. ``CacheInvalidator.invalidate`` only clears keys for
+        # operations that have a matching pattern (see
+        # ``_find_matching_patterns``); without these two, an
+        # ``invalidate_model_cache(model, "upsert", ...)`` /
+        # ``invalidate_model_cache(model, "bulk_upsert", ...)`` call finds
+        # zero patterns and silently no-ops, leaving a stale primed
+        # list/count entry served forever. Same version-wildcard sweep as
+        # the create/update/delete patterns (``rules/tenant-isolation.md``
+        # Rule 3a).
+        upsert_pattern = InvalidationPattern(
+            model="*",
+            operation="upsert",
+            invalidates=[f"{prefix}:{{model}}:*"],
+        )
+
+        bulk_upsert_pattern = InvalidationPattern(
+            model="*",
+            operation="bulk_upsert",
+            invalidates=[f"{prefix}:{{model}}:*"],
+        )
+
         # Register patterns
         patterns = [
             create_pattern,
@@ -270,6 +292,8 @@ class ListNodeCacheIntegration:
             bulk_create_pattern,
             bulk_update_pattern,
             bulk_delete_pattern,
+            upsert_pattern,
+            bulk_upsert_pattern,
         ]
 
         for pattern in patterns:

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -5713,6 +5713,16 @@ class DataFlow(DataFlowEventMixin):
             List of CREATE INDEX SQL statements
         """
         table_name = self._class_name_to_table_name(model_name)
+        # Defense-in-depth (dataflow-identifier-safety MUST-1/MUST-5): the
+        # index/field/foreign_key identifiers below are already validated before
+        # interpolation, but the derived table_name was not. Validate it too so
+        # a future refactor sourcing the table name from a user-influenced path
+        # (tenant prefix, config, registry) cannot silently reopen a CREATE
+        # INDEX ... ON {table_name} injection vector. #1537 touched these exact
+        # CREATE INDEX lines, so hardening is in-scope per scanner-surface symmetry.
+        from dataflow.query.models import validate_identifier as _validate_id
+
+        _validate_id(table_name)
         indexes = []
 
         # Get model configuration for custom indexes
@@ -5741,12 +5751,20 @@ class DataFlow(DataFlowEventMixin):
 
                     unique_keyword = "UNIQUE " if unique else ""
                     fields_str = ", ".join(fields)
-                    sql = f"CREATE {unique_keyword}INDEX IF NOT EXISTS {index_name} ON {table_name} ({fields_str});"
+                    # MySQL's CREATE INDEX does NOT support IF NOT EXISTS
+                    # (unlike PostgreSQL/SQLite); emitting it raises a 1064
+                    # syntax error and the index — including the UNIQUE index a
+                    # single-record upsert conflict target relies on (#1537) —
+                    # never gets created. schema_state_manager.py already
+                    # branches on this for the migration-history table; mirror
+                    # it here for model indexes.
+                    if_not_exists = (
+                        "" if database_type.lower() == "mysql" else "IF NOT EXISTS "
+                    )
+                    sql = f"CREATE {unique_keyword}INDEX {if_not_exists}{index_name} ON {table_name} ({fields_str});"
                     indexes.append(sql)
 
-        # Add automatic indexes for foreign keys
-        from dataflow.query.models import validate_identifier as _validate_id
-
+        # Add automatic indexes for foreign keys (_validate_id imported above).
         relationships = self.get_relationships(model_name)
         for rel_name, rel_info in relationships.items():
             if rel_info.get("type") == "belongs_to" and rel_info.get("foreign_key"):
@@ -5754,7 +5772,11 @@ class DataFlow(DataFlowEventMixin):
                 _validate_id(foreign_key)
                 index_name = f"idx_{table_name}_{foreign_key}"
                 _validate_id(index_name)
-                sql = f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name} ({foreign_key});"
+                # MySQL rejects IF NOT EXISTS on CREATE INDEX (see above).
+                if_not_exists = (
+                    "" if database_type.lower() == "mysql" else "IF NOT EXISTS "
+                )
+                sql = f"CREATE INDEX {if_not_exists}{index_name} ON {table_name} ({foreign_key});"
                 indexes.append(sql)
 
         return indexes
@@ -8196,9 +8218,20 @@ class DataFlow(DataFlowEventMixin):
             error = stmt_result.get("exception") or RuntimeError(
                 stmt_result.get("error") or "DDL failed"
             )
-            # "already exists" is acceptable per legacy semantics.
+            # "already exists" is acceptable per legacy semantics. MySQL's
+            # CREATE INDEX has no IF NOT EXISTS (#1537 dropped it, else 1064),
+            # so a re-migration against an existing table raises 1061 "Duplicate
+            # key name" — the same benign already-present signal. Scope 1061 to
+            # CREATE INDEX statements so a duplicate key WITHIN a CREATE TABLE
+            # definition still surfaces. Mirrors schema_state_manager.py.
             err_text = str(stmt_result.get("error") or "")
-            if "already exists" in err_text.lower():
+            err_lower = err_text.lower()
+            _is_create_index = bool(
+                re.search(r"(?i)\bCREATE\s+(UNIQUE\s+)?INDEX\b", statement)
+            )
+            if "already exists" in err_lower or (
+                _is_create_index and "duplicate key name" in err_lower
+            ):
                 logger.debug(
                     "engine.ddl_already_exists",
                     extra={"statement": statement[:100]},
@@ -8290,8 +8323,18 @@ class DataFlow(DataFlowEventMixin):
             error = stmt_result.get("exception") or RuntimeError(
                 stmt_result.get("error") or "DDL failed"
             )
+            # See sync _execute_ddl above: MySQL re-migration raises 1061
+            # "Duplicate key name" on the IF-NOT-EXISTS-less CREATE INDEX (#1537);
+            # treat it as benign (scoped to CREATE INDEX) alongside "already
+            # exists". Mirrors schema_state_manager.py.
             err_text = str(stmt_result.get("error") or "")
-            if "already exists" in err_text.lower():
+            err_lower = err_text.lower()
+            _is_create_index = bool(
+                re.search(r"(?i)\bCREATE\s+(UNIQUE\s+)?INDEX\b", statement)
+            )
+            if "already exists" in err_lower or (
+                _is_create_index and "duplicate key name" in err_lower
+            ):
                 logger.debug(
                     "engine.ddl_async_already_exists",
                     extra={"statement": statement[:100]},
@@ -8521,9 +8564,29 @@ class DataFlow(DataFlowEventMixin):
                 for index_sql in indexes:
                     idx_result = executor.execute_ddl(index_sql)
                     if not idx_result.get("success"):
-                        logger.warning(
-                            f"Failed to create index for '{model_name}': {idx_result.get('error')}"
-                        )
+                        idx_error = str(idx_result.get("error") or "")
+                        idx_error_lower = idx_error.lower()
+                        # MySQL re-migration (#1537): CREATE INDEX has no IF NOT
+                        # EXISTS on MySQL, so re-running against an existing table
+                        # raises 1061 "Duplicate key name". Treat that (and the
+                        # PG/SQLite "already exists" form) as benign — the index
+                        # is already present. Mirrors schema_state_manager.py so a
+                        # restart does NOT emit a spurious WARN.
+                        if (
+                            "duplicate key name" in idx_error_lower
+                            or "already exists" in idx_error_lower
+                        ):
+                            logger.debug(
+                                "engine.index_already_exists_ignoring",
+                                extra={
+                                    "model_name": model_name,
+                                    "error": idx_error,
+                                },
+                            )
+                        else:
+                            logger.warning(
+                                f"Failed to create index for '{model_name}': {idx_error}"
+                            )
 
                 # Mark as ensured in cache
                 schema_checksum = None
@@ -8588,13 +8651,30 @@ class DataFlow(DataFlowEventMixin):
     def _create_tables_batch(self, model_names: list) -> None:
         """Create tables for multiple models in a single database connection.
 
-        Uses SyncDDLExecutor.execute_ddl_batch() to run all CREATE TABLE and
-        CREATE INDEX statements through one connection. This eliminates the
-        rapid open/close churn that overwhelms Docker Desktop's vpnkit proxy
-        when creating tables for many models (e.g., 21 models = 63+ connections
-        reduced to 1 connection).
+        Uses :meth:`SyncDDLExecutor.execute_ddl_batch_per_statement` to run all
+        CREATE TABLE and CREATE INDEX statements through one connection. This
+        eliminates the rapid open/close churn that overwhelms Docker Desktop's
+        vpnkit proxy when creating tables for many models (e.g., 21 models =
+        63+ connections reduced to 1 connection).
 
-        Falls back to per-model _create_table_sync() if batching fails.
+        Issue #1537 (regression fix): the batch previously used the
+        abort-on-first-error :meth:`execute_ddl_batch`. On a MySQL re-migration
+        the batch aborted at an existing table's ``CREATE INDEX`` (1061
+        "Duplicate key name" — MySQL's ``CREATE INDEX`` has no ``IF NOT
+        EXISTS``); the round-1 benign-1061 disposition then marked EVERY model
+        ensured and skipped the fallback, so a NEW model whose ``CREATE TABLE``
+        was ordered AFTER the abort never ran yet was cached as ensured — first
+        CRUD on it failed table-not-found and never self-healed. The
+        per-statement executor runs ALL statements (no abort): an existing
+        index's 1061 is benign-skipped per-statement (DEBUG), the new table's
+        CREATE TABLE still runs, and a REAL failure on any statement still
+        surfaces. Each model is marked ensured based on ITS OWN CREATE TABLE
+        succeeding (or already existing) — never because a sibling's index 1061
+        was benign.
+
+        Failed CREATE TABLE statements are recorded via ``_record_failed_ddl``
+        so the next ``ensure_table_exists()`` fails-fast (auto_migrate=True) or
+        log-and-continues (auto_migrate="warn"), matching ``_create_table_sync``.
 
         Args:
             model_names: List of model names to create tables for.
@@ -8634,19 +8714,87 @@ class DataFlow(DataFlowEventMixin):
             if not all_sql:
                 return
 
-            # Execute all DDL in one connection
+            # Execute all DDL in one connection, per-statement (issue #1537).
+            # execute_ddl_batch_per_statement does NOT abort on first error, so
+            # an existing model's CREATE INDEX raising 1061 no longer masks a
+            # later NEW model's CREATE TABLE. Each statement's success/failure is
+            # captured independently and dispositioned per-model below.
             # Issue #1502: for bare ``:memory:`` write DDL to the per-instance
             # shared-cache URI so tables land in the SAME DB CRUD reads from.
             executor = SyncDDLExecutor(self._memory_db_uri or database_url)
-            result = executor.execute_ddl_batch(all_sql)
+            results = executor.execute_ddl_batch_per_statement(all_sql)
 
-            if result.get("success"):
-                logger.debug(
-                    "Batch DDL: created %d tables + indexes in single connection",
-                    len(model_names),
-                )
-                # Mark all as ensured in cache
-                for model_name in model_names:
+            # Per-model disposition: a model is marked ensured ONLY if its OWN
+            # CREATE TABLE succeeded (or was benign-already-exists) — never
+            # because a sibling's index 1061 was benign. This mirrors the
+            # per-statement disposition already used by ``_execute_ddl`` /
+            # ``_execute_ddl_async`` and the ensure/record semantics of
+            # ``_create_table_sync``.
+            for model_name in model_names:
+                start, count = model_sql_map[model_name]
+                table_ok = False
+                for offset in range(count):
+                    idx = start + offset
+                    stmt = all_sql[idx]
+                    stmt_result = results[idx]
+                    # The first statement of every model's slice is its
+                    # CREATE TABLE; the remainder are its CREATE INDEX rows.
+                    is_create_table = offset == 0
+
+                    if stmt_result.get("success"):
+                        logger.debug(
+                            "engine.batch_ddl_executed",
+                            extra={
+                                "statement": stmt[:100],
+                                "duration_ms": stmt_result.get("duration_ms"),
+                            },
+                        )
+                        if is_create_table:
+                            table_ok = True
+                        continue
+
+                    err_text = str(stmt_result.get("error") or "")
+                    err_lower = err_text.lower()
+                    # Benign already-present signal: PG/SQLite "already exists"
+                    # (any object) OR MySQL 1061 "Duplicate key name" scoped to a
+                    # CREATE INDEX (MySQL CREATE INDEX has no IF NOT EXISTS, so a
+                    # re-migration re-runs it against an existing table). A 1061
+                    # INSIDE a CREATE TABLE is a genuine schema bug and falls
+                    # through to the real-failure path. Mirrors
+                    # schema_state_manager.py + _execute_ddl.
+                    _is_create_index = bool(
+                        re.search(r"(?i)\bCREATE\s+(UNIQUE\s+)?INDEX\b", stmt)
+                    )
+                    if "already exists" in err_lower or (
+                        _is_create_index and "duplicate key name" in err_lower
+                    ):
+                        logger.debug(
+                            "engine.batch_ddl_already_exists",
+                            extra={"statement": stmt[:100]},
+                        )
+                        # A CREATE TABLE that "already exists" IS ensured.
+                        if is_create_table:
+                            table_ok = True
+                        continue
+
+                    # Real failure on this statement — surface it (never swallow).
+                    logger.error(
+                        "engine.batch_ddl_failed",
+                        extra={"statement": stmt[:100], "error": err_text},
+                    )
+                    error = stmt_result.get("exception") or RuntimeError(
+                        err_text or "DDL failed"
+                    )
+                    if is_create_table:
+                        # CREATE TABLE genuinely failed — do NOT mark ensured.
+                        # Record so the next ensure_table_exists() fails-fast
+                        # (auto_migrate=True) or log-and-continues ("warn").
+                        self._record_failed_ddl(model_name, error, stmt)
+                    # Index / FK / other real failures continue under legacy
+                    # semantics (same as _create_table_sync / _execute_ddl):
+                    # logged at ERROR above, non-fatal to the table's existence.
+
+                if table_ok:
                     schema_checksum = None
                     model_info = self._models.get(model_name)
                     if model_info and self._schema_cache.enable_schema_validation:
@@ -8656,31 +8804,6 @@ class DataFlow(DataFlowEventMixin):
                     self._schema_cache.mark_table_ensured(
                         model_name, database_url, schema_checksum
                     )
-            else:
-                error = result.get("error", "")
-                executed = result.get("executed_count", 0)
-                if "already exists" in error.lower():
-                    logger.debug(
-                        "Batch DDL: some tables already exist (OK), "
-                        "executed %d/%d statements",
-                        executed,
-                        len(all_sql),
-                    )
-                    # Mark all as ensured (they exist either way)
-                    for model_name in model_names:
-                        self._schema_cache.mark_table_ensured(
-                            model_name, database_url, None
-                        )
-                else:
-                    logger.warning(
-                        "Batch DDL failed at statement %d: %s. "
-                        "Falling back to per-model creation.",
-                        executed + 1,
-                        error,
-                    )
-                    # Fallback: try each model individually
-                    for model_name in model_names:
-                        self._create_table_sync(model_name)
 
         except ImportError:
             # SyncDDLExecutor not available — fall back to per-model
@@ -8778,8 +8901,19 @@ class DataFlow(DataFlowEventMixin):
                         )
                     else:
                         error = result.get("error", "")
-                        # "already exists" is OK
-                        if "already exists" in error.lower():
+                        # "already exists" is OK. MySQL's CREATE INDEX has no
+                        # IF NOT EXISTS (#1537), so a re-migration raises 1061
+                        # "Duplicate key name" — the same benign already-present
+                        # signal; scope 1061 to CREATE INDEX so a duplicate key
+                        # inside a CREATE TABLE still surfaces. Mirrors
+                        # schema_state_manager.py.
+                        error_lower = error.lower()
+                        _is_create_index = bool(
+                            re.search(r"(?i)\bCREATE\s+(UNIQUE\s+)?INDEX\b", statement)
+                        )
+                        if "already exists" in error_lower or (
+                            _is_create_index and "duplicate key name" in error_lower
+                        ):
                             success_count += 1
                             logger.debug(
                                 f"Table/index already exists (OK): {statement[:60]}..."

--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -172,7 +172,7 @@ class BulkUpsertConflictTargetError(DataFlowError):
 
 class UpsertConflictTargetError(DataFlowError):
     """Raised when a single-record upsert's ``conflict_on`` target is not backed
-    by a PRIMARY KEY or UNIQUE constraint (issue #1520).
+    by a PRIMARY KEY or UNIQUE constraint (PostgreSQL #1520 / MySQL #1537).
 
     On PostgreSQL a native ``INSERT ... ON CONFLICT (cols) DO UPDATE`` requires
     the conflict-target columns to be a PK or UNIQUE key, and the statement is
@@ -181,18 +181,31 @@ class UpsertConflictTargetError(DataFlowError):
     use a precheck and therefore never reaches this error). When the target is
     not unique, PostgreSQL rejects the statement with the opaque driver message
     "there is no unique or exclusion constraint matching the ON CONFLICT
-    specification". DataFlow converts that into this actionable typed error
-    rather than surfacing the raw driver text (which never names ``conflict_on``,
-    the offending field, or the remedy).
+    specification"; DataFlow converts that REACTIVELY into this actionable typed
+    error rather than surfacing the raw driver text (which never names
+    ``conflict_on``, the offending field, or the remedy).
+
+    On MySQL the same requirement holds but the failure mode differs: MySQL's
+    ``INSERT ... ON DUPLICATE KEY UPDATE`` has no explicit conflict target and
+    auto-detects whichever UNIQUE/PRIMARY key a row violates. A
+    ``conflict_on=[non_unique_field]`` upsert therefore raises NO driver error —
+    it silently falls through to a plain INSERT on the fresh ``id`` PK and lands
+    a duplicate row. Because there is no error to catch, DataFlow raises this
+    error PROACTIVELY: before executing the upsert it queries
+    ``information_schema.statistics`` for a UNIQUE/PRIMARY index whose column set
+    exactly matches ``conflict_on`` and raises here when none exists (#1537).
+    MySQL has no WHERE-precheck fallback (unlike SQLite) — the conflict target
+    MUST be a real unique key.
 
     This is the single-record sibling of :class:`BulkUpsertConflictTargetError`.
 
     Attributes:
         conflict_on: The conflict-target columns the caller requested.
         model_name: The model the upsert targeted (best-effort; may be None).
-        original_error: The underlying driver exception, if any.
+        original_error: The underlying driver exception, if any (PostgreSQL
+            only; the MySQL proactive precheck has no driver error to attach).
 
-    Recovery (PostgreSQL — the conflict target MUST be enforceable):
+    Recovery (PostgreSQL AND MySQL — the conflict target MUST be enforceable):
 
     1. Declare the field(s) ``unique=True`` on the model so DataFlow's migration
        creates the backing UNIQUE constraint.

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -3484,6 +3484,103 @@ class NodeGenerator:
 
                         created_flag = not row_exists
 
+                    elif database_type.lower() == "mysql":
+                        # Issue #1537: MySQL's ON DUPLICATE KEY UPDATE has NO
+                        # explicit conflict target — MySQL auto-detects whichever
+                        # UNIQUE/PRIMARY key a candidate row violates. DataFlow
+                        # mandates an `id` PK and generates a fresh id on the
+                        # create branch, so a conflict_on=[non_unique_field]
+                        # upsert hits no key violation → a plain INSERT lands a
+                        # DUPLICATE row and conflict_on is silently ignored. This
+                        # is the MySQL analog of #1520 (PostgreSQL), but a
+                        # SILENT-wrong-result failure mode: MySQL raises no error,
+                        # so the reactive `_is_conflict_target_error` catch below
+                        # (which converts PostgreSQL's opaque driver message) can
+                        # never fire. The complement is a PROACTIVE precheck:
+                        # verify a UNIQUE/PRIMARY index whose column set is
+                        # EXACTLY set(conflict_columns) backs the target BEFORE
+                        # building the ON DUPLICATE KEY UPDATE; if absent, raise
+                        # the same typed UpsertConflictTargetError (#1520) naming
+                        # conflict_on + the remedy.
+                        mysql_precheck_node = (
+                            self.dataflow_instance._get_or_create_async_sql_node(
+                                database_type
+                            )
+                        )
+
+                        # information_schema.statistics.table_schema / table_name
+                        # are string VALUES, not SQL identifiers — bind them as
+                        # parameters (DATABASE() for the live schema, %s for the
+                        # table) so the lookup is injection-safe. table_name is
+                        # ALSO validated by _vid above; this binding is the
+                        # defense-in-depth for the information_schema lookup
+                        # itself (rules/security.md § Parameterized Queries,
+                        # rules/dataflow-identifier-safety.md). non_unique = 0
+                        # selects UNIQUE and PRIMARY indexes only.
+                        index_query = (
+                            "SELECT index_name, column_name "
+                            "FROM information_schema.statistics "
+                            "WHERE table_schema = DATABASE() "
+                            "AND table_name = %s "
+                            "AND non_unique = 0"
+                        )
+                        index_result = await mysql_precheck_node.async_run(
+                            query=index_query,
+                            params=[table_name],
+                            fetch_mode="all",
+                            validate_queries=False,
+                            transaction_mode="auto",
+                        )
+
+                        # Group the fetched rows into {index_name: {columns}}.
+                        unique_index_columns: Dict[str, set] = {}
+                        if (
+                            index_result
+                            and "result" in index_result
+                            and "data" in index_result["result"]
+                        ):
+                            index_rows = index_result["result"]["data"]
+                            if isinstance(index_rows, list):
+                                for _row in index_rows:
+                                    if not isinstance(_row, dict):
+                                        continue
+                                    _idx = _row.get("index_name") or _row.get(
+                                        "INDEX_NAME"
+                                    )
+                                    _col = _row.get("column_name") or _row.get(
+                                        "COLUMN_NAME"
+                                    )
+                                    if _idx is None or _col is None:
+                                        continue
+                                    unique_index_columns.setdefault(_idx, set()).add(
+                                        _col
+                                    )
+
+                        # ON DUPLICATE KEY UPDATE behaves as upsert-on-conflict_on
+                        # ONLY when conflict_on is ITSELF a unique/primary key.
+                        # Require an EXACT column-set match: a unique index over a
+                        # superset/subset of conflict_columns would trigger on a
+                        # DIFFERENT conflict and silently ignore the caller's
+                        # intent. A conflict_on that IS the `id` PK matches the
+                        # PRIMARY index here and correctly proceeds.
+                        target_columns = set(conflict_columns)
+                        has_matching_unique_index = any(
+                            cols == target_columns
+                            for cols in unique_index_columns.values()
+                        )
+                        if not has_matching_unique_index:
+                            logger.debug(
+                                "upsert.mysql.conflict_target_not_unique",
+                                extra={
+                                    "model": self.model_name,
+                                    "conflict_on": list(conflict_columns),
+                                },
+                            )
+                            raise UpsertConflictTargetError(
+                                conflict_on=conflict_columns,
+                                model_name=self.model_name,
+                            )
+
                     # Build upsert query using dialect abstraction.
                     # SQLite: emit an explicit INSERT/UPDATE from the pre-check
                     # result (row_exists) instead of INSERT ... ON CONFLICT, which
@@ -3576,6 +3673,31 @@ class NodeGenerator:
                             row = self._deserialize_json_fields(row)
                             # DATETIME SERIALIZATION FIX: Serialize datetime objects to ISO strings
                             row = self._serialize_datetime_fields(row)
+
+                            # Issue #1538: invalidate the node-level query cache
+                            # (``_cache_integration``) after a successful upsert,
+                            # exactly as the create/update/delete branches do
+                            # (see the ``update`` branch above). Without this the
+                            # UPDATE branch of an upsert leaves a previously-primed
+                            # list/count entry in the node cache; a subsequent
+                            # ``db.express.list(..., cache_ttl=0)`` bypasses the
+                            # Express cache but still hits the stale node-cache
+                            # entry and returns the pre-update row. The Express
+                            # layer's ``_invalidate_model_cache`` only clears the
+                            # Express cache manager, a DIFFERENT backend from
+                            # ``_cache_integration`` — so this node-side call is
+                            # the only thing that clears the node query cache on
+                            # the upsert path. Paired with the ``upsert`` pattern
+                            # registered in
+                            # ``list_node_integration._setup_invalidation_patterns``
+                            # (without a matching pattern this call would no-op).
+                            cache_integration = getattr(
+                                self.dataflow_instance, "_cache_integration", None
+                            )
+                            if cache_integration:
+                                cache_integration.invalidate_model_cache(
+                                    self.model_name, "upsert", row
+                                )
 
                             # Return structure contract:
                             # {

--- a/packages/kailash-dataflow/src/dataflow/migrations/sync_ddl_executor.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/sync_ddl_executor.py
@@ -18,6 +18,7 @@ This architecture solves the Docker/FastAPI auto_migrate issue:
 """
 
 import logging
+import re
 import sqlite3
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -25,6 +26,34 @@ from kailash.db.dialect import _validate_identifier
 from kailash.utils.url_credentials import mask_url
 
 logger = logging.getLogger(__name__)
+
+_CREATE_INDEX_RE = re.compile(r"(?i)\bCREATE\s+(UNIQUE\s+)?INDEX\b")
+
+
+def _is_benign_ddl_object_exists(error_str: str, sql: Optional[str]) -> bool:
+    """Return True when a failed DDL statement means the object already exists.
+
+    Benign already-present signals for an idempotent DDL re-run:
+
+    * PostgreSQL / SQLite — ``"... already exists"`` (any object).
+    * MySQL — error 1061 ``"Duplicate key name"`` on a ``CREATE INDEX``. MySQL's
+      ``CREATE INDEX`` has no ``IF NOT EXISTS`` (issue #1537 dropped it because
+      MySQL rejects it with a 1064 syntax error), so re-migrating an existing
+      table raises 1061. Scope the 1061 tolerance to ``CREATE INDEX`` so a
+      duplicate key *inside* a ``CREATE TABLE`` definition — a genuine schema
+      authoring bug — still surfaces as an error.
+
+    Mirrors ``schema_state_manager.py``'s index-already-exists tolerance. This
+    only governs the LOG LEVEL of the executor's own line; the caller still
+    receives ``{"success": False, "error": ...}`` and applies its own
+    disposition.
+    """
+    error_lower = error_str.lower()
+    if "already exists" in error_lower:
+        return True
+    if "duplicate key name" in error_lower and sql and _CREATE_INDEX_RE.search(sql):
+        return True
+    return False
 
 
 class SyncDDLExecutor:
@@ -214,10 +243,27 @@ class SyncDDLExecutor:
             return {"success": True, "sql": sql}
 
         except Exception as e:
-            logger.error(
-                "sync_ddl_executor.ddl_execution_failed", extra={"error": str(e)}
-            )
-            return {"success": False, "error": str(e), "sql": sql}
+            error_str = str(e)
+            # #1537: MySQL's CREATE INDEX has no IF NOT EXISTS, so a re-migration
+            # (auto_migrate on an existing table) raises 1061 "Duplicate key
+            # name". That — and the PG/SQLite "already exists" form — means the
+            # object is already present, which is benign for an idempotent DDL
+            # re-run. Log it at DEBUG, not ERROR (scope 1061 to CREATE INDEX so a
+            # duplicate key inside a CREATE TABLE still surfaces as ERROR). The
+            # return value is unchanged: the caller still receives
+            # {success: False, error} and applies its own disposition. Mirrors
+            # schema_state_manager.py's index-already-exists tolerance.
+            if _is_benign_ddl_object_exists(error_str, sql):
+                logger.debug(
+                    "sync_ddl_executor.ddl_object_already_exists",
+                    extra={"error": error_str, "sql": (sql or "")[:100]},
+                )
+            else:
+                logger.error(
+                    "sync_ddl_executor.ddl_execution_failed",
+                    extra={"error": error_str},
+                )
+            return {"success": False, "error": error_str, "sql": sql}
 
         finally:
             if conn:
@@ -260,17 +306,30 @@ class SyncDDLExecutor:
             return {"success": True, "executed_count": executed}
 
         except Exception as e:
-            logger.error(
-                "sync_ddl_executor.ddl_batch_execution_failed_at_statement",
-                extra={"executed_1": executed + 1, "error": str(e)},
+            error_str = str(e)
+            failed_sql = (
+                sql_statements[executed] if executed < len(sql_statements) else None
             )
+            # #1537: a MySQL re-migration aborts this batch at the first
+            # IF-NOT-EXISTS-less CREATE INDEX with 1061 "Duplicate key name" —
+            # a benign already-present object (scoped to CREATE INDEX). Log at
+            # DEBUG, not ERROR; the caller still gets {success: False, error}
+            # and decides. Mirrors schema_state_manager.py.
+            if _is_benign_ddl_object_exists(error_str, failed_sql):
+                logger.debug(
+                    "sync_ddl_executor.ddl_batch_object_already_exists",
+                    extra={"executed_1": executed + 1, "error": error_str},
+                )
+            else:
+                logger.error(
+                    "sync_ddl_executor.ddl_batch_execution_failed_at_statement",
+                    extra={"executed_1": executed + 1, "error": error_str},
+                )
             return {
                 "success": False,
-                "error": str(e),
+                "error": error_str,
                 "executed_count": executed,
-                "failed_sql": (
-                    sql_statements[executed] if executed < len(sql_statements) else None
-                ),
+                "failed_sql": failed_sql,
             }
 
         finally:

--- a/packages/kailash-dataflow/src/dataflow/sql/dialects.py
+++ b/packages/kailash-dataflow/src/dataflow/sql/dialects.py
@@ -323,9 +323,17 @@ class MySQLDialect(SQLDialect):
     ) -> UpsertQuery:
         """Build MySQL upsert with ON DUPLICATE KEY UPDATE."""
 
-        # Build INSERT clause
+        # Build INSERT clause.
+        # MySQL's adapter (aiomysql) binds POSITIONAL %s placeholders — it does
+        # NOT understand the :p<i> named style the PostgreSQL/SQLite builders
+        # emit (AsyncSQLDatabaseNode's MySQL branch keeps the query verbatim and
+        # passes params as a tuple, so a :p0 query yields "not all arguments
+        # converted during string formatting"). Emit %s here, matching the
+        # hand-built %s create/update SQL in core/nodes.py. nodes.py passes
+        # ``list(upsert_query.params.values())`` — an ordered list — which lines
+        # up positionally with these %s placeholders. (#1537)
         insert_columns = list(insert_data.keys())
-        insert_placeholders = [f":p{i}" for i in range(len(insert_columns))]
+        insert_placeholders = ["%s" for _ in range(len(insert_columns))]
 
         # Build UPDATE clause
         update_clauses = []

--- a/packages/kailash-dataflow/tests/regression/test_issue_1537_mysql_index_idempotency.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1537_mysql_index_idempotency.py
@@ -1,0 +1,341 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #1537 (follow-up) — MySQL CREATE INDEX must be
+idempotent across auto_migrate re-runs (app-restart scenario).
+
+The #1537 fix dropped ``IF NOT EXISTS`` from every MySQL ``CREATE INDEX`` in
+``engine._generate_indexes_sql`` because MySQL rejects ``IF NOT EXISTS`` on
+``CREATE INDEX`` with a 1064 syntax error — so the UNIQUE index a single-record
+upsert conflict target relies on was NEVER created before. That fix is correct,
+but it introduced a NEW failure mode on re-migration: an application that starts
+with ``auto_migrate=True`` against an ALREADY-migrated table re-issues the
+``CREATE INDEX`` statements, and MySQL raises error 1061 "Duplicate key name".
+
+The benign-error tolerance in the DDL execution paths only matched
+``"already exists"`` (PostgreSQL / SQLite), NOT MySQL's ``"duplicate key name"``,
+so every restart logged an ERROR + WARNINGs and thrashed the batch-DDL path into
+per-model fallback (connection churn). Functionally the index existed and upsert
+worked — but the noise violates ``rules/zero-tolerance.md`` Rule 1 (a warning is
+an error) and ``rules/observability.md`` Rule 5 (WARN+-clean gate).
+
+The canonical tolerance already existed in
+``schema_state_manager.py`` (``"duplicate key name" in err or "already exists"``)
+for the migration-history table's index; the follow-up mirrors it in every DDL
+execution path that can see a MySQL ``CREATE INDEX`` 1061:
+
+* ``sync_ddl_executor.execute_ddl`` / ``execute_ddl_batch`` (the ROOT log sites),
+* ``engine._execute_ddl`` / ``_execute_ddl_async`` (per-statement batch),
+* ``engine._create_tables_batch`` (the abort-on-first-error batch → the
+  "Batch DDL failed at statement N ... Falling back to per-model" WARN),
+* ``engine._create_table_sync`` index loop (the "Failed to create index" WARN),
+* ``engine.create_tables_sync`` (standalone all-statements loop).
+
+The 1061 tolerance is scoped to ``CREATE INDEX`` statements so a duplicate key
+inside a ``CREATE TABLE`` definition — a genuine authoring bug — still surfaces.
+
+This test migrates a model with a UNIQUE ``__dataflow__`` index TWICE without
+dropping the table between (a FRESH ``DataFlow`` instance for the second
+migration, so the in-memory schema cache is empty — the literal app-restart
+condition), and asserts the second ``auto_migrate``:
+
+1. does NOT raise, and
+2. emits NO WARN+ log for the duplicate index (no ``ddl_execution_failed`` /
+   ``ddl_batch_execution_failed_at_statement`` / "Duplicate key name" /
+   "Failed to create index" / "Batch DDL failed at statement" at WARNING+),
+3. and DOES take the benign already-present DEBUG path (positive proof the
+   tolerance fired, not that the code path was simply skipped).
+
+Permanent regression test — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from dataflow import DataFlow
+
+# Real MySQL 8.0 on port 3307 (compose: db kailash_test, root/test_password).
+MYSQL_URL = "mysql://root:test_password@localhost:3307/kailash_test"
+
+
+async def _drop_table(table: str) -> None:
+    """Drop the test table on real MySQL so each run starts clean / re-runnable."""
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=MYSQL_URL,
+        database_type="mysql",
+        query=f"DROP TABLE IF EXISTS {table}",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+async def _table_exists(table: str) -> bool:
+    """Return True iff *table* exists on real MySQL (behavioral proof, not a
+    schema-cache read — the cache is exactly what the regression corrupts)."""
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=MYSQL_URL,
+        database_type="mysql",
+        query=f"SHOW TABLES LIKE '{table}'",
+        validate_queries=False,
+    )
+    result = await node.async_run()
+    await node.cleanup()
+    data = result["result"]["data"] if isinstance(result, dict) else []
+    return len(data) > 0
+
+
+def _define_idem_model(db: DataFlow):
+    """Register a fresh model class carrying a UNIQUE ``__dataflow__`` index on
+    the given DataFlow instance.
+
+    A NEW class object is created on each call (same ``__name__`` → same table
+    name → same index name) so the two instances mirror a real app restart:
+    the module is re-imported and the decorated class is re-created against a
+    fresh DataFlow — NOT the same class object re-decorated.
+    """
+
+    @db.model
+    class Issue1537IdemDoc:
+        id: str
+        email: str  # backed by the UNIQUE index below
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    return Issue1537IdemDoc
+
+
+def _is_dup_index_warn_plus(rec: logging.LogRecord) -> bool:
+    """True for a WARNING+ record that signals a duplicate-index DDL failure —
+    the exact regression this test guards against."""
+    if rec.levelno < logging.WARNING:
+        return False
+    combined = " ".join(
+        [
+            rec.getMessage().lower(),
+            str(getattr(rec, "error", "")).lower(),
+        ]
+    )
+    return (
+        "duplicate key name" in combined
+        or "ddl_execution_failed" in combined
+        or "ddl_batch_execution_failed_at_statement" in combined
+        or "failed to create index" in combined
+        or "batch ddl failed at statement" in combined
+    )
+
+
+def _is_benign_already_present_debug(rec: logging.LogRecord) -> bool:
+    """True for a DEBUG record proving the benign already-present tolerance
+    fired on the re-migration (index already exists → swallowed)."""
+    if rec.levelno != logging.DEBUG:
+        return False
+    combined = " ".join(
+        [
+            rec.getMessage().lower(),
+            str(getattr(rec, "error", "")).lower(),
+        ]
+    )
+    return "already_exist" in combined or "already exist" in combined
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_re_migration_unique_index_is_idempotent(caplog):
+    """AC: a second ``auto_migrate`` against an existing MySQL table with a
+    UNIQUE ``__dataflow__`` index does NOT raise and emits NO duplicate-index
+    WARN+ — the app-restart idempotency the #1537 IF-NOT-EXISTS removal broke."""
+    # --- First migration: clean CREATE TABLE + CREATE UNIQUE INDEX ---
+    db1 = DataFlow(MYSQL_URL, auto_migrate=True)
+    _define_idem_model(db1)
+    table = db1._models["Issue1537IdemDoc"]["table_name"]
+    await _drop_table(table)
+
+    try:
+        db1._ensure_connected()  # runs _create_tables_batch → table + unique idx
+        db1.close()
+
+        # --- Second migration: FRESH instance (empty schema cache = restart) ---
+        # The benign already-present path logs at DEBUG on the DDL loggers, which
+        # the SDK floors above DEBUG. Lower the SPECIFIC child loggers (setting
+        # the "dataflow" parent alone does not lower children that carry their
+        # own level) so the benign DEBUG line is emitted and captured; caplog
+        # auto-restores the levels at test end.
+        caplog.clear()
+        caplog.set_level(logging.DEBUG, logger="dataflow.core.engine")
+        caplog.set_level(logging.DEBUG, logger="dataflow.migrations.sync_ddl_executor")
+        db2 = DataFlow(MYSQL_URL, auto_migrate=True)
+        _define_idem_model(db2)
+        # MUST NOT raise: the re-issued CREATE UNIQUE INDEX 1061 is benign.
+        db2._ensure_connected()
+        db2.close()
+
+        # (1) No duplicate-index WARN+ on the second migration.
+        offenders = [r for r in caplog.records if _is_dup_index_warn_plus(r)]
+        assert offenders == [], [
+            (r.levelname, r.name, r.getMessage(), getattr(r, "error", None))
+            for r in offenders
+        ]
+
+        # (2) Positive proof the benign already-present tolerance actually fired
+        # (the 1061 was swallowed at DEBUG, not merely skipped).
+        benign = [r for r in caplog.records if _is_benign_already_present_debug(r)]
+        assert benign, (
+            "expected a benign already-present DEBUG log on the second migration; "
+            "captured DEBUG events: "
+            + str(
+                [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+            )
+        )
+    finally:
+        await _drop_table(table)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_re_migration_upsert_still_works_after_restart(caplog):
+    """AC (no-regression): after the second (WARN-clean) migration, the UNIQUE
+    index still backs a single-record upsert conflict target end-to-end — the
+    index really exists, not merely 'error swallowed'."""
+    db1 = DataFlow(MYSQL_URL, auto_migrate=True)
+    _define_idem_model(db1)
+    table = db1._models["Issue1537IdemDoc"]["table_name"]
+    await _drop_table(table)
+
+    try:
+        db1._ensure_connected()
+        db1.close()
+
+        db2 = DataFlow(MYSQL_URL, auto_migrate=True)
+        _define_idem_model(db2)
+        db2._ensure_connected()
+
+        email = f"restart-{int(time.time() * 1_000_000)}@example.com"
+        # First upsert on the UNIQUE email → INSERT.
+        await db2.express.upsert_advanced(
+            "Issue1537IdemDoc",
+            where={"email": email},
+            create={"id": "u1", "email": email, "name": "First"},
+            update={"name": "First"},
+            conflict_on=["email"],
+        )
+        # Second upsert on the same email → UPDATE in place (index-backed), no dup.
+        await db2.express.upsert_advanced(
+            "Issue1537IdemDoc",
+            where={"email": email},
+            create={"id": "u2", "email": email, "name": "Second"},
+            update={"name": "Second"},
+            conflict_on=["email"],
+        )
+        assert await db2.express.count("Issue1537IdemDoc", {"email": email}) == 1
+        db2.close()
+    finally:
+        await _drop_table(table)
+
+
+def _define_batch_model_a(db: DataFlow):
+    """Model A: carries a UNIQUE ``__dataflow__`` index (the 1061 source on
+    re-migration). Registered FIRST so its CREATE INDEX is ordered BEFORE B's
+    CREATE TABLE in the single batch — the exact interleaving that made the
+    abort-on-first-error ``execute_ddl_batch`` mask B."""
+
+    @db.model
+    class Issue1537BatchA:
+        id: str
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    return Issue1537BatchA
+
+
+def _define_batch_model_b(db: DataFlow):
+    """Model B: a NEW model added at the SECOND migration (app restart + new
+    model). Its CREATE TABLE is ordered AFTER A's CREATE INDEX in the batch, so
+    the round-1 abort-on-first-error path never created it yet cached it as
+    ensured — the HIGH regression this test locks closed."""
+
+    @db.model
+    class Issue1537BatchB:
+        id: str
+        title: str
+
+    return Issue1537BatchB
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_batch_re_migration_creates_new_model_after_existing_index(
+    caplog,
+):
+    """AC (HIGH regression, issue #1537 round-2): a re-migration batch where an
+    EXISTING model A (with a UNIQUE index) is interleaved with a NEW model B must
+    still CREATE B's table.
+
+    Verbatim repro the round-1 abort-on-first-error path produced:
+        migration 2 (restart + new model B): A exists=True, B exists=False  ← B MASKED
+
+    Expected after the per-statement fix:
+        migration 2 (restart + new model B): A exists=True, B exists=True
+
+    Asserts (a) B's table EXISTS on real MySQL after the 2nd migration, (b) A's
+    index 1061 produced NO WARN+ (caplog), (c) an insert on B succeeds.
+    """
+    # --- Migration 1: ONLY model A exists (B not defined yet) ---
+    db1 = DataFlow(MYSQL_URL, auto_migrate=True)
+    _define_batch_model_a(db1)
+    table_a = db1._models["Issue1537BatchA"]["table_name"]
+    await _drop_table(table_a)
+
+    # Determine B's table name via a throwaway registration so we can pre-drop it.
+    db_probe = DataFlow(MYSQL_URL, auto_migrate=False)
+    _define_batch_model_b(db_probe)
+    table_b = db_probe._models["Issue1537BatchB"]["table_name"]
+    db_probe.close()
+    await _drop_table(table_b)
+
+    try:
+        db1._ensure_connected()  # creates A + unique index only
+        db1.close()
+
+        assert await _table_exists(table_a) is True, "migration 1 must create A"
+        assert (
+            await _table_exists(table_b) is False
+        ), "B must NOT exist before migration 2 (it is the newly-added model)"
+
+        # --- Migration 2: FRESH instance (restart) registering A AND new B ---
+        caplog.clear()
+        caplog.set_level(logging.DEBUG, logger="dataflow.core.engine")
+        caplog.set_level(logging.DEBUG, logger="dataflow.migrations.sync_ddl_executor")
+        db2 = DataFlow(MYSQL_URL, auto_migrate=True)
+        _define_batch_model_a(db2)  # registered FIRST → CREATE INDEX A precedes B
+        _define_batch_model_b(db2)  # NEW model → CREATE TABLE B ordered AFTER
+        db2._ensure_connected()  # single batch: [CREATE TABLE A, CREATE INDEX A(1061), CREATE TABLE B]
+
+        # (a) B's table EXISTS — the regression is CLOSED (was False when masked).
+        assert (
+            await _table_exists(table_b) is True
+        ), "REGRESSION: new model B's table was masked by A's benign index 1061"
+        assert await _table_exists(table_a) is True
+
+        # (b) A's re-run unique index 1061 produced NO duplicate-index WARN+.
+        offenders = [r for r in caplog.records if _is_dup_index_warn_plus(r)]
+        assert offenders == [], [
+            (r.levelname, r.name, r.getMessage(), getattr(r, "error", None))
+            for r in offenders
+        ]
+
+        # (c) CRUD on B works end-to-end (the table really exists, not just cached).
+        await db2.express.create("Issue1537BatchB", {"id": "b1", "title": "hello"})
+        assert await db2.express.count("Issue1537BatchB", {"id": "b1"}) == 1
+        db2.close()
+    finally:
+        await _drop_table(table_a)
+        await _drop_table(table_b)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1537_mysql_single_upsert_conflict_target.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1537_mysql_single_upsert_conflict_target.py
@@ -1,0 +1,293 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1537 — MySQL single-record upsert with
+``conflict_on`` on a field that has no backing PRIMARY KEY / UNIQUE constraint.
+
+Before #1537, a single-record MySQL upsert (``db.express.upsert`` /
+``upsert_advanced`` / the generated ``{Model}UpsertNode``) with
+``conflict_on=["field"]`` where ``field`` is not unique SILENTLY upserted on the
+``id`` PK instead of the requested field. MySQL's ``INSERT ... ON DUPLICATE KEY
+UPDATE`` has no explicit conflict target and auto-detects whichever
+UNIQUE/PRIMARY key a row violates; DataFlow mandates an ``id`` PK and generates a
+fresh ``id`` on the create branch, so no key was violated → a plain INSERT
+landed a DUPLICATE row and ``conflict_on`` was ignored. No error was raised —
+the failure mode was a silent-wrong-result.
+
+Why MySQL differs from the PostgreSQL fix (#1520): PostgreSQL's ``ON CONFLICT``
+raises the opaque driver message "there is no unique or exclusion constraint
+matching the ON CONFLICT specification" when the target is non-unique, which
+DataFlow catches REACTIVELY and converts to
+:class:`UpsertConflictTargetError`. MySQL produces NO error, so there is nothing
+to catch. The MySQL fix is a PROACTIVE ``information_schema.statistics`` precheck
+that verifies a UNIQUE/PRIMARY index whose column set is exactly
+``set(conflict_on)`` backs the target BEFORE the upsert executes; if absent it
+raises the same typed :class:`UpsertConflictTargetError` (naming the field +
+remedy). No runtime DDL — auto-creating the index is BLOCKED per
+``schema-migration.md`` Rule 1 and would fail on existing duplicate data.
+
+The precheck lives at the single-record upsert execute site in
+``dataflow/core/nodes.py`` (the one chokepoint every express.upsert /
+upsert_advanced / sync variant / {Model}UpsertNode call funnels through),
+alongside the SQLite WHERE-precheck (#1508) and the PostgreSQL reactive catch
+(#1520).
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.exceptions import (
+    BulkUpsertConflictTargetError,
+    UpsertConflictTargetError,
+)
+
+# Real MySQL 8.0 on port 3307 (compose: db kailash_test, root/test_password).
+# DataFlow connection strings use the ``mysql://`` scheme.
+MYSQL_URL = "mysql://root:test_password@localhost:3307/kailash_test"
+
+
+def _uid(prefix: str = "u") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+async def _drop_table(table: str) -> None:
+    """Drop the test table on real MySQL so each run starts clean.
+
+    The #1520 suite learned that persistent duplicate data from a prior run
+    breaks re-runs; drop-first + auto_migrate re-creates a clean schema.
+    """
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=MYSQL_URL,
+        database_type="mysql",
+        query=f"DROP TABLE IF EXISTS {table}",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+async def _raw_rows(table: str, where_col: str, where_val: str) -> list:
+    """Ground-truth read-back on a fresh MySQL connection (committed state),
+    independent of the express read-cache layer."""
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=MYSQL_URL,
+        database_type="mysql",
+        query=f"SELECT * FROM {table} WHERE {where_col} = %s",
+        validate_queries=False,
+    )
+    result = await node.async_run(params=[where_val], fetch_mode="all")
+    await node.cleanup()
+    rows = result.get("result", {}).get("data", []) if result else []
+    return rows if isinstance(rows, list) else []
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: MySQL — the live #1537 error path (real MySQL on port 3307)
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_single_upsert_non_unique_conflict_target_raises():
+    """AC1: MySQL single-record ``db.express.upsert`` with ``conflict_on`` on a
+    NON-unique field raises the typed :class:`UpsertConflictTargetError` (naming
+    the field + remedy) instead of silently landing a duplicate row on the id PK.
+    No row lands — the proactive precheck aborts BEFORE the INSERT executes."""
+    db = DataFlow(MYSQL_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1537MyNonuniq:
+        id: str
+        tag: str  # deliberately NOT unique — the bug's precondition
+        body: str
+
+    table = db._models["Issue1537MyNonuniq"]["table_name"]
+    await _drop_table(table)
+    db._ensure_connected()
+
+    try:
+        with pytest.raises(UpsertConflictTargetError) as excinfo:
+            await db.express.upsert(
+                "Issue1537MyNonuniq",
+                {"id": _uid("row"), "tag": "t", "body": "one"},
+                conflict_on=["tag"],
+            )
+
+        # The typed error names conflict_on + the field + the remedy.
+        msg = str(excinfo.value)
+        assert "tag" in msg
+        assert "unique" in msg.lower()
+        assert "unique=True" in msg
+        assert excinfo.value.conflict_on == ["tag"]
+        assert excinfo.value.model_name == "Issue1537MyNonuniq"
+
+        # No row landed on the raise (precheck aborted before INSERT).
+        assert await db.express.count("Issue1537MyNonuniq") == 0
+    finally:
+        await _drop_table(table)
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_single_upsert_non_unique_no_duplicate_on_repeat():
+    """AC1b (the silent-wrong-result core): repeating a non-unique-conflict_on
+    upsert must NOT accumulate duplicate rows. Pre-fix, each call landed a fresh
+    id-PK INSERT (2 calls → 2 rows). Post-fix, each call raises and zero rows
+    land — proven by a ground-truth read-back on a fresh connection."""
+    db = DataFlow(MYSQL_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1537MyDup:
+        id: str
+        tag: str  # NOT unique
+        body: str
+
+    table = db._models["Issue1537MyDup"]["table_name"]
+    await _drop_table(table)
+    db._ensure_connected()
+
+    tag = _uid("tag")
+    try:
+        for body in ("one", "two"):
+            with pytest.raises(UpsertConflictTargetError):
+                await db.express.upsert(
+                    "Issue1537MyDup",
+                    {"id": _uid("row"), "tag": tag, "body": body},
+                    conflict_on=["tag"],
+                )
+
+        # Ground-truth: zero rows for this tag on real MySQL (no silent dups).
+        rows = await _raw_rows(table, "tag", tag)
+        assert rows == [], rows
+        assert await db.express.count("Issue1537MyDup") == 0
+    finally:
+        await _drop_table(table)
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_single_upsert_unique_conflict_target_still_works():
+    """AC2 (no-regression): MySQL single-record upsert on a DECLARED-UNIQUE
+    ``conflict_on`` field still works end-to-end — INSERT then UPDATE IN PLACE,
+    no duplicate row. The new precheck must NOT break the happy path."""
+    db = DataFlow(MYSQL_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1537MyUniq:
+        id: str
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    table = db._models["Issue1537MyUniq"]["table_name"]
+    await _drop_table(table)
+    db._ensure_connected()
+
+    email = f"{_uid('alice')}@example.com"
+    try:
+        # First upsert → INSERT (email absent).
+        await db.express.upsert_advanced(
+            "Issue1537MyUniq",
+            where={"email": email},
+            create={"id": _uid("u"), "email": email, "name": "Alice New"},
+            update={"name": "Alice New"},
+            conflict_on=["email"],
+        )
+        # Ground-truth read-back on a fresh MySQL connection (committed state),
+        # independent of the express read-cache — exactly one row after INSERT.
+        r1 = await _raw_rows(table, "email", email)
+        assert len(r1) == 1, r1
+        assert r1[0]["name"] == "Alice New"
+        original_id = r1[0]["id"]
+
+        # Second upsert on the same email → UPDATE in place, same id, no dup.
+        await db.express.upsert_advanced(
+            "Issue1537MyUniq",
+            where={"email": email},
+            create={"id": _uid("u2"), "email": email, "name": "Alice Updated"},
+            update={"name": "Alice Updated"},
+            conflict_on=["email"],
+        )
+
+        # Ground-truth read-back: still exactly one row (ON DUPLICATE KEY UPDATE
+        # matched the UNIQUE email index — no second INSERT), same id, carrying
+        # the UPDATE payload. Asserts the happy path did NOT regress.
+        rows = await _raw_rows(table, "email", email)
+        assert len(rows) == 1, rows
+        assert rows[0]["id"] == original_id
+        assert rows[0]["name"] == "Alice Updated"
+    finally:
+        await _drop_table(table)
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_mysql_single_upsert_on_id_pk_still_works():
+    """AC3 (no-over-block): the default ``conflict_on`` — the ``id`` PRIMARY KEY —
+    MUST still upsert. The precheck matches the PRIMARY index and proceeds; a
+    conflict_on that IS a real key is never blocked."""
+    db = DataFlow(MYSQL_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1537MyPk:
+        id: str
+        name: str
+
+    table = db._models["Issue1537MyPk"]["table_name"]
+    await _drop_table(table)
+    db._ensure_connected()
+
+    rid = _uid("pk")
+    try:
+        # conflict_on defaults to the id PK (express.upsert uses ["id"]).
+        await db.express.upsert("Issue1537MyPk", {"id": rid, "name": "First"})
+        await db.express.upsert("Issue1537MyPk", {"id": rid, "name": "Second"})
+
+        # Ground-truth: one row, updated in place on the PK conflict.
+        rows = await _raw_rows(table, "id", rid)
+        assert len(rows) == 1, rows
+        assert await db.express.count("Issue1537MyPk") == 1
+        fresh = await db.express.read("Issue1537MyPk", rid)
+        assert fresh["name"] == "Second"
+    finally:
+        await _drop_table(table)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier-1: structural pins on the typed error (no DB) — dialect-inclusive
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+def test_upsert_conflict_target_error_actionable_for_mysql_field():
+    """The typed error names conflict_on, the offending field, and the remedy —
+    the SAME type PostgreSQL #1520 raises (single shared type for both dialects,
+    so callers ``except UpsertConflictTargetError`` once)."""
+    e = UpsertConflictTargetError(conflict_on=["tag"], model_name="Issue1537MyNonuniq")
+    msg = str(e)
+    assert "conflict_on" in msg
+    assert "tag" in msg
+    assert "unique=True" in msg  # the actionable remedy
+    assert e.conflict_on == ["tag"]
+    assert e.model_name == "Issue1537MyNonuniq"
+
+
+@pytest.mark.regression
+def test_upsert_conflict_target_error_type_identity():
+    """#1537 (MySQL single-record) reuses the #1520 :class:`UpsertConflictTargetError`
+    and stays distinct from the bulk (#1519) type so callers can catch one
+    without the other — both derive from DataFlowError."""
+    from dataflow.core.exceptions import DataFlowError
+
+    assert not issubclass(UpsertConflictTargetError, BulkUpsertConflictTargetError)
+    assert not issubclass(BulkUpsertConflictTargetError, UpsertConflictTargetError)
+    assert issubclass(UpsertConflictTargetError, DataFlowError)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1538_pg_express_list_stale_after_upsert_update.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1538_pg_express_list_stale_after_upsert_update.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1538 — PostgreSQL ``db.express.list`` returns a
+STALE row after an upsert that took the UPDATE branch, even with ``cache_ttl=0``.
+
+Root cause (confirmed by live PG:5434 reproduction, not hypothesis):
+
+DataFlow has TWO independent cache layers on the Express read path:
+
+1. the **Express cache** (``DataFlowExpress._cache_manager``), which
+   ``cache_ttl=0`` correctly bypasses (``_cache_get`` returns ``None`` when
+   ``effective_ttl <= 0``); and
+2. the **node query cache** (``DataFlow._cache_integration``), consulted by the
+   generated ``{Model}ListNode`` with ``enable_cache=True`` by default — a
+   DIFFERENT backend that ``cache_ttl=0`` on the Express layer does NOT touch.
+
+A prior ``db.express.list(...)`` primes layer (2). The single-record
+``UpsertNode`` (``dataflow/core/nodes.py`` ``operation == "upsert"``) then failed
+to invalidate layer (2) after a successful upsert — every sibling write branch
+(create / update / delete / bulk_*) called
+``cache_integration.invalidate_model_cache(...)`` but the single upsert branch
+did not. Compounding it, ``ListNodeCacheIntegration._setup_invalidation_patterns``
+registered no ``upsert`` / ``bulk_upsert`` pattern, so even the calls that DID
+exist (bulk_upsert) matched zero patterns in ``CacheInvalidator.invalidate`` and
+silently no-op'd. Net effect: the upsert-UPDATE left the primed list/count entry
+in the node cache and the next ``list(cache_ttl=0)`` served the pre-update row.
+
+A plain ``db.express.update`` did NOT exhibit the bug because ``UpdateNode``
+already calls ``invalidate_model_cache(model, "update", row)`` and the ``update``
+pattern was registered — hence the control case below MUST stay fresh.
+
+The fix (two surgical, additive parts):
+  * ``dataflow/core/nodes.py`` — the single upsert success path now calls
+    ``cache_integration.invalidate_model_cache(self.model_name, "upsert", row)``.
+  * ``dataflow/cache/list_node_integration.py`` — register ``upsert`` and
+    ``bulk_upsert`` invalidation patterns (version-wildcard sweep).
+
+Not MVCC / connection-snapshot: the raw read-back below and an
+``enable_cache=False`` node read both return the fresh row from the same pool
+while the cached Express read returned stale — proving the staleness lived in
+the node cache, not an open transaction.
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dataflow import DataFlow
+
+
+def _email(prefix: str = "alice") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}@example.com"
+
+
+@pytest.fixture
+async def pg_suite():
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+async def _drop_table(url, table):
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=url,
+        database_type="postgresql",
+        query=f"DROP TABLE IF EXISTS {table} CASCADE",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# AC1 — the exact #1538 sequence: upsert(INSERT) → list(prime) →
+#        upsert(UPDATE) → list(cache_ttl=0) MUST see the UPDATED value.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_express_list_fresh_after_upsert_update(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "person1538_as")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Person1538A:
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    await db.initialize()
+    email = _email()
+
+    # 1. upsert → INSERT
+    await db.express.upsert(
+        "Person1538A", {"email": email, "name": "Alice New"}, conflict_on=["email"]
+    )
+    # 2. prime the node-level list cache
+    primed = await db.express.list("Person1538A", {"email": email})
+    assert [r["name"] for r in primed] == ["Alice New"]
+
+    # 3. upsert → UPDATE branch
+    await db.express.upsert(
+        "Person1538A",
+        {"email": email, "name": "Alice Updated"},
+        conflict_on=["email"],
+    )
+
+    # 4. list with cache_ttl=0 MUST reflect the UPDATE, not the primed value.
+    after = await db.express.list("Person1538A", {"email": email}, cache_ttl=0)
+    assert [r["name"] for r in after] == ["Alice Updated"], (
+        "Express list served a STALE row after upsert-UPDATE (issue #1538). "
+        "The node-level _cache_integration was not invalidated by the upsert."
+    )
+
+    # Read-back through the harness connection (bypasses BOTH DataFlow cache
+    # layers) proves the DB row itself is correct — i.e. this was a cache bug,
+    # not a write/MVCC bug.
+    async with pg_suite.get_connection() as conn:
+        raw = await conn.fetchval(
+            "SELECT name FROM person1538_as WHERE email = $1", email
+        )
+    assert raw == "Alice Updated"
+
+
+# ---------------------------------------------------------------------------
+# AC2 — control: plain express.update MUST stay fresh (it already invalidated
+#        the node cache; the differentiator that made #1538 upsert-specific).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_express_list_fresh_after_plain_update_control(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "person1538_bs")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Person1538B:
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    await db.initialize()
+    email = _email("bob")
+
+    await db.express.upsert(
+        "Person1538B", {"email": email, "name": "Bob New"}, conflict_on=["email"]
+    )
+    primed = await db.express.list("Person1538B", {"email": email})
+    assert [r["name"] for r in primed] == ["Bob New"]
+
+    rec = await db.express.find_one("Person1538B", {"email": email})
+    await db.express.update("Person1538B", rec["id"], {"name": "Bob Updated"})
+
+    after = await db.express.list("Person1538B", {"email": email}, cache_ttl=0)
+    assert [r["name"] for r in after] == ["Bob Updated"]
+
+    async with pg_suite.get_connection() as conn:
+        raw = await conn.fetchval(
+            "SELECT name FROM person1538_bs WHERE email = $1", email
+        )
+    assert raw == "Bob Updated"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — same-class fix: bulk_upsert UPDATE branch MUST also invalidate the node
+#        cache (its invalidate_model_cache call previously no-op'd for lack of a
+#        registered "bulk_upsert" pattern).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_express_list_fresh_after_bulk_upsert_update(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "person1538_cs")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Person1538C:
+        email: str
+        name: str
+        __dataflow__ = {"indexes": [{"fields": ["email"], "unique": True}]}
+
+    await db.initialize()
+    email = _email("carol")
+
+    await db.express.bulk_upsert(
+        "Person1538C",
+        [{"email": email, "name": "Carol New"}],
+        conflict_on=["email"],
+    )
+    primed = await db.express.list("Person1538C", {"email": email})
+    assert [r["name"] for r in primed] == ["Carol New"]
+
+    await db.express.bulk_upsert(
+        "Person1538C",
+        [{"email": email, "name": "Carol Updated"}],
+        conflict_on=["email"],
+    )
+
+    after = await db.express.list("Person1538C", {"email": email}, cache_ttl=0)
+    assert [r["name"] for r in after] == ["Carol Updated"], (
+        "Express list served a STALE row after bulk_upsert-UPDATE (issue #1538 "
+        "same-class): the 'bulk_upsert' invalidation pattern was not registered."
+    )
+
+    async with pg_suite.get_connection() as conn:
+        raw = await conn.fetchval(
+            "SELECT name FROM person1538_cs WHERE email = $1", email
+        )
+    assert raw == "Carol Updated"

--- a/packages/kailash-dataflow/tests/unit/migrations/test_sync_ddl_executor.py
+++ b/packages/kailash-dataflow/tests/unit/migrations/test_sync_ddl_executor.py
@@ -190,3 +190,61 @@ class TestSyncDDLEdgeCases:
 
         executor = SyncDDLExecutor(f"sqlite:///{db_path}")
         assert executor.table_exists("this_table_does_not_exist") is False
+
+
+@pytest.mark.unit
+class TestIsBenignDDLObjectExists:
+    """Pin the scoping of ``_is_benign_ddl_object_exists`` — the single guarantee
+    the whole 1061-tolerance (issue #1537) rests on.
+
+    The batch/per-statement re-migration paths mark a model's table ensured (and
+    swallow the error at DEBUG) ONLY when this helper returns True. If the scoping
+    ever loosens so that a 1061 INSIDE a ``CREATE TABLE`` (a genuine schema
+    authoring bug) is treated as benign, real failures would be masked; if it
+    tightens so that a re-run ``CREATE INDEX`` 1061 is NOT benign, every MySQL
+    restart re-emits a WARN. This test locks both edges.
+    """
+
+    def test_1061_inside_create_table_is_not_benign(self):
+        """A 1061 'Duplicate key name' raised by a CREATE TABLE definition is a
+        genuine schema bug — MUST surface (False), NOT be swallowed."""
+        from dataflow.migrations.sync_ddl_executor import (
+            _is_benign_ddl_object_exists,
+        )
+
+        err = "(1061, \"Duplicate key name 'idx_email'\")"
+        sql = "CREATE TABLE `docs` (id INT, email VARCHAR(255), UNIQUE KEY `idx_email` (email), KEY `idx_email` (email))"
+        assert _is_benign_ddl_object_exists(err, sql) is False
+
+    def test_1061_on_create_index_is_benign(self):
+        """A 1061 'Duplicate key name' raised by a re-run CREATE INDEX (MySQL has
+        no IF NOT EXISTS) means the index already exists — benign (True)."""
+        from dataflow.migrations.sync_ddl_executor import (
+            _is_benign_ddl_object_exists,
+        )
+
+        err = "(1061, \"Duplicate key name 'idx_email'\")"
+        sql = "CREATE UNIQUE INDEX `idx_email` ON `docs` (`email`)"
+        assert _is_benign_ddl_object_exists(err, sql) is True
+
+    def test_1064_syntax_on_create_index_is_not_benign(self):
+        """A real 1064 syntax error on a CREATE INDEX is NOT an already-present
+        signal — MUST surface (False) even though the statement is CREATE INDEX."""
+        from dataflow.migrations.sync_ddl_executor import (
+            _is_benign_ddl_object_exists,
+        )
+
+        err = "(1064, \"You have an error in your SQL syntax near 'ONN'\")"
+        sql = "CREATE INDEX `idx_email` ONN `docs` (`email`)"
+        assert _is_benign_ddl_object_exists(err, sql) is False
+
+    def test_already_exists_on_create_table_is_benign(self):
+        """PostgreSQL / SQLite 'already exists' on any object (here CREATE TABLE)
+        is the canonical benign already-present signal (True)."""
+        from dataflow.migrations.sync_ddl_executor import (
+            _is_benign_ddl_object_exists,
+        )
+
+        err = 'relation "docs" already exists'
+        sql = 'CREATE TABLE "docs" (id INTEGER PRIMARY KEY, email TEXT)'
+        assert _is_benign_ddl_object_exists(err, sql) is True


### PR DESCRIPTION
## Summary

Two DataFlow upsert-family bug fixes, follow-ups from the #1520 red-team.

### #1537 — MySQL single-record upsert silently ignored `conflict_on`
`ON DUPLICATE KEY UPDATE` has no explicit conflict target, so a single-record upsert on a non-unique `conflict_on` field generated a fresh `id`, hit no PK conflict, and silently INSERTed a duplicate instead of upserting — no error. The PostgreSQL #1520 reactive error-catch cannot apply (MySQL raises nothing). A proactive `information_schema.statistics` precheck now verifies a UNIQUE/PK index exactly backs `conflict_on` and raises the typed `UpsertConflictTargetError` (naming the field + remedy) otherwise.

Verifying the remedy surfaced that MySQL single-record upsert was **entirely non-functional** beforehand — two pre-existing bugs fixed so the remedy is real:
- `CREATE INDEX IF NOT EXISTS` is a MySQL syntax error (1064) → declared-unique indexes were never created.
- The dialect emitted `:p0` named placeholders; aiomysql binds positional `%s`.

Dropping `IF NOT EXISTS` for MySQL then made re-migration raise 1061 "Duplicate key name" on every restart. The benign tolerance is now scoped to `CREATE INDEX` (a 1061 inside a `CREATE TABLE`, 1064, and permission errors still surface as ERROR), and `_create_tables_batch` was switched from the abort-on-first executor to the existing non-aborting per-statement executor so a newly-added model's table is still created past an existing model's benign 1061.

### #1538 — PG `express.list(cache_ttl=0)` served stale rows after an upsert-UPDATE
DataFlow has two cache layers; `cache_ttl=0` bypasses the express cache but not the node query cache (which a prior `list()` primes). The upsert path never invalidated the node query cache (every sibling create/update/delete did), and no `upsert`/`bulk_upsert` invalidation pattern was registered so the call would have no-op'd regardless. Registered both patterns + invalidate on upsert success — also closing the same latent bug for `bulk_upsert`. MVCC snapshot pinning was tested and ruled out (raw read + `enable_cache=False` both read fresh).

## Testing

Tier-2 against real MySQL 8.0 + PostgreSQL (no mocking) + Tier-1 unit. New regression tests pin every finding:
- `test_issue_1537_mysql_single_upsert_conflict_target.py` — error-path raise, no-row-lands, no-regression happy path, id-PK/declared-unique allow.
- `test_issue_1537_mysql_index_idempotency.py` — re-migration WARN-clean + multi-model new-model-after-existing-index (the batch masking case).
- `test_issue_1538_pg_express_list_stale_after_upsert_update.py` — the exact upsert→list→upsert-UPDATE→list sequence + plain-update control + bulk_upsert variant.
- `test_sync_ddl_executor.py::TestIsBenignDDLObjectExists` — 1061 benign only on `CREATE INDEX`, not `CREATE TABLE`.

3-round adversarial red-team (reviewer + security-reviewer + dataflow-specialist) converged clean; sibling suites (#1508/#1519/#1520) stay green; `pytest --collect-only` exit 0.

## Related issues

Fixes #1537
Fixes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)