### PR TITLE
chore(coc): ship kailash-py un-enrolled + wire /certify no-assist gate (full-cohort redteam)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -738,3 +738,44 @@ changes:
       commands/ecosystem-init.md are on the self-referential-codify.md Rule 2 allowlist ->
       the mandatory multi-agent redteam-with-tests round is satisfied by R1's 3 genuinely-run
       independent specialists. Receipt: workspaces/mops-onboarding/journal/0030.
+
+      FIFTH APPEND 2026-07-08 (exhaustive full-cohort executable-surface pass, journal/0031).
+      A user-approved exhaustive pass walked every EXECUTABLE surface (code blocks, function-call
+      signatures, cited hooks/bins, hook REGISTRATIONS) across all 14 cohort files — since the
+      FOURTH-APPEND HIGH lived in a code block, not a prose citation. Findings + a co-owner
+      architecture decision:
+
+      - HOOK-WIRING (settings-governed, NOT synced — recorded for context): probe-phase-guard.js
+        (the PR #355 R1 security HIGH-1 closure — the /certify probe no-assist gate) exists +
+        ships audit fixtures, and certify.md:64 + skills/42-certify:58 both claim it is
+        "registered in .claude/settings.json for matcher Read|Grep|Glob|WebFetch" — but it was
+        registered in NO settings surface, so it never fired (the /certify SOLO gate was
+        prose-only, re-opening the security HIGH). Wired it under that exact matcher; verified
+        live (no lockfile -> {continue:true}; lockfile+Read -> [BLOCK]). Clone-safe (lockfile-gated).
+        settings.json is /settings-governed, outside the self-referential-codify allowlist, so
+        this is a repo-config fix, not a synced-artifact change.
+      - ENROLLMENT-OPERATIONS.MD CAVEAT (GLOBAL synced rule — flows to consumers): added a
+        "Distributable-Repo Caveat" section. Root cause verified this pass: a PUBLIC/fork-template
+        repo whose committed operators.roster.json carries a LIVE genesis makes EVERY clone
+        resolve coordination ON (isCoordinationEnabled reads the committed roster's anchored
+        genesis; .claude/learning/ is gitignored). Paired with committed coordination-ENFORCEMENT
+        hooks, signing-mutation-guard would degraded-read-only-brick a fresh forker. The caveat
+        codifies: distributable repos ship UN-ENROLLED (PLACEHOLDER genesis); the 6 enforcement
+        hooks MUST NOT be in committed settings.json (operator-local -> gitignored
+        settings.local.json); lockfile-gated hooks (probe-phase-guard) ARE clone-safe in committed
+        settings.json. This is the institutional lesson every downstream distributable consumer
+        needs.
+      - REPO-STATE (kailash-py-specific, NOT synced): shipped kailash-py un-enrolled — committed
+        roster reset to the canonical clean-instantiate PLACEHOLDER shape so clones resolve
+        coordination OFF. Repo-specific state, not a synced artifact; noted for Gate-1 context only.
+
+      CLASSIFICATION: GLOBAL for the enrollment-operations.md caveat ONLY (the synced rule; the
+      distributable-repo discipline applies to every consumer that is itself downloadable/forkable).
+      The probe-phase-guard settings.json wiring + the placeholder roster are repo/settings-governed
+      state, NOT synced artifacts — recorded here for Gate-1 transparency, not for distribution.
+      enrollment-operations.md is on the self-referential-codify.md Rule 2 allowlist; the multi-agent
+      gate is satisfied by R1's 3 genuinely-run independent specialists + this pass's mechanical
+      executable-surface verification (per-hook fixture dry-runs + isCoordinationEnabled +
+      roster-schema-validate + disclosure-scanner, all orchestrator-run with real output; the R2
+      subagent wave remained account-limit-throttled, so verification stayed orchestrator-direct per
+      the evidence gate). Receipt: workspaces/mops-onboarding/journal/0031.

--- a/.claude/operators.roster.json
+++ b/.claude/operators.roster.json
@@ -1,22 +1,22 @@
 {
   "$schema": "https://terrene.foundation/schemas/operators.roster.schema.json",
   "genesis": {
-    "repo_owner": "terrene-foundation",
-    "repo_owner_kind": "org",
-    "root_commit": "166c5eab84c39822b6e06ac47954cb3230de1d8c",
+    "repo_owner": "PLACEHOLDER-owner",
+    "repo_owner_kind": "user",
+    "root_commit": "0000000",
     "genesis_generation": 0
   },
   "persons": {
-    "pid-esperie-2b8cb994": {
-      "display_id": "esperie",
+    "PLACEHOLDER-owner": {
+      "display_id": "placeholder-owner",
       "role": "owner",
-      "github_login": "esperie",
+      "github_login": "PLACEHOLDER-owner",
       "host_role": "human",
       "keys": [
         {
-          "type": "ssh",
-          "fingerprint": "SHA256:ZJJ4BzXTDOS2WMGbNmesXb5K2VGzSvk3O30DmKacml0",
-          "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC8QXej8+gMWK04XapFrSV9fgzWlyssT+0aAIIwSXT27"
+          "type": "gpg",
+          "fingerprint": "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+          "pubkey": "PLACEHOLDER"
         }
       ]
     }

--- a/.claude/rules/enrollment-operations.md
+++ b/.claude/rules/enrollment-operations.md
@@ -255,8 +255,30 @@ Verified against `validate-bash-command.js`, `integrity-guard.js`, `signing-muta
 `genesis-ceremony.js`, `coordination-log.js`, and `operator-id.js`. Distributes to BUILD + USE
 repos via `/codify` → loom Gate-1 → `/sync`.
 
+## Distributable-Repo Caveat — Public / Fork-Template Repos Ship Un-Enrolled
+
+A repo that is publicly downloadable or forked as a template (this repo IS one) MUST ship
+**un-enrolled**: the committed `operators.roster.json` MUST carry a `PLACEHOLDER-` genesis
+(`repo_owner: "PLACEHOLDER-owner"`, `root_commit: "0000000"`), NOT a live `genesis.root_commit`.
+`coordination-mode.js::isCoordinationEnabled` resolves Tier-4 implicit-ON from the **committed**
+roster's anchored genesis, and `.claude/learning/` (the local genesis-anchor + `.initialized`) is
+gitignored — so a committed LIVE genesis makes every clone resolve coordination **ON** by
+inheritance, while a `PLACEHOLDER-` genesis (`_isGenesisAnchored` → false) keeps clones **OFF**. A
+forker enrolls their OWN clone via `/ecosystem-init` / `/whoami --register`. Committing a live
+genesis to a distributable repo is BLOCKED.
+
+The coordination-ENFORCEMENT PreToolUse hooks (`integrity-guard.js`, `signing-mutation-guard.js`,
+`journal-write-guard.js`, `genesis-anchor-guard.js`, `adjacency-leasecheck.js`, `operator-gate.js`)
+MUST NOT be registered in the **committed** `.claude/settings.json` of a distributable repo: paired
+with a live committed genesis they would fire in every clone, and `signing-mutation-guard.js` would
+drop a fresh forker (no signing key) into degraded read-only — bricking their fork. Operator-local
+enforcement belongs in the gitignored `.claude/settings.local.json` (per-operator, never inherited
+by a clone). A lockfile-gated hook like `probe-phase-guard.js` (fires only during an active
+`/certify` gate) IS clone-safe in the committed `settings.json` and SHOULD ship there so every
+consumer's `/certify` no-assist gate has structural teeth.
+
 **Length rationale (per `rule-authoring.md` MUST NOT § "Rules longer than 200 lines").** File is
-~270 lines (per `wc -l`), over the 200 guidance. Named rationale: **guard-trap scope** — the rule
+~290 lines (per `wc -l`), over the 200 guidance. Named rationale: **guard-trap scope** — the rule
 codifies SIX MUST clauses — three fail-closed boundary guards (MUST 1/2/3) + three gate-review
 clauses (MUST 4/5/6), consistent with § "Violation scope" above — each requiring the
 DO / DO NOT + BLOCKED-corpus + `**Why:**` structure `rule-authoring.md` Rules 2/3/4 mandate, plus

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,6 +71,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Read|Grep|Glob|WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/probe-phase-guard.js\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/workspaces/mops-onboarding/journal/0031-DECISION-ship-public-repo-unenrolled-plus-certify-gate-wiring.md
+++ b/workspaces/mops-onboarding/journal/0031-DECISION-ship-public-repo-unenrolled-plus-certify-gate-wiring.md
@@ -1,0 +1,91 @@
+---
+type: DECISION
+date: 2026-07-08
+slug: ship-public-repo-unenrolled-plus-certify-gate-wiring
+relates_to: 0030-AMENDMENT-independent-reconvergence-cert-helper-high
+---
+
+# DECISION — Ship kailash-py un-enrolled (public repo) + wire the /certify no-assist gate
+
+Extends journal/0030. The exhaustive full-cohort onboarding redteam (user-approved after the
+independent re-convergence) walked every EXECUTABLE surface — code blocks, function-call
+signatures, cited hooks/bins, and hook REGISTRATIONS — across all 14 cohort files, since the
+prior HIGH lived in a code block, not a prose citation. Two significant findings + one
+user-directed architecture decision landed.
+
+## Finding 1 (fixed) — /certify no-assist gate had no structural teeth
+
+`probe-phase-guard.js` is the PR #355 R1 security HIGH-1 closure — a `severity:block`
+PreToolUse hook that blocks orchestrator `Read/Grep/Glob/WebFetch` while a
+`.claude/.certify-in-probe-<vid>.lock` exists, so a new operator cannot be COACHED through
+the SOLO certification gate. The hook exists + ships audit fixtures, and BOTH `certify.md:64`
+and `skills/42-certify:58` claim it is "registered in `.claude/settings.json` for matcher
+`Read|Grep|Glob|WebFetch`" and "fires whether the LLM remembers or not" — but it was
+registered in NO settings surface (repo/global settings.json + settings.local.json + no
+hooks.json), so it never fired. The security HIGH PR #355 closed was inert.
+
+Fix: registered the hook under matcher `Read|Grep|Glob|WebFetch` (exactly the docs' claim +
+the hook header), timeout 5s. Verified live against its fixtures: no lockfile →
+`{continue:true}`; lockfile + Read → `[BLOCK]`. Clone-safe: lockfile-gated, so silent unless
+an active `/certify` runs. Commit `974305312`.
+
+## Finding 2 → user decision — the public repo shipped coordination-ON to every clone
+
+Six coordination-ENFORCEMENT PreToolUse hooks (`integrity-guard`, `signing-mutation-guard`,
+`journal-write-guard`, `genesis-anchor-guard`, `adjacency-leasecheck`, `operator-gate`) are
+registered in NO settings surface and composed by no registered hook (the many
+`integrity-guard` mentions in `validate-bash-command.js` are comments). They therefore do
+not fire — the codify-branch discipline this repo follows was convention-only.
+
+Root cause (verified): the committed `operators.roster.json` carried a LIVE
+`genesis.root_commit` (166c5eab), and `coordination-mode.js::isCoordinationEnabled` resolves
+Tier-4 implicit-ON from the COMMITTED roster (the local `.claude/learning/` genesis-anchor is
+gitignored). So every clone/fork of this PUBLIC repo inherited coordination = ON — this
+working copy returned `true`. That is exactly why the enforcement hooks could NOT be wired
+into committed settings.json: `signing-mutation-guard` would drop a fresh forker (no signing
+key) into degraded read-only, bricking their fork. The co-owner asked the decisive question —
+"if we do the enrolment here, will it mess up the clones?" — and the answer is yes.
+
+**Decision (co-owner, verbatim: "approved your recommendation, we should ship this
+un-enrolled"):**
+
+- Do NOT wire the coordination-enforcement hooks into committed settings.json (would brick
+  clones). Operator-local enforcement, if ever wanted, goes in the gitignored
+  `settings.local.json`.
+- Ship the public repo UN-ENROLLED: replace the committed roster with the canonical
+  PLACEHOLDER shape `clean-instantiate.mjs` produces (`repo_owner "PLACEHOLDER-owner"`,
+  `root_commit "0000000"`, one `PLACEHOLDER-owner` person + synthetic key). Verified:
+  `isCoordinationEnabled(cwd)` now returns `false` (clones resolve OFF); roster-schema-validate
+  `{valid:true}`; 0 residual esperie identity tokens in the committed public repo; disclosure
+  scanner exit 0. A forker enrolls their own clone via `/ecosystem-init` / `/whoami --register`.
+  Commit `862d28904`.
+- Codify the lesson: `enrollment-operations.md` gains a "Distributable-Repo Caveat" section so
+  no future session re-enrolls the public repo or wires enforcement hooks into committed
+  settings (either bricks clones).
+
+## Alternatives considered
+
+- **Wire the 6 enforcement hooks into committed settings.json** (my initial Option A) —
+  REJECTED once the committed-roster-forces-clones-ON mechanism was verified: it bricks every
+  clone. The co-owner's question surfaced this before it shipped.
+- **Leave the live genesis committed, add enforcement only in settings.local.json** — viable
+  for esperie's local enforcement, but leaves clones inheriting coordination-ON with esperie's
+  identity as genesis owner (a latent trap + an identity footprint). Shipping un-enrolled is
+  cleaner for a public fork-template.
+- **Full `clean-instantiate.mjs` run** — REJECTED: it also deletes `journal/`, resets
+  ecosystem.json/tenant-denylist, and runs assert-zero — far beyond the one-file roster reset
+  needed, and would nuke this workspace's journals.
+
+## For Discussion
+
+1. Counterfactual: if the co-owner had NOT asked "will it mess up the clones?", the initial
+   Option-A (wire the enforcement hooks into committed settings.json) would have shipped and
+   bricked every fresh fork on first edit. What structural check would have caught the
+   committed-roster-forces-clones-ON coupling BEFORE the wiring PR? (Candidate: a
+   distributable-repo lint asserting the committed roster is PLACEHOLDER + no
+   coordination-enforcement hook in committed settings.json — the caveat's mechanical twin.)
+2. esperie's OWN working copy now resolves coordination OFF (reads the placeholder committed
+   roster). The local gitignored genesis-anchor is now orphaned. If real multi-operator
+   coordination is ever needed in kailash-py, is a Tier-2 local override (gitignored
+   `{enabled:true}`) + settings.local.json enforcement the intended path, or should genuine
+   multi-operator work happen in a non-public repo?


### PR DESCRIPTION
## Summary

The exhaustive full-cohort onboarding redteam (walking every **executable** surface — code blocks, function signatures, cited hooks/bins, hook **registrations** — since the prior HIGH lived in a code block) surfaced two issues and one co-owner architecture decision.

## 1. `/certify` no-assist gate had no structural teeth (fixed)

`probe-phase-guard.js` — the **PR #355 R1 security HIGH-1 closure** (blocks orchestrator `Read/Grep/Glob/WebFetch` during a `/certify` gate so a new operator can't be coached through the SOLO knowledge test) — exists with audit fixtures, and `certify.md` + skill 42 both claim it's *"registered in settings.json for matcher `Read|Grep|Glob|WebFetch`"*. It was registered in **no** settings surface, so it never fired. Wired it under that exact matcher; verified live against its fixtures (no lockfile → passthrough; lockfile + Read → `[BLOCK]`). Clone-safe (lockfile-gated).

## 2. The public repo shipped `coordination = ON` to every clone (decision: ship un-enrolled)

Six coordination-**enforcement** hooks (`integrity-guard`, `signing-mutation-guard`, `journal-write-guard`, `genesis-anchor-guard`, `adjacency-leasecheck`, `operator-gate`) are wired nowhere — deliberately, it turns out. The committed `operators.roster.json` carried a **live** `genesis.root_commit`, and `isCoordinationEnabled` resolves implicit-ON from the *committed* roster, so **every clone/fork inherited coordination ON** (verified: working copy returned `true`). Wiring the enforcement hooks into committed settings.json would then have `signing-mutation-guard` drop a fresh forker (no signing key) into degraded read-only — **bricking their fork**.

Co-owner decision (approved): **ship un-enrolled**. Replaced the committed roster with the canonical `clean-instantiate` PLACEHOLDER shape (`repo_owner: PLACEHOLDER-owner`, `root_commit: 0000000`). Verified: `isCoordinationEnabled` now returns **`false`** (clones resolve OFF), `roster-schema-validate {valid:true}`, **0 residual esperie identity tokens** in the public repo, disclosure scanner exit 0. Forkers enroll their own clone via `/ecosystem-init` / `/whoami --register`.

## 3. Codified the lesson

`enrollment-operations.md` gains a **Distributable-Repo Caveat**: distributable repos ship un-enrolled (PLACEHOLDER genesis); the 6 enforcement hooks MUST NOT be in committed settings.json (operator-local → gitignored `settings.local.json`); lockfile-gated hooks like `probe-phase-guard` ARE clone-safe in committed settings.json. FIFTH APPEND carries the caveat (a GLOBAL synced rule) to loom Gate-1; the settings wiring + placeholder roster are repo/settings-governed state (context only, not synced).

## Verification

All orchestrator-run with real output (the R2 subagent wave remained account-limit-throttled; an errored agent is zero evidence per the evidence gate, so verification stayed orchestrator-direct): per-hook fixture dry-runs, `isCoordinationEnabled` before/after, `roster-schema-validate`, disclosure scanner exit 0.

## Related issues

Receipt: `workspaces/mops-onboarding/journal/0031`. Extends journals 0027–0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)