### PR TITLE
fix(dataflow): drain bridge-loop adapter pools before loop close (#1572)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/adapters/mysql.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/mysql.py
@@ -10,11 +10,11 @@ import traceback
 import warnings
 from typing import Any, Dict, List, Tuple
 
+from ..core.exceptions import (  # Issue #1552: redact driver-error VALUES
+    sanitize_db_error,
+)
 from .base import DatabaseAdapter
 from .dialect import DialectManager
-from ..core.exceptions import (
-    sanitize_db_error,
-)  # Issue #1552: redact driver-error VALUES
 from .exceptions import AdapterError, ConnectionError, QueryError, TransactionError
 
 _mysql_dialect = DialectManager.get_dialect("mysql")
@@ -93,6 +93,16 @@ class MySQLAdapter(DatabaseAdapter):
             # Create connection pool
             self.connection_pool = await aiomysql.create_pool(**params)
             self.is_connected = True
+
+            # Issue #1572: this 1-conn reachability probe pool may be created
+            # on a transient bridge loop; register ``close_connection_pool`` so
+            # the bridge drains it before closing the loop (no-op on a
+            # persistent app loop — the BRIDGE_LOOP_ATTR marker gates it).
+            from kailash.utils.loop_pool_registry import (
+                register_pool_drain_on_current_loop,
+            )
+
+            register_pool_drain_on_current_loop(self.close_connection_pool)
 
             # Route host/port/database through ``safe_log_value`` so
             # Emit a connection-established INFO without any URL-derived

--- a/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
@@ -10,11 +10,11 @@ import traceback
 import warnings
 from typing import Any, Dict, List, Tuple
 
+from ..core.exceptions import (  # Issue #1552: redact driver-error VALUES
+    sanitize_db_error,
+)
 from .base import DatabaseAdapter
 from .dialect import DialectManager
-from ..core.exceptions import (
-    sanitize_db_error,
-)  # Issue #1552: redact driver-error VALUES
 from .exceptions import AdapterError, ConnectionError, QueryError, TransactionError
 
 _pg_dialect = DialectManager.get_dialect("postgresql")
@@ -84,6 +84,17 @@ class PostgreSQLAdapter(DatabaseAdapter):
             params["reset"] = reset_connection
             self.connection_pool = await asyncpg.create_pool(**params)
             self.is_connected = True
+
+            # Issue #1572: this reachability-probe pool may be created on a
+            # transient bridge loop; register ``close_connection_pool`` so the
+            # bridge drains it before closing the loop (no-op on a persistent
+            # app loop — the BRIDGE_LOOP_ATTR marker gates it). Symmetry with
+            # the MySQL adapter + future-proofing for probe-on-bridge paths.
+            from kailash.utils.loop_pool_registry import (
+                register_pool_drain_on_current_loop,
+            )
+
+            register_pool_drain_on_current_loop(self.close_connection_pool)
 
             # Emit a connection-established INFO without any URL-derived
             # fields (host, port, database). CodeQL's

--- a/packages/kailash-dataflow/src/dataflow/core/async_utils.py
+++ b/packages/kailash-dataflow/src/dataflow/core/async_utils.py
@@ -28,6 +28,13 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Callable, Coroutine, Optional, TypeVar
 
+# Issue #1572: core kailash owns the transient-bridge-loop marker + the
+# per-loop pool drain registry. dataflow -> kailash is the legal import
+# direction; both a dataflow adapter pool and a core EnterpriseConnectionPool
+# pool register through this single registry so the bridge can drain them
+# before it closes the transient loop they were created on.
+from kailash.utils.loop_pool_registry import BRIDGE_LOOP_ATTR, drain_loop_pools
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -123,8 +130,12 @@ def async_safe_run(coro: Coroutine[Any, Any, T], timeout: Optional[float] = None
     Execute a coroutine safely in any context.
 
     This function intelligently handles async/sync boundaries:
-    - If no event loop is running: uses asyncio.run() (standard sync context)
-    - If event loop is running: uses thread pool with separate event loop
+    - If no event loop is running: runs the coroutine on a fresh transient
+      loop via ``_run_on_new_loop`` (which drains issue-#1572 bridge pools and
+      preserves asyncio.run()'s shutdown_asyncgens / shutdown_default_executor
+      semantics), standard sync context.
+    - If event loop is running: uses a thread pool whose worker runs the
+      coroutine on the same ``_run_on_new_loop`` transient-loop path.
 
     This replaces unsafe `asyncio.run()` calls that fail in FastAPI/Docker.
 
@@ -171,20 +182,17 @@ def async_safe_run(coro: Coroutine[Any, Any, T], timeout: Optional[float] = None
             loop = None
 
         if not loop_is_running:
-            # No event loop running - safe to use asyncio.run()
+            # No event loop running - run on a fresh transient loop. We use
+            # ``_run_on_new_loop`` instead of bare ``asyncio.run()`` so that
+            # pools created on this loop (issue #1572) are drained before the
+            # loop closes; the helper preserves asyncio.run()'s semantics
+            # (shutdown_asyncgens, set_event_loop(None)).
             context = get_execution_context()
             logger.debug(
-                f"async_safe_run: No running loop, using asyncio.run() [context={context}]"
+                f"async_safe_run: No running loop, using transient loop [context={context}]"
             )
 
-            if timeout is not None:
-
-                async def with_timeout():
-                    return await asyncio.wait_for(coro, timeout=timeout)
-
-                return asyncio.run(with_timeout())
-            else:
-                return asyncio.run(coro)
+            return _run_on_new_loop(coro, timeout=timeout)
 
         # Event loop is running - need to use thread pool
         context = get_execution_context()
@@ -221,31 +229,9 @@ def _run_in_thread_pool(
     result_container = {"result": None, "exception": None}
 
     def run_coro_in_new_loop():
-        """Execute coroutine in a new event loop in this thread."""
+        """Execute coroutine on a fresh transient event loop in this thread."""
         try:
-            # Create new event loop for this thread
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            try:
-                if timeout is not None:
-
-                    async def with_timeout():
-                        return await asyncio.wait_for(coro, timeout=timeout)
-
-                    result_container["result"] = new_loop.run_until_complete(
-                        with_timeout()
-                    )
-                else:
-                    result_container["result"] = new_loop.run_until_complete(coro)
-            finally:
-                # Clean up: cancel pending tasks and close loop
-                try:
-                    _cancel_all_tasks(new_loop)
-                except Exception as e:
-                    logger.warning(
-                        "async_utils.error_cancelling_tasks", extra={"error": str(e)}
-                    )
-                new_loop.close()
+            result_container["result"] = _run_on_new_loop(coro, timeout=timeout)
         except Exception as e:
             result_container["exception"] = e
 
@@ -269,6 +255,87 @@ def _run_in_thread_pool(
         raise result_container["exception"]
 
     return result_container["result"]
+
+
+def _run_on_new_loop(
+    coro: Coroutine[Any, Any, T], timeout: Optional[float] = None
+) -> T:
+    """Run ``coro`` on a fresh transient event loop, draining bridge pools first.
+
+    This is the single loop-owning code path for BOTH the no-running-loop
+    branch of :func:`async_safe_run` (formerly a bare ``asyncio.run``) and the
+    thread-pool worker branch. Both create-run-close a transient loop, and
+    both are the SAME leak class for issue #1572: a pool created on the loop
+    (an adapter reachability probe, or ``EnterpriseConnectionPool`` min-size
+    connections) is bound to it, so once the loop closes the pool's transports
+    belong to a dead loop and surface at GC as ``RuntimeError: Event loop is
+    closed`` / ``ResourceWarning: Unclosed connection``.
+
+    The fix: stamp the loop with :data:`BRIDGE_LOOP_ATTR` so pool-creation
+    sites register their async close method via
+    :func:`register_pool_drain_on_current_loop`, then in ``finally`` drain
+    those pools (while the loop is still alive) BEFORE cancelling tasks and
+    closing. The teardown order matters: DRAIN -> cancel_all_tasks ->
+    shutdown_asyncgens -> close, so connections close gracefully. The
+    ``shutdown_asyncgens`` + ``set_event_loop(None)`` steps preserve
+    ``asyncio.run()`` semantics for the sync branch that previously used it.
+    """
+    new_loop = asyncio.new_event_loop()
+    # Mark this loop transient so pool-creation sites register a drain against
+    # it (persistent app loops lack the marker and are never registered).
+    setattr(new_loop, BRIDGE_LOOP_ATTR, True)
+    asyncio.set_event_loop(new_loop)
+    try:
+        if timeout is not None:
+
+            async def with_timeout():
+                return await asyncio.wait_for(coro, timeout=timeout)
+
+            return new_loop.run_until_complete(with_timeout())
+        return new_loop.run_until_complete(coro)
+    finally:
+        # (a) Drain pools created on this transient loop BEFORE cancel/close,
+        #     so aiomysql/asyncpg transports close gracefully while the loop
+        #     still lives (issue #1572). Best-effort — never raise in teardown.
+        try:
+            new_loop.run_until_complete(drain_loop_pools(new_loop))
+        except Exception as e:
+            # Log the exception TYPE only — never str(e), which could embed a
+            # credential-bearing DSN (security.md / observability.md 6.3),
+            # matching the drain registry's own logging discipline.
+            logger.debug(
+                "async_utils.error_draining_pools",
+                extra={"error_type": type(e).__name__},
+            )
+        # (b) Cancel any still-pending tasks (existing behavior).
+        try:
+            _cancel_all_tasks(new_loop)
+        except Exception as e:
+            logger.warning(
+                "async_utils.error_cancelling_tasks", extra={"error": str(e)}
+            )
+        # (c) Shut down async generators — preserves asyncio.run() semantics
+        #     for the sync branch that previously called asyncio.run().
+        try:
+            new_loop.run_until_complete(new_loop.shutdown_asyncgens())
+        except Exception as e:
+            logger.debug(
+                "async_utils.error_shutting_down_asyncgens",
+                extra={"error_type": type(e).__name__},
+            )
+        # (d) Shut down the loop's default thread/process executor — the final
+        #     step asyncio.run() performs, restored here for the no-running-loop
+        #     branch that previously delegated to asyncio.run().
+        try:
+            new_loop.run_until_complete(new_loop.shutdown_default_executor())
+        except Exception as e:
+            logger.debug(
+                "async_utils.error_shutting_down_default_executor",
+                extra={"error_type": type(e).__name__},
+            )
+        # (e) Close the loop, then (f) detach it from this thread.
+        new_loop.close()
+        asyncio.set_event_loop(None)
 
 
 def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:

--- a/packages/kailash-dataflow/tests/integration/test_issue_1572_bridge_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1572_bridge_loop_pool_drain.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 regression test for issue #1572 — bridge-loop pool leak.
+
+DataFlow's sync->async bridge (``dataflow.core.async_utils`` — the
+``async_safe_run`` / ``_run_in_thread_pool`` path) runs coroutines on a
+*transient* event loop it creates, runs, and closes. When a coroutine on that
+loop creates an aiomysql / asyncpg pool (an adapter reachability probe, or
+``EnterpriseConnectionPool`` min-size connections), the pool's transports are
+bound to the transient loop. Once the loop closes, those transports belong to
+a dead loop and can never be drained — surfacing at GC time as
+``RuntimeError: Event loop is closed`` + ``ResourceWarning: Unclosed
+connection`` from the aiomysql / asyncpg finalizers, long after
+``db.close_async()`` has (correctly) done everything it can.
+
+The fix (``kailash.utils.loop_pool_registry`` + the bridge ``finally`` drain)
+closes those pools while the transient loop is still alive.
+
+Test strategy — two layers:
+
+* **PRIMARY (deterministic).** Drive ``async_safe_run`` from WITHIN a running
+  loop (forcing the thread-pool bridge branch), open a REAL adapter pool inside
+  the driven coroutine (so it is created ON the transient bridge loop), and
+  assert the pool was drained (``adapter._pool is None``) after
+  ``async_safe_run`` returns. WITHOUT the fix the drain never runs and the pool
+  object survives — a clean, timing-independent pass/fail. This is the path the
+  root-cause diagnosis (issue #1572) identifies.
+* **SECONDARY (symptom-path GC capture).** A full express CRUD + ``close_async``
+  cycle, then a forced GC with warning + unraisable capture, asserting neither
+  the ResourceWarning nor the "Event loop is closed" RuntimeError surfaces.
+
+Per ``rules/testing.md`` § 3-Tier: NO MOCKING — real containers only:
+* PostgreSQL — ``postgresql://test_user:test_password@localhost:5434/kailash_test``
+* MySQL — ``mysql://kailash_test:test_password@localhost:3307/kailash_test``
+  (container ``kailash_sdk_test_mysql``; MYSQL_USER=kailash_test, grant host '%').
+
+TRAP (do NOT "fix" by adding a pytest flag): running with
+``-W error::PytestUnraisableExceptionWarning`` turns the GC-time warning into a
+mid-teardown error that cascades into a spurious "Record id=N not found". The
+GC layer asserts on CAPTURED warnings/unraisables directly and MUST NOT be run
+under that flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import gc
+import os
+import sys
+import warnings
+
+import pytest
+
+from dataflow import DataFlow
+
+# The sync->async bridge under test.
+from dataflow.core.async_utils import async_safe_run
+
+# Core adapters whose connect() registers a bridge-loop pool drain (#1572).
+from kailash.nodes.data.async_sql import (
+    DatabaseConfig,
+    DatabaseType,
+    MySQLAdapter,
+    PostgreSQLAdapter,
+)
+
+POSTGRES_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+MYSQL_URL = os.getenv(
+    "TEST_MYSQL_URL",
+    # Container ``kailash_sdk_test_mysql`` provisions MYSQL_USER=kailash_test
+    # (grant host '%'), NOT test_user; aiomysql uses these host/port/creds.
+    "mysql://kailash_test:test_password@localhost:3307/kailash_test",
+)
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY — deterministic bridge-drain assertion
+# ---------------------------------------------------------------------------
+
+
+def _open_pool_on_bridge(adapter):
+    """Coroutine factory: open the adapter's pool, then return.
+
+    Run via ``async_safe_run`` from a running-loop context, this executes on
+    the transient bridge loop. ``adapter.connect()`` creates the real pool
+    (asyncpg min_size=1 / aiomysql minsize>=1 open connections eagerly) ON that
+    bridge loop and registers ``adapter.disconnect`` for drain-before-close.
+    """
+
+    async def _coro():
+        await adapter.connect()
+        assert adapter._pool is not None  # pool really opened on the bridge loop
+        return "opened"
+
+    return _coro()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_postgres_bridge_drain_disconnects_pool():
+    """PG: a pool opened on the transient bridge loop is drained before close.
+
+    Fails without the fix — the bridge never calls disconnect, so
+    ``adapter._pool`` survives as a live pool bound to a now-dead loop.
+    """
+    assert (
+        asyncio.get_running_loop().is_running()
+    )  # async_safe_run -> thread-pool bridge
+    adapter = PostgreSQLAdapter(
+        DatabaseConfig(type=DatabaseType.POSTGRESQL, connection_string=POSTGRES_URL)
+    )
+    try:
+        result = async_safe_run(_open_pool_on_bridge(adapter))
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {POSTGRES_URL!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+    assert result == "opened"
+    # The bridge drained the pool while its loop was still alive:
+    assert adapter._pool is None, (
+        "PostgreSQL pool created on the transient bridge loop was NOT drained "
+        "before the loop closed (issue #1572 regression)"
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mysql_bridge_drain_disconnects_pool():
+    """MySQL: a pool opened on the transient bridge loop is drained before close."""
+    assert (
+        asyncio.get_running_loop().is_running()
+    )  # async_safe_run -> thread-pool bridge
+    adapter = MySQLAdapter(
+        DatabaseConfig(type=DatabaseType.MYSQL, connection_string=MYSQL_URL)
+    )
+    try:
+        result = async_safe_run(_open_pool_on_bridge(adapter))
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {MYSQL_URL!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+    assert result == "opened"
+    assert adapter._pool is None, (
+        "MySQL pool created on the transient bridge loop was NOT drained before "
+        "the loop closed (issue #1572 regression)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SECONDARY — symptom-path GC capture over a full express lifecycle
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _capture_gc_teardown_signals():
+    """Capture ResourceWarnings AND unraisable exceptions during a GC sweep."""
+    unraisables = []
+    old_hook = sys.unraisablehook
+
+    def _record_unraisable(unraisable):
+        unraisables.append(unraisable)
+
+    sys.unraisablehook = _record_unraisable
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            yield caught, unraisables
+    finally:
+        sys.unraisablehook = old_hook
+
+
+def _resource_warning_hits(caught):
+    return [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, ResourceWarning) and "nclosed conn" in str(w.message)
+    ]
+
+
+def _event_loop_closed_hits(unraisables):
+    hits = []
+    for u in unraisables:
+        exc = getattr(u, "exc_value", None)
+        if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+            hits.append(str(exc))
+    return hits
+
+
+async def _express_lifecycle_gc_capture(database_url: str):
+    """Full express CRUD + close_async, then GC-capture teardown signals."""
+    try:
+        db = DataFlow(database_url=database_url, auto_migrate=True)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {database_url!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+
+    @db.model
+    class _Widget1572Sec:
+        id: int
+        name: str
+        value: int
+
+    await db.create_tables_async()
+    created = await db.express.create(
+        "_Widget1572Sec", {"id": 1, "name": "alice", "value": 1}
+    )
+    assert created is not None and created.get("id") == 1
+    await db.express.update("_Widget1572Sec", 1, {"value": 2})
+    await db.express.delete("_Widget1572Sec", 1)
+    await db.close_async()
+
+    del db
+    del _Widget1572Sec
+
+    with _capture_gc_teardown_signals() as (caught, unraisables):
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0)
+        gc.collect()
+
+    return _resource_warning_hits(caught), _event_loop_closed_hits(unraisables)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_postgres_express_lifecycle_no_gc_warnings():
+    """PG: full CRUD + close_async leaves no unclosed-connection / dead-loop signal."""
+    rw_hits, loop_hits = await _express_lifecycle_gc_capture(POSTGRES_URL)
+    assert rw_hits == [], f"PostgreSQL leaked unclosed connections at GC: {rw_hits}"
+    assert (
+        loop_hits == []
+    ), f"PostgreSQL produced 'Event loop is closed' at GC: {loop_hits}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mysql_express_lifecycle_no_gc_warnings():
+    """MySQL: full CRUD + close_async leaves no unclosed-connection / dead-loop signal."""
+    rw_hits, loop_hits = await _express_lifecycle_gc_capture(MYSQL_URL)
+    assert rw_hits == [], f"MySQL leaked unclosed connections at GC: {rw_hits}"
+    assert loop_hits == [], f"MySQL produced 'Event loop is closed' at GC: {loop_hits}"

--- a/packages/kailash-dataflow/tests/unit/test_loop_pool_registry.py
+++ b/packages/kailash-dataflow/tests/unit/test_loop_pool_registry.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the per-loop pool drain registry (issue #1572).
+
+The registry lives in core kailash (``kailash.utils.loop_pool_registry``)
+because ``dataflow`` -> ``kailash`` is the only legal import direction. A
+dataflow adapter pool registers DIRECTLY; a core ``EnterpriseConnectionPool``
+pool is covered TRANSITIVELY via its inner adapter's ``connect()`` (both flow
+through this one registry). These are Tier-1 unit tests of the registry
+contract — no database, no infrastructure; the end-to-end bridge-drain
+behavior against real MySQL/PG is exercised by
+``tests/integration/test_issue_1572_bridge_loop_pool_drain.py``.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from kailash.utils.loop_pool_registry import (
+    _DRAIN_TIMEOUT_SECONDS,
+    BRIDGE_LOOP_ATTR,
+    _registry,
+    drain_loop_pools,
+    register_pool_drain_on_current_loop,
+)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_register_is_noop_without_bridge_marker():
+    """A running loop that LACKS the marker must not accumulate registrations.
+
+    This is the memory-leak defense: pools created on a persistent app loop
+    (FastAPI / Jupyter / a user's own asyncio.run) are never registered, so
+    the registry cannot grow on a long-lived loop.
+    """
+    loop = asyncio.get_running_loop()
+    assert not getattr(loop, BRIDGE_LOOP_ATTR, False)
+
+    async def _drain():
+        pass  # pragma: no cover — must never be registered/invoked
+
+    register_pool_drain_on_current_loop(_drain)
+
+    assert id(loop) not in _registry
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_register_and_drain_invokes_and_pops_when_marked():
+    """A marked loop registers the drain, drain_loop_pools runs it, then pops."""
+    loop = asyncio.get_running_loop()
+    setattr(loop, BRIDGE_LOOP_ATTR, True)
+    try:
+        calls = []
+
+        async def _drain():
+            calls.append("drained")
+
+        register_pool_drain_on_current_loop(_drain)
+        assert id(loop) in _registry
+        assert len(_registry[id(loop)]) == 1
+
+        await drain_loop_pools(loop)
+
+        # Drain callable invoked exactly once...
+        assert calls == ["drained"]
+        # ...and the entry popped (so a dead id(loop) is never retained).
+        assert id(loop) not in _registry
+    finally:
+        # Leave no marker/entry behind for sibling tests sharing this loop.
+        _registry.pop(id(loop), None)
+        delattr(loop, BRIDGE_LOOP_ATTR)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_drain_never_raises_when_a_drain_callable_raises():
+    """Best-effort teardown: a raising drain is logged at DEBUG, never propagated.
+
+    A raise out of drain_loop_pools would crash the bridge worker in its
+    finally block. All registered drains must be attempted even if one raises.
+    """
+    loop = asyncio.get_running_loop()
+    setattr(loop, BRIDGE_LOOP_ATTR, True)
+    try:
+        calls = []
+
+        async def _boom():
+            calls.append("boom")
+            raise RuntimeError("pool close failed")
+
+        async def _ok():
+            calls.append("ok")
+
+        register_pool_drain_on_current_loop(_boom)
+        register_pool_drain_on_current_loop(_ok)
+
+        # Must NOT raise despite _boom raising.
+        await drain_loop_pools(loop)
+
+        # Both drains attempted (the raise did not abort the loop over drains).
+        assert calls == ["boom", "ok"]
+        assert id(loop) not in _registry
+    finally:
+        _registry.pop(id(loop), None)
+        delattr(loop, BRIDGE_LOOP_ATTR)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_drain_bounds_a_slow_callable_by_timeout():
+    """A drain that hangs > _DRAIN_TIMEOUT_SECONDS is bounded, not awaited forever.
+
+    #1572 redteam Round 1: an unbounded drain of a hung disconnect() would be a
+    NEW hang surface (pre-fix bare asyncio.run never awaited pool close). The
+    drain MUST return in ~timeout, MUST NOT raise, and MUST still run siblings.
+    """
+    loop = asyncio.get_running_loop()
+    setattr(loop, BRIDGE_LOOP_ATTR, True)
+    try:
+        calls = []
+
+        async def _hangs():
+            calls.append("hang_started")
+            # Sleep well past the drain bound; wait_for must cancel this.
+            await asyncio.sleep(_DRAIN_TIMEOUT_SECONDS + 30)
+            calls.append("hang_finished")  # pragma: no cover — cancelled first
+
+        async def _ok():
+            calls.append("ok")
+
+        register_pool_drain_on_current_loop(_hangs)
+        register_pool_drain_on_current_loop(_ok)
+
+        # Patch the module constant to a tiny bound so the test is fast, then
+        # assert the drain returns within a small multiple of it.
+        import kailash.utils.loop_pool_registry as registry_mod
+
+        original = registry_mod._DRAIN_TIMEOUT_SECONDS
+        registry_mod._DRAIN_TIMEOUT_SECONDS = 0.05
+        try:
+            started = time.monotonic()
+            await drain_loop_pools(loop)  # must NOT hang, must NOT raise
+            elapsed = time.monotonic() - started
+        finally:
+            registry_mod._DRAIN_TIMEOUT_SECONDS = original
+
+        # Returned in ~timeout, nowhere near the 30s sleep.
+        assert elapsed < 5.0
+        # The hung drain started but was cut off; the sibling still ran.
+        assert "hang_started" in calls
+        assert "hang_finished" not in calls
+        assert "ok" in calls
+        assert id(loop) not in _registry
+    finally:
+        _registry.pop(id(loop), None)
+        delattr(loop, BRIDGE_LOOP_ATTR)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_drain_unknown_loop_is_noop():
+    """drain_loop_pools on a loop with no registrations returns cleanly."""
+    loop = asyncio.get_running_loop()
+    # No marker, no registration.
+    await drain_loop_pools(loop)  # must not raise
+    assert id(loop) not in _registry
+
+
+@pytest.mark.regression
+def test_register_without_running_loop_is_silent_noop():
+    """No running loop -> silent no-op (nothing to bind a drain against)."""
+
+    async def _drain():
+        pass  # pragma: no cover
+
+    # Called from sync context: asyncio.get_running_loop() raises RuntimeError,
+    # which the helper swallows silently.
+    register_pool_drain_on_current_loop(_drain)  # must not raise

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -53,6 +53,7 @@ from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.nodes.data.exceptions import PoolExhaustedError
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
+from kailash.utils.loop_pool_registry import register_pool_drain_on_current_loop
 from kailash.utils.url_credentials import redact_pool_key
 
 logger = logging.getLogger(__name__)
@@ -1163,11 +1164,18 @@ class PostgreSQLAdapter(DatabaseAdapter):
             max_inactive_connection_lifetime=300.0,
             init=_init_connection,
         )
+        # Issue #1572: if this pool was created on a transient bridge loop,
+        # register ``disconnect`` so the bridge drains it before closing the
+        # loop (no-op on a persistent app loop — the marker gates it).
+        register_pool_drain_on_current_loop(self.disconnect)
 
     async def disconnect(self) -> None:
-        """Close connection pool."""
+        """Close connection pool (idempotent)."""
         if self._pool:
             await self._pool.close()
+            # Null the pool so a later cleanup()/bridge-drain double-close is a
+            # guarded no-op (issue #1572).
+            self._pool = None
 
     async def execute(
         self,
@@ -1550,12 +1558,19 @@ class MySQLAdapter(DatabaseAdapter):
             autocommit=False,
             connect_timeout=10,
         )
+        # Issue #1572: if this pool was created on a transient bridge loop,
+        # register ``disconnect`` so the bridge drains it before closing the
+        # loop (no-op on a persistent app loop — the marker gates it).
+        register_pool_drain_on_current_loop(self.disconnect)
 
     async def disconnect(self) -> None:
-        """Close connection pool."""
+        """Close connection pool (idempotent)."""
         if self._pool:
             self._pool.close()
             await self._pool.wait_closed()
+            # Null the pool so a later cleanup()/bridge-drain double-close is a
+            # guarded no-op (issue #1572).
+            self._pool = None
 
     async def execute(
         self,

--- a/src/kailash/utils/loop_pool_registry.py
+++ b/src/kailash/utils/loop_pool_registry.py
@@ -1,0 +1,162 @@
+"""Per-loop connection-pool drain registry (issue #1572).
+
+DataFlow's sync->async bridge (``dataflow.core.async_utils`` — the
+``async_safe_run`` / ``_run_in_thread_pool`` path) runs coroutines on a
+*transient* event loop that it creates, runs to completion, and closes.
+When a coroutine run on such a loop creates an aiomysql / asyncpg
+connection pool (a reachability probe in ``MySQLAdapter`` /
+``PostgreSQLAdapter``, or the ``EnterpriseConnectionPool`` min-size
+connections), the pool's transports are bound to that transient loop.
+Once the loop is closed the transports belong to a dead loop and can
+never be drained — surfacing at GC time as ``RuntimeError: Event loop
+is closed`` and ``ResourceWarning: Unclosed connection`` from
+``aiomysql``/``asyncpg`` finalizers, long after ``db.close_async()``
+has (correctly) done everything it can.
+
+This module lets the bridge drain those pools *while the transient loop
+is still alive*. Pool-creation sites call
+:func:`register_pool_drain_on_current_loop` with their pool's async
+close method; the bridge calls :func:`drain_loop_pools` inside its
+``finally`` block BEFORE cancelling tasks and closing the loop.
+
+Design notes:
+
+* Core kailash owns the marker attribute name
+  (:data:`BRIDGE_LOOP_ATTR`) and the registry because ``dataflow`` ->
+  ``kailash`` is the only legal import direction. A dataflow adapter
+  pool registers DIRECTLY (its ``create_connection_pool`` calls
+  :func:`register_pool_drain_on_current_loop`); a core
+  :class:`EnterpriseConnectionPool` pool is covered TRANSITIVELY —
+  ``EnterpriseConnectionPool.initialize()`` calls its inner
+  ``PostgreSQLAdapter`` / ``MySQLAdapter`` ``connect()``, which is the
+  registered site. Both therefore flow through this single registry.
+* Registration is gated on the marker so pools created on a persistent
+  application loop (FastAPI, Jupyter, a user's own ``asyncio.run``) are
+  NEVER registered — the registry only ever holds entries for loops the
+  bridge itself created and will drain-then-close. This prevents
+  unbounded accumulation / a memory leak on long-lived app loops.
+* The drain path is strictly best-effort: teardown must never raise.
+"""
+
+import asyncio
+import logging
+import threading
+from typing import Awaitable, Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Marker attribute stamped by the bridge onto every transient loop it
+# creates. Core OWNS this name so dataflow + core agree on the single
+# discriminator that says "this loop is bridge-transient; drain its
+# pools before close". ``getattr(loop, BRIDGE_LOOP_ATTR, False)``.
+BRIDGE_LOOP_ATTR = "_kailash_transient_bridge_loop"
+
+# Per-drain wall-clock bound. A hung/slow adapter ``disconnect()`` must NOT
+# block the bridge forever — the pre-fix bare ``asyncio.run`` never awaited a
+# pool close, so an unbounded drain would be a NEW hang surface. 5.0s matches
+# the pool-lock timeout used by ``async_sql`` (#1572 redteam Round 1).
+_DRAIN_TIMEOUT_SECONDS = 5.0
+
+# id(loop) -> list of zero-arg async drain callables (bound pool-close
+# methods). Keyed by id() because event loops are not hashable-by-value
+# and we only ever look them up while the loop object is alive.
+_registry: Dict[int, List[Callable[[], Awaitable[None]]]] = {}
+_registry_lock = threading.Lock()
+
+
+def register_pool_drain_on_current_loop(
+    drain: Callable[[], Awaitable[None]],
+) -> None:
+    """Register ``drain`` to run when the CURRENT loop is torn down.
+
+    Resolves the running loop; if there is no running loop this is a
+    silent no-op (nothing to drain against). Registers ``drain`` ONLY
+    when the running loop carries the :data:`BRIDGE_LOOP_ATTR` marker —
+    i.e. it is a transient loop the bridge created and will drain via
+    :func:`drain_loop_pools` before closing. Pools created on a
+    persistent app loop are intentionally never registered, so the
+    registry cannot accumulate entries on a long-lived loop.
+
+    Args:
+        drain: A zero-arg coroutine function that closes the pool (e.g.
+            an adapter's bound ``disconnect`` / ``close_connection_pool``
+            method). MUST be idempotent — it may be invoked once here and
+            again by a later ``cleanup()``/``close_async()``.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — nothing to bind a drain against.
+        return
+
+    if not getattr(loop, BRIDGE_LOOP_ATTR, False):
+        # Persistent app loop (FastAPI / Jupyter / user asyncio.run):
+        # the caller owns teardown; never register (would leak entries).
+        return
+
+    with _registry_lock:
+        _registry.setdefault(id(loop), []).append(drain)
+
+
+async def drain_loop_pools(loop: asyncio.AbstractEventLoop) -> None:
+    """Drain every pool registered against ``loop`` (best-effort).
+
+    Pops the drain list for ``id(loop)`` under the lock, then awaits
+    each drain callable. This runs inside the bridge's ``finally``
+    block BEFORE task cancellation and loop close, so connections close
+    gracefully while the loop is still alive.
+
+    Best-effort by contract: each ``await drain()`` is bounded by
+    :data:`_DRAIN_TIMEOUT_SECONDS` and guarded; on timeout or failure it
+    logs at DEBUG and continues. This function NEVER raises — it is
+    teardown, and a raise here would crash the bridge worker.
+
+    Security: logs ONLY ``id(loop)`` and counts — never a pool key,
+    DSN, connection string, or exception-embedded text (they may carry
+    credentials, per ``rules/security.md`` § "No secrets in logs").
+    """
+    with _registry_lock:
+        drains = _registry.pop(id(loop), None)
+
+    if not drains:
+        return
+
+    logger.debug(
+        "loop_pool_registry.drain.start",
+        extra={"loop_id": id(loop), "pool_count": len(drains)},
+    )
+
+    drained = 0
+    for drain in drains:
+        try:
+            # Bound each drain so a hung disconnect() can't block the bridge.
+            await asyncio.wait_for(drain(), timeout=_DRAIN_TIMEOUT_SECONDS)
+            drained += 1
+        except asyncio.TimeoutError:
+            # Drain exceeded the bound — abandon it and move on; teardown
+            # must not hang. Log id(loop) only (no key/DSN).
+            logger.debug(
+                "loop_pool_registry.drain.timeout",
+                extra={"loop_id": id(loop)},
+            )
+        except Exception as exc:  # noqa: BLE001 — teardown must not raise
+            # Guarded per rules/zero-tolerance.md Rule 3 (acceptable
+            # teardown except -> logger.debug, never a bare pass). Log the
+            # exception TYPE only — never str(exc), which could embed a
+            # credential-bearing DSN (rules/security.md, observability 6.3).
+            logger.debug(
+                "loop_pool_registry.drain.error",
+                extra={"loop_id": id(loop), "error_type": type(exc).__name__},
+            )
+
+    logger.debug(
+        "loop_pool_registry.drain.done",
+        extra={"loop_id": id(loop), "drained": drained, "pool_count": len(drains)},
+    )
+
+
+__all__ = [
+    "BRIDGE_LOOP_ATTR",
+    "register_pool_drain_on_current_loop",
+    "drain_loop_pools",
+]


### PR DESCRIPTION
## Summary

DataFlow's sync→async bridge (`async_safe_run` / `_run_in_thread_pool`) runs coroutines on a **transient** event loop it creates, runs, and closes. aiomysql/asyncpg pools created on that loop (an adapter reachability probe + `EnterpriseConnectionPool` min-size connections) were never drained before the loop closed, so their transports were left bound to a dead loop and surfaced ~10 GC-time `RuntimeError: Event loop is closed` + `ResourceWarning: Unclosed connection` from `Connection.__del__` **after** `await db.close_async()`. `close_async()`/`cleanup()` cannot fix it — once the loop closes the transports belong to a dead loop.

## Fix

- **`kailash.utils.loop_pool_registry`** (new, core kailash): a per-loop drain registry gated on a transient-bridge-loop marker. Adapters register their pool-close method at pool creation; the bridge drains registered pools **before** closing the loop.
- Drain is **bounded (5s/pool), best-effort, never raises** — a hung `disconnect()` cannot block the bridge.
- **Marker-gated**: persistent app loops (FastAPI/Jupyter) lack the marker and are never registered → a live app pool is never drained.
- Applied to **both** bridge branches (thread-pool + no-running-loop), same bug class.
- Registry lives in **core kailash** so both a DataFlow adapter pool and a core `EnterpriseConnectionPool` pool (covered **transitively** via its inner adapter's `connect()`) register through one path.
- Credential hygiene: drain path logs only `id(loop)` + counts + `type(exc).__name__` — never a pool key/DSN.

## Testing

Tier-2 regression on **real** PostgreSQL:5434 + MySQL:3307 (no mocking):
- **Deterministic bridge-drain assertion** (`adapter._pool is None` after the bridge returns) — **FAILS pre-fix** (reproduces the exact `Connection.__del__` `RuntimeError`), **passes post-fix**. Verified via stash-flip.
- Express-lifecycle GC-capture + 6 registry unit tests (incl. timeout-bound + never-raises). **10/10 green.** No regression across the existing async-bridge suite (66 tests) or core adapters (5 tests); `--collect-only` clean (6660 collected).

## Redteam

3 rounds (parallel reviewer + security-reviewer + adversarial correctness). Bounded the drain timeout (R1 MED). Converged.

## Known follow-up (out of this shard's scope)

Sibling **non-bridge** transient loops (schema discovery via `asyncio.run`; owned per-instance `self._loop` in engine/model_registry/express/transactions) are a pre-existing, heterogeneous same-class gap — they don't route through the bridge and need per-site transient-vs-owned lifecycle analysis. Tracked separately (see follow-up issue). The Rust SDK bridge should be inspected for the equivalent transient-loop pool-leak class (cross-SDK).

## Related issues

Fixes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)