### PR TITLE
fix(coc): enrollment-operations MUST-3 guard-mechanics accuracy (re-convergence #7)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -897,3 +897,47 @@ changes:
       line…"); claim/release-claim/claims M1-era coordination-log writes cite coc-sign+transport not
       coc-append/coc-emit (helper-naming drift, substantively MUST-1-compliant). Receipt:
       workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence6.md.
+  - type: rule_update
+    artifact: enrollment-operations
+    files:
+      - .claude/rules/enrollment-operations.md
+      - .claude/skills/45-genesis-bootstrap/SKILL.md
+    classification_suggestion: global
+    context:
+      'Follow-on to the onboarding-suite proposal above: closes the TWO items the 2026-07-09
+      re-convergence #6 flagged as deferred-for-loom (see this codify_session tail).
+
+
+      F1 (FIXED — enrollment-operations.md MUST-3 + genesis-bootstrap skill): the categorical wording
+      ("no inline node -e for watched-state mutation") over-claimed against the actual guard and
+      falsely flagged /certify Step 2''s SAFE inline reserveJournalSlotSigned(...) call. Ground-truth
+      verification of detectStateFileMutation (violation-patterns.js) + STATE_PATH_RX
+      (validate-bash-command.js:456) established the real enforced invariant: the guard fires ONLY on
+      a STATE_PATH_RX literal on the command line, and it is READ/WRITE-AGNOSTIC (a path-presence
+      detector, not mutation-aware — an inline READ naming a watched path is blocked too). MUST-3
+      rewritten to state that precisely: script-by-path for authored mutations; a delegated
+      signed-emit helper (reserveJournalSlotSigned / emitSignedRecord routing through
+      coc-emit.js::emitSignedRecord per multi-operator-coordination.md MUST-1, path internal)
+      PERMITTED inline; a raw-fs wrapper / concat-path / arg-supplied appendStamped all BLOCKED or
+      script-by-path (the last matching 42-certify Step 4). "Owns the write internally" made
+      NECESSARY-BUT-NOT-SUFFICIENT (a wrapper hiding a raw fs.writeFileSync is not a signed-emit
+      helper). Same read/write-agnostic accuracy propagated to the cross-referenced depth-file
+      45-genesis-bootstrap/SKILL.md (4 write-only-framing instances corrected) + a phantom whoami.md
+      cross-reference fixed.
+
+
+      F2 (REFUTED — no edit): the proposed "align claim/release-claim/claims coordination-log write
+      citations to coc-emit/coc-append" is refuted by the runtime — emitSignedRecord serves NO
+      claim/release/reap record; the actual claim-writer adjacency-leasecheck.js::autoClaim +
+      reap-ceremony.js still use coc-sign.js::sign + transport-filesystem.js; coc-append.js is the
+      observations/violations helper. The commands are ACCURATE to the code; editing them would
+      introduce a NEW command<->code divergence (spec-accuracy per journal/0035 §3). Left unchanged.
+
+
+      Converged via 7-round multi-agent redteam-with-tests (reviewer + security-reviewer +
+      cc-architect; self-referential-codify.md MUST-1 gate — enrollment-operations.md is
+      allowlisted). Distributable invariant re-verified GREEN after every edit (roster PLACEHOLDER,
+      0/6 enforcement hooks committed, probe-phase-guard=1, disclosure scanner exit 0). Accepted
+      non-blocking: the MUST-3 SAFE-helper paragraph over-density — candidate for extraction to
+      45-genesis-bootstrap in the canonical loom pass. Receipt:
+      workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence7.md.'

--- a/.claude/rules/enrollment-operations.md
+++ b/.claude/rules/enrollment-operations.md
@@ -86,32 +86,76 @@ editing on main first is harmless."
 (branch + signer + scope); a write off it bypasses the concurrency + provenance substrate, and a
 suffixed branch name silently disagrees with the guard about what a codify branch IS.
 
-### 3. Ceremony State-Mutations Run Script-By-Path, Never An Inline Interpreter Body
+### 3. Ceremony State-Mutations Keep The Watched-State Path Off The Mutating Command Line
 
-Any ceremony step that MUTATES a watched state file MUST run as a bare `node <file>` (a script
-authored to disk, then run by path) — NOT a `node -e` / `python -c` body.
-`validate-bash-command.js`'s `detectStateFileMutationSegmentAware` guard (the segment-aware wrapper
-from `violation-patterns.js`) blocks interpreter (`-c`/`-e`/`-m`), redirect,
-and file-utility bodies that write a path matching `STATE_PATH_RX` (the watched state files); a
-`node <file>` keeps that path in the script body, off the scanned command line (mechanics in
-`skills/45-genesis-bootstrap` § The script-by-path pattern). Inlining the mutation is BLOCKED.
+Any ceremony step that RAW-MUTATES a watched state file — an inline `node -e` / `python -c`
+body, a redirect, or a file-utility (`cp`/`mv`/`tee`/`sed -i`) — MUST NOT put the
+`STATE_PATH_RX` write on the bash command line. The satisfying pattern for an AUTHORED mutation
+is script-by-path: a bare `node <file>` (a script authored to disk, then run by path) keeps the
+watched path in the script body, off the scanned command line (mechanics in
+`skills/45-genesis-bootstrap` § The script-by-path pattern).
+`validate-bash-command.js`'s `detectStateFileMutationSegmentAware` guard (the segment-aware
+wrapper from `violation-patterns.js`) fires on EXACTLY this — it blocks an interpreter
+(`-c`/`-e`/`-m`), redirect, or file-utility body ONLY when a path matching `STATE_PATH_RX` (the
+watched state files) appears as a literal on the command line (each layer requires a
+`STATE_PATH_RX` match on the command line — or a redirect target — before it fires). A raw
+inline mutation that puts the watched-state path on the command line is BLOCKED — including a path
+assembled by string concatenation to dodge the literal match (a raw inline write of a watched
+state file is BLOCKED regardless of how its path is spelled; the guard's literal-match is
+defense-in-depth, not the whole contract).
+
+**SAFE — a signed-emit helper call is NOT a raw inline mutation, but only a specific shape
+qualifies.** An inline `node -e` is PERMITTED only when BOTH hold: (a) no `STATE_PATH_RX` literal
+appears in the call's command-line arguments, AND (b) the write is DELEGATED to a signed-emit
+helper that routes its watched-path write through `coc-emit.js::emitSignedRecord`, enforcing the
+stamp / chain / sign contract (`multi-operator-coordination.md` MUST-1). Two of the ceremony's
+signed-emit helpers satisfy both (condition (b) is the governing test, not this list):
+`reserveJournalSlotSigned` (builds the coordination-log path INTERNALLY, routes through
+`emitSignedRecord`) and `emitSignedRecord` itself (opts-only; the path is derived from
+`opts.repoDir`) — this is how `/certify` Step 2 reserves its journal slot inline
+(`reserveJournalSlotSigned(process.cwd(), {...})`). "Owns the write internally" is NECESSARY BUT
+NOT SUFFICIENT: a function hiding a raw `fs.writeFileSync` of a watched path is NOT a signed-emit
+helper (it does not enforce MUST-1) and is BLOCKED exactly like the concat-evasion above; and a
+helper whose SIGNATURE takes the watched path as an ARGUMENT — e.g.
+`appendStamped(repoDir, filePath, …)` (`coc-append.js`, the observations/violations stamped-append
+helper) — puts the literal on the command line, DOES trip the guard, and MUST be script-by-path
+(`skills/42-certify/SKILL.md` Step 4). The MUST targets a RAW inline write OR an arg-supplied
+watched path; it does NOT license every helper call — while a categorical "no inline interpreter
+body" would over-block the safe `reserveJournalSlotSigned` case.
 
 ```bash
 # DO — author the script, run it bare; the watched path is in the file body
 node /tmp/scratch/ceremony-step.js
 
-# DO NOT — inline interpreter body that writes a watched state file
+# DO — inline SIGNED-EMIT helper; the watched path is INTERNAL to the helper (guard passes)
+node -e 'require("./.claude/hooks/lib/journal-reserve.js").reserveJournalSlotSigned(process.cwd(), {dir, identity, type, topic})'
+
+# DO NOT — raw inline body writing a watched-state-path LITERAL on the command line
 node -e 'require("fs").writeFileSync(".claude/operators.roster.json", x)'    # severity: block
 python3 -c 'open(".claude/learning/coordination-log.jsonl","a").write(rec)'  # severity: block
+
+# DO NOT — helper whose signature carries the watched path as an ARGUMENT (literal reaches the line)
+node -e 'require("./.claude/hooks/lib/coc-append.js").appendStamped(cwd, ".claude/learning/violations.jsonl", rec, {})'  # severity: block → use script-by-path
 ```
 
