### PR TITLE
fix(dataflow): make generated CRUD nodes transaction-aware (#1581)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -9112,6 +9112,8 @@ class DataFlow(DataFlowEventMixin):
                 SchemaModificationNode,
                 TransactionCommitNode,
                 TransactionRollbackNode,
+                TransactionRollbackToSavepointNode,
+                TransactionSavepointNode,
                 TransactionScopeNode,
             )
         except ImportError:
@@ -9121,6 +9123,19 @@ class DataFlow(DataFlowEventMixin):
         NodeRegistry.register(TransactionScopeNode, alias="TransactionScopeNode")
         NodeRegistry.register(TransactionCommitNode, alias="TransactionCommitNode")
         NodeRegistry.register(TransactionRollbackNode, alias="TransactionRollbackNode")
+        # #1581: the savepoint nodes were defined + exported but never registered,
+        # so no workflow could reach them (orphan). Register them alongside the
+        # other transaction nodes — single-record CRUD is now transaction-aware,
+        # so a ROLLBACK TO SAVEPOINT discards post-savepoint single-record CRUD
+        # writes. (Bulk write nodes are not yet scope-aware — see the #1581 bulk
+        # follow-up — so a post-savepoint BULK write is NOT discarded yet.)
+        NodeRegistry.register(
+            TransactionSavepointNode, alias="TransactionSavepointNode"
+        )
+        NodeRegistry.register(
+            TransactionRollbackToSavepointNode,
+            alias="TransactionRollbackToSavepointNode",
+        )
 
         # Register schema nodes
         NodeRegistry.register(SchemaModificationNode, alias="SchemaModificationNode")
@@ -9130,6 +9145,10 @@ class DataFlow(DataFlowEventMixin):
         self._nodes["TransactionScopeNode"] = TransactionScopeNode
         self._nodes["TransactionCommitNode"] = TransactionCommitNode
         self._nodes["TransactionRollbackNode"] = TransactionRollbackNode
+        self._nodes["TransactionSavepointNode"] = TransactionSavepointNode
+        self._nodes["TransactionRollbackToSavepointNode"] = (
+            TransactionRollbackToSavepointNode
+        )
         self._nodes["SchemaModificationNode"] = SchemaModificationNode
         self._nodes["MigrationNode"] = MigrationNode
 

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -58,6 +58,58 @@ from .exceptions import is_conflict_target_error as _is_conflict_target_error
 from .logging_config import mask_sensitive_values  # Phase 7: Sensitive value masking
 
 
