### PR TITLE
fix(dataflow): drain transient/owned loop adapter pools on teardown + dataflow 2.13.20 (#1575)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [2.13.20] — 2026-07-06 — Transient/owned loops outside the bridge drain their adapter pools on teardown (#1575)
+
+### Fixed
+
+- **Non-bridge transient loops that create an adapter pool during schema discovery no longer leak it on the exception path (#1575).** `DataFlowEngine._inspect_database_schema_real` (reached from the sync `discover_schema`) opens a real asyncpg / aiosqlite adapter, walks the catalog, and closes it — but pre-fix the close sat OUTSIDE any `try/finally`, so a mid-discovery exception jumped over it and stranded the connection on a loop that then closed, surfacing as GC-time `RuntimeError: Event loop is closed` / `ResourceWarning: Unclosed connection`. Both the PostgreSQL and the SQLite inspection branches now drain the adapter in a guarded `finally` on every exit path (idempotent; logs the exception type only, never a DSN). The transient loop-creating sites (`discover_schema`, `validate_schema`, the `current_schema` fallback, and the model-registry workflow bridge) are additionally routed through `async_safe_run`, which stamps each transient loop with the `BRIDGE_LOOP_ATTR` marker so any pool created on it is drained by the #1572 registry before the loop closes (defense-in-depth atop the inspector's own `try/finally`).
+- **`SyncExpress` (`db.express_sync`) now closes its persistent owned event loop and drains its loop-bound connections on owner teardown (#1575).** The sync Express surface runs all operations on a persistent background-thread loop, so aiosqlite/asyncpg connections bind to that loop and survive across calls. Pre-fix nothing tore that loop down — every `DataFlow` instance that used `db.express_sync` leaked a daemon thread + event loop + its bound connections, and at interpreter shutdown the daemon thread was killed with connections still bound (the same `Unclosed connection` class). `DataFlow.close()` / `close_async()` now drive a new `SyncExpress.close()` that drains the loop-bound adapters ON the owning loop (while it is alive) and then stops, joins (bounded 5s), and closes it; a `__del__` emits a `ResourceWarning` if the caller never closed the `DataFlow` (mirrors the existing `SyncTransactionManager` teardown). The other owned per-instance loop (`SyncTransactionManager`) was already correct — its per-transaction connections close in a `finally` before the loop closes, so no pool outlives the drain.
+- **`SyncExpress` dispatch is hardened against concurrent / after-close use.** `_run_sync` now raises a typed "SyncExpress is closed" error (instead of an opaque `AttributeError`) when called after `db.close()`, and a call in flight when `close()` runs settles with `CancelledError` in bounded time rather than blocking the caller thread forever on `future.result()`; the submit-vs-close window is serialized under the existing pending-futures lock (real work is never serialized — `future.result()` stays outside the lock).
+
+### Tests
+
+- **#1575:** Tier-2 regression against real PostgreSQL (5434), MySQL (3307), and file-backed SQLite — deterministic exception-path drain assertions for the PG + SQLite inspect branches (fail pre-fix, pass post-fix), a `SyncExpress` owned-loop lifecycle GC-capture on both PG and MySQL (thread joined, no `Unclosed connection` / `Event loop is closed`), a model-registry bridge-reroute invariant, the after-close typed-error + concurrent-close no-strand hardening tests, and an idempotent-close test. 11/11 green; suite runs clean under `-W error::ResourceWarning`.
+
 ## [2.13.19] — 2026-07-05 — Sync→async bridge drains adapter pools before closing its transient loop (#1572)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.19"
+version = "2.13.20"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.19"
+__version__ = "2.13.20"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -4494,11 +4494,15 @@ class DataFlow(DataFlowEventMixin):
             Dictionary containing PostgreSQL schema information
         """
 
-        try:
-            # Get PostgreSQL adapter for real introspection
-            from ..adapters.postgresql import PostgreSQLAdapter
+        # Issue #1575: create the adapter BEFORE the try so the ``finally``
+        # can always close its pool — including on a mid-discovery exception,
+        # where the asyncpg pool would otherwise leak (bound to a possibly
+        # transient loop that then closes -> "Event loop is closed" +
+        # "Unclosed connection" at GC, the #1572 leak class).
+        from ..adapters.postgresql import PostgreSQLAdapter
 
-            adapter = PostgreSQLAdapter(database_url)
+        adapter = PostgreSQLAdapter(database_url)
+        try:
             await adapter.create_connection_pool()
 
             schema = {}
@@ -4627,8 +4631,6 @@ class DataFlow(DataFlowEventMixin):
                     "indexes": indexes,
                 }
 
-            await adapter.close_connection_pool()
-
             # Add reverse has_many relationships
             self._add_reverse_relationships_real(schema)
 
@@ -4642,6 +4644,20 @@ class DataFlow(DataFlowEventMixin):
                 "engine.postgresql_schema_discovery_failed", extra={"error": str(e)}
             )
             raise
+        finally:
+            # Issue #1575: drain the adapter pool on EVERY exit path (success AND
+            # mid-discovery exception). Idempotent (close_connection_pool guards
+            # on self.connection_pool) and guarded so a close failure never masks
+            # the original error nor leaks a credential-bearing string — log the
+            # exception TYPE only (rules/observability.md 6.3 + the
+            # loop_pool_registry teardown discipline).
+            try:
+                await adapter.close_connection_pool()
+            except Exception as close_exc:  # noqa: BLE001 — teardown must not raise
+                logger.debug(
+                    "engine.postgresql_schema_discovery.pool_close_failed",
+                    extra={"error_type": type(close_exc).__name__},
+                )
 
     async def _inspect_sqlite_schema_real(self, database_url: str) -> Dict[str, Any]:
         """Inspect SQLite database schema using sqlite_master table.
@@ -4669,11 +4685,13 @@ class DataFlow(DataFlowEventMixin):
                 )
                 raise enhanced
 
-        try:
-            # Get SQLite adapter for real introspection
-            from ..adapters.sqlite import SQLiteAdapter
+        # Issue #1575: create the adapter BEFORE the try so the ``finally`` can
+        # always disconnect it — including on a mid-discovery exception, where
+        # the connection would otherwise leak on a possibly-transient loop.
+        from ..adapters.sqlite import SQLiteAdapter
 
-            adapter = SQLiteAdapter(database_url)
+        adapter = SQLiteAdapter(database_url)
+        try:
             await adapter.connect()
 
             schema = {}
@@ -4774,8 +4792,6 @@ class DataFlow(DataFlowEventMixin):
                     "indexes": indexes,
                 }
 
-            await adapter.disconnect()
-
             # Add reverse has_many relationships
             self._add_reverse_relationships_real(schema)
 
@@ -4789,6 +4805,17 @@ class DataFlow(DataFlowEventMixin):
                 "engine.sqlite_schema_discovery_failed", extra={"error": str(e)}
             )
             raise
+        finally:
+            # Issue #1575: disconnect on EVERY exit path. Guarded so a close
+            # failure never masks the original error; log the exception TYPE
+            # only (rules/observability.md 6.3).
+            try:
+                await adapter.disconnect()
+            except Exception as close_exc:  # noqa: BLE001 — teardown must not raise
+                logger.debug(
+                    "engine.sqlite_schema_discovery.pool_close_failed",
+                    extra={"error_type": type(close_exc).__name__},
+                )
 
     def _normalize_sqlite_type(self, sqlite_type: str) -> str:
         """Normalize SQLite data types to standard types."""
@@ -4915,8 +4942,12 @@ class DataFlow(DataFlowEventMixin):
                             "This prevents deadlocks with session-scoped pytest event loops. "
                             "See: DATAFLOW-SESSION-LOOP-DEADLOCK-001"
                         )
