### PR TITLE
fix(coc): certify coordination-ON write-surface conformance (onboarding re-convergence #6)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -850,3 +850,50 @@ changes:
       all edits (roster PLACEHOLDER, 0/6 enforcement hooks committed, probe-phase-guard=1, disclosure
       scanner exit 0). Receipt: workspaces/mops-onboarding/04-validate/redteam-2026-07-08-reconvergence5.md
       + journal/0032.
+
+  - type: rule_update
+    artifact: onboarding-suite-certify-coordination-on-conformance
+    files:
+      - .claude/skills/42-certify/SKILL.md
+      - .claude/commands/certify.md
+      - .claude/commands/claim.md
+      - .claude/commands/onboard.md
+      - .claude/skills/41-onboard/SKILL.md
+      - .claude/commands/ecosystem-init.md
+      - .claude/skills/43-ecosystem-init/SKILL.md
+      - .claude/skills/45-genesis-bootstrap/SKILL.md
+      - .claude/commands/posture.md
+    classification_suggestion: global
+    context: >
+      Re-convergence #6 fixes to the onboarding suite (kailash-py, 10-round multi-agent redteam,
+      ~30 adversarial agents, the self-referential-codify.md Rule 1 gate; converged 0 CRIT/0 HIGH/0 MED
+      across 2 consecutive clean rounds). SECURITY/CORRECTNESS-RELEVANT + HIGHEST cross-SDK priority —
+      the headline is a PRE-EXISTING gap every prior convergence (#1-#5) missed because kailash-py
+      ships coordination-OFF (integrity-guard / journal-write-guard / codify-lease all passthrough):
+      /certify's write surface was NEVER reconciled with the coordination-ON (enrolled) substrate it
+      ships into. A sibling SDK's synced /certify almost certainly carries the identical gap. Fixes,
+      all source-verified against the actual hooks (integrity-guard.js findCoveringLease/watched-subtrees,
+      codify-lease.js acquire/release/MANDATORY_SCOPE, journal-reserve.js VALID_TYPES,
+      operator-id.js resolveIdentity working-tree roster read): (1) certify pass + deferral journal
+      entries now acquire/release a covering codify-lease on a codify/<display_id>-<date> branch
+      (skill Steps 1.5/5), scope ["journal/"] (DIRECTORY scope load-bearing — findCoveringLease matches
+      trailing-slash-dir prefix, a bare filename does not, MANDATORY_SCOPE excludes journal/);
+      (2) deferral entry type DEFER->DECISION + topic certify-defer-<id> (DEFER is NOT in
+      journal-reserve.js::VALID_TYPES -> old contract failed the reservation closed); (3) brief
+      .pending/ receipts moved OUT of the journal/ subtree -> workspaces/_certify/.pending/
+      (integrity-guard watches ^workspaces/<name>/journal/); (4) entry gate corrected to the
+      code-accurate model — resolveIdentity reads the WORKING-TREE roster, so certify runs on the
+      enrollment branch (row visible) OR after merge; registration precedes certification; certification
+      gates /claim. Plus command<->skill + lifecycle fixes: certify Phase-0 (validate-cert-bank.mjs
+      security scan + consent STOP) added to the skill (was command-only — a security-scan drop on the
+      skill-followed path); claim.md SAME-conflict dead-end (nonexistent /lease-override + a
+      /release-claim invocation its own bind-check rejects) -> sibling-self-release/reap; onboard +
+      certify just-enrolled PR-pending branch; genesis double-run idempotency boundary (45 <->
+      ecosystem-init C3); posture.md self-contradiction; claim.md phantom test-path citation genericized.
+      Distributable invariant re-verified intact after all edits (roster PLACEHOLDER, 0/6 enforcement
+      hooks committed, probe-phase-guard=1, disclosure scanner exit 0, 1559 files). TWO items
+      deliberately NOT fixed (out of scope, flagged for loom/rule-owner): enrollment-operations.md
+      MUST-3 categorical wording vs certify Step-2 safe-inline node -e (tighten to "…on the command
+      line…"); claim/release-claim/claims M1-era coordination-log writes cite coc-sign+transport not
+      coc-append/coc-emit (helper-naming drift, substantively MUST-1-compliant). Receipt:
+      workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md.

--- a/.claude/commands/certify.md
+++ b/.claude/commands/certify.md
@@ -20,7 +20,7 @@ Resolve identity structurally — NOT by prose-claim. The orchestrator MUST run 
 node -e 'const r = require("./.claude/hooks/lib/operator-id.js").resolveIdentity(process.cwd()); process.stdout.write(JSON.stringify(r));'
 ```
 
-Treat as STOP (do NOT fall through to Phase A) when the parsed JSON has ANY of: `verified_id == null`, `person_id == null`, `posture == "L2_SUPERVISED"` AND no roster row, OR a non-zero exit code from the node invocation. On STOP, surface to the operator: "Identity check failed: you are not rostered (`/whoami --register` first) — `/certify` needs a roster row to record the pass against." Do NOT proceed prose-only; the structural Bash check IS the gate.
+Treat as STOP (do NOT fall through to Phase A) when the parsed JSON has ANY of: `verified_id == null`, `person_id == null`, `posture == "L2_SUPERVISED"` AND no roster row, OR a non-zero exit code from the node invocation. On STOP, surface — **branched on the just-enrolled case**: if the operator just ran `/enroll` or `/whoami --register`, their roster row is on their `codify/<display_id>-<date>` branch but not yet merged to `main` → "Run `/certify` FROM your `codify/<display_id>-<date>` branch — `resolveIdentity` reads the WORKING-TREE roster (`operator-id.js` `_readJsonSafe(rosterPath)`), so your row is visible there and the pass entry lands on the same branch (riding your enrollment PR); OR await the PR merge and run it on `main`. On `main` before the merge you resolve as not-yet-rostered."; otherwise → "Identity check failed: you are not rostered (`/whoami --register` first) — `/certify` needs a roster row to record the pass against." Do NOT proceed prose-only; the structural Bash check IS the gate.
 
 After identity passes, validate the bank file structurally:
 
@@ -28,7 +28,7 @@ After identity passes, validate the bank file structurally:
 node .claude/bin/validate-cert-bank.mjs specs/_certification.yaml
 ```
 
-Treat as STOP on non-zero exit (any CRIT/HIGH finding). The validator covers: bank existence + YAML validity, schema shape (version, sections, per-question id/kind/expected), citation-path allowlist (`{specs,rules,.claude}/**` only — no `..` traversal, no absolute paths), length caps on prompt/options/rubric/expected, prompt-injection signal scan, and secret-shaped-token rejection. A bank that fails any check is institutionally untrusted; do NOT proceed to brief.
+Treat as STOP on non-zero exit (any CRIT/HIGH finding). The validator covers: bank existence + YAML validity, schema shape (version, sections, per-question id/kind/expected), citation-path allowlist (`{specs,rules,.claude}/**` only — no `..` traversal, no absolute paths), length caps (advisory/MED — flagged, non-blocking) on prompt/options/rubric/expected, prompt-injection signal scan, and secret-shaped-token rejection. A bank that fails any CRIT/HIGH check (citation/injection/secret) is institutionally untrusted; do NOT proceed to brief.
 
 Then read the operator's required consent (the bank's `version` + `bank_version` + record-of-pass-tied-to-verified_id implications):
 
@@ -45,7 +45,7 @@ All three STOP conditions are structural (exit code + file existence + explicit 
 
 ### 2. Phase A — Brief (read receipts)
 
-Walk the operator through the critical-knowledge surface in fixed order: `specs/_index.md` (if present) → repo `CLAUDE.md` → CO-category rules (`rules/autonomous-execution.md`, `rules/agent-reasoning.md`, `rules/artifact-flow.md`) → `/posture show` (trust posture state) → `.claude/team-memory/` index → last 5 `journal/DECISION-*.md` entries. For each section, summarize in plain language and write a "read receipt" to `workspaces/_certify/journal/.pending/certify-brief-<display_id>-<date>.md`. Receipts are scrubbed per `rules/user-flow-validation.md` MUST-6 before write (no secrets, no downstream client tokens).
+Walk the operator through the critical-knowledge surface in fixed order: `specs/_index.md` (if present) → repo `CLAUDE.md` → CO-category rules (`rules/autonomous-execution.md`, `rules/agent-reasoning.md`, `rules/artifact-flow.md`) → `/posture show` (trust posture state) → `.claude/team-memory/` index → last 5 `journal/DECISION-*.md` entries. For each section, summarize in plain language and write a "read receipt" to `workspaces/_certify/.pending/certify-brief-<display_id>-<date>.md` (ephemeral scratch — deliberately OUTSIDE any `journal/` subtree so it does NOT trip `integrity-guard`'s `workspaces/<name>/journal/` watch, which under coordination-ON would halt the Phase-A write before any lease exists). Receipts are scrubbed per `rules/user-flow-validation.md` MUST-6 before write (no secrets, no downstream client tokens).
 
 ### 3. Phase B — Probe (one question at a time)
 
@@ -69,31 +69,31 @@ If the orchestrator crashes mid-probe, the operator MUST manually remove the sta
 
 After the full pass, tally pass/fail per question. If 100% → record pass (Step 5). If <100% → list every failed question with "re-read §X" pointing at the cited spec section, allow the operator to re-read, then retry ONLY the failed questions. Loop until 100%. Each retry attempt is recorded with `attempts:` in the final journal entry.
 
-### 5. Emit pass receipt + roster registration nudge
+### 5. Emit pass receipt
 
-On pass: write a `journal/NNNN-DECISION-certify-<display_id>-<date>.md` entry naming the operator's `display_id` + `verified_id`, the bank version (`specs/_certification.yaml::bank_version` — the operator-visible dated tag, NOT the schema-version int `::version`), the per-question pass/fail/attempts tally, and the timestamp. Surface to the operator: "Certification passed. Next: `/whoami --register` (if not already rostered) → `/claim <path>` to start work." Until pass, the operator remains `L2_SUPERVISED` via the existing trust-posture machinery (no command-side change — `posture.json` already enforces L2 for unrostered operators per `rules/multi-operator-coordination.md` §1).
+On pass: write the pass receipt under a covering codify-lease (skill Step 1.5 `acquireCodifyLease` → Step 5 `releaseCodifyLease` — `integrity-guard` halts an unleased `journal/` write under coordination-ON) via the `reserveJournalSlotSigned` helper (skill Steps 2–3) at its returned `r.reservation.filename` — a `DECISION` journal entry naming the operator's `display_id` + `verified_id`, the bank version (`specs/_certification.yaml::bank_version` — the operator-visible dated tag, NOT the schema-version int `::version`), the per-question pass/fail/attempts tally, and the timestamp. Surface to the operator: "Certification passed. Next: `/onboard` (re-read team state) → `/claim <path>` to start work." (No registration nudge — the entry gate already required the roster row to be present, so the operator is rostered by construction.) Until pass, the operator remains `L2_SUPERVISED` via the existing trust-posture machinery (no command-side change — `posture.json` already enforces L2 for unrostered operators per `rules/multi-operator-coordination.md` §1).
 
 ### Failure modes (typed errors — no silent fallbacks per `rules/zero-tolerance.md` Rule 3)
 
-- Unregistered operator → STOP, instruct `/whoami --register`.
+- Unregistered operator → STOP; branch per the Step-1 gate: just ran `/enroll`/`/whoami --register` → "run `/certify` from your `codify/<display_id>-<date>` branch (roster row visible in the working tree) or await the PR merge"; otherwise → instruct `/whoami --register`.
 - Missing `specs/_certification.yaml` → STOP with seed-template instruction.
-- Operator abandons mid-gate → write a `journal/NNNN-DEFER-certify-<display_id>-incomplete.md` with attempts-so-far; operator stays `L2_SUPERVISED`; re-running `/certify` resumes from question 1 (NOT mid-gate — the gate is full-bank).
+- Operator abandons mid-gate → write a deferral entry via the same `reserveJournalSlotSigned` helper (`type: "DECISION"`, `topic: "certify-defer-<display_id>"` — `DEFER` is NOT a canonical journal type, so passing it fails the reservation) with attempts-so-far, under the SAME codify-branch + covering-lease ceremony as the pass receipt (skill Steps 1.5/5 — the deferral entry is a `journal/` write `integrity-guard` gates under coordination-ON); operator stays `L2_SUPERVISED`; re-running `/certify` resumes from question 1 (NOT mid-gate — the gate is full-bank).
 - Bank schema invalid (missing `expected:`, missing `grading_rubric:` on short-answer) → STOP, surface the offending question id + instruction to fix the bank.
 
 ## Output format
 
-Default markdown narrative. The brief phase writes per-section read receipts to `workspaces/_certify/journal/.pending/`. The probe + gate run inline in the session. The final pass writes a committed `journal/NNNN-DECISION-certify-<display_id>-<date>.md` entry per `rules/journal.md`.
+Default markdown narrative. The brief phase writes per-section read receipts to `workspaces/_certify/.pending/`. The probe + gate run inline in the session. The final pass writes a committed `DECISION` journal entry via the `reserveJournalSlotSigned` helper (the skill's canonical slot-reservation path, at its returned `r.reservation.filename`) per `rules/journal.md`.
 
 ## Next steps after certify
 
 ```
-Next: /whoami --register (if not already rostered) → /onboard (re-read team state)
+Next: /onboard (re-read team state)
       → /claim <path> (when starting your first piece of work)
 ```
 
 ## Notes
 
-- This command is a state-write command (writes brief receipts + a committed pass journal entry). It does NOT modify roster, posture, lease, or the coordination log — pass status is captured in the journal entry; subsequent commands (`/whoami --register`, `/claim`, `/codify`) handle roster and lease writes.
+- This command is a state-write command: it writes brief receipts + a committed pass journal entry, **acquires a covering codify-lease around that write** (the pass entry is a codify-class `journal/` write `integrity-guard` gates — skill Steps 1.5/5), and **emits signed coordination-log records** for it (the `journal-slot-reservation` + `journal-body-anchor` ceremony). It does NOT modify the roster or posture. Registration (`/whoami --register`) is a PREREQUISITE done BEFORE certify (the entry gate requires the roster row present); `/claim` handles claim writes.
 - Procedure detail (failure-mode handling, YAML schema, LLM-judge prompt shape, retry-loop discipline) lives in `.claude/skills/42-certify/SKILL.md`. Update the skill, not this command, when the procedure changes.
 - The question bank itself (`specs/_certification.yaml`) lives in the CONSUMER repo, NOT loom. Loom ships a starter template at `.claude/templates/specs/_certification.yaml`; each downstream repo copies it once into `specs/` and curates its own questions citing its own critical spec sections.
 - Curated bank, NOT LLM-generated: a 100% gate against hallucinated questions is unfair. Maintenance cost (spec edits flag stale citations) is the price of fairness.

--- a/.claude/commands/claim.md
+++ b/.claude/commands/claim.md
@@ -24,13 +24,13 @@ Per multi-operator-coc architecture §4.1 + §4.2: claims are advisory (leases-a
 4. **Project active sibling claims** — filter `accepted` by `type === "claim"`, exclude own `verified_id`, exclude released/reaped (rule 7 isClaimActive predicate).
 5. **Evaluate §4.1 relation** via `.claude/hooks/lib/adjacency.js::sameReason` then `adjacentReason` against the candidate path. Pass `{ phase, candidateCommits }` opts where known (the optional axis-3 cohort promotion).
 6. **Dispatch by verdict:**
-   - **SAME** → halt-and-report. Print the conflicting `claim_id`, sibling `display_id`, and the matched predicate (`exact` / `dir-contains` / `workspace` / `commit-cohort` / `axis-3`). Do NOT append a claim record (this prevents the F2-1 race-to-write). Direct the operator to either `/release-claim <conflicting-ref>` (if the sibling has consented) or proceed via `lease-override` (gate-approval needed; see §4.5).
+   - **SAME** → halt-and-report. Print the conflicting `claim_id`, sibling `display_id`, and the matched predicate (`exact` / `dir-contains` / `workspace` / `commit-cohort` / `axis-3`). Do NOT append a claim record (this prevents the F2-1 race-to-write). Surface the resolution paths: (a) **sibling self-release** — ask the sibling to run `/release-claim <their-own-ref>` on THEIR machine (self-release requires `verified_id == self`, so only the sibling can release the sibling's claim; the operator running `/release-claim` on the sibling's ref is rejected by the bind check); OR (b) **reap, only if stale** — if the sibling's claim is past `LIVENESS_TTL_MS`, `/release-claim --reap <conflicting-ref> --cosigner <person_id>`. A SAME-override WITHOUT the sibling's release requires a `lease-override` gate-approval record (architecture §4.5) — a loom-internal advanced path, NOT a consumer slash-command.
    - **ADJACENT** → write the claim record with `content.granted_relation = "ADJACENT"` and `content.advisory = true`. Print the nearby sibling's `claim_id` and the matched predicate.
    - **INDEPENDENT** → write the claim record with `content.granted_relation = "INDEPENDENT"`. Silent success.
 
 ## Record shape
 
-The claim shape MUST match M2 B1's auto-claim shape exactly (parity asserted by `tests/integration/claim-commands.test.js::claim_writes_record_with_correct_shape_matching_b1_auto_claim`). The only difference: B1 sets `content.auto = true` on the implicit-coordination path; `/claim` omits the `auto` field on the explicit path.
+The claim shape MUST match M2 B1's auto-claim shape exactly (parity asserted by the loom multi-operator claim-shape test). The only difference: B1 sets `content.auto = true` on the implicit-coordination path; `/claim` omits the `auto` field on the explicit path.
 
 ```js
 {

--- a/.claude/commands/ecosystem-init.md
+++ b/.claude/commands/ecosystem-init.md
@@ -56,14 +56,21 @@ Collect the NAME→remote bindings for this ecosystem's logical keys (the EXACT 
 `artifact-flow.md` § "Repo Classes Map 1:1 To Resolver Logical Keys": `build.{py,rs,prism}`,
 `use-template.{…}`, `loom`, `atelier`, `downstream.<slug>`). Run the disclosure scan (invariant 1).
 Human-confirm the org slugs (invariant 2). Write the `remote_links` block of `.claude/bin/ecosystem.json`
-per the D6 schema (`ecosystem-config.mjs` is the reader; `getRemoteLink(key)` / `resolveRemote(key)` are
-the accessors). NEVER edit a synced artifact to carry the registry inline (`cross-repo.md` MUST NOT).
+per the D6 schema (`ecosystem-config.mjs::getRemoteLink(key)` reads it; `bin/lib/loom-links.mjs::resolveRemote(key)`
+is the local⊕remote join accessor). NEVER edit a synced artifact to carry the registry inline (`cross-repo.md` MUST NOT).
 
 ### C3 — establish the genesis trust-root
 
 Invoke `runEnrollmentCeremony` (invariant 3). For an org-owned fork the verified-org-admin attestation
 is the trust anchor (issue #358 org-owned bootstrap); for a user-owned fork the signed root commit is.
 Owner-class gate; the signed `genesis-anchor` record lands in the coordination log.
+
+**Idempotency boundary with `45-genesis-bootstrap`:** the first-owner runbook `skills/45-genesis-bootstrap`
+runs THIS SAME ceremony (`runEnrollmentCeremony` + fold-clean verify) as its own step. If you followed
+`45` to fold-clean completion, C3 is already satisfied — re-running `runEnrollmentCeremony` on identical
+pinned facts does NOT fork the trust root (fold rule 9a); verify the anchor already folded
+(`foldLog(...) → accepted:[anchor], rejected:[], forks:[]`) and skip to C2/C4/C5. Run the ceremony here
+ONLY if `45` was not run (e.g. the roster owner entry was hand-authored without the ceremony step).
 
 ### C2 — set the four remaining ecosystem-relative params
 

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -14,7 +14,7 @@ Onboard the operator into the current repo's multi-operator COC state. Read-only
 
 ### 1. Identify the operator
 
-Resolve identity via `.claude/hooks/lib/operator-id.js::resolveIdentity()`. The result includes `display_id`, `verified_id`, and the operator's roster status. If the operator is not registered, surface the `/whoami --register` instruction and stop — onboarding past identity is not safe.
+Resolve identity via `.claude/hooks/lib/operator-id.js::resolveIdentity()`. The result includes `display_id`, `verified_id`, and the operator's roster status. If the operator is not registered, stop — onboarding past identity is not safe — and surface the message **branched on the just-enrolled case**: "if you just ran `/enroll` or `/whoami --register`, your roster row is an unmerged PR, not yet on `main` — await the merge (or stay on your `codify/<display_id>-<date>` branch) before treating `/onboard` identity as final; otherwise run `/whoami --register`."
 
 ### 2. Read the team-memory surface
 
@@ -64,7 +64,7 @@ In `--json` mode, emit a structured object: `{operator, team_memory, workspace, 
 
 ### Failure modes (typed errors — no silent fallbacks per `rules/zero-tolerance.md` Rule 3)
 
-- Unregistered operator → STOP, instruct `/whoami --register`.
+- Unregistered operator → STOP; branch the message: just ran `/enroll`/`/whoami --register` → "roster PR not yet merged to `main` — await the merge or stay on your `codify/<display_id>-<date>` branch"; otherwise → instruct `/whoami --register`.
 - Missing `.claude/team-memory/` directory → empty section (not an error; fresh repo).
 - Corrupt `posture.json` (state-io.js returns fail-closed L1) → surface verbatim; do NOT proceed.
 - Missing roster (`.claude/operators.roster.json`) → STOP, instruct genesis ceremony.
@@ -78,7 +78,7 @@ Action Items is the actionable footer: every gate the operator must clear (pendi
 ## Next steps after onboarding
 
 ```
-Next: /whoami (verify identity) → /claims (see what's locked) → /analyze or /implement (start work)
+Next: /whoami (verify identity) → /claims (see what's locked) → /certify (knowledge gate — required before claiming non-trivial work) → /claim <path> → /analyze or /implement (start work)
 ```
 
 ## Notes

--- a/.claude/commands/posture.md
+++ b/.claude/commands/posture.md
@@ -108,7 +108,7 @@ For Steps 1/2 nonce flow, write nonce to file with mode 0600. Hooks read the fil
 ## Posture-bound restrictions on this command
 
 - `/posture init`, `show`, `history`, `violations` work at any posture (read or single-write fresh init).
-- `/posture upgrade`, `/posture override` are NEVER usable below L1 (always available regardless of posture — humans must always have escape hatch).
+- `/posture upgrade`, `/posture override` are NEVER disabled — always available regardless of posture, even at L1 (humans must always have the escape hatch).
 - Agent invoking `/posture upgrade` autonomously without user instruction = `acknowledgement_failure` violation logged.
 
 ## Output canonical format

--- a/.claude/skills/41-onboard/SKILL.md
+++ b/.claude/skills/41-onboard/SKILL.md
@@ -40,7 +40,7 @@ identity = operatorId.resolveIdentity()
 if (identity.blocked_into) → emit "/whoami --register" + stop
 ```
 
-The blocked_into value (`UNROSTERED_BLOCKED_INTO` or `NO_KEY_BLOCKED_INTO`) is the action the operator must take. Do NOT proceed to subsequent sections if blocked — the rest of the briefing assumes a registered identity.
+The blocked_into value (`UNROSTERED_BLOCKED_INTO` or `NO_KEY_BLOCKED_INTO`) is the action the operator must take. Do NOT proceed to subsequent sections if blocked — the rest of the briefing assumes a registered identity. **Branch the emitted message on the just-enrolled case:** if the operator just ran `/enroll` or `/whoami --register`, their roster row is an unmerged PR not yet on `main` — surface "await the roster PR merge (or stay on your `codify/<display_id>-<date>` branch) before treating `/onboard` identity as final"; otherwise emit `/whoami --register`. (An `UNROSTERED_BLOCKED_INTO` on `main` right after `/enroll` is the PR-pending state, NOT a never-registered operator — do not bounce them into a redundant re-registration.)
 
 ### 2. Team-memory surface
 

--- a/.claude/skills/42-certify/SKILL.md
+++ b/.claude/skills/42-certify/SKILL.md
@@ -19,22 +19,55 @@ This skill is the procedural detail for the `/certify` command (`.claude/command
 
 `/certify` writes state, but a narrow set:
 
-| Surface                                      | Phase                    | Write?                                                                          |
-| -------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------- |
-| `workspaces/_certify/journal/.pending/*`     | Brief                    | Yes — per-section read receipts (scrubbed per `user-flow-validation.md` MUST-6) |
-| In-session probe state                       | Probe                    | No persisted file; tally lives in orchestrator context                          |
-| `journal/NNNN-DECISION-certify-*.md`         | Pass (gate met)          | Yes — committed pass receipt                                                    |
-| `journal/NNNN-DEFER-certify-*-incomplete.md` | Abandon mid-gate         | Yes — deferral receipt; operator stays L2_SUPERVISED                            |
-| `posture.json`                               | (n/a — no posture write) | No — trust-posture machinery already enforces L2 for unrostered operators       |
-| `operators.roster.json`                      | (n/a — no roster write)  | No — pass nudges operator to `/whoami --register`                               |
+| Surface                                                 | Phase                        | Write?                                                                                                                                                                            |
+| ------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workspaces/_certify/.pending/*`                        | Brief                        | Yes — ephemeral read receipts, OUTSIDE any `journal/` subtree (dodges integrity-guard's `workspaces/<name>/journal/` watch); scrubbed per `user-flow-validation.md` MUST-6        |
+| In-session probe state                                  | Probe                        | No persisted file; tally lives in orchestrator context                                                                                                                            |
+| `journal/NNNN-<display_id>-DECISION-certify-pass-*.md`  | Pass (gate met)              | Yes — committed pass receipt (name from `reserveJournalSlotSigned`)                                                                                                               |
+| `journal/NNNN-<display_id>-DECISION-certify-defer-*.md` | Abandon mid-gate             | Yes — deferral receipt (`type: "DECISION"`, `topic: "certify-defer-<display_id>"` — `DEFER` is NOT a canonical journal type per `rules/journal.md`); operator stays L2_SUPERVISED |
+| `posture.json`                                          | (n/a — no posture write)     | No — trust-posture machinery already enforces L2 for unrostered operators                                                                                                         |
+| `operators.roster.json`                                 | (n/a — no roster write)      | No — certify never writes the roster; registration is a PREREQUISITE authored before the entry gate                                                                               |
+| `.claude/learning/codify-lease.json` (on-disk mutex)    | Pass + Abandon (Steps 1.5/5) | Yes — a covering codify-lease acquired around the pass OR DEFER write, released at Step 5                                                                                         |
+| `.claude/learning/coordination-log.jsonl`               | Pass + Abandon (Steps 1.5–5) | Yes (coordination-ON) — signed `codify-lease` / `journal-slot-reservation` / `journal-body-anchor` / `codify-lease-release` records via canonical emit helpers                    |
 
-Pass is captured in the journal entry, NOT in a roster row. The roster row is the separate operator-registration step; certification is the prerequisite recorded in `journal/`.
+Pass is captured in the journal entry, NOT in a roster row. The roster row is authored by the separate registration step (a PREREQUISITE the entry gate requires present); certification is recorded in `journal/` and gates the operator's first `/claim`.
 
 ## Section-by-section runbook
 
+### Phase 0 — Prerequisites (identity + bank validation + consent)
+
+Runs BEFORE Phase A. Three structural STOP gates — mirror of `commands/certify.md` Step 1; all three are structural (exit code + file existence + explicit user input), not LLM-judgment, so a session that skims this prose still fails on the wire.
+
+**Step 0.a — Resolve identity structurally** (NOT by prose-claim):
+
+```bash
+node -e 'const r = require("./.claude/hooks/lib/operator-id.js").resolveIdentity(process.cwd()); process.stdout.write(JSON.stringify(r));'
+```
+
+STOP (do NOT fall through to Phase A) when the parsed JSON has ANY of: `verified_id == null`, `person_id == null`, `posture == "L2_SUPERVISED"` AND no roster row, OR a non-zero exit code. On STOP surface — **branched on the just-enrolled case**: if the operator just ran `/enroll` or `/whoami --register`, their roster row is on their `codify/<display_id>-<date>` branch but not yet merged to `main` → "Run `/certify` FROM your `codify/<display_id>-<date>` branch — `resolveIdentity` reads the WORKING-TREE roster (`operator-id.js` `_readJsonSafe(rosterPath)`), so your row is visible there and the pass entry lands on the same branch (riding your enrollment PR); OR await the PR merge and run it on `main`. On `main` before the merge you resolve as not-yet-rostered."; otherwise → "Identity check failed: you are not rostered (`/whoami --register` first) — `/certify` needs a roster row to record the pass against."
+
+**Step 0.b — Validate the bank file structurally** (the security scan — NOT the schema-shape-only check):
+
+```bash
+node .claude/bin/validate-cert-bank.mjs specs/_certification.yaml
+```
+
+STOP on non-zero exit (any CRIT/HIGH finding). The validator covers: bank existence + YAML validity, schema shape (version, sections, per-question id/kind/expected), **citation-path allowlist (`{specs,rules,.claude}/**` only — no `..` traversal, no absolute paths), length caps (advisory/MED — flagged, non-blocking) on prompt/options/rubric/expected, prompt-injection signal scan, and secret-shaped-token rejection.** A bank that fails any CRIT/HIGH check (citation/injection/secret) is institutionally untrusted; do NOT proceed to brief. This binary validator IS the authoritative bank-trust gate — the § Question bank schema check at probe start is a re-confirmation of shape, NOT a substitute for this security scan.
+
+**Step 0.c — Consent gate** (the bank's `bank_version` + record-of-pass-tied-to-`verified_id` implications):
+
+```
+Surface to operator:
+  "/certify will record a per-question pass/fail tally tied to your
+   verified_id in a committed journal entry. The bank version is
+   <bank_version>. Proceed? (y/N)"
+```
+
+STOP unless the operator answers `y` — explicit per-operator consent is required before institutional knowledge about the operator's competency lands in the audit trail.
+
 ### Phase A — Brief
 
-Walk these surfaces in fixed order; for each, summarize in plain language (per `rules/communication.md`), then write a read receipt to `workspaces/_certify/journal/.pending/certify-brief-<display_id>-<YYYY-MM-DD>.md`:
+Walk these surfaces in fixed order; for each, summarize in plain language (per `rules/communication.md`), then write a read receipt to `workspaces/_certify/.pending/certify-brief-<display_id>-<YYYY-MM-DD>.md` (ephemeral scratch, deliberately OUTSIDE any `journal/` subtree — `integrity-guard` watches `workspaces/<name>/journal/`, so a Phase-A receipt under `journal/` would halt un-leased under coordination-ON; these receipts are NOT codify-class journal entries):
 
 1. `specs/_index.md` if present (domain truth surface). If absent, surface "this repo has no specs index; brief covers rules + journal only."
 2. Repo `CLAUDE.md` — the always-loaded directives and navigation.
@@ -110,6 +143,21 @@ node -e 'const r = require("./.claude/hooks/lib/operator-id.js").resolveIdentity
 
 Parse and bind `verified_id`, `person_id`, `display_id` from the JSON result. STOP if any are null.
 
+**Step 1.5 — Get on a codify branch + acquire a covering codify-lease (the pass entry is a codify-class `journal/` write).** Under coordination-ON, `integrity-guard.js` requires a `journal/` Write to be BOTH on a `codify/<display_id>-<date>` branch (`isCodifyBranch` — a write on `main` is `severity: block` BEFORE the lease is even consulted) AND under a covering `codify-lease` record (`findCoveringLease` → `halt-and-report` otherwise). So, before the Step-3 Write:
+
+- **(a) Ensure HEAD is your `codify/<display_id>-<date>` branch** — the enrollment branch if certifying same-day pre-merge, ELSE cut one: `git checkout -b "codify/<display_id>-$(date -u +%Y-%m-%d)" origin/main`. `acquireCodifyLease` only COMPUTES the branch NAME (it does NOT `git switch`), so YOU must be on the branch first.
+- **(b) Acquire the lease** via a script-by-path `node <file>` (state-mutating ceremony step per `enrollment-operations.md` MUST-3 — author the script with the same `cat > "${TMPDIR:-/tmp}/…cjs" <<'CEREMONY'` … `CEREMONY` write-then-run wrapper Step 4 uses) calling:
+
+```js
+acquireCodifyLease({
+  displayId,
+  scopeFiles: ["journal/"],
+  repoDir: process.cwd(),
+});
+```
+
+`scopeFiles: ["journal/"]` (trailing-slash DIRECTORY scope) is load-bearing: `findCoveringLease` matches a scope entry against the `journal/`-prefixed rel-path only by exact-equality, trailing-slash-dir-prefix, or bare-dir-prefix — a bare filename (`NNNN-…md`) would NOT match, and `MANDATORY_SCOPE` (`learning-codified.json` + `latest.yaml`) does not cover `journal/`. `acquireCodifyLease` (`.claude/hooks/lib/codify-lease.js`) returns `{ ok, lease, branch, record_emit }`. On `{ ok: true }` proceed to Step 2; if `record_emit.ok` is false surface its `reason` (a lease invisible to siblings per `knowledge-convergence.md` MUST-3 — the lease still holds). On `{ ok: false }` STOP and surface the conflicting holder + `reason`. **Note:** `acquireCodifyLease` also fail-closes on a dirty SCOPE working tree (the lease scope is `MANDATORY_SCOPE ∪ ["journal/"]`, so an unrelated uncommitted `journal/` entry ALSO triggers the `scope-dirty` STOP) or a git error EVEN under coordination-OFF (only the record-emit + integrity-guard enforcement are OFF no-ops) — surface and resolve rather than assume a no-op.
+
 **Step 2 — Reserve the slot via the fold-anchored helper.** Supply the Step-1 JSON
 as `IDENTITY_JSON` ON the invocation (the helper reads it from `process.env`; without
 the prefix `identity` is `undefined` and the reserve fails closed):
@@ -129,6 +177,8 @@ process.stdout.write(JSON.stringify(r));
 ```
 
 (`$identity_json` is the raw JSON captured from Step 1's stdout.)
+
+Inline `node -e` is safe HERE (unlike Step 4's `appendStamped`, which MUST be script-by-path per `enrollment-operations.md` MUST-3): `validate-bash-command.js`'s `detectStateFileMutationSegmentAware` scans the COMMAND LINE for a `STATE_PATH_RX` literal, and this invocation passes only `process.cwd()` — the `coordination-log.jsonl` path the helper emits to is internal to `journal-reserve.js`, never on the command line. Step 4's `appendStamped(cwd, COORD_LOG, …)` puts the state path in an argument, so it MUST be hidden in a `node <file>` script.
 
 The **fold-anchored** helper is `reserveJournalSlotSigned` — NOT the pure `reserveJournalSlot`, which computes off the filesystem only and emits nothing, so the Step-3 Write would halt "slot unreserved" at `journal-write-guard.js`. It returns `{ ok: true, reservation: { slot: "NNNN", filename: "NNNN-<display_id>-DECISION-certify-pass-<display_id>.md", ... }, record }` on success, or `{ ok: false, error, reason, step }` on failure — STOP and surface `reason` when `ok` is false. The slot is `max(disk high-water, fold-accepted reservation high-water)` AND the helper emits the signed `journal-slot-reservation` coordination-log record `journal-write-guard.js` folds — so the Step-3 Write is permitted and two concurrent `/certify` sessions remain distinguishable on disk.
 
@@ -192,9 +242,11 @@ The `appendStamped()` helper stamps `verified_id`+`person_id`+`seq`+`prev_hash`+
 
 **Why this matters:** at fold time, `foldAnchorPredicate` re-hashes the journal body and compares against `sha256_of_content_bytes` in the signed anchor. Tamper post-write fails verification AND names the anchor's SIGNER per `knowledge-convergence.md` MUST NOT clause "Treat a body-anchor finding as accusing the journal's frontmatter author when the anchor predicate names a DIFFERENT signer." The pass receipt's cryptographic integrity is what distinguishes /certify from theater.
 
+**Step 5 — Release the covering codify-lease** (paired with Step 1.5). After the pass entry + body-anchor land, release via a script-by-path `node <file>` (same `cat > …cjs <<'CEREMONY'` write-then-run wrapper as Step 4) calling `releaseCodifyLease({ repoDir: process.cwd(), displayId })` (`.claude/hooks/lib/codify-lease.js` — the helper derives the `leasePath` from `repoDir` internally per Sec-MED-3; callers MUST NOT supply `leasePath`). This emits the paired `codify-lease-release` coordination-log record under coordination-ON. In a coordination-OFF repo it releases the on-disk mutex with no record.
+
 ## Question bank schema
 
-`specs/_certification.yaml` (consumer repo's curated bank). The orchestrator validates this schema at probe start; missing required fields → STOP with the offending question id.
+`specs/_certification.yaml` (consumer repo's curated bank). The authoritative bank-trust gate is the Phase-0 `validate-cert-bank.mjs` binary (schema shape + citation-path allowlist + injection scan + secret-token rejection); the probe-start re-confirmation of this schema shape is a defence-in-depth re-check, NOT a substitute — missing required fields → STOP with the offending question id.
 
 ```yaml
 version: 1 # schema version (currently 1)
@@ -225,19 +277,19 @@ Ordering convention: easy questions first, hard last. The bank's curator owns or
 
 - **Empty bank** (`questions: []` after expansion): STOP, surface "bank is empty — seed it from `.claude/templates/specs/_certification.yaml` before running /certify."
 - **Schema invalid** (missing `expected:`, missing `grading_rubric:` on a `short_answer`, unknown `kind:`): STOP, name the offending question id.
-- **Operator abandons mid-gate**: write `journal/NNNN-DEFER-certify-<display_id>-incomplete.md`; operator stays `L2_SUPERVISED`. Re-running `/certify` restarts from question 1 — the gate is full-bank; partial-bank carry-forward is intentionally NOT supported (the bank is the unit of certification, not individual questions).
+- **Operator abandons mid-gate**: write a deferral entry via the same `reserveJournalSlotSigned` helper with `type: "DECISION"`, `topic: "certify-defer-<display_id>"` (→ `NNNN-<display_id>-DECISION-certify-defer-<display_id>.md` at its returned `r.reservation.filename`). The entry carries the SAME frontmatter shape as the pass receipt (Step 3) — `type: DECISION`, `author: co-authored`, `verified_id`/`person_id`/`display_id` from Step 1, `bank_version` — with `topic: "certify-defer: <display_id>"` and the attempts-so-far tally in the body; the same Step-4 body-anchor applies. **`DEFER` is NOT a canonical journal `type`** (`journal-reserve.js::VALID_TYPES` = DECISION/DISCOVERY/TRADE-OFF/RISK/CONNECTION/GAP/AMENDMENT per `rules/journal.md`); passing `type: "DEFER"` fails the reservation closed. Operator stays `L2_SUPERVISED`. Re-running `/certify` restarts from question 1 — the gate is full-bank; partial-bank carry-forward is intentionally NOT supported (the bank is the unit of certification, not individual questions). **The deferral write is a codify-class `journal/` write too** — under coordination-ON it MUST follow the SAME ceremony as the pass receipt (Step 1.5: ensure the `codify/<display_id>-<date>` branch + `acquireCodifyLease({ scopeFiles: ["journal/"], displayId, repoDir })`; Step 5: `releaseCodifyLease`). Without it, `integrity-guard` hard-blocks the deferral write on `main` (off-codify-branch) or halts it un-leased on a codify branch — the same gate the pass path clears. Under coordination-OFF `integrity-guard` passes through and the ceremony is a no-op.
 - **Bank's cited spec section missing on disk**: warn in the brief receipt; the question is still asked (the operator is being tested on the rule's content as the bank's curator captured it; the missing spec is a separate fix-the-bank task).
 
 ## Next steps after certify
 
-Pass → `/whoami --register` (if unrostered) → `/onboard` (re-read team state with verified identity) → `/claim <path>` (start work).
+Pass → `/onboard` (re-read team state with verified identity) → `/claim <path>` (start work). No registration nudge — the entry gate already required the roster row present, so the operator is rostered by construction.
 
 Until pass, the operator stays `L2_SUPERVISED` via `posture.json` (no certify-side write needed — `multi-operator-coordination.md` §1 already enforces L2 default for unrostered operators).
 
 ## Composition with other commands
 
 - **`/onboard`** answers "who am I + what's the team state" (read-only). `/certify` adds the knowledge-gate. Run `/onboard` first.
-- **`/whoami --register`** is the roster-write. `/certify` does NOT register; the pass journal entry is the prerequisite the next session points at when reviewing the roster-PR.
+- **`/whoami --register`** is the roster-write and a PREREQUISITE — the entry gate requires the roster row present (`resolveIdentity` reads the working-tree roster, so it is visible on the enrollment `codify/<display_id>-<date>` branch or on `main` after merge). `/certify` does NOT register. Run on the enrollment branch (the pass entry rides the roster PR) or after merge; the pass gates the operator's first `/claim`.
 - **`/codify`** authors rules; `/certify` tests knowledge of rules. When a `/codify` lands a load-bearing rule, the consumer repo's bank curator should add a question covering it; without that, the bank goes stale relative to the live rule corpus.
 
 ## Origin

--- a/.claude/skills/43-ecosystem-init/SKILL.md
+++ b/.claude/skills/43-ecosystem-init/SKILL.md
@@ -59,6 +59,13 @@ It is fail-CLOSED — any failed gh-api verification refuses to emit the genesis
   `/whoami --register` then promote the role on the resulting PR first. The full first-owner runbook for
   hand-authoring that owner entry (signing-key-first, the script-by-path roster write, fold-clean verify)
   is `skills/45-genesis-bootstrap/SKILL.md` — it is the step that PRECEDES this one on a fresh fork.
+- **Idempotency boundary with `45`**: `skills/45-genesis-bootstrap` runs THIS SAME `runEnrollmentCeremony`
+  plus fold-clean verify as its own final step — it is NOT merely roster-prep. If you followed `45` to
+  fold-clean completion, C3 is already satisfied: re-running the ceremony on identical pinned facts does
+  NOT fork the trust root (fold rule 9a). Verify the anchor already folded
+  (`foldLog(...) → accepted:[anchor], rejected:[], forks:[]`) and skip to C2/C4/C5. Run C3's ceremony here
+  ONLY if `45` was not run to completion (e.g. the owner roster entry was hand-authored without the
+  ceremony step). Exactly one of {`45`, C3} owns the ceremony run per fresh fork.
 
 The signed `genesis-anchor` lands in `.claude/learning/coordination-log.jsonl` (fold rule 9a accepts the
 first verifying owner-bound anchor as the trust root). The consumer-relevant operational gotchas an

--- a/.claude/skills/45-genesis-bootstrap/SKILL.md
+++ b/.claude/skills/45-genesis-bootstrap/SKILL.md
@@ -76,7 +76,9 @@ for them) and starts each session with `/onboard`.
 
 ## The bootstrap sequence
 
-1. **Hand-author the bootstrap roster** on the codify branch. The `/whoami --register` path
+1. **Hand-author the bootstrap roster** on the codify branch — signing key ALREADY configured
+   (pre-flight gate 1 precedes this whole sequence; this tracked-file write is permitted only
+   because signing is set). The `/whoami --register` path
    assumes an EXISTING roster; on a fresh repo the first roster is authored by hand. The genesis
    owner's entry MUST carry `role: owner`, the correct `github_login` (the verified external
    repo owner), and the signing key's `{type, fingerprint, pubkey}`. `person_id` is
@@ -86,7 +88,9 @@ for them) and starts each session with `/onboard`.
    `{ provider, repo_owner, repo_owner_kind: "user"|"org", root_commit }`.
 2. **Schema-validate** the roster BEFORE committing — `valid: false` is a hard stop:
    `.claude/hooks/lib/roster-schema-validate.js::validate(roster)` returns `{valid, errors[]}`.
-3. **Configure signing** (pre-flight gate 1) if not already done.
+3. **Re-confirm signing** is configured (pre-flight gate 1 checkpoint) — signing MUST already be
+   set from pre-flight before step 1's roster write; this is the verification checkpoint, NOT the
+   first configuration.
 4. **Run the ceremony** via `.claude/hooks/lib/genesis-ceremony.js::runEnrollmentCeremony(opts)`
    (signature at `genesis-ceremony.js`). `opts` keys:
    `{ roster, repo: {owner, name}, signingKeyPath, signingKeyFingerprint, ghApi,
@@ -94,6 +98,11 @@ transportAppend, keyType }`. `signingKeyPath` is the PRIVATE key; `ghApi` is a s
    wrapper around `gh api`; `transportAppend` is a sync append of the signed record to
    `.claude/learning/coordination-log.jsonl`. Returns `{ ok, error?, reason?, step? }`,
    fail-CLOSED. (The same path `/whoami --enroll-genesis` drives — see `commands/whoami.md`.)
+   **This ceremony IS `/ecosystem-init` C3.** Running `45` to fold-clean completion satisfies
+   C3 — the ceremony is idempotent on identical pinned facts (fold rule 9a), so a later
+   `/ecosystem-init` re-run does not fork the trust root; C3 verifies the already-folded anchor
+   and proceeds to the remaining config params. Exactly one of {`45`, `/ecosystem-init` C3} owns
+   the ceremony run per fresh fork.
 5. **Verify** (next section).
 
 The `genesis-anchor` lands in `.claude/learning/coordination-log.jsonl` (gitignored, per-clone

--- a/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md
+++ b/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md
@@ -1,0 +1,100 @@
+# /redteam — mops-onboarding independent re-convergence #6 — 2026-07-09
+
+Repo: `terrene-foundation/kailash-py` (PUBLIC distributable BUILD, ships UN-ENROLLED).
+Posture: **L5_DELEGATED** (fresh-repo default; `.claude/learning/` gitignored → reads fresh).
+Method: `/autonomize` + `/redteam` to convergence. **10 rounds, ~30 parallel adversarial agents**
+(waves of ~2–3, throttle-aware). Convergence at **0 CRIT / 0 HIGH / 0 MED across 2 consecutive
+clean rounds (R9 + R10)**. This suite is COC-artifacts (no code/tests/frontend); ground-truth
+verification against the actual hook/lib/schema source stands in for Criteria 4.
+
+## Outcome
+
+**CONVERGED. 9 working-tree files edited** (uncommitted — BUILD-repo commit gate; land via
+`/codify` → `codify/esperie-2026-07-09` → PR → admin-merge, the self-referential-codify Rule-1
+multi-agent gate already satisfied by these 10 rounds). Distributable invariant re-verified intact
+on committed HEAD AND after every edit: roster `PLACEHOLDER-owner`/`0000000`/gen 0 · 0/6
+coordination-enforcement hooks in committed `settings.json` · `probe-phase-guard` = 1 · 0 esperie
+tokens in committed roster · disclosure scanner exit 0 (1559 files).
+
+Files: `commands/{certify,claim,ecosystem-init,onboard,posture}.md` ·
+`skills/{41-onboard,42-certify,43-ecosystem-init,45-genesis-bootstrap}/SKILL.md`.
+
+## The headline find — a PRE-EXISTING certify coordination-ON write-surface conformance gap
+
+Prior convergences (#1–#5) validated the suite under the lenses they applied and never exercised
+`/certify`'s write surface against the **coordination-ON (enrolled) substrate** — because kailash-py
+itself ships coordination-OFF, where `integrity-guard` / `journal-write-guard` passthrough. This
+re-convergence walked that surface end-to-end and found `/certify` was never reconciled with the
+multi-operator write discipline. Resolved across R5–R8 to a complete, source-verified coverage of all
+8 certify writes:
+
+- **Pass + deferral journal entries** are codify-class `journal/` writes → now acquire a covering
+  `codify-lease` (`acquireCodifyLease({scopeFiles:["journal/"]})`) on a `codify/<display_id>-<date>`
+  branch (Step 1.5) and release it (Step 5). `["journal/"]` DIRECTORY scope is load-bearing —
+  `findCoveringLease` matches a trailing-slash-dir prefix; a bare filename does not, and
+  `MANDATORY_SCOPE` doesn't cover `journal/`.
+- **Deferral entry `type`** corrected `DEFER` → `DECISION` + `topic:"certify-defer-<id>"` — `DEFER`
+  is NOT in `journal-reserve.js::VALID_TYPES`, so the old contract failed the reservation closed.
+- **Brief `.pending/` receipts** moved OUT of the `journal/` subtree → `workspaces/_certify/.pending/`
+  (integrity-guard watches `^workspaces/<name>/journal/`; Phase-A receipts under `journal/` would halt
+  un-leased before any lease exists). They are ephemeral scratch, not codify-class entries.
+- Entry-gate corrected to the code-accurate model: `resolveIdentity` reads the **working-tree** roster,
+  so certify runs on the enrollment `codify/<id>-<date>` branch (roster row visible) OR after merge;
+  registration precedes certification; certification gates `/claim`.
+
+Verified against source: `integrity-guard.js` (watched subtrees + `findCoveringLease`), `codify-lease.js`
+(`acquireCodifyLease`/`releaseCodifyLease`/`MANDATORY_SCOPE`), `journal-reserve.js::VALID_TYPES`,
+`operator-id.js::resolveIdentity` (`_readJsonSafe` working-tree read), `validate-bash-command.js::STATE_PATH_RX`.
+
+## Findings + dispositions (by round)
+
+| Round | Finding(s)                                                                                                                                                        | Severity           | Disposition                                        |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| R1    | certify skill drops `validate-cert-bank.mjs` security scan + consent STOP (Phase 0 absent)                                                                        | HIGH               | Added Phase 0 to skill mirroring command Step 1    |
+| R1    | certify pass-receipt filename command↔skill drift; onboard PR-pending bounce; genesis double-run idempotency; 45 signing-order                                    | MED×3 + LOW        | Fixed all; command↔skill mirrored                  |
+| R2    | claim.md SAME-conflict handoff → nonexistent `/lease-override` + wrong `/release-claim` invocation; F2-fix stale DEFER mirror; length-caps/posture/step-2 wording | MED×2 + LOW×4      | Fixed                                              |
+| R3    | certify entry-gate just-enrolled sibling gap; certify exit next-steps contradiction; onboard ladder; claim.md phantom test citation                               | MED×2 + LOW×2      | Fixed                                              |
+| R4    | certify **lifecycle-model contradiction** (register-first vs certify-first) — traced to an R3 over-constraint; corrected to code-accurate working-tree model      | HIGH               | Fixed (reversed own R3 error with source evidence) |
+| R5    | certify pass-write **lease gap** (integrity-guard halts un-leased journal write under coordination-ON); certify.md:96 false "no coordination-log" claim           | HIGH + MED         | Added lease ceremony; corrected contract           |
+| R6    | lease-fix bugs: scope shape (`r.reservation.filename` ≠ `journal/`-prefixed candidate), branch over-claim, contract-table omission                                | HIGH + MED×2 + LOW | Corrected to `["journal/"]` scope + branch-ensure  |
+| R7    | abandon-path DEFER write lacked the lease ceremony (sibling gap); OFF fail-closed caveat; wrapper pointers                                                        | MED + LOW×2        | Fixed                                              |
+| R8    | brief `.pending/` receipts hit `workspaces/<name>/journal/` watch; DEFER `type` invalid                                                                           | HIGH×2             | Fixed (move receipts; DECISION+certify-defer)      |
+| R9    | **WRITE SURFACE FULLY COVERED — 0 gaps** (8-path table, source-verified); 2 non-blocking LOW                                                                      | CLEAN              | LOW-2 fixed; LOW-1 dispositioned                   |
+| R10   | certify pair SETTLED; suite CLEAN                                                                                                                                 | CLEAN              | —                                                  |
+
+### LOW dispositioned NOT-fixed (out of scope / rule-owner refinement)
+
+- **enrollment-operations.md MUST-3 categorical wording vs certify Step-2 inline `node -e`.** Step 2
+  (`reserveJournalSlotSigned`) is verified SAFE (the state path is internal to the helper, never on the
+  command line, so `STATE_PATH_RX`/`detectStateFileMutationSegmentAware` don't fire), and the skill
+  documents this. MUST-3's title reads categorically ("no `node -e` for watched-state mutation"); the
+  precise fix is to tighten MUST-3's wording ("…on the command line…") — a rule-authoring refinement
+  in a self-referential rule, out of this certify-focused convergence's scope. Noted for the
+  enrollment-operations owner.
+- **claim/release-claim/claims coordination-log writes** cite `coc-sign.js::sign` + filesystem-transport
+  rather than `coc-append.js`/`coc-emit.js` (M1-era 2026-05-2x commands, pre-coc-emit-consolidation).
+  Substantively satisfies `multi-operator-coordination.md` MUST-1 (stamped/chained/signed); helper-naming
+  drift only, outside this suite's changed surface. Noted for a future coc-emit-alignment sweep.
+
+## Convergence criteria
+
+1. 0 CRITICAL ✓ · 2. 0 HIGH ✓ · 3. 2 consecutive clean rounds ✓ (R9 + R10 both 0 CRIT/HIGH/MED) ·
+2. claim/citation compliance ground-truth-verified against actual hook/lib/schema source (8-path
+   write-surface coverage table + ~18 citation spot-checks + command↔skill parity) · 5–7. N/A
+   (COC-artifact suite — no new code modules / frontend; probe-phase-guard ships committed audit fixtures).
+
+## KEY institutional lessons (candidates for /codify)
+
+- **A command's write surface must be reconciled with the coordination-ON substrate, not only its
+  coordination-OFF passthrough.** `/certify` was validated 5× in a coordination-OFF repo where every
+  integrity-guard / journal-write-guard / codify-lease gate passes through; its journal writes were never
+  exercised against the enrolled substrate they ship into. The full write-surface enumeration (every
+  filesystem/state write × every guard, under coordination-ON) is the lens that closes this class — and
+  it must be run to COMPLETION per-round (the "one sibling gap per round" pattern is the tell that the
+  enumeration was partial).
+- **A fix on one execution path implies the sibling paths.** Pass-path lease → abandon-path lease;
+  pass-entry type → brief-receipt path + deferral type. `command-skill-parity` + multi-site-plumbing,
+  generalized to "same-surface writes get the same treatment."
+- **The code is the authority for a lifecycle claim.** The R3→R4 entry-gate error (over-constraining to
+  "await merge") was corrected only by reading `resolveIdentity`'s working-tree roster read — an artifact
+  claiming you can't do what the code permits is a spec-accuracy defect.

--- a/workspaces/mops-onboarding/journal/0034-DECISION-codify-reconvergence6-certify-coordination-on-conformance.md
+++ b/workspaces/mops-onboarding/journal/0034-DECISION-codify-reconvergence6-certify-coordination-on-conformance.md
@@ -1,0 +1,64 @@
+---
+type: DECISION
+date: 2026-07-09
+slug: codify-reconvergence6-certify-coordination-on-conformance
+relates_to: 0033-DECISION-codify-command-skill-parity-rule
+---
+
+# DECISION — /codify re-convergence #6: land certify coordination-ON write-surface conformance + BUILD→loom proposal
+
+Re-convergence #6 (`/autonomize` + `/redteam`, 10 rounds, ~30 parallel adversarial agents; converged
+0 CRIT/0 HIGH/0 MED across 2 consecutive clean rounds R9+R10) is codified and landed. Full report:
+`workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md`.
+
+## What was landed (9 artifact files, this codify branch `codify/esperie-2026-07-09`)
+
+`commands/{certify,claim,ecosystem-init,onboard,posture}.md` +
+`skills/{41-onboard,42-certify,43-ecosystem-init,45-genesis-bootstrap}/SKILL.md`.
+
+**The headline — a PRE-EXISTING gap #1–#5 all missed.** kailash-py ships coordination-OFF, so
+`integrity-guard` / `journal-write-guard` / `codify-lease` passthrough. Every prior convergence
+validated `/certify` in that passthrough regime and never exercised the **coordination-ON (enrolled)
+substrate the artifact ships into**. Walking the certify write surface end-to-end (R5–R8) found +
+fixed, to source-verified full coverage of all 8 certify writes:
+
+- Pass + deferral `journal/` entries now acquire/release a covering **codify-lease** on a
+  `codify/<id>-<date>` branch (skill Steps 1.5/5), scope `["journal/"]` (DIRECTORY scope load-bearing:
+  `findCoveringLease` matches trailing-slash-dir prefix; a bare filename does not; `MANDATORY_SCOPE`
+  excludes `journal/`).
+- Deferral entry type `DEFER`→`DECISION` + `topic: certify-defer-<id>` (`DEFER` ∉
+  `journal-reserve.js::VALID_TYPES` → old contract failed the reservation closed).
+- Brief `.pending/` receipts moved OUT of `journal/` → `workspaces/_certify/.pending/`
+  (`integrity-guard` watches `^workspaces/<name>/journal/`).
+- Entry gate corrected to the code-accurate model (`resolveIdentity` reads the WORKING-TREE roster →
+  certify runs on the enrollment branch OR after merge; registration precedes certification;
+  certification gates `/claim`). An R3 over-constraint ("await merge, branch not enough") was reversed
+  in R4 with source evidence.
+
+Plus R1–R4 command↔skill + lifecycle fixes: certify Phase-0 (`validate-cert-bank.mjs` + consent STOP)
+added to the skill (a security-scan drop on the skill-followed path); claim.md SAME-conflict dead-end
+(nonexistent `/lease-override` + a `/release-claim` invocation its own bind-check rejects) →
+sibling-self-release/reap; onboard + certify just-enrolled PR-pending branch; genesis double-run
+idempotency; posture.md self-contradiction; claim.md phantom test citation.
+
+## Routing (COC-artifact change → BUILD→loom, NOT cross-SDK issue)
+
+Per `artifact-flow.md` + the #5 precedent (journal/0031): these are COC-artifact changes → the
+BUILD→loom proposal (`latest.yaml`, entry `onboarding-suite-certify-coordination-on-conformance`,
+flagged security-relevant + highest cross-SDK priority) IS the propagation path. loom Gate-1 +
+`/sync-to-use` redistribute the corrected suite to the Rust SDK + downstream. Do NOT file a
+cross-SDK BUILD issue (wrong lane).
+
+## Deliberately NOT fixed (out of scope — next session, per user directive)
+
+- `enrollment-operations.md` MUST-3 categorical wording vs certify Step-2 safe-inline `node -e`
+  (the fix is to tighten MUST-3 to "…on the command line…" — a self-referential rule refinement).
+- `claim`/`release-claim`/`claims` M1-era coordination-log writes cite `coc-sign`+transport not
+  `coc-append`/`coc-emit` (helper-naming drift, substantively MUST-1-compliant).
+
+## Distributable invariant — re-verified GREEN (committed HEAD + after every edit)
+
+roster PLACEHOLDER-owner/0000000/gen 0 · 0/6 coordination-enforcement hooks in committed
+settings.json · probe-phase-guard=1 · 0 esperie tokens in committed roster · disclosure exit 0
+(1559 files). The 9 edits are all prose in `commands/` + `skills/`; none touch settings.json, roster,
+or posture. The repo continues to ship un-enrolled, distributable-safe.

--- a/workspaces/mops-onboarding/journal/0035-DISCOVERY-validate-write-surface-against-coordination-on-substrate.md
+++ b/workspaces/mops-onboarding/journal/0035-DISCOVERY-validate-write-surface-against-coordination-on-substrate.md
@@ -1,0 +1,51 @@
+---
+type: DISCOVERY
+date: 2026-07-09
+slug: validate-write-surface-against-coordination-on-substrate
+relates_to: 0034-DECISION-codify-reconvergence6-certify-coordination-on-conformance
+---
+
+# DISCOVERY — validate a command's write surface against the coordination-ON substrate it ships into
+
+Three institutional patterns surfaced in re-convergence #6 that the next session (and any `/redteam`
+of a command that writes state) should inherit.
+
+## 1. A passthrough regime hides a whole conformance class
+
+kailash-py ships coordination-OFF: `integrity-guard`, `journal-write-guard`, `signing-mutation-guard`,
+and the `codify-lease` gate ALL early-`passthrough()` when `!isCoordinationEnabled`. `/certify` was
+validated FIVE times in that regime and every gate its journal writes must clear was dormant — so a
+whole class of defects (writes that halt under the enrolled substrate) was structurally invisible.
+The suite is DISTRIBUTED into enrolled (coordination-ON) repos, where those gates fire.
+
+**Lesson:** when a command WRITES state and is distributed to repos that may run coordination-ON, the
+`/redteam` MUST enumerate **every filesystem/state write × every guard, under coordination-ON**, not
+only the passthrough mode the authoring repo happens to run. Verify against the actual hook source
+(`integrity-guard.js` watched-subtrees + `findCoveringLease`, `journal-reserve.js::VALID_TYPES`,
+`codify-lease.js::MANDATORY_SCOPE`, `validate-bash-command.js::STATE_PATH_RX`). Produce the full
+per-write coverage table and run it to COMPLETION each round — the "one sibling gap surfaced per
+round" pattern (4 straight rounds here) is the tell that the enumeration was PARTIAL.
+
+## 2. A fix on one execution path implies its sibling paths
+
+Every certify fix had a sibling the first pass missed: pass-path lease → abandon-path lease;
+pass-entry type validity → brief-receipt path + deferral type; entry-gate message → failure-mode
+message. This is `command-skill-parity` + `security.md` multi-site-kwarg-plumbing generalized to
+**"same-surface writes get the same treatment."** When you harden one write, grep for every sibling
+write on the same surface and harden all of them in the same shard.
+
+## 3. The code is the authority for a lifecycle claim
+
+The R3→R4 entry-gate error over-constrained certify ("await your enrollment PR merge; staying on your
+branch is not enough"). It was corrected only by reading `operator-id.js::resolveIdentity` —
+`_readJsonSafe(rosterPath)` reads the WORKING-TREE roster, so the roster row IS visible on the
+enrollment branch and certify CAN run there. An artifact that claims you cannot do what the code
+permits is a `spec-accuracy` defect. When a lifecycle/ordering claim is uncertain, the enforcement
+code — not the artifact's prior prose, not a plausible mental model — is the authority.
+
+## Method note (for the /redteam that finds this class)
+
+The lens that finally closed it (R9) was a dedicated agent producing the EXHAUSTIVE per-write ×
+per-guard coverage table with source citations, prompted explicitly to "not stop at the first gap —
+enumerate ALL of them." Partial enumeration is why it took 4 rounds; the complete table is what
+broke the pattern.


### PR DESCRIPTION
## Summary

Onboarding-suite re-convergence #6 (`/autonomize` + `/redteam`, 10 rounds, ~30 parallel adversarial agents; converged **0 CRIT / 0 HIGH / 0 MED across 2 consecutive clean rounds**). Lands 9 COC-artifact fixes + a BUILD→loom proposal for cross-SDK distribution.

**Headline — a pre-existing gap #1–#5 all missed.** kailash-py ships coordination-OFF, so `integrity-guard` / `journal-write-guard` / `codify-lease` passthrough; every prior convergence validated `/certify` in that passthrough regime and never exercised the **coordination-ON (enrolled) substrate the suite ships into**. Walking the full certify write surface (source-verified against the actual hooks) fixed all 8 write paths:

- Pass + deferral `journal/` entries now acquire/release a covering **codify-lease** on a `codify/<id>-<date>` branch (skill Steps 1.5/5), scope `["journal/"]` (directory scope is load-bearing — `findCoveringLease` matches trailing-slash-dir; `MANDATORY_SCOPE` excludes `journal/`).
- Deferral entry `type` `DEFER`→`DECISION` + `topic: certify-defer-<id>` (`DEFER` ∉ `journal-reserve.js::VALID_TYPES` → old contract failed the reservation closed).
- Brief `.pending/` receipts moved OUT of `journal/` → `workspaces/_certify/.pending/` (`integrity-guard` watches `^workspaces/<name>/journal/`).
- Entry gate corrected to the code-accurate model (`resolveIdentity` reads the working-tree roster → certify on the enrollment branch OR after merge; registration precedes certification; certification gates `/claim`).

Plus R1–R4 command↔skill + lifecycle fixes: certify Phase-0 (`validate-cert-bank.mjs` security scan + consent STOP) added to the skill (a security-scan drop on the skill-followed path); `claim.md` SAME-conflict dead-end (nonexistent `/lease-override` + a `/release-claim` invocation its own bind-check rejects) → sibling-self-release/reap; onboard + certify just-enrolled PR-pending branch; genesis double-run idempotency; `posture.md` self-contradiction; `claim.md` phantom test citation.

## Distributable invariant — re-verified intact

roster `PLACEHOLDER-owner`/`0000000`/gen 0 · 0/6 coordination-enforcement hooks in committed `settings.json` · `probe-phase-guard` = 1 · 0 operator tokens in committed roster · disclosure scan exit 0. All 9 edits are prose in `commands/` + `skills/`; the repo continues to ship un-enrolled.

## Gate

Self-referential-codify Rule 1 multi-agent gate satisfied by the 10 redteam rounds (reviewer + security-reviewer + cc-architect lenses; R9 write-surface coverage agent returned "FULLY COVERED — 0 gaps"; R10 fully clean). Two items deliberately deferred out-of-scope (flagged for loom/rule-owner + next session): `enrollment-operations.md` MUST-3 wording; `claim`/`release-claim` M1-era `coc-append` helper-naming drift.

## Related

Receipt: `workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md` · journal 0034/0035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)