-**BLOCKED rationalizations:** "one-liner is faster" / "the guard flags read-only node too" (it
-does not — only state-file mutation) / "I'll disable the bash guard for the ceremony" / "bundling
-node with the gh call in one command is tidier" (re-introduces a scanned token).
+**BLOCKED rationalizations:** "one-liner is faster" / "my read of the log is fine inline" (WRONG —
+the guard is read/write-AGNOSTIC: it fires on ANY interpreter `-c`/`-e`/`-m` body that names a
+watched-state-path LITERAL on the command line, read OR write; run even READS script-by-path, as
+MUST-4 does) / "I'll disable the bash
+guard for the ceremony" / "bundling node with the gh call in one command is tidier" (re-introduces
+a scanned token) / "I'll build the watched path by string concat so the literal never matches" (a
+raw inline write of a watched state file is BLOCKED regardless — use script-by-path or a
+signed-emit helper) / "it's a helper call, so it's blessed" (only a signed-emit helper that keeps
+the watched path off the command line qualifies — a helper taking the path as an argument, or one
+hiding a raw `fs` write, does not).
 
 **Why:** The guard closes the bypass where `permissions.deny` on Edit/Write does not cover
-bash-mediated mutations; script-by-path satisfies it WITHOUT weakening it, and keeping
-`node <file>` a bare command keeps the scanned command line clean.
+bash-mediated mutations; the guard-enforced invariant is "no watched-state-path LITERAL on the
+command line (read OR write)." Script-by-path (authored mutation, or even a read of the log) and a
+signed-emit helper that keeps the path internal (delegated mutation) both satisfy it; a categorical
+"no inline interpreter body" over-claims and
+falsely flags `/certify`'s safe `reserveJournalSlotSigned` call, while an unqualified "any helper
+is fine" under-claims and licenses an arg-supplied `appendStamped` the guard blocks.
 
 ### 4. Verify The Genesis Folds Clean Before Declaring "Enrolled"
 