+async def _run_sql_in_scope(node: Any, sql_node: Any, **kwargs: Any) -> Dict[str, Any]:
+    """Run an ``AsyncSQLDatabaseNode`` call, joining an active transaction scope.
+
+    Issue #1581: generated DataFlow CRUD nodes ran every statement on their own
+    cached ``AsyncSQLDatabaseNode`` in ``transaction_mode="auto"`` (per-statement
+    autocommit), so a CRUD write inside a ``TransactionScopeNode`` workflow
+    committed independently and survived a later rollback.
+
+    ``TransactionScopeNode`` stores an ``_AdapterTransactionScope`` under the
+    workflow-context key ``active_transaction`` (the runtime injects the SAME
+    ``_workflow_context`` dict onto every node in the workflow). When a scope is
+    present, this helper passes ``scope.transaction`` — the raw adapter txn
+    handle — into ``async_run`` so the statement runs ON the scope's connection.
+    The scope's ``TransactionCommitNode`` / ``TransactionRollbackNode`` then
+    governs the CRUD write. Reads (LIST/READ/COUNT) join too, giving
+    read-your-writes inside the scope.
+
+    When no scope is active (``db.express`` calls, or a workflow with no
+    transaction node) the call is byte-identical to the prior direct
+    ``sql_node.async_run(**kwargs)`` — auto-commit behavior is preserved.
+
+    An explicit ``transaction`` already present in ``kwargs`` is never
+    overridden.
+    """
+    if "transaction" not in kwargs:
+        scope = node.get_workflow_context("active_transaction")
+        if scope is not None:
+            # Fail closed: an active scope with no usable transaction handle must
+            # NOT silently auto-commit (that is the exact #1581 escape). The only
+            # producer of ``active_transaction`` is TransactionScopeNode, which
+            # stores an _AdapterTransactionScope exposing ``.transaction`` — so a
+            # missing handle means a contract violation, not a benign no-op.
+            txn = getattr(scope, "transaction", None)
+            if txn is None:
+                from kailash.sdk_exceptions import NodeExecutionError
+
+                raise NodeExecutionError(
+                    "active_transaction present in workflow context but exposes no "
+                    f"'.transaction' handle (got {type(scope).__name__}); refusing to "
+                    "run a CRUD write auto-commit and escape the transaction scope "
+                    "(#1581). The scope must be an _AdapterTransactionScope."
+                )
+            kwargs["transaction"] = txn
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "nodes.crud_joined_transaction_scope",
+                extra={"node": type(node).__name__},
+            )
+    return await sql_node.async_run(**kwargs)
+
+
 def _normalize_field_specs(fields: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     """Normalize a model-fields dict into the canonical {"type": <type>, ...} shape.
 
@@ -1884,7 +1936,9 @@ class NodeGenerator:
                         )
 
                         # Execute the async node properly in async context
-                        result = await sql_node.async_run(
+                        result = await _run_sql_in_scope(
+                            self,
+                            sql_node,
                             query=query,
                             params=serialized_values,  # Use serialized values
                             fetch_mode=fetch_mode,
@@ -1924,7 +1978,9 @@ class NodeGenerator:
                                         f"SELECT * FROM {quoted_table} "
                                         f"WHERE {dialect.quote_identifier('id')} = ?"
                                     )
-                                    readback_result = await sql_node.async_run(
+                                    readback_result = await _run_sql_in_scope(
+                                        self,
+                                        sql_node,
                                         query=readback_query,
                                         params=[record_id],
                                         fetch_mode="one",
@@ -2119,32 +2175,54 @@ class NodeGenerator:
                                     # Add explicit type casting for parameter $11
                                     fixed_sql = query.replace("$11", "$11::integer")
 
-                                    # Import and retry with the fixed SQL
-                                    from kailash.nodes.data.async_sql import (
-                                        AsyncSQLDatabaseNode,
+                                    # #1581: inside a workflow transaction scope the
+                                    # retry MUST run on the POOLED node that joins the
+                                    # scope's connection. A fresh non-pooled node uses a
+                                    # different connection and would silently escape the
+                                    # transaction — the create would commit independently
+                                    # and survive a rollback (the exact bug #1581 fixes).
+                                    scope = self.get_workflow_context(
+                                        "active_transaction"
                                     )
-
-                                    sql_node = AsyncSQLDatabaseNode(
-                                        connection_string=connection_string,
-                                        database_type=database_type,
-                                    )
-                                    # Fresh (non-pooled) node — clean it up after the
-                                    # query so its connection does not leak a
-                                    # ResourceWarning on GC (issue #1560; same class as
-                                    # the 2.13.15 bulk_upsert._execute_query and
-                                    # BulkCreatePoolNode._process_direct fixes). The
-                                    # result dict is fully materialized by async_run,
-                                    # so cleanup after is safe.
-                                    try:
-                                        result = await sql_node.async_run(
+                                    if scope is not None:
+                                        pooled_node = self.dataflow_instance._get_or_create_async_sql_node(
+                                            database_type
+                                        )
+                                        result = await _run_sql_in_scope(
+                                            self,
+                                            pooled_node,
                                             query=fixed_sql,
                                             params=values,
                                             fetch_mode="one",  # RETURNING clause should return one record
                                             validate_queries=False,
-                                            transaction_mode="auto",  # Ensure auto-commit for create operations
                                         )
-                                    finally:
-                                        await sql_node.cleanup()
+                                    else:
+                                        # No scope: retry on a fresh (non-pooled) node.
+                                        from kailash.nodes.data.async_sql import (
+                                            AsyncSQLDatabaseNode,
+                                        )
+
+                                        sql_node = AsyncSQLDatabaseNode(
+                                            connection_string=connection_string,
+                                            database_type=database_type,
+                                        )
+                                        # Fresh node — clean it up after the query so its
+                                        # connection does not leak a ResourceWarning on GC
+                                        # (issue #1560; same class as the 2.13.15
+                                        # bulk_upsert._execute_query and
+                                        # BulkCreatePoolNode._process_direct fixes). The
+                                        # result dict is fully materialized by async_run,
+                                        # so cleanup after is safe.
+                                        try:
+                                            result = await sql_node.async_run(
+                                                query=fixed_sql,
+                                                params=values,
+                                                fetch_mode="one",  # RETURNING clause should return one record
+                                                validate_queries=False,
+                                                transaction_mode="auto",  # Ensure auto-commit for create operations
+                                            )
+                                        finally:
+                                            await sql_node.cleanup()
 
                                     if (
                                         result
@@ -2306,7 +2384,9 @@ class NodeGenerator:
                         query, read_params
                     )
 
-                    result = await sql_node.async_run(
+                    result = await _run_sql_in_scope(
+                        self,
+                        sql_node,
                         query=query,
                         params=read_params,
                         fetch_mode="one",
@@ -2726,7 +2806,9 @@ class NodeGenerator:
                         # Apply tenant isolation to the query
                         query, values = self._apply_tenant_isolation(query, values)
 
-                        result = await sql_node.async_run(
+                        result = await _run_sql_in_scope(
+                            self,
+                            sql_node,
                             query=query,
                             params=values,
                             fetch_mode="one",
@@ -2910,7 +2992,9 @@ class NodeGenerator:
                         query, delete_params
                     )
 
-                    result = await sql_node.async_run(
+                    result = await _run_sql_in_scope(
+                        self,
+                        sql_node,
                         query=query,
                         params=delete_params,
                         fetch_mode="one",
@@ -3177,7 +3261,9 @@ class NodeGenerator:
                         sql_node = self.dataflow_instance._get_or_create_async_sql_node(
                             db_type
                         )
-                        sql_result = await sql_node.async_run(
+                        sql_result = await _run_sql_in_scope(
+                            self,
+                            sql_node,
                             query=query,
                             params=params,
                             fetch_mode="all" if not count_only else "one",
@@ -3517,7 +3603,9 @@ class NodeGenerator:
                             check_query, check_params
                         )
 
-                        check_result = await sql_node.async_run(
+                        check_result = await _run_sql_in_scope(
+                            self,
+                            sql_node,
                             query=check_query,
                             params=check_params,
                             fetch_mode="one",
@@ -3610,7 +3698,9 @@ class NodeGenerator:
                                 "AND table_name = %s "
                                 "AND non_unique = 0"
                             )
-                            index_result = await mysql_precheck_node.async_run(
+                            index_result = await _run_sql_in_scope(
+                                self,
+                                mysql_precheck_node,
                                 query=index_query,
                                 params=[table_name],
                                 fetch_mode="all",
@@ -3722,7 +3812,9 @@ class NodeGenerator:
                     # For SQLite, sql_node was already created during pre-check
 
                     try:
-                        result = await sql_node.async_run(
+                        result = await _run_sql_in_scope(
+                            self,
+                            sql_node,
                             query=query,
                             params=params,
                             fetch_mode="one",
@@ -3958,7 +4050,9 @@ class NodeGenerator:
                     sql_node = self.dataflow_instance._get_or_create_async_sql_node(
                         db_type
                     )
-                    result = await sql_node.async_run(
+                    result = await _run_sql_in_scope(
+                        self,
+                        sql_node,
                         query=query,
                         params=params,
                         fetch_mode="one",

--- a/packages/kailash-dataflow/src/dataflow/nodes/transaction_nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/transaction_nodes.py
@@ -16,16 +16,15 @@ import logging
 import uuid
 from typing import Any, Dict, Optional
 
-from kailash.nodes.base import NodeParameter
-from kailash.nodes.base_async import AsyncNode
-from kailash.sdk_exceptions import NodeExecutionError
-
 # Issue #1552: redact driver-error column VALUES (PG ``DETAIL: Key(col)=(value)``,
 # MySQL ``Duplicate entry 'value'``) before baking the raw exception text into a
 # user-facing NodeExecutionError message. A COMMIT of deferred constraints raises
 # a value-bearing driver error; the raw exception is preserved as ``__cause__``
 # (``from e``) for traceback diagnosability — only the message string is sanitized.
 from dataflow.core.exceptions import sanitize_db_error
+from kailash.nodes.base import NodeParameter
+from kailash.nodes.base_async import AsyncNode
+from kailash.sdk_exceptions import NodeExecutionError
 
 logger = logging.getLogger(__name__)
 
@@ -375,7 +374,7 @@ class TransactionSavepointNode(AsyncNode):
         # Validate savepoint name to prevent SQL injection
         import re
 
-        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$", savepoint_name):
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,62}", savepoint_name):
             raise NodeExecutionError(
                 f"Invalid savepoint name '{savepoint_name}': must be alphanumeric/underscores, "
                 "start with a letter or underscore, and be 1-63 characters"
@@ -455,7 +454,7 @@ class TransactionRollbackToSavepointNode(AsyncNode):
         # Validate savepoint name to prevent SQL injection
         import re
 
-        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$", savepoint_name):
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,62}", savepoint_name):
             raise NodeExecutionError(
                 f"Invalid savepoint name '{savepoint_name}': must be alphanumeric/underscores, "
                 "start with a letter or underscore, and be 1-63 characters"

--- a/packages/kailash-dataflow/tests/integration/transactions/test_dataflow_node_transaction_awareness.py
+++ b/packages/kailash-dataflow/tests/integration/transactions/test_dataflow_node_transaction_awareness.py
@@ -143,24 +143,16 @@ class TestDataFlowNodeRealTransactionAwareness:
             parameters={"workflow_context": {"dataflow_instance": db}},
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Deferred contract: generated DataFlow CRUD nodes are not yet "
-            "transaction-aware. RollbackTestProductCreateNode executes on its "
-            "own cached AsyncSQLDatabaseNode with transaction_mode='auto' "
-            "(per-statement autocommit) and does NOT join the workflow-context "
-            "transaction opened by TransactionScopeNode. The CREATE therefore "
-            "commits independently and survives the rollback. The rollback node "
-            "itself works (status == 'rolled_back'); what is missing is CRUD "
-            "participation in the scope transaction. When CRUD nodes learn to "
-            "read 'active_transaction' from workflow context and run on that "
-            "connection, this test XPASSes and the marker MUST be removed "
-            "same-shard (see rules/testing.md § xfail-strict). Tracked by #1581."
-        ),
-    )
     def test_dataflow_rollback_transaction(self, test_suite):
-        """Test that rollback prevents data from being committed."""
+        """Test that rollback prevents data from being committed.
+
+        #1581: generated DataFlow CRUD nodes are now transaction-aware — a
+        CreateNode inside a TransactionScopeNode reads 'active_transaction' from
+        workflow context (via DataFlowNode._run_sql_in_scope → the scope's
+        borrowed transaction) and runs on the scope's connection, so
+        TransactionRollbackNode discards the create. Previously xfail-strict
+        (CRUD auto-committed independently and survived the rollback).
+        """
         import sys
 
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))

--- a/packages/kailash-dataflow/tests/integration/transactions/test_workflow_context_integration.py
+++ b/packages/kailash-dataflow/tests/integration/transactions/test_workflow_context_integration.py
@@ -35,196 +35,89 @@ class TestDataFlowNodeTransactionAwareness:
     """Test DataFlow node transaction awareness."""
 
     def test_dataflow_node_uses_transaction_connection(self, test_suite):
-        """Test that DataFlow nodes use connection from transaction context."""
-        from dataflow import DataFlow
-        from dataflow.nodes.transaction_nodes import (
-            TransactionCommitNode,
-            TransactionScopeNode,
-        )
+        """Generated DataFlow CRUD nodes run on the scope's transaction connection.
 
-        # Create DataFlow instance with test database
-        # Using the test PostgreSQL instance on port 5434
+        #1581: this previously wrapped each CRUD node in a threaded
+        ``PythonCodeNode`` and hand-injected ``active_transaction``. That path
+        only "passed" because CRUD nodes IGNORED ``active_transaction`` and
+        auto-committed on their own thread-loop connection (the exact #1581 bug)
+        — and asyncpg connections are event-loop-bound, so a CRUD node that
+        genuinely joins the scope cannot run cross-loop. The corrected test
+        exercises the REAL path: CRUD nodes as direct workflow nodes on the
+        runtime loop, joining the scope's connection (read-your-writes) and
+        surviving the commit.
+        """
+        import time
+
+        from dataflow import DataFlow
+
         db = DataFlow(database_url=test_suite.config.url)
 
-        # Define a test model
         @db.model
         class TestUser:
             name: str
             email: str
             age: int = 18
 
-        # Ensure table exists - DataFlow should create it automatically
-        # but we'll use a simple check to ensure it's there
-        try:
-            # Try to query the table to ensure it exists
-            from kailash.runtime.local import LocalRuntime
+        db.create_tables()
+        email = f"tx_test_{int(time.time() * 1_000_000)}@example.com"
 
-            check_workflow = WorkflowBuilder()
-            check_workflow.add_node("TestUserListNode", "check", {"limit": 1})
-            runtime = LocalRuntime()
-            runtime.execute(
-                check_workflow.build(),
-                parameters={"workflow_context": {"dataflow_instance": db}},
-            )
-        except Exception:
-            # Table might not exist, that's okay - DataFlow will create it on first use
-            pass
-
-        # Create workflow
         workflow = WorkflowBuilder()
-
-        # Start transaction
         workflow.add_node(
             "TransactionScopeNode", "start_tx", {"isolation_level": "READ_COMMITTED"}
         )
-
-        # Use PythonCodeNode to create user within transaction
-        # This avoids the validation issue with dynamically generated nodes
         workflow.add_node(
-            "PythonCodeNode",
+            "TestUserCreateNode",
             "create_user",
-            {
-                "code": """
-# Get the DataFlow instance and transaction connection from context
-dataflow_instance = get_workflow_context('dataflow_instance')
-tx_connection = get_workflow_context('transaction_connection')
-
-# Import the generated node class
-TestUserCreateNode = dataflow_instance._nodes['TestUserCreateNode']
-
-# Create node instance and set workflow context
-create_node = TestUserCreateNode()
-create_node._workflow_context = {
-    'dataflow_instance': dataflow_instance,
-    'transaction_connection': tx_connection,
-    'active_transaction': get_workflow_context('active_transaction')
-}
-
-# Execute the create operation
-result = create_node.execute(
-    name="Transaction Test User",
-    email="tx_test@example.com",
-    age=25
-)
-"""
-            },
+            {"name": "Transaction Test User", "email": email, "age": 25},
         )
-
-        # List users within same transaction
+        # List within the SAME transaction — must see the uncommitted row
+        # (read-your-writes), proving the CRUD ran on the scope's connection.
         workflow.add_node(
-            "PythonCodeNode",
+            "TestUserListNode",
             "list_in_tx",
-            {
-                "code": """
-# Get context
-dataflow_instance = get_workflow_context('dataflow_instance')
-tx_connection = get_workflow_context('transaction_connection')
-
-# Use list node
-TestUserListNode = dataflow_instance._nodes['TestUserListNode']
-list_node = TestUserListNode()
-list_node._workflow_context = {
-    'dataflow_instance': dataflow_instance,
-    'transaction_connection': tx_connection,
-    'active_transaction': get_workflow_context('active_transaction')
-}
-
-# List users with the test email
-result = list_node.execute(
-    filter={"email": "tx_test@example.com"},
-    limit=10
-)
-"""
-            },
+            {"filter": {"email": email}, "limit": 10},
         )
-
-        # Commit transaction
         workflow.add_node("TransactionCommitNode", "commit_tx", {})
-
-        # List users after commit (without transaction)
-        workflow.add_node(
-            "PythonCodeNode",
-            "list_after_commit",
-            {
-                "code": """
-# Get DataFlow instance (no transaction context)
-dataflow_instance = get_workflow_context('dataflow_instance')
-
-# Use list node without transaction
-TestUserListNode = dataflow_instance._nodes['TestUserListNode']
-list_node = TestUserListNode()
-list_node._workflow_context = {
-    'dataflow_instance': dataflow_instance
-}
-
-# List users
-result = list_node.execute(
-    filter={"email": "tx_test@example.com"},
-    limit=10
-)
-"""
-            },
-        )
-
-        # Connect nodes
-        workflow.add_connection("start_tx", "result", "create_user", "input_data")
-        workflow.add_connection("create_user", "result", "list_in_tx", "input_data")
-        workflow.add_connection("list_in_tx", "result", "commit_tx", "input_data")
         workflow.add_connection(
-            "commit_tx", "result", "list_after_commit", "input_data"
+            "start_tx", "transaction_id", "create_user", "transaction_id"
         )
+        workflow.add_connection("create_user", "id", "list_in_tx", "previous_id")
+        workflow.add_connection("list_in_tx", "count", "commit_tx", "record_count")
 
-        # Execute with DataFlow instance in context
         runtime = LocalRuntime()
-        results, run_id = runtime.execute(
-            workflow.build(), parameters={"workflow_context": {"dataflow_instance": db}}
+        results, _ = runtime.execute(
+            workflow.build(),
+            parameters={"workflow_context": {"dataflow_instance": db}},
         )
 
-        # Verify transaction was used
-        create_result = results.get("create_user", {}).get("result", {})
-        list_in_tx_result = results.get("list_in_tx", {}).get("result", {})
+        create_result = results.get("create_user", {})
+        list_in_tx_result = results.get("list_in_tx", {})
         commit_result = results.get("commit_tx", {})
-        list_after_result = results.get("list_after_commit", {}).get("result", {})
 
-        # User should be created
+        # User created inside the transaction.
         assert "id" in create_result
         assert create_result.get("name") == "Transaction Test User"
 
-        # User should be visible within transaction (before commit)
-        assert list_in_tx_result.get("count", 0) >= 1
+        # Visible within the transaction BEFORE commit (read-your-writes) —
+        # proves the LIST joined the scope's connection.
+        assert list_in_tx_result.get("count", 0) == 1
         tx_users = list_in_tx_result.get("records", [])
-        assert any(u["email"] == "tx_test@example.com" for u in tx_users)
+        assert any(u["email"] == email for u in tx_users)
 
-        # Transaction should commit successfully
-        # The TransactionCommitNode returns mock results since we're in test mode
-        assert "status" in commit_result or "result" in commit_result
+        # Transaction committed.
+        assert commit_result.get("status") == "committed"
 
-        # User should still be visible after commit
-        assert list_after_result.get("count", 0) >= 1
-        after_users = list_after_result.get("records", [])
-        assert any(u["email"] == "tx_test@example.com" for u in after_users)
-
-        # Cleanup - delete test data
-        created_id = create_result.get("id")
-        if created_id:
-            workflow_cleanup = WorkflowBuilder()
-            workflow_cleanup.add_node(
-                "PythonCodeNode",
-                "cleanup",
-                {
-                    "code": f"""
-dataflow_instance = get_workflow_context('dataflow_instance')
-TestUserDeleteNode = dataflow_instance._nodes['TestUserDeleteNode']
-delete_node = TestUserDeleteNode()
-delete_node._workflow_context = {{'dataflow_instance': dataflow_instance}}
-result = delete_node.execute(id={created_id})
-"""
-                },
-            )
-            runtime.execute(
-                workflow_cleanup.build(),
-                parameters={"workflow_context": {"dataflow_instance": db}},
-            )
+        # Still visible after commit, on a separate (no-scope) read.
+        verify = WorkflowBuilder()
+        verify.add_node(
+            "TestUserListNode", "check", {"filter": {"email": email}, "limit": 10}
+        )
+        verify_results, _ = runtime.execute(
+            verify.build(),
+            parameters={"workflow_context": {"dataflow_instance": db}},
+        )
+        assert verify_results.get("check", {}).get("count", 0) == 1
 
     def test_dataflow_node_without_transaction_context(self, test_suite):
         """Test DataFlow nodes work normally without transaction context."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1560_create_retry_node_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1560_create_retry_node_leak.py
@@ -150,11 +150,19 @@ def test_retry_site_wraps_async_run_in_cleanup():
     runtime contract (``rules/testing.md`` Behavioral Regression)."""
     src = Path(__file__).resolve().parents[2] / "src/dataflow/core/nodes.py"
     text = src.read_text()
-    # Locate the $11 retry construction and assert a cleanup() follows within it.
+    # Locate the $11 retry block, then the throwaway (non-pooled) node it
+    # constructs. #1581 routes the in-scope retry through the POOLED node (the
+    # pool owns that connection's lifecycle, so it needs no explicit cleanup);
+    # only the no-scope path builds a fresh AsyncSQLDatabaseNode, and THAT is the
+    # node the #1560 leak-fix must clean up. Anchor on the fresh-node
+    # construction so a legitimate scope-branch insertion above it (as #1581 did)
+    # cannot silently slide the cleanup out of a fixed char window.
     anchor = text.index("PARAM $11 FIX: Detected parameter $11 issue")
-    window = text[anchor : anchor + 2600]
-    assert "await sql_node.cleanup()" in window, (
+    retry_region = text[anchor : anchor + 4000]
+    node_pos = retry_region.index("sql_node = AsyncSQLDatabaseNode(")
+    tail = retry_region[node_pos:]
+    assert "await sql_node.cleanup()" in tail, (
         "the #1560 retry node is no longer cleaned up — the throwaway "
         "AsyncSQLDatabaseNode leak has been reintroduced"
     )
-    assert "finally:" in window
+    assert "finally:" in tail

--- a/packages/kailash-dataflow/tests/regression/test_issue_1581_crud_transaction_awareness.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1581_crud_transaction_awareness.py
@@ -1,0 +1,476 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1581 — generated DataFlow CRUD nodes were NOT
+transaction-aware: they ran every statement on their own cached
+``AsyncSQLDatabaseNode`` in ``transaction_mode="auto"`` (per-statement
+autocommit), so a CRUD write inside a ``TransactionScopeNode`` workflow
+committed independently and survived a later ``TransactionRollbackNode``.
+
+Root cause (confirmed by live PG:5434 + SQLite reproduction, not hypothesis):
+
+``TransactionScopeNode`` stores an ``_AdapterTransactionScope`` under the
+workflow-context key ``active_transaction`` (the runtime injects the SAME
+``_workflow_context`` dict onto every node in the workflow — verified by
+``id()`` equality of the context dict across the scope node and the CRUD node).
+The generated CRUD nodes never read that key: each called
+``sql_node.async_run(..., transaction_mode="auto")`` on the cached node, and the
+``transaction_mode`` input was INERT (``async_run`` reads it from config at
+init, never from inputs). So the CRUD write auto-committed on its own
+connection and no rollback could reach it.
+
+The fix (two surgical parts):
+  * core ``kailash.nodes.data.async_sql`` — ``_AdapterTransactionScope`` gained
+    a ``.transaction`` property (the raw adapter txn handle), and
+    ``AsyncSQLDatabaseNode.async_run`` / ``execute_many_async`` accept an
+    explicit ``transaction=`` input threaded to a borrow-don't-own branch in
+    ``_execute_with_transaction`` / ``_execute_many_with_transaction`` (run ON
+    the borrowed txn; do NOT begin/commit/rollback).
+  * ``dataflow.core.nodes`` — every generated CRUD site routes through
+    ``_run_sql_in_scope(node, sql_node, **kw)``, which reads
+    ``active_transaction`` off workflow context and passes ``scope.transaction``
+    into ``async_run``. The PG ``$11`` param-type retry fallback was ALSO fixed
+    (it spawned a fresh non-pooled node that escaped the scope — now, when a
+    scope is active, the retry runs on the pooled node that joins it).
+
+Reads join too (LIST/READ/COUNT), giving read-your-writes inside the scope; a
+``ROLLBACK TO SAVEPOINT`` discards post-savepoint CRUD writes because the CRUD
+runs on the scope's connection.
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dataflow import DataFlow
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+@pytest.fixture
+async def pg_suite():
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+async def _drop_table(url: str, table: str) -> None:
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=url,
+        database_type="postgresql",
+        query=f"DROP TABLE IF EXISTS {table} CASCADE",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+async def _raw_count(url: str, table: str, sku: str) -> int:
+    """Count rows via a FRESH asyncpg connection — proves what actually
+    committed to the database, independent of any pool / cache / scope."""
+    import asyncpg
+
+    conn = await asyncpg.connect(url)
+    try:
+        return await conn.fetchval(f"SELECT count(*) FROM {table} WHERE sku = $1", sku)
+    finally:
+        await conn.close()
+
+
+def _sku(prefix: str = "s1581") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+def _ctx(db: DataFlow) -> dict:
+    return {"workflow_context": {"dataflow_instance": db}}
+
+
+# ---------------------------------------------------------------------------
+# AC1 — commit PERSISTS: a CREATE inside a scope is durable after commit.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_create_in_scope_persists_after_commit(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_commit_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581CommitProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("commit")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode", "start_tx", {"isolation_level": "READ_COMMITTED"}
+    )
+    workflow.add_node(
+        "Issue1581CommitProductCreateNode",
+        "create",
+        {"name": "Committed", "sku": sku},
+    )
+    workflow.add_node("TransactionCommitNode", "commit_tx", {})
+    workflow.add_connection("start_tx", "transaction_id", "create", "transaction_id")
+    workflow.add_connection("create", "id", "commit_tx", "record_count")
+
+    runtime = LocalRuntime()
+    results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("commit_tx", {}).get("status") == "committed"
+    # Durable on a FRESH connection → genuinely committed.
+    assert await _raw_count(url, "issue1581_commit_products", sku) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC2 — rollback DISCARDS: a CREATE inside a scope does NOT survive rollback.
+#        (This is the exact #1581 bug: pre-fix the CREATE auto-committed.)
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_create_in_scope_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_rollback_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581RollbackProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("rollback")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode",
+        "start_tx",
+        {"isolation_level": "READ_COMMITTED", "rollback_on_error": True},
+    )
+    workflow.add_node(
+        "Issue1581RollbackProductCreateNode",
+        "create",
+        {"name": "Doomed", "sku": sku},
+    )
+    # Trigger node returns normally (does NOT raise — raising would abort the
+    # whole workflow before rollback_tx runs). It just signals the rollback.
+    workflow.add_node(
+        "PythonCodeNode",
+        "trigger_error",
+        {"code": "result = {'status': 'error', 'message': 'force rollback'}"},
+    )
+    workflow.add_node("TransactionRollbackNode", "rollback_tx", {})
+    workflow.add_connection("start_tx", "result", "create", "input_data")
+    workflow.add_connection("create", "result", "trigger_error", "input_data")
+    workflow.add_connection("trigger_error", "result", "rollback_tx", "input_data")
+
+    runtime = LocalRuntime()
+    results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # The write MUST NOT have committed — pre-fix this was 1 (auto-commit).
+    assert await _raw_count(url, "issue1581_rollback_products", sku) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC3 — read-your-writes: a LIST inside the scope sees the uncommitted CREATE
+#        (reads join the scope's connection too).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_read_your_writes_inside_scope(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_ryw_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581RywProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("ryw")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode", "start_tx", {"isolation_level": "READ_COMMITTED"}
+    )
+    workflow.add_node(
+        "Issue1581RywProductCreateNode", "create", {"name": "Fresh", "sku": sku}
+    )
+    workflow.add_node(
+        "Issue1581RywProductListNode",
+        "list_in_tx",
+        {"filter": {"sku": sku}, "limit": 10},
+    )
+    workflow.add_node("TransactionCommitNode", "commit_tx", {})
+    workflow.add_connection("start_tx", "transaction_id", "create", "transaction_id")
+    workflow.add_connection("create", "id", "list_in_tx", "previous_id")
+    workflow.add_connection("list_in_tx", "count", "commit_tx", "record_count")
+
+    runtime = LocalRuntime()
+    results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    # The in-scope LIST saw the row created earlier in the SAME transaction,
+    # BEFORE commit — read-your-writes.
+    assert results.get("list_in_tx", {}).get("count") == 1
+    assert results.get("commit_tx", {}).get("status") == "committed"
+
+
+# ---------------------------------------------------------------------------
+# AC4 — back-compat: NO scope → CRUD still auto-commits (express path).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_no_scope_still_autocommits(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_nocope_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581NocopeProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("noscope")
+
+    # express.create runs with NO workflow transaction scope → must persist.
+    await db.express.create(
+        "Issue1581NocopeProduct", {"name": "Autocommit", "sku": sku}
+    )
+    assert await _raw_count(url, "issue1581_nocope_products", sku) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC5 — savepoint: ROLLBACK TO SAVEPOINT discards a post-savepoint CRUD write
+#        while keeping the pre-savepoint one (CRUD runs on the scope conn).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_rollback_to_savepoint_discards_post_savepoint_create(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_sp_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581SpProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku_a = _sku("sp-keep")
+    sku_b = _sku("sp-drop")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode", "start_tx", {"isolation_level": "READ_COMMITTED"}
+    )
+    workflow.add_node(
+        "Issue1581SpProductCreateNode", "create_a", {"name": "Keep", "sku": sku_a}
+    )
+    # TransactionSavepointNode's param is "name"; the rollback node's is
+    # "savepoint" (distinct param names in the SDK).
+    workflow.add_node("TransactionSavepointNode", "sp", {"name": "sp1"})
+    workflow.add_node(
+        "Issue1581SpProductCreateNode", "create_b", {"name": "Drop", "sku": sku_b}
+    )
+    workflow.add_node(
+        "TransactionRollbackToSavepointNode", "rollback_sp", {"savepoint": "sp1"}
+    )
+    workflow.add_node("TransactionCommitNode", "commit_tx", {})
+    workflow.add_connection("start_tx", "result", "create_a", "input_data")
+    workflow.add_connection("create_a", "result", "sp", "input_data")
+    workflow.add_connection("sp", "result", "create_b", "input_data")
+    workflow.add_connection("create_b", "result", "rollback_sp", "input_data")
+    workflow.add_connection("rollback_sp", "result", "commit_tx", "input_data")
+
+    runtime = LocalRuntime()
+    results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("commit_tx", {}).get("status") == "committed"
+    # A (before savepoint) survives; B (after savepoint) was rolled back.
+    assert await _raw_count(url, "issue1581_sp_products", sku_a) == 1
+    assert await _raw_count(url, "issue1581_sp_products", sku_b) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC6 — SQLite parity: rollback discards the CRUD write on SQLite too.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_sqlite_create_in_scope_discarded_after_rollback(tmp_path):
+    url = f"sqlite:///{tmp_path}/issue1581.db"
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581SqliteProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("sqlite")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode",
+        "start_tx",
+        {"isolation_level": "READ_COMMITTED", "rollback_on_error": True},
+    )
+    workflow.add_node(
+        "Issue1581SqliteProductCreateNode",
+        "create",
+        {"name": "Doomed", "sku": sku},
+    )
+    workflow.add_node(
+        "PythonCodeNode",
+        "trigger_error",
+        {"code": "result = {'status': 'error', 'message': 'force rollback'}"},
+    )
+    workflow.add_node("TransactionRollbackNode", "rollback_tx", {})
+    workflow.add_connection("start_tx", "result", "create", "input_data")
+    workflow.add_connection("create", "result", "trigger_error", "input_data")
+    workflow.add_connection("trigger_error", "result", "rollback_tx", "input_data")
+
+    runtime = LocalRuntime()
+    results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # Verify via the framework read (SQLite file store) that the row is gone.
+    remaining = await db.express.list("Issue1581SqliteProduct", {"sku": sku})
+    assert remaining == []
+
+
+# ---------------------------------------------------------------------------
+# AC7 — fail-closed: an active scope whose object exposes no `.transaction`
+#        handle MUST raise, NOT silently auto-commit (zero-tolerance Rule 3).
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+async def test_run_sql_in_scope_fails_closed_without_transaction_handle():
+    from dataflow.core.nodes import _run_sql_in_scope
+    from kailash.sdk_exceptions import NodeExecutionError
+
+    class _ScopeWithoutTransaction:
+        """A stand-in for a corrupt/unexpected active_transaction object."""
+
+    class _FakeNode:
+        def get_workflow_context(self, key, default=None):
+            if key == "active_transaction":
+                return _ScopeWithoutTransaction()
+            return default
+
+    class _FakeSqlNode:
+        async def async_run(self, **kwargs):  # must NEVER be reached
+            raise AssertionError(
+                "async_run must not run — the helper must fail closed first"
+            )
+
+    with pytest.raises(NodeExecutionError, match="escape the transaction scope"):
+        await _run_sql_in_scope(_FakeNode(), _FakeSqlNode(), query="SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# AC8 — core batch borrow: execute_many_async(transaction=<borrowed>) runs ON
+#        the borrowed transaction (rollback discards) and does NOT auto-commit.
+#        Gives the #1581 batch plumbing a real consumer + test.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_execute_many_async_borrowed_transaction_rollback_discards(pg_suite):
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_batch_rows")
+
+    node = AsyncSQLDatabaseNode(connection_string=url, database_type="postgresql")
+    adapter = await node._get_adapter()
+    await adapter.execute("CREATE TABLE IF NOT EXISTS issue1581_batch_rows (sku TEXT)")
+    sku = _sku("batch")
+
+    # Borrow a transaction via the uniform adapter.transaction() contract, run a
+    # batch INSERT on it, then roll it back — the rows MUST NOT persist.
+    async with adapter.transaction() as scope:
+        await node.execute_many_async(
+            "INSERT INTO issue1581_batch_rows (sku) VALUES (:sku)",
+            [{"sku": sku}, {"sku": sku}, {"sku": sku}],
+            transaction=scope.transaction,
+        )
+        await scope.rollback()
+
+    assert await _raw_count(url, "issue1581_batch_rows", sku) == 0
+    await node.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# AC9 — DEFERRED CONTRACT (xfail-strict): bulk write nodes are NOT yet
+#        transaction-aware. A BulkCreate inside a rolled-back scope currently
+#        auto-commits and survives. When #1585 makes bulk scope-aware this test
+#        XPASSes and the marker MUST be removed same-shard (rules/testing.md
+#        § xfail-strict). Tracked by #1585.
+# ---------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Deferred: bulk CRUD nodes bypass the transaction scope (bulk.py / "
+        "bulk_create_pool.py / bulk_upsert.py run auto-commit and do not join "
+        "active_transaction). A BulkCreate inside a rolled-back TransactionScope "
+        "auto-commits and survives, so count is 2 (not 0). XPASSes when #1585 "
+        "makes bulk scope-aware; remove marker same-shard. Tracked by #1585."
+    ),
+)
+async def test_bulk_create_in_scope_discarded_after_rollback_xfail(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1581_bulk_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1581BulkProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("bulk")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode",
+        "start_tx",
+        {"isolation_level": "READ_COMMITTED", "rollback_on_error": True},
+    )
+    workflow.add_node(
+        "Issue1581BulkProductBulkCreateNode",
+        "bulk",
+        {"data": [{"name": "A", "sku": sku}, {"name": "B", "sku": sku}]},
+    )
+    workflow.add_node(
+        "PythonCodeNode",
+        "trigger_error",
+        {"code": "result = {'status': 'error'}"},
+    )
+    workflow.add_node("TransactionRollbackNode", "rollback_tx", {})
+    workflow.add_connection("start_tx", "result", "bulk", "input_data")
+    workflow.add_connection("bulk", "result", "trigger_error", "input_data")
+    workflow.add_connection("trigger_error", "result", "rollback_tx", "input_data")
+
+    runtime = LocalRuntime()
+    runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    # DESIRED (post-#1585) behavior: rollback discards the bulk write.
+    assert await _raw_count(url, "issue1581_bulk_products", sku) == 0

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -1032,6 +1032,21 @@ class _AdapterTransactionScope:
         self._rolled_back = True
         await self._adapter.rollback_transaction(self._txn)
 
+    @property
+    def transaction(self) -> Any:
+        """The raw adapter transaction handle for ``adapter.execute(transaction=...)``.
+
+        This is the same object ``adapter.begin_transaction()`` returns — the
+        exact shape the ``execute`` / ``execute_many`` ``transaction=`` kwarg
+        expects. DataFlow's generated CRUD nodes read this off the
+        workflow-context scope (``active_transaction``) and pass it into
+        ``AsyncSQLDatabaseNode.async_run(transaction=...)`` so a CRUD statement
+        joins the scope's transaction instead of opening its own auto-commit
+        transaction (#1581). Exposed as a property so callers never reach into
+        the private ``_txn`` attribute.
+        """
+        return self._txn
+
 
 class _AdapterTransactionContext:
     """Async context manager returned by :meth:`DatabaseAdapter.transaction`.
@@ -5058,6 +5073,11 @@ class AsyncSQLDatabaseNode(AsyncNode):
             parameter_types = inputs.get(
                 "parameter_types", self.config.get("parameter_types")
             )
+            # #1581: an explicit borrowed transaction (a workflow-context
+            # scope's raw txn handle, threaded by DataFlow's generated CRUD
+            # nodes). When present the query runs ON that transaction and the
+            # node does NOT begin/commit/rollback — the scope owns lifecycle.
+            borrowed_transaction = inputs.get("transaction")
 
             if not query:
                 raise NodeExecutionError("No query provided")
@@ -5123,6 +5143,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
                 fetch_size=fetch_size,
                 user_context=user_context,
                 parameter_types=parameter_types,
+                transaction=borrowed_transaction,
             )
 
             # Check for special SQLite lastrowid result
@@ -5346,7 +5367,10 @@ class AsyncSQLDatabaseNode(AsyncNode):
             )
 
     async def execute_many_async(
-        self, query: str, params_list: list[dict[str, Any]]
+        self,
+        query: str,
+        params_list: list[dict[str, Any]],
+        transaction: Optional[Any] = None,
     ) -> dict[str, Any]:
         """Execute the same query multiple times with different parameters.
 
@@ -5401,6 +5425,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
                 adapter=adapter,
                 query=query,
                 params_list=params_list,  # type: ignore[arg-type]
+                transaction=transaction,
             )
 
             return {
@@ -5489,6 +5514,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
         fetch_size: Optional[int],
         user_context: Any | None = None,
         parameter_types: Optional[dict[str, str]] = None,
+        transaction: Optional[Any] = None,
     ) -> Any:
         """Execute query with retry logic for transient failures.
 
@@ -5518,6 +5544,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
                     fetch_mode=fetch_mode,
                     fetch_size=fetch_size,
                     parameter_types=parameter_types,
+                    transaction=transaction,
                 )
 
                 # Apply data masking if access control is enabled
