### PR TITLE
chore(codify): /sweep report — post re-convergence #10 clean close

### DIFF
--- a/workspaces/mops-onboarding/04-validate/sweep-2026-07-09-postconvergence10.md
+++ b/workspaces/mops-onboarding/04-validate/sweep-2026-07-09-postconvergence10.md
@@ -1,0 +1,63 @@
+# /sweep — kailash-py (post re-convergence #10) — 2026-07-09
+
+Repo: `terrene-foundation/kailash-py` (PUBLIC distributable BUILD). Run after re-convergence #10
+converged + landed (PR #1630, merge `1bb097e4e`). Project-scoped (Sweeps 1–8, current repo);
+Sweep 9 N/A by policy (BUILD repo, not the loom carve-out holder).
+
+## Outcome
+
+**CLEAN — 0 findings actionable by this session.** Two informational surfaces (Sweep 8 sub-package
+release state; Sweep 9 operator-local resolver config), both pre-existing / operator-local and NOT
+introduced or ownable by this COC re-convergence session. No inline fixes required.
+
+## Sweep results
+
+| Sweep | Scope                                        | Result                                                                                                                                                                                                                                                               |
+| ----- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Active todos (all workspaces)                | none                                                                                                                                                                                                                                                                 |
+| 2     | Pending journal entries (`.pending/`)        | none                                                                                                                                                                                                                                                                 |
+| 3     | GH open issues (this repo)                   | 15 open — standing SDK backlog (dataflow / kaizen / governance / EATP), all recent (2026-07-03..07-08), none stale, none related to the COC onboarding suite. Informational, not this session's scope.                                                               |
+| 4     | Open PRs + stale branches                    | 0 open PRs; 0 unmerged remote branches (codify branch merged + pruned) ✓                                                                                                                                                                                             |
+| 5     | Redteam gaps vs specs                        | N/A — `mops-onboarding` is a COC-artifact workspace with no `workspaces/*/specs/`; redteam already run to convergence #10 (`redteam-2026-07-09-reconvergence10.md`). Sentinel: `<!-- sweep-redteam:v1:N/A reason=no-workspace-specs no_specs=true no_tool=false -->` |
+| 6     | Workspace / worktree / forest-ledger hygiene | Clean — 0 stale `.session-notes` (>30d); only the main checkout (0 orphan worktrees); 0 stale `.pending`; forest-ledger aggregate OK (`1 workspace ledger; all open IDs reflected in root`)                                                                          |
+| 7     | Process hygiene                              | Clean — working tree carries only the untracked session-local `.session-notes`; `origin/main...HEAD` = `0 / 0` (in sync); no new stub markers (session touched `.claude/` + `workspaces/` only, no `src/`/`packages/`)                                               |
+| 8     | Release readiness                            | See finding S8 below                                                                                                                                                                                                                                                 |
+| 9     | Cross-ecosystem roll-up                      | N/A by policy — see finding S9 below                                                                                                                                                                                                                                 |
+
+## Findings (informational — none actionable this session)
+
+### [LOW] [Sweep 8] 14 unreleased kailash-dataflow commits vs the core `v2.45.6` tag
+
+- **Location:** `packages/kailash-dataflow/src` — 14 commits since tag `v2.45.6` (e.g. `46edf8c02`
+  `__tablename__` hardening, `cc541cc3e` "release 2.14.3", `08d3929b1` auto-migrate ALTER-ADD).
+- **Disposition:** SURFACE-TO-USER (human-gated). These are **kailash-dataflow** sub-package commits
+  on their own `2.14.x` cadence (last `release 2.14.3`); they only read as "unreleased" because the
+  mechanical diff base is the _core_ `kailash` tag `v2.45.6` (core `__version__` = 2.45.6, in sync).
+- **Why it matters:** DataFlow release timing is a structural human gate + owner call, and entirely
+  independent of this COC re-convergence session. Not auto-releasable; flagged for visibility only.
+
+### [LOW] [Sweep 9] operator-local resolver mis-classifies this BUILD clone as an orchestration root
+
+- **Location:** operator-local `loom-links.local.json` (gitignored, not a committed artifact).
+  `isConfigured: true`, `resolveRole: null` → the Sweep-9 gate (`!isConfigured || role∈{build,use-consumer}`)
+  does not suppress, so it reported "orchestration root" from a BUILD repo.
+- **Disposition:** N/A by policy — `repo-scope-discipline.md` names loom the SOLE cross-ecosystem
+  carve-out holder; kailash-py is a BUILD repo, so the cross-repo roll-up was NOT run (no cross-repo
+  reads from a BUILD session). Sentinel: `<!-- sweep-ecosystem:v1:N/A reason=not-orchestration-root (BUILD repo) -->`
+- **Why it matters:** operator MAY add `role: build` to their local `loom-links.local.json` for this
+  clone so Sweep 9 self-suppresses correctly here. Operator-local config only — no shipped-artifact impact.
+
+## Cross-cutting
+
+- The re-convergence #10 work (onboard DEFER phantom-type fix + receipts + BUILD→loom proposal
+  append) is fully landed on main; disclosure forward-fix intact; PR queue empty.
+- The forest ledger (F6 scanner-parity, F10 onboard-fix) is routed to loom via `latest.yaml` for
+  Gate-1 pickup on the next `/sync-from-build`; no BUILD-side action pending.
+
+## Recommended next-session items (ranked; human decides)
+
+1. (Owner call, not this session) Decide kailash-dataflow release timing for the 14 unreleased
+   `2.14.x` commits — independent of the COC line.
+2. (Optional, operator-local) Add `role: build` to this clone's `loom-links.local.json` to
+   self-suppress Sweep 9.
+3. Nothing else outstanding on the COC onboarding line — re-convergence #10 is a clean close.


### PR DESCRIPTION
Repo-wide `/sweep` after re-convergence #10 converged + landed (PR #1630).

**Outcome: CLEAN** — 0 findings actionable this session. Two informational surfaces, both pre-existing / operator-local:
- Sweep 8: 14 unreleased kailash-dataflow (`2.14.x`) commits vs the core `v2.45.6` tag — sub-package release state, human-gated, unrelated to this COC line.
- Sweep 9: operator-local resolver mis-classifies this BUILD clone as an orchestration root (`role: null`) — N/A by policy (`repo-scope-discipline.md`: loom is the sole carve-out); no cross-repo reads run.

Sweeps 1/2/4/5/6/7 all clean; Sweep 3 = 15 standing SDK issues (recent, none stale, none COC-related).

## Related issues
None — closure receipt for the mops-onboarding re-convergence #10 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)