@@ -278,7 +322,7 @@ by a clone). A lockfile-gated hook like `probe-phase-guard.js` (fires only durin
 consumer's `/certify` no-assist gate has structural teeth.
 
 **Length rationale (per `rule-authoring.md` MUST NOT § "Rules longer than 200 lines").** File is
-~290 lines (per `wc -l`), over the 200 guidance. Named rationale: **guard-trap scope** — the rule
+~335 lines (per `wc -l`), over the 200 guidance. Named rationale: **guard-trap scope** — the rule
 codifies SIX MUST clauses — three fail-closed boundary guards (MUST 1/2/3) + three gate-review
 clauses (MUST 4/5/6), consistent with § "Violation scope" above — each requiring the
 DO / DO NOT + BLOCKED-corpus + `**Why:**` structure `rule-authoring.md` Rules 2/3/4 mandate, plus

--- a/.claude/skills/45-genesis-bootstrap/SKILL.md
+++ b/.claude/skills/45-genesis-bootstrap/SKILL.md
@@ -136,12 +136,14 @@ person whose `github_login` resolves to that login, bound to the signing key's f
 segment-aware wrapper from `violation-patterns.js`) on every
 Bash command — a three-layer detector (its docstring at `validate-bash-command.js`:
 "redirects, file utilities, **interpreter -c/-e/-m bodies**") that BLOCKS (severity: block) any
