### PR TITLE
docs(deploy): release record for kailash-dataflow 2.13.22 (#1585)

### DIFF
--- a/deploy/deployments/2026-07-06-dataflow-2.13.22-1585.md
+++ b/deploy/deployments/2026-07-06-dataflow-2.13.22-1585.md
@@ -1,0 +1,38 @@
+# Deployment — kailash-dataflow 2.13.22 (#1585)
+
+**Date:** 2026-07-06
+**Type:** dataflow-only patch release (no core change)
+**Issue:** #1585 (follow-up to #1581 — BULK CRUD nodes escaped an enclosing `TransactionScopeNode`: they auto-committed on their own connection, so a bulk write inside a rolled-back scope SURVIVED the rollback — the same silent data-integrity violation #1581 fixed for single-record CRUD, at a larger blast radius)
+
+## What shipped
+
+- **kailash-dataflow 2.13.21 → 2.13.22** — the bulk write path now threads the scope's borrowed transaction handle so bulk writes run ON the scope's connection and are discarded on rollback:
+  - **Generated `<Model>Bulk*Node` (Path A, cached pooled node):** a shared `_resolve_scope_transaction(node)` helper (extracted from #1581's `_run_sql_in_scope`, same fail-closed guard) resolves the active scope at the four bulk dispatch sites in `core/nodes.py`; each `bulk_*()` in `features/bulk.py` threads `transaction=` into every `AsyncSQLDatabaseNode.async_run(transaction=...)` site (all four verbs, the bulk-delete pre-count SELECT, and the SQLite upsert insert/update-breakdown COUNT) → the #1581 borrow-don't-own branch. No-scope path is byte-identical to prior auto-commit.
+  - **Standalone `DataFlowBulkUpsertNode` / `BulkCreatePoolNode` (Path B, fresh non-pooled nodes):** both thread the borrowed handle to their fresh execution node. The key architectural insight: the borrowed handle is a `(conn, tx)` tuple carrying its OWN connection, so `adapter.execute_many(query, params, transaction)` runs on the scope's connection regardless of which node issues it. `DataFlowBulkUpsertNode.async_run` normally resolves through `async_safe_run` (a SEPARATE event loop where a borrowed asyncpg connection cannot be used), so when a scope is active it bypasses that boundary and awaits `_perform_bulk_upsert` directly on the runtime loop. `BulkCreatePoolNode` forces its direct borrow path when a scope is active (its own connection pool cannot join the scope).
+  - **Fail-closed (symmetric):** an active scope exposing no `.transaction` handle raises `NodeExecutionError` (shared helper); and a standalone bulk node inside a scope with no `connection_string` to join the scope raises rather than returning a fabricated-success simulation stub — enforced on BOTH `BulkCreatePoolNode` and `DataFlowBulkUpsertNode`.
+- **Behavior change (CHANGELOG § Changed):** `DataFlowBulkUpsertNode` now raises `NodeExecutionError` on a batch/DB failure instead of returning `{"success": False, ...}` — a scoped bulk failure must fail the node so the enclosing scope rolls back (aligns its hard-error contract with the sibling `BulkCreatePoolNode`, which already raises). The delegation/express path (`db.bulk.bulk_upsert` → `features/bulk.py`) is unaffected and continues to return the per-row outcome dict.
+
+**dataflow-only rationale:** the borrow-don't-own branch (`_execute_with_transaction` / `_execute_many_with_transaction` in core `kailash.nodes.data.async_sql`) already shipped in **kailash 2.45.5** (#1581). #1585 makes the bulk path CONSUME those existing symbols — **no new core symbols**, so no core release; floor stays `kailash>=2.45.5`.
+
+## Fix + release chain
+
+- Fix PR **#1593** (merge `b601d8201`, fix commit `e704c350c`) — full matrix GREEN (20 SUCCESS / 4 SKIPPED / 0 fail on head `e704c350c`). #1585 auto-closed via `Closes #1585`.
+- Tag `dataflow-v2.13.22` → **Publish to PyPI** OIDC run **28802882155** SUCCESS (GitHub Release created).
+- TestPyPI skipped per the patch human-approval precedent (user: "approved publish").
+
+## Verification (clean-venv, live PyPI)
+
+`uv pip install --refresh kailash-dataflow==2.13.22` (PyPI JSON metadata reported 2.13.22 on attempt 2 after the documented PyPI/uv index-propagation lag; uv index-cache lagged the simple index, so the clean-venv install completed via the `pip --no-cache-dir` fallback per `build-repo-release-discipline.md` Rule 2):
+
+- `dataflow.__version__ == "2.13.22"`.
+- New surface importable: `from dataflow.core.nodes import _resolve_scope_transaction` — the fix shipped, not just the version bump.
+
+## Test + red-team evidence
+
+- Tier-2 regression on real PostgreSQL:5434 + file-backed SQLite (`test_issue_1585_bulk_transaction_awareness.py`): **10/10 green** — rollback-discards for all four bulk verbs, commit-persists (bulk create), SQLite parity, both standalone nodes (exercising the `async_safe_run` bypass + the pool-bypass), and fail-closed guards for both standalone nodes (AC9/AC10). Rollback outcomes asserted via a FRESH asyncpg connection independent of any pool/cache/scope. The #1581 `xfail(strict=True)` bulk deferral pin was removed same-shard (now a real passing test). Combined #1585 + #1581 transaction-awareness suites: **19 passed**.
+- Red team — findings round → fix → clean round (3 parallel reviewers): R1 dataflow-specialist CLEAN (all 7 invariants verified behaviorally on live PG); reviewer CLEAN + 1 Important (new test file `LocalRuntime` deprecation) + 2 Minor coverage notes; security-reviewer **MEDIUM** (asymmetric fail-closed guard — `bulk_upsert.py` lacked the no-`connection_string`-under-scope guard its sibling carries, allowing fabricated `success:True` under a scope) + 1 LOW (informational, pre-existing bulk error-dict semantics, not a commit-escape). Fixes: symmetric guard + `NodeExecutionError` added to the typed-reraise tuple (guard propagates loudly) + AC10 regression + `with LocalRuntime()` conversion. R2 reviewer + security-reviewer both CLEAN — MEDIUM + Important resolved, no new findings.
+
+## Out-of-scope (tracked separately, SHA-verified pre-existing)
+
+- **#1594** (NEW) — `test_bulk_upsert_comprehensive.py::test_bulk_upsert_large_mixed_batch` HANGS (>60s) + `test_v052_bug_reproduction.py` ×2 failures. Proven pre-existing on main HEAD `473a104d7` (reproduced with the #1585 diff reverted via a saved patch, then restored losslessly). Different bug class (large-batch upsert), not gating CI (main shipped green). Filed, unstarted.
+- Cross-SDK #1585 inspection of the Rust SDK for the same bulk-transaction-awareness gap → requires explicit cross-repo authorization (`repo-scope-discipline.md`), not self-initiated.


### PR DESCRIPTION
Post-publish release record for **kailash-dataflow 2.13.22** (#1585 — bulk CRUD nodes are transaction-aware).

- Publish to PyPI run `28802882155` SUCCESS; GitHub Release created for tag `dataflow-v2.13.22`.
- Clean-venv install of 2.13.22 verified; `_resolve_scope_transaction` surface importable.
- Fix PR #1593 (merge `b601d8201`); 10 Tier-2 tests on live PG + SQLite; redteam-converged.

Docs-only (deploy record). No source/version change.

## Related issues

Refs #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)