### PR TITLE
release: kailash 2.45.5 + kailash-dataflow 2.13.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.45.5] - 2026-07-06
+
+### Added
+
+- **`AsyncSQLDatabaseNode` is transaction-scope aware (#1581).** `_AdapterTransactionScope` gained a `.transaction` property exposing the raw driver transaction handle, and `async_run` now reads `inputs.get("transaction")` and threads it through `_execute_with_retry` → `_execute_with_transaction` (and the batch path `execute_many_async` → `_execute_many_with_transaction`). When a transaction handle is supplied, a new leading borrow-don't-own branch runs `adapter.execute(..., transaction=...)` with NO begin/commit/rollback — the enclosing scope owns the lifecycle — so a statement issued inside a `TransactionScopeNode` participates in that transaction instead of autocommitting on its own connection. The handle is param-threaded, never stored on the (shared, cached) node instance, so concurrent operations cannot leak one scope's transaction into another.
+
+### Fixed
+
+- **Uniform `adapter.transaction()` contract + pool-safe commit/rollback (#1580).** The PostgreSQL, MySQL, and SQLite adapters now expose a single consistent `transaction()` async-context contract; commit/rollback return the borrowed connection to the pool exactly once (the prior double-release and begin-orphan paths are closed), and the SQLite terminal-close path is quiet so it cannot mask the underlying driver error. This is the core half of the adapter-transaction correctness work that #1581's DataFlow transaction-awareness builds on.
+
 ## [2.45.4] - 2026-07-05
 
 ### Added

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [2.13.21] — 2026-07-06 — Generated CRUD nodes are transaction-aware; Express cache adapter closed on teardown (#1581, #1587)
+
+### Fixed
+
+- **Generated DataFlow CRUD nodes now participate in an enclosing `TransactionScopeNode` (#1581).** Previously every generated CRUD node ran each statement on its own cached `AsyncSQLDatabaseNode` in `transaction_mode="auto"` (per-statement autocommit) — the `transaction_mode="auto"` kwarg at the call sites was inert because `async_run` read the mode from config at init, never from inputs. Inside a `TransactionScopeNode` a CRUD write therefore committed independently and **survived a later `TransactionRollbackNode`** (a silent data-integrity violation). A module-level `_run_sql_in_scope(node, sql_node, **kw)` now reads `active_transaction` off the workflow context and injects `scope.transaction` (requires core `kailash>=2.45.5`); all 10 single-record CRUD sites (create/read/update/delete/list/count/upsert + the MySQL pre-check + the read-back) route through it, so reads inside the scope see the scope's uncommitted writes and writes are discarded on rollback. **Fail-closed:** an active scope with no `.transaction` handle raises `NodeExecutionError` rather than silently autocommitting. The PostgreSQL `$11`-param-type retry fallback was fixed to run on the POOLED node (joining the scope) instead of a fresh non-pooled node that would escape it. Bulk CRUD nodes (`BulkCreate/Update/Delete/Upsert`) are a separate subsystem and are NOT yet scope-aware — tracked as follow-up #1585 (an `xfail(strict=True)` pin holds the gap).
+- **`TransactionSavepointNode` and `TransactionRollbackToSavepointNode` are now registered (#1581).** Both were defined and exported but never registered with the node registry, so no workflow could reach them. With single-record CRUD now transaction-aware, a `ROLLBACK TO SAVEPOINT` discards post-savepoint single-record CRUD writes. The savepoint-name validation was tightened from `re.match(...$)` to `re.fullmatch(...)` (the `$` form accepted a trailing newline), newly load-bearing now that the nodes are reachable.
+- **The Express cache backend is closed on `DataFlow.close()` / `close_async()` (#1587).** `DataFlowExpress` eagerly auto-detects a cache backend at construction; when Redis is reachable that is an `AsyncRedisCacheAdapter` owning a `ThreadPoolExecutor`. Neither close path tore it down, so every `DataFlow` closed via the documented cleanup path (FastAPI lifespan, async fixture) leaked the executor's worker threads (`ResourceWarning: AsyncRedisCacheAdapter not closed` at GC). `AsyncRedisCacheAdapter` gains a sync `close()` sibling to `close_async()`; `DataFlowExpress` gains `close()`/`close_async()` closing its `_cache_manager`; and both `DataFlow` close paths now tear down the async Express instance AND the engine-level `_cache_integration` adapter. `close_async` offloads the blocking executor shutdown via `asyncio.to_thread` so it does not freeze the event loop. The leak was invisible on `[dev]`-only CI (no Redis reachable → in-memory fallback → no executor).
+
+### Tests
+
+- **#1581:** regression suite `test_issue_1581_crud_transaction_awareness.py` — 8 passed + 1 `xfail(strict=True)` (commit-persists, rollback-discards, read-your-writes, no-scope-autocommits, savepoint-partial, SQLite parity, fail-closed, core batch-borrow, and the bulk-in-scope escape pinned for #1585). Plus the #1560 retry-cleanup source-pin re-anchored to survive the #1581 scope-branch restructure.
+- **#1587:** `test_dataflow_close_cache_adapter_leak.py` — deterministic (recording cache-manager, no Redis dependency) coverage of the close wiring on both sync and async paths, both the Express and the `_cache_integration` adapters, plus the `asyncio.to_thread` offload path.
+
 ## [2.13.20] — 2026-07-06 — Transient/owned loops outside the bridge drain their adapter pools on teardown (#1575)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.20"
+version = "2.13.21"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.45.4",
+    "kailash>=2.45.5",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.20"
+__version__ = "2.13.21"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.4"
+version = "2.45.5"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.4"
+__version__ = "2.45.5"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release-prep (version anchors + CHANGELOG). No source changes — the code shipped in #1586 (#1581) and #1587. On a `release/*` branch so the PR-gate matrix auto-skips per the ci-runners release-skip rule.

## Versions

| Package | From | To |
|---|---|---|
| `kailash` | 2.45.4 | **2.45.5** |
| `kailash-dataflow` | 2.13.20 | **2.13.21** |

`kailash-dataflow` dependency pin bumped `kailash>=2.45.4` → `kailash>=2.45.5` — #1581's DataFlow fix routes the transaction handle through core's new `AsyncSQLDatabaseNode.async_run(inputs["transaction"])` branch, which lands in 2.45.5.

## What's in it

**kailash 2.45.5** (`src/kailash/nodes/data/async_sql.py`):
- #1580 — uniform `adapter.transaction()` contract + pool-safe commit/rollback (double-release + begin-orphan closed; quiet SQLite teardown).
- #1581 — `AsyncSQLDatabaseNode` transaction-scope aware (`.transaction` property + borrow-don't-own branch, param-threaded, no instance-state leak).

**kailash-dataflow 2.13.21**:
- #1581 — generated CRUD nodes participate in `TransactionScopeNode` (writes discarded on rollback, read-your-writes inside scope, fail-closed); savepoint nodes registered; `re.fullmatch` savepoint-name validation. Bulk nodes deferred to #1585 (xfail-strict pin).
- #1587 — Express + engine cache `AsyncRedisCacheAdapter` closed on `DataFlow.close()`/`close_async()` (thread-pool leak; `asyncio.to_thread` offload).

## Publish gate

Publishing to PyPI is **not** done by this PR and awaits maintainer authorization (immutable upload). Publish order: `kailash` first, then `kailash-dataflow`.

## Related issues

Releases #1581 and #1587. Bulk transaction-awareness follow-up tracked in #1585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)