-                    # Loop reported as not running — safe to use asyncio.run()
-                    discovered_schema = asyncio.run(
+                    # Loop reported as not running — bridge via async_safe_run
+                    # (issue #1575): it runs the coroutine on a transient loop
+                    # stamped with BRIDGE_LOOP_ATTR, so an adapter pool created
+                    # during inspection is drained before the loop closes
+                    # (defense-in-depth atop the inspector's own try/finally).
+                    discovered_schema = async_safe_run(
                         self._inspect_database_schema_real()
                     )
                 except RuntimeError as e:
@@ -4924,8 +4955,8 @@ class DataFlow(DataFlowEventMixin):
                         # Re-raise our own error
                         raise
                     # asyncio.get_running_loop() raised → no event loop running
-                    logger.debug("No existing event loop, using asyncio.run()")
-                    discovered_schema = asyncio.run(
+                    logger.debug("No existing event loop, using async_safe_run()")
+                    discovered_schema = async_safe_run(
                         self._inspect_database_schema_real()
                     )
 
@@ -6872,20 +6903,18 @@ class DataFlow(DataFlowEventMixin):
                     f"Existing schema mode enabled. Validating compatibility for '{model_name}'..."
                 )
 
-                import asyncio
-
                 async def validate_schema():
                     return await self._validate_existing_schema_compatibility(
                         model_name, target_schema
                     )
 
-                try:
-                    loop = asyncio.get_event_loop()
-                    is_compatible = loop.run_until_complete(validate_schema())
-                except RuntimeError:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                    is_compatible = loop.run_until_complete(validate_schema())
+                # Issue #1575: route through async_safe_run — the canonical
+                # sync->async bridge. It stamps the transient loop with
+                # BRIDGE_LOOP_ATTR (so any pool created during validation drains
+                # before close) AND closes the loop deterministically. The prior
+                # ``new_event_loop()`` fallback never closed its loop, leaking a
+                # loop resource on every existing-schema-mode validation.
+                is_compatible = async_safe_run(validate_schema())
 
                 if not is_compatible:
                     # Enhanced error with catalog-based solutions (DF-501)
@@ -7021,22 +7050,14 @@ class DataFlow(DataFlowEventMixin):
                     self._migration_system, "inspector"
                 ):
                     try:
-                        # Use asyncio to get current schema
-                        import asyncio
-
-                        try:
-                            loop = asyncio.get_event_loop()
-                            current_schema = loop.run_until_complete(
-                                self._migration_system.inspector.get_current_schema()
-                            )
-                        except RuntimeError:
-                            # Create new event loop if none exists
-                            loop = asyncio.new_event_loop()
-                            asyncio.set_event_loop(loop)
-                            current_schema = loop.run_until_complete(
-                                self._migration_system.inspector.get_current_schema()
-                            )
-                            loop.close()
+                        # Issue #1575: route through async_safe_run — stamps the
+                        # transient loop with BRIDGE_LOOP_ATTR (so any pool the
+                        # inspector opens drains before close) and guarantees the
+                        # loop is closed. The prior ``get_event_loop()`` branch
+                        # never closed its loop.
+                        current_schema = async_safe_run(
+                            self._migration_system.inspector.get_current_schema()
+                        )
 
                         logger.debug(
                             f"Existing schema mode: preserving {len(current_schema)} existing tables (via fallback)"

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10530,7 +10530,7 @@ class DataFlow(DataFlowEventMixin):
             except Exception as e:
                 logger.debug(
                     "engine.error_closing_express_sync",
-                    extra={"error": str(e)},
+                    extra={"error_type": type(e).__name__},
                 )
             finally:
                 self._express_sync = None
@@ -10720,7 +10720,7 @@ class DataFlow(DataFlowEventMixin):
             except Exception as e:
                 logger.debug(
                     "engine.error_closing_express_sync",
-                    extra={"error": str(e)},
+                    extra={"error_type": type(e).__name__},
                 )
             finally:
                 self._express_sync = None

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10517,6 +10517,24 @@ class DataFlow(DataFlowEventMixin):
             finally:
                 self._transactions_sync = None
 
+        # Issue #1575 — stop the SyncExpress BG event-loop thread BEFORE the
+        # pool/adapter teardown below. SyncExpress owns a persistent daemon-loop
+        # and the Express CRUD nodes it caches are bound to THAT loop; its
+        # close() drains those nodes ON the owning loop first, so the
+        # _async_sql_node_cache teardown (which runs on a transient loop via
+        # async_safe_run) cannot strand a connection on a dead loop. Lazy
+        # attribute — only present if a caller accessed `db.express_sync`.
+        if hasattr(self, "_express_sync") and self._express_sync is not None:
+            try:
+                self._express_sync.close()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_express_sync",
+                    extra={"error": str(e)},
+                )
+            finally:
+                self._express_sync = None
+
         # Stop pool monitor
         if self._pool_monitor is not None:
             try:
@@ -10690,6 +10708,22 @@ class DataFlow(DataFlowEventMixin):
                 )
             finally:
                 self._transactions_sync = None
+
+        # Issue #1575 — stop the SyncExpress BG event-loop thread BEFORE the
+        # pool/adapter teardown. close() runs its drain on the SyncExpress
+        # OWNING loop (a different thread), so blocking here briefly on its
+        # bounded join does not touch this coroutine's loop. Lazy attribute —
+        # only present if a caller accessed `db.express_sync`.
+        if hasattr(self, "_express_sync") and self._express_sync is not None:
+            try:
+                self._express_sync.close()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_express_sync",
+                    extra={"error": str(e)},
+                )
+            finally:
+                self._express_sync = None
 
         # Stop pool monitor (same cleanup as sync close())
         if self._pool_monitor is not None:

--- a/packages/kailash-dataflow/src/dataflow/core/model_registry.py
+++ b/packages/kailash-dataflow/src/dataflow/core/model_registry.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional, Tuple
 
+from .async_utils import async_safe_run
 from .type_introspection import union_non_none_args
 
 try:
@@ -317,8 +318,12 @@ class ModelRegistry:
             in_event_loop = False
 
         if not in_event_loop:
-            # Safe to run the async variant directly.
-            result = asyncio.run(runtime.execute_workflow_async(built, inputs={}))
+            # Issue #1575: async_safe_run runs the coroutine on a transient loop
+            # stamped with BRIDGE_LOOP_ATTR, so any adapter / EnterpriseConnectionPool
+            # the DDL workflow opens on that loop is drained before it closes.
+            # Bare asyncio.run left those pools bound to a dead loop ->
+            # "Event loop is closed" + "Unclosed connection" at GC (#1572 class).
+            result = async_safe_run(runtime.execute_workflow_async(built, inputs={}))
             return _normalize_runtime_result(result)
 
         # We're inside an event loop; can't call asyncio.run.
@@ -326,21 +331,13 @@ class ModelRegistry:
         # runtime captured above — NOT self.runtime, which would re-resolve to
         # the sync singleton in the worker thread's loop-less context (#1498).
         def _run_in_thread() -> Any:
-            new_loop = asyncio.new_event_loop()
-            try:
-                asyncio.set_event_loop(new_loop)
-                return new_loop.run_until_complete(
-                    runtime.execute_workflow_async(built, inputs={})
-                )
-            finally:
-                try:
-                    new_loop.close()
-                except Exception:  # pragma: no cover — shutdown hygiene
-                    logger.debug(
-                        "model_registry.workflow_bridge.loop_close_failed",
-                        exc_info=True,
-                    )
-                asyncio.set_event_loop(None)
+            # Issue #1575: the worker thread owns no running loop, so
+            # async_safe_run routes through _run_on_new_loop — it stamps
+            # BRIDGE_LOOP_ATTR, drains any pool the DDL workflow opens on the
+            # transient loop, then closes it with asyncio.run() semantics. The
+            # runtime was resolved in the caller frame (issue #1498) and is
+            # closed over here, so no sync-singleton re-resolution occurs.
+            return async_safe_run(runtime.execute_workflow_async(built, inputs={}))
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=1,

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -50,6 +50,7 @@ import logging
 import os
 import threading
 import time
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from dataflow.cache.auto_detection import CacheBackend
@@ -2093,6 +2094,12 @@ class SyncExpress:
         self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
         self._thread.start()
 
