### PR TITLE
docs(workspace): journals 0012-0021 + sweep report (mops-onboarding)

### DIFF
--- a/workspaces/mops-onboarding/04-validate/sweep-2026-07-06.md
+++ b/workspaces/mops-onboarding/04-validate/sweep-2026-07-06.md
@@ -1,0 +1,86 @@
+# /sweep — kailash-py — 2026-07-06 (session 6, post-#1585 release)
+
+Repo-wide outstanding-work sweep. Board is near-clean: #1585 shipped + published this
+session; no open PRs, no active todos, no stub markers in changed code, both packages
+released. ONE FIX-NOW hygiene gap (uncommitted workspace journals). Backlog is 14 open
+issues, all genuinely actionable (none stale-closeable).
+
+## Findings
+
+### [LOW] [Sweep 7] 10 workspace journal entries untracked (0012–0021) — FIX-NOW
+
+- **Location:** `workspaces/mops-onboarding/journal/0012…0021-*.md`
+- **Disposition:** FIX-NOW (committed this sweep — see Action).
+- **Evidence:** 11 journals tracked in git (0001–0011); 10 (0012–0021) untracked. The
+  convention IS to commit workspace journals during active work (0001–0011 are committed
+  while mops-onboarding is still the active workspace).
+- **Why it matters:** Journals are institutional knowledge (DECISION/AMENDMENT/DISCOVERY/
+  AUTHORIZATION). Uncommitted, they are lost on any clean checkout and invisible to
+  `git log --grep`. `zero-tolerance.md` Rule 1 — found it, own it.
+- **Action taken:** `git add` + commit the 10 journals (SHA recorded in the sweep-commit).
+  Active `.session-notes` left untracked deliberately — the convention commits it at
+  archive time (only `_archive/*/.session-notes` are tracked), not during active work.
+
+### [INFO] [Sweep 3] 14 open issues — all genuinely actionable backlog (0 stale, 0 deferred-labeled)
+
+- **Location:** current repo.
+- **Disposition:** QUEUED-WITH-VALUE-RANK (no closures; all recent 2026-07-03…07-06).
+- **Categories:**
+  - **DataFlow correctness/test** — #1594 (bulk_upsert large-batch HANG + v052 ×2, filed
+    this session; NEXT candidate), #1584 (4 pre-existing txn-suite failures), #1582
+    (removed-API xfail restoration), #1573 (AutoMigrationSystem ignores `__tablename__`),
+    #1526 (multi_tenant id-alone PK cross-tenant hazard), #1532 (delegate-connectors
+    consolidation).
+  - **SAFR governance cluster** (F14) — #1510 (agnostic hardening BH1-BH5) + #1514/#1515/
+    #1516/#1517. **BLOCKED on user scoping** (per session notes F14) — value-anchor:
+    governance brief; needs user to scope before work.
+  - **EATP v3** — #1590 (RFC 8785 JCS encoder + conditional subject_hash), #1591 (WEFT
+    event schema + conformance vectors), #1592 (BilateralDelegation / ClearanceAttestation /
+    VERIFY_CH elements).
+- **Why it matters:** No issue is closeable-on-delivery or stale-abandon; `not_planned`
+  auto-closure is BLOCKED (`value-prioritization.md` MUST-4). Left as the live backlog.
+
+### CLEAN sweeps
+
+- **[Sweep 1]** Active todos: none (`workspaces/*/todos/active/` empty).
+- **[Sweep 2]** Pending journal entries: none (`journal/.pending/` empty).
+- **[Sweep 4]** Open PRs: none. Unmerged remote branches: none. (#1593 + #1595 merged +
+  branches deleted this session.)
+- **[Sweep 5]** N/A — `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`
+  (0 `workspaces/*/specs/` dirs; `tools/sweep-redteam.py` present but no per-workspace specs
+  to scan — mops-onboarding is a program/ops workspace, not a spec-driven feature build).
+- **[Sweep 6]** Worktrees: only main @ `a5b3167b5` (clean). Stale session-notes (>30d): none.
+  Forest-ledger `--aggregate`: OK (1 workspace ledger; all open IDs reflected in root
+  `.session-notes.shared.md` — no stranded workstreams).
+- **[Sweep 7]** Stub markers (`TODO/FIXME/HACK/XXX/NotImplementedError`) in this session's
+  changed source: none. main 0/0 with origin/main (in sync).
+- **[Sweep 8]** Release readiness: CLEAN. Core `v2.45.5` — no shippable `src/` diff.
+  `dataflow-v2.13.22` — no shippable `packages/kailash-dataflow/src` diff. All 9 packages
+  at PyPI parity.
+- **[Sweep 9]** N/A — BUILD repo (kailash-py), not the loom orchestration root.
+
+## Cross-cutting observations
+
+1. **Session closed cleanly** — #1585 is the only workstream this session; it is fully
+   converged, merged, published (2.13.22), verified, and documented. No loose ends from it.
+2. **The DataFlow test-health cluster is converging into a theme** — #1594 (bulk_upsert
+   hang) + #1584 (4 txn-suite failures) + #1582 (removed-API xfails) are all
+   pre-existing-test-debt in the same subsystem. A single focused session could sweep all
+   three (they share the transaction/bulk test surface).
+3. **Two BLOCKED-on-user clusters persist** — SAFR governance (#1510/#1514-1517, needs
+   scoping) and the mops-onboarding program itself (F1, Phase 2-rs + Phase 3 loom). Neither
+   is agent-actionable without user direction.
+
+## Recommended next-session items (ranked)
+
+1. **#1594 + #1584 + #1582 — DataFlow test-health sweep (HIGH).** Same subsystem, all
+   pre-existing test debt; #1594's large-batch hang is the highest-value (a genuine code
+   bug, not just test restoration). Value-anchor: SDK correctness / green test suite.
+2. **#1573 — AutoMigrationSystem `__tablename__` (MED).** Self-contained DataFlow
+   correctness bug; custom table names silently ignored on migration paths.
+3. **#1526 — multi_tenant id-alone PK cross-tenant hazard (MED, design).** Data-integrity /
+   tenant-isolation class; needs a design decision first.
+4. **SAFR governance cluster (#1510/#1514-1517) — BLOCKED, surface for user scoping.**
+5. **EATP v3 (#1590/#1591/#1592) — larger feature work; needs prioritization vs the above.**
+
+Human owns the pick — this report is the deliverable, not the decision.

--- a/workspaces/mops-onboarding/journal/0012-AUTHORIZATION-cross-repo-kailash-rs-1552-cross-sdk.md
+++ b/workspaces/mops-onboarding/journal/0012-AUTHORIZATION-cross-repo-kailash-rs-1552-cross-sdk.md
@@ -1,0 +1,49 @@
+---
+type: DECISION
+date: 2026-07-05
+author: human
+display_id: esperie
+person_id: esperie
+project: dataflow-driver-error-sanitization-1552
+topic: cross-repo authorization — kailash-rs READ inspection + cross-SDK issue FILING for the #1552 DML driver-error leak class
+phase: codify
+---
+
+# AUTHORIZATION — kailash-rs inspection + cross-SDK filing for the #1552 leak class
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Grant (repo-scope-discipline.md User-Authorized Exception — all 5 conditions)
+
+- **Requester:** esperie (user), genuine user turn (2026-07-05).
+- **Verbatim instruction:** _"approved, authorize kailash-rs read for cross-SDK inspection, then file to kailash-rs"_
+- **Target repo:** `esperie-enterprise/kailash-rs` (private; the Rust SDK — per the
+  `reference_kailash_rs_repo_location` memory, NOT `terrene-foundation/kailash-rs`).
+  Local clone confirmed at `build/kailash-rs` (git remote =
+  `git@github.com:esperie-enterprise/kailash-rs.git`).
+- **Bounded action (TWO parts, both explicitly authorized this turn):**
+  1. **READ** — inspect the Rust SDK's DataFlow-equivalent for the same bug class
+     as kailash-py #1552: raw DB-driver-error VALUES (PG `DETAIL: Key(col)=(value)`
+     / `Failing row contains(...)`, MySQL `Duplicate entry 'value'`) rendered
+     verbatim into logs / returned errors / raised messages / persisted audit on
+     reachable write/DML paths, without a `sanitize_db_error`-equivalent redactor.
+  2. **FILE** — open ONE cross-SDK GitHub issue on `esperie-enterprise/kailash-rs`
+     if the class is present (per `cross-sdk-inspection.md` Rule 1-2: `cross-sdk`
+     label + cross-reference to kailash-py#1552). This satisfies
+     `upstream-issue-hygiene.md` MUST-1's same-session human gate.
+- **Timestamp:** 2026-07-05 (this session).
+
+## Scope fence (condition 5 — exactly the named actions, nothing more)
+
+- READ is inspection-only: NO writes, NO branches, NO edits to kailash-rs source.
+- FILE is exactly ONE cross-SDK issue on the named repo; body scrubbed per
+  `upstream-issue-hygiene.md` MUST-2/3 (no consumer/workspace/finding-tag/internal-path
+  leakage; scoped to the Rust SDK API surface + minimal repro + cross-ref).
+- No incidental reads of other repos; no fix PRs against kailash-rs (a fix is a
+  separate dedicated kailash-rs session).
+
+## Disposition
+
+Findings recorded here + surfaced to the user; the cross-SDK issue number recorded
+on completion. Any rs REMEDIATION (code fix) is deferred to a dedicated kailash-rs
+session — this grant covers inspect + file only.

--- a/workspaces/mops-onboarding/journal/0013-AMENDMENT-kailash-rs-1552-cross-sdk-outcome.md
+++ b/workspaces/mops-onboarding/journal/0013-AMENDMENT-kailash-rs-1552-cross-sdk-outcome.md
@@ -1,0 +1,51 @@
+---
+type: AMENDMENT
+date: 2026-07-05
+author: agent
+display_id: esperie
+person_id: esperie
+project: dataflow-driver-error-sanitization-1552
+topic: outcome of the authorized kailash-rs cross-SDK inspection + filing (0012)
+phase: codify
+relates_to: 0012-AUTHORIZATION-cross-repo-kailash-rs-1552-cross-sdk
+---
+
+# AMENDMENT — kailash-rs #1552 cross-SDK inspection: outcome
+
+Extends the 0012 authorization receipt with the completed disposition.
+
+## Inspection findings (READ, per grant part 1)
+
+The #1552 driver-error leak class IS present in the Rust SDK, with **no
+`sanitize_db_error`-equivalent** driver-error redactor (only `sanitize_validation_errors`
+
+- classification redaction + `sql_log_mask` which masks _password literals_ in
+  `CREATE ROLE/USER` DDL, not driver-error values):
+
+* `crates/kailash-dataflow/src/error.rs` — `DataFlowError::Database(#[from] sqlx::Error)`
+  with `#[error("database error: {0}")]` renders the raw `sqlx::Error` verbatim;
+  `DDLFailed { message: err.to_string() }` captures the raw driver string. Both reach
+  logs + the returned `NodeError` (via `impl From<DataFlowError> for NodeError`).
+* **Dialect-scoped severity** (the honest nuance): on **MySQL** the value is in the
+  driver PRIMARY message (`Duplicate entry '<value>' for key`) that sqlx `Display`
+  renders → LEAKS. On **PostgreSQL** the value lives in the `DETAIL` field, which the
+  code never accesses (`grep .detail()` → zero hits) and sqlx's default `Display`
+  omits → the PG value does NOT currently leak via this path.
+
+## Filing (per grant part 2)
+
+Filed **esperie-enterprise/kailash-rs#1639** — `cross-sdk` label, cross-referenced to
+kailash-py#1552, scrubbed per `upstream-issue-hygiene.md` MUST-2/3 (SDK-API-surface
+scope + minimal MySQL repro + acceptance criteria; no consumer/workspace/path leakage).
+
+## Cross-reference direction (Rule 6 compliance)
+
+Referenced rs#1639 → kailash-py#1552 only. Did NOT add a reverse comment on the public
+#1552 naming the private rs repo — that would leak the private-repo slug into a
+public artifact per `cross-sdk-inspection.md` Rule 6.
+
+## Deferred
+
+The rs REMEDIATION (add the redactor + route `Database`/`DDLFailed` renders through it,
+mirroring #1552) is a dedicated kailash-rs session — NOT covered by the 0012 grant
+(inspect + file only). Tracked as rs#1639.

--- a/workspaces/mops-onboarding/journal/0014-DECISION-dataflow-2.13.16-redteam-convergence.md
+++ b/workspaces/mops-onboarding/journal/0014-DECISION-dataflow-2.13.16-redteam-convergence.md
@@ -1,0 +1,68 @@
+---
+type: DECISION
+date: 2026-07-05
+author: agent
+display_id: esperie
+person_id: esperie
+project: dataflow-2.13.16-legacy-migration-and-leak-cleanup
+topic: DataFlow 2.13.16 red-team convergence receipt — #1559/#1560/#1561/#1562
+phase: redteam
+relates_to: 0013-AMENDMENT-kailash-rs-1552-cross-sdk-outcome
+---
+
+# DECISION — DataFlow 2.13.16 red-team converged (2 rounds)
+
+Coordination receipt for the F10 follow-up batch surfaced by the 2.13.15 red-team.
+Branch `fix/dataflow-2.13.16-legacy-migration-mysql-and-leak-cleanup`, tip `75c3f8e50`,
+base `main` `ba60d2bc3`. NOT pushed — merge + PyPI publish gated on user confirmation.
+
+## Fixes (commit SHAs)
+
+| Issue | Fix | Commit |
+| ----- | --- | ------ |
+| #1559 | legacy `AutoMigrationSystem` emitted Postgres-only DDL on MySQL (`_detect_database_type` never returned "mysql"); + MySQL migration-table DDL variant + `_ensure_migration_table`/`_load_migration_history` MySQL branches | `4a69e6ec1` (+ `4da723196` teardown) |
+| #1560 | throwaway `AsyncSQLDatabaseNode` in the `$11` create-retry leaked a connection → `try/finally: cleanup()` | `be484d1d0` |
+| #1561 | SQLi-suite fixtures leaked `AsyncSQLDatabaseNode` → `try/finally` cleanup; all 18 injection assertions preserved | `da3284073` |
+| #1562 | removed 5 zero-caller dead methods: `_generate_bulk_sql` + `generate_all_crud_sql` (`f74b22f60`) + the 3 transitively-dead `_generate_{insert,update,delete}_sql` exposed by that removal (`e2a777c17`) | `f74b22f60` + `e2a777c17` |
+| — | version bump 2.13.15→2.13.16 (both anchors) + CHANGELOG | `75c3f8e50` |
+
+## Red-team rounds (durable verdicts)
+
+- **Round 1** (reviewer + security-reviewer + closure-parity, parallel; agents
+  `a1bdd4d66aff1db97`/`acd4e259d7e91d113`/`a3543d5be68a914fa`):
+  security CLEAN; closure-parity no UNMET criteria; reviewer MERGE-WITH-FIXES —
+  one finding: the #1562 `generate_all_crud_sql` deletion left 3 transitively-dead
+  helpers. Fixed `e2a777c17` (autonomous-execution Rule 4 same-shard fix).
+  All suites green on real MySQL 8.0.46 + PostgreSQL.
+- **Round 2** (reviewer + holistic verifier, parallel; agents
+  `a10b7591210738da9`/`a5193d75a67d692f1`): code CLEAN both lenses (exactly 5
+  methods removed, all 8 remaining `_generate_*` have live callers, no new orphan,
+  #1559 mysql branch correct, version consistent). One durable-artifact finding:
+  CHANGELOG said "four" removed vs actual five → corrected (amended into `75c3f8e50`).
+  Suites re-run green: MySQL 3/3, PG 2/2 (0 ResourceWarnings), SQLi 18/18,
+  adapters 198, 4156 collected exit 0.
+
+Both findings were non-code (one dead-code completeness, one CHANGELOG count) and
+are fixed + verified. Code surface independently verified clean by 5 agent-passes
+across 2 rounds. Convergence criteria met.
+
+## Deferred (tracked, NOT actioned this session)
+
+- `_get_table_columns_async` (`core/engine.py`) is a PRE-EXISTING zero-caller orphan
+  (not exposed by this batch; different bug class). Removing an advertised
+  "async-context entry point" is a design decision → follow-up issue, not force-fit
+  into a patch release.
+- Full removal of the zero-caller `get_upsert_sql`/`upsert_clause` adapter family
+  (base `@abstractmethod` + all 3 concrete overrides): deletion-in-isolation breaks
+  instantiation → a public-API `zero-tolerance` Rule-6a deprecation-cycle change,
+  deferred as a separate PR.
+- Pre-existing CWD-fragile test `test_bulk_upsert_no_quote_escape_in_source`
+  (SHA `7a4fd3647`, untouched by this branch): optional path-anchoring hardening.
+
+## Pending user-gated actions (shared-state)
+
+1. push → PR → CI → admin-merge → `/release` → PyPI 2.13.16.
+2. Issue comments: #1560 premise correction ("per `$11`-retry invocation", not
+   "per call"); #1562 scope note (2 of 3 named methods retained as abstractmethod
+   overrides; dead-family removal deferred).
+3. File follow-up issue for the `_get_table_columns_async` orphan.

--- a/workspaces/mops-onboarding/journal/0015-DECISION-dataflow-2.13.17-redteam-convergence.md
+++ b/workspaces/mops-onboarding/journal/0015-DECISION-dataflow-2.13.17-redteam-convergence.md
@@ -1,0 +1,126 @@
+---
+type: DECISION
+date: 2026-07-05
+author: agent
+project: dataflow-2.13.17-async-column-detection-and-upsert-family-removal
+topic: DataFlow 2.13.17 red-team convergence receipt — #1564 (async column detection + dead upsert-family removal)
+phase: redteam
+relates_to: 0014-DECISION-dataflow-2.13.16-redteam-convergence
+verified_id: esperie
+person_id: esperie
+display_id: esperie
+tags: [dataflow, redteam, "1564", async-column-detection, updated_at, dead-code]
+---
+
+# DECISION — DataFlow 2.13.17 red-team converged (2 rounds)
+
+Coordination receipt for GitHub issue #1564 (the deferred tail of the 2.13.16 red-team).
+Working tree on `main`, NOT committed — branch/PR/CI/merge/`/release` gated on user
+confirmation (BUILD repo). Base `main` `082215197`.
+
+## What #1564 turned out to be
+
+The issue framed two "small" cleanups. Investigation (ground-truth verified) reclassified
+Part 2 from a design-cleanup into a **real latent bug**:
+
+- **Part 1 (dead code — as framed):** the zero-caller `get_upsert_sql`
+  (`database/multi_database.py::DatabaseAdapter`) and `upsert_clause`
+  (`adapters/dialect.py::SQLDialect`) abstractmethod families — each a base
+  `@abstractmethod` + PG/MySQL/SQLite overrides, **8 methods** — undocumented,
+  unexported, zero-caller.
+- **Part 2 (latent bug — NOT "delete the orphan"):** every DataFlow workflow-node
+  CRUD SQL generator runs inside `async def async_run` (`core/nodes.py`; the sync
+  `run()` is a thin `async_safe_run(self.async_run(...))`). The 5 column-detection
+  sites called the **sync** `_get_table_columns`, which raises "cannot be called
+  from a running async context" inside any event loop and returns `[]`. So
+  `has_updated_at` was ALWAYS False → the UPDATE/UPSERT SET clause never bumped
+  `updated_at` on PostgreSQL/SQLite (MySQL masked it via `ON UPDATE CURRENT_TIMESTAMP`),
+  and node SELECT column lists dropped `created_at`/`updated_at`. Proven RED on main:
+  `updated_at == created_at` after a delayed node UPDATE.
+
+## Design decision (dataflow-specialist consult → hybrid, perf-safe)
+
+Deleting the orphan would cement the bug; naively wiring `_get_table_columns_async`
+(→ whole-catalog `discover_schema_async`) would add a per-op introspection round-trip.
+The specialist-recommended **hybrid** (Approach C) resolves both:
+
+- **Managed path** (`auto_migrate and not existing_schema_mode`): derive columns from
+  in-memory model metadata at **ZERO DB cost** — `_generate_create_table_sql`
+  unconditionally appends both timestamps (invariant proven set+order-equal vs
+  `PRAGMA table_info` across edge cases: custom fields, explicit timestamps, field
+  named `id`, custom `__tablename__`).
+- **Existing-schema / non-auto-migrate path**: cached async catalog introspection
+  (`_get_table_columns_async`, memoized per `sha256(db_url)[:16]:table` in a new
+  `_column_cache`, invalidated by `clear_schema_cache`/`clear_table_cache`).
+
+New engine methods: `_resolve_table_columns_async`, `_resolve_columns_via_introspection`,
+`_generate_select_sql_async`, `_build_select_sql_templates` (shared pure builder). The
+now-orphaned sync `_generate_select_sql` + `_get_table_columns` were **deleted** (round-1
+finding). 5 node sites converted to `await` the resolver/async-twin.
+
+**No-shim decision (deviation from #1564's stated Rule-6a approach):** Part 1 removed
+with NO deprecation shim. Evidence: the 8 methods are undocumented, not exported from any
+package `__init__`, zero-caller SDK-wide; removing a base `@abstractmethod` + all overrides
+is a relaxing change (external subclasses stay valid, classes stay instantiable). Rule 6a
+protects _documented public API_; these are internal dead code. Aligns with the standing
+no-shims preference. Flagged in the CHANGELOG.
+
+## Files (working tree)
+
+`packages/kailash-dataflow/`: `src/dataflow/core/engine.py`, `src/dataflow/core/nodes.py`,
+`src/dataflow/adapters/dialect.py`, `src/dataflow/database/multi_database.py`,
+`CHANGELOG.md`, `pyproject.toml`, `src/dataflow/__init__.py` (version 2.13.16→2.13.17,
+both anchors verified) + new `tests/regression/test_issue_1564_async_column_detection.py`
+(6 tests: AC1 update-bump SQLite, AC2 upsert-bump + CREATE-branch, AC3 SELECT-timestamps,
+AC4 managed zero-DB-IO boundary-injection, AC5 existing-schema custom-`__tablename__`
+introspection + cache-evict, AC6 real PostgreSQL).
+
+## Red-team rounds (durable verdicts)
+
+- **Round 1** (reviewer `af3defa4197bd1d14` + security-reviewer `a1b032470ec39ceb6` +
+  dataflow-specialist `a7ea01552e3d2dfda`, parallel): no BLOCKER/HIGH. Managed-derivation
+  invariant proven HOLDS. Findings → all fixed:
+  - MED (orphan): sync `_generate_select_sql` + `_get_table_columns` newly zero-caller →
+    deleted (verified `discover_schema` sync retains other callers; no cascade).
+  - MED (sec): `_column_cache` key held raw DB URL → SHA-256-hashed (sibling pattern).
+  - MED (test): AC5 `__dataflow__` table_name was a no-op → rewrote with `__tablename__`
+    ≠ default plural (now exercises custom-name introspection; passes → resolution honors
+    `__tablename__` via `model_info["table_name"]`, engine.py:2040).
+  - LOW: sanitize introspection-fallback log; assert upsert CREATE-branch; None-guard the
+    `_unique_index_cache.clear()` sibling.
+- **Round 2** (reviewer `ae5fc40eeab9bccb6` + security-reviewer `a0775ae013396e9f3` +
+  dataflow-specialist `aa70b447c904c3a88`, parallel): code-review CLEAN, domain CLEAN
+  (invariant + custom-`__tablename__` correctness re-confirmed end-to-end), security MED-1
+  hash PASSED + one new LOW (the round-1 sanitize landed on a handler shadowed by
+  `_get_table_columns_async`'s own catch; `sanitize_db_error` doesn't redact DSNs anyway).
+  LOW → fixed: all 4 introspection-fallback DEBUG logs now emit `type(e).__name__` (no
+  DSN/value can leak), grep-verified + 6/6 re-run green.
+
+Convergence criteria met: 2 independent Round-2 reviewers CLEAN; the residual security-LOW
+closed with grep + test evidence (a behavior-inert logging-value change in cold except paths).
+
+## Test evidence (all green)
+
+- `pytest --collect-only` = **6614 collected**, exit 0.
+- New #1564 suite: **6 passed** (SQLite AC1-5 + real PostgreSQL AC6); RED→GREEN proven
+  (stash-src on main → `updated_at == created_at` fails AC1).
+- Regression suite: **563 passed, 4 skipped** (pre- and post-fix identical).
+- Core+schema unit: **816 passed**.
+- MySQL node UPDATE smoke (real 8.0.46): `updated_at` bumped, no crash.
+
+## Deferred / notes (tracked, NOT actioned)
+
+- Pre-existing dataflow package lint/type debt (Pyright unused-import/param,
+  reportOptionalMemberAccess, unreachable code, `async_run` too-complex) — different bug
+  class, exceeds this shard, NOT swept (would be its own mypy-hygiene shard).
+- Pre-existing sibling inconsistency: `_unique_index_cache` keys the RAW db_url (the new
+  `_column_cache` hashes it) — in-memory-key-only, never logged; the new code is the more
+  defensive; out of scope.
+- MySQL aiomysql teardown `Event loop is closed` on GC — test-script teardown artifact,
+  not in the suite's clean output; not a defect.
+
+## Pending user-gated actions (shared-state — BUILD repo)
+
+1. branch (`release/v2.13.17` or `fix/...`) → commit → push → PR → CI → admin-merge →
+   `/release` → PyPI 2.13.17.
+2. Close #1564 (both parts delivered) with the merged-PR reference.

--- a/workspaces/mops-onboarding/journal/0016-AUTHORIZATION-cross-repo-loom-log-triage-issue.md
+++ b/workspaces/mops-onboarding/journal/0016-AUTHORIZATION-cross-repo-loom-log-triage-issue.md
@@ -1,0 +1,44 @@
+---
+type: AUTHORIZATION
+date: 2026-07-05
+author: human
+display_id: esperie
+person_id: esperie
+project: log-triage-gate-rule5a-excluded-files
+topic: cross-repo authorization — file ONE GitHub issue on loom for the log-triage-gate.js EXCLUDED_FILES (Rule 5a) fix
+phase: codify
+---
+
+# AUTHORIZATION — file a loom GitHub issue for the log-triage-gate Rule-5a fix
+
+cross-repo-authorized: esperie-enterprise/loom
+
+## Grant (repo-scope-discipline.md User-Authorized Exception)
+
+- **Requester:** esperie (user), genuine user turn (2026-07-05).
+- **Verbatim instruction:** _"please file gh issue to loom, loom will take it up from there"_
+  (following prior-turn approval of the Rule-5a fix; user redirected the disposition
+  from a cross-repo EDIT to a cross-repo ISSUE FILING).
+- **Target repo:** `esperie-enterprise/loom` (the COC authority repo; remote confirmed
+  `git@github.com:esperie-enterprise/loom.git`).
+- **Bounded action:** file ONE GitHub issue describing the `log-triage-gate.js`
+  false-positive (`.journal-skipped.log` audit log matched by the WARN+ scanner) and
+  the `observability.md` Rule 5a `EXCLUDED_FILES` fix. loom takes it up via its own
+  `/codify` + sync.
+- **Timestamp:** 2026-07-05 (this session).
+
+## Scope fence (condition 5)
+
+- Exactly ONE issue on the named repo; body scrubbed per `upstream-issue-hygiene.md`
+  MUST-2/3 (no workspace name, no operator-specific paths, no commit-subject text —
+  generic loom-hook mechanism + the Rule-5a patch + acceptance criteria only).
+- NO edit/branch/commit against loom (the earlier Option-A cross-repo EDIT was declined
+  in favor of this filing after loom was found mid-`/codify` on branch
+  `codify/esperie-2026-07-05`, which made a foreign-session edit a collision hazard).
+
+## Outcome
+
+Filed **esperie-enterprise/loom#817**. Process note: the issue was filed on the user's
+direct in-turn instruction; this receipt was written immediately after (the
+`journaled-before-acting` step trailed the action by one tool call for a low-risk,
+explicitly-directed, scrubbed issue filing to the user's own COC repo).

--- a/workspaces/mops-onboarding/journal/0017-DISCOVERY-issue-1572-bridge-loop-pool-leak-root-cause.md
+++ b/workspaces/mops-onboarding/journal/0017-DISCOVERY-issue-1572-bridge-loop-pool-leak-root-cause.md
@@ -1,0 +1,56 @@
+# 0017 — DISCOVERY: #1572 real root cause is bridge-loop adapter-pool lifecycle (not close_async)
+
+**Date:** 2026-07-05
+**Type:** DISCOVERY (+ DECISION: Option A approved)
+**Issue:** kailash-py #1572 (MySQL adapter pool not drained on close_async / Event loop is closed at GC)
+
+## Symptom (reproduced, real MySQL:3307 + PG:5434)
+
+`await db.close_async()` after an express/node CRUD cycle emits ~10 GC-time
+`RuntimeError: Event loop is closed` + `ResourceWarning: Unclosed connection`
+from `aiomysql/connection.py:1131 Connection.__del__` (aiomysql 0.3.2 — latest;
+`__del__` unconditionally calls `self.close()` → `transport.close()` on the loop).
+MEDIUM / cosmetic: connections reclaimed at process exit, no data/runtime impact.
+Reproduces on BOTH sync-node path AND pure-async `db.express` path.
+
+## Two hypotheses PROVEN WRONG (both no-ops)
+
+1. **Issue's hypothesis** — `close_async()` never calls
+   `MySQLAdapter.close_connection_pool()`. Wrong layer.
+2. **My initial hypothesis** — `close_async()` never drains
+   `AsyncSQLDatabaseNode._shared_pools`. True that close_async does not call
+   `clear_shared_pools`, but IRRELEVANT: the express pool's cached node in
+   `_async_sql_node_cache` has a byte-identical `_pool_key`, so the existing
+   node-cache teardown (`engine.py:10695-10708` → `cleanup():6646`
+   `del _shared_pools[key]; await adapter.disconnect()`) already drains it.
+   `_shared_pools` is size 0 after `close_async`. dataflow-specialist prototyped
+   the `_shared_pools`-drain fix: warning count stayed 10/10.
+
+## Verified root cause (specialist instrumented `aiomysql.Connection.__init__`; I verified the mechanism)
+
+~6 of ~12 connections are created on **transient bridge event loops**, NOT in
+`_shared_pools`, and are never drained before their loop closes:
+
+- `async_utils.py:223-248 run_coro_in_new_loop` (the `async_safe_run` bridge)
+  creates a new loop in a thread pool, runs the coro, then `_cancel_all_tasks` +
+  `new_loop.close()` — **without disconnecting adapter pools created on it**.
+- Origins: `DataFlow.__init__` reachability probe (`adapters/mysql.py:76→94
+create_connection_pool`, 1 conn) + `initialize()`/auto-migrate DDL
+  (`async_sql.py:611 EnterpriseConnectionPool.initialize`, min_size=5 → 5 conns).
+- `initialize_pool()` bridges to sync via `async_safe_run` at `engine.py:1840`;
+  `engine.py:6436` documents "binds each to a fresh, short-lived loop".
+  An aiomysql pool bound to an already-closed loop cannot be drained (transports
+  belong to the dead loop) — same reason `cleanup()` early-returns on a closed loop
+  (`async_sql.py:6608-6615`). Only correct drain point = while the bridge loop lives.
+
+## DECISION — Option A approved (user, 2026-07-05)
+
+Fix at the bridge-loop boundary: in `run_coro_in_new_loop`, BEFORE
+`new_loop.close()`, drain adapter pools created on that loop (via a per-loop
+adapter registry populated on adapter `connect()`). Best-effort/guarded so
+teardown never raises; log ONLY counts + loop id (pool keys carry creds —
+`security.md`; use `redact_pool_key`). General (catches all origins present +
+future). Rejected: Option B (fix the 2 originating paths — brittle);
+close-method drain (proven no-op).
+
+## Not started. Cross-SDK: the Rust SDK MySQL binding may share the gap (issue note).

--- a/workspaces/mops-onboarding/journal/0018-AMENDMENT-issue-1572-fix-shipped-redteam-convergence.md
+++ b/workspaces/mops-onboarding/journal/0018-AMENDMENT-issue-1572-fix-shipped-redteam-convergence.md
@@ -1,0 +1,66 @@
+# 0018 — AMENDMENT: #1572 bridge-loop pool drain shipped + redteam converged
+
+**Date:** 2026-07-05
+**Type:** AMENDMENT (of 0017 DISCOVERY/DECISION)
+**Author:** agent
+**Issue:** kailash-py #1572 → PR #1574 (fix) + #1575 (follow-up)
+**relates_to:** 0017-DISCOVERY-issue-1572-bridge-loop-pool-leak-root-cause
+
+## Outcome
+
+Option A (approved in 0017) implemented, redteamed to convergence, committed on
+`fix/dataflow-1572-bridge-loop-pool-drain` (commit `3ab9e0e4a`), pushed as **PR #1574**.
+
+Fix shape (as approved): per-loop drain registry `kailash.utils.loop_pool_registry`
+(core kailash, so both a DataFlow adapter pool AND a core `EnterpriseConnectionPool`
+pool — covered transitively via its inner adapter `connect()` — register through one
+path). The bridge `dataflow.core.async_utils._run_on_new_loop` marks its transient
+loop and drains registered pools BEFORE `close()`. Applied to BOTH bridge branches
+(thread-pool + the no-running-loop `asyncio.run` branch — same bug class). Registration
+sites: core `async_sql.py` PG/MySQL `connect()`; dataflow `adapters/{mysql,postgresql}.py`
+`create_connection_pool`. Marker-gated so persistent app loops (FastAPI/Jupyter) are
+never registered/drained.
+
+## Verification (first-hand)
+
+Deterministic Tier-2 regression on real PG:5434 + MySQL:3307: `adapter._pool is None`
+after `async_safe_run` returns. **Stash-flip proved the guard genuine** — with the fix
+stashed, the test reproduced the EXACT #1572 symptom (`RuntimeError: Event loop is closed`
+from `aiomysql/connection.py:1131 Connection.__del__`); with the fix applied, 10/10 green.
+No regression across the existing async-bridge suite (66) + core adapters (5); collection
+clean (6660).
+
+## Redteam — 3 rounds to convergence
+
+- **R1** (reviewer + security-reviewer + correctness adversary, parallel): no CRIT/HIGH.
+  1 MED regression — the drain had no timeout; a hung `disconnect()` would block the
+  bridge forever (pre-fix bare `asyncio.run` never awaited pool close, so this was a NEW
+  hang surface). + several LOW. All folded: bounded each drain at 5s (`asyncio.wait_for`),
+  `shutdown_default_executor` parity, removed unused `discard_loop` (orphan), regression
+  markers + infra-skip guards, narrowed drain-error logs to `type(exc).__name__` (never
+  `str(exc)` — no DSN can surface).
+- **R2** (reviewer + adversary): CONVERGED — all R1 items confirmed closed first-hand;
+  the `wait_for`-cancel-mid-`close()` bounded-leak is the intended tradeoff (strictly
+  better than pre-fix leak AND better than infinite hang). All 5 correctness probes refuted.
+- **R3** (fresh-eyes holistic): safe to commit; surfaced MED-1 (sibling non-bridge loops)
+  - LOW-1 (in-scope log consistency). LOW-1 fixed; MED-1 deferred (below).
+
+## Deferred (out of this shard's budget)
+
+- **#1575 (filed):** sibling non-bridge transient loops (schema discovery `asyncio.run`
+  in `engine._inspect_database_schema_real`, not in try/finally → leaks on exception;
+  `new_event_loop()` in engine/model_registry; **owned/long-lived** `self._loop` in
+  express/transactions which must NOT be drained via the transient registry). Heterogeneous,
+  multi-subsystem, needs per-site transient-vs-owned analysis → a distinct shard, not a
+  continuation (autonomous-execution Rule 4 bounded-by-budget carve-out).
+- **ECP captured-ref (R1 Probe 1):** `EnterpriseConnectionPool._pool` keeps a ref to the
+  drained pool; only bites on ECP-reuse-after-loop-death, which was already broken and the
+  pools are one-shot. Pre-existing, not a regression. Folded into #1575's audit scope.
+- **Cross-SDK:** the Rust SDK bridge may share this transient-loop pool-leak class
+  (cross-sdk-inspection MUST-1). Needs a user-authorized cross-repo action per
+  repo-scope-discipline — NOT self-initiated.
+
+## Status
+
+PR #1574 open; CI running at time of writing. Next: merge on green (admin), then /release
+(BUILD-repo discipline — tag-triggered OIDC `dataflow-v<ver>`, no manual twine).

--- a/workspaces/mops-onboarding/journal/0019-DECISION-issue-1581-crud-transaction-awareness-converged.md
+++ b/workspaces/mops-onboarding/journal/0019-DECISION-issue-1581-crud-transaction-awareness-converged.md
@@ -1,0 +1,109 @@
+# 0019 — DECISION: #1581 CRUD transaction-awareness — implemented + redteam-CONVERGED
+
+**Date:** 2026-07-06 (session 4)
+**Type:** DECISION (implementation + validation outcome)
+**Issue:** #1581 — generated DataFlow CRUD nodes not transaction-aware
+**Status:** SHIPPED to working tree, redteam-converged (2 consecutive clean rounds). NOT yet PR'd (awaiting user authorization — BUILD-repo shared-state gate).
+
+## What was wrong (#1581)
+
+Generated DataFlow CRUD nodes ran every statement on their own cached
+`AsyncSQLDatabaseNode` in `transaction_mode="auto"` (per-statement autocommit).
+Inside a `TransactionScopeNode` workflow, a CRUD write committed independently
+and **survived a later `TransactionRollbackNode`** — a silent data-integrity
+violation. The `transaction_mode="auto"` kwarg at the 10 call sites was INERT
+(`async_run` reads it from config at init, never from inputs).
+
+## The fix (single-record CRUD)
+
+- **Core `src/kailash/nodes/data/async_sql.py`** — `_AdapterTransactionScope`
+  gained a `.transaction` property (raw txn handle). `AsyncSQLDatabaseNode.async_run`
+  reads `inputs.get("transaction")`, threaded through `_execute_with_retry` →
+  `_execute_with_transaction` where a new leading `if transaction is not None:`
+  borrow-don't-own branch runs `adapter.execute(..., transaction=...)` with NO
+  begin/commit/rollback (scope owns lifecycle). Same for the batch path
+  (`execute_many_async` → `_execute_many_with_transaction`). Param-threaded, NOT
+  instance-state mutation (the cached node is shared across ops — mutating
+  `_active_transaction` would leak the scope).
+- **DataFlow `packages/kailash-dataflow/src/dataflow/core/nodes.py`** —
+  module-level `_run_sql_in_scope(node, sql_node, **kw)` reads `active_transaction`
+  off workflow context and injects `scope.transaction`. All 10 CRUD sites
+  (create/read/update/delete/list/count/upsert + mysql-precheck + readback)
+  routed through it. **Fail-closed:** an active scope with no `.transaction`
+  handle raises `NodeExecutionError` (never silent auto-commit). The PG `$11`
+  param-type retry fallback fixed: when a scope is active the `$11::integer`
+  retry runs on the POOLED node (joins the scope) instead of a fresh non-pooled
+  node that escaped it.
+- **`engine.py`** — registered the previously-orphaned `TransactionSavepointNode`
+  - `TransactionRollbackToSavepointNode` (defined + exported but never
+    registered → unreachable by any workflow).
+- **`transaction_nodes.py`** — savepoint-name validation `re.match(...$)` →
+  `re.fullmatch(...)` (newly load-bearing once the nodes are reachable; `$`
+  accepted a trailing newline).
+
+## Scoping questions (answered under /autonomize, with evidence)
+
+1. **Reads join too?** YES — `_run_sql_in_scope` covers LIST/READ/COUNT →
+   read-your-writes inside the scope (verified AC3).
+2. **PG `$11` retry fresh-node escape?** MUST-handle — fixed (pooled node when
+   scope active).
+3. **Bulk symmetric plumbing?** Core `execute_many_async(transaction=...)` added;
+   the DataFlow bulk path is a SEPARATE shard (see #1585).
+
+## Redteam convergence (2 clean rounds)
+
+- **Round 1** (3 parallel: reviewer + security-reviewer + dataflow-specialist):
+  single-record fix VERIFIED correct+complete (no missed sites, no instance
+  mutation, borrow-branch correct, connection identity sound, tenant isolation
+  preserved). Findings: **HIGH** bulk ops bypass the scope; **LOW×3** (silent
+  auto-commit fallback, savepoint regex trailing-newline, engine comment
+  over-claim). LOWs fixed in-shard; bulk → #1585.
+- **Round 2** (reviewer + dataflow-specialist): ROUND 2 CLEAN — all 3 LOW fixes
+  verified correct, no new defects. Convergence verifier: CONVERGED, bulk
+  disposition SOUND.
+
+## The bulk gap → #1585 (deferred, correctly)
+
+Bulk CRUD nodes (`BulkCreate/Update/Delete/Upsert`) dispatch to
+`dataflow_instance.bulk.bulk_*()` — a separate subsystem (`features/bulk.py`
+1862 LOC + `bulk_create_pool.py` 580 + `bulk_upsert.py` 872 = 3314 LOC) that
+runs auto-commit on fresh non-pooled nodes and never reads `active_transaction`.
+Threading the scope through it (connection-management surgery across 3 files,
+plus batch-atomicity invariants) far exceeds one shard's budget → **filed #1585**
+
+- **xfail-strict pin** `test_bulk_create_in_scope_discarded_after_rollback_xfail`
+  (DB probe confirmed 2 rows persist past rollback — the pin captures the real
+  gap; XPASSes → strict-fail → marker removed when #1585 lands).
+
+## Tests
+
+`packages/kailash-dataflow/tests/regression/test_issue_1581_crud_transaction_awareness.py`
+— 8 passed + 1 xfailed (AC1 commit-persists, AC2 rollback-discards, AC3
+read-your-writes, AC4 no-scope-autocommits, AC5 savepoint-partial, AC6 SQLite
+parity, AC7 fail-closed, AC8 core batch-borrow, AC9 bulk xfail-strict). Flipped
+the strict-xfail on `test_dataflow_rollback_transaction` (now XPASSes). Fixed
+the contrived `test_workflow_context_integration.py::test_dataflow_node_uses_transaction_connection`
+(its threaded-PythonCodeNode harness only "passed" because of the #1581 bug;
+rewrote to the real direct-node path). Broader: 46 passed + 6 xfailed
+(transactions + #1580 + #1581 package-tree), 9 passed root async_sql cleanup.
+
+## Also fixed (pre-existing #1580 orphan, zero-tolerance Rule 1)
+
+`tests/integration/nodes/test_async_sql_transaction_cleanup.py` imported
+`PostgreSQLTransactionContext` — a symbol #1580 removed (absent on main HEAD
+`1473b23ad`; not caused by this session) without sweeping the test. Ported both
+tests to the current `adapter.transaction()` contract.
+
+## Release scope delta
+
+The fix lands in **core kailash** (`async_sql.py`) AND **kailash-dataflow**
+(`nodes.py`, `engine.py`, `transaction_nodes.py`) — so BOTH a `kailash` patch
+AND a `kailash-dataflow` patch now have src changes (the prior session's #1580
+was core-only; this adds dataflow src). Release scope must be re-derived at
+release time.
+
+## Next
+
+`/todos`→done, `/implement`→done, `/redteam`→CONVERGED. Awaiting user
+authorization to open the PR (BUILD-repo shared-state gate). Then release
+(kailash + kailash-dataflow patch) — user holds timing.

--- a/workspaces/mops-onboarding/journal/0020-AMENDMENT-issue-1581-merged-plus-1587-cache-adapter-leak.md
+++ b/workspaces/mops-onboarding/journal/0020-AMENDMENT-issue-1581-merged-plus-1587-cache-adapter-leak.md
@@ -1,0 +1,71 @@
+# 0020 — AMENDMENT: #1581 merged (PR #1586) + #1587 cache-adapter leak discovered & fixed
+
+**Date:** 2026-07-06 (session 5)
+**Type:** AMENDMENT (extends 0019 — merge outcome + adjacent discovery)
+**Relates to:** 0019 (#1581 convergence)
+**Issues:** #1581 (merged), #1587 (new, cache-adapter leak)
+**Status:** #1581 MERGED to main (merge commit `02b1ca89b`); #1587 PR open, CI running; release pending (user holds PyPI timing).
+
+## #1586 (#1581) — CI blocker found and fixed, then merged
+
+On session start, PR #1586 CI showed one real failure (both duplicate runs):
+`test_issue_1560_create_retry_node_leak.py::test_retry_site_wraps_async_run_in_cleanup`.
+
+Root cause: the #1560 **source-pin** asserted the throwaway-node `cleanup()` lived
+within a fixed 2600-char window from the `PARAM $11 FIX` anchor. #1581 inserted a
+~40-line transaction-scope branch **above** the fresh-node path (in-scope retries
+now run on the POOLED node, which the pool cleans up), sliding
+`await sql_node.cleanup()` to offset 3626 — past the window. The #1560 invariant
+itself was **intact**: the throwaway `AsyncSQLDatabaseNode` is created ONLY on the
+no-scope path and is still wrapped in `try/finally: cleanup()`.
+
+Fix (commit `b21e54f04`): re-anchor the source-pin on the **fresh-node construction
+site** (`sql_node = AsyncSQLDatabaseNode(`) instead of a fixed char window, so a
+legitimate scope-branch insertion above it cannot slide the cleanup out of range.
+Re-pushed → full matrix (Py3.11–3.14 + DataFlow infra + PACT) green on head
+`b21e54f04` → admin-merged (`02b1ca89b`), branch deleted.
+
+## #1587 — pre-existing cache-adapter leak (adjacent discovery, separate bug class)
+
+While running the full infra-free regression gate locally, a DIFFERENT test failed:
+`test_dataflow_close_async_closes_cleanly` — `ResourceWarning: AsyncRedisCacheAdapter
+not closed` after `close_async()`. Proven **pre-existing on main** (the only engine.py
+change in #1581 was the savepoint-node registration; `git diff 1473b23ad HEAD` confirms).
+
+Root cause: `DataFlowExpress.__init__` eagerly auto-detects a cache backend; when Redis
+is reachable that is an `AsyncRedisCacheAdapter` owning a `ThreadPoolExecutor`. Neither
+`DataFlow.close()` nor `close_async()` tore it down → the executor's worker threads leak
+on every documented cleanup path (FastAPI lifespan, async fixture). **Invisible on
+`[dev]`-only CI** (no Redis → in-memory fallback → no executor), surfacing only where
+Redis is up — which is why #1586 CI stayed green.
+
+Fix (PR #1587, commit `a9895804e`, off main):
+
+- `AsyncRedisCacheAdapter` gains a sync `close()` sibling to `close_async()` (idempotent
+  executor shutdown; safe on the blocking path).
+- `DataFlowExpress` gains `close()`/`close_async()` closing `_cache_manager`
+  (getattr-guarded → in-memory fallback no-ops).
+- Both `DataFlow` close paths tear down the async Express instance AND the engine-level
+  `_cache_integration` adapter.
+- Regression `test_dataflow_close_cache_adapter_leak.py`: **deterministic** (recording
+  cache-manager, no Redis dependency) pins the close wiring on both paths — a
+  warning-based test would pass vacuously on a `[dev]`-only runner.
+
+## Process incident — errant `git stash pop` (recovered, no loss)
+
+A `git stash push -- <path>` issued from inside `packages/kailash-dataflow/` doubled the
+path and failed to create a stash; the follow-up `git stash pop` then applied an
+UNRELATED pre-existing 1654-file "release-prep" stash (`stash@{0}`) onto the tree,
+polluting ~hundreds of files with 2 merge conflicts. Recovery was lossless: the stash
+was **preserved** (the conflicted pop did not drop it), my 4 real files were backed up
+to `/tmp`, and `git checkout HEAD -- .` restored the tree to origin/main before
+reapplying the 4 files. **Lesson:** never run `git stash` pathspecs from a subdirectory
+without absolute/repo-relative paths; verify no pre-existing stash before any `pop`.
+
+## Release scope (next)
+
+- **kailash** 2.45.4 → 2.45.5 — `async_sql.py` (#1580 + #1581).
+- **kailash-dataflow** 2.13.20 → 2.13.21 — #1581 (nodes.py/engine.py/transaction_nodes.py)
+  - #1587 (async_redis_adapter.py/engine.py/express.py) once #1587 merges.
+
+Re-derive both at `/release`; user holds PyPI timing.

--- a/workspaces/mops-onboarding/journal/0021-AMENDMENT-issue-1585-bulk-transaction-awareness-shipped.md
+++ b/workspaces/mops-onboarding/journal/0021-AMENDMENT-issue-1585-bulk-transaction-awareness-shipped.md
@@ -1,0 +1,102 @@
+# 0021 — AMENDMENT: #1585 bulk CRUD transaction-awareness implemented + redteam-CONVERGED
+
+**Date:** 2026-07-06 (session 6)
+**Type:** AMENDMENT (extends 0019/0020 — the deferred bulk gap #1585 is now closed)
+**Relates to:** 0019 (#1581 convergence, where bulk was deferred to #1585), 0020 (#1581+#1587 shipped)
+**Issue:** #1585 — bulk CRUD nodes not transaction-aware (follow-up to #1581)
+**Status:** SHIPPED to PR #1593 (branch `fix/1585-bulk-crud-transaction-awareness`, commit `e704c350c`), CI running, redteam-converged. Release pending (kailash-dataflow 2.13.21 → 2.13.22; user holds PyPI timing).
+
+## What was wrong (#1585)
+
+#1581 made single-record CRUD transaction-aware but the BULK write surface
+(`BulkCreate/Update/Delete/Upsert`) still ran `transaction_mode="auto"` on its own
+connection — a bulk write inside a `TransactionScopeNode` committed independently
+and **survived a later `TransactionRollbackNode`**. Same silent data-integrity
+violation as #1581, larger blast radius (bulk moves more rows). The AC9
+`xfail(strict=True)` pin in the #1581 suite captured the gap.
+
+## The fix — thread the borrowed scope transaction through the bulk path
+
+The core hook (`AsyncSQLDatabaseNode.async_run(transaction=…)` → borrow-don't-own
+branch) already shipped in #1581 (kailash 2.45.5). #1585 is **DataFlow-only**: it
+makes the bulk path CONSUME that hook. Key architectural insight verified against
+the adapter code: the borrowed handle is a `(conn, tx)` tuple carrying its OWN
+connection, so `adapter.execute_many(query, params, transaction)` runs on the
+scope's connection regardless of which node issues it — this dissolves the
+"fresh node opens a different connection" problem for the standalone nodes.
+
+- **Path A** (generated `<Model>Bulk*Node` → `features/bulk.py`, cached POOLED
+  node): new module-level `_resolve_scope_transaction(node)` extracted from
+  #1581's `_run_sql_in_scope` (shared fail-closed guard). The 4 bulk dispatch
+  sites in `core/nodes.py` resolve the scope once and pass `transaction=`; each
+  `bulk_*()` threads it into every `async_run` site (all 4 verbs + the
+  bulk-delete pre-count SELECT + the SQLite upsert insert/update-breakdown COUNT).
+- **Path B** (standalone `DataFlowBulkUpsertNode` / `BulkCreatePoolNode`, FRESH
+  non-pooled nodes): both thread the handle to their fresh execution node.
+  - `DataFlowBulkUpsertNode.async_run` normally routes through
+    `_execute_with_connection` → `async_safe_run`, which runs on a SEPARATE event
+    loop (a borrowed asyncpg conn is loop-bound and cannot cross it). Fix: when a
+    scope is active, BYPASS that boundary and `await _perform_bulk_upsert`
+    directly on the runtime loop.
+  - `BulkCreatePoolNode` forces its direct borrow path when a scope is active
+    (its own connection pool cannot join the scope).
+  - Both **fail closed** (raise `NodeExecutionError`) when a scope is active but
+    they cannot join it (no `connection_string`), rather than returning a
+    fabricated-success simulation stub.
+
+## Redteam convergence (findings round → fix → clean round; #1581 precedent)
+
+- **Round 1** (3 parallel: dataflow-specialist + reviewer + security-reviewer):
+  - dataflow-specialist: **CLEAN** — all 7 invariants (borrow semantics, no-scope
+    byte-identity, cross-loop correctness, batch atomicity, fail-closed, tenant
+    isolation, pooled-path-forces-direct) verified behaviorally on live PG.
+  - reviewer: **CLEAN** + 1 Important (new test file introduced `LocalRuntime`
+    deprecation warnings) + 2 Minor coverage notes (acceptable).
+  - security-reviewer: **MEDIUM** — asymmetric fail-closed guard: `bulk_upsert.py`
+    lacked the no-`connection_string`-under-scope guard its sibling
+    `bulk_create_pool.py` carries; under a scope it fell into the dry-run-shaped
+    `else` branch and returned fabricated `success:True`. + 1 LOW (informational,
+    pre-existing bulk error-dict semantics, not a commit-escape → no action).
+- **Fixes:** added the symmetric guard + added `NodeExecutionError` to the
+  typed-reraise tuple so the guard propagates loudly (also makes the DB-error
+  path raise instead of returning `success:False` — a BENEFICIAL contract change,
+  documented in the CHANGELOG § Changed; aligns with `BulkCreatePoolNode`); added
+  AC10 regression; converted the new test file to `with LocalRuntime()`.
+- **Round 2** (reviewer + security-reviewer re-verify the delta): both **CLEAN** —
+  MEDIUM resolved, Important resolved, no new findings.
+
+## Tests
+
+`test_issue_1585_bulk_transaction_awareness.py` — 10 tests on live PG + SQLite
+(rollback-discards ×4 verbs, commit-persists, SQLite parity, both standalone nodes
+exercising the async_safe_run bypass + pool-bypass, both fail-closed guards).
+Removed the #1581 AC9 xfail pin (now a real passing test). #1585 + #1581 suites:
+**19 passed** (verified count).
+
+## Pre-existing hang found (NOT #1585 — separate bug class, filed)
+
+While running the broader bulk suite, `test_bulk_upsert_comprehensive.py::test_bulk_upsert_large_mixed_batch`
+HANGS (>60s) and `test_v052_bug_reproduction.py` has 2 failures. Proven
+**pre-existing on main HEAD `473a104d7`** (reproduced with the #1585 diff reverted
+via a saved patch, then restored losslessly). Different bug class (large-batch
+upsert), not gating CI (main shipped green). Filed as a tracking issue; NOT in
+#1585 scope.
+
+## Process note
+
+Dispatched the read-only `security-reviewer` with a Bash evidence-gate task; it
+correctly declined the Bash part (no Bash tool) and delivered its security
+verdict. The 19-passed evidence came from the Bash-capable reviewer + local runs.
+Next time: don't hand the evidence-gate pytest run to a read-only specialist
+(agents.md tool-inventory MUST).
+
+## Release scope
+
+**kailash-dataflow only** 2.13.21 → 2.13.22 (nodes.py/bulk.py/bulk_create_pool.py/
+bulk_upsert.py). NO core `kailash` bump (borrow branch already in 2.45.5). Version
+anchors bumped (pyproject.toml + `__init__.py`); CHANGELOG 2.13.22 written.
+
+## Next
+
+PR #1593 CI → admin-merge → `/release` kailash-dataflow 2.13.22 (user holds PyPI
+timing). Then `/wrapup`.


### PR DESCRIPTION
Commits 10 accumulated workspace journal entries (0012–0021) that were untracked while the convention tracks them (0001–0011 committed), plus the 2026-07-06 repo-wide `/sweep` report.

Journals cover: cross-repo authorizations (kailash-rs #1552, loom log-triage), DataFlow redteam DECISIONs (2.13.16/2.13.17), and the #1572 / #1581 / #1585 outcomes. `/sweep` FIX-NOW per zero-tolerance Rule 1 — preserves the institutional-knowledge trail in git.

Workspace-only diff (no source/version change) — carve-out, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)