### PR TITLE
fix(dataflow): close the Express cache adapter on DataFlow teardown

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
@@ -400,13 +400,20 @@ class AsyncRedisCacheAdapter:
 
         Per ``rules/patterns.md`` § Async Resource Cleanup, callers MUST
         invoke this (or use the adapter as an ``async with`` context) to
-        release the executor's worker threads. ``__del__`` only emits a
-        ``ResourceWarning`` — it does NOT call shutdown, because doing so
-        from a GC finalizer deadlocks against the root logging lock.
+        release the executor's worker threads. ``__del__`` emits a
+        ``ResourceWarning`` AND calls ``shutdown(wait=False)`` (a purely
+        synchronous, non-logging call that is safe from a finalizer); it does
+        NOT call ``close``/``close_async``, because their ``logger.debug`` line
+        would fire from inside GC's logging machinery and deadlock against the
+        root logging lock (see ``__del__``).
+
+        The join is offloaded via ``asyncio.to_thread`` so ``shutdown(wait=True)``
+        (which blocks until every worker thread exits) does not freeze the event
+        loop while the pool drains.
         """
         if self._closed:
             return
-        self._executor.shutdown(wait=True)
+        await asyncio.to_thread(self._executor.shutdown, wait=True)
         self._closed = True
         logger.debug("AsyncRedisCacheAdapter executor shut down")
 

--- a/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
@@ -410,6 +410,22 @@ class AsyncRedisCacheAdapter:
         self._closed = True
         logger.debug("AsyncRedisCacheAdapter executor shut down")
 
+    def close(self) -> None:
+        """Synchronously shut down the executor thread pool.
+
+        The sync sibling of ``close_async`` for callers already on a
+        blocking path (``DataFlow.close()``). ``ThreadPoolExecutor.shutdown``
+        is purely synchronous, and the ``logger.debug`` here is safe because
+        it runs only on an explicit close — NOT from ``__del__`` (see
+        ``__del__`` for the finalizer/root-logging-lock deadlock distinction
+        that forbids logging from the finalizer path).
+        """
+        if self._closed:
+            return
+        self._executor.shutdown(wait=True)
+        self._closed = True
+        logger.debug("AsyncRedisCacheAdapter executor shut down (sync)")
+
     def __del__(self, _warnings=warnings) -> None:
         """Emit ResourceWarning if the adapter was not closed.
 

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10535,6 +10535,21 @@ class DataFlow(DataFlowEventMixin):
             finally:
                 self._express_sync = None
 
+        # Close the async Express instance's cache backend (sync path). See the
+        # close_async() counterpart: DataFlowExpress eagerly auto-detects a
+        # cache backend, and a Redis-reachable AsyncRedisCacheAdapter leaks its
+        # ThreadPoolExecutor threads unless closed. The in-memory fallback
+        # no-ops. Eager attribute — created in __init__.
+        express_async = getattr(self, "_express_dataflow", None)
+        if express_async is not None:
+            try:
+                express_async.close()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_express_async",
+                    extra={"error_type": type(e).__name__},
+                )
+
         # Stop pool monitor
         if self._pool_monitor is not None:
             try:
@@ -10577,6 +10592,25 @@ class DataFlow(DataFlowEventMixin):
                         extra={"db_type": db_type, "error": str(e)},
                     )
             self._async_sql_node_cache.clear()
+
+        # Close the query-cache adapter's executor thread pool. When the cache
+        # backend auto-detected to AsyncRedisCacheAdapter (Redis reachable), it
+        # owns a ThreadPoolExecutor whose worker threads leak (ResourceWarning
+        # at GC) unless explicitly closed. AsyncRedisCacheAdapter.close() is a
+        # sync shutdown (safe on this blocking path); the in-memory fallback has
+        # no close(), so the getattr guard no-ops on that branch.
+        integration = getattr(self, "_cache_integration", None)
+        if integration is not None:
+            manager = getattr(integration, "cache_manager", None)
+            closer = getattr(manager, "close", None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception as e:
+                    logger.debug(
+                        "engine.error_closing_cache_adapter", extra={"error": str(e)}
+                    )
+            self._cache_integration = None
 
         # Clean up connection manager
         # close_all_connections() is async; bridge to sync via async_safe_run.
@@ -10725,6 +10759,21 @@ class DataFlow(DataFlowEventMixin):
             finally:
                 self._express_sync = None
 
+        # Close the async Express instance's cache backend. DataFlowExpress
+        # eagerly auto-detects a cache backend at construction; when Redis is
+        # reachable that is an AsyncRedisCacheAdapter owning a ThreadPoolExecutor
+        # whose worker threads leak (ResourceWarning at GC) unless closed. The
+        # in-memory fallback no-ops. Eager attribute — created in __init__.
+        express_async = getattr(self, "_express_dataflow", None)
+        if express_async is not None:
+            try:
+                await express_async.close_async()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_express_async",
+                    extra={"error_type": type(e).__name__},
+                )
+
         # Stop pool monitor (same cleanup as sync close())
         if self._pool_monitor is not None:
             try:
@@ -10761,6 +10810,26 @@ class DataFlow(DataFlowEventMixin):
                         extra={"db_type": db_type, "error": str(e)},
                     )
             self._async_sql_node_cache.clear()
+
+        # Close the query-cache adapter's executor thread pool. When the cache
+        # backend auto-detected to AsyncRedisCacheAdapter (Redis reachable), it
+        # owns a ThreadPoolExecutor whose worker threads leak (ResourceWarning
+        # at GC) unless explicitly closed — neither close path used to tear it
+        # down. The in-memory fallback has no close_async, so the getattr guard
+        # no-ops on that branch.
+        integration = getattr(self, "_cache_integration", None)
+        if integration is not None:
+            manager = getattr(integration, "cache_manager", None)
+            closer = getattr(manager, "close_async", None)
+            if callable(closer):
+                try:
+                    await closer()
+                except Exception as e:
+                    logger.debug(
+                        "engine.error_closing_cache_adapter_async",
+                        extra={"error": str(e)},
+                    )
+            self._cache_integration = None
 
         # Clean up connection manager
         if hasattr(self, "_connection_manager") and self._connection_manager:

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10608,7 +10608,8 @@ class DataFlow(DataFlowEventMixin):
                     closer()
                 except Exception as e:
                     logger.debug(
-                        "engine.error_closing_cache_adapter", extra={"error": str(e)}
+                        "engine.error_closing_cache_adapter",
+                        extra={"error_type": type(e).__name__},
                     )
             self._cache_integration = None
 

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -2048,6 +2048,31 @@ class DataFlowExpress:
 
         return {"imported": imported, "errors": errors}
 
+    async def close_async(self) -> None:
+        """Release Express-owned resources — the cache backend's executor.
+
+        When the cache backend auto-detected to ``AsyncRedisCacheAdapter``
+        (Redis reachable), it owns a ``ThreadPoolExecutor`` whose worker
+        threads leak (``ResourceWarning`` at GC) unless explicitly closed.
+        The in-memory fallback has no ``close_async``, so the getattr guard
+        no-ops on that branch. Wired into :func:`DataFlow.close_async` so
+        ``async with DataFlow(...)`` callers do not close it manually.
+        Idempotent — ``AsyncRedisCacheAdapter.close_async`` guards double-close.
+        """
+        closer = getattr(self._cache_manager, "close_async", None)
+        if callable(closer):
+            await closer()
+
+    def close(self) -> None:
+        """Sync sibling of :func:`close_async` — release the cache backend's
+        executor on a blocking teardown path (``DataFlow.close``). The
+        in-memory fallback has no ``close``, so the getattr guard no-ops.
+        Idempotent.
+        """
+        closer = getattr(self._cache_manager, "close", None)
+        if callable(closer):
+            closer()
+
 
 ExpressDataFlow = DataFlowExpress  # Deprecated alias
 