+        # Issue #1575 — explicit close path (mirrors SyncTransactionManager).
+        # `_closed` lets `__del__` distinguish "user forgot to close"
+        # (ResourceWarning) from "user closed correctly" (silent), and makes
+        # `close()` idempotent.
+        self._closed = False
+
     def _run_sync(self, coro):
         """Run an async coroutine synchronously on the persistent event loop.
 
@@ -2103,6 +2110,155 @@ class SyncExpress:
         """
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         return future.result()
+
+    # --- Lifecycle (issue #1575) ---
+
+    async def _drain_loop_resources(self) -> None:
+        """Disconnect express-loop-bound resources — runs ON the BG loop.
+
+        Submitted via ``run_coroutine_threadsafe`` by :meth:`close`, so every
+        ``await`` here closes a resource bound to THIS persistent loop while it
+        is still alive. The Express CRUD path caches ``AsyncSQLDatabaseNode``
+        instances keyed by ``(node, loop_id)`` on the OWNING DataFlow; the node
+        created for an Express call made through this sync surface is bound to
+        this background loop. ``DataFlow.close()`` otherwise drains that cache
+        via ``async_safe_run`` on a DIFFERENT (transient) loop, which cannot
+        close a pool bound to this one — leaking the connection to GC
+        (``RuntimeError: Event loop is closed`` / ``ResourceWarning: Unclosed
+        connection``). Draining here, on the owning loop, is the fix.
+
+        Best-effort by contract: guarded per resource, never raises, logs the
+        exception TYPE only — never ``str(exc)`` / a DSN / a pool key
+        (``rules/observability.md`` 6.3 + the loop_pool_registry discipline).
+        """
+        try:
+            loop_id = id(asyncio.get_running_loop())
+        except RuntimeError:  # pragma: no cover — always running here
+            return
+
+        # (1) Disconnect cached AsyncSQLDatabaseNode adapters bound to THIS loop,
+        #     then drop them from the owning cache so DataFlow.close() does not
+        #     re-await them on a transient loop. Nodes bound to a DIFFERENT loop
+        #     (or created loop-less, loop_id=None) that are NOT ours are left in
+        #     place for the owner to drain.
+        db = getattr(self._express, "_db", None)
+        node_cache = getattr(db, "_async_sql_node_cache", None)
+        if isinstance(node_cache, dict):
+            for db_type, entry in list(node_cache.items()):
+                try:
+                    node, cached_loop_id = entry
+                except (TypeError, ValueError):
+                    continue
+                if cached_loop_id is not None and cached_loop_id != loop_id:
+                    continue  # bound to another loop; not this surface's to drain
+                teardown = getattr(node, "cleanup", None) or getattr(
+                    node, "close", None
+                )
+                if callable(teardown):
+                    try:
+                        await teardown()
+                    except Exception as exc:  # noqa: BLE001 — teardown must not raise
+                        logger.debug(
+                            "express.sync.node_drain_failed",
+                            extra={"error_type": type(exc).__name__},
+                        )
+                node_cache.pop(db_type, None)
+
+        # (2) Close the Express cache backend if it holds loop-bound resources
+        #     (AsyncRedisCacheAdapter.close_async); InMemoryCache holds none.
+        cache = getattr(self._express, "_cache_manager", None)
+        closer = getattr(cache, "close_async", None) or getattr(cache, "close", None)
+        if callable(closer):
+            try:
+                result = closer()
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:  # noqa: BLE001 — teardown must not raise
+                logger.debug(
+                    "express.sync.cache_close_failed",
+                    extra={"error_type": type(exc).__name__},
+                )
+
+    def close(self) -> None:
+        """Drain express-loop-bound pools, then stop the BG event-loop thread.
+
+        Wired into :func:`DataFlow.close` / :func:`DataFlow.close_async` so
+        ``with DataFlow(...)`` / ``async with`` callers do not need to invoke
+        this manually. Idempotent — safe to call repeatedly.
+
+        Order matters: DRAIN on the owning loop (while it is alive) BEFORE the
+        loop stops, so aiosqlite/asyncpg connections created by Express through
+        this sync surface close gracefully instead of stranding on a dead loop
+        (issue #1575). Every step is guarded and logs the exception TYPE only.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        loop = self._loop
+        thread = self._thread
+        # Drop references first so any concurrent `_run_sync` observes the
+        # closed state (its `run_coroutine_threadsafe` will raise, not hang).
+        self._loop = None
+        self._thread = None
+
+        # (a) Drain express-loop-bound resources ON the owning loop, bounded so
+        #     a hung disconnect cannot block teardown forever.
+        if loop is not None and loop.is_running():
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._drain_loop_resources(), loop
+                )
+                future.result(timeout=5.0)
+            except Exception as exc:  # noqa: BLE001 — teardown must not raise
+                logger.debug(
+                    "express.sync.drain_failed",
+                    extra={"error_type": type(exc).__name__},
+                )
+
+        # (b) Stop the loop, (c) join the BG thread (bounded), (d) close the loop.
+        if loop is not None and loop.is_running():
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except RuntimeError:
+                # Loop already stopped/destroyed — the closed flag prevents reuse.
+                pass
+
+        if thread is not None and thread.is_alive():
+            # Bounded join — the loop stops near-instantly; a 5s ceiling
+            # prevents a pathological hang from deadlocking teardown.
+            thread.join(timeout=5.0)
+
+        if loop is not None:
+            try:
+                loop.close()
+            except RuntimeError:
+                # Loop may already be closed by run_forever() shutdown —
+                # the closed flag is the source of truth.
+                pass
+
+    def __del__(self, _warnings: Any = warnings) -> None:
+        """Emit ``ResourceWarning`` if the BG thread was not stopped cleanly.
+
+        Per ``rules/patterns.md`` § Async Resource Cleanup: emit warning, do
+        nothing else. We do NOT call ``close`` here — touching the BG loop /
+        thread (or any log-emitting path) from a finalizer is the deadlock
+        pattern that rule documents. Real cleanup is the caller's via
+        ``db.close()`` / ``await db.close_async()``.
+        """
+        if not getattr(self, "_closed", True):
+            try:
+                _warnings.warn(
+                    f"{type(self).__name__} not closed; call "
+                    f"db.close()/await db.close_async() to stop the BG "
+                    f"event loop thread cleanly.",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+            except Exception:
+                # Finalizer must not raise. Hooks/cleanup carve-out per
+                # rules/zero-tolerance.md Rule 3.
+                pass
 
     def _check_append_only(self, model: str, operation: str) -> None:
         """Sync delegate to :meth:`DataFlowExpress._check_append_only`.

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -2100,6 +2100,17 @@ class SyncExpress:
         # `close()` idempotent.
         self._closed = False
 
+        # Issue #1575 (Round-3) — track in-flight futures so a concurrent
+        # `close()` can cancel them within bounded time instead of stranding the
+        # caller on a no-timeout `future.result()` when the loop stops mid-call.
+        self._pending: set = set()
+        self._pending_lock = threading.Lock()
+
+    def _discard_pending(self, future: Any) -> None:
+        """Done-callback: drop a settled future from the in-flight set."""
+        with self._pending_lock:
+            self._pending.discard(future)
+
     def _run_sync(self, coro):
         """Run an async coroutine synchronously on the persistent event loop.
 
@@ -2108,7 +2119,29 @@ class SyncExpress:
         critical for database drivers like aiosqlite that bind connections to
         the loop they were created on.
         """
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        # Issue #1575 (Round-3) — closed-guard BEFORE submit. If the owning loop
+        # was torn down (or is being torn down) by close(), the coroutine can
+        # never run. Close it (avoids the "coroutine was never awaited"
+        # RuntimeWarning) and raise a TYPED error, not the opaque
+        # `AttributeError: 'NoneType' object has no attribute
+        # 'call_soon_threadsafe'` that `run_coroutine_threadsafe(coro, None)`
+        # would raise (zero-tolerance.md Rule 3a). Mirrors SyncTransactionManager.
+        loop = self._loop
+        if self._closed or loop is None:
+            coro.close()
+            raise RuntimeError(
+                "SyncExpress is closed — the DataFlow was closed via "
+                "db.close()/await db.close_async(); construct a fresh DataFlow "
+                "instance for further sync Express operations."
+            )
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        # Track the future so a concurrent close() can cancel it (bounded settle
+        # via CancelledError) rather than leaving this thread blocked on
+        # future.result() forever once the loop stops. The done-callback discards
+        # it as soon as it settles (normal completion, error, or cancellation).
+        with self._pending_lock:
+            self._pending.add(future)
+        future.add_done_callback(self._discard_pending)
         return future.result()
 
     # --- Lifecycle (issue #1575) ---
@@ -2179,6 +2212,21 @@ class SyncExpress:
                     extra={"error_type": type(exc).__name__},
                 )
 
