### PR TITLE
fix(coc): certify no-assist gate covers Phase C retry loop + onboarding lifecycle fixes (re-convergence #5)

### DIFF
--- a/.claude/commands/certify.md
+++ b/.claude/commands/certify.md
@@ -71,7 +71,7 @@ After the full pass, tally pass/fail per question. If 100% → record pass (Step
 
 ### 5. Emit pass receipt + roster registration nudge
 
-On pass: write a `journal/NNNN-DECISION-certify-<display_id>-<date>.md` entry naming the operator's `display_id` + `verified_id`, the bank version (`specs/_certification.yaml::version`), the per-question pass/fail/attempts tally, and the timestamp. Surface to the operator: "Certification passed. Next: `/whoami --register` (if not already rostered) → `/claim <path>` to start work." Until pass, the operator remains `L2_SUPERVISED` via the existing trust-posture machinery (no command-side change — `posture.json` already enforces L2 for unrostered operators per `rules/multi-operator-coordination.md` §1).
+On pass: write a `journal/NNNN-DECISION-certify-<display_id>-<date>.md` entry naming the operator's `display_id` + `verified_id`, the bank version (`specs/_certification.yaml::bank_version` — the operator-visible dated tag, NOT the schema-version int `::version`), the per-question pass/fail/attempts tally, and the timestamp. Surface to the operator: "Certification passed. Next: `/whoami --register` (if not already rostered) → `/claim <path>` to start work." Until pass, the operator remains `L2_SUPERVISED` via the existing trust-posture machinery (no command-side change — `posture.json` already enforces L2 for unrostered operators per `rules/multi-operator-coordination.md` §1).
 
 ### Failure modes (typed errors — no silent fallbacks per `rules/zero-tolerance.md` Rule 3)
 

--- a/.claude/commands/ecosystem-init.md
+++ b/.claude/commands/ecosystem-init.md
@@ -80,8 +80,12 @@ detection. Skip for a full-Kailash fork.
 
 ### C5 — hand off
 
-Print: "Ecosystem configured. Each operator now runs `/enroll`, then `/onboard` at the start of every
-session." Does NOT enroll the initiating operator (invariant 4).
+Print: "Ecosystem configured. Each TEAMMATE now runs `/enroll`, then `/onboard` at the start of every
+session." Does NOT enroll the initiating operator (invariant 4) — the genesis owner is ALREADY rostered
+(their `role: owner` entry was hand-authored in the genesis-bootstrap step that precedes C3, per
+`skills/45-genesis-bootstrap`), so the owner runs `/onboard` directly and does NOT re-run `/enroll` (which
+would open a redundant `contributor` registration over their existing owner identity). `/enroll` is the
+join path for teammates who are not yet in the roster.
 
 ## Posture-bound restrictions
 

--- a/.claude/commands/enroll.md
+++ b/.claude/commands/enroll.md
@@ -21,7 +21,7 @@ per-operator gitignored layer. Procedure detail lives in `.claude/skills/44-enro
 1. **B1 roster registration wraps the EXISTING `/whoami --register` path.** Roster registration is the
    2-of-N-quorum PR-gated write described in `multi-operator-coordination.md` §1 — the ONLY roster-write
    path. `/enroll` does NOT re-implement it; it invokes `/whoami --register` (derive `person_id`, cut the
-   `codify/<id>-<date>` branch off `main`, schema-validate, commit, push, open PR). NEVER writes
+   `codify/<display_id>-<date>` branch off `main`, schema-validate, commit, push, open PR). NEVER writes
    `operators.roster.json` directly to `main` (branch protection rejects it).
 2. **B2 local-links is per-operator gitignored — NO disclosure gate.** The NAME→on-disk-path layer
    (`loom-links.local.json`, `loom-links.mjs` precedence `$LOOM_LINKS_CONFIG` > local > fail-loud) is
@@ -62,8 +62,12 @@ layout-agnostic.
 
 ### B3 — hand off
 
-Print: "Enrolled. Run `/onboard` at the start of every session." Does NOT perform the session-entry reads
-(invariant 3).
+Print: "Enrollment PR opened. Once it merges to `main`, run `/onboard` at the start of every session."
+Does NOT perform the session-entry reads (invariant 3). The roster registration is a PR (B1), not a
+direct write, so it is not on `main` until merged: `/onboard` run on `main` before the merge resolves the
+operator as not-yet-rostered (it reads the committed roster); on the operator's own
+`codify/<display_id>-<date>` branch the working-tree roster edit already resolves. Await the merge (or stay
+on the branch) before treating `/onboard` identity as final.
 
 ## Why a separate command (not a `/whoami` flag)
 

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -40,7 +40,7 @@ Read `.claude/learning/posture.json` via `state-io.js::readPosture()`. Surface:
 
 - Current `posture` (L5_DELEGATED through L1_PSEUDO_AGENT)
 - `since` timestamp + the most recent `transition_history` entry's reason
-- `pending_verification[]` — every rule_id awaiting a `[ack: <rule_id>]` receipt (per `rules/trust-posture.md` MUST-7's grace mechanism)
+- `pending_verification[]` — every rule_id awaiting a `[ack: <rule_id>]` receipt (per `rules/trust-posture.md` MUST-6 § Grace Period Semantics, which defines the `pending_verification` + 7-day grace mechanism)
 
 If any rule_id is in `pending_verification`, the onboarding output names it and instructs the operator: their next response in a real session must include the `[ack: <rule_id>]` token to clear the gate.
 

--- a/.claude/skills/41-onboard/SKILL.md
+++ b/.claude/skills/41-onboard/SKILL.md
@@ -102,7 +102,7 @@ else:
 
 The M5 session-start hook (`multi-operator-sessionstart.js`) computes this surface. `/onboard` calls the same helper (extracted into a shared library at M5 time) OR re-derives via `git log --since` against `.claude/rules/`.
 
-For each modified rule file, grep for MUST clauses (`grep -n '^### .*MUST'`) added/changed in the diff window. These are the candidates for `pending_verification` per `rules/trust-posture.md` MUST-7.
+For each modified rule file, grep for MUST clauses (`grep -n '^### .*MUST'`) added/changed in the diff window. These are the candidates for `pending_verification` per `rules/trust-posture.md` MUST-6 § Grace Period Semantics (the clause that puts a freshly-authored rule into `pending_verification` for its 7-day grace window).
 
 ### 7. Action items
 

--- a/.claude/skills/42-certify/SKILL.md
+++ b/.claude/skills/42-certify/SKILL.md
@@ -67,13 +67,7 @@ For each question:
    - `short_answer`: orchestrator LLM judges the answer against `expected:` (canonical answer) + the `grading_rubric:` bullets (acceptance criteria). Return `{verdict: pass|fail, rationale: <one sentence>}`.
 5. Record the per-question result in orchestrator context: `{id, verdict, attempts: 1}`.
 
-**Step N (probe exit, end of Phase B before transition to Phase C): remove the lockfile:**
-
-```bash
-rm -f ".claude/.certify-in-probe-${VERIFIED_ID}.lock"
-```
-
-Phase C judgement does NOT require retrieval (the bank ships the canonical answer + rubric inline), so the lockfile MUST be removed before Phase C begins — otherwise Phase C's structural identity-write + journal-slot-reserve operations are unaffected (those are Bash + Write, not retrieval tools), but a future iteration of this skill that adds retrieval steps to Phase C would silently break unless this Step is honored.
+**The lockfile PERSISTS through Phase C — do NOT remove it at the Phase B→C transition.** Phase C's gate retry loop RE-RUNS the probe on the failed questions (§ Phase C below, `re-run probe on q`), and those retries MUST stay no-assist exactly as the initial probe does. The structural `probe-phase-guard.js` guard therefore MUST remain active until the gate is fully resolved — removing the lockfile before Phase C would open an un-guarded retrieval window during the exact retry loop the gate exists to protect (an operator asking "what's the answer?" during a retry could then be assisted via an orchestrator Read/Grep). The lockfile is removed at Phase C exit ONLY — see Phase C § Step N. This matches `commands/certify.md` § "Phase B — Probe": `rm` fires at "Probe exit (Phase C complete OR abandoned mid-gate)", never before.
 
 **NO Claude-assistance during the probe.** If the operator asks "can you explain that section again?" or "what's the answer?", the orchestrator MUST refuse with one sentence: "I cannot assist during the gate phase; re-read the cited section and answer when ready." This refusal is now belt-and-suspenders — the structural hook is the primary defense; the prose refusal handles edge cases (operator pasting in a Read tool call directly via the orchestrator's tool surface would be blocked by the hook; operator asking for prose rephrasing is blocked by this refusal). Both layers fire together per `probe-driven-verification.md` MUST-4 (structural hook + prose-discipline gate-review counterpart).
 
@@ -95,6 +89,14 @@ else:
 ```
 
 The gate is 100% strict. There is no partial credit, no "close enough", no "the operator clearly understands the concept but worded it differently." If the answer fails the rubric, it fails the gate. The operator re-reads the cited section and retries.
+
+**Step N (gate exit): remove the lockfile — the SINGLE removal site, on BOTH the pass path AND the abandon path:**
+
+```bash
+rm -f ".claude/.certify-in-probe-${VERIFIED_ID}.lock"
+```
+
+The `probe-phase-guard.js` guard spanned Phase B AND the Phase C retry loop; this is the one place it is torn down — once the gate is fully resolved (100% pass recorded) OR the operator abandons mid-gate (§ Failure modes: the same `rm` runs so the lockfile is never left stale). If the orchestrator crashes mid-gate, the operator removes the stale lockfile manually (`rm .claude/.certify-in-probe-*.lock`) before re-running `/certify`.
 
 ### Pass receipt
 
@@ -240,4 +242,4 @@ Until pass, the operator stays `L2_SUPERVISED` via `posture.json` (no certify-si
 
 ## Origin
 
-2026-05-25 co-owner-directed COC tooling. Receipt: `journal/0158-DECISION-certify-onboarding-mechanism-2026-05-25.md`. Skill body ~140 lines per `rules/cc-artifacts.md` Rule 2 (progressive disclosure — SKILL.md answers 80% of routine questions without sub-file reads).
+2026-05-25 co-owner-directed COC tooling. Receipt: `journal/0158-DECISION-certify-onboarding-mechanism-2026-05-25.md`. Skill body follows `rules/cc-artifacts.md` Rule 2 (progressive disclosure — SKILL.md answers 80% of routine questions without sub-file reads).

--- a/.claude/skills/43-ecosystem-init/SKILL.md
+++ b/.claude/skills/43-ecosystem-init/SKILL.md
@@ -9,7 +9,7 @@ The procedure backing `.claude/commands/ecosystem-init.md` (the once-per-fork ec
 command body holds the five load-bearing invariants + the ceremony order; this skill holds the
 step-by-step procedure, the input prompts, the D6 schema field set, and the exact tool-call shapes.
 
-Three onboarding surfaces (the core distinction — `02-plans/02-ga-ecosystem-onboarding.md`):
+Three onboarding surfaces (the core distinction — see (loom-internal reference)):
 
 | Surface           | Moment                     | Writes                                | Frequency       |
 | ----------------- | -------------------------- | ------------------------------------- | --------------- |
@@ -56,7 +56,9 @@ It is fail-CLOSED — any failed gh-api verification refuses to emit the genesis
   `verification.verified == true`, author == declared owner) is the anchor.
 - **Pre-condition**: the genesis-owner's `person_id` MUST already be in `operators.roster.json` with
   `role: owner` and the correct `github_login`. On a truly fresh fork, edit the bootstrap roster or run
-  `/whoami --register` then promote the role on the resulting PR first.
+  `/whoami --register` then promote the role on the resulting PR first. The full first-owner runbook for
+  hand-authoring that owner entry (signing-key-first, the script-by-path roster write, fold-clean verify)
+  is `skills/45-genesis-bootstrap/SKILL.md` — it is the step that PRECEDES this one on a fresh fork.
 
 The signed `genesis-anchor` lands in `.claude/learning/coordination-log.jsonl` (fold rule 9a accepts the
 first verifying owner-bound anchor as the trust root). The consumer-relevant operational gotchas an
@@ -85,8 +87,11 @@ If the fork's build is NOT Kailash, invoke the EXISTING `/onboard-stack` (detect
 
 ### C5 — hand off (invariant 4)
 
-Print: "Ecosystem configured. Each operator now runs `/enroll`, then `/onboard` at the start of every
-session." Do NOT enroll the initiating operator — that is `/enroll`'s gated job.
+Print: "Ecosystem configured. Each TEAMMATE now runs `/enroll`, then `/onboard` at the start of every
+session." Do NOT enroll the initiating operator — that is `/enroll`'s gated job. The genesis owner is
+ALREADY rostered (their `role: owner` entry was hand-authored in the genesis-bootstrap step that precedes
+C3, per `skills/45-genesis-bootstrap`), so the owner runs `/onboard` directly and does NOT re-run
+`/enroll` (which would open a redundant `contributor` registration over their existing owner identity).
 
 ## Operational runbook
 

--- a/.claude/skills/44-enroll/SKILL.md
+++ b/.claude/skills/44-enroll/SKILL.md
@@ -9,7 +9,7 @@ The procedure backing `.claude/commands/enroll.md` (the once-per-operator ceremo
 ecosystem already configured by `/ecosystem-init`). The command body holds the three load-bearing
 invariants; this skill holds the step-by-step procedure and the exact tool-call shapes.
 
-Three onboarding surfaces (`02-plans/02-ga-ecosystem-onboarding.md`): `/onboard` (read, every session),
+Three onboarding surfaces (see (loom-internal reference)): `/onboard` (read, every session),
 `/enroll` (operator, once), `/ecosystem-init` (fork, once). They share ZERO write-authority.
 
 ## Ceremony steps: B1 → B2 → B3
@@ -60,9 +60,13 @@ Pre-existing operators on any other layout (flat `~/repos/<slug>`, nested) proce
 
 ### B3 — hand off (invariant 3)
 
-Print: "Enrolled. Run `/onboard` at the start of every session." `/enroll` does NOT perform the
-session-entry reads (roster + posture + team-memory + claims) — that is `/onboard`'s read-only job
-(`knowledge-convergence.md` MUST-5).
+Print: "Enrollment PR opened. Once it merges to `main`, run `/onboard` at the start of every session."
+`/enroll` does NOT perform the session-entry reads (roster + posture + team-memory + claims) — that is
+`/onboard`'s read-only job (`knowledge-convergence.md` MUST-5). The roster registration (B1) is a PR, not
+a direct write, so it is not on `main` until merged: `/onboard` run on `main` before the merge resolves
+the operator as not-yet-rostered (it reads the committed roster); on the operator's own
+`codify/<display_id>-<date>` branch the working-tree roster edit already resolves. Await the merge (or stay
+on the branch) before treating `/onboard` identity as final.
 
 ## Why a separate command (not a `/whoami` flag)
 

--- a/workspaces/mops-onboarding/04-validate/redteam-2026-07-08-reconvergence5.md
+++ b/workspaces/mops-onboarding/04-validate/redteam-2026-07-08-reconvergence5.md
@@ -1,0 +1,103 @@
+# /redteam — mops-onboarding independent re-convergence #5 — 2026-07-08
+
+Repo: `terrene-foundation/kailash-py` (PUBLIC distributable BUILD, ships UN-ENROLLED).
+Posture: **L5_DELEGATED** (fresh-repo default; `.claude/learning/` gitignored → reads fresh).
+Method: `/autonomize` + `/redteam` to convergence. 7 rounds, ~18 parallel adversarial agents
+(waves of ~3, throttle-aware). Convergence at **0 CRIT / 0 HIGH / 0 MED across 2 consecutive
+clean rounds** (Criteria 1–3), with the field/citation + registration-parity ground-truth
+verifications standing in for Criteria 4 (this is a COC-artifact suite, no code/tests/frontend).
+
+## Ground-truth re-verification of the 6 load-bearing "ships un-enrolled" claims (Round 1)
+
+| Claim                              | Command                                                        | Result                                              |
+| ---------------------------------- | -------------------------------------------------------------- | --------------------------------------------------- |
+| isCoordinationEnabled(cwd)         | `coordination-mode.js::isCoordinationEnabled` (script-by-path) | `false` (source `default-off`) ✓                    |
+| roster genesis owner               | `git show HEAD:.claude/operators.roster.json`                  | `PLACEHOLDER-owner`, root_commit `0000000`, gen 0 ✓ |
+| probe-phase-guard registered       | `grep -c` committed settings.json                              | 1 ✓                                                 |
+| 6 enforcement hooks committed      | `grep -c` each in settings.json                                | 0 / 6 ✓                                             |
+| esperie tokens in committed roster | `git show HEAD:…                                               | grep -ic esperie`                                   | 0 ✓ |
+| disclosure scanner                 | `node .claude/bin/scan-synced-disclosure.mjs`                  | clean, 0 findings, 1558 files, exit 0 ✓             |
+
+## Round-by-round
+
+| Round | Lens(es)                                                                                     | Verdict                                                                               |
+| ----- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| R1    | hook-registration parity · cited-symbol/bin existence · distributable-invariant completeness | CLEAN (0 CRIT/HIGH/MED; only informational LOWs)                                      |
+| R2    | operator-lifecycle walk · cross-artifact consistency+structural · cross-reference accuracy   | 4 MED (3 lifecycle handoff + 1 xref) + LOWs                                           |
+| R3    | fix-verification · fresh lifecycle re-walk                                                   | fixes CLEAN; re-walk found 2 command↔skill sibling divergences my R2 fixes introduced |
+| R4    | full-cohort command↔skill parity sweep · holistic                                            | 1 MED (pre-existing certify no-assist lockfile divergence)                            |
+| R5    | certify-fix verify + parity re-sweep · holistic                                              | parity CLEAN; holistic 2 LOW                                                          |
+| R6    | fresh holistic · parity+coherence                                                            | parity CLEAN; holistic 1 LOW (pre-existing wrong-key citation)                        |
+| R7    | final holistic · exhaustive field-citation hunt + invariant                                  | **CLEAN both agents** — 0 CRIT/HIGH/MED, 40+ field/helper citations verified          |
+
+## Findings + dispositions (severity-ordered)
+
+### MED (all fixed + verified)
+
+1. **certify no-assist gate — command↔skill divergence on lockfile removal timing (SECURITY-relevant).**
+   `commands/certify.md` keeps the `probe-phase-guard.js` lockfile through the Phase C gate
+   ("Probe exit (Phase C complete OR abandoned mid-gate)"), but `skills/42-certify` removed it
+   "end of Phase B before transition to Phase C" — and Phase C's gate loop RE-RUNS the probe on
+   failed questions (`re-run probe on q`). An orchestrator following the skill tore down the
+   no-assist guard exactly during the retry loop the gate exists to protect, leaving only prose
+   refusal (belt, no suspenders). Fix: skill now states the lockfile PERSISTS through Phase C,
+   single removal at Phase C exit (pass OR abandon), matching the command. (This is the PR #355
+   security HIGH-1 mechanism — the guard was inert-during-retries on the skill path.)
+2. **enroll B3 premature "Enrolled" before the roster PR merges.** `commands/enroll.md` B3 printed
+   "Enrolled. Run /onboard" while the roster registration is still an unmerged PR → `/onboard` on
+   `main` pre-merge resolves the operator as not-yet-rostered (a confusing bounce-back loop). Fix:
+   B3 now prints "Enrollment PR opened. Once it merges to main, run /onboard" + the branch-vs-main
+   roster-visibility explanation. Propagated to `skills/44-enroll` B3 (byte-aligned).
+3. **cross-reference drift — MUST-7 cited for the grace/pending_verification mechanism.**
+   `onboard.md` §4 + `skills/41-onboard` §6 cited `trust-posture.md MUST-7` for the grace
+   mechanism, which is defined in **MUST-6 § Grace Period Semantics** (§7 is the wiring-requirement
+   clause). Fix: both re-pointed to MUST-6.
+
+### LOW (fixed)
+
+- **F1 discoverability** — `skills/43-ecosystem-init` C3 precondition now cross-links
+  `skills/45-genesis-bootstrap` (the first-owner roster-hand-author runbook that PRECEDES C3).
+- **F2 owner-vs-teammate** — `ecosystem-init` C5 "Each operator now runs /enroll" → "Each TEAMMATE
+  …" + note the genesis owner is already rostered and runs `/onboard` directly (propagated to
+  skill 43 C5, byte-aligned).
+- **`<id>` → `<display_id>`** consistency in `enroll.md` invariant-1.
+- **certify footer stale line-count** ("Skill body ~140 lines"; actual 245 after the security fix)
+  → dropped the number, kept the progressive-disclosure point.
+- **command↔skill scrub asymmetry** — skills 43/44 raw `02-plans/02-ga-…` path → genericized to
+  `(loom-internal reference)` matching their commands.
+- **certify receipt wrong-key citation** — `commands/certify.md` receipt cited
+  `_certification.yaml::version` (schema int `1`) for "the bank version"; the operator-visible
+  field is `::bank_version` (the skill records this correctly). Fix: command → `::bank_version`.
+
+### Verified NON-defects (dispositioned, not "fixed")
+
+- **F4** (onboard `/whoami --register` nag) — `operator-id.js::resolveIdentity` returns a SOLO
+  identity when `!isCoordinationEnabled` (no `blocked_into`), so the nag never fires on this OFF
+  repo. Behavior correct; not a defect.
+- **F5** (certify "if not already rostered" next-step) — a conditional no-op-when-rostered guard;
+  defensively correct, not vestigial.
+
+### Out-of-scope / accepted (NOT convergence blockers)
+
+- `commands/whoami.md` 152 raw lines: body = 149 (≤150 per Rule 3, frontmatter excluded);
+  delivered at 152 upstream via 2026-07-02 `/sync-to-build` (not this suite's edits); plausibly
+  under Rule 3's procedural named-rationale exception. A loom-side concern — editing a synced
+  command BUILD-side would create loom drift.
+- No mechanical distributable-repo lint (journal/0031 "For Discussion" candidate); `ecosystem.json`
+  not gitignored (the deliberate opt-in enable path); 42-certify skill `name:` strips number-prefix
+  (historically tolerated, no dir collision); illustrative unbound pseudocode in 41-onboard.
+
+## Convergence criteria
+
+1. 0 CRITICAL ✓ (all rounds) · 2. 0 HIGH ✓ (all rounds) · 3. 2 consecutive clean rounds ✓ (R6
+   substantive-clean, R7 fully clean) · 4. spec/claim compliance grep/AST-verified ✓ (6 claims + 40+
+   field/helper citations + registration parity, all ground-truth) · 5–7. N/A (COC-artifact suite —
+   no new code modules / frontend; probe-phase-guard ships committed audit fixtures).
+
+## Diff: 13 edits across 8 files (working tree — UNCOMMITTED, BUILD-repo commit gate)
+
+commands/{onboard,enroll,ecosystem-init,certify}.md · skills/{41-onboard,42-certify,
+43-ecosystem-init,44-enroll}/SKILL.md. All self-referential-codify surface → the 7-round
+multi-agent redteam-with-tests IS the required self-referential gate (self-referential-codify.md
+Rule 1). Distributable invariant re-confirmed intact AFTER all edits (roster PLACEHOLDER, 0/6
+enforcement hooks, probe-phase-guard=1, disclosure scanner exit 0).

--- a/workspaces/mops-onboarding/journal/0032-AMENDMENT-independent-reconvergence5-certify-security-plus-lifecycle.md
+++ b/workspaces/mops-onboarding/journal/0032-AMENDMENT-independent-reconvergence5-certify-security-plus-lifecycle.md
@@ -1,0 +1,66 @@
+---
+type: AMENDMENT
+date: 2026-07-08
+slug: independent-reconvergence5-certify-security-plus-lifecycle
+relates_to: 0031-DECISION-ship-public-repo-unenrolled-plus-certify-gate-wiring
+---
+
+# AMENDMENT — Independent re-convergence #5: certify no-assist SECURITY divergence + lifecycle-walk gaps
+
+Extends journal/0031. A fresh `/autonomize` + `/redteam`-to-convergence pass over the
+mops-onboarding suite (7 rounds, ~18 parallel adversarial agents, distinct lenses per round). The
+prior two convergences (PR #1622, #1623) had walked registration/symbol/prose surfaces; this pass
+added the **operator-lifecycle user-flow walk** and the **command↔skill parity** lenses, which
+surfaced what the earlier lenses structurally could not. All findings fixed to 0 CRIT/0 HIGH/0 MED
+across 2 consecutive clean rounds. 13 edits across 8 files — working tree, UNCOMMITTED (BUILD-repo
+commit gate).
+
+## The one SECURITY-relevant finding (MED, fixed) — certify no-assist gate had a skill↔command divergence
+
+`probe-phase-guard.js` (PR #355 security HIGH-1 closure, wired into committed settings.json in
+PR #1623) blocks orchestrator `Read/Grep/Glob/WebFetch` while `.certify-in-probe-<vid>.lock`
+exists, so an operator cannot be COACHED through the SOLO gate. The **command** (`certify.md`)
+kept the lockfile through Phase C — "Probe exit (Phase C complete OR abandoned mid-gate)". The
+**skill** (`42-certify`, the procedure-of-record) removed it "end of Phase B before transition to
+Phase C", rationalizing "Phase C does not require retrieval". But Phase C's gate loop RE-RUNS the
+probe on failed questions (`re-run probe on q`) — so an orchestrator following the skill tore down
+the structural no-assist guard exactly during the retry loop the gate exists to protect, leaving
+only prose refusal. Fix: the skill now states the lockfile PERSISTS through Phase C with a single
+removal at Phase C exit (pass OR abandon), matching the command. The security gate PR #355/#1623
+established was inert-during-retries on the skill-followed path; it now has teeth end-to-end.
+
+## The other findings (all fixed + verified)
+
+- **MED — enroll B3 premature "Enrolled" before roster PR merges** → "Enrollment PR opened. Once it
+  merges to main, run /onboard" + branch-vs-main roster-visibility note; propagated to skill 44.
+- **MED — MUST-7 cited for the grace/pending_verification mechanism** (defined in trust-posture
+  MUST-6 § Grace Period Semantics) → re-pointed onboard.md + skill 41 to MUST-6.
+- **LOW cluster** — 43→45 genesis-bootstrap cross-link; ecosystem C5 "TEAMMATE"/owner clarity
+  (propagated to skill 43); `<id>`→`<display_id>`; certify footer stale line-count dropped;
+  skills 43/44 raw `02-plans/` path genericized to `(loom-internal reference)`; certify receipt
+  `::version`→`::bank_version` (schema-int vs operator-visible dated tag).
+- **Verified NON-defects** (dispositioned, NOT edited): F4 onboard nag (resolveIdentity returns a
+  solo identity when coordination OFF — no `blocked_into`, no nag); F5 certify "if not already
+  rostered" (defensive conditional, not vestigial).
+
+## Institutional lessons (do NOT regress)
+
+- **command↔skill parity is its own lens.** The certify security divergence + the enroll/ecosystem
+  print-string divergences (one pair introduced by fixing the command but not the skill) all lived
+  in the command-vs-backing-skill delta — invisible to single-file review. When a command edit
+  changes a print string / gate / precondition, the backing skill's mirror MUST move in the same
+  shard (the security.md Multi-Site-Plumbing bug class, one abstraction up).
+- **A wired security hook can still be inert on one execution path.** probe-phase-guard was
+  correctly registered (PR #1623) yet the skill removed its trigger before the gate retry loop —
+  "the hook is registered" ≠ "the guard covers the whole gated window". Verify the guard's
+  lifecycle spans the ENTIRE protected activity, not just its opening.
+- **Distributable invariant re-confirmed intact AFTER all edits** — the 13 doc edits touched no
+  roster/settings/state surface; clones still resolve coordination OFF (roster PLACEHOLDER,
+  root_commit 0000000, 0/6 enforcement hooks committed, probe-phase-guard=1, disclosure scan exit 0).
+
+## Landing
+
+Working-tree edits only (BUILD repo — commit stays with the user). Recommended: land on
+`codify/esperie-2026-07-08` (or a fresh date-terminal codify branch) → PR → admin-merge, matching
+the #1622/#1623 pattern. All 8 files are self-referential-codify surface, so the 7-round
+multi-agent redteam-with-tests IS the self-referential gate (self-referential-codify.md Rule 1).


### PR DESCRIPTION
## Summary

Independent `/redteam` re-convergence #5 of the mops-onboarding COC-artifact suite (7 rounds, ~18 parallel adversarial agents, `/autonomize`). Converged **0 CRITICAL / 0 HIGH / 0 MED across 2 consecutive clean rounds**. 13 edits across 8 files.

The prior two convergences (#1622/#1623) walked the registration/symbol/prose surfaces; this pass added the **operator-lifecycle walk** and **command↔skill parity** lenses, which surfaced what the earlier lenses structurally could not.

### Security-relevant fix — /certify no-assist gate was inert on one path
`probe-phase-guard.js` (PR #355 security HIGH-1 closure, wired into committed `settings.json` in #1623) blocks orchestrator retrieval while the probe lockfile exists, so a new operator cannot be *coached* through the SOLO gate. The **command** (`certify.md`) kept the lockfile through Phase C ("Probe exit (Phase C complete OR abandoned mid-gate)"); the **skill** (`42-certify`, procedure-of-record) removed it before Phase C. But Phase C's gate loop **re-runs the probe on failed questions** — so an orchestrator following the skill tore the guard down exactly during the retry loop it protects. Fixed: skill now keeps the lockfile through Phase C, single removal at Phase C exit. *"Registered" ≠ "covers the whole gated window."*

### Other fixes
- **enroll** printed "Enrolled" before the roster PR merges → now explains the merge/branch dependency (so `/onboard` doesn't bounce a just-enrolled forker back to registration); propagated to skill 44.
- **grace/pending_verification** mechanism cited as `trust-posture.md` MUST-7 → it's **MUST-6 § Grace Period Semantics** (onboard.md + skill 41).
- **certify receipt** cited `_certification.yaml::version` (schema int) for "the bank version" → `::bank_version` (operator-visible dated tag).
- LOW polish serving the "teams struggling with genesis onboarding" brief: 43→45 genesis-bootstrap cross-link; ecosystem C5 owner-vs-teammate clarity (propagated to skill 43); `<id>`→`<display_id>`; certify footer stale line-count dropped; skills 43/44 raw `02-plans/` path genericized.
- **2 reported findings verified as false positives** (resolveIdentity returns a solo identity when coordination is OFF → the onboard nag never fires; a certify guard is defensive) — correctly left unchanged, not "fixed".

### Distributable invariant intact after all edits
Committed roster PLACEHOLDER, 0/6 coordination-enforcement hooks committed, probe-phase-guard registered, disclosure scanner exit 0 — clones still ship un-enrolled. The doc edits touched no roster/settings/state surface.

All 8 `.claude/` files are self-referential-codify surface; the 7-round multi-agent redteam-with-tests **is** the required self-referential gate (`self-referential-codify.md` Rule 1). Receipts: `workspaces/mops-onboarding/04-validate/redteam-2026-07-08-reconvergence5.md` + `journal/0032`.

## Related issues

Extends the mops-onboarding program (journal/0031, PRs #1622/#1623). No open issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)