@@ -5627,6 +5654,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
         adapter: DatabaseAdapter,
         query: str,
         params_list: list[Union[tuple, dict]],
+        transaction: Optional[Any] = None,
     ) -> int:
         """Execute batch operation with retry logic.
 
@@ -5650,6 +5678,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
                     adapter=adapter,
                     query=query,
                     params_list=params_list,
+                    transaction=transaction,
                 )
 
             except Exception as e:
@@ -5729,6 +5758,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
         adapter: DatabaseAdapter,
         query: str,
         params_list: list[Union[tuple, dict]],
+        transaction: Optional[Any] = None,
     ) -> int:
         """Execute batch operation with automatic transaction management.
 
@@ -5736,6 +5766,10 @@ class AsyncSQLDatabaseNode(AsyncNode):
             adapter: Database adapter
             query: SQL query to execute
             params_list: List of parameter dictionaries
+            transaction: An explicit borrowed transaction handle (#1581). When
+                provided, the batch runs ON that transaction and this method
+                does NOT begin/commit/rollback — the borrowing scope owns the
+                transaction lifecycle.
 
         Returns:
             Number of affected rows (estimated)
@@ -5743,6 +5777,14 @@ class AsyncSQLDatabaseNode(AsyncNode):
         Raises:
             Exception: Re-raises any execution errors after rollback
         """
+        if transaction is not None:
+            # #1581: borrowed transaction (a workflow-context scope). Run ON the
+            # caller's transaction; the scope's commit/rollback node governs the
+            # batch. Mirrors the manual `_active_transaction` branch below but
+            # sources the handle from the explicit param (see
+            # _execute_with_transaction for why instance state is not mutated).
+            await adapter.execute_many(query, params_list, transaction)
+            return len(params_list)
         if self._active_transaction:
             # Use existing transaction (manual mode)
             await adapter.execute_many(query, params_list, self._active_transaction)
@@ -5784,6 +5826,7 @@ class AsyncSQLDatabaseNode(AsyncNode):
         fetch_mode: FetchMode,
         fetch_size: Optional[int],
         parameter_types: Optional[dict[str, str]] = None,
+        transaction: Optional[Any] = None,
     ) -> Any:
         """Execute query with automatic transaction management.
 
@@ -5793,6 +5836,10 @@ class AsyncSQLDatabaseNode(AsyncNode):
             params: Query parameters
             fetch_mode: How to fetch results
             fetch_size: Number of rows for 'many' mode
+            transaction: An explicit borrowed transaction handle (#1581). When
+                provided, the query runs ON that transaction and this method
+                does NOT begin/commit/rollback — the borrowing scope owns the
+                transaction lifecycle.
 
         Returns:
             Query results
@@ -5800,6 +5847,22 @@ class AsyncSQLDatabaseNode(AsyncNode):
         Raises:
             Exception: Re-raises any execution errors after rollback
         """
+        if transaction is not None:
+            # #1581: borrowed transaction (a workflow-context scope). Run ON the
+            # caller's transaction; do NOT begin/commit/rollback — the scope's
+            # commit/rollback node governs the write. This mirrors the manual
+            # `_active_transaction` branch below but sources the handle from the
+            # explicit param instead of mutating instance state (the per-loop
+            # cached node is shared across operations, so mutating
+            # `_active_transaction` would leak the scope into unrelated calls).
+            return await adapter.execute(
+                query=query,
+                params=params,
+                fetch_mode=fetch_mode,
+                fetch_size=fetch_size,
+                transaction=transaction,
+                parameter_types=parameter_types,
+            )
         if self._active_transaction:
             # Use existing transaction (manual mode)
             return await adapter.execute(

--- a/tests/integration/nodes/test_async_sql_transaction_cleanup.py
+++ b/tests/integration/nodes/test_async_sql_transaction_cleanup.py
@@ -271,22 +271,20 @@ class TestAsyncSQLTransactionCleanup:
 
     @pytest.mark.asyncio
     async def test_transaction_context_manager_pattern(self, postgres_adapter):
-        """Test using transaction context manager for automatic cleanup."""
-        # This test verifies the new PostgreSQLTransactionContext pattern
+        """Test using transaction context manager for automatic cleanup.
 
-        # Arrange
-        from kailash.nodes.data.async_sql import PostgreSQLTransactionContext
-
-        # Act - Use context manager
-        async with PostgreSQLTransactionContext(
-            postgres_adapter._pool
-        ) as transaction_ctx:
+        #1580 replaced the old ``PostgreSQLTransactionContext`` with the uniform
+        ``adapter.transaction()`` async-CM yielding an ``_AdapterTransactionScope``
+        (``.connection`` + ``.transaction`` + async ``.commit()`` / ``.rollback()``).
+        """
+        # Act - Use the uniform transaction() async context manager
+        async with postgres_adapter.transaction() as scope:
             await postgres_adapter.execute(
                 "INSERT INTO test_transaction_cleanup (value) VALUES ($1)",
                 params=["context_test"],
-                transaction=transaction_ctx,
+                transaction=scope.transaction,
             )
-            await transaction_ctx.commit()
+            await scope.commit()
 
         # Assert - Data should be in database
         result = await postgres_adapter.execute(
@@ -297,19 +295,14 @@ class TestAsyncSQLTransactionCleanup:
 
     @pytest.mark.asyncio
     async def test_transaction_context_auto_rollback_on_error(self, postgres_adapter):
-        """Test context manager auto-rollback on exception."""
-        # Arrange
-        from kailash.nodes.data.async_sql import PostgreSQLTransactionContext
-
-        # Act & Assert
+        """Test context manager auto-rollback on exception (#1580 contract)."""
+        # Act & Assert - the async CM rolls back when the body raises.
         with pytest.raises(ValueError):
-            async with PostgreSQLTransactionContext(
-                postgres_adapter._pool
-            ) as transaction_ctx:
+            async with postgres_adapter.transaction() as scope:
                 await postgres_adapter.execute(
                     "INSERT INTO test_transaction_cleanup (value) VALUES ($1)",
                     params=["auto_rollback_test"],
-                    transaction=transaction_ctx,
+                    transaction=scope.transaction,
                 )
                 raise ValueError("Simulated error")
 


### PR DESCRIPTION
## Summary

Generated DataFlow CRUD nodes ran every statement on their own cached `AsyncSQLDatabaseNode` in `transaction_mode="auto"` (per-statement autocommit), so a CRUD write inside a `TransactionScopeNode` workflow committed independently and **survived a later `TransactionRollbackNode`** — a silent data-integrity violation. The `transaction_mode="auto"` kwarg at the call sites was inert (`async_run` reads it from config at init, never from inputs), so a "transaction" gave users no actual atomicity.

## Fix (single-record CRUD)

- **core `src/kailash/nodes/data/async_sql.py`** — `_AdapterTransactionScope` gains a `.transaction` property (raw txn handle); `async_run` / `execute_many_async` accept an explicit `transaction=` input threaded to a **borrow-don't-own** branch in `_execute_with_transaction` / `_execute_many_with_transaction` (run ON the borrowed txn; the scope owns commit/rollback). Param-threaded, not instance-state mutation (the cached node is shared across operations).
- **`packages/kailash-dataflow/src/dataflow/core/nodes.py`** — module-level `_run_sql_in_scope()` reads `active_transaction` off workflow context and injects `scope.transaction`; all 10 CRUD sites (create/read/update/delete/list/count/upsert + mysql-precheck + readback) route through it. **Fails closed** if a scope lacks `.transaction` (no silent auto-commit). The PG `$11` param-type retry now runs on the pooled node when a scope is active, instead of a fresh non-pooled node that escaped it.
- **`engine.py`** — register the previously-orphaned `TransactionSavepointNode` + `TransactionRollbackToSavepointNode` (defined + exported but never registered → unreachable by any workflow).
- **`transaction_nodes.py`** — savepoint-name `re.match(...$)` → `re.fullmatch` (newly load-bearing once the nodes are reachable; `$` accepted a trailing newline).

Reads join too (LIST/READ/COUNT) → read-your-writes inside the scope; `ROLLBACK TO SAVEPOINT` discards post-savepoint single-record CRUD writes.

## Scope boundary — bulk deferred to #1585

Bulk CRUD nodes (`BulkCreate/Update/Delete/Upsert`) dispatch to a separate ~3.3k-LOC subsystem (`features/bulk.py` + `bulk_create_pool.py` + `bulk_upsert.py`) that runs auto-commit on fresh non-pooled nodes and never reads `active_transaction`. Threading the scope through it is a separate shard → filed **#1585** and pinned by an **xfail-strict** regression tripwire (`test_bulk_create_in_scope_discarded_after_rollback_xfail`) that XPASSes (strict-fails) the moment bulk is fixed.

## Testing

- **9 new Tier-2 regression tests** (real PostgreSQL:5434 + SQLite): commit-persists, rollback-discards, read-your-writes, savepoint-partial, no-scope-autocommits (back-compat), fail-closed, core batch-borrow, SQLite parity, + the bulk xfail pin. `8 passed + 1 xfailed`.
- Flipped the strict-xfail on `test_dataflow_rollback_transaction` (now XPASSes; marker removed).
- Rewrote the contrived `test_workflow_context_integration.py::test_dataflow_node_uses_transaction_connection` (its threaded-PythonCodeNode harness only "passed" because of this bug) to the real direct-node path.
- Repaired 2 pre-existing tests orphaned by #1580's contract rewrite (imported the removed `PostgreSQLTransactionContext`).
- Broader: 46 passed + 6 xfailed (transactions + #1580 + #1581 package-tree); 9 passed root async_sql cleanup.
- **Redteam-converged**: 2 consecutive clean rounds, 5 adversarial agent reviews (correctness + security + closure-parity).

## Related issues

Fixes #1581
Follow-up: #1585 (bulk transaction-awareness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)