+        # (3) Issue #1575 (Round-3): cancel every OTHER task still pending on
+        #     this loop. An in-flight `_run_sync` coroutine submitted before
+        #     `close()` runs as a task here; once the loop stops its
+        #     ``run_coroutine_threadsafe`` future would never settle, hanging the
+        #     caller's no-timeout ``future.result()`` FOREVER. Cancelling the
+        #     task makes that future resolve with ``CancelledError`` (bounded)
+        #     instead. Runs LAST, on the loop, so the drain above is unaffected.
+        try:
+            current = asyncio.current_task()
+            for task in asyncio.all_tasks():
+                if task is not current:
+                    task.cancel()
+        except RuntimeError:  # pragma: no cover — no running loop (unreachable here)
+            pass
+
     def close(self) -> None:
         """Drain express-loop-bound pools, then stop the BG event-loop thread.
 
@@ -2197,13 +2245,16 @@ class SyncExpress:
 
         loop = self._loop
         thread = self._thread
-        # Drop references first so any concurrent `_run_sync` observes the
-        # closed state (its `run_coroutine_threadsafe` will raise, not hang).
+        # Drop references first so any concurrent/after-close `_run_sync` observes
+        # the closed state and raises the typed closed-error (never AttributeError
+        # via run_coroutine_threadsafe(None), never a hang) — issue #1575 Round-3.
         self._loop = None
         self._thread = None
 
         # (a) Drain express-loop-bound resources ON the owning loop, bounded so
-        #     a hung disconnect cannot block teardown forever.
+        #     a hung disconnect cannot block teardown forever. The drain's final
+        #     step cancels every in-flight task on the loop so a slow call
+        #     submitted before close() settles with CancelledError (bounded).
         if loop is not None and loop.is_running():
             try:
                 future = asyncio.run_coroutine_threadsafe(
@@ -2215,6 +2266,16 @@ class SyncExpress:
                     "express.sync.drain_failed",
                     extra={"error_type": type(exc).__name__},
                 )
+
+        # (a2) Cancel any still-tracked in-flight futures. On-loop task
+        #      cancellation (drain step 3) covers coroutines already scheduled as
+        #      tasks; this covers the narrow window where a future was submitted
+        #      but its task had not yet been scheduled, so its caller's
+        #      future.result() cannot hang past close.
+        with self._pending_lock:
+            pending = list(self._pending)
+        for pending_future in pending:
+            pending_future.cancel()
 
         # (b) Stop the loop, (c) join the BG thread (bounded), (d) close the loop.
         if loop is not None and loop.is_running():

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -2126,20 +2126,30 @@ class SyncExpress:
         # `AttributeError: 'NoneType' object has no attribute
         # 'call_soon_threadsafe'` that `run_coroutine_threadsafe(coro, None)`
         # would raise (zero-tolerance.md Rule 3a). Mirrors SyncTransactionManager.
-        loop = self._loop
-        if self._closed or loop is None:
-            coro.close()
-            raise RuntimeError(
-                "SyncExpress is closed — the DataFlow was closed via "
-                "db.close()/await db.close_async(); construct a fresh DataFlow "
-                "instance for further sync Express operations."
-            )
-        future = asyncio.run_coroutine_threadsafe(coro, loop)
-        # Track the future so a concurrent close() can cancel it (bounded settle
-        # via CancelledError) rather than leaving this thread blocked on
-        # future.result() forever once the loop stops. The done-callback discards
-        # it as soon as it settles (normal completion, error, or cancellation).
+        #
+        # Issue #1575 (Round-4) — serialize [closed-check + submit + track] under
+        # _pending_lock so it strictly orders against close()'s [flip _closed +
+        # snapshot _pending], which takes the SAME lock. Either this submits and
+        # tracks the future BEFORE close flips _closed (→ close's snapshot sees it
+        # and cancels it), or close flips _closed first (→ this raises). Neither
+        # branch leaves an untracked future submitted onto a stopping loop — the
+        # narrow submit-during-close hang window is closed.
+        #
+        # run_coroutine_threadsafe under the lock only SCHEDULES onto the loop; it
+        # does not re-enter _pending_lock. The done-callback and future.result()
+        # stay OUTSIDE the lock so a fast/cancelled future firing _discard_pending
+        # (which takes _pending_lock) cannot deadlock against a held lock, and the
+        # actual work is never serialized.
         with self._pending_lock:
+            loop = self._loop
+            if self._closed or loop is None:
+                coro.close()
+                raise RuntimeError(
+                    "SyncExpress is closed — the DataFlow was closed via "
+                    "db.close()/await db.close_async(); construct a fresh DataFlow "
+                    "instance for further sync Express operations."
+                )
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
             self._pending.add(future)
         future.add_done_callback(self._discard_pending)
         return future.result()
@@ -2241,13 +2251,22 @@ class SyncExpress:
         """
         if self._closed:
             return
-        self._closed = True
+
+        # Issue #1575 (Round-4) — flip _closed AND snapshot the in-flight futures
+        # atomically under _pending_lock so this strictly orders against
+        # _run_sync's guarded [check + submit + track] (same lock). A future
+        # submitted+tracked before this flip IS in `pending` (→ cancelled below);
+        # a submit racing in after this flip sees _closed and raises. Neither
+        # leaves an untracked future stranded on a stopping loop — no hang window.
+        with self._pending_lock:
+            self._closed = True
+            pending = list(self._pending)
 
         loop = self._loop
         thread = self._thread
-        # Drop references first so any concurrent/after-close `_run_sync` observes
-        # the closed state and raises the typed closed-error (never AttributeError
-        # via run_coroutine_threadsafe(None), never a hang) — issue #1575 Round-3.
+        # Drop references so any after-close `_run_sync` observes the closed state
+        # and raises the typed closed-error (never AttributeError via
+        # run_coroutine_threadsafe(None), never a hang) — issue #1575 Round-3/4.
         self._loop = None
         self._thread = None
 
@@ -2267,13 +2286,11 @@ class SyncExpress:
                     extra={"error_type": type(exc).__name__},
                 )
 
-        # (a2) Cancel any still-tracked in-flight futures. On-loop task
-        #      cancellation (drain step 3) covers coroutines already scheduled as
-        #      tasks; this covers the narrow window where a future was submitted
+        # (a2) Cancel the in-flight futures snapshotted atomically above. On-loop
+        #      task cancellation (drain step 3) covers coroutines already scheduled
+        #      as tasks; this covers the narrow window where a future was submitted
         #      but its task had not yet been scheduled, so its caller's
         #      future.result() cannot hang past close.
-        with self._pending_lock:
-            pending = list(self._pending)
         for pending_future in pending:
             pending_future.cancel()
 

--- a/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
@@ -66,6 +66,13 @@ POSTGRES_URL = os.getenv(
     "TEST_DATABASE_URL",
     "postgresql://test_user:test_password@localhost:5434/kailash_test",
 )
+# aiomysql speaks the bare ``mysql://`` scheme (ConnectionParser maps
+# mysql / mysql+* -> database_type "mysql"); container kailash_sdk_test_mysql
+# provisions MYSQL_USER=kailash_test on port 3307.
+MYSQL_URL = os.getenv(
+    "TEST_MYSQL_URL",
+    "mysql://kailash_test:test_password@localhost:3307/kailash_test",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -569,3 +576,169 @@ def test_express_sync_concurrent_close_does_not_strand_inflight_call_sqlite():
             "CancelledError",
             "RuntimeError",
         }, f"unexpected settlement exception: {worker_result!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC#2 real-MySQL coverage — express_sync owned-loop teardown (aiomysql path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_express_sync_lifecycle_no_gc_dead_loop_signal_mysql():