-command whose body MUTATES a watched state file. `STATE_PATH_RX` matches `posture.json`,
+command that puts a watched-state-path LITERAL on the scanned command line (read OR write — it is
+path-presence-based, not mutation-aware). `STATE_PATH_RX` matches `posture.json`,
 `violations.jsonl`, `coordination-log.jsonl`, `.initialized`, the heartbeat/session-end caches,
-and `operators.roster.json`. So a `node -e '…fs.writeFileSync(".claude/operators.roster.json"…)'`
-roster write is blocked — the state-file path is on the command line the detector scans. (This
-is why the illustrative `node -e` in `commands/whoami.md` § `--register` is blocked in practice;
-that command's "Implementation notes" name the "ceremony-script-by-path constraint.")
+and `operators.roster.json` (among others). So a `node -e '…fs.writeFileSync(".claude/operators.roster.json"…)'`
+roster write is blocked — the state-file path is on the command line the detector scans. (This is
+why `commands/whoami.md` § `--register` uses the script-by-path `cat > …cjs` + `node <file>` form
+rather than an inline `node -e`; that command's "Implementation notes" name the
+"ceremony-script-by-path constraint.")
 
 The fix is NOT to weaken the guard. Route every state-mutating ceremony step through a script:
 
@@ -156,8 +158,10 @@ node -e 'require("fs").writeFileSync(".claude/operators.roster.json", x)'   # BL
 ```
 
 Keep `node <file>` a BARE command — bundling it with `gh …` or a heredoc in one compound
-command can re-introduce a scanned mutation token. Read-only `node -e` (no watched-state path)
-is NOT blocked; only state-file mutation is.
+command can re-introduce a scanned mutation token. An inline `node -e` naming NO watched-state
+path is not blocked; but the guard is read/write-AGNOSTIC — it fires on ANY interpreter body that
+names a watched-state-path LITERAL on the command line, read OR write (so run even a READ of the
+log script-by-path — see Verify below).
 
 ## Verify (before declaring "enrolled")
 

--- a/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence7.md
+++ b/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence7.md
@@ -1,0 +1,106 @@
+# /redteam — mops-onboarding re-convergence #7 (F1 + F2 outstanding-ledger closure) — 2026-07-09
+
+Repo: `terrene-foundation/kailash-py` (PUBLIC distributable BUILD, ships UN-ENROLLED).
+Posture: **L5_DELEGATED** (fresh-repo default; `.claude/learning/` gitignored → reads fresh).
+Method: `/autonomize` + `/redteam` to convergence. Scope: the F1/F2 items deferred as non-blocking
+LOWs in re-convergence #6 (`redteam-2026-07-09-reconvergence6.md` § "LOW dispositioned NOT-fixed").
+**7 rounds, 18 adversarial agent-passes** (waves of ~3, throttle-aware). This is a COC-artifact
+suite (no code/tests/frontend) — Criteria-4 stand-in is ground-truth verification against the
+actual hook/lib source.
+
+## Outcome
+
+**CONVERGED. 2 working-tree files edited** (uncommitted — BUILD-repo commit gate; land via
+`/codify` → `codify/esperie-2026-07-09` → PR → admin-merge + a BUILD→loom proposal for cross-SDK
+distribution). Distributable invariant re-verified GREEN on committed HEAD after every edit: roster
+`PLACEHOLDER-owner`/`0000000`/gen 0 · 0/6 coordination-enforcement hooks in committed
+`settings.json` · `probe-phase-guard` = 1 · disclosure scanner exit 0 (1559 files).
+
+Files: `.claude/rules/enrollment-operations.md` (MUST-3) · `.claude/skills/45-genesis-bootstrap/SKILL.md`
+(§ script-by-path).
+
+## The two outstanding items — dispositions
+
+### F1 — enrollment-operations.md MUST-3 categorical wording (FIXED)
+
+The #6 LOW noted MUST-3's title/opening read categorically ("no inline `node -e` for watched-state
+mutation"), which falsely flagged `/certify` Step 2's SAFE inline `reserveJournalSlotSigned(...)`
+call. Ground-truth verification of the guard (`detectStateFileMutation` in `violation-patterns.js`
+
+- `STATE_PATH_RX` in `validate-bash-command.js:456`) established the real enforced invariant:
+  **the guard fires ONLY when a `STATE_PATH_RX` literal appears on the command line — and it is
+  read/write-AGNOSTIC (a path-presence detector, not mutation-aware)**. MUST-3 was rewritten to state
+  that invariant precisely:
+
+* The satisfying pattern for an authored mutation is script-by-path (path off the command line).
+* A delegated **signed-emit** helper (`reserveJournalSlotSigned` / `emitSignedRecord`) that routes
+  its watched-path write through `coc-emit.js::emitSignedRecord` (enforcing
+  `multi-operator-coordination.md` MUST-1) and keeps the path INTERNAL is PERMITTED inline — this is
+  the `/certify` Step-2 case the categorical wording wrongly flagged.
+* "Owns the write internally" is NECESSARY BUT NOT SUFFICIENT: a wrapper hiding a raw
+  `fs.writeFileSync`, a concat-assembled path, and a helper taking the watched path as an ARGUMENT
+  (`appendStamped(repoDir, filePath, …)`) are all BLOCKED / script-by-path — the last matching
+  `skills/42-certify/SKILL.md` Step 4.
+
+The same read/write-agnostic accuracy was propagated to the cross-referenced depth-file
+`skills/45-genesis-bootstrap/SKILL.md` (four instances of the write-only framing corrected), and a
+phantom cross-reference (an "illustrative `node -e` in whoami.md" that does not exist) was corrected
+to describe whoami.md's actual script-by-path form.
+
+### F2 — claim/release-claim/claims helper-naming "drift" (REFUTED — no edit)
+
+The #6 LOW proposed aligning the `/claim`,`/release-claim`,`/claims` commands' coordination-log
+write citations (`coc-sign.js::sign` + `transport-filesystem.js`) to the consolidated
+`coc-emit.js::emitSignedRecord`. Ground-truth verification REFUTES the premise:
+
+- `emitSignedRecord` serves NONE of the claim/release/reap record types (only journal-slot /
+  codify-lease / capability-ledger / membership records).
+- The actual claim-writer `adjacency-leasecheck.js::autoClaim` STILL builds the record inline, signs
+  via `coc-sign.js::sign`, and appends via `transport-filesystem.js::appendRecord`; `reap-ceremony.js`
+  signs via `coc-sign.js`. `coc-append.js::appendStamped` is the observations/violations helper, NOT
+  the coordination-log write path.
+
+The commands are **accurate to the runtime**. Editing them to cite `emitSignedRecord` would introduce
+a NEW command↔code divergence (a `spec-accuracy` defect per journal/0035 §3 "the code is the
+authority"). Disposition: **no edit**. (Independently confirmed by all three R1 agents + R3/R7.)
+
+## Findings + dispositions (by round)
+
+| Round | Finding(s)                                                                                                                    | Severity | Disposition                                                                                                 |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| R1    | carve-out over-reach: `appendStamped` (arg-path) wrongly listed as inline-safe; "blessed" defined by porous "owns internally" | HIGH×2   | Narrowed to signed-emit pair; `appendStamped` → counter-example; "blessed"=routes-through-emitSignedRecord  |
+| R2    | consolidated fix verified                                                                                                     | CLEAN    | —                                                                                                           |
+| R3    | MUST-3 BLOCKED parenthetical "guard flags read-only node (it does not)" factually wrong — guard is read/write-agnostic        | MED      | Corrected to read/write-AGNOSTIC                                                                            |
+| R4    | 2 same-class residuals: MUST-3 `**Why:**` invariant ("no…write") + depth-file "only state-file mutation is [blocked]"         | MED×2    | Both corrected; a 4th instance (skill guard-desc "MUTATES") found by orchestrator sweep + fixed             |
+| R5    | read/write class verified fully closed across both files                                                                      | CLEAN    | —                                                                                                           |
+| R6    | phantom citation: skill claims an "illustrative `node -e` in whoami.md" that does not exist                                   | LOW      | Reworded to whoami.md's actual script-by-path form; R5 partial-enumeration LOW closed with "(among others)" |
+| R7    | definitive exhaustive audit — every claim + cross-ref grep-verified accurate                                                  | CLEAN    | Convergence confirmed                                                                                       |
+
+## Convergence criteria
+
+1. 0 CRITICAL ✓ · 2. 0 HIGH ✓ (since R2) · 3. clean R5 (full 3-agent) + clean R7 (reviewer + security)
+   bracketing a single fixed LOW at R6 (per re-convergence #6 precedent, non-blocking LOWs do not break
+   a clean round; the R6 LOW was additionally fixed and R7 confirms the fix introduced nothing new) ·
+2. every guard-mechanics claim + every cross-reference ground-truth-verified against
+   `violation-patterns.js` / `validate-bash-command.js` / `journal-reserve.js` / `coc-emit.js` /
+   `coc-append.js` / `whoami.md` / `42-certify` · 5–7. N/A (COC-artifact suite).
+
+## Accepted non-blocking (documented; NOT convergence-blocking)
+
+- **MUST-3 over-density** — the SAFE-helper qualification paragraph is dense (~18 lines). Load-bearing
+  (it closes a genuine over-block AND under-block); the structural extraction of the helper-qualification
+  depth to `skills/45-genesis-bootstrap` is best done in the canonical loom pass, alongside any future
+  `/codify` that touches this rule. Path-scoped rule → no baseline-emission cost.
+
+## KEY institutional lessons (candidates for /codify)
+
+- **A guard's DESCRIPTION must match its DETECTION mechanism, not its NAME or PURPOSE.** The detector is
+  named `detectStateFileMutation` and exists to block state MUTATIONS, but it is a path-presence
+  detector — read/write-agnostic. Four separate artifact sentences described it as mutation-only; the
+  cascade closed only when the enumeration was run to completion across BOTH the rule and its depth-file
+  (journal/0035 method note confirmed again: partial enumeration is why it took R3→R6).
+- **"The code is the authority" refutes a queued finding, not just a lifecycle claim.** F2 was a queued
+  "drift" item whose premise dissolved on reading the actual claim-writer — the correct action was NO
+  edit, preventing a new divergence.
+- **A carve-out fence must be a verifiable property, not a circular one.** "Owns the write internally"
+  is satisfied by a malicious wrapper; "routes through `emitSignedRecord` (MUST-1)" is code-inspectable.

--- a/workspaces/mops-onboarding/journal/0036-AMENDMENT-reconvergence7-must3-readwrite-accuracy-f2-refutation.md
+++ b/workspaces/mops-onboarding/journal/0036-AMENDMENT-reconvergence7-must3-readwrite-accuracy-f2-refutation.md
@@ -1,0 +1,51 @@
+---
+type: AMENDMENT
+date: 2026-07-09
+slug: reconvergence7-must3-readwrite-accuracy-f2-refutation
+relates_to: 0034-DECISION-codify-reconvergence6-certify-coordination-on-conformance
+---
+
+# AMENDMENT — re-convergence #7 closes the #6 outstanding ledger (F1 fixed, F2 refuted)
+
+Re-convergence #6 (journal/0034) deferred two items as non-blocking LOWs "noted for the owner /
+a future sweep." This session (`/autonomize` + `/redteam`, 7 rounds, 18 adversarial agent-passes)
+took both to disposition. Full report:
+`workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence7.md`.
+
+## F1 — `enrollment-operations.md` MUST-3 wording (FIXED)
+
+MUST-3 read categorically ("no inline `node -e` for watched-state mutation"), which falsely
+flagged `/certify` Step 2's SAFE inline `reserveJournalSlotSigned(...)` call. Ground-truth
+verification of the guard (`detectStateFileMutation` + `STATE_PATH_RX`) established the real
+invariant: the guard fires ONLY on a `STATE_PATH_RX` literal on the command line, and it is
+**read/write-AGNOSTIC (a path-presence detector, not mutation-aware)**. MUST-3 now states that
+precisely: script-by-path for authored mutations; a delegated **signed-emit** helper
+(`reserveJournalSlotSigned` / `emitSignedRecord`, routing through `coc-emit.js::emitSignedRecord`
+per `multi-operator-coordination.md` MUST-1) permitted inline; a raw-`fs` wrapper / concat-path /
+arg-supplied `appendStamped` all BLOCKED. The same read/write-agnostic accuracy was propagated to
+the cross-referenced depth-file `skills/45-genesis-bootstrap/SKILL.md` (four write-only-framing
+instances corrected) and a phantom whoami.md cross-reference was corrected.
+
+## F2 — claim/release-claim/claims helper citations (REFUTED — no edit)
+
+The proposed "align to `coc-emit`/`coc-append`" is refuted by the runtime: `emitSignedRecord`
+serves no claim/release/reap record; the actual claim-writer `adjacency-leasecheck.js::autoClaim`
+
+- `reap-ceremony.js` still use `coc-sign.js::sign` + `transport-filesystem.js`; `coc-append.js` is
+  the observations/violations helper. The commands are ACCURATE to the code; editing them would
+  introduce a NEW command↔code divergence (`spec-accuracy` per journal/0035 §3). Disposition: leave.
+
+## State + receipts
+
+- 2 working-tree files edited (`rules/enrollment-operations.md`, `skills/45-genesis-bootstrap/SKILL.md`),
+  uncommitted — BUILD-repo commit gate; awaiting `/codify` landing (`codify/esperie-2026-07-09` →
+  PR → admin-merge) + a BUILD→loom proposal for cross-SDK distribution.
+- Convergence: clean R5 (3 agents) + clean R7 (reviewer + security), bracketing a single fixed LOW
+  at R6; every guard-mechanics claim + cross-reference ground-truth-verified.
+- Distributable invariant GREEN throughout (committed roster PLACEHOLDER / 0 enforcement hooks in
+  committed settings.json / probe-phase-guard present / disclosure scan exit 0).
+
+## Accepted non-blocking (carried)
+
+- MUST-3 over-density — the SAFE-helper qualification depth is a candidate for extraction to
+  `skills/45-genesis-bootstrap` in the canonical loom pass; path-scoped rule → no baseline cost.


### PR DESCRIPTION
## Summary

Closes the two items re-convergence #6 deferred to a fresh session (F1 fixed, F2 refuted).

- **F1 (fixed):** `enrollment-operations.md` MUST-3 categorically banned inline `node -e` for watched-state mutation, which falsely flagged `/certify` Step-2's *safe* inline `reserveJournalSlotSigned` call. Ground-truth verification of the guard (`detectStateFileMutation` + `STATE_PATH_RX`) established the real invariant: the guard fires **only** on a `STATE_PATH_RX` literal on the command line, and it is **read/write-agnostic** (path-presence, not mutation-aware). MUST-3 rewritten to that invariant; the same accuracy propagated to the cross-referenced depth-file `45-genesis-bootstrap/SKILL.md` (4 write-only-framing instances) + a phantom `whoami.md` cross-reference fixed.
- **F2 (refuted, no edit):** the proposed `claim`/`release-claim`/`claims` helper-naming "alignment" is refuted by the runtime — the commands are **accurate to the code**; `emitSignedRecord` serves no claim/release/reap record, and the actual claim-writer still uses `coc-sign` + `transport-filesystem`. Editing would introduce a *new* command↔code divergence (spec-accuracy per journal/0035 §3).

## Validation

7-round self-referential multi-agent redteam (reviewer + security-reviewer + cc-architect), converged clean R5 + clean R7 bracketing a single fixed LOW at R6. Every guard-mechanics claim + cross-reference ground-truth-verified. Distributable "ships un-enrolled" invariant re-verified GREEN after every edit (placeholder roster, 0/6 coordination-enforcement hooks in committed settings.json, probe-phase-guard present, disclosure scan clean).

## Related issues

No GH issue — closes the F1/F2 items in the re-convergence #6 ledger. BUILD→loom proposal appended (`.claude/.proposals/latest.yaml`, pending_review) for cross-SDK distribution.

Receipt: `workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence7.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)