--- a/packages/kailash-dataflow/tests/regression/test_dataflow_close_cache_adapter_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_dataflow_close_cache_adapter_leak.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: ``DataFlow.close`` / ``close_async`` MUST close the Express cache
+backend's executor thread pool.
+
+``DataFlowExpress.__init__`` eagerly auto-detects a cache backend. When Redis is
+reachable that backend is an ``AsyncRedisCacheAdapter`` owning a
+``ThreadPoolExecutor``; neither ``DataFlow.close()`` nor ``DataFlow.close_async()``
+used to tear it down, so the worker threads leaked and the adapter emitted
+``ResourceWarning: AsyncRedisCacheAdapter not closed`` at GC. The fix gives
+``DataFlowExpress`` a ``close``/``close_async`` that closes ``_cache_manager`` and
+wires both engine close paths to invoke it.
+
+These tests are DETERMINISTIC and infra-free: the real leak only manifests when
+Redis is reachable (the in-memory fallback owns no executor), which would make a
+warning-based test pass vacuously on a ``[dev]``-only CI runner. Instead they
+inject a recording cache-manager and assert the close wiring actually invokes it
+on BOTH paths — the wiring is what regressed, and the wiring is what we pin.
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import pytest
+from dataflow import DataFlow
+
+
+class _RecordingCacheManager:
+    """Stand-in for the auto-detected cache backend that records teardown.
+
+    Mirrors the ``AsyncRedisCacheAdapter`` teardown surface (a sync ``close`` and
+    an async ``close_async``) so the engine's duck-typed teardown reaches it.
+    """
+
+    def __init__(self) -> None:
+        self.close_called = False
+        self.close_async_called = False
+
+    def close(self) -> None:
+        self.close_called = True
+
+    async def close_async(self) -> None:
+        self.close_async_called = True
+
+
+def test_dataflow_express_exposes_cache_close_methods():
+    """``DataFlowExpress`` MUST expose sync ``close`` and async ``close_async`` so
+    the engine teardown has a wiring target (the methods that regressed absent)."""
+    from dataflow.features.express import DataFlowExpress
+
+    assert callable(getattr(DataFlowExpress, "close", None)), (
+        "DataFlowExpress.close missing — the sync engine close() path has no way "
+        "to release the cache backend's executor thread pool"
+    )
+    assert callable(getattr(DataFlowExpress, "close_async", None)), (
+        "DataFlowExpress.close_async missing — the async engine close_async() "
+        "path has no way to release the cache backend's executor thread pool"
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_async_closes_express_cache_backend():
+    """``DataFlow.close_async()`` MUST call the Express cache backend's
+    ``close_async`` so a Redis-backed adapter's executor is torn down."""
+    db = DataFlow("sqlite:///:memory:")
+    recorder = _RecordingCacheManager()
+    # Inject the recording backend where the real AsyncRedisCacheAdapter lives.
+    db._express_dataflow._cache_manager = recorder
+
+    await db.close_async()
+
+    assert recorder.close_async_called, (
+        "DataFlow.close_async() did not close the Express cache backend — the "
+        "AsyncRedisCacheAdapter executor thread pool leaks on GC"
+    )
+
+
+def test_close_sync_closes_express_cache_backend():
+    """``DataFlow.close()`` MUST call the Express cache backend's sync ``close``."""
+    db = DataFlow("sqlite:///:memory:")
+    recorder = _RecordingCacheManager()
+    db._express_dataflow._cache_manager = recorder
+
+    db.close()
+
+    assert recorder.close_called, (
+        "DataFlow.close() did not close the Express cache backend — the "
+        "AsyncRedisCacheAdapter executor thread pool leaks on GC"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_redis_adapter_has_idempotent_sync_and_async_close():
+    """The adapter MUST expose an idempotent sync ``close`` AND ``close_async``
+    (both shut the executor); double-close is a no-op."""
+    from concurrent.futures import ThreadPoolExecutor
+    from unittest.mock import MagicMock
+
+    from dataflow.cache.async_redis_adapter import AsyncRedisCacheAdapter
+
+    adapter = AsyncRedisCacheAdapter(redis_manager=MagicMock())
+    assert isinstance(adapter._executor, ThreadPoolExecutor)
+    assert adapter._closed is False
+
+    adapter.close()
+    assert adapter._closed is True
+    adapter.close()  # idempotent — no raise
+    await adapter.close_async()  # already closed — no raise
+    assert adapter._closed is True

--- a/packages/kailash-dataflow/tests/regression/test_dataflow_close_cache_adapter_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_dataflow_close_cache_adapter_leak.py
@@ -91,6 +91,47 @@ def test_close_sync_closes_express_cache_backend():
 
 
 @pytest.mark.asyncio
+async def test_close_async_closes_engine_cache_integration_backend():
+    """``DataFlow.close_async()`` MUST also close the engine-level
+    ``_cache_integration`` cache backend — a SECOND, distinct adapter (own
+    executor) auto-detected in ``_initialize_cache_integration``, separate from
+    the Express one. Pins the ``_cache_integration`` teardown block so deleting
+    it does not pass silently."""
+    from types import SimpleNamespace
+
+    db = DataFlow("sqlite:///:memory:")
+    recorder = _RecordingCacheManager()
+    # _cache_integration wraps its backend as `.cache_manager` (ListNodeCacheIntegration).
+    db._cache_integration = SimpleNamespace(cache_manager=recorder)
+
+    await db.close_async()
+
+    assert recorder.close_async_called, (
+        "DataFlow.close_async() did not close the engine-level _cache_integration "
+        "backend — its AsyncRedisCacheAdapter executor leaks on GC"
+    )
+    assert db._cache_integration is None
+
+
+def test_close_sync_closes_engine_cache_integration_backend():
+    """``DataFlow.close()`` MUST also close the engine-level ``_cache_integration``
+    backend via its sync ``close`` (sync path counterpart of the test above)."""
+    from types import SimpleNamespace
+
+    db = DataFlow("sqlite:///:memory:")
+    recorder = _RecordingCacheManager()
+    db._cache_integration = SimpleNamespace(cache_manager=recorder)
+
+    db.close()
+
+    assert recorder.close_called, (
+        "DataFlow.close() did not close the engine-level _cache_integration "
+        "backend — its AsyncRedisCacheAdapter executor leaks on GC"
+    )
+    assert db._cache_integration is None
+
+
+@pytest.mark.asyncio
 async def test_async_redis_adapter_has_idempotent_sync_and_async_close():
     """The adapter MUST expose an idempotent sync ``close`` AND ``close_async``
     (both shut the executor); double-close is a no-op."""
@@ -108,3 +149,23 @@ async def test_async_redis_adapter_has_idempotent_sync_and_async_close():
     adapter.close()  # idempotent — no raise
     await adapter.close_async()  # already closed — no raise
     assert adapter._closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_async_shuts_executor_via_offload_path():
+    """``close_async()`` on a FRESH adapter (no prior sync ``close()``) MUST run
+    the ``asyncio.to_thread(shutdown, wait=True)`` offload path and mark the
+    adapter closed. The idempotency test above closes sync-first, which
+    short-circuits ``close_async``; this test pins the offload path itself so a
+    regression in it cannot ship green."""
+    from unittest.mock import MagicMock
+
+    from dataflow.cache.async_redis_adapter import AsyncRedisCacheAdapter
+
+    adapter = AsyncRedisCacheAdapter(redis_manager=MagicMock())
+    assert adapter._closed is False
+
+    await adapter.close_async()  # exercises the to_thread offload (no prior close)
+
+    assert adapter._closed is True
+    assert adapter._executor._shutdown is True


### PR DESCRIPTION
## Summary

`DataFlowExpress.__init__` eagerly auto-detects a cache backend. When Redis is reachable, that backend is an `AsyncRedisCacheAdapter` owning a `ThreadPoolExecutor` — but neither `DataFlow.close()` nor `DataFlow.close_async()` tore it down. Every `DataFlow` closed via the documented cleanup path (FastAPI lifespan, async pytest fixture, `with`/`async with`) leaked the executor's worker threads and emitted `ResourceWarning: AsyncRedisCacheAdapter not closed` at GC.

The leak is invisible on `[dev]`-only CI (no Redis reachable → in-memory fallback → no executor), surfacing only in environments where Redis is up.

## Fix

- `AsyncRedisCacheAdapter` gains a sync `close()` sibling to `close_async()` (idempotent executor shutdown; safe on a blocking teardown path — no logging from the finalizer, per `rules/patterns.md` § Async Resource Cleanup).
- `DataFlowExpress` gains `close()`/`close_async()` that close its `_cache_manager` (getattr-guarded so the in-memory fallback no-ops).
- Both `DataFlow` close paths now tear down the async Express instance **and** the engine-level `_cache_integration` adapter.

## Tests

`packages/kailash-dataflow/tests/regression/test_dataflow_close_cache_adapter_leak.py` pins the close wiring **deterministically** (a recording cache-manager, no Redis dependency) on both sync and async paths — a warning-based test would pass vacuously on a `[dev]`-only runner. The pre-existing `test_dataflow_close_async_closes_cleanly` (which caught this locally where Redis is reachable) also now passes.

## Related issues

Discovered while validating #1581 locally (unrelated bug class; pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)