+    """MySQL: express_sync CRUD + db.close() leaves no unclosed-conn/dead-loop GC signal.
+
+    AC#2 requires the transient/owned-loop leak class to be regression-tested on
+    real MySQL as well as PG. Exercises the aiomysql path through the owned
+    SyncExpress background loop: a real aiomysql connection binds to that loop on
+    the first CRUD call. WITHOUT the owned-loop teardown fix the daemon thread is
+    killed at interpreter shutdown with the aiomysql pool still bound to its loop
+    -> ResourceWarning: Unclosed connection. WITH it, db.close() drains the pool
+    on the owning loop first and joins the thread.
+    """
+    try:
+        db = DataFlow(database_url=MYSQL_URL)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"MySQL at {MYSQL_URL!r} not reachable ({exc}); this Tier-2 test "
+            f"requires the real container to be up"
+        )
+
+    @db.model
+    class _Widget1575ExpressMysql:
+        id: int
+        name: str
+        value: int
+
+    db.create_tables()
+    sync_ex = db.express_sync
+    thread = sync_ex._thread
+    # Unique id per run — the MySQL container is shared and rows persist.
+    record_id = int(time.time() * 1000) % 2_000_000_000
+    try:
+        sync_ex.create(
+            "_Widget1575ExpressMysql",
+            {"id": record_id, "name": "alice", "value": 1},
+        )
+        assert sync_ex.read("_Widget1575ExpressMysql", record_id)["value"] == 1
+        sync_ex.delete("_Widget1575ExpressMysql", record_id)  # clean up the row
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        db.close()
+        pytest.skip(f"MySQL express_sync CRUD failed against real container ({exc})")
+
+    db.close()
+    assert not thread.is_alive(), "SyncExpress MySQL thread NOT joined after db.close()"
+
+    del db
+
+    with _capture_gc_teardown_signals() as (caught, unraisables):
+        for _ in range(3):
+            gc.collect()
+        gc.collect()
+
+    rw_hits = _resource_warning_hits(caught)
+    loop_hits = _event_loop_closed_hits(unraisables)
+    assert (
+        rw_hits == []
+    ), f"MySQL express_sync leaked unclosed connections at GC: {rw_hits}"
+    assert (
+        loop_hits == []
+    ), f"MySQL express_sync produced 'Event loop is closed' at GC: {loop_hits}"
+
+
+# ---------------------------------------------------------------------------
+# Site #4 — model_registry sync->async workflow bridge (lighter invariant)
+# ---------------------------------------------------------------------------
+#
+# The round-1 fix rerouted model_registry's transient-loop bridge
+# (_execute_workflow_sync_safe, model_registry.py ~326/340) from bare
+# asyncio.run / new_event_loop onto async_safe_run (BRIDGE_LOOP_ATTR marker +
+# drain + asyncio.run semantics). INSPECTION EVIDENCE: the model registry
+# executes ALL its DDL/DML through the SYNC ``SQLDatabaseNode`` (model_registry.py
+# line 36 docstring "executes its DDL/DML through SQLDatabaseNode"; line 262
+# "SQLAlchemy-sync"; every add_node call uses "SQLDatabaseNode", ZERO
+# AsyncSQLDatabaseNode references). SQLDatabaseNode uses SQLAlchemy's SYNC engine
+# with process-wide _shared_pools that are NOT bound to the transient event loop.
+# So this bridge genuinely CANNOT create an asyncpg/aiomysql pool bound to the
+# transient loop — it is NOT the #1575 leak class, and a deterministic
+# pool-drain bite does not apply here (per the coordinator's fallback clause).
+# The lighter invariant below exercises the REAL bridge path (not a stub) and
+# asserts the reroute (a) still returns correct results and (b) leaves no leaked
+# event loop / "Event loop is closed" GC signal from the transient-loop lifecycle.
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_model_registry_bridge_no_dead_loop_gc_signal_pg():
+    """model_registry sync->async bridge runs on a clean transient loop (#1575 site #4).
+
+    Called from within a running event loop (this async test), the registry's
+    runtime resolves to AsyncLocalRuntime, so _execute_workflow_sync_safe takes
+    the worker-thread branch that routes through async_safe_run -> _run_on_new_loop
+    (the rerouted path). Asserts the real bridge returns the SELECT result AND the
+    transient loop is torn down with no dead-loop / unclosed-connection GC signal.
+    """
+    try:
+        db = DataFlow(database_url=POSTGRES_URL)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {POSTGRES_URL!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+
+    from kailash.workflow.builder import WorkflowBuilder
+
+    registry = getattr(db, "_model_registry", None)
+    if registry is None:  # pragma: no cover — registry is created in __init__
+        db.close()
+        pytest.skip("DataFlow._model_registry not initialised")
+
+    # Confirm we exercise the AsyncLocalRuntime worker-thread bridge (the
+    # rerouted async_safe_run path), not the direct sync path.
+    from kailash.runtime import AsyncLocalRuntime
+
+    assert isinstance(
+        registry.runtime, AsyncLocalRuntime
+    ), "expected AsyncLocalRuntime under a running loop to hit the rerouted bridge"
+
+    def _run_bridge():
+        # Build a trivial SELECT workflow through the registry's own
+        # SQLDatabaseNode path and drive it through the rerouted bridge.
+        workflow = WorkflowBuilder()
+        workflow.add_node(
+            "SQLDatabaseNode",
+            "probe_bridge",
+            {
+                "connection_string": POSTGRES_URL,
+                "database_type": "postgresql",
+                "query": "SELECT 1 AS one",
+            },
+        )
+        return registry._execute_workflow_sync_safe(workflow)
+
+    try:
+        # The bridge's ThreadPoolExecutor blocks; run it off the test's loop.
+        results, _run_id = await asyncio.to_thread(_run_bridge)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        db.close()
+        pytest.skip(f"model_registry bridge failed against real container ({exc})")
+
+    assert isinstance(results, dict)
+
+    db.close()
+    del db
+
+    with _capture_gc_teardown_signals() as (caught, unraisables):
+        for _ in range(3):
+            gc.collect()
+        gc.collect()
+
+    rw_hits = _resource_warning_hits(caught)
+    loop_hits = _event_loop_closed_hits(unraisables)
+    assert (
+        rw_hits == []
+    ), f"model_registry bridge leaked unclosed connections at GC: {rw_hits}"
+    assert (
+        loop_hits == []
+    ), f"model_registry bridge produced 'Event loop is closed' at GC: {loop_hits}"

--- a/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
@@ -52,6 +52,7 @@ import gc
 import os
 import sys
 import tempfile
+import threading
 import time
 import warnings
 
@@ -457,3 +458,114 @@ def test_express_sync_lifecycle_no_gc_dead_loop_signal_pg():
     assert (
         loop_hits == []
     ), f"express_sync produced 'Event loop is closed' at GC: {loop_hits}"
+
+
+# ---------------------------------------------------------------------------
+# ROUND-3 hardening — defects the owned-loop close() fix introduced
+# ---------------------------------------------------------------------------
+#
+# The SyncExpress.close() teardown (Round-2) introduced two concurrency defects
+# in the sync dispatch surface: (1) a call submitted AFTER close() hit
+# run_coroutine_threadsafe(coro, None) -> opaque AttributeError instead of a
+# clear closed-error; (2) a call IN-FLIGHT when close() stopped the loop blocked
+# forever on a no-timeout future.result(). Round-3 hardens _run_sync with a
+# closed-guard + tracks/cancels in-flight futures so both settle in bounded time.
+
+
+def test_express_sync_call_after_close_raises_typed_error_sqlite():
+    """A sync Express call AFTER db.close() raises a TYPED closed-error (#1575 R3).
+
+    Deterministic bite: WITHOUT the closed-guard, _run_sync submits to
+    run_coroutine_threadsafe(coro, None) after close() nulled the loop, raising
+    ``AttributeError: 'NoneType' object has no attribute 'call_soon_threadsafe'``.
+    WITH the guard it raises a clear ``RuntimeError("SyncExpress is closed …")``.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "reg1575_after_close.db")
+        db = DataFlow(database_url=f"sqlite:///{db_path}")
+
+        @db.model
+        class _Widget1575AfterClose:
+            id: int
+            name: str
+
+        db.create_tables()
+        sync_ex = db.express_sync
+        sync_ex.create("_Widget1575AfterClose", {"id": 1, "name": "alice"})
+
+        db.close()
+
+        # The captured (now-closed) SyncExpress must reject further calls with a
+        # TYPED error — not AttributeError, not a hang.
+        with pytest.raises(RuntimeError, match="SyncExpress is closed"):
+            sync_ex.create("_Widget1575AfterClose", {"id": 2, "name": "bob"})
+        with pytest.raises(RuntimeError, match="SyncExpress is closed"):
+            sync_ex.read("_Widget1575AfterClose", 1)
+
+
+def test_express_sync_concurrent_close_does_not_strand_inflight_call_sqlite():
+    """A slow in-flight sync call settles (bounded) when close() races it (#1575 R3).
+
+    Deterministic bite: a worker thread submits a slow coroutine through
+    ``_run_sync`` (blocking on the no-timeout ``future.result()``); the main
+    thread calls ``db.close()`` while it is in-flight. WITHOUT the drain-time
+    task cancellation, stopping the loop strands the worker's future FOREVER —
+    the worker thread never settles (``join(timeout=8)`` finds it still alive).
+    WITH the fix the drain cancels the in-flight task, the future resolves with
+    CancelledError, and the worker settles well within the join ceiling.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "reg1575_concurrent_close.db")
+        db = DataFlow(database_url=f"sqlite:///{db_path}")
+
+        @db.model
+        class _Widget1575Concurrent:
+            id: int
+            name: str
+
+        db.create_tables()
+        sync_ex = db.express_sync
+        # Warm the loop with a real connection bound to the BG loop.
+        sync_ex.create("_Widget1575Concurrent", {"id": 1, "name": "alice"})
+
+        worker_result: dict = {}
+        started = threading.Event()
+
+        def _worker():
+            # A slow coroutine submitted through the real sync dispatch path.
+            # It runs as a task ON the owned background loop; close() must make
+            # this settle rather than hang.
+            started.set()
+            try:
+                sync_ex._run_sync(asyncio.sleep(30))
+                worker_result["outcome"] = "completed"
+            except BaseException as exc:  # CancelledError is BaseException-derived
+                worker_result["outcome"] = "settled"
+                worker_result["exc_type"] = type(exc).__name__
+
+        worker = threading.Thread(target=_worker, name="reg1575-inflight", daemon=True)
+        worker.start()
+        assert started.wait(timeout=2.0)
+        # Give the coroutine time to actually be scheduled as a task on the loop.
+        time.sleep(0.5)
+
+        # Close the DataFlow (and thus the SyncExpress owned loop) while the slow
+        # call is in-flight on another thread.
+        db.close()
+
+        # The worker MUST settle within a bounded wall-clock — NOT hang forever.
+        worker.join(timeout=8.0)
+        assert not worker.is_alive(), (
+            "in-flight SyncExpress call hung past db.close() — a concurrent close "
+            "strands the caller on future.result() (issue #1575 Round-3)"
+        )
+        assert worker_result.get("outcome") == "settled", (
+            f"expected the in-flight call to settle with an exception, got "
+            f"{worker_result!r}"
+        )
+        # CancelledError (from task cancellation) or the typed closed-RuntimeError
+        # are both acceptable bounded settlements; a hang is not.
+        assert worker_result.get("exc_type") in {
+            "CancelledError",
+            "RuntimeError",
+        }, f"unexpected settlement exception: {worker_result!r}"

--- a/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
@@ -182,26 +182,33 @@ async def test_pg_inspect_closes_pool_on_mid_discovery_exception(monkeypatch):
 async def test_sqlite_inspect_disconnects_on_mid_discovery_exception(monkeypatch):
     """SQLite: a mid-discovery exception still disconnects the adapter (try/finally)."""
     engine = DataFlow(database_url="sqlite:///:memory:")
-    with tempfile.TemporaryDirectory() as tmp:
-        db_path = os.path.join(tmp, "regression_1575.db")
-        sqlite_url = f"sqlite:///{db_path}"
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "regression_1575.db")
+            sqlite_url = f"sqlite:///{db_path}"
 
