### PR TITLE
fix(dataflow): Model.query_builder() respects __tablename__ (#1614) + query-surface table-identifier hardening

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.14.4] — 2026-07-08 — `Model.query_builder()` respects `__tablename__` (#1614) + query-surface table-identifier hardening
+
+### Fixed
+
+- **`Model.query_builder()` now respects `__tablename__` (`core/engine.py`, #1614; query-surface sibling of #1541/#1573).** #1541 (CREATE INDEX / FK ALTER) and #1573 (migration trigger/diff/tracking paths) closed the `__tablename__` asymmetry on the DDL/migration surface. The **query** surface was the remaining sibling: the `query_builder` classmethod bound during model registration resolved the table via `_class_name_to_table_name(cls.__name__)` (the pluralized class-name default) instead of the `__tablename__`-respecting `_get_table_name`. For a model with a custom `__tablename__`, `Model.query_builder().build_select(...)` built `SELECT ... FROM <pluralized_default>` against a table that does not exist (the real table is the custom `__tablename__`), so every `query_builder`-built query on such a model targeted the wrong / nonexistent table. The binding now routes through `_get_table_name(cls.__name__)` — the same resolver CREATE TABLE, the index/FK generators (#1541), and the migration paths (#1573) already use. Behavioral regression tests (real PostgreSQL) prove `query_builder().build_select()` targets the custom table and a written row round-trips through the built query (RED→GREEN verified; pre-fix the round-trip raised `UndefinedTableError` against the nonexistent default table). Query-surface audit confirmed no other `_class_name_to_table_name` caller needed the swap (the remaining callers are either already `__tablename__`-respecting via the stored `table_name`, or the intentional pluralized-default `_relationships` FK-detection contract left unchanged per #1541).
+
+### Security
+
+- **Query-builder table identifiers are now fail-closed (`database/query_builder.py`, #1614 hardening).** Because #1614 newly routes the raw developer-authored `__tablename__` into `QueryBuilder`, the table-name quoting path now validates every table identifier through the same dialect helper the DDL path uses (`DialectManager.get_dialect(...).quote_identifier` — allowlist `^[a-zA-Z_][a-zA-Z0-9_]*$` + length limit + reject-don't-escape, raising `InvalidIdentifierError`), giving the query surface the same fail-closed table-identifier safety as CREATE TABLE / the index/FK/migration paths (`dataflow-identifier-safety.md` MUST-1/2/5). Scope is the **table name** only (a pure identifier): the SELECT/INSERT/SET **field list** — which legitimately carries aggregate/alias expressions such as `COUNT(*) AS total` — is deliberately left on the non-validating field quoter, and a regression test pins that field-expression contract so the hardening cannot over-reach. Output is byte-identical to the prior per-dialect quoting for every valid table identifier; only crafted/invalid table names are newly rejected. Regression tests assert injection-shaped table names are rejected across `build_select`/`build_count`/`build_insert`/`build_update`/`build_delete`/`join` on all three dialects.
+
 ## [2.14.3] — 2026-07-08 — AutoMigrationSystem trigger/tracking paths respect `__tablename__` (#1573)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.14.3"
+version = "2.14.4"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.14.3"
+__version__ = "2.14.4"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -2212,7 +2212,12 @@ class DataFlow(DataFlowEventMixin):
             """Create a QueryBuilder instance for this model."""
             from ..database.query_builder import create_query_builder
 
-            table_name = self._class_name_to_table_name(cls.__name__)
+            # issue #1614 (query-surface sibling of #1541/#1573): resolve
+            # ``__tablename__`` via ``_get_table_name`` so query_builder targets
+            # the same table CREATE TABLE / the index/FK generators / the
+            # migration paths use — NOT the pluralized class-name default, which
+            # points at a nonexistent table for a custom-``__tablename__`` model.
+            table_name = self._get_table_name(cls.__name__)
             return create_query_builder(table_name, self.config.database.url)
 
         # Bind the method as a classmethod

--- a/packages/kailash-dataflow/src/dataflow/database/query_builder.py
+++ b/packages/kailash-dataflow/src/dataflow/database/query_builder.py
@@ -245,7 +245,7 @@ class QueryBuilder:
             raise ValueError(f"Invalid join type: {join_type}")
 
         self.joins.append(
-            f"{join_type.upper()} JOIN {self._quote_identifier(table)} ON {on_condition}"
+            f"{join_type.upper()} JOIN {self._quote_table_name(table)} ON {on_condition}"
         )
         return self
 
@@ -284,7 +284,7 @@ class QueryBuilder:
             select_clause = f"SELECT {', '.join(quoted_fields)}"
 
         # Build FROM clause
-        from_clause = f"FROM {self._quote_identifier(self.table_name)}"
+        from_clause = f"FROM {self._quote_table_name(self.table_name)}"
 
         # Build JOIN clauses
         join_clause = " ".join(self.joins) if self.joins else ""
@@ -356,7 +356,7 @@ class QueryBuilder:
             placeholders.append(self._get_parameter_placeholder())
             values.append(value)
 
-        query = f"INSERT INTO {self._quote_identifier(self.table_name)} ({', '.join(fields)}) VALUES ({', '.join(placeholders)})"
+        query = f"INSERT INTO {self._quote_table_name(self.table_name)} ({', '.join(fields)}) VALUES ({', '.join(placeholders)})"
 
         # Add RETURNING clause for PostgreSQL
         if self.database_type == DatabaseType.POSTGRESQL:
@@ -389,7 +389,7 @@ class QueryBuilder:
         if self.conditions:
             where_clause = f"WHERE {' AND '.join(self.conditions)}"
 
-        query = f"UPDATE {self._quote_identifier(self.table_name)} {set_clause} {where_clause}"
+        query = f"UPDATE {self._quote_table_name(self.table_name)} {set_clause} {where_clause}"
 
         # Add RETURNING clause for PostgreSQL
         if self.database_type == DatabaseType.POSTGRESQL:
@@ -412,7 +412,7 @@ class QueryBuilder:
         if self.conditions:
             where_clause = f"WHERE {' AND '.join(self.conditions)}"
 
-        query = f"DELETE FROM {self._quote_identifier(self.table_name)} {where_clause}"
+        query = f"DELETE FROM {self._quote_table_name(self.table_name)} {where_clause}"
 
         # Add RETURNING clause for PostgreSQL
         if self.database_type == DatabaseType.POSTGRESQL:
@@ -432,7 +432,7 @@ class QueryBuilder:
         if self.conditions:
             where_clause = f"WHERE {' AND '.join(self.conditions)}"
 
-        query = f"SELECT COUNT(*) FROM {self._quote_identifier(self.table_name)} {where_clause}"
+        query = f"SELECT COUNT(*) FROM {self._quote_table_name(self.table_name)} {where_clause}"
 
         return query, self.parameters
 
@@ -447,7 +447,15 @@ class QueryBuilder:
             return "?"
 
     def _quote_identifier(self, identifier: str) -> str:
-        """Quote identifier based on database type."""
+        """Quote a field-list identifier based on database type.
+
+        Used for the SELECT/GROUP BY/ORDER BY/INSERT/SET **field** list, which
+        legitimately carries aggregate and alias EXPRESSIONS (``COUNT(*)``,
+        ``x AS y``) — NOT just plain identifiers — so this path deliberately
+        does NOT allowlist-validate (that would break the accepted expression
+        contract). Table names, which ARE pure identifiers, go through the
+        fail-closed ``_quote_table_name`` instead (issue #1614).
+        """
         # Handle dot notation (e.g., "user.email")
         parts = identifier.split(".")
 
@@ -459,6 +467,35 @@ class QueryBuilder:
             quoted_parts = [f'"{part}"' for part in parts]
 
         return ".".join(quoted_parts)
+
+    def _quote_table_name(self, table_name: str) -> str:
+        """Quote a TABLE identifier, validating each part fail-closed.
+
+        A table name is a pure identifier (never an aggregate/alias
+        expression), so — unlike the field list (see ``_quote_identifier``) —
+        it routes every dot-separated part through the dialect's validating
+        ``quote_identifier`` (allowlist regex ``^[a-zA-Z_][a-zA-Z0-9_]*$`` +
+        length limit + reject-don't-escape), giving the QUERY surface the same
+        fail-closed table-identifier safety as the DDL path
+        (``dataflow-identifier-safety.md`` MUST-1/2/5). This is the issue
+        #1614 surface: the ``query_builder`` binding previously fed only the
+        derived pluralized-default table name here; #1614 routes the raw
+        developer-authored ``__tablename__`` through this path, so an
+        invalid/crafted table identifier MUST raise ``InvalidIdentifierError``
+        rather than break out of the quotes.
+
+        Output is byte-identical to the prior per-dialect quoting for every
+        valid table identifier (PostgreSQL/SQLite double-quote the part, MySQL
+        backtick-quotes it) — the dialect quote characters match exactly.
+        """
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(self.database_type.value)
+        # Preserve dot-notation support (e.g. "schema.table") — validate + quote
+        # each part independently, exactly as the prior implementation split.
+        return ".".join(
+            dialect.quote_identifier(part) for part in table_name.split(".")
+        )
 
     def reset(self) -> "QueryBuilder":
         """Reset the builder to initial state."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1614_tablename_query_builder.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1614_tablename_query_builder.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1614 — ``Model.query_builder()`` ignored
+``__tablename__``.
+
+Query-surface sibling of #1541 (CREATE INDEX / FK ALTER) and #1573 (migration
+trigger/diff/tracking paths). Those closed the ``__tablename__`` asymmetry on
+the DDL/migration surface by routing every table-name resolution through the
+``__tablename__``-respecting resolver ``_get_table_name``. The QUERY surface was
+the remaining sibling: the ``query_builder`` classmethod bound during model
+registration (``engine.py``, ``_register_model_internal``) resolved the table
+via ``_class_name_to_table_name(cls.__name__)`` — the pluralized class-name
+default — NOT ``_get_table_name``. For a model with a custom ``__tablename__``,
+``Model.query_builder().build_select(...)`` produced ``SELECT ... FROM
+<pluralized_default>`` against a table that does not exist (the real table is
+the custom ``__tablename__``), so every ``query_builder``-built query on such a
+model targeted the wrong / nonexistent table.
+
+The fix routes the ``query_builder`` binding through
+``_get_table_name(cls.__name__)`` — the same resolver CREATE TABLE, the
+index/FK generators (#1541), and the migration paths (#1573) already use.
+
+RED→GREEN proven (against real PostgreSQL) with the ``engine.py`` fix reverted to
+``_class_name_to_table_name``:
+  * ``test_query_builder_build_select_targets_custom_tablename`` — the built
+    SELECT targets the pluralized default, so the "custom present / default
+    absent" assertions fail.
+  * ``test_query_builder_round_trips_row_from_custom_table`` — the built SELECT
+    targets the nonexistent pluralized-default table, so executing it against
+    the real database raises ``UndefinedTableError`` and the row never
+    round-trips.
+Restoring the fix makes them pass. The default table name is computed from
+``_class_name_to_table_name`` at runtime (never hardcoded), so the
+default-absent assertion cannot be vacuously satisfied by a mis-guessed
+pluralization (``rules/verify-claims-before-write.md``).
+
+Behavioral (NO mocking, real PostgreSQL on port 5434). Assertions query the
+real catalog / the engine's own resolution, NOT source text
+(``rules/testing.md`` § Behavioral Regression Tests Over Source-Grep).
+
+Permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+
+Run:
+    TEST_DATABASE_URL="postgresql://test_user:test_password@localhost:5434/kailash_test" \
+      .venv/bin/python -m pytest \
+      packages/kailash-dataflow/tests/regression/test_issue_1614_tablename_query_builder.py \
+      -p no:xdist -o "addopts=" -q --tb=short
+"""
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from dataflow import DataFlow
+from dataflow.adapters.exceptions import InvalidIdentifierError
+from dataflow.database.query_builder import DatabaseType, QueryBuilder
+
+PG_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+# --------------------------------------------------------------------------
+# Raw read-back helper (reflects COMMITTED state, bypasses DataFlow entirely).
+# --------------------------------------------------------------------------
+async def _pg_drop(url: str, *tables: str) -> None:
+    conn = await asyncpg.connect(url)
+    try:
+        for t in tables:
+            await conn.execute(f'DROP TABLE IF EXISTS "{t}" CASCADE')
+    finally:
+        await conn.close()
+
+
+# --------------------------------------------------------------------------
+# Test 1 — the deterministic distinguisher: build_select targets __tablename__.
+# RED without the fix: the built SELECT targets the pluralized class default.
+# No DB round-trip needed — this exercises the query_builder binding + SQL
+# construction directly (query_builder resolves the table at build time).
+# --------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_query_builder_build_select_targets_custom_tablename():
+    """``Model.query_builder().build_select(...)`` MUST target the resolved
+    ``__tablename__`` — not the pluralized class-name default (issue #1614)."""
+    custom = f"acct_q1614_{uuid.uuid4().hex[:8]}"
+
+    db = DataFlow(PG_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1614QueryAccount:
+        __tablename__ = custom
+
+        id: str
+        name: str
+
+    # Compute the pluralized default from the engine's own converter — a
+    # hardcoded guess makes the "absent" assertion vacuous.
+    default_plural = db._class_name_to_table_name("Issue1614QueryAccount")
+    assert default_plural != custom  # the two names MUST differ for this test
+
+    # Sanity: the resolver itself honors __tablename__ (from #1541).
+    assert db._get_table_name("Issue1614QueryAccount") == custom
+
+    builder = Issue1614QueryAccount.query_builder()
+    builder.where("id", "$eq", "some-id")
+    sql, _params = builder.build_select(["id", "name"])
+
+    assert (
+        custom in sql
+    ), f"query_builder SELECT must target the custom table '{custom}' (issue #1614)"
+    assert (
+        default_plural not in sql
+    ), "query_builder SELECT must NOT target the pluralized default table"
+
+
+# --------------------------------------------------------------------------
+# Test 2 — behavioral end-to-end (AC2): a row written to a custom-__tablename__
+# model round-trips through query_builder's own SELECT against the real table.
+# RED without the fix: the built SELECT targets the nonexistent pluralized
+# default, so executing it raises UndefinedTableError and the row never returns.
+# --------------------------------------------------------------------------
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_query_builder_round_trips_row_from_custom_table():
+    """A row written to a custom-``__tablename__`` model MUST round-trip through
+    the SQL ``query_builder`` builds — proving query_builder targets the real
+    (custom) table, not the nonexistent pluralized default (issue #1614)."""
+    custom = f"acct_r1614_{uuid.uuid4().hex[:8]}"
+    default_plural = None  # bound before the finally references it
+
+    db = DataFlow(PG_URL, auto_migrate=True)
+
+    @db.model
+    class Issue1614RoundTripAccount:
+        __tablename__ = custom
+
+        id: str
+        name: str
+
+    default_plural = db._class_name_to_table_name("Issue1614RoundTripAccount")
+    assert default_plural != custom
+
+    await db.initialize()
+    try:
+        await db.create_tables_async()
+
+        rid = f"acct-{uuid.uuid4().hex[:8]}"
+        await db.express.create(
+            "Issue1614RoundTripAccount", {"id": rid, "name": "round-trip-1614"}
+        )
+
+        # Build the read query through query_builder (the surface under test),
+        # then execute its SQL against the real database. PostgreSQL emits
+        # native ``$N`` placeholders, so asyncpg runs (sql, params) directly.
+        builder = Issue1614RoundTripAccount.query_builder()
+        builder.where("id", "$eq", rid)
+        sql, params = builder.build_select(["id", "name"])
+
+        # Pre-fix, `sql` targets the nonexistent pluralized-default table and
+        # this execute raises asyncpg.UndefinedTableError.
+        conn = await asyncpg.connect(PG_URL)
+        try:
+            row = await conn.fetchrow(sql, *params)
+        finally:
+            await conn.close()
+
+        assert row is not None, (
+            "query_builder's SELECT must return the written row from the custom "
+            f"table '{custom}' (issue #1614)"
+        )
+        assert row["id"] == rid
+        assert row["name"] == "round-trip-1614"
+
+        await db.express.close_async()
+    finally:
+        await _pg_drop(PG_URL, *(t for t in (custom, default_plural) if t))
+
+
+# --------------------------------------------------------------------------
+# Test 3 — defense-in-depth (surfaced by the #1614 security review): the TABLE
+# surface is fail-closed. Before #1614, query_builder fed only the derived
+# pluralized-default table name into its quoter; #1614 routes the raw
+# developer-authored ``__tablename__`` there, so the TABLE-name quoter MUST
+# validate (allowlist regex + reject-don't-escape) exactly as the DDL path does
+# — a crafted table identifier raises InvalidIdentifierError instead of breaking
+# out of the quotes (dataflow-identifier-safety.md MUST-1/2/5). The scope is the
+# TABLE name only: the field list legitimately carries aggregate/alias
+# EXPRESSIONS (``COUNT(*) AS total``), which are NOT plain identifiers and MUST
+# NOT be allowlist-rejected (that contract is pinned below so a future
+# over-reach fails loudly). No DB needed — rejection happens at SQL-build time.
+# --------------------------------------------------------------------------
+@pytest.mark.regression
+def test_query_builder_rejects_injection_shaped_table_name():
+    """QueryBuilder TABLE-name quoting is fail-closed across every dialect (the
+    #1614-activated surface), while valid table names still build
+    byte-identically (issue #1614 hardening)."""
+    payload = 'x"; DROP TABLE users; --'
+
+    for db_type in (
+        DatabaseType.POSTGRESQL,
+        DatabaseType.MYSQL,
+        DatabaseType.SQLITE,
+    ):
+        # Malicious TABLE name (the surface #1614 newly routes __tablename__ to)
+        # — rejected across EVERY build_* verb + join, so a future refactor that
+        # bypasses the shared _quote_table_name on any one verb fails loudly.
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder(payload, db_type).build_select(["id"])
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder(payload, db_type).build_count()
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder(payload, db_type).build_insert({"id": 1})
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder(payload, db_type).build_update({"name": "x"})
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder(payload, db_type).build_delete()
+        # A malicious JOIN target is a table too — fail-closed at join() time.
+        with pytest.raises(InvalidIdentifierError):
+            QueryBuilder("accounts", db_type).join(payload, "1=1")
+
+        # Valid table name still builds — zero-delta for the legitimate path.
+        qb_ok = QueryBuilder("accounts", db_type)
+        sql, _ = qb_ok.build_select(["id", "name"])
+        assert "accounts" in sql
+        assert "id" in sql and "name" in sql
+
+
+@pytest.mark.regression
+def test_query_builder_field_list_still_accepts_aggregate_expressions():
+    """The FIELD list contract is preserved: aggregate/alias expressions
+    (``COUNT(*) as total``) are NOT plain identifiers and MUST still build — the
+    #1614 TABLE-name hardening MUST NOT over-reach onto the field surface
+    (guards the regression the #1614 redteam caught: strict field validation
+    broke ``COUNT(*) as ...`` on the public build_select API)."""
+    for db_type in (
+        DatabaseType.POSTGRESQL,
+        DatabaseType.MYSQL,
+        DatabaseType.SQLITE,
+    ):
+        qb = QueryBuilder("orders", db_type)
+        # Aggregate + alias field expressions must pass through unrejected.
+        sql, _ = qb.build_select(["user_id", "status", "COUNT(*) as order_count"])
+        assert "COUNT(*)" in sql
+        assert "order_count" in sql


### PR DESCRIPTION
## Summary

`Model.query_builder()` ignored `__tablename__` — the **query-surface** sibling of #1541 (DDL index/FK) and #1573 (migration paths), both already fixed. The `query_builder` classmethod resolved the table via `_class_name_to_table_name(cls.__name__)` (pluralized class-name default) instead of the `__tablename__`-respecting `_get_table_name`. For a model with a custom `__tablename__`, `query_builder().build_select(...)` targeted a nonexistent pluralized-default table (round-trip raised `UndefinedTableError`).

**Fix** (`core/engine.py`): the binding now routes through `_get_table_name(cls.__name__)` — the same resolver CREATE TABLE / #1541 / #1573 already use. 1-site change; query-surface audit confirmed no other `_class_name_to_table_name` caller needed the swap (the `_relationships` pluralized-default contract is intentionally left unchanged per the #1541 trap).

## Security hardening (`database/query_builder.py`)

Because the fix newly routes the raw developer-authored `__tablename__` into `QueryBuilder`, the **table-name** quoting path is now fail-closed — it validates every table identifier through the same dialect helper the DDL path uses (`DialectManager.get_dialect(...).quote_identifier`: allowlist `^[a-zA-Z_][a-zA-Z0-9_]*$` + length + reject-don't-escape → `InvalidIdentifierError`), giving the query surface parity with the DDL/migration paths (`dataflow-identifier-safety.md` MUST-1/2/5).

Scope is the **table name only** (a pure identifier). The SELECT/INSERT/SET **field list** legitimately carries aggregate/alias expressions (`COUNT(*) AS total`) and stays on the non-validating field quoter — a regression test pins that contract so the hardening cannot over-reach. Byte-identical output for every valid table identifier; only crafted/invalid table names are newly rejected.

## Tests

Behavioral regression tests (real PostgreSQL, `tests/regression/test_issue_1614_tablename_query_builder.py`):
- `build_select` targets the custom `__tablename__` table + a written row round-trips through the built query (RED→GREEN verified).
- Injection-shaped table names rejected across `build_select`/`build_count`/`build_insert`/`build_update`/`build_delete`/`join` on all three dialects.
- Aggregate/alias field-expression contract pinned (guards against hardening over-reach).

Zero-delta confirmed via apples-to-apples stash comparison: no new failures introduced (pre-existing LIMIT-parameterization test drift in the query_builder integration suite is unrelated and unchanged — see note below).

## Redteam

Converged (2 consecutive clean rounds) after 4 adversarial rounds — reviewer + security-reviewer caught and corrected an initial validation over-reach (strict field validation broke aggregates) → redesigned to table-only validation.

## Note — pre-existing baseline (out of scope)

`tests/integration/query_builder/test_query_builder_{postgresql,mysql}.py` has 5 pre-existing failures asserting inline `LIMIT 10` where the impl emits safe parameterized `LIMIT $2`/`%s` — stale-test drift, a distinct bug class, unchanged by this PR. Recommend a focused follow-up.

## Related issues

Fixes #1614. Query-surface sibling of #1541 / #1573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)