### PR TITLE
chore(release): kailash 2.45.4 + kailash-dataflow 2.13.19 (#1572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.45.4] - 2026-07-05
+
+### Added
+
+- **`kailash.utils.loop_pool_registry`** — a per-loop connection-pool drain registry for DataFlow's sync→async bridge (#1572). Adapter pools (aiomysql/asyncpg) created on a transient bridge loop (`async_safe_run` / `_run_in_thread_pool`) previously had their transports bound to that loop with no way to drain them before the loop closed — `close_async()` could not help because once the loop is closed the transports belong to a dead loop. Pool-creation sites now call `register_pool_drain_on_current_loop(drain)`, gated on a `BRIDGE_LOOP_ATTR` marker the bridge stamps onto loops it creates; persistent application loops (FastAPI, Jupyter) never carry the marker and are never registered, so a live app pool is never touched. The bridge calls `drain_loop_pools(loop)` in its `finally` block, before task cancellation and loop close, bounding each drain to 5s and never raising. Core owns the registry (not DataFlow) because `dataflow -> kailash` is the only legal import direction, so both a DataFlow adapter pool and a core `EnterpriseConnectionPool` pool (covered transitively via its inner adapter's `connect()`) register through the same path.
+
+### Fixed
+
+- **`AsyncSQL` PostgreSQL/MySQL adapter `connect()` now registers its pool for bridge-loop drain, and `disconnect()` is idempotent (#1572).** `PostgreSQLAdapter.connect()` / `MySQLAdapter.connect()` call `register_pool_drain_on_current_loop(self.disconnect)` immediately after pool creation (a no-op off the transient bridge loop); `disconnect()` now nulls `self._pool` after closing so a later `cleanup()` / bridge-drain double-close is a guarded no-op instead of a double-close error. This closes the core half of the ~10 GC-time `RuntimeError: Event loop is closed` / `ResourceWarning: Unclosed connection` reports that surfaced after `await db.close_async()` on DataFlow's bridge; see kailash-dataflow 2.13.19 for the bridge-side half (`dataflow.core.async_utils`).
+
 ## [2.45.3] - 2026-07-03
 
 ### Fixed

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.13.19] — 2026-07-05 — Sync→async bridge drains adapter pools before closing its transient loop (#1572)
+
+### Fixed
+
+- **The sync→async bridge (`async_utils`) no longer leaves MySQL/PostgreSQL adapter pools bound to a dead event loop after `await db.close_async()` (#1572).** `async_safe_run` / `_run_in_thread_pool` run coroutines on a _transient_ loop that is created, run to completion, and closed; a pool created during that run (an adapter reachability probe, or `EnterpriseConnectionPool` min-size connections) had its aiomysql/asyncpg transports bound to that loop, and once the loop closed the transports could never be drained — surfacing as ~10 GC-time `RuntimeError: Event loop is closed` / `ResourceWarning: Unclosed connection` from `Connection.__del__`, well after `close_async()` had done everything it could. Both bridge branches (thread-pool worker and the no-running-loop path) now route through a single `_run_on_new_loop` helper that stamps each transient loop with a marker and drains every pool registered against it — bounded to 5s per pool, best-effort, never raising — BEFORE cancelling tasks and closing the loop. Persistent application loops (FastAPI, Jupyter) are never marked and therefore never drained, so a live app pool is untouched. The registry lives in core `kailash` (`kailash.utils.loop_pool_registry`, kailash 2.45.4) because `dataflow -> kailash` is the only legal import direction; DataFlow's `PostgreSQLAdapter`/`MySQLAdapter` register their pool's `disconnect` at pool-creation time. **Floor bumped to `kailash>=2.45.4`** — this release will not import against an older core.
+- **Follow-up tracked separately (#1575):** sibling non-bridge transient loops (schema discovery, and the owned per-instance loops in `engine`/`model_registry`/`express`/`transactions`) are a pre-existing, heterogeneous same-class gap outside this fix's shard budget.
+
+### Tests
+
+- **#1572:** Tier-2 regression against real PostgreSQL (5434) and MySQL (3307) — a deterministic bridge-drain assertion (`adapter._pool is None` after the bridge returns) that fails pre-fix (reproducing the exact `Connection.__del__` `RuntimeError`) and passes post-fix, plus an Express-lifecycle GC-capture test and 6 registry unit tests. 10/10 green.
+
 ## [2.13.18] — 2026-07-05 — Driver-error redaction broadened to value-bearing non-dup-key errors (#1569) & `__tablename__`-aware index/FK DDL (#1541)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.18"
+version = "2.13.19"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.45.3",
+    "kailash>=2.45.4",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.18"
+__version__ = "2.13.19"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.3"
+version = "2.45.4"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.3"
+__version__ = "2.45.4"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep for the already-merged #1572 fix (PR #1574, "drain bridge-loop adapter pools before loop close"). Core ships first because the fix added a new core `kailash` module that DataFlow's adapters import directly — a dataflow-only release would `ImportError` on install.

| Package | Before | After |
|---|---|---|
| `kailash` (core) | 2.45.3 | **2.45.4** |
| `kailash-dataflow` | 2.13.18 | **2.13.19** (floor bumped `kailash>=2.45.3` → `kailash>=2.45.4`) |

- Core-first because dataflow imports the new `kailash.utils.loop_pool_registry` (the per-loop connection-pool drain registry) — `PostgreSQLAdapter`/`MySQLAdapter.connect()` register their pool's drain against it, and dataflow's sync→async bridge (`async_utils`) drains registered pools before closing its transient loop. Bumping dataflow's floor to `kailash>=2.45.4` prevents `pip` from resolving dataflow 2.13.19 against a core release that predates the module it imports.
- No sibling drift: kaizen/nexus have not moved since their last release; the only commit in core since 2.45.3 is the #1572 fix.
- CHANGELOG.md and `packages/kailash-dataflow/CHANGELOG.md` each gain a matching entry, cross-referencing one another and the tracked follow-up (#1575 — sibling non-bridge transient loops, out of this fix's shard budget).

## Test plan

- [x] `pre-commit run --files <edited files>` — all hooks green (black/isort/ruff/doc-style/Tier-1 unit tests), no re-formatting needed beyond markdown italics normalization already reflected in this diff
- [x] All 5 version anchors verified by direct grep post-edit (`pyproject.toml::version`, `src/kailash/__init__.py::__version__`, `packages/kailash-dataflow/pyproject.toml::version`, `packages/kailash-dataflow/src/dataflow/__init__.py::__version__`, `packages/kailash-dataflow/pyproject.toml` `kailash>=` floor)
- [ ] TestPyPI validation + production publish — **explicitly out of scope for this PR**; this is release-prep only, no tag pushed, no package published (tag-push is the OIDC publish trigger and requires separate human authorization)

## Related issues

Prepares the release of #1572 (fixed by PR #1574). Follow-up tracked separately: #1575 (sibling non-bridge transient loops).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>