-        _FailMidDiscoverySQLiteAdapter.instances.clear()
-        monkeypatch.setattr(
-            "dataflow.adapters.sqlite.SQLiteAdapter",
-            _FailMidDiscoverySQLiteAdapter,
-        )
+            _FailMidDiscoverySQLiteAdapter.instances.clear()
+            monkeypatch.setattr(
+                "dataflow.adapters.sqlite.SQLiteAdapter",
+                _FailMidDiscoverySQLiteAdapter,
+            )
 
-        with pytest.raises(RuntimeError, match="injected mid-discovery failure"):
-            await engine._inspect_sqlite_schema_real(sqlite_url)
+            with pytest.raises(RuntimeError, match="injected mid-discovery failure"):
+                await engine._inspect_sqlite_schema_real(sqlite_url)
 
-        assert _FailMidDiscoverySQLiteAdapter.instances, "adapter never constructed"
-        adapter = _FailMidDiscoverySQLiteAdapter.instances[-1]
-        assert adapter.disconnect_calls >= 1, (
-            "SQLite adapter was NOT disconnected on the mid-discovery exception "
-            "path — the try/finally in _inspect_sqlite_schema_real is missing "
-            "(issue #1575 regression)"
-        )
+            assert _FailMidDiscoverySQLiteAdapter.instances, "adapter never constructed"
+            adapter = _FailMidDiscoverySQLiteAdapter.instances[-1]
+            assert adapter.disconnect_calls >= 1, (
+                "SQLite adapter was NOT disconnected on the mid-discovery exception "
+                "path — the try/finally in _inspect_sqlite_schema_real is missing "
+                "(issue #1575 regression)"
+            )
+    finally:
+        # Close the DataFlow so its persistent sync ``_memory_connection``
+        # (sqlite3.connect for the ``:memory:`` engine) does not surface a
+        # ``ResourceWarning: unclosed database`` at GC (test-cleanup hygiene,
+        # rules/testing.md § Test Resource Cleanup).
+        engine.close()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
@@ -1,0 +1,309 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 regression test for issue #1575 — transient-loop pool leak (sibling of #1572).
+
+#1572 fixed the sync->async *bridge* (``dataflow.core.async_utils``) so a pool
+created on a transient bridge loop is drained before the loop closes. #1575 is
+the SIBLING gap: transient / owned loops OUTSIDE the bridge that also create
+adapter pools and leak them the same way.
+
+The load-bearing anchor is ``DataFlowEngine._inspect_database_schema_real``
+(reached from the sync ``discover_schema``). It opens a real asyncpg /
+aiosqlite adapter, walks the catalog, and closes the adapter — but pre-fix the
+close was OUTSIDE any ``try/finally``, so a mid-discovery exception jumped over
+it and leaked the connection pool on a (possibly transient) loop that then
+closed -> ``RuntimeError: Event loop is closed`` + ``ResourceWarning: Unclosed
+connection`` at GC.
+
+The fix wraps the adapter close in ``try/finally`` (both the PostgreSQL and the
+SQLite branch) AND routes the transient ``asyncio.run`` / ``new_event_loop``
+sites (``discover_schema``, ``validate_schema``, ``current_schema`` fallback,
+and the model-registry workflow bridge) through ``async_safe_run``, which
+stamps the transient loop with ``BRIDGE_LOOP_ATTR`` so any pool created on it
+drains before close.
+
+Test strategy:
+
+* **PRIMARY (deterministic, the exception path AC#4).** A protocol-satisfying
+  adapter subclass (NOT a mock — it opens a REAL pool via
+  ``super().create_connection_pool()`` against the real container, then raises a
+  non-connection error mid-discovery) records whether ``close_connection_pool``
+  ran. WITHOUT the ``finally`` the close never runs and the pool survives; WITH
+  it the close runs on the exception path. Clean, timing-independent pass/fail.
+* **SUCCESS path.** The same adapter without an injected failure still drains
+  its pool on the happy path (guards against a refactor deleting the close).
+* **SYMPTOM-path GC capture.** The sync ``discover_schema(use_real_inspection=True)``
+  full cycle, then a forced GC, asserting neither the ResourceWarning nor the
+  "Event loop is closed" RuntimeError surfaces.
+
+Per ``rules/testing.md`` § 3-Tier: NO MOCKING — real containers only:
+* PostgreSQL — ``postgresql://test_user:test_password@localhost:5434/kailash_test``
+
+The adapter subclasses here are the ``rules/testing.md`` § "Protocol-Satisfying
+Deterministic Adapters" carve-out: real adapters (real pool, real driver) with
+one deterministic overridden method — NOT ``unittest.mock`` / ``MagicMock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import gc
+import os
+import sys
+import tempfile
+import warnings
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.adapters.postgresql import PostgreSQLAdapter
+from dataflow.adapters.sqlite import SQLiteAdapter
+
+POSTGRES_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+# ---------------------------------------------------------------------------
+# Protocol-satisfying deterministic adapters (real pool + injected failure)
+# ---------------------------------------------------------------------------
+
+
+class _FailMidDiscoveryPGAdapter(PostgreSQLAdapter):
+    """Real asyncpg adapter that opens a real pool, then fails mid-discovery.
+
+    ``create_connection_pool`` opens a REAL asyncpg pool against the container;
+    ``execute_query`` raises a non-connection ``RuntimeError`` on the first
+    catalog query. ``close_connection_pool`` records each call so the test can
+    assert the ``finally`` drained the pool on the exception path.
+    """
+
+    instances: list["_FailMidDiscoveryPGAdapter"] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    async def execute_query(self, query, params=None):
+        raise RuntimeError("injected mid-discovery failure (#1575 regression)")
+
+    async def close_connection_pool(self):
+        self.close_calls += 1
+        await super().close_connection_pool()
+
+
+class _CountingClosePGAdapter(PostgreSQLAdapter):
+    """Real adapter that only counts close_connection_pool calls (success path)."""
+
+    instances: list["_CountingClosePGAdapter"] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    async def close_connection_pool(self):
+        self.close_calls += 1
+        await super().close_connection_pool()
+
+
+class _FailMidDiscoverySQLiteAdapter(SQLiteAdapter):
+    """Real SQLite adapter that connects, then fails on the first catalog query."""
+
+    instances: list["_FailMidDiscoverySQLiteAdapter"] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disconnect_calls = 0
+        type(self).instances.append(self)
+
+    async def execute_query(self, query, params=None):
+        raise RuntimeError("injected mid-discovery failure (#1575 regression)")
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        await super().disconnect()
+
+
+def _make_pg_engine():
+    try:
+        return DataFlow(database_url=POSTGRES_URL)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {POSTGRES_URL!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY — deterministic exception-path drain (AC#4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pg_inspect_closes_pool_on_mid_discovery_exception(monkeypatch):
+    """PG: a mid-discovery exception still drains the adapter pool (try/finally).
+
+    WITHOUT the fix, ``close_connection_pool`` is skipped when ``execute_query``
+    raises, so ``close_calls == 0`` and the real pool leaks -> this assertion
+    fails. WITH the fix, the ``finally`` drains it on the exception path.
+    """
+    engine = _make_pg_engine()
+    _FailMidDiscoveryPGAdapter.instances.clear()
+    # Route the method's lazy ``from ..adapters.postgresql import PostgreSQLAdapter``
+    # to the deterministic subclass (real pool + injected failure).
+    monkeypatch.setattr(
+        "dataflow.adapters.postgresql.PostgreSQLAdapter",
+        _FailMidDiscoveryPGAdapter,
+    )
+
+    with pytest.raises(RuntimeError, match="injected mid-discovery failure"):
+        await engine._inspect_postgresql_schema_real(POSTGRES_URL)
+
+    assert _FailMidDiscoveryPGAdapter.instances, "adapter was never constructed"
+    adapter = _FailMidDiscoveryPGAdapter.instances[-1]
+    assert adapter.close_calls >= 1, (
+        "PostgreSQL adapter pool was NOT closed on the mid-discovery exception "
+        "path — the try/finally in _inspect_postgresql_schema_real is missing "
+        "(issue #1575 regression)"
+    )
+    assert adapter.connection_pool is None, "pool object survived the drain"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sqlite_inspect_disconnects_on_mid_discovery_exception(monkeypatch):
+    """SQLite: a mid-discovery exception still disconnects the adapter (try/finally)."""
+    engine = DataFlow(database_url="sqlite:///:memory:")
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "regression_1575.db")
+        sqlite_url = f"sqlite:///{db_path}"
+
+        _FailMidDiscoverySQLiteAdapter.instances.clear()
+        monkeypatch.setattr(
+            "dataflow.adapters.sqlite.SQLiteAdapter",
+            _FailMidDiscoverySQLiteAdapter,
+        )
+
+        with pytest.raises(RuntimeError, match="injected mid-discovery failure"):
+            await engine._inspect_sqlite_schema_real(sqlite_url)
+
+        assert _FailMidDiscoverySQLiteAdapter.instances, "adapter never constructed"
+        adapter = _FailMidDiscoverySQLiteAdapter.instances[-1]
+        assert adapter.disconnect_calls >= 1, (
+            "SQLite adapter was NOT disconnected on the mid-discovery exception "
+            "path — the try/finally in _inspect_sqlite_schema_real is missing "
+            "(issue #1575 regression)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SUCCESS path — the drain still runs on the happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pg_inspect_closes_pool_on_success(monkeypatch):
+    """PG: the success path drains the adapter pool exactly once."""
+    engine = _make_pg_engine()
+    _CountingClosePGAdapter.instances.clear()
+    monkeypatch.setattr(
+        "dataflow.adapters.postgresql.PostgreSQLAdapter",
+        _CountingClosePGAdapter,
+    )
+
+    try:
+        schema = await engine._inspect_postgresql_schema_real(POSTGRES_URL)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(f"PG inspection failed against real container ({exc})")
+
+    assert isinstance(schema, dict)
+    assert _CountingClosePGAdapter.instances, "adapter was never constructed"
+    adapter = _CountingClosePGAdapter.instances[-1]
+    assert adapter.close_calls == 1, (
+        f"expected exactly one pool close on the success path, got "
+        f"{adapter.close_calls}"
+    )
+    assert adapter.connection_pool is None
+
+
+# ---------------------------------------------------------------------------
+# SYMPTOM-path GC capture over the sync discover_schema transient-loop path
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _capture_gc_teardown_signals():
+    """Capture ResourceWarnings AND unraisable exceptions during a GC sweep."""
+    unraisables = []
+    old_hook = sys.unraisablehook
+
+    def _record_unraisable(unraisable):
+        unraisables.append(unraisable)
+
+    sys.unraisablehook = _record_unraisable
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            yield caught, unraisables
+    finally:
+        sys.unraisablehook = old_hook
+
+
+def _resource_warning_hits(caught):
+    return [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, ResourceWarning) and "nclosed conn" in str(w.message)
+    ]
+
+
+def _event_loop_closed_hits(unraisables):
+    hits = []
+    for u in unraisables:
+        exc = getattr(u, "exc_value", None)
+        if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+            hits.append(str(exc))
+    return hits
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_pg_discover_schema_no_gc_dead_loop_signal():
+    """Sync discover_schema over the transient loop leaves no dead-loop GC signal.
+
+    ``discover_schema(use_real_inspection=True)`` runs the inspection coroutine
+    on a transient loop via ``async_safe_run`` (which stamps BRIDGE_LOOP_ATTR
+    and drains registered pools before close). Combined with the inspector's
+    own try/finally, a full sync discovery must leave no unclosed-connection /
+    "Event loop is closed" signal at GC.
+    """
+    engine = _make_pg_engine()
+
+    # Sync bridge path — this is the transient-loop site #1575 targets.
+    schema = engine.discover_schema(use_real_inspection=True)
+    assert isinstance(schema, dict)
+
+    del engine
+
+    with _capture_gc_teardown_signals() as (caught, unraisables):
+        for _ in range(3):
+            gc.collect()
+        gc.collect()
+
+    rw_hits = _resource_warning_hits(caught)
+    loop_hits = _event_loop_closed_hits(unraisables)
+    assert (
+        rw_hits == []
+    ), f"discover_schema leaked unclosed connections at GC: {rw_hits}"
+    assert (
+        loop_hits == []
+    ), f"discover_schema produced 'Event loop is closed' at GC: {loop_hits}"

--- a/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1575_transient_loop_pool_drain.py
@@ -52,6 +52,7 @@ import gc
 import os
 import sys
 import tempfile
+import time
 import warnings
 
 import pytest
@@ -307,3 +308,145 @@ def test_pg_discover_schema_no_gc_dead_loop_signal():
     assert (
         loop_hits == []
     ), f"discover_schema produced 'Event loop is closed' at GC: {loop_hits}"
+
+
+# ---------------------------------------------------------------------------
+# OWNED-LOOP teardown — SyncExpress (issue #1575, Round-2 gap)
+# ---------------------------------------------------------------------------
+#
+# SyncExpress owns a PERSISTENT daemon-thread event loop; DB connections opened
+# by Express through the sync surface BIND to that loop. Before this fix,
+# SyncExpress had no close()/__del__ and DataFlow.close()/close_async() never
+# tore it down, so every DataFlow that touched db.express_sync leaked
+# {daemon thread + loop + loop-bound connections} on owner teardown — surfacing
+# at interpreter shutdown as ResourceWarning: Unclosed connection. The fix adds
+# SyncExpress.close() (drain-on-owning-loop, then stop+join+close) + __del__,
+# wired into DataFlow.close()/close_async().
+
+
+def test_express_sync_close_joins_thread_and_closes_owned_loop_sqlite():
+    """db.close() tears down the SyncExpress owned loop + BG thread (#1575).
+
+    Deterministic bite: WITHOUT the fix, SyncExpress has no close() and
+    DataFlow.close() never tears it down, so the daemon thread stays alive and
+    the loop stays open after db.close() — this assertion fails. WITH the fix,
+    the thread is joined and the loop is closed.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "reg1575_express.db")
+        db = DataFlow(database_url=f"sqlite:///{db_path}")
+
+        @db.model
+        class _Widget1575Express:
+            id: int
+            name: str
+
+        db.create_tables()
+
+        # Access express_sync — creates the owned loop + daemon thread.
+        sync_ex = db.express_sync
+        thread = sync_ex._thread
+        loop = sync_ex._loop
+        assert thread is not None and thread.is_alive()
+        assert loop is not None and not loop.is_closed()
+
+        # Real CRUD through the sync surface — opens a real aiosqlite connection
+        # BOUND to the owned background loop (the leak vector).
+        created = sync_ex.create("_Widget1575Express", {"id": 1, "name": "alice"})
+        assert created["id"] == 1
+        assert sync_ex.read("_Widget1575Express", 1)["name"] == "alice"
+
+        # Owner teardown MUST close the SyncExpress owned loop + join the thread.
+        db.close()
+
+        assert not thread.is_alive(), (
+            "SyncExpress background thread NOT joined after db.close() — the "
+            "owned loop + its bound connections leak (issue #1575)"
+        )
+        assert (
+            loop.is_closed()
+        ), "SyncExpress owned event loop NOT closed after db.close() (#1575)"
+        assert getattr(sync_ex, "_closed", False) is True
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_express_sync_close_is_idempotent_sqlite():
+    """SyncExpress.close() is safe to call repeatedly (owner + explicit)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "reg1575_express_idem.db")
+        db = DataFlow(database_url=f"sqlite:///{db_path}")
+
+        @db.model
+        class _Widget1575ExpressIdem:
+            id: int
+            name: str
+
+        db.create_tables()
+        sync_ex = db.express_sync
+        sync_ex.create("_Widget1575ExpressIdem", {"id": 1, "name": "bob"})
+
+        sync_ex.close()
+        # Second + third calls must be no-ops, not raise.
+        sync_ex.close()
+        db.close()
+        assert getattr(sync_ex, "_closed", False) is True
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_express_sync_lifecycle_no_gc_dead_loop_signal_pg():
+    """PG: express_sync CRUD + db.close() leaves no unclosed-conn / dead-loop GC signal.
+
+    Exercises the asyncpg path (Postgres) through the owned SyncExpress loop.
+    WITHOUT the fix the daemon thread is killed at interpreter shutdown with the
+    asyncpg pool still bound to its loop -> ResourceWarning. WITH the fix,
+    db.close() drains the pool on the owning loop first.
+    """
+    try:
+        db = DataFlow(database_url=POSTGRES_URL)
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        pytest.skip(
+            f"database at {POSTGRES_URL!r} not reachable ({exc}); this Tier-2 "
+            f"test requires the real container to be up"
+        )
+
+    @db.model
+    class _Widget1575ExpressPg:
+        id: int
+        name: str
+        value: int
+
+    db.create_tables()
+    sync_ex = db.express_sync
+    thread = sync_ex._thread
+    # Unique id per run — the PG container is shared and rows persist across
+    # runs, so a fixed id would collide on the pkey (test isolation, not the
+    # leak under test).
+    record_id = int(time.time() * 1000) % 2_000_000_000
+    try:
+        sync_ex.create(
+            "_Widget1575ExpressPg", {"id": record_id, "name": "alice", "value": 1}
+        )
+        assert sync_ex.read("_Widget1575ExpressPg", record_id)["value"] == 1
+        sync_ex.delete("_Widget1575ExpressPg", record_id)  # clean up the row
+    except Exception as exc:  # pragma: no cover — infra-down skip
+        db.close()
+        pytest.skip(f"PG express_sync CRUD failed against real container ({exc})")
+
+    db.close()
+    assert not thread.is_alive(), "SyncExpress PG thread NOT joined after db.close()"
+
+    del db
+
+    with _capture_gc_teardown_signals() as (caught, unraisables):
+        for _ in range(3):
+            gc.collect()
+        gc.collect()
+
+    rw_hits = _resource_warning_hits(caught)
+    loop_hits = _event_loop_closed_hits(unraisables)
+    assert rw_hits == [], f"express_sync leaked unclosed connections at GC: {rw_hits}"
+    assert (
+        loop_hits == []
+    ), f"express_sync produced 'Event loop is closed' at GC: {loop_hits}"


### PR DESCRIPTION
## Summary

Fixes #1575 — the sibling of #1572. Adapter pools created on transient / owned event loops **outside** the sync→async bridge leaked at GC (`RuntimeError: Event loop is closed` / `ResourceWarning: Unclosed connection`). This closes every remaining site the #1572 bridge fix did not cover.

## What changed (per the #1575 AC, transient-vs-owned classification)

- **Schema-discovery inspect paths (AC#4)** — `_inspect_database_schema_real` (PG + SQLite branches) now drains the adapter in a guarded `try/finally` on **every** exit path (idempotent; logs exception type only, never a DSN). Pre-fix the close sat outside `try/finally`, so a mid-discovery exception stranded the pool.
- **Transient loop-creating sites** — `discover_schema`, `validate_schema`, the `current_schema` fallback, and the model-registry workflow bridge route through `async_safe_run` (stamps `BRIDGE_LOOP_ATTR` → #1572 registry drains the loop before close). The running-loop `DATAFLOW-SESSION-LOOP-DEADLOCK-001` guard is preserved unchanged.
- **`SyncExpress` (`db.express_sync`) owned persistent loop** — previously had **no** teardown, leaking {daemon thread + loop + loop-bound connections} on every `DataFlow` that used it. Now `DataFlow.close()`/`close_async()` drive `SyncExpress.close()`, which drains loop-bound adapters **on the owning loop** then stops/joins/closes it; a `__del__` emits `ResourceWarning` if never closed (mirrors `SyncTransactionManager`). `SyncTransactionManager` was already correct (per-transaction connections close before the loop does).
- **Dispatch hardening** — `_run_sync` raises a typed "closed" error after `db.close()` (not an opaque `AttributeError`); a call in flight when `close()` runs settles with `CancelledError` in bounded time instead of hanging on `future.result()` forever (submit-vs-close serialized under the existing pending-futures lock; `result()` stays outside the lock).

**dataflow-only release** — uses the existing `kailash.utils.loop_pool_registry` (kailash 2.45.4); no new core symbols, floor stays `kailash>=2.45.4`. Bumps kailash-dataflow **2.13.19 → 2.13.20**.

## Tests (Tier-2, real infra — NO mocking)

Real PostgreSQL:5434 + MySQL:3307 + file-backed SQLite. Deterministic exception-path drain assertions (fail pre-fix / pass post-fix), `SyncExpress` owned-loop lifecycle GC-capture on PG **and** MySQL, model-registry bridge invariant, after-close typed-error + concurrent-close no-strand hardening, idempotent-close. **11/11 green; suite clean under `-W error::ResourceWarning`.**

## Red team → convergence (5 rounds)

- **R1** (reviewer + security-reviewer + adversarial): core transient-drain CLEAN.
- **R2** deep-lens: caught the `SyncExpress` owned-loop teardown gap (HIGH) → fixed.
- **R3** adversarial: caught fix-introduced concurrent-close hang + typed-guard gap + a strict secret-logging deviation → all hardened.
- **R4** (2 agents): CLEAN — TOCTOU unreproducible in 1500 stressed settlements; warnings proven pre-existing.
- **R5** (main-loop, comprehensive): CLEAN — model_registry no-pool claim verified (33 sync nodes, 0 async), MySQL test runs, F2 stress 960 settlements / 0 hangs / 0 deadlocks.

Owned-loop teardown, concurrency, and idempotency independently stress-verified. Pre-existing, SHA-verified out-of-scope items (14 `tests/integration/transactions/` failures; #1552-class `str(e)` schema-discovery logs) tracked separately.

## Related issues

Fixes #1575. Sibling of #1572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)