### PR TITLE
fix(dataflow): 2.13.18 — value-bearing driver-error redaction (#1569) + __tablename__ index/FK DDL (#1541) + real-infra test conversion (#1503)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [2.13.18] — 2026-07-05 — Driver-error redaction broadened to value-bearing non-dup-key errors (#1569) & `__tablename__`-aware index/FK DDL (#1541)
+
+### Fixed
+
+- **Security (#1569):** `sanitize_db_error` now redacts value-bearing driver errors
+  beyond the four duplicate-key shapes — previously any other value-bearing error
+  rendered the offending user value verbatim into logs / node-return dicts. Covered,
+  dialect-family-scoped (fail-closed, not per-errno): MySQL `Incorrect <type> value`
+  / `Truncated incorrect <TYPE> value` (errno 1292/1366); PostgreSQL `invalid input
+syntax/value for …`, `date/time field value out of range`, `value "<v>" is out of
+range for type <t>` (numeric overflow), and `malformed (array|range) literal`.
+  Diagnostic shape (error code, type word, column/constraint name) is preserved;
+  column-name-only errors (MySQL 1264/1406/1265) pass through unredacted.
+- **#1541:** `auto_migrate` now resolves a model's `__tablename__` when generating
+  `CREATE INDEX` and foreign-key `ALTER TABLE` DDL. Previously these used the default
+  pluralized class name, so a custom-`__tablename__` model's declared indexes and FK
+  constraints targeted a non-existent table and were silently skipped (WARN-only) —
+  the index/FK never materialized. Identifier-validation guards are preserved.
+
+### Tests
+
+- **#1503:** `tests/integration/core_engine/test_production_dataflow.py` converted off
+  a mock engine to the real `DataFlow` against real infrastructure (PostgreSQL, MySQL,
+  file-backed SQLite), resolving a Tier-2 NO-MOCKING violation; assertions re-grounded
+  on the real node return-shape contract with cross-connection read-back verification.
+
 ## [2.13.17] — 2026-07-05 — Node CRUD async column detection (updated_at bump + full SELECT columns) & dead upsert-family removal (#1564)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.17"
+version = "2.13.18"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.17"
+__version__ = "2.13.18"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -6023,7 +6023,13 @@ class DataFlow(DataFlowEventMixin):
         Returns:
             List of CREATE INDEX SQL statements
         """
-        table_name = self._class_name_to_table_name(model_name)
+        # Issue #1541: resolve the model's ACTUAL table name (respects
+        # ``__tablename__``) — NOT the pluralized class-name default. CREATE TABLE
+        # (_generate_create_table_sql) uses the resolved name; the CREATE INDEX DDL
+        # here MUST target the same table or the declared indexes are emitted
+        # against a non-existent table and silently WARN-skipped, so a
+        # custom-__tablename__ model's indexes never materialize.
+        table_name = self._get_table_name(model_name)
         # Defense-in-depth (dataflow-identifier-safety MUST-1/MUST-5): the
         # index/field/foreign_key identifiers below are already validated before
         # interpolation, but the derived table_name was not. Validate it too so
@@ -6104,7 +6110,11 @@ class DataFlow(DataFlowEventMixin):
         Returns:
             List of ALTER TABLE SQL statements for foreign keys
         """
-        table_name = self._class_name_to_table_name(model_name)
+        # Issue #1541: the owning table of the FK ALTER MUST be the model's
+        # resolved table (respects ``__tablename__``), matching CREATE TABLE —
+        # otherwise a custom-__tablename__ model's FK constraint targets a
+        # non-existent default-named table and is silently WARN-skipped.
+        table_name = self._get_table_name(model_name)
         constraints = []
 
         # Get relationships for this model
@@ -6119,7 +6129,8 @@ class DataFlow(DataFlowEventMixin):
 
                 # Defense-in-depth (rules/dataflow-identifier-safety.md MUST 1):
                 # validate every identifier before interpolation into DDL.
-                # `table_name` comes from `_class_name_to_table_name`,
+                # `table_name` comes from `_get_table_name` (respects
+                # `__tablename__`; a user-supplied override — issue #1541),
                 # `foreign_key` / `target_table` / `target_key` come from
                 # model-relationship metadata which is model-registry-derived
                 # today but may be caller-influenced after a future refactor.

--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -408,6 +408,84 @@ def _redact_mysql_dup_entry(match: "re.Match[str]") -> str:
 # the newline to the final ``}`` (fail-closed — a single driver error's ``str(e)``).
 _MONGO_DUP_KEY_RE = re.compile(r"dup key:\s*\{.*\}", re.IGNORECASE | re.DOTALL)
 
+# Issue #1569: value-bearing NON-dup-key driver errors. The four regexes above
+# cover only the duplicate-key/constraint shapes; ANY OTHER driver error that
+# echoes a user VALUE (a malformed date, a non-UTF8 string, an out-of-range
+# number, a failed type cast) rendered that value VERBATIM into logs / node-return
+# dicts — the same PII-to-logs boundary #1552 closed for dup-key, re-opened for
+# every type/format violation. Surfaced as an adjacent gap in the #1567 red-team.
+#
+# FAIL-CLOSED DESIGN DECISION (issue #1569 AC #3) — DIALECT-SCOPED FAMILY redaction,
+# NOT per-errno whack-a-mole AND NOT a blanket quoted-literal sweep:
+#   * Per-errno shapes (add a regex per errno) would leave the NEXT value-bearing
+#     errno leaking until someone files it — the whack-a-mole the issue rejects.
+#   * A blanket "redact every quoted literal" would ALSO strip the diagnostic
+#     schema names (column / key / constraint names) the dup-key redactors above
+#     deliberately PRESERVE, and over-redact benign quoted identifiers.
+#   The chosen middle ground: one regex per DIALECT covering its whole value-
+#   echoing FAMILY, anchored on the error-text preamble so the value is redacted
+#   while the type word + trailing "for column '<col>'" schema name survive.
+#
+# Covered families (value is echoed → redacted):
+#   * MySQL errno 1292 ER_TRUNCATED_WRONG_VALUE — "Incorrect <type> value: '<v>'"
+#     AND "Truncated incorrect <TYPE> value: '<v>'" (datetime/integer/decimal/
+#     double/…); errno 1366 ER_TRUNCATED_WRONG_VALUE_FOR_FIELD — "Incorrect string
+#     value: '<v>' for column '<c>' at row <n>". One family regex covers all.
+#   * PostgreSQL, value AFTER a colon — "invalid input syntax for [type] <t>:
+#     \"<v>\"", "invalid input value for [enum] <t>: \"<v>\"", "date/time field
+#     value out of range: \"<v>\"", "time zone displacement out of range: \"<v>\"",
+#     "malformed (array|range) literal: \"<v>\"" (all empirically confirmed).
+#   * PostgreSQL, value BEFORE the descriptor — "value \"<v>\" is out of range for
+#     type <t>" (numeric overflow, errcode 22003; empirically confirmed against PG
+#     — the value is BETWEEN ``value `` and `` is out of range``, NOT after a
+#     trailing colon, so the colon-anchored family regex above cannot reach it).
+#   PG echoes the value DOUBLE-quoted in the PRIMARY message (not a DETAIL: clause,
+#   so _DETAIL_RE never reached it).
+# Explicitly NOT redacted (documented — these errno shapes echo only the COLUMN
+# name, no user value, so the schema name is preserved by design, matching the
+# dup-key keyname treatment): MySQL 1264 "Out of range value for column '<c>'",
+# 1406 "Data too long for column '<c>'", 1265 "Data truncated for column '<c>'";
+# PG "value too long for type character varying(N)".
+#
+# _MYSQL_INCORRECT_VALUE_RE: greedy value ('.*') with DOTALL, bounded by a
+# LOOKAHEAD so the closing "'" sits just before an optional " for column '<c>' at
+# row <n>" suffix OR the message terminator ('"', ')', whitespace, EOS/newline) —
+# the #1557 greedy-to-final-suffix discipline. The suffix + terminators live in
+# the lookahead, so they are NOT consumed and the column NAME is preserved. DOTALL
+# lets a value with an embedded quote/newline (a TEXT column) span to the final
+# suffix (fail-closed — the input is one driver error's str(e)).
+_MYSQL_INCORRECT_VALUE_RE = re.compile(
+    r"((?:Truncated incorrect|Incorrect) (?:\w+ )?value): '.*'"
+    r"(?=(?: for column '[^'\n]*' at row \d+)?[\"')\s]*(?:$|\n))",
+    re.IGNORECASE | re.DOTALL,
+)
+# _PG_QUOTED_VALUE_RE: PG echoes the offending value DOUBLE-quoted at the tail of
+# the primary message. Anchored on the known value-echoing PG phrase lead-ins so
+# benign quoted identifiers elsewhere are untouched; greedy value bounded by a
+# lookahead requiring only closing chars ()/./whitespace) before EOS/newline (so
+# a trailing "\nHINT: …" continuation is preserved). Value redacted, phrase +
+# type name preserved.
+_PG_QUOTED_VALUE_RE = re.compile(
+    r'((?:invalid input syntax for (?:type )?[^\n:"]*'
+    r'|invalid input value for (?:enum )?[^\n:"]*'
+    r"|date/time field value out of range"
+    r"|time zone displacement out of range"
+    r"|malformed (?:array|range) literal)): \"(?:.*)\""
+    r"(?=[)\s.]*(?:$|\n))",
+    re.IGNORECASE | re.DOTALL,
+)
+# _PG_VALUE_OUT_OF_RANGE_RE (issue #1569 red-team): the PG numeric-overflow shape
+# ``value "<v>" is out of range for type <t>`` (errcode 22003) puts the value
+# BEFORE the descriptor, so _PG_QUOTED_VALUE_RE's colon-anchored family cannot
+# reach it. Empirically confirmed emitted by PG for int/smallint/bigint casts.
+# Redact the double-quoted value, preserve the ``type <t>`` name. Greedy value
+# anchored to the required `` is out of range for type <t>`` suffix (#1557
+# greedy-to-final-suffix discipline; DOTALL for a value with an embedded newline).
+_PG_VALUE_OUT_OF_RANGE_RE = re.compile(
+    r'(value) "(?:.*)"( is out of range for type \w+)',
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 def sanitize_db_error(msg: str) -> str:
     """Redact column VALUES from a DB driver error message.
@@ -418,9 +496,14 @@ def sanitize_db_error(msg: str) -> str:
     on a column OTHER than the conflict target cannot leak user data into
     logs or the returned error string.
 
-    Covers PostgreSQL (``DETAIL:`` clauses, ``Key (col)=(value)``) AND
-    MySQL/MariaDB (``Duplicate entry 'value' for key 'name'``) driver-error
-    shapes; SQLite ``UNIQUE constraint failed: table.col`` carries no value.
+    Covers PostgreSQL (``DETAIL:`` clauses, ``Key (col)=(value)``,
+    ``invalid input syntax/value for …: "<v>"``, ``… value out of range: "<v>"``)
+    AND MySQL/MariaDB (``Duplicate entry 'value' for key 'name'``,
+    ``Incorrect <type> value: '<v>'`` / ``Truncated incorrect <TYPE> value:
+    '<v>'`` errno 1292/1366) driver-error shapes — dup-key AND the value-bearing
+    non-dup-key families (issue #1569); SQLite ``UNIQUE constraint failed:
+    table.col`` carries no value. Column-name-only shapes (MySQL ``Out of range
+    value for column``, ``Data too long for column``) are preserved unredacted.
     """
     if not isinstance(msg, str):
         return "<non-string error>"
@@ -438,6 +521,17 @@ def sanitize_db_error(msg: str) -> str:
     msg = _MYSQL_DUP_ENTRY_RE.sub(_redact_mysql_dup_entry, msg)
     # Issue #1556: MongoDB E11000 ``dup key: { field: "value" }`` payload.
     msg = _MONGO_DUP_KEY_RE.sub("dup key: { [REDACTED] }", msg)
+    # Issue #1569: value-bearing NON-dup-key families. MySQL ``Incorrect <type>
+    # value: '<v>'`` / ``Truncated incorrect <TYPE> value: '<v>'`` (errno
+    # 1292/1366) and PostgreSQL ``invalid input syntax/value for …: "<v>"`` /
+    # ``… value out of range: "<v>"``. Redact the value, preserve the type word +
+    # any trailing ``for column '<c>'`` schema name. Disjoint preambles from the
+    # dup-key subs above, so ordering is irrelevant.
+    msg = _MYSQL_INCORRECT_VALUE_RE.sub(r"\1: '[REDACTED]'", msg)
+    msg = _PG_QUOTED_VALUE_RE.sub(r'\1: "[REDACTED]"', msg)
+    # Issue #1569 red-team: PG numeric-overflow ``value "<v>" is out of range for
+    # type <t>`` (value BEFORE the descriptor — the colon-anchored sub above misses it).
+    msg = _PG_VALUE_OUT_OF_RANGE_RE.sub(r'\1 "[REDACTED]"\2', msg)
     return msg
 
 

--- a/packages/kailash-dataflow/tests/integration/core_engine/test_production_dataflow.py
+++ b/packages/kailash-dataflow/tests/integration/core_engine/test_production_dataflow.py
@@ -1,257 +1,301 @@
 """
 Comprehensive integration tests for production DataFlow with real databases.
 
-This test suite verifies that the production DataFlow implementation actually
-works with real databases, replacing the broken mock-based tests.
+Tier-2 integration suite exercising the REAL ``dataflow.core.engine.DataFlow``
+against real infrastructure. Converted from a MOCK engine
+(``DataFlowProductionEngine``) under issue #1503 — the mock returned hardcoded
+rows so every "verify data in database" assertion passed without real
+persistence, a NO-MOCKING (tests/CLAUDE.md §2, rules/testing.md Tier-2)
+violation.
+
+Real-infrastructure policy:
+
+- **PostgreSQL** via ``IntegrationTestSuite`` (port 5434, db ``kailash_test``).
+  Write read-backs run through a real asyncpg connection acquired from the
+  suite pool (``test_suite.get_connection()``) — a *separate* connection from
+  DataFlow's own pool, proving cross-connection persistence.
+- **SQLite** is file-backed via ``tempfile`` (NOT ``:memory:`` — DataFlow's
+  migration pool opens multiple short-lived connections and bare ``:memory:``
+  gives each its own database, breaking the migration handshake). DataFlow's
+  SQLite pool connection is NOT visible to a fresh ``sqlite3.connect(path)``
+  client (documented multi-connection caveat, tests/CLAUDE.md), so SQLite
+  read-backs go through DataFlow READ/LIST nodes — still a real query against
+  the same file through the engine (State Persistence Verification).
+- **MySQL** is gated by a live-connection probe (suite convention, port 3307);
+  it SKIPS when MySQL is absent from the environment (acceptable
+  cannot-execute-in-this-env skip, NOT a mock, NOT a masked failure).
+
+Observed real node return contract (no ``success``/``data`` wrapper — the mock's
+shape was fiction):
+
+- CreateNode  → flat record dict; PG/MySQL include ``id``; SQLite returns
+  ``rows_affected`` with NO ``id`` (capture id from a subsequent LIST).
+- ReadNode    → flat record dict + ``found``; not-found sets ``error``.
+- ListNode    → ``{"records": [...], "count": N, "limit": ...}``.
+- UpdateNode  → flat updated record + ``updated`` (SQLite may not echo changed
+  columns flat — verify via read-back).
+- DeleteNode  → ``{"id": ..., "deleted": True}``.
+- Bulk*Node   → ``{"success": True, "processed": N, "inserted"/"updated": N,
+  "operation": ...}``.
+
+Success is the ABSENCE of an ``error`` key (the ``test_sqlite_integration``
+reference-test convention), never a mock ``success is True`` flag.
 """
 
-import asyncio
 import os
+import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
-from typing import Any, Dict
 
 import pytest
 from kailash.runtime.local import LocalRuntime
-from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
+from kailash.sdk_exceptions import WorkflowValidationError
 from kailash.workflow.builder import WorkflowBuilder
 
-from dataflow.core.config import DatabaseConfig, DataFlowConfig, Environment
+# REAL production engine (NOT the tests.fixtures mock).
+from dataflow import DataFlow
 
-# Import production implementation (moved to tests.fixtures in v0.7.0)
-from tests.fixtures.engine_testing_mocks import DataFlowProductionEngine as DataFlow
 from tests.infrastructure.test_harness import IntegrationTestSuite
+
+try:
+    import pymysql
+
+    PYMYSQL_AVAILABLE = True
+except ImportError:  # pragma: no cover - env-dependent
+    PYMYSQL_AVAILABLE = False
+
+
+# --------------------------------------------------------------------------- #
+# MySQL availability probe (suite convention — real connection, no mock).
+# --------------------------------------------------------------------------- #
+def _mysql_url() -> str:
+    """Resolve the MySQL test URL (env override → SDK Docker default 3307)."""
+    return os.getenv(
+        "TEST_MYSQL_URL",
+        os.getenv(
+            "MYSQL_URL",
+            "mysql://kailash_test:test_password@localhost:3307/kailash_test",
+        ),
+    )
+
+
+def _is_mysql_available() -> bool:
+    """True only when a real MySQL server answers on the test port."""
+    if not PYMYSQL_AVAILABLE:
+        return False
+    try:
+        conn = pymysql.connect(
+            host="localhost",
+            port=3307,
+            database="kailash_test",
+            user="kailash_test",
+            password="test_password",
+            connect_timeout=3,
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
 
 
 @pytest.fixture
 async def test_suite():
-    """Create complete integration test suite with infrastructure."""
+    """Create complete integration test suite with real infrastructure."""
     suite = IntegrationTestSuite()
     async with suite.session():
         yield suite
 
 
+@pytest.fixture
+def runtime():
+    """Context-managed LocalRuntime for workflow execution (auto-cleanup)."""
+    with LocalRuntime() as rt:
+        yield rt
+
+
 class TestProductionDataFlowRealDatabase:
-    """Test DataFlow with real database operations - no mocks allowed."""
+    """Test the real DataFlow engine with real database operations — no mocks."""
 
-    @pytest.fixture
-    def postgres_config(self, test_suite):
-        """PostgreSQL test configuration."""
-        return {
-            "database_url": test_suite.config.url,
-            "pool_size": 10,
-            "monitoring": True,
-            "cache_enabled": False,  # Disable cache for cleaner tests
-        }
+    # ------------------------------------------------------------------ #
+    # Shared CRUD cycle — real writes, every write verified with a read-back.
+    # ------------------------------------------------------------------ #
+    async def _run_crud_cycle(self, db, runtime, *, dialect, test_suite=None):
+        """Full CRUD cycle against the real engine with real read-backs."""
 
-    @pytest.fixture
-    def mysql_config(self, test_suite):
-        """MySQL test configuration (fallback for MySQL-specific tests)."""
-        return {
-            "database_url": os.getenv(
-                "TEST_MYSQL_URL",
-                "mysql+pymysql://root:password@localhost:3306/dataflow_test",
-            ),
-            "pool_size": 10,
-            "monitoring": True,
-            "cache_enabled": False,
-        }
+        @db.model
+        class TestProduct:
+            name: str
+            price: float
+            category: str = "general"
+            active: bool = True
 
-    @pytest.fixture
-    def sqlite_config(self):
-        """SQLite test configuration."""
-        return {
-            "database_url": "sqlite:///test_dataflow.db",
-            "pool_size": 5,
-            "monitoring": False,
-            "cache_enabled": False,
-        }
+        await db.initialize()
+        table = db._get_table_name("TestProduct")
+
+        # For PostgreSQL, ensure a clean slate and read back through a
+        # SEPARATE real connection from the suite pool.
+        if dialect == "postgresql":
+            await db.ensure_table_exists("TestProduct")
+            async with test_suite.get_connection() as conn:
+                await conn.execute(f"DELETE FROM {table}")
+
+        async def read_back(pid):
+            """Return the persisted row as a dict, or None if absent.
+
+            PostgreSQL: SELECT via a separate asyncpg connection (proves the
+            write is visible cross-connection). SQLite/MySQL: DataFlow READ
+            node against the same file/db through the engine — a fresh
+            sqlite3 client cannot see DataFlow's pooled connection.
+            """
+            if dialect == "postgresql":
+                async with test_suite.get_connection() as conn:
+                    row = await conn.fetchrow(
+                        f"SELECT id, name, price, category, active "
+                        f"FROM {table} WHERE id = $1",
+                        pid,
+                    )
+                    return dict(row) if row else None
+            w = WorkflowBuilder()
+            w.add_node("TestProductReadNode", "rb", {"id": pid})
+            r, _ = runtime.execute(w.build())
+            res = r["rb"]
+            return None if res.get("error") else res
+
+        # ---- CREATE -------------------------------------------------- #
+        w = WorkflowBuilder()
+        w.add_node(
+            "TestProductCreateNode",
+            "create_product",
+            {"name": "Test Laptop", "price": 999.99, "category": "electronics"},
+        )
+        cr, _ = runtime.execute(w.build())
+        assert not cr["create_product"].get(
+            "error"
+        ), f"CREATE failed in {dialect}: {cr['create_product'].get('error')}"
+
+        # Capture id: PG/MySQL return it on create; SQLite does not — read
+        # it back from a LIST (real query).
+        product_id = cr["create_product"].get("id")
+        if product_id is None:
+            w = WorkflowBuilder()
+            w.add_node(
+                "TestProductListNode",
+                "seed_list",
+                {"filter": {"category": "electronics"}, "limit": 50},
+            )
+            lr, _ = runtime.execute(w.build())
+            records = lr["seed_list"]["records"]
+            assert records, f"created product not listed in {dialect}"
+            product_id = records[0]["id"]
+        assert product_id is not None
+
+        # Verify CREATE persisted (read-back).
+        persisted = await read_back(product_id)
+        assert persisted is not None, f"product not persisted in {dialect}"
+        assert persisted["name"] == "Test Laptop"
+        assert abs(float(persisted["price"]) - 999.99) < 0.01
+        assert persisted["category"] == "electronics"
+
+        # ---- READ (node) --------------------------------------------- #
+        w = WorkflowBuilder()
+        w.add_node("TestProductReadNode", "read_product", {"id": product_id})
+        rr, _ = runtime.execute(w.build())
+        assert not rr["read_product"].get(
+            "error"
+        ), f"READ failed in {dialect}: {rr['read_product'].get('error')}"
+        assert rr["read_product"]["name"] == "Test Laptop"
+
+        # ---- UPDATE (filter + fields) -------------------------------- #
+        w = WorkflowBuilder()
+        w.add_node(
+            "TestProductUpdateNode",
+            "update_product",
+            {
+                "filter": {"id": product_id},
+                "fields": {"price": 899.99, "active": False},
+            },
+        )
+        ur, _ = runtime.execute(w.build())
+        assert not ur["update_product"].get(
+            "error"
+        ), f"UPDATE failed in {dialect}: {ur['update_product'].get('error')}"
+
+        # Verify UPDATE persisted (read-back — the UpdateNode may not echo
+        # changed columns flat on every dialect, so the read-back is the
+        # authoritative State-Persistence check).
+        persisted = await read_back(product_id)
+        assert persisted is not None
+        assert abs(float(persisted["price"]) - 899.99) < 0.01
+        assert persisted["active"] in (False, 0)
+
+        # ---- LIST ---------------------------------------------------- #
+        w = WorkflowBuilder()
+        w.add_node(
+            "TestProductListNode",
+            "list_products",
+            {"filter": {"category": "electronics"}, "limit": 50},
+        )
+        lr, _ = runtime.execute(w.build())
+        assert not lr["list_products"].get(
+            "error"
+        ), f"LIST failed in {dialect}: {lr['list_products'].get('error')}"
+        products = lr["list_products"]["records"]
+        assert any(p["id"] == product_id for p in products)
+
+        # ---- DELETE -------------------------------------------------- #
+        w = WorkflowBuilder()
+        w.add_node("TestProductDeleteNode", "delete_product", {"id": product_id})
+        dr, _ = runtime.execute(w.build())
+        assert not dr["delete_product"].get(
+            "error"
+        ), f"DELETE failed in {dialect}: {dr['delete_product'].get('error')}"
+
+        # Verify DELETE persisted (read-back returns None).
+        assert (
+            await read_back(product_id)
+        ) is None, f"product still present after delete in {dialect}"
 
     @pytest.mark.requires_postgres
-    def test_postgresql_crud_operations(self, test_suite, postgres_config):
-        """Test complete CRUD cycle with PostgreSQL."""
-        self._test_database_crud_operations(postgres_config, "PostgreSQL")
+    async def test_postgresql_crud_operations(self, test_suite, runtime):
+        """Complete CRUD cycle with real PostgreSQL + cross-connection read-backs."""
+        db = DataFlow(test_suite.config.url)
+        try:
+            await self._run_crud_cycle(
+                db, runtime, dialect="postgresql", test_suite=test_suite
+            )
+        finally:
+            await db.close_async()
 
     @pytest.mark.requires_mysql
-    def test_mysql_crud_operations(self, test_suite, mysql_config):
-        """Test complete CRUD cycle with MySQL."""
-        self._test_database_crud_operations(mysql_config, "MySQL")
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="this file uses a MOCK engine (DataFlowProductionEngine, line 23) "
-        "whose @db.model does not register nodes with the SDK NodeRegistry — a "
-        "Tier-2 NO-MOCKING violation; see #1503. Real-engine SQLite CRUD is covered "
-        "by test_sqlite_integration::test_auto_generated_nodes. Remove when #1503 lands.",
+    @pytest.mark.skipif(
+        not _is_mysql_available(),
+        reason="MySQL not available on port 3307 — real infra absent "
+        "(cannot-execute-in-this-env skip; NOT mocked). Start Docker MySQL to run.",
     )
-    def test_sqlite_crud_operations(self, test_suite, sqlite_config):
-        """Test complete CRUD cycle with SQLite."""
-        self._test_database_crud_operations(sqlite_config, "SQLite")
-
-    def _test_database_crud_operations(self, db_config: Dict[str, Any], db_type: str):
-        """Test CRUD operations with real database persistence."""
-
-        # Initialize DataFlow with real database
-        db = DataFlow(**db_config)
-
+    async def test_mysql_crud_operations(self, runtime):
+        """Complete CRUD cycle with real MySQL (skips when MySQL is absent)."""
+        db = DataFlow(_mysql_url())
         try:
-            # Define test model
-            @db.model
-            class TestProduct:
-                name: str
-                price: float
-                category: str = "general"
-                active: bool = True
-
-            # Verify table was created
-            assert db._table_exists("testproduct"), f"Table not created in {db_type}"
-
-            runtime = LocalRuntime()
-
-            # TEST CREATE - Real database insert
-            print(f"\n=== Testing CREATE with {db_type} ===")
-            create_workflow = WorkflowBuilder()
-            create_workflow.add_node(
-                "TestProductCreateNode",
-                "create_product",
-                {"name": "Test Laptop", "price": 999.99, "category": "electronics"},
-            )
-
-            create_results, _ = runtime.execute(create_workflow.build())
-
-            # Verify creation result
-            assert create_results["create_product"]["success"] is True
-            assert create_results["create_product"]["data"]["name"] == "Test Laptop"
-            assert create_results["create_product"]["data"]["price"] == 999.99
-
-            product_id = create_results["create_product"]["data"]["id"]
-            assert product_id is not None
-            print(f"✅ Created product with ID: {product_id}")
-
-            # Verify data actually exists in database
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute(
-                    (
-                        "SELECT name, price, category FROM testproduct WHERE id = %s"
-                        if db_type != "SQLite"
-                        else "SELECT name, price, category FROM testproduct WHERE id = ?"
-                    ),
-                    (product_id,),
-                )
-                row = cursor.fetchone()
-                assert row is not None, f"Product not found in {db_type} database"
-                assert row[0] == "Test Laptop"
-                assert abs(row[1] - 999.99) < 0.01  # Float comparison
-                assert row[2] == "electronics"
-
-            print(f"✅ Data verified in {db_type} database")
-
-            # TEST READ - Real database select
-            print(f"\n=== Testing READ with {db_type} ===")
-            read_workflow = WorkflowBuilder()
-            read_workflow.add_node(
-                "TestProductReadNode", "read_product", {"id": product_id}
-            )
-
-            read_results, _ = runtime.execute(read_workflow.build())
-
-            assert read_results["read_product"]["success"] is True
-            assert read_results["read_product"]["data"]["id"] == product_id
-            assert read_results["read_product"]["data"]["name"] == "Test Laptop"
-            print(f"✅ Read product: {read_results['read_product']['data']['name']}")
-
-            # TEST UPDATE - Real database update
-            print(f"\n=== Testing UPDATE with {db_type} ===")
-            update_workflow = WorkflowBuilder()
-            update_workflow.add_node(
-                "TestProductUpdateNode",
-                "update_product",
-                {"id": product_id, "price": 899.99, "active": False},
-            )
-
-            update_results, _ = runtime.execute(update_workflow.build())
-
-            assert update_results["update_product"]["success"] is True
-            assert update_results["update_product"]["data"]["price"] == 899.99
-            assert update_results["update_product"]["data"]["active"] is False
-            print(
-                f"✅ Updated product price to: {update_results['update_product']['data']['price']}"
-            )
-
-            # Verify update in database
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute(
-                    (
-                        "SELECT price, active FROM testproduct WHERE id = %s"
-                        if db_type != "SQLite"
-                        else "SELECT price, active FROM testproduct WHERE id = ?"
-                    ),
-                    (product_id,),
-                )
-                row = cursor.fetchone()
-                assert row is not None
-                assert abs(row[0] - 899.99) < 0.01
-                assert (
-                    row[1] is False or row[1] == 0
-                )  # Different boolean representations
-
-            # TEST LIST - Real database query
-            print(f"\n=== Testing LIST with {db_type} ===")
-            list_workflow = WorkflowBuilder()
-            list_workflow.add_node(
-                "TestProductListNode",
-                "list_products",
-                {"filter": {"category": "electronics"}, "limit": 10},
-            )
-
-            list_results, _ = runtime.execute(list_workflow.build())
-
-            assert list_results["list_products"]["success"] is True
-            products = list_results["list_products"]["data"]
-            assert len(products) >= 1
-            assert any(p["id"] == product_id for p in products)
-            print(f"✅ Listed {len(products)} products")
-
-            # TEST DELETE - Real database delete
-            print(f"\n=== Testing DELETE with {db_type} ===")
-            delete_workflow = WorkflowBuilder()
-            delete_workflow.add_node(
-                "TestProductDeleteNode", "delete_product", {"id": product_id}
-            )
-
-            delete_results, _ = runtime.execute(delete_workflow.build())
-
-            assert delete_results["delete_product"]["success"] is True
-            print(f"✅ Deleted product with ID: {product_id}")
-
-            # Verify deletion in database
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute(
-                    (
-                        "SELECT id FROM testproduct WHERE id = %s"
-                        if db_type != "SQLite"
-                        else "SELECT id FROM testproduct WHERE id = ?"
-                    ),
-                    (product_id,),
-                )
-                row = cursor.fetchone()
-                assert (
-                    row is None
-                ), f"Product still exists in {db_type} database after deletion"
-
-            print(f"✅ All CRUD operations successful with {db_type}")
-
+            await self._run_crud_cycle(db, runtime, dialect="mysql")
         finally:
-            # Clean up
-            db.close_sync()
+            await db.close_async()
+
+    async def test_sqlite_crud_operations(self, runtime):
+        """Complete CRUD cycle with real file-backed SQLite + node read-backs."""
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        db = DataFlow(f"sqlite:///{db_path}")
+        try:
+            await self._run_crud_cycle(db, runtime, dialect="sqlite")
+        finally:
+            await db.close_async()
+            if os.path.exists(db_path):
+                os.unlink(db_path)
 
     @pytest.mark.requires_postgres
-    def test_bulk_operations_real_database(self, test_suite, postgres_config):
-        """Test bulk operations with real database."""
-
-        db = DataFlow(**postgres_config)
-
+    async def test_bulk_operations_real_database(self, test_suite, runtime):
+        """Bulk create/update against real PostgreSQL, verified with read-backs."""
+        db = DataFlow(test_suite.config.url)
         try:
 
             @db.model
@@ -260,82 +304,73 @@ class TestProductionDataFlowRealDatabase:
                 value: int
                 category: str = "test"
 
-            runtime = LocalRuntime()
+            await db.initialize()
+            table = db._get_table_name("BulkTestModel")
+            await db.ensure_table_exists("BulkTestModel")
+            async with test_suite.get_connection() as conn:
+                await conn.execute(f"DELETE FROM {table}")
 
-            # Test bulk create with large dataset
-            print("\n=== Testing BULK CREATE ===")
+            n_rows = 200
             bulk_data = [
                 {"name": f"Item_{i}", "value": i, "category": f"cat_{i % 5}"}
-                for i in range(1000)  # Test with 1000 records
+                for i in range(n_rows)
             ]
 
-            bulk_workflow = WorkflowBuilder()
-            bulk_workflow.add_node(
+            # ---- BULK CREATE ---------------------------------------- #
+            w = WorkflowBuilder()
+            w.add_node(
                 "BulkTestModelBulkCreateNode",
                 "bulk_create",
                 {"data": bulk_data, "batch_size": 100},
             )
+            start = time.time()
+            br, _ = runtime.execute(w.build())
+            elapsed = time.time() - start
 
-            start_time = time.time()
-            bulk_results, _ = runtime.execute(bulk_workflow.build())
-            elapsed_time = time.time() - start_time
+            bc = br["bulk_create"]
+            assert not bc.get("error"), f"BULK CREATE failed: {bc.get('error')}"
+            assert bc["success"] is True
+            assert bc["processed"] == n_rows
+            assert bc["inserted"] == n_rows
 
-            assert bulk_results["bulk_create"]["success"] is True
-            assert bulk_results["bulk_create"]["records_processed"] == 1000
+            # Read-back: real row count via a separate connection.
+            async with test_suite.get_connection() as conn:
+                count = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            assert count == n_rows, f"expected {n_rows} rows, found {count}"
+            assert elapsed > 0
 
-            # Calculate throughput
-            throughput = 1000 / elapsed_time
-            print(
-                f"✅ Bulk created 1000 records in {elapsed_time:.2f}s ({throughput:.0f} records/sec)"
-            )
-
-            # Verify data in database
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute("SELECT COUNT(*) FROM bulktestmodel")
-                count = cursor.fetchone()[0]
-                assert count == 1000, f"Expected 1000 records, found {count}"
-
-            # Test bulk update
-            print("\n=== Testing BULK UPDATE ===")
-            bulk_update_workflow = WorkflowBuilder()
-            bulk_update_workflow.add_node(
+            # ---- BULK UPDATE ---------------------------------------- #
+            expected_updated = sum(1 for i in range(n_rows) if i % 5 == 0)
+            w = WorkflowBuilder()
+            w.add_node(
                 "BulkTestModelBulkUpdateNode",
                 "bulk_update",
                 {
                     "filter": {"category": "cat_0"},
-                    "update": {"value": 9999},
+                    "fields": {"value": 9999},
                     "batch_size": 50,
                 },
             )
+            ur, _ = runtime.execute(w.build())
+            bu = ur["bulk_update"]
+            assert not bu.get("error"), f"BULK UPDATE failed: {bu.get('error')}"
+            assert bu["success"] is True
 
-            update_results, _ = runtime.execute(bulk_update_workflow.build())
-            assert update_results["bulk_update"]["success"] is True
-
-            # Verify updates
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute(
-                    "SELECT COUNT(*) FROM bulktestmodel WHERE value = 9999"
+            # Read-back: verify exactly the cat_0 rows were updated.
+            async with test_suite.get_connection() as conn:
+                updated = await conn.fetchval(
+                    f"SELECT COUNT(*) FROM {table} WHERE value = 9999"
                 )
-                updated_count = cursor.fetchone()[0]
-                assert (
-                    updated_count == 200
-                ), f"Expected 200 updated records, found {updated_count}"  # Every 5th record
-
-            print(f"✅ Bulk updated {updated_count} records")
-
+            assert (
+                updated == expected_updated
+            ), f"expected {expected_updated} updated rows, found {updated}"
         finally:
-            db.close_sync()
+            await db.close_async()
 
     @pytest.mark.requires_postgres
-    def test_security_features_real_database(self, test_suite, postgres_config):
-        """Test security features with real database."""
-
-        # Enable security features
-        config = postgres_config.copy()
-        config.update({"multi_tenant": True, "audit_logging": True})
-
-        db = DataFlow(**config)
-
+    async def test_security_features_real_database(self, test_suite, runtime):
+        """Real multi-tenant isolation + input-sanitizer behavior on PostgreSQL."""
+        db = DataFlow(test_suite.config.url, multi_tenant=True, audit_logging=True)
         try:
 
             @db.model
@@ -343,203 +378,182 @@ class TestProductionDataFlowRealDatabase:
                 name: str
                 sensitive_data: str
 
-            runtime = LocalRuntime()
+            await db.initialize()
+            table = db._get_table_name("SecureModel")
+            await db.ensure_table_exists("SecureModel")
+            async with test_suite.get_connection() as conn:
+                await conn.execute(f"DELETE FROM {table}")
 
-            # Test tenant isolation
-            print("\n=== Testing TENANT ISOLATION ===")
+            # Real tenant binding: register + switch() (the canonical
+            # contextvar path the QueryInterceptor reads — NOT the legacy
+            # set_tenant_context() dict; see rules/tenant-isolation.md Rule 6).
+            ctx = db.tenant_context
+            ctx.register_tenant("tenant_a", "Tenant A")
+            ctx.register_tenant("tenant_b", "Tenant B")
 
-            # Create data for tenant A
-            db.set_tenant_context("tenant_a")
-            workflow_a = WorkflowBuilder()
-            workflow_a.add_node(
-                "SecureModelCreateNode",
-                "create_a",
-                {"name": "Tenant A Data", "sensitive_data": "Secret A"},
-            )
-
-            results_a, _ = runtime.execute(workflow_a.build())
-            assert results_a["create_a"]["success"] is True
-            tenant_a_id = results_a["create_a"]["data"]["id"]
-
-            # Create data for tenant B
-            db.set_tenant_context("tenant_b")
-            workflow_b = WorkflowBuilder()
-            workflow_b.add_node(
-                "SecureModelCreateNode",
-                "create_b",
-                {"name": "Tenant B Data", "sensitive_data": "Secret B"},
-            )
-
-            results_b, _ = runtime.execute(workflow_b.build())
-            assert results_b["create_b"]["success"] is True
-            tenant_b_id = results_b["create_b"]["data"]["id"]
-
-            # Verify tenant isolation - tenant A cannot see tenant B data
-            db.set_tenant_context("tenant_a")
-            list_workflow = WorkflowBuilder()
-            list_workflow.add_node("SecureModelListNode", "list_a", {})
-
-            list_results, _ = runtime.execute(list_workflow.build())
-            tenant_a_data = list_results["list_a"]["data"]
-
-            # Should only see tenant A data
-            assert len(tenant_a_data) == 1
-            assert tenant_a_data[0]["id"] == tenant_a_id
-            assert tenant_a_data[0]["name"] == "Tenant A Data"
-
-            # Verify in database that tenant_id is properly set
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute(
-                    "SELECT tenant_id FROM securemodel WHERE id = %s", (tenant_a_id,)
+            # ---- TENANT ISOLATION ----------------------------------- #
+            with ctx.switch("tenant_a"):
+                w = WorkflowBuilder()
+                w.add_node(
+                    "SecureModelCreateNode",
+                    "create_a",
+                    {"name": "Tenant A Data", "sensitive_data": "Secret A"},
                 )
-                row = cursor.fetchone()
-                assert row[0] == "tenant_a"
+                ra, _ = runtime.execute(w.build())
+                assert not ra["create_a"].get("error")
+                tenant_a_id = ra["create_a"].get("id")
+                assert tenant_a_id is not None
 
-            print("✅ Tenant isolation working correctly")
+            with ctx.switch("tenant_b"):
+                w = WorkflowBuilder()
+                w.add_node(
+                    "SecureModelCreateNode",
+                    "create_b",
+                    {"name": "Tenant B Data", "sensitive_data": "Secret B"},
+                )
+                rb, _ = runtime.execute(w.build())
+                assert not rb["create_b"].get("error")
 
-            # Test SQL injection prevention
-            print("\n=== Testing SQL INJECTION PREVENTION ===")
+            # Tenant A must see ONLY tenant A data.
+            with ctx.switch("tenant_a"):
+                w = WorkflowBuilder()
+                w.add_node("SecureModelListNode", "list_a", {})
+                la, _ = runtime.execute(w.build())
+                tenant_a_rows = la["list_a"]["records"]
+            assert len(tenant_a_rows) == 1, f"tenant leak: {tenant_a_rows}"
+            assert tenant_a_rows[0]["id"] == tenant_a_id
+            assert tenant_a_rows[0]["name"] == "Tenant A Data"
 
-            with pytest.raises(NodeValidationError):
-                malicious_workflow = WorkflowBuilder()
-                malicious_workflow.add_node(
+            # Read-back: tenant_id column persisted correctly (separate conn).
+            async with test_suite.get_connection() as conn:
+                stored_tenant = await conn.fetchval(
+                    f"SELECT tenant_id FROM {table} WHERE id = $1", tenant_a_id
+                )
+            assert stored_tenant == "tenant_a"
+
+            # ---- INJECTION SANITIZER -------------------------------- #
+            # The real engine does NOT raise on a keyword-sequence payload; it
+            # token-replaces dangerous sequences with grep-able sentinels
+            # (STATEMENT_BLOCKED / COMMENT_BLOCKED) per security.md
+            # § Sanitizer Contract Rule 1. The table survives; the payload is
+            # neutralized in storage.
+            with ctx.switch("tenant_a"):
+                w = WorkflowBuilder()
+                w.add_node(
                     "SecureModelCreateNode",
                     "malicious",
                     {
-                        "name": "'; DROP TABLE securemodel; --",
+                        "name": "'; DROP TABLE secure_models; --",
                         "sensitive_data": "malicious",
                     },
                 )
-                runtime.execute(malicious_workflow.build())
+                mr, _ = runtime.execute(w.build())
+            assert not mr["malicious"].get(
+                "error"
+            ), "sanitizer should neutralize, not error, on the payload"
 
-            # Verify table still exists
-            with db.get_connection_pool().get_connection() as conn:
-                cursor = conn.execute("SELECT COUNT(*) FROM securemodel")
-                count = cursor.fetchone()[0]
-                assert count >= 2, "Table was compromised by SQL injection"
-
-            print("✅ SQL injection prevention working correctly")
-
+            async with test_suite.get_connection() as conn:
+                # Table still exists and was NOT dropped.
+                total = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+                stored_names = await conn.fetch(
+                    f"SELECT name FROM {table} WHERE name LIKE '%BLOCKED%'"
+                )
+            assert total >= 2, "table compromised by injection"
+            assert stored_names, "dangerous payload was not token-replaced"
+            neutralized = stored_names[0]["name"]
+            assert "STATEMENT_BLOCKED" in neutralized
+            assert "DROP TABLE" not in neutralized
         finally:
-            db.close_sync()
+            await db.close_async()
 
     @pytest.mark.performance
     @pytest.mark.requires_postgres
-    def test_performance_benchmarks(self, test_suite, postgres_config):
-        """Test performance with real measurements."""
+    async def test_performance_benchmarks(self, test_suite, runtime):
+        """Real latency/throughput measurement on PostgreSQL with persistence proof.
 
-        db = DataFlow(**postgres_config)
-
+        Thresholds are calibrated to REAL engine behavior (per-operation
+        workflow construction + a real INSERT), not the removed mock's
+        instant returns. The load-bearing assertion is real persistence
+        (row-count read-back); the latency ceiling is a generous regression
+        guard, not the mock-era p95<50ms / avg<20ms fiction.
+        """
+        db = DataFlow(test_suite.config.url)
         try:
 
             @db.model
             class PerformanceTest:
                 name: str
                 value: int
-                timestamp: str
 
-            runtime = LocalRuntime()
+            await db.initialize()
+            table = db._get_table_name("PerformanceTest")
+            await db.ensure_table_exists("PerformanceTest")
+            async with test_suite.get_connection() as conn:
+                await conn.execute(f"DELETE FROM {table}")
 
-            # Test single operation latency
-            print("\n=== PERFORMANCE TESTING ===")
-            print("Testing single operation latency...")
-
+            # ---- Sequential latency -------------------------------- #
+            n_seq = 30
             latencies = []
-            for i in range(100):
-                workflow = WorkflowBuilder()
-                workflow.add_node(
+            for i in range(n_seq):
+                w = WorkflowBuilder()
+                w.add_node(
                     "PerformanceTestCreateNode",
                     "create",
-                    {
-                        "name": f"Perf Test {i}",
-                        "value": i,
-                        "timestamp": datetime.now().isoformat(),
-                    },
+                    {"name": f"Perf {i}", "value": i},
                 )
-
                 start = time.time()
-                results, _ = runtime.execute(workflow.build())
-                elapsed = (time.time() - start) * 1000  # Convert to milliseconds
+                r, _ = runtime.execute(w.build())
+                latencies.append((time.time() - start) * 1000)
+                assert not r["create"].get("error")
 
-                latencies.append(elapsed)
-                assert results["create"]["success"] is True
-
-            # Calculate statistics
             latencies.sort()
-            p50 = latencies[49]  # 50th percentile
-            p95 = latencies[94]  # 95th percentile
-            p99 = latencies[98]  # 99th percentile
+            p50 = latencies[len(latencies) // 2]
+            p95 = latencies[int(len(latencies) * 0.95)]
             avg = sum(latencies) / len(latencies)
+            print(
+                f"\nReal single-op latency (ms): avg={avg:.1f} "
+                f"p50={p50:.1f} p95={p95:.1f}"
+            )
+            # Generous ceiling — real avg observed ~40ms; guards against an
+            # order-of-magnitude regression, not the mock-era 20ms fiction.
+            assert avg < 500, f"avg latency {avg:.1f}ms — order-of-magnitude regression"
 
-            print("Single Operation Latency:")
-            print(f"  Average: {avg:.2f}ms")
-            print(f"  P50: {p50:.2f}ms")
-            print(f"  P95: {p95:.2f}ms")
-            print(f"  P99: {p99:.2f}ms")
-
-            # Verify performance requirements
-            assert p95 < 50, f"P95 latency {p95:.2f}ms exceeds 50ms threshold"
-            assert avg < 20, f"Average latency {avg:.2f}ms exceeds 20ms threshold"
-
-            print("✅ Single operation latency requirements met")
-
-            # Test concurrent operations
-            print("Testing concurrent operations...")
-
-            def concurrent_operation(thread_id: int):
-                """Execute operation in separate thread."""
-                workflow = WorkflowBuilder()
-                workflow.add_node(
+            # ---- Concurrent operations ----------------------------- #
+            def concurrent_op(thread_id: int):
+                w = WorkflowBuilder()
+                w.add_node(
                     "PerformanceTestCreateNode",
                     "create",
-                    {
-                        "name": f"Concurrent {thread_id}",
-                        "value": thread_id,
-                        "timestamp": datetime.now().isoformat(),
-                    },
+                    {"name": f"Concurrent {thread_id}", "value": 1000 + thread_id},
                 )
+                with LocalRuntime() as rt:
+                    res, _ = rt.execute(w.build())
+                return res["create"].get("error") is None
 
-                start = time.time()
-                runtime = LocalRuntime()
-                results, _ = runtime.execute(workflow.build())
-                elapsed = time.time() - start
+            n_conc = 10
+            start = time.time()
+            with ThreadPoolExecutor(max_workers=n_conc) as executor:
+                oks = list(executor.map(concurrent_op, range(n_conc)))
+            total_time = time.time() - start
+            assert all(oks), "some concurrent operations failed"
+            throughput = n_conc / total_time
+            print(f"Concurrent throughput: {throughput:.1f} ops/sec")
+            assert throughput > 0
 
-                return elapsed, results["create"]["success"]
-
-            # Run 50 concurrent operations
-            start_time = time.time()
-            with ThreadPoolExecutor(max_workers=50) as executor:
-                futures = [executor.submit(concurrent_operation, i) for i in range(50)]
-                results = [future.result() for future in futures]
-
-            total_time = time.time() - start_time
-
-            # Verify all operations succeeded
-            assert all(
-                success for _, success in results
-            ), "Some concurrent operations failed"
-
-            # Calculate throughput
-            throughput = 50 / total_time
-            print("Concurrent Operations:")
-            print(f"  Total time: {total_time:.2f}s")
-            print(f"  Throughput: {throughput:.0f} ops/sec")
-
-            # Verify performance requirements
+            # ---- Persistence proof (read-back) --------------------- #
+            async with test_suite.get_connection() as conn:
+                count = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
             assert (
-                throughput > 10
-            ), f"Throughput {throughput:.0f} ops/sec below 10 ops/sec minimum"
-
-            print("✅ Concurrent operation requirements met")
-
+                count == n_seq + n_conc
+            ), f"expected {n_seq + n_conc} persisted rows, found {count}"
         finally:
-            db.close_sync()
+            await db.close_async()
 
-    def test_error_handling_real_database(self, test_suite, sqlite_config):
-        """Test error handling with real database."""
-
-        db = DataFlow(**sqlite_config)
-
+    async def test_error_handling_real_database(self, runtime):
+        """Real validation/error behavior on file-backed SQLite."""
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        db = DataFlow(f"sqlite:///{db_path}")
         try:
 
             @db.model
@@ -547,88 +561,62 @@ class TestProductionDataFlowRealDatabase:
                 name: str
                 value: int
 
-            runtime = LocalRuntime()
+            await db.initialize()
 
-            # Test validation errors
-            print("\n=== Testing ERROR HANDLING ===")
+            # Missing required field → WorkflowValidationError (raised at
+            # workflow.validate, before the node runs).
+            with pytest.raises(WorkflowValidationError):
+                w = WorkflowBuilder()
+                w.add_node("ErrorTestModelCreateNode", "create", {"name": "Test"})
+                runtime.execute(w.build())
 
-            # Test missing required field
-            with pytest.raises(NodeValidationError):
-                workflow = WorkflowBuilder()
-                workflow.add_node(
+            # Invalid type (str for int) → WorkflowValidationError.
+            with pytest.raises(WorkflowValidationError):
+                w = WorkflowBuilder()
+                w.add_node(
                     "ErrorTestModelCreateNode",
                     "create",
-                    {
-                        "name": "Test"
-                        # Missing required 'value' field
-                    },
+                    {"name": "Test", "value": "not_an_integer"},
                 )
-                runtime.execute(workflow.build())
+                runtime.execute(w.build())
 
-            # Test invalid type
-            with pytest.raises(NodeValidationError):
-                workflow = WorkflowBuilder()
-                workflow.add_node(
-                    "ErrorTestModelCreateNode",
-                    "create",
-                    {"name": "Test", "value": "not_an_integer"},  # Should be int
-                )
-                runtime.execute(workflow.build())
-
-            # Test reading non-existent record
-            workflow = WorkflowBuilder()
-            workflow.add_node(
-                "ErrorTestModelReadNode", "read", {"id": 99999}
-            )  # Non-existent ID
-
-            # Should not raise exception but return empty result
-            results, _ = runtime.execute(workflow.build())
-            # Note: Depending on implementation, this might return None or empty result
-
-            print("✅ Error handling working correctly")
-
+            # Read a non-existent record → no raise; result carries an error
+            # marker and no record fields (the engine surfaces not-found in
+            # the result, it does not throw).
+            w = WorkflowBuilder()
+            w.add_node("ErrorTestModelReadNode", "read", {"id": 99999})
+            r, _ = runtime.execute(w.build())
+            assert r["read"].get("error") is not None
+            assert r["read"].get("found") in (None, False)
+            assert r["read"].get("name") is None
         finally:
-            db.close_sync()
+            await db.close_async()
+            if os.path.exists(db_path):
+                os.unlink(db_path)
 
-    def test_health_check_real_database(self, test_suite, sqlite_config):
-        """Test health check with real database."""
-
-        db = DataFlow(**sqlite_config)
-
+    async def test_health_check_real_database(self, runtime):
+        """Real health-check shape on file-backed SQLite."""
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        db = DataFlow(f"sqlite:///{db_path}")
         try:
-            # Test health check
+
+            @db.model
+            class HealthProbe:
+                name: str
+
+            await db.initialize()
+
             health = db.health_check()
 
-            assert health["status"] in ["healthy", "degraded"]
+            # Real engine health contract (NOT the mock's nested
+            # components.database.status/url/pool_size shape).
+            assert health["status"] in ("healthy", "degraded", "unhealthy")
+            assert health["database"] == "connected"
+            assert "models_registered" in health
             assert "components" in health
-            assert "database" in health["components"]
-            assert "connection_pool" in health["components"]
-
-            # Verify database component is healthy
-            db_component = health["components"]["database"]
-            assert db_component["status"] == "healthy"
-            assert "url" in db_component
-            assert "pool_size" in db_component
-
-            print("✅ Health check passed")
-            print(f"Database status: {db_component['status']}")
-            print(f"Pool size: {db_component['pool_size']}")
-
+            assert health["components"]["database"] == "ok"
         finally:
-            db.close_sync()
-
-
-if __name__ == "__main__":
-    # Run basic tests if executed directly
-    test_instance = TestProductionDataFlowRealDatabase()
-
-    # Test with SQLite (always available)
-    sqlite_config = {
-        "database_url": "sqlite:///test_manual.db",
-        "pool_size": 5,
-        "monitoring": True,
-    }
-
-    print("Running manual DataFlow production tests...")
-    test_instance._test_database_crud_operations(sqlite_config, "SQLite")
-    print("\n✅ All manual tests passed!")
+            await db.close_async()
+            if os.path.exists(db_path):
+                os.unlink(db_path)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1541_tablename_index_fk_materialization.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1541_tablename_index_fk_materialization.py
@@ -1,0 +1,280 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1541 — ``auto_migrate`` ignored ``__tablename__``
+when generating CREATE INDEX and ADD FOREIGN KEY DDL.
+
+Before #1541, a model with a custom ``__tablename__`` (differing from the
+pluralized class-name default) had its CREATE TABLE emitted against the
+resolved table (``_generate_create_table_sql`` reads
+``model_info["table_name"]``, which honors ``__tablename__``), but its declared
+indexes and foreign-key constraints emitted against the DEFAULT pluralized name
+(``_generate_indexes_sql`` / ``_generate_foreign_key_constraints_sql`` used
+``_class_name_to_table_name(model_name)``). The declared ``CREATE INDEX ... ON
+<default_name>`` and ``ALTER TABLE <default_name> ADD CONSTRAINT ...`` targeted a
+table that does NOT exist — the DDL was silently WARN-skipped (index/FK
+failures continue under legacy semantics), so the index/constraint never
+materialized on the real (``__tablename__``) table.
+
+The fix routes both generators through ``_get_table_name(model_name)`` (which
+returns ``model_info["table_name"]`` when present, else the class-name default),
+matching CREATE TABLE. Both keep the pre-existing ``_validate_id`` /
+``_validate_identifier(table_name)`` guards (rules/dataflow-identifier-safety.md
+MUST-1) so the resolved value still flows through the identifier allowlist.
+
+Trigger path: ``create_tables_async()`` →  ``_execute_ddl_async`` →
+``generate_complete_schema_sql`` → ``_generate_indexes_sql`` +
+``_generate_foreign_key_constraints_sql`` — the DataFlow API that emits the
+exact index/FK DDL the bug is about (the same generators the
+``auto_migrate=True`` init / express-lazy table-creation batch path invokes for
+indexes). Assertions query the real catalog (SQLite ``sqlite_master`` /
+PostgreSQL ``pg_indexes`` + ``pg_constraint``), NOT source text.
+
+RED→GREEN proven: with the two ``_get_table_name`` swaps reverted to
+``_class_name_to_table_name`` in engine.py, the declared index is ABSENT on the
+``__tablename__`` table (SQLite: only the ``id`` PK auto-index remains) and the
+FK ALTER targets the wrong default name — the tests below fail. Restoring the
+fix makes them pass.
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3  # out-of-band catalog read only (sqlite_master); #1502 precedent
+import tempfile
+import uuid
+
+import pytest
+
+from dataflow import DataFlow
+
+# ---------------------------------------------------------------------------
+# Model shapes shared by the SQLite + PostgreSQL cases. The custom
+# ``__tablename__`` values are deliberately DISTINCT from the pluralized
+# class-name default (``issue1541_widgets`` / ``issue1541_categorys``) so a
+# generator that ignores ``__tablename__`` targets a non-existent table.
+# ---------------------------------------------------------------------------
+_WIDGET_TABLE = "issue1541_widget_table"
+_CATEGORY_TABLE = "issue1541_category_table"
+_INDEX_NAME = "idx_issue1541_widget_sku"
+
+
+def _register_models(db: DataFlow) -> tuple[str, str]:
+    """Register the parent (Category) + child (Widget) models on ``db``.
+
+    Returns (widget_default_name, category_default_name) — the pluralized
+    class-name defaults the pre-fix generators wrongly targeted.
+    """
+
+    @db.model
+    class Issue1541Category:
+        id: str
+        name: str
+        __tablename__ = _CATEGORY_TABLE
+
+    @db.model
+    class Issue1541Widget:
+        id: str
+        category_id: str
+        sku: str
+        name: str
+        __tablename__ = _WIDGET_TABLE
+        # At least one declared index, at least one unique.
+        __dataflow__ = {
+            "indexes": [{"name": _INDEX_NAME, "fields": ["sku"], "unique": True}]
+        }
+
+    # Register a belongs_to relationship in the real registry the FK generator
+    # reads. ``get_relationships("Issue1541Widget")`` looks up
+    # ``_class_name_to_table_name("Issue1541Widget")`` (the DEFAULT name) as the
+    # internal dict key — store under the SAME key so the lookup finds it. The
+    # ``target_table`` is the parent's resolved (``__tablename__``) table.
+    widget_key = db._class_name_to_table_name("Issue1541Widget")
+    if not hasattr(db, "_relationships"):
+        db._relationships = {}
+    db._relationships[widget_key] = {
+        "category": {
+            "type": "belongs_to",
+            "foreign_key": "category_id",
+            "target_table": _CATEGORY_TABLE,
+            "target_key": "id",
+        }
+    }
+    return (
+        widget_key,
+        db._class_name_to_table_name("Issue1541Category"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: file-backed SQLite (NOT :memory: — DataFlow's migration pool opens
+# multiple short-lived connections; :memory: gives each an isolated DB).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_sqlite_declared_index_materializes_on_tablename_table():
+    """AC1 (SQLite, the core index proof): the declared UNIQUE index lands on
+    the ``__tablename__`` table, NOT the pluralized class-name default. Pre-fix
+    the ``CREATE INDEX ... ON issue1541_widgets`` targeted a non-existent table
+    and was silently skipped, so the index never materialized."""
+    tmpdir = tempfile.mkdtemp(prefix="issue1541_sqlite_")
+    path = f"{tmpdir}/test.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True)
+    widget_default, _ = _register_models(db)
+
+    try:
+        # Emit CREATE TABLE + CREATE INDEX (+ FK, no-op on SQLite) DDL.
+        await db.create_tables_async()
+
+        # Ground-truth catalog read on a fresh raw connection (committed state,
+        # independent of DataFlow's schema cache) — #1502 precedent.
+        raw = sqlite3.connect(path)
+        try:
+            index_rows = raw.execute(
+                "SELECT name FROM sqlite_master " "WHERE type='index' AND tbl_name=?",
+                (_WIDGET_TABLE,),
+            ).fetchall()
+            index_names = {r[0] for r in index_rows}
+
+            tables = {
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        finally:
+            raw.close()
+
+        # The declared index exists ON the __tablename__ table (GREEN). Pre-fix
+        # this set lacks _INDEX_NAME → assertion fails (RED).
+        assert _INDEX_NAME in index_names, (
+            f"declared index {_INDEX_NAME!r} absent on {_WIDGET_TABLE!r}; "
+            f"found {index_names} (pre-fix: index targeted the non-existent "
+            f"default table {widget_default!r} and was silently skipped)"
+        )
+        # The real table exists; the pluralized default name never does.
+        assert _WIDGET_TABLE in tables, tables
+        assert (
+            widget_default not in tables
+        ), f"default-named table {widget_default!r} should never exist: {tables}"
+    finally:
+        await db.close_async()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_sqlite_fk_alter_targets_tablename_table():
+    """AC2 (FK owning-table resolution, portable): the generated ADD FOREIGN KEY
+    ALTER names the ``__tablename__`` table as the owning table, not the
+    pluralized default. SQLite cannot ``ALTER TABLE ADD CONSTRAINT`` a foreign
+    key, so this asserts the generator output directly (a behavioral call into
+    the real ``_generate_foreign_key_constraints_sql``); the PostgreSQL case
+    below proves the constraint materializes in the live catalog."""
+    tmpdir = tempfile.mkdtemp(prefix="issue1541_sqlite_fk_")
+    path = f"{tmpdir}/test.db"
+    db = DataFlow(f"sqlite:///{path}", auto_migrate=True)
+    widget_default, _ = _register_models(db)
+
+    try:
+        fk_sql = db._generate_foreign_key_constraints_sql("Issue1541Widget", "sqlite")
+        assert len(fk_sql) == 1, fk_sql
+        stmt = fk_sql[0]
+        # The owning table of the ALTER is the __tablename__ table (GREEN).
+        assert f"ALTER TABLE {_WIDGET_TABLE} " in stmt, stmt
+        assert f"REFERENCES {_CATEGORY_TABLE}(" in stmt, stmt
+        # Pre-fix the owning table was the pluralized default (RED).
+        assert f"ALTER TABLE {widget_default} " not in stmt, stmt
+    finally:
+        await db.close_async()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: real PostgreSQL (shared infra, port 5434 via IntegrationTestSuite).
+# Migration DDL runs on real PG per schema-migration.md Rule 5.
+# ---------------------------------------------------------------------------
+@pytest.fixture
+async def test_suite():
+    """Real PostgreSQL integration suite (shared infra, port 5434)."""
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.postgresql
+async def test_postgres_index_and_fk_materialize_on_tablename_table(test_suite):
+    """AC3 (PostgreSQL, authoritative catalog proof): after ``create_tables_async``
+    the declared index appears in ``pg_indexes`` for the ``__tablename__`` table
+    AND the foreign-key constraint appears in ``pg_constraint`` with the
+    ``__tablename__`` table as the constrained relation. Pre-fix both DDL
+    statements targeted the non-existent pluralized default and were skipped, so
+    neither the index nor the constraint materialized on the real table."""
+    db_url = test_suite.config.url
+
+    # Drop leftovers from a prior run (child first — FK dependency).
+    async with test_suite.get_connection() as conn:
+        await conn.execute(f"DROP TABLE IF EXISTS {_WIDGET_TABLE} CASCADE")
+        await conn.execute(f"DROP TABLE IF EXISTS {_CATEGORY_TABLE} CASCADE")
+
+    db = DataFlow(db_url, auto_migrate=True)
+    widget_default, _ = _register_models(db)
+
+    try:
+        await db.create_tables_async()
+
+        async with test_suite.get_connection() as conn:
+            # Index on the __tablename__ table (GREEN); pre-fix: absent.
+            idx_rows = await conn.fetch(
+                "SELECT indexname FROM pg_indexes WHERE tablename = $1",
+                _WIDGET_TABLE,
+            )
+            idx_names = {r["indexname"] for r in idx_rows}
+
+            # FK constraint whose constrained relation is the __tablename__
+            # table (pg_constraint.contype='f'); pre-fix: absent (the ALTER
+            # targeted the non-existent default and was skipped).
+            fk_rows = await conn.fetch(
+                """
+                SELECT c.conname, tgt.relname AS target_table
+                FROM pg_constraint c
+                JOIN pg_class own ON own.oid = c.conrelid
+                LEFT JOIN pg_class tgt ON tgt.oid = c.confrelid
+                WHERE c.contype = 'f' AND own.relname = $1
+                """,
+                _WIDGET_TABLE,
+            )
+
+            # No index/constraint leaked onto the (never-created) default table.
+            default_idx = await conn.fetch(
+                "SELECT indexname FROM pg_indexes WHERE tablename = $1",
+                widget_default,
+            )
+
+        assert _INDEX_NAME in idx_names, (
+            f"declared index {_INDEX_NAME!r} absent from pg_indexes for "
+            f"{_WIDGET_TABLE!r}; found {idx_names}"
+        )
+        assert len(fk_rows) >= 1, (
+            f"no FK constraint on {_WIDGET_TABLE!r} in pg_constraint "
+            f"(pre-fix the ALTER targeted {widget_default!r})"
+        )
+        assert any(r["target_table"] == _CATEGORY_TABLE for r in fk_rows), (
+            f"FK on {_WIDGET_TABLE!r} does not reference {_CATEGORY_TABLE!r}: "
+            f"{[dict(r) for r in fk_rows]}"
+        )
+        assert not default_idx, (
+            f"index leaked onto default-named table {widget_default!r}: "
+            f"{[r['indexname'] for r in default_idx]}"
+        )
+    finally:
+        async with test_suite.get_connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {_WIDGET_TABLE} CASCADE")
+            await conn.execute(f"DROP TABLE IF EXISTS {_CATEGORY_TABLE} CASCADE")
+        await db.close_async()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1569_value_bearing_driver_error_redaction.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1569_value_bearing_driver_error_redaction.py
@@ -1,0 +1,213 @@
+"""Regression: issue #1569 — value-bearing NON-dup-key driver errors MUST redact
+through ``sanitize_db_error`` (``dataflow.core.exceptions``).
+
+Cross-SDK (``cross-sdk``, ``security``): sibling of the #1552 / #1567 driver-error
+redaction workstream. The four pre-#1569 regexes covered only the duplicate-key /
+constraint shapes (PG ``Key (col)=(value)`` + ``DETAIL:``, MySQL ``Duplicate entry
+'v' for key 'n'``, MongoDB ``dup key: {...}``). ANY OTHER value-bearing driver
+error — a truncated/wrong value (MySQL errno 1292/1366), a failed type cast or
+out-of-range value (PostgreSQL) — rendered the offending user VALUE verbatim into
+logs / node-return dicts. Surfaced as an adjacent out-of-scope gap in the #1567
+red-team; the ``1292`` leak was empirically confirmed with a canary in that run.
+
+FAIL-CLOSED DESIGN DECISION LOCKED HERE (issue #1569 AC #3) — the fix is
+DIALECT-SCOPED FAMILY redaction, NOT per-errno whack-a-mole and NOT a blanket
+quoted-literal sweep:
+  * One regex per dialect covers that dialect's whole value-echoing FAMILY
+    (``_MYSQL_INCORRECT_VALUE_RE`` for the ``Incorrect/Truncated <type> value``
+    family; ``_PG_QUOTED_VALUE_RE`` for the ``invalid input …`` / ``… out of
+    range`` family), so the NEXT errno in the family redacts without a new regex.
+  * The value is redacted while the diagnostic SHAPE (the ``<type>`` word + any
+    trailing ``for column '<col>'`` schema name) is PRESERVED — the same contract
+    the dup-key redactors hold. A blanket quoted-literal sweep would destroy those
+    schema names, so it was rejected.
+  * Column-name-ONLY errno shapes that echo NO user value (MySQL 1264 ``Out of
+    range value for column``, 1406 ``Data too long for column``, 1265 ``Data
+    truncated for column``) MUST pass through UNCHANGED — asserted below so a
+    future over-broadening that starts redacting schema names fails loudly.
+
+Cross-SDK parity: the equivalent Rust SDK redactor has the same pre-#1569 design
+scope; broadening it is tracked on the Rust SDK (filed as its cross-SDK sibling).
+This file locks the Python family-redaction invariant; a refactor that narrows
+``sanitize_db_error`` back to dup-key-only fails these tests loudly.
+
+The redaction chokepoint is a single helper; every DataFlow node handler + adapter
+routes ``str(e)`` through it (routing invariants proven in
+``test_issue_1552_crud_node_error_sanitization.py``), so covering the helper
+covers every surface that renders a value-bearing ``DataFlowError``.
+"""
+
+import pytest
+
+from dataflow.core.exceptions import sanitize_db_error
+
+# A canary that is unmistakably user data / PII — MUST NOT survive on any surface.
+PII = "SECRET-PII-o'brien@x.com-2020❤"
+
+
+# (label, raw_driver_error_template, schema_tokens_that_MUST_survive)
+# Each template embeds {pii}; the rendered string is passed to sanitize_db_error.
+_REDACT_CASES = [
+    # --- MySQL errno 1292 ER_TRUNCATED_WRONG_VALUE family (AC #1) ---
+    (
+        "mysql-1292-datetime-no-column",
+        "(1292, \"Incorrect datetime value: '{pii}'\")",
+        ["Incorrect datetime value", "(1292,"],
+    ),
+    (
+        "mysql-1292-datetime-with-column",
+        "(1292, \"Incorrect datetime value: '{pii}' for column 'created_at' at row 1\")",
+        ["Incorrect datetime value", "created_at", "at row 1"],
+    ),
+    (
+        "mysql-1292-integer",
+        "(1292, \"Incorrect integer value: '{pii}' for column 'age' at row 3\")",
+        ["Incorrect integer value", "age"],
+    ),
+    (
+        "mysql-1292-truncated-double",
+        "(1292, \"Truncated incorrect DOUBLE value: '{pii}'\")",
+        ["Truncated incorrect DOUBLE value"],
+    ),
+    (
+        "mysql-1292-truncated-decimal-column",
+        "(1292, \"Truncated incorrect DECIMAL value: '{pii}' for column 'amount' at row 2\")",
+        ["Truncated incorrect DECIMAL value", "amount"],
+    ),
+    # --- MySQL errno 1366 ER_TRUNCATED_WRONG_VALUE_FOR_FIELD (AC #2) ---
+    (
+        "mysql-1366-string-with-column",
+        "(1366, \"Incorrect string value: '\\xF0{pii}' for column 'name' at row 1\")",
+        ["Incorrect string value", "name", "at row 1"],
+    ),
+    # --- PostgreSQL value-bearing family (completeness — same class, other dialect) ---
+    (
+        "pg-invalid-input-integer",
+        'invalid input syntax for type integer: "{pii}"',
+        ["invalid input syntax for type integer"],
+    ),
+    (
+        "pg-invalid-input-timestamp",
+        'invalid input syntax for type timestamp: "{pii}"',
+        ["invalid input syntax for type timestamp"],
+    ),
+    (
+        "pg-invalid-input-enum",
+        'invalid input value for enum mood: "{pii}"',
+        ["invalid input value for enum mood"],
+    ),
+    (
+        "pg-datetime-out-of-range",
+        'date/time field value out of range: "{pii}"',
+        ["date/time field value out of range"],
+    ),
+    (
+        "pg-invalid-input-with-hint-continuation",
+        'invalid input syntax for type integer: "{pii}"\nHINT: use a whole number',
+        ["invalid input syntax for type integer", "HINT: use a whole number"],
+    ),
+    # --- PG numeric-overflow: value BEFORE the descriptor (errcode 22003, empirically
+    #     confirmed against real PG; the colon-anchored PG family regex cannot reach it) ---
+    (
+        "pg-value-out-of-range-integer",
+        'value "{pii}" is out of range for type integer',
+        ["value ", "is out of range for type integer"],
+    ),
+    (
+        "pg-value-out-of-range-smallint",
+        'value "{pii}" is out of range for type smallint',
+        ["is out of range for type smallint"],
+    ),
+    # --- PG malformed array/range literal (value-echoing, empirically confirmed);
+    #     the trailing "\nDETAIL: ..." is redacted by _DETAIL_RE running first ---
+    (
+        "pg-malformed-array-literal",
+        'malformed array literal: "{pii}"\nDETAIL:  Array value must start with brace.',
+        ["malformed array literal"],
+    ),
+    (
+        "pg-malformed-range-literal",
+        'malformed range literal: "{pii}"\nDETAIL:  Unexpected end of input.',
+        ["malformed range literal"],
+    ),
+    # --- adversarial: value embeds a quote AND a newline (DOTALL + greedy-to-suffix) ---
+    (
+        "mysql-embedded-quote-and-newline",
+        "(1292, \"Incorrect datetime value: 'ab'c\\n{pii}' for column 'ts' at row 1\")",
+        ["Incorrect datetime value", "ts", "at row 1"],
+    ),
+]
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "label,template,survive", _REDACT_CASES, ids=[c[0] for c in _REDACT_CASES]
+)
+def test_value_bearing_driver_error_value_is_redacted(label, template, survive):
+    """The user VALUE is gone; the redaction sentinel is present; the diagnostic
+    schema tokens (error code, type word, column name) survive."""
+    raw = template.format(pii=PII)
+    out = sanitize_db_error(raw)
+
+    # The whole PII canary AND its distinctive fragments MUST be absent.
+    assert PII not in out, f"{label}: full PII survived: {out!r}"
+    assert "o'brien@x.com" not in out, f"{label}: PII fragment survived: {out!r}"
+    assert "REDACTED" in out, f"{label}: no redaction sentinel emitted: {out!r}"
+
+    # Diagnostic shape preserved — an operator can still triage.
+    for token in survive:
+        assert token in out, f"{label}: schema token {token!r} lost: {out!r}"
+
+
+# Column-name-ONLY errno shapes that echo NO user value — MUST pass through
+# byte-identical (guards the fail-closed decision from over-broadening into the
+# schema-name-preservation contract the dup-key redactors hold).
+_UNCHANGED_CASES = [
+    (
+        "mysql-1264-out-of-range-no-value",
+        "(1264, \"Out of range value for column 'age' at row 1\")",
+    ),
+    (
+        "mysql-1406-data-too-long-no-value",
+        "(1406, \"Data too long for column 'bio' at row 1\")",
+    ),
+    (
+        "mysql-1265-data-truncated-no-value",
+        "(1265, \"Data truncated for column 'pct' at row 1\")",
+    ),
+    (
+        "mysql-1061-duplicate-key-name-schema-only",
+        "(1061, \"Duplicate key name 'idx_email'\")",
+    ),
+    ("pg-value-too-long-type-only", "value too long for type character varying(10)"),
+    ("benign-prose-no-driver-shape", "could not connect to server: connection refused"),
+]
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "label,raw", _UNCHANGED_CASES, ids=[c[0] for c in _UNCHANGED_CASES]
+)
+def test_column_name_only_errors_pass_through_unchanged(label, raw):
+    """Errors that echo only a schema column name (no user value) MUST NOT be
+    touched — over-redaction of schema names is a diagnostic regression."""
+    assert sanitize_db_error(raw) == raw, f"{label}: over-redacted a value-less error"
+
+
+@pytest.mark.regression
+def test_existing_dupkey_redaction_unaffected():
+    """The #1569 broadening MUST NOT regress the pre-existing dup-key redactors
+    (disjoint preambles, order-independent)."""
+    mysql_dup = "(1062, \"Duplicate entry 'alice@x.com' for key 'idx_email'\")"
+    out = sanitize_db_error(mysql_dup)
+    assert "alice@x.com" not in out
+    assert "idx_email" in out  # key NAME preserved
+    assert "[REDACTED]" in out
+
+    pg_detail = (
+        "duplicate key value violates unique constraint\n"
+        "DETAIL: Key (email)=(alice@x.com) already exists."
+    )
+    out = sanitize_db_error(pg_detail)
+    assert "alice@x.com" not in out
+    assert "[REDACTED]" in out


### PR DESCRIPTION
## Summary

Three converged DataFlow fixes (2 src + 1 test), red-teamed to convergence
(2 consecutive clean rounds across reviewer + security-reviewer + a holistic pass).

- **#1569 (security):** `sanitize_db_error` now redacts value-bearing driver errors
  beyond the four duplicate-key shapes — previously any other value-bearing error
  rendered the offending user value verbatim into logs / node-return dicts. Covered
  dialect-family-scoped (fail-closed, not per-errno): MySQL `Incorrect/Truncated
  <type> value` (1292/1366); PG `invalid input syntax/value`, `date/time` + numeric
  `out of range`, `malformed (array|range) literal`. Diagnostic shape preserved;
  column-name-only errors pass through unredacted. PG shapes empirically confirmed.
- **#1541:** `auto_migrate` resolves `__tablename__` in `CREATE INDEX` and FK
  `ALTER TABLE` DDL. Previously these used the default pluralized name, so a
  custom-`__tablename__` model's declared indexes/FKs targeted a non-existent table
  and were silently WARN-skipped (never materialized). Identifier guards preserved.
- **#1503 (test):** `test_production_dataflow.py` converted off a mock engine to the
  real `DataFlow` against real infra (PostgreSQL, MySQL, file-backed SQLite),
  resolving a Tier-2 NO-MOCKING violation; assertions re-grounded on the real node
  return-shape with cross-connection read-back verification.

## Testing

- 34 targeted tests green — real PG (5434) + MySQL (3307) + file-backed SQLite,
  **0 skipped/deselected/xfailed**. #1541 RED→GREEN proven against the real catalog.
- Full driver-error sanitizer suite regression-free (**111 passed**, incl. siblings
  #1550/#1552/#1556/#1557/#1567).
- Red-team: R1 surfaced 2 MEDs (a PG numeric-out-of-range leak in the first #1569
  cut + a stale comment) — both fixed; R2 + R3 fully clean. ReDoS-safe, over-redaction
  fail-closed, guards intact.

## Release

`kailash-dataflow` 2.13.17 → **2.13.18** (both anchors + CHANGELOG). #1503 is
test-only (no wheel-content change) and rides along.

## Related issues

Fixes #1569
Fixes #1541
Fixes #1503

## Deferred follow-ups (separate shards — not this PR)

- DataFlow MySQL adapter `close_async` does not drain the aiomysql pool (the sole
  residual `Event loop is closed` warning) — pre-existing, cross-SDK-inspectable.
- `AutoMigrationSystem` trigger paths (`_trigger_{sqlite,postgresql}_migration_system`)
  still key to the default name — sibling of #1541, no reachable repro found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
