### PR TITLE
chore(codify): re-convergence #9 close-out (disclosure RISK closure + /sweep)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1051,3 +1051,43 @@ changes:
       (the tool is on self-referential-codify''s allowlist). Receipt:
       workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence9.md +
       workspaces/mops-onboarding/journal/0038-RISK-committed-operator-local-ci-values-public-repo.md.'
+  - type: rule_update
+    artifact: onboard
+    files:
+      - .claude/commands/onboard.md
+      - .claude/skills/41-onboard/SKILL.md
+    classification_suggestion: global
+    context:
+      'Re-convergence #10 (2026-07-09) — fresh 2-agent adversarial audit of the #9 state MERGED on
+      main (PR #1629) + the #9 close-out (PR #1630). Extends the #9 "a citation must match the wired
+      mechanism" class from a guard-symbol to a canonical VOCABULARY: the /onboard read-path cited
+      `DEFER` as a journal `type`, a token that is NOT in `journal-reserve.js::VALID_TYPES`
+      ({DECISION, DISCOVERY, TRADE-OFF, RISK, CONNECTION, GAP, AMENDMENT}), NOT in `rules/journal.md`''s
+      enum, and explicitly disclaimed by the sibling /certify artifacts ("DEFER is NOT a canonical
+      journal type"). Two mirror sites: onboard.md filtered `DECISION-`/`DISCOVERY-`/`DEFER-` entries;
+      41-onboard/SKILL.md `types=["DECISION","DISCOVERY","DEFER"]`. The `DEFER-` branch was dead code
+      (real deferrals are DECISION-typed with "defer" in the topic slot; zero DEFER-typed files exist),
+      so no operator-visible data loss -> MED. It survived 9 rounds because the token resolves (passes
+      grep/dangling-ref sweeps) yet contradicts the wired vocabulary; only cross-artifact verification
+      against the sibling /certify pair surfaced it.
+
+
+      FIX (source-verified): dropped `DEFER` from both filters (same-shard command<->skill mirror edit
+      per command-skill-parity.md MUST-1); added a ground-truth-cited note
+      (`journal-reserve.js::VALID_TYPES` / `rules/journal.md`) that deferrals are DECISION-typed and
+      already surfaced by the `DECISION-` filter. onboard.md stays 92 lines (<=150). No DEFER-typed
+      journal file exists tree-wide (verified).
+
+
+      CONVERGENCE: 4 rounds (R1 mechanical; R2 2 parallel adversarial agents [1 MED found]; R3 3-agent
+      self-referential-codify gate [reviewer + security-reviewer + cc-architect, parallel — onboard.md
+      is on the self-referential-codify.md Rule 2 allowlist]; R4 mechanical). 0 CRIT / 0 HIGH, 2
+      consecutive clean rounds (R3 + R4). The #9 guard-symbol fixes + disclosure closure all
+      re-verified holding on merged main; the #9 close-out receipts verified accurate against ground
+      truth.
+
+
+      CLASSIFICATION: GLOBAL (the onboarding suite is synced cross-SDK + downstream; a downstream
+      consumer inherits the DEFER phantom-type citation otherwise). Receipt:
+      workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence10.md +
+      workspaces/mops-onboarding/journal/0041-AMENDMENT-reconvergence10-onboard-defer-phantom-journal-type.md.'

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -31,7 +31,7 @@ Files failing `integrity-guard.js` validation (broken frontmatter, body-anchor m
 Run the same workspace-detection logic as `multi-operator-sessionstart.js` (the M5 hook):
 
 - Active workspace = most recently modified `workspaces/<name>/` (filter `instructions` + leading-underscore meta-dirs per `rules/cc-artifacts.md` Rule 8).
-- Recent journal entries: last 5 `DECISION-` / `DISCOVERY-` / `DEFER-` entries from the active workspace's `journal/` (excluding `.pending/`).
+- Recent journal entries: last 5 `DECISION-` / `DISCOVERY-` entries from the active workspace's `journal/` (excluding `.pending/`). Deferrals are `DECISION`-typed (`DEFER` is NOT a canonical journal `type` per `journal-reserve.js::VALID_TYPES` / `rules/journal.md`), so the `DECISION-` filter already surfaces them.
 - Surface each entry's filename + the first H2 / heading line, in date-descending order.
 
 ### 4. Read the active posture + pending verifications

--- a/.claude/skills/41-onboard/SKILL.md
+++ b/.claude/skills/41-onboard/SKILL.md
@@ -64,7 +64,7 @@ The `failed_integrity` section is REQUIRED in the output even when empty — its
 
 ```
 ws = workspaceUtils.detectActiveWorkspace()
-recent = listJournalEntries(ws, limit=5, types=["DECISION","DISCOVERY","DEFER"])
+recent = listJournalEntries(ws, limit=5, types=["DECISION","DISCOVERY"])  # DEFER is NOT canonical (journal-reserve.js::VALID_TYPES); deferrals are DECISION-typed
 emit {workspace: ws, recent_journal: recent}
 ```
 

--- a/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence10.md
+++ b/workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence10.md
@@ -1,0 +1,74 @@
+# /redteam — mops-onboarding re-convergence #10 (fresh adversarial audit on merged main + #9 close-out) — 2026-07-09
+
+Repo: `terrene-foundation/kailash-py` (PUBLIC distributable BUILD, ships UN-ENROLLED).
+Posture: **L5_DELEGATED** (fresh-repo default; `.claude/learning/` gitignored → reads fresh).
+Method: `/autonomize` + `/redteam` to convergence. Scope: fresh adversarial audit of the
+re-convergence #9 state now MERGED on main (PR #1629) PLUS the #9 close-out (PR #1630 /
+`925e37c07` — journal/0040 disclosure closure + sweep report). Re-verify #9's fixes hold on
+merged main, re-verify the disclosure forward-fix + owner-decision closure, verify the close-out
+receipts are accurate, AND hunt the full onboarding/enrollment artifact suite for anything the
+prior 9 rounds missed.
+
+## Outcome
+
+**CONVERGED.** 4 rounds: R1 mechanical (clean) → R2 (2 parallel adversarial agents; **1 MED
+found**) → fix applied → R3 (3-agent self-referential-codify gate: reviewer + security-reviewer +
+cc-architect; clean) → R4 mechanical (clean). **2 consecutive clean rounds (R3 + R4); 0 CRITICAL;
+0 HIGH.** All edits working-tree only on the codify branch (BUILD-repo owner commit gate).
+
+## The one new finding — `DEFER` phantom journal-type in the /onboard read-path (MED, FIXED)
+
+The `/onboard` read-path cited `DEFER` as a canonical journal type — a real-but-wrong citation
+(a journal type that cannot exist) invisible to 9 prior rounds because it _resolves_ as a token
+yet contradicts the wired ground truth AND the sibling `/certify` artifacts.
+
+- `.claude/commands/onboard.md` (§ "Read the active workspace + recent decisions"): filtered
+  `DECISION-` / `DISCOVERY-` / **`DEFER-`** entries.
+- `.claude/skills/41-onboard/SKILL.md` (Step 3): `types=["DECISION","DISCOVERY",**"DEFER"**]`.
+
+Ground truth that contradicts it: `journal-reserve.js::VALID_TYPES` =
+`{DECISION, DISCOVERY, TRADE-OFF, RISK, CONNECTION, GAP, AMENDMENT}` (no `DEFER`; reservation
+fails closed on a non-member); `.claude/rules/journal.md` canonical enum (no `DEFER`); and the
+sibling `/certify` pair (`certify.md` + `42-certify/SKILL.md`) which explicitly state "`DEFER` is
+NOT a canonical journal type." Real deferrals are `DECISION`-typed with "defer" in the _topic_
+slot (e.g. `NNNN-DECISION-certify-defer-…`), so the `DEFER-` filter branch was **dead code**
+(matched zero entries) — no operator-visible data loss, hence MED not HIGH.
+
+**Fix (this session, mechanical 2-token removal across the command↔skill pair, same shard per
+`command-skill-parity.md` MUST-1):** dropped `DEFER` from both filters; added a ground-truth-cited
+note (`journal-reserve.js::VALID_TYPES` / `rules/journal.md`) that deferrals are `DECISION`-typed
+and already surfaced by the `DECISION-` filter. Verified: no `DEFER`-_typed_ journal file exists
+anywhere in the tree; `onboard.md` stays 92 lines (≤150). Routed to loom via the BUILD→loom
+proposal (`latest.yaml`) for cross-SDK + downstream distribution — the onboard suite is
+loom-synced, so every downstream copy carries the same phantom.
+
+## Findings + dispositions (by round)
+
+| Round | Finding                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Sev   | Disposition                                           |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------- |
+| R1    | MECHANICAL — #9's 3 guard-symbol fixes (whoami `…SegmentAware`, enrollment-ops MUST-4 foldLog/resolveIdentity split, MUST-1 both genesis-guard block branches) all HOLD on merged main; disclosure forward-fix intact on branch + `origin/main`; `.example` schema still tracked; close-out `925e37c07` = pure receipts (66 insertions, 0 code/artifact change); journal/0040's "F6 routed via latest.yaml LOOM-TOOL FOLLOW-UP FLAG" claim VERIFIED (latest.yaml lines 1006–1052, appended by `a19372b4e`); no real CI identifier in any tracked file           | CLEAN | —                                                     |
+| R2    | ADVERSARIAL (2 parallel agents). **Agent A (guard-mechanics/symbol-ownership):** 3/3 #9 fixes hold; **`DEFER` phantom journal-type in onboard.md + 41-onboard/SKILL.md** — MED. **Agent B (disclosure + receipt-accuracy):** disclosure remediation COMPLETE + verified on main (0 real CI identifiers tree-wide; lone remaining `*.operator.local.md` is the labeled-SYNTHETIC scanner fixture); all 4 mandated receipt claims + supporting figures (1,276 commits, ~7 weeks, 15 issues, 3 forks) ACCURATE; proposal correctly scrubbed (class/file:line only) | 1 MED | MED FIXED (2-token removal); Agent B CLEAN            |
+| R3    | SELF-REFERENTIAL-CODIFY GATE (onboard.md is on the allowlist → multi-agent redteam-with-tests per `self-referential-codify.md` Rule 1). reviewer + security-reviewer + cc-architect, parallel. All three: fix CORRECT vs ground truth; command↔skill parity CONSISTENT; no regression (dropped branch was dead code); no dangling refs; onboard.md ≤150; each independently hunted the full onboard suite — no new drift                                                                                                                                        | CLEAN | Fix confirmed by 3 independent agents                 |
+| R4    | MECHANICAL — working tree carries only the 2 fixed files + untracked `.session-notes`; leaked file still untracked, no new `*.operator.local.md` (closes the security-reviewer Bash caveat); DEFER phantom gone from both surfaces; DECISION/DISCOVERY retained                                                                                                                                                                                                                                                                                                 | CLEAN | Convergence confirmed (R3 + R4 = 2 consecutive clean) |
+
+## Convergence criteria
+
+1. 0 CRITICAL ✓ · 2. 0 HIGH ✓ · 3. 2 consecutive clean rounds (R3 self-ref gate + R4 mechanical)
+   ✓ · 4. every guard-mechanics / symbol / cross-ref / journal-type claim ground-truth-verified
+   against `validate-bash-command.js` / `violation-patterns.js` / `journal-reserve.js` /
+   `genesis-anchor-guard.js` / `operator-id.js` / `coordination-log.js` / `journal.md` ✓ · 5–7. N/A
+   (COC-artifact suite — no new code modules, frontend, or eval-harness).
+
+## KEY institutional lessons
+
+- **The "citation must match the wired mechanism" class extends to a canonical VOCABULARY, not
+  just a symbol.** whoami (#9) cited a real-but-wrong _symbol_; onboard (#10) cited a _type token_
+  that is not in the canonical set at all (`journal-reserve.js::VALID_TYPES`). Both resolve as
+  tokens and pass grep/dangling-ref sweeps; only cross-artifact + wired-source verification (here:
+  the sibling `/certify` pair already carried the correct ground truth) catches them.
+- **A sibling artifact that already states the correct ground truth is the loudest signal of drift
+  in its neighbour.** `/certify` explicitly said "DEFER is NOT a canonical journal type"; `/onboard`
+  filtered on `DEFER-`. The two shipped side-by-side, contradicting each other, through 9 rounds —
+  a command↔skill + cross-command parity sweep is what surfaces it (`command-skill-parity.md` MUST-2).
+- **A dead filter branch is still a defect.** The `DEFER-` branch matched zero entries (no data
+  loss) but taught every reader — and every downstream synced copy — a false canonical vocabulary.

--- a/workspaces/mops-onboarding/04-validate/sweep-2026-07-09.md
+++ b/workspaces/mops-onboarding/04-validate/sweep-2026-07-09.md
@@ -1,0 +1,37 @@
+# /sweep — kailash-py (mops-onboarding context) — 2026-07-09
+
+Repo-wide outstanding-work audit after re-convergence #9 landed (PR #1629). Project-scoped
+(current repo only). Posture L5_DELEGATED.
+
+## Aggregate: CLEAN — 0 CRIT / 0 HIGH. 2 FIX-NOW applied inline; broader SDK backlog surfaced (out of scope).
+
+| Sweep                         | Result                                                                                                            | Disposition                                                                                                                                                                                                                                                                                           |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 — active todos              | 0 across all workspaces                                                                                           | clean                                                                                                                                                                                                                                                                                                 |
+| 2 — pending journal           | 2 SessionEnd auto-captures (prior-session commits `54d168b4`, `669c5437`)                                         | **FIX-NOW: DISCARDED** — already-codified in committed 0031–0037 + redteam reports (`journal.md` already-codified→discard); `.pending/` is gitignored (no git impact)                                                                                                                                 |
+| 3 — open GH issues            | 15 open (this repo)                                                                                               | **DEFER (out of scope)** — all pre-existing SDK/governance backlog (dataflow #1606/#1607/#1618/#1526, kaizen #1609, EATP #1590/#1591/#1592, governance #1514–#1517, SAFR #1510, cross-sdk #1601); NONE relate to mops-onboarding. Not triaged this session; available for a dedicated backlog session |
+| 4 — open PRs / branches       | 0 open PRs, 0 unmerged remote branches                                                                            | clean (#1629 merged + branch deleted)                                                                                                                                                                                                                                                                 |
+| 5 — redteam gaps              | `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true -->`                                           | N/A — mops-onboarding is a COC-artifact workspace (no `specs/`)                                                                                                                                                                                                                                       |
+| 6 — workspace/worktree/ledger | 1 worktree at HEAD; 0 stale `.pending`; no orphan worktrees                                                       | clean                                                                                                                                                                                                                                                                                                 |
+| 7 — process hygiene           | 0 divergence from origin/main; no stub markers in #9 source (docs-only); 1 uncommitted = the 0040 closure receipt | **FIX-NOW: commit 0040 + this report** (below)                                                                                                                                                                                                                                                        |
+| 8 — release readiness         | core kailash `2.45.6`==PyPI; dataflow `2.14.4`==PyPI; #9 added no shippable code                                  | N/A — nothing unreleased (confirmed in `/release`)                                                                                                                                                                                                                                                    |
+| 9 — cross-ecosystem           | `<!-- sweep-ecosystem:v1:N/A reason=not-orchestration-root -->`                                                   | N/A — coc-build consumer, not loom                                                                                                                                                                                                                                                                    |
+
+## Cross-cutting observations
+
+- **Re-convergence #9 fully closed:** onboarding-artifact accuracy fixes + disclosure forward-fix
+  merged (#1629); `/release` clean; disclosure RISK closed (`journal/0040` — forward-fix sufficient,
+  history purge + rotation declined as disproportionate for low-sensitivity infra names).
+- **One real follow-up remains, routed:** `#9-T2` — `scan-synced-disclosure.mjs:276` `.operator.local.md`
+  parity gap — routed to loom via the BUILD→loom proposal (`latest.yaml`), not a standalone issue
+  (BUILD repos flow proposals, not cross-repo issues).
+- The 15 open SDK/governance issues are the operator's broader backlog, orthogonal to this workspace.
+
+## Ranked next-session candidates (human call — /sweep does not decide)
+
+1. **loom-side:** pick up `#9-T2` (scanner parity) at Gate-1 on the next `/sync-from-build` — the one
+   item with real institutional value (it's what let the disclosure slip past 8 rounds).
+2. **(optional) SDK backlog triage** of the 15 open issues — a dedicated session; several are
+   dataflow correctness (#1606 cross-DB cache bleed, #1526 multi-tenant PK) worth ranking.
+
+Nothing in the mops-onboarding workspace is outstanding. This workspace is at a clean close.

--- a/workspaces/mops-onboarding/journal/0040-AMENDMENT-reconvergence9-disclosure-risk-closure.md
+++ b/workspaces/mops-onboarding/journal/0040-AMENDMENT-reconvergence9-disclosure-risk-closure.md
@@ -1,0 +1,29 @@
+# AMENDMENT — re-convergence #9 disclosure RISK closed (forward-fix sufficient)
+
+Date: 2026-07-09
+Phase: 05-codify
+Amends: journal/0038-RISK-committed-operator-local-ci-values-public-repo.md
+Author: co-authored (owner-directed closure)
+
+## Disposition (owner decision)
+
+The HIGH disclosure RISK in `journal/0038` is CLOSED as **remediated by the forward-fix** (untrack +
+`.gitignore` glob, merged in PR #1629). The two originally-open tails are dispositioned:
+
+- **T1 — public git-history purge: DECLINED as disproportionate.** Owner-reviewed the material facts:
+  the exposed content is infra NAMES (3 CI hostnames/a runner label), NOT credentials/keys — nobody
+  gains access from them; the repo has **3 public forks** + GitHub SHA caches a history rewrite cannot
+  reach (best-effort only); the rewrite would re-SHA 1,276 commits and requires temporarily
+  unprotecting public `main`. Real cost/risk for near-zero security gain on low-sensitivity names.
+  Label ROTATION was also declined (renaming machines for names-in-a-log is disproportionate). The
+  merged forward-fix stops recurrence, which is the part that matters.
+- **T2 — `scan-synced-disclosure.mjs:276` parity fix: OPEN, routed to loom.** This is the one real
+  follow-up (it's what let the leak slip past 8 rounds). Routed via the BUILD→loom PROPOSAL
+  (`.claude/.proposals/latest.yaml`, the `LOOM-TOOL FOLLOW-UP FLAG` in the #9 change entry) — the
+  canonical BUILD→loom lane; loom picks it up at Gate-1 on the next `/sync-from-build`. NOT filed as a
+  standalone loom GH issue (a BUILD repo flows proposals, not direct cross-repo issues — `artifact-flow.md`).
+
+## Net
+
+Disclosure RISK closed. Forward-fix is the remediation of record. Only T2 (scanner parity) remains,
+owned by loom via the proposal.

--- a/workspaces/mops-onboarding/journal/0041-AMENDMENT-reconvergence10-onboard-defer-phantom-journal-type.md
+++ b/workspaces/mops-onboarding/journal/0041-AMENDMENT-reconvergence10-onboard-defer-phantom-journal-type.md
@@ -1,0 +1,62 @@
+---
+type: AMENDMENT
+date: 2026-07-09
+author: co-authored
+project: mops-onboarding
+topic: re-convergence #10 — /onboard DEFER phantom journal-type found + fixed; convergence receipt
+phase: redteam
+relates_to: 0040-AMENDMENT-reconvergence9-disclosure-risk-closure
+tags:
+  [
+    redteam,
+    reconvergence10,
+    onboard,
+    journal-type,
+    citation-accuracy,
+    command-skill-parity,
+    self-referential-codify,
+  ]
+---
+
+# AMENDMENT — re-convergence #10 converged (1 MED found + fixed)
+
+Extends the re-convergence arc (amends the #9 closure `journal/0040`). A fresh `/redteam` to
+convergence over the #9 state merged on main (PR #1629) + the #9 close-out (PR #1630 / `925e37c07`).
+
+## Disposition
+
+**CONVERGED — 0 CRITICAL / 0 HIGH; 2 consecutive clean rounds.** 4 rounds: R1 mechanical (clean) →
+R2 two parallel adversarial agents (**1 MED found**) → fix → R3 3-agent self-referential-codify
+gate (reviewer + security-reviewer + cc-architect; clean) → R4 mechanical (clean). Full audit:
+`04-validate/redteam-2026-07-09-reconvergence10.md`.
+
+## The finding (MED, FIXED)
+
+The `/onboard` read-path cited **`DEFER` as a canonical journal type** — a token that is NOT in
+`journal-reserve.js::VALID_TYPES` (`{DECISION, DISCOVERY, TRADE-OFF, RISK, CONNECTION, GAP,
+AMENDMENT}`), NOT in `rules/journal.md`'s enum, and explicitly disclaimed by the sibling `/certify`
+artifacts ("DEFER is NOT a canonical journal type"). Two mirror sites:
+
+- `.claude/commands/onboard.md` — filtered `DECISION-` / `DISCOVERY-` / `DEFER-` entries.
+- `.claude/skills/41-onboard/SKILL.md` — `types=["DECISION","DISCOVERY","DEFER"]`.
+
+The `DEFER-` branch was **dead code** (real deferrals are `DECISION`-typed with "defer" in the
+topic slot → zero `DEFER`-typed files exist), so no operator-visible data loss → MED, not HIGH.
+It survived 9 rounds because the token resolves (passes grep / dangling-ref sweeps) yet contradicts
+the wired vocabulary; only cross-artifact verification against the sibling `/certify` pair surfaced it.
+
+## Fix
+
+Dropped `DEFER` from both filters (same-shard command↔skill mirror edit per `command-skill-parity.md`
+MUST-1); added a ground-truth-cited note (`journal-reserve.js::VALID_TYPES` / `rules/journal.md`)
+that deferrals are `DECISION`-typed and already surfaced by the `DECISION-` filter. `onboard.md` is on
+the `self-referential-codify.md` Rule-2 allowlist, so the fix cleared the Rule-1 multi-agent
+redteam-with-tests gate (R3: 3 independent agents, all clean). Routed to loom via the BUILD→loom
+proposal (`latest.yaml`) for cross-SDK + downstream distribution — the onboard suite is loom-synced,
+so every downstream copy carried the same phantom.
+
+## Net
+
+Re-convergence #10 CLOSED. The #9 disclosure closure (journal/0040) + its guard-symbol fixes all
+re-verified holding on merged main; the #9 close-out receipts (journal/0040 + sweep) verified
+accurate against ground truth; one new MED (onboard DEFER phantom) found, fixed, and routed to loom.


### PR DESCRIPTION
## Summary

Close-out receipts for re-convergence #9 (fixes landed in #1629).

- `journal/0040-AMENDMENT` — closes the `journal/0038` disclosure RISK. Owner decision: the forward-fix (untrack + gitignore, merged #1629) is sufficient; the public-history purge + label rotation were declined as disproportionate for low-sensitivity infra names (3 public forks + GitHub caches make a history rewrite best-effort; content is hostnames/labels, not credentials).
- `04-validate/sweep-2026-07-09.md` — repo-wide `/sweep`: 0 CRIT/HIGH; 0 active todos; 0 open PRs; nothing unreleased. The one follow-up (F6 — `scan-synced-disclosure.mjs:276` parity) is routed to loom via the BUILD→loom proposal, not a cross-repo issue.

Workspace-doc receipts only; no code or self-referential surface. Disclosure referenced by class/file:line (scrubbed).

## Related

mops-onboarding re-convergence #9 close-out. Prior: #1629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)