### PR TITLE
fix(dataflow): bulk CRUD nodes are transaction-aware (#1585)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [2.13.22] — 2026-07-06 — Bulk CRUD nodes are transaction-aware (#1585)
+
+### Fixed
+
+- **Bulk CRUD nodes now participate in an enclosing `TransactionScopeNode` (#1585).** #1581 made single-record CRUD nodes transaction-aware but left the bulk write surface (`BulkCreate`/`BulkUpdate`/`BulkDelete`/`BulkUpsert`) running auto-commit on its own connection — so a bulk write inside a `TransactionScopeNode` committed independently and **survived a later `TransactionRollbackNode`** (the same silent data-integrity violation as #1581, at a larger blast radius since bulk ops move more rows). The fix threads the scope's borrowed transaction handle through the bulk path so bulk writes run ON the scope's connection and are discarded on rollback:
+  - **Generated `<Model>Bulk*Node` (Path A):** a shared `_resolve_scope_transaction(node)` helper (extracted from the #1581 `_run_sql_in_scope`, same fail-closed guard) resolves the active scope at the four bulk dispatch sites in `core/nodes.py`; each `bulk_*()` in `features/bulk.py` accepts a `transaction=` handle and threads it into every `AsyncSQLDatabaseNode.async_run(transaction=...)` site (all four verbs, the bulk-delete pre-count SELECT, and the SQLite upsert insert/update-breakdown COUNT) — routing to the #1581 borrow-don't-own branch (requires core `kailash>=2.45.5`). When no scope is active the path is byte-identical to the prior auto-commit behavior.
+  - **Standalone `DataFlowBulkUpsertNode` / `BulkCreatePoolNode` (Path B):** both resolve the scope in their execution path and thread the borrowed handle to their fresh execution node. `DataFlowBulkUpsertNode.async_run` normally resolves through `async_safe_run` (a separate event loop where a borrowed asyncpg connection cannot be used), so when a scope is active it bypasses that boundary and awaits directly on the runtime loop. `BulkCreatePoolNode` forces its direct borrow path when a scope is active (its own connection pool cannot join the scope).
+  - **Fail-closed:** an active scope exposing no `.transaction` handle raises `NodeExecutionError` (shared helper); and a standalone bulk node inside a scope with no `connection_string` to join the scope raises rather than returning a fabricated-success simulation stub — symmetric across `BulkCreatePoolNode` and `DataFlowBulkUpsertNode`.
+- Removes the `xfail(strict=True)` deferral pin `test_bulk_create_in_scope_discarded_after_rollback` in the #1581 regression suite (it now passes as a real test).
+
+### Changed
+
+- **`DataFlowBulkUpsertNode` now raises `NodeExecutionError` on a batch/DB failure instead of returning `{"success": False, ...}` (#1585).** `NodeExecutionError` was added to the typed-reraise set in `_perform_bulk_upsert` so the new fail-closed scope guard propagates loudly (a scoped bulk failure must fail the node so the enclosing scope rolls back, not return a soft outcome the workflow might commit over). This aligns the standalone upsert node's hard-error contract with its sibling `BulkCreatePoolNode`, which already raises on DB errors. The delegation/express path (`db.bulk.bulk_upsert` → `features/bulk.py`) is unaffected and continues to return the per-row outcome dict.
+
+### Tests
+
+- **#1585:** new regression suite `test_issue_1585_bulk_transaction_awareness.py` — 10 tests against live PostgreSQL + SQLite: commit-persists (bulk create), rollback-discards for all four bulk verbs, SQLite parity, both standalone nodes (exercising the `async_safe_run` bypass and the pool-bypass), and fail-closed guards for both standalone nodes (AC9/AC10). Rollback outcomes are asserted via a fresh asyncpg connection independent of any pool/cache/scope. Full #1585 + #1581 transaction-awareness suites: 19 passed.
+
 ## [2.13.21] — 2026-07-06 — Generated CRUD nodes are transaction-aware; Express cache adapter closed on teardown (#1581, #1587)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.13.21"
+version = "2.13.22"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.13.21"
+__version__ = "2.13.22"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -58,6 +58,42 @@ from .exceptions import is_conflict_target_error as _is_conflict_target_error
 from .logging_config import mask_sensitive_values  # Phase 7: Sensitive value masking
 
 
+def _resolve_scope_transaction(node: Any) -> Optional[Any]:
+    """Return the active transaction-scope handle for a generated node, or ``None``.
+
+    ``TransactionScopeNode`` stores an ``_AdapterTransactionScope`` under the
+    workflow-context key ``active_transaction`` (the runtime injects the SAME
+    ``_workflow_context`` dict onto every node in the workflow). This helper
+    reads that scope and returns ``scope.transaction`` — the raw adapter txn
+    handle ``(conn, tx)`` — so the caller can thread it into
+    ``async_run(transaction=...)`` / ``bulk_*(transaction=...)``. Because the
+    handle carries its OWN connection, the borrow branch in
+    ``AsyncSQLDatabaseNode`` runs the statement ON the scope's connection
+    regardless of which node/adapter issues it — the mechanism that makes both
+    single-record CRUD (#1581) and bulk writes (#1585) join the scope.
+
+    Fail-closed (#1581/#1585): an active scope that exposes no ``.transaction``
+    handle raises ``NodeExecutionError`` rather than letting the write
+    auto-commit and escape the scope. Returns ``None`` when no scope is active
+    (``db.express`` calls, or a workflow with no transaction node) so the caller
+    preserves the prior auto-commit behavior byte-for-byte.
+    """
+    scope = node.get_workflow_context("active_transaction")
+    if scope is None:
+        return None
+    txn = getattr(scope, "transaction", None)
+    if txn is None:
+        from kailash.sdk_exceptions import NodeExecutionError
+
+        raise NodeExecutionError(
+            "active_transaction present in workflow context but exposes no "
+            f"'.transaction' handle (got {type(scope).__name__}); refusing to "
+            "run a write auto-commit and escape the transaction scope "
+            "(#1581/#1585). The scope must be an _AdapterTransactionScope."
+        )
+    return txn
+
+
 async def _run_sql_in_scope(node: Any, sql_node: Any, **kwargs: Any) -> Dict[str, Any]:
     """Run an ``AsyncSQLDatabaseNode`` call, joining an active transaction scope.
 
@@ -66,40 +102,20 @@ async def _run_sql_in_scope(node: Any, sql_node: Any, **kwargs: Any) -> Dict[str
     autocommit), so a CRUD write inside a ``TransactionScopeNode`` workflow
     committed independently and survived a later rollback.
 
-    ``TransactionScopeNode`` stores an ``_AdapterTransactionScope`` under the
-    workflow-context key ``active_transaction`` (the runtime injects the SAME
-    ``_workflow_context`` dict onto every node in the workflow). When a scope is
-    present, this helper passes ``scope.transaction`` — the raw adapter txn
-    handle — into ``async_run`` so the statement runs ON the scope's connection.
-    The scope's ``TransactionCommitNode`` / ``TransactionRollbackNode`` then
-    governs the CRUD write. Reads (LIST/READ/COUNT) join too, giving
-    read-your-writes inside the scope.
+    When a scope is present, this helper passes ``scope.transaction`` — the raw
+    adapter txn handle — into ``async_run`` so the statement runs ON the scope's
+    connection. The scope's ``TransactionCommitNode`` / ``TransactionRollbackNode``
+    then governs the CRUD write. Reads (LIST/READ/COUNT) join too, giving
+    read-your-writes inside the scope. Scope resolution + the fail-closed guard
+    live in :func:`_resolve_scope_transaction` (shared with the #1585 bulk path).
 
-    When no scope is active (``db.express`` calls, or a workflow with no
-    transaction node) the call is byte-identical to the prior direct
-    ``sql_node.async_run(**kwargs)`` — auto-commit behavior is preserved.
-
-    An explicit ``transaction`` already present in ``kwargs`` is never
-    overridden.
+    When no scope is active the call is byte-identical to the prior direct
+    ``sql_node.async_run(**kwargs)`` — auto-commit behavior is preserved. An
+    explicit ``transaction`` already present in ``kwargs`` is never overridden.
     """
     if "transaction" not in kwargs:
-        scope = node.get_workflow_context("active_transaction")
-        if scope is not None:
-            # Fail closed: an active scope with no usable transaction handle must
-            # NOT silently auto-commit (that is the exact #1581 escape). The only
-            # producer of ``active_transaction`` is TransactionScopeNode, which
-            # stores an _AdapterTransactionScope exposing ``.transaction`` — so a
-            # missing handle means a contract violation, not a benign no-op.
-            txn = getattr(scope, "transaction", None)
-            if txn is None:
-                from kailash.sdk_exceptions import NodeExecutionError
-
-                raise NodeExecutionError(
-                    "active_transaction present in workflow context but exposes no "
-                    f"'.transaction' handle (got {type(scope).__name__}); refusing to "
-                    "run a CRUD write auto-commit and escape the transaction scope "
-                    "(#1581). The scope must be an _AdapterTransactionScope."
-                )
+        txn = _resolve_scope_transaction(node)
+        if txn is not None:
             kwargs["transaction"] = txn
             import logging
 
@@ -4134,6 +4150,14 @@ class NodeGenerator:
                     data = validated_inputs.get("data", [])
                     batch_size = validated_inputs.get("batch_size", 1000)
 
+                    # #1585: resolve the active transaction scope ONCE for every
+                    # bulk op so bulk writes join a TransactionScopeNode and are
+                    # governed by its commit/rollback (parity with single-record
+                    # CRUD's _run_sql_in_scope). Fail-closed if a scope is present
+                    # but exposes no `.transaction` handle. ``None`` when no scope
+                    # is active → bulk_*() preserves prior auto-commit behavior.
+                    scope_txn = _resolve_scope_transaction(self)
+
                     if operation == "bulk_create" and (data or "data" in kwargs_fixed):
                         # Use DataFlow's bulk create operations
                         try:
@@ -4141,6 +4165,7 @@ class NodeGenerator:
                                 model_name=self.model_name,
                                 data=data,
                                 batch_size=batch_size,
+                                transaction=scope_txn,  # #1585: join active scope
                                 **{
                                     k: v
                                     for k, v in kwargs_fixed.items()
@@ -4262,6 +4287,7 @@ class NodeGenerator:
                                 filter_criteria=filter_criteria,
                                 update_values=update_values,
                                 batch_size=batch_size,
+                                transaction=scope_txn,  # #1585: join active scope
                                 **{
                                     k: v
                                     for k, v in kwargs.items()
@@ -4374,6 +4400,7 @@ class NodeGenerator:
                                 data=data,
                                 filter_criteria=filter_criteria,
                                 batch_size=batch_size,
+                                transaction=scope_txn,  # #1585: join active scope
                                 **{
                                     k: v
                                     for k, v in kwargs_fixed.items()
@@ -4464,6 +4491,7 @@ class NodeGenerator:
                                 conflict_resolution=conflict_resolution,
                                 conflict_on=conflict_on,
                                 batch_size=batch_size,
+                                transaction=scope_txn,  # #1585: join active scope
                                 **{
                                     k: v
                                     for k, v in kwargs_fixed.items()

--- a/packages/kailash-dataflow/src/dataflow/features/bulk.py
+++ b/packages/kailash-dataflow/src/dataflow/features/bulk.py
@@ -337,9 +337,17 @@ class BulkOperations:
         model_name: str,
         data: List[Dict[str, Any]],
         batch_size: int = 1000,
+        transaction: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Perform bulk create operation."""
+        """Perform bulk create operation.
+
+        #1585: when ``transaction`` is a borrowed adapter txn handle ``(conn, tx)``
+        (threaded from a generated bulk node inside a ``TransactionScopeNode``),
+        every batch INSERT runs ON that transaction's connection instead of
+        auto-committing on its own — so a bulk write inside a rolled-back scope
+        is discarded. ``None`` (``db.express``/no-scope) preserves auto-commit.
+        """
         import logging
 
         logger = logging.getLogger(__name__)
@@ -487,6 +495,7 @@ class BulkOperations:
                     fetch_mode="all",
                     validate_queries=False,
                     transaction_mode="auto",
+                    transaction=transaction,  # #1585: join active scope (None = auto-commit)
                 )
 
                 logger.warning("bulk.bulk_create_sql_result", extra={"result": result})
@@ -551,9 +560,15 @@ class BulkOperations:
         filter_criteria: Optional[Dict[str, Any]] = None,
         update_values: Optional[Dict[str, Any]] = None,
         batch_size: int = 1000,
+        transaction: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Perform bulk update operation."""
+        """Perform bulk update operation.
+
+        #1585: a borrowed ``transaction`` handle makes every UPDATE run ON the
+        scope's connection (joins a ``TransactionScopeNode``); ``None`` preserves
+        auto-commit.
+        """
         import logging
 
         logger = logging.getLogger(__name__)
@@ -706,6 +721,7 @@ class BulkOperations:
                     fetch_mode="all",
                     validate_queries=False,
                     transaction_mode="auto",
+                    transaction=transaction,  # #1585: join active scope (None = auto-commit)
                 )
 
                 logger.warning("bulk.bulk_update_sql_result", extra={"result": result})
@@ -898,6 +914,7 @@ class BulkOperations:
                             fetch_mode="all",
                             validate_queries=False,
                             transaction_mode="auto",
+                            transaction=transaction,  # #1585: join active scope
                         )
 
                         # Extract rows_affected
@@ -960,9 +977,15 @@ class BulkOperations:
         data: Optional[List[Dict[str, Any]]] = None,
         filter_criteria: Optional[Dict[str, Any]] = None,
         batch_size: int = 1000,
+        transaction: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Perform bulk delete operation."""
+        """Perform bulk delete operation.
+
+        #1585: a borrowed ``transaction`` handle makes the DELETE (and its
+        pre-delete existence SELECT) run ON the scope's connection (joins a
+        ``TransactionScopeNode``); ``None`` preserves auto-commit.
+        """
         import logging
 
         logger = logging.getLogger(__name__)
@@ -1068,6 +1091,7 @@ class BulkOperations:
                     fetch_mode="all",
                     validate_queries=False,
                     transaction_mode="auto",
+                    transaction=transaction,  # #1585: read-your-writes inside scope
                 )
                 logger.warning(
                     "bulk.bulk_delete_pre_delete_count_check",
@@ -1085,6 +1109,7 @@ class BulkOperations:
                     fetch_mode="all",
                     validate_queries=False,
                     transaction_mode="auto",
+                    transaction=transaction,  # #1585: join active scope (None = auto-commit)
                 )
 
                 logger.warning("bulk.bulk_delete_sql_result", extra={"result": result})
@@ -1154,9 +1179,14 @@ class BulkOperations:
         conflict_resolution: str = "update",
         batch_size: int = 1000,
         conflict_on: Optional[List[str]] = None,
+        transaction: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Perform bulk upsert (insert or update) operation.
+
+        #1585: a borrowed ``transaction`` handle makes every UPSERT batch run ON
+        the scope's connection (joins a ``TransactionScopeNode``); ``None``
+        preserves auto-commit.
 
         Args:
             model_name: Name of the model
@@ -1423,7 +1453,11 @@ class BulkOperations:
                     "ignore",
                 ):
                     preexisting = await self._count_existing_conflicts(
-                        sql_node, table_name, conflict_columns, batch
+                        sql_node,
+                        table_name,
+                        conflict_columns,
+                        batch,
+                        transaction=transaction,  # #1585: read-your-writes in scope
                     )
 
                 try:
@@ -1433,6 +1467,7 @@ class BulkOperations:
                         fetch_mode="all",
                         validate_queries=False,
                         transaction_mode="auto",
+                        transaction=transaction,  # #1585: join active scope
                     )
                 except Exception as exec_err:
                     # Issue #1519: a conflict target that is not a PK/UNIQUE key
@@ -1708,6 +1743,7 @@ class BulkOperations:
         table_name: str,
         conflict_columns: List[str],
         batch: List[Dict[str, Any]],
+        transaction: Optional[Any] = None,
     ) -> int:
         """Count rows already present matching the batch's conflict-target keys.
 
@@ -1747,6 +1783,7 @@ class BulkOperations:
             fetch_mode="all",
             validate_queries=False,
             transaction_mode="auto",
+            transaction=transaction,  # #1585: count on the scope's connection
         )
         rows = []
         if result and "result" in result:

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_create_pool.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_create_pool.py
@@ -149,7 +149,25 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
             # Track whether connection pool was actually used
             actually_used_pool = False
 
-            if use_pooled_connection and self.connection_pool_id:
+            # #1585: if this node runs inside a TransactionScopeNode, the write
+            # MUST join the scope's connection so a later rollback discards it.
+            # The pooled path uses an UNRELATED connection pool that cannot join
+            # the scope, so force the direct borrow path when a scope is active
+            # (the borrowed txn handle carries the scope's connection). Resolving
+            # here is loop-safe: async_run awaits _perform_bulk_create directly on
+            # the runtime's event loop (no async_safe_run boundary), so the
+            # borrowed asyncpg connection stays on its owning loop. Fail-closed if
+            # the scope exposes no `.transaction` handle.
+            from ..core.nodes import _resolve_scope_transaction
+
+            scope_txn = _resolve_scope_transaction(self)
+
+            if scope_txn is not None:
+                # Force direct execution ON the scope's connection (bypass pool).
+                results = await self._process_direct(
+                    data, tenant_id, return_ids, dry_run, transaction=scope_txn
+                )
+            elif use_pooled_connection and self.connection_pool_id:
                 # Try to process using connection pool
                 results, actually_used_pool = await self._process_with_pool_tracked(
                     data, tenant_id, return_ids, dry_run
@@ -339,6 +357,7 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
         tenant_id: Optional[str],
         return_ids: bool,
         dry_run: bool,
+        transaction: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Process bulk create without connection pool (fallback implementation).
 
@@ -347,6 +366,12 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
 
         Note: This implementation mirrors the standard BulkOperations.bulk_create()
         pattern but operates within the node architecture.
+
+        #1585: ``transaction`` is a borrowed adapter txn handle ``(conn, tx)`` from
+        an active ``TransactionScopeNode`` (resolved in ``_perform_bulk_create``).
+        When present, every batch INSERT runs ON that connection instead of
+        auto-committing, so the write joins the scope and is discarded on
+        rollback. ``None`` preserves the prior auto-commit behavior.
         """
         if dry_run:
             return {
@@ -365,6 +390,21 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
         # Check if connection_string is available
         connection_string = getattr(self, "connection_string", None)
         if not connection_string:
+            if transaction is not None:
+                # #1585 fail-closed: an active transaction scope with no
+                # connection_string cannot join the scope, and returning the
+                # simulation stub below would report fabricated success while
+                # writing nothing — the caller would believe the bulk write
+                # persisted inside the scope. Refuse rather than silently no-op.
+                from kailash.sdk_exceptions import NodeExecutionError
+
+                raise NodeExecutionError(
+                    "BulkCreatePoolNode is inside a TransactionScopeNode but has "
+                    "no connection_string to join the scope's connection (#1585). "
+                    "Provide connection_string, or use the generated "
+                    "'<Model>BulkCreateNode' / db.express.bulk_create which are "
+                    "scope-aware."
+                )
             # Fallback to simulation mode for backward compatibility
             # This allows tests to run without requiring a real database connection
             # In production, either connection_string or use_pooled_connection should be provided
@@ -532,7 +572,9 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
                     transaction_mode="auto",
                 )
                 try:
-                    result = await sql_node.async_run()
+                    # #1585: transaction=None → auto-commit (unchanged); a
+                    # borrowed scope handle → run ON the scope's connection.
+                    result = await sql_node.async_run(transaction=transaction)
                 finally:
                     await sql_node.cleanup()
 

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
@@ -150,13 +150,39 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
     async def async_run(self, **kwargs) -> dict[str, Any]:
         """Execute bulk upsert operation asynchronously with connection pool support."""
+        # #1585: if this node runs inside a TransactionScopeNode, the upsert MUST
+        # join the scope's connection so a rollback discards it. The scope's
+        # asyncpg connection is bound to the runtime's event loop, but
+        # _execute_with_connection resolves the coroutine via async_safe_run(),
+        # which runs it on a SEPARATE loop/thread — a borrowed connection cannot
+        # cross that boundary. So when a scope is active, await _perform_bulk_upsert
+        # DIRECTLY on the runtime loop (where the borrowed connection lives) and
+        # thread the borrowed transaction through to the fresh execution node.
+        # Fail-closed if the scope exposes no `.transaction` handle.
+        from ..core.nodes import _resolve_scope_transaction
+
+        scope_txn = _resolve_scope_transaction(self)
+        if scope_txn is not None:
+            return await self._perform_bulk_upsert(
+                _scope_transaction=scope_txn, **kwargs
+            )
+
+        # No scope: preserve the prior sync/async_safe_run execution path.
         # _execute_with_connection is synchronous: when operation_func is a
         # coroutine function it internally resolves via async_safe_run() and
         # returns the already-resolved dict result. The value is NOT awaitable.
         return self._execute_with_connection(self._perform_bulk_upsert, **kwargs)
 
-    async def _perform_bulk_upsert(self, **kwargs) -> dict[str, Any]:
-        """Perform the actual bulk upsert operation."""
+    async def _perform_bulk_upsert(
+        self, _scope_transaction: Optional[Any] = None, **kwargs
+    ) -> dict[str, Any]:
+        """Perform the actual bulk upsert operation.
+
+        #1585: ``_scope_transaction`` is a borrowed adapter txn handle from an
+        active ``TransactionScopeNode`` (threaded from ``async_run`` when a scope
+        is present). It is forwarded to ``_execute_real_bulk_upsert`` →
+        ``_execute_query`` so every UPSERT runs ON the scope's connection.
+        """
         import time
 
         start_time = time.time()
@@ -187,6 +213,27 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                     f"Data validation failed: {validation_result['errors']}"
                 )
 
+            # #1585 fail-closed (symmetric with BulkCreatePoolNode): a standalone
+            # upsert inside a TransactionScopeNode with no connection_string cannot
+            # join the scope. Falling through to the dry-run-shaped else branch
+            # below would report fabricated success (rows_affected=len(data)) while
+            # writing nothing AND discarding the borrowed handle — the caller would
+            # believe the upsert persisted inside the scope. Refuse rather than
+            # silently no-op (the _execute_query guard fires too late; the else
+            # branch short-circuits before any query runs).
+            if (
+                _scope_transaction is not None
+                and not self.connection_string
+                and not dry_run
+            ):
+                raise NodeExecutionError(
+                    "DataFlowBulkUpsertNode is inside a TransactionScopeNode but "
+                    "has no connection_string to join the scope's connection "
+                    "(#1585). Provide connection_string, or use the generated "
+                    "'<Model>BulkUpsertNode' / db.express.bulk_upsert which are "
+                    "scope-aware."
+                )
+
             # Execute the bulk upsert operation
             if self.connection_string and not dry_run:
                 # Remove parameters that are passed explicitly to avoid duplicate argument error
@@ -208,6 +255,7 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                     return_records,
                     merge_strategy,
                     conflict_on,
+                    _scope_transaction=_scope_transaction,  # #1585: join active scope
                     **kwargs_copy,
                 )
             else:
@@ -284,11 +332,20 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
             return result
 
-        except (ValueError, NodeValidationError, BulkUpsertConflictTargetError):
+        except (
+            ValueError,
+            NodeValidationError,
+            NodeExecutionError,
+            BulkUpsertConflictTargetError,
+        ):
             # Issue #1519: a conflict-target error is a caller error, not a
             # transient DB failure — surface it as a typed raise (like ValueError
             # / NodeValidationError) instead of flattening it into a
             # {"success": False} dict a caller might treat as a soft outcome.
+            # #1585: NodeExecutionError (the fail-closed scope guard above) is
+            # likewise a caller/config error and MUST propagate as a raise, not be
+            # flattened — a refused scope-join must be loud, matching the sibling
+            # BulkCreatePoolNode's fail-closed raise.
             raise
         except Exception as e:
             # Issue #1552 (FIX 6 sweep): DataFlowBulkUpsertNode runs real upserts;
@@ -325,9 +382,15 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         return_records: bool,
         merge_strategy: str,
         conflict_on: List[str],
+        _scope_transaction: Optional[Any] = None,
         **kwargs,
     ) -> tuple[int, int, int, List[Dict[str, Any]], int]:
-        """Execute real bulk upsert using database connection."""
+        """Execute real bulk upsert using database connection.
+
+        #1585: ``_scope_transaction`` (a borrowed adapter txn handle) is forwarded
+        to every ``_execute_query`` call so the UPSERT runs ON the scope's
+        connection and joins an active ``TransactionScopeNode``.
+        """
         try:
             # Import here to avoid circular imports
             from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
@@ -408,9 +471,17 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                     # `// 2`). The batch is already deduped on conflict_on, so
                     # each matching pre-existing key is exactly one UPDATE.
                     preexisting = await self._count_existing_conflicts(
-                        batch, conflict_on, **kwargs
+                        batch,
+                        conflict_on,
+                        transaction=_scope_transaction,  # #1585: count on scope conn
+                        **kwargs,
                     )
-                    result = await self._execute_query(query, params=params, **kwargs)
+                    result = await self._execute_query(
+                        query,
+                        params=params,
+                        transaction=_scope_transaction,  # #1585: join active scope
+                        **kwargs,
+                    )
 
                     # Process result to count upserts and get records
                     batch_rows, batch_inserted, batch_updated, batch_records = (
@@ -824,9 +895,14 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         self,
         query: str,
         params: Optional[List[Any]] = None,
+        transaction: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Execute parameterized SQL query (issue #492).
+
+        #1585: ``transaction`` is a borrowed adapter txn handle ``(conn, tx)`` from
+        an active ``TransactionScopeNode``. When present the fresh execution node
+        runs ON that connection (joins the scope); ``None`` = auto-commit.
 
         ``params`` is a flat positional list bound by the driver and
         forwarded through ``AsyncSQLDatabaseNode``.
@@ -863,7 +939,9 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         # so its connection does not leak a ResourceWarning on GC. The result dict
         # is fully materialized by async_run, so cleanup after is safe.
         try:
-            return await db_node.async_run(query=query, params=params)
+            return await db_node.async_run(
+                query=query, params=params, transaction=transaction
+            )
         finally:
             await db_node.cleanup()
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1581_crud_transaction_awareness.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1581_crud_transaction_awareness.py
@@ -44,10 +44,10 @@ from __future__ import annotations
 import time
 
 import pytest
-
-from dataflow import DataFlow
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
 
 
 @pytest.fixture
@@ -361,8 +361,9 @@ async def test_sqlite_create_in_scope_discarded_after_rollback(tmp_path):
 # ---------------------------------------------------------------------------
 @pytest.mark.regression
 async def test_run_sql_in_scope_fails_closed_without_transaction_handle():
-    from dataflow.core.nodes import _run_sql_in_scope
     from kailash.sdk_exceptions import NodeExecutionError
+
+    from dataflow.core.nodes import _run_sql_in_scope
 
     class _ScopeWithoutTransaction:
         """A stand-in for a corrupt/unexpected active_transaction object."""
@@ -416,25 +417,17 @@ async def test_execute_many_async_borrowed_transaction_rollback_discards(pg_suit
 
 
 # ---------------------------------------------------------------------------
-# AC9 — DEFERRED CONTRACT (xfail-strict): bulk write nodes are NOT yet
-#        transaction-aware. A BulkCreate inside a rolled-back scope currently
-#        auto-commits and survives. When #1585 makes bulk scope-aware this test
-#        XPASSes and the marker MUST be removed same-shard (rules/testing.md
-#        § xfail-strict). Tracked by #1585.
+# AC9 — bulk scope-awareness (CLOSED by #1585): a BulkCreate inside a
+#        rolled-back TransactionScope is discarded. This was the xfail-strict
+#        deferral pin for #1585; the fix (thread scope.transaction through the
+#        bulk dispatch → features/bulk.py) landed, so the marker is removed here
+#        same-shard (rules/testing.md § xfail-strict). Full bulk coverage
+#        (update/delete/upsert, SQLite, standalone nodes) lives in
+#        test_issue_1585_bulk_transaction_awareness.py.
 # ---------------------------------------------------------------------------
 @pytest.mark.regression
 @pytest.mark.integration
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Deferred: bulk CRUD nodes bypass the transaction scope (bulk.py / "
-        "bulk_create_pool.py / bulk_upsert.py run auto-commit and do not join "
-        "active_transaction). A BulkCreate inside a rolled-back TransactionScope "
-        "auto-commits and survives, so count is 2 (not 0). XPASSes when #1585 "
-        "makes bulk scope-aware; remove marker same-shard. Tracked by #1585."
-    ),
-)
-async def test_bulk_create_in_scope_discarded_after_rollback_xfail(pg_suite):
+async def test_bulk_create_in_scope_discarded_after_rollback(pg_suite):
     url = pg_suite.config.url
     await _drop_table(url, "issue1581_bulk_products")
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1585_bulk_transaction_awareness.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1585_bulk_transaction_awareness.py
@@ -1,0 +1,463 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1585 — BULK DataFlow nodes were NOT
+transaction-aware (the follow-up to #1581, which fixed single-record CRUD).
+
+Pre-fix, ``BulkCreate``/``BulkUpdate``/``BulkDelete``/``BulkUpsert`` ran on their
+own cached ``AsyncSQLDatabaseNode`` in ``transaction_mode="auto"`` (per-statement
+autocommit). Inside a ``TransactionScopeNode`` workflow a bulk write committed
+independently and SURVIVED a later ``TransactionRollbackNode`` — the same silent
+data-integrity violation #1581 fixed for single-record CRUD, at a larger blast
+radius (bulk ops move more rows).
+
+The fix threads the scope's borrowed transaction handle through the bulk path:
+
+  * Path A (generated ``<Model>Bulk*Node`` → ``db.bulk.bulk_*`` in
+    ``features/bulk.py``): the 4 dispatch sites in ``core/nodes.py`` resolve the
+    active scope via ``_resolve_scope_transaction`` and pass ``transaction=`` into
+    ``bulk_*()``, which forwards it to every ``sql_node.async_run(transaction=...)``
+    — routing to the #1581 borrow-don't-own branch. The borrowed handle is a
+    ``(conn, tx)`` tuple that carries the scope's connection, so the batch INSERT
+    runs ON the scope's connection and a rollback discards it. When no scope is
+    active the call is byte-identical to the prior auto-commit path.
+
+  * Path B (standalone ``DataFlowBulkUpsertNode`` / ``BulkCreatePoolNode``, which
+    spawn FRESH non-pooled nodes): each resolves the scope in its execution path
+    and threads the borrowed handle to the fresh node's ``async_run``. The upsert
+    node normally resolves via ``async_safe_run`` (a SEPARATE event loop where a
+    borrowed asyncpg connection cannot be used), so when a scope is active it
+    bypasses that boundary and awaits directly on the runtime loop. The pool node
+    forces its direct borrow path (its own pool cannot join the scope).
+
+Verified against live PG:5434 + SQLite — NOT hypothesis. Permanent regression
+tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
+
+# Import the standalone Path B nodes so their @register_node decorators run and
+# the string node types ("DataFlowBulkUpsertNode" / "BulkCreatePoolNode") resolve
+# in the workflow builder's registry.
+from dataflow.nodes.bulk_create_pool import BulkCreatePoolNode  # noqa: F401
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode  # noqa: F401
+
+
+@pytest.fixture
+async def pg_suite():
+    from tests.infrastructure.test_harness import IntegrationTestSuite
+
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+async def _drop_table(url: str, table: str) -> None:
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    node = AsyncSQLDatabaseNode(
+        connection_string=url,
+        database_type="postgresql",
+        query=f"DROP TABLE IF EXISTS {table} CASCADE",
+        validate_queries=False,
+    )
+    await node.async_run()
+    await node.cleanup()
+
+
+async def _raw_count(url: str, table: str, sku: str) -> int:
+    """Count rows via a FRESH asyncpg connection — proves what actually
+    committed, independent of any pool / cache / scope."""
+    import asyncpg
+
+    conn = await asyncpg.connect(url)
+    try:
+        return await conn.fetchval(f"SELECT count(*) FROM {table} WHERE sku = $1", sku)
+    finally:
+        await conn.close()
+
+
+async def _raw_name(url: str, table: str, sku: str) -> str | None:
+    import asyncpg
+
+    conn = await asyncpg.connect(url)
+    try:
+        return await conn.fetchval(f"SELECT name FROM {table} WHERE sku = $1", sku)
+    finally:
+        await conn.close()
+
+
+def _sku(prefix: str = "s1585") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+def _ctx(db: DataFlow) -> dict:
+    return {"workflow_context": {"dataflow_instance": db}}
+
+
+def _rollback_workflow(bulk_node_type: str, bulk_id: str, bulk_params: dict):
+    """A TransactionScopeNode → <bulk> → trigger → TransactionRollbackNode graph.
+
+    The trigger returns normally (does NOT raise — raising would abort the whole
+    workflow before rollback_tx runs); it just signals the rollback.
+    """
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode",
+        "start_tx",
+        {"isolation_level": "READ_COMMITTED", "rollback_on_error": True},
+    )
+    workflow.add_node(bulk_node_type, bulk_id, bulk_params)
+    workflow.add_node(
+        "PythonCodeNode",
+        "trigger_error",
+        {"code": "result = {'status': 'error', 'message': 'force rollback'}"},
+    )
+    workflow.add_node("TransactionRollbackNode", "rollback_tx", {})
+    workflow.add_connection("start_tx", "result", bulk_id, "input_data")
+    workflow.add_connection(bulk_id, "result", "trigger_error", "input_data")
+    workflow.add_connection("trigger_error", "result", "rollback_tx", "input_data")
+    return workflow
+
+
+# ===========================================================================
+# Path A — generated <Model>Bulk*Node → features/bulk.py (cached pooled node)
+# ===========================================================================
+
+
+# AC1 — commit PERSISTS: a BulkCreate inside a scope is durable after commit.
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_bulk_create_persists_after_commit(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1585_commit_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585CommitProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("commit")
+
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "TransactionScopeNode",
+        "start_tx",
+        {"isolation_level": "READ_COMMITTED", "rollback_on_error": True},
+    )
+    workflow.add_node(
+        "Issue1585CommitProductBulkCreateNode",
+        "bulk",
+        {"data": [{"name": "A", "sku": sku}, {"name": "B", "sku": sku}]},
+    )
+    workflow.add_node("TransactionCommitNode", "commit_tx", {})
+    workflow.add_connection("start_tx", "result", "bulk", "input_data")
+    workflow.add_connection("bulk", "result", "commit_tx", "input_data")
+
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("commit_tx", {}).get("status") == "committed"
+    # Both rows MUST be durable after commit.
+    assert await _raw_count(url, "issue1585_commit_products", sku) == 2
+
+
+# AC2 — rollback DISCARDS a BulkCreate (the core #1585 bug at the create surface).
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_bulk_create_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1585_create_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585CreateProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("create")
+
+    workflow = _rollback_workflow(
+        "Issue1585CreateProductBulkCreateNode",
+        "bulk",
+        {"data": [{"name": "A", "sku": sku}, {"name": "B", "sku": sku}]},
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # Pre-fix this was 2 (bulk auto-committed and survived the rollback).
+    assert await _raw_count(url, "issue1585_create_products", sku) == 0
+
+
+# AC3 — rollback DISCARDS a BulkUpdate: the pre-scope value survives.
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_bulk_update_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1585_update_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585UpdateProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("update")
+
+    # Seed a committed row (no scope → auto-commit) with name "original".
+    await db.express.create("Issue1585UpdateProduct", {"name": "original", "sku": sku})
+    assert await _raw_name(url, "issue1585_update_products", sku) == "original"
+
+    workflow = _rollback_workflow(
+        "Issue1585UpdateProductBulkUpdateNode",
+        "bulk",
+        {"filter": {"sku": sku}, "fields": {"name": "mutated"}},
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # The UPDATE MUST have been discarded — the seeded value survives.
+    assert await _raw_name(url, "issue1585_update_products", sku) == "original"
+
+
+# AC4 — rollback DISCARDS a BulkDelete: the row survives the rolled-back delete.
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_bulk_delete_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1585_delete_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585DeleteProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("delete")
+
+    # Seed two committed rows.
+    await db.express.create("Issue1585DeleteProduct", {"name": "keep", "sku": sku})
+    await db.express.create("Issue1585DeleteProduct", {"name": "keep", "sku": sku})
+    assert await _raw_count(url, "issue1585_delete_products", sku) == 2
+
+    workflow = _rollback_workflow(
+        "Issue1585DeleteProductBulkDeleteNode",
+        "bulk",
+        {"filter": {"sku": sku}},
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # The DELETE MUST have been discarded — both rows survive.
+    assert await _raw_count(url, "issue1585_delete_products", sku) == 2
+
+
+# AC5 — rollback DISCARDS a BulkUpsert (insert path).
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_pg_bulk_upsert_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+    await _drop_table(url, "issue1585_upsert_products")
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585UpsertProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("upsert")
+
+    # Upsert on the PK: every record MUST supply the conflict-target column.
+    # Fresh (non-existent) ids → INSERT via ON CONFLICT (id); rollback discards.
+    base_id = int(time.time() * 1000) % 2_000_000_000
+    workflow = _rollback_workflow(
+        "Issue1585UpsertProductBulkUpsertNode",
+        "bulk",
+        {
+            "data": [
+                {"id": base_id, "name": "A", "sku": sku},
+                {"id": base_id + 1, "name": "B", "sku": sku},
+            ],
+            "conflict_on": ["id"],
+            "conflict_resolution": "update",
+        },
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    assert await _raw_count(url, "issue1585_upsert_products", sku) == 0
+
+
+# AC6 — SQLite parity: rollback discards a BulkCreate on SQLite too.
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_sqlite_bulk_create_discarded_after_rollback(tmp_path):
+    url = f"sqlite:///{tmp_path}/issue1585.db"
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585SqliteBulkProduct:
+        name: str
+        sku: str
+
+    await db.initialize()
+    sku = _sku("sqlite")
+
+    workflow = _rollback_workflow(
+        "Issue1585SqliteBulkProductBulkCreateNode",
+        "bulk",
+        {"data": [{"name": "A", "sku": sku}, {"name": "B", "sku": sku}]},
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    remaining = await db.express.list("Issue1585SqliteBulkProduct", {"sku": sku})
+    assert remaining == []
+
+
+# ===========================================================================
+# Path B (AC3 in #1585) — standalone fresh-node bulk nodes join the scope.
+# These validate that the async_safe_run bypass (bulk_upsert) and the
+# force-direct-borrow routing (bulk_create_pool) keep the write on the scope's
+# connection so a rollback discards it.
+# ===========================================================================
+
+
+# AC7 — standalone DataFlowBulkUpsertNode inside a scope is discarded on
+#        rollback (exercises the async_safe_run bypass in async_run).
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_standalone_bulk_upsert_node_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585StandaloneUpsert:
+        name: str
+        sku: str
+
+    await db.initialize()
+    # The standalone node writes to a raw table by name — resolve the model's
+    # ACTUAL table name (DataFlow pluralizes the class name).
+    table = db._class_name_to_table_name("Issue1585StandaloneUpsert")
+    sku = _sku("saupsert")
+
+    workflow = _rollback_workflow(
+        "DataFlowBulkUpsertNode",
+        "bulk",
+        {
+            "table_name": table,
+            "connection_string": url,
+            "database_type": "postgresql",
+            "data": [{"name": "A", "sku": sku}],
+            "conflict_columns": ["id"],
+        },
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    # Pre-fix the fresh non-pooled node auto-committed and survived rollback.
+    assert await _raw_count(url, table, sku) == 0
+
+
+# AC8 — standalone BulkCreatePoolNode (direct path) inside a scope is discarded
+#        on rollback (exercises the force-direct-borrow routing).
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_standalone_bulk_create_pool_node_discarded_after_rollback(pg_suite):
+    url = pg_suite.config.url
+
+    db = DataFlow(url, auto_migrate=True)
+
+    @db.model
+    class Issue1585StandalonePool:
+        name: str
+        sku: str
+
+    await db.initialize()
+    table = db._class_name_to_table_name("Issue1585StandalonePool")
+    sku = _sku("sapool")
+
+    workflow = _rollback_workflow(
+        "BulkCreatePoolNode",
+        "bulk",
+        {
+            "table_name": table,
+            "connection_string": url,
+            "database_type": "postgresql",
+            "data": [{"name": "A", "sku": sku}, {"name": "B", "sku": sku}],
+        },
+    )
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build(), parameters=_ctx(db))
+
+    assert results.get("rollback_tx", {}).get("status") == "rolled_back"
+    assert await _raw_count(url, table, sku) == 0
+
+
+# AC9 — fail-closed: a BulkCreatePoolNode inside a scope with NO connection_string
+#        MUST raise rather than silently no-op (returning the simulation stub
+#        would report fabricated success while writing nothing).
+@pytest.mark.regression
+async def test_bulk_create_pool_node_fails_closed_without_connection_string():
+    from kailash.sdk_exceptions import NodeExecutionError
+
+    from dataflow.nodes.bulk_create_pool import BulkCreatePoolNode
+
+    class _Scope:
+        transaction = ("fake_conn", "fake_tx")  # non-None handle
+
+    node = BulkCreatePoolNode(table_name="t", database_type="postgresql")
+    # Inject an active scope with a usable handle but give the node no
+    # connection_string — it cannot join, so it MUST fail closed.
+    node._workflow_context = {"active_transaction": _Scope()}
+
+    with pytest.raises(NodeExecutionError, match="TransactionScopeNode"):
+        await node.async_run(data=[{"name": "A", "sku": "x"}])
+
+
+# AC10 — fail-closed SYMMETRY: DataFlowBulkUpsertNode inside a scope with NO
+#        connection_string MUST raise too (its dry-run-shaped else branch would
+#        otherwise report fabricated success — rows_affected=len(data) — while
+#        writing nothing and discarding the borrowed handle). Mirrors AC9 for the
+#        sibling standalone node (security-reviewer #1585 MEDIUM).
+@pytest.mark.regression
+async def test_bulk_upsert_node_fails_closed_without_connection_string():
+    from kailash.sdk_exceptions import NodeExecutionError
+
+    from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
+
+    class _Scope:
+        transaction = ("fake_conn", "fake_tx")  # non-None handle
+
+    # No connection_string; real (non-dry-run) data inside an active scope.
+    node = DataFlowBulkUpsertNode(table_name="t", database_type="postgresql")
+    node._workflow_context = {"active_transaction": _Scope()}
+
+    with pytest.raises(NodeExecutionError, match="TransactionScopeNode"):
+        await node.async_run(data=[{"id": 1, "name": "A"}])


### PR DESCRIPTION
## Summary

Bulk write nodes (`BulkCreate`/`BulkUpdate`/`BulkDelete`/`BulkUpsert`) escaped an enclosing `TransactionScopeNode` — they auto-committed on their own connection, so a bulk write inside a rolled-back scope **survived the rollback**. This is the same silent data-integrity violation #1581 fixed for single-record CRUD, at a larger blast radius. The fix threads the scope's borrowed transaction handle through the bulk path so bulk writes run ON the scope's connection and are discarded on rollback.

- **Path A** (generated `<Model>Bulk*Node` → `features/bulk.py`): shared `_resolve_scope_transaction` helper (extracted from #1581's `_run_sql_in_scope`, same fail-closed guard) resolves the active scope at the 4 dispatch sites in `core/nodes.py`; each `bulk_*()` threads `transaction=` into every `async_run` site → the #1581 borrow-don't-own branch. No-scope path is byte-identical to prior auto-commit.
- **Path B** (standalone `DataFlowBulkUpsertNode` / `BulkCreatePoolNode`): both thread the borrowed handle to their fresh execution node. The upsert node bypasses its `async_safe_run` boundary (a separate event loop the borrowed asyncpg connection cannot cross) and awaits on the runtime loop when a scope is active; the pool node forces its direct borrow path. Both fail closed (raise) if they cannot join a scope rather than returning a fabricated-success stub.

## Changed behavior

`DataFlowBulkUpsertNode` now raises `NodeExecutionError` on a batch/DB failure instead of returning `{"success": False}`, so a scoped bulk failure fails the node and the scope rolls back — aligning its contract with the sibling `BulkCreatePoolNode`. The delegation/express path (`db.bulk.bulk_upsert`) is unaffected.

## Tests

- New `test_issue_1585_bulk_transaction_awareness.py` — 10 tests on live PostgreSQL + SQLite: rollback-discards for all four bulk verbs, commit-persists, SQLite parity, both standalone nodes (exercising the `async_safe_run` bypass + pool-bypass), and fail-closed guards for both standalone nodes. Rollback outcomes asserted via a fresh asyncpg connection independent of any pool/cache/scope.
- Removes the #1581 `xfail(strict=True)` bulk deferral pin (now a real passing test).
- #1585 + #1581 transaction-awareness suites: **19 passed**.

DataFlow-only change (kailash-dataflow 2.13.21 → 2.13.22); the core borrow branch shipped in `kailash 2.45.5` (#1581). Red-teamed to convergence (dataflow-specialist + reviewer + security-reviewer; one MEDIUM — asymmetric fail-closed guard — fixed and re-verified clean).

## Related issues

Closes #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)