### PR TITLE
fix(dataflow): parameterized-LIMIT test drift (#1618), enterprise-doc __dataflow__ fiction purge (#1607), #1606 keyspace tripwire

### DIFF
--- a/packages/kailash-dataflow/docs/advanced/database-optimization.md
+++ b/packages/kailash-dataflow/docs/advanced/database-optimization.md
@@ -195,24 +195,12 @@ class Event:
     event_type: str
     data: dict
 
-    __dataflow__ = {
-        'partitioning': {
-            'strategy': 'range',
-            'key': 'timestamp',
-            'interval': 'monthly',
-            'retention': {
-                'keep_months': 12,
-                'archive_months': 24,
-                'delete_after': 36
-            },
-            'automatic': {
-                'create_ahead': 3,  # Create 3 months ahead
-                'maintenance_schedule': 'daily'
-            }
-        }
-    }
+    # NOTE: Table partitioning is NOT a `@db.model` config key. Partitioning is
+    # applied at the database/DDL layer through a numbered migration (see the
+    # schema-migration guide), not via `__dataflow__`. The only performance knob
+    # exposed on the model is `indexes`.
 
-# Partition maintenance
+# Partition maintenance (partition DDL is created/managed by migrations)
 workflow.add_node("PartitionMaintenanceNode", "maintain_partitions", {
     "operations": [
         {
@@ -246,17 +234,8 @@ class Customer:
     region: str
     name: str
 
-    __dataflow__ = {
-        'partitioning': {
-            'strategy': 'list',
-            'key': 'region',
-            'partitions': {
-                'us_customers': ['us-east', 'us-west'],
-                'eu_customers': ['eu-west', 'eu-central'],
-                'asia_customers': ['asia-pacific', 'asia-south']
-            }
-        }
-    }
+    # NOTE: List/range partitioning is applied at the database/DDL layer via a
+    # numbered migration, not through a `@db.model` config key.
 ```
 
 ## Materialized Views

--- a/packages/kailash-dataflow/docs/advanced/multi-tenant.md
+++ b/packages/kailash-dataflow/docs/advanced/multi-tenant.md
@@ -81,9 +81,13 @@ class Product:
             {'fields': ['tenant_id', 'id']},  # Composite index
             {'fields': ['tenant_id', 'name']}
         ],
-        'row_level_security': True  # Enable RLS
     }
 ```
+
+> **Row-level security / authorization is not a DataFlow model key.** Access
+> control (who may read/write which rows) is the domain of PACT governance
+> (`kailash-pact`), not DataFlow. Use DataFlow's `multi_tenant=True` for tenant
+> scoping of data; enforce row-level authorization policies through PACT.
 
 ## Tenant Provisioning
 

--- a/packages/kailash-dataflow/docs/advanced/security.md
+++ b/packages/kailash-dataflow/docs/advanced/security.md
@@ -34,14 +34,16 @@ class User:
     locked_until: datetime
     last_login: datetime
 
-    __dataflow__ = {
-        'security': {
-            'sensitive_fields': ['password_hash', 'totp_secret'],
-            'audit_fields': ['email', 'last_login'],
-            'encrypt_fields': ['totp_secret']
-        }
-    }
+    # Field-level sensitivity is NOT a `__dataflow__` model key. Classify
+    # sensitive fields with the `@classify` decorator (see the classification
+    # guide) and enable field encryption via the DataFlow() ENCRYPTION
+    # progressive-disclosure feature — not a per-model config dict.
 ```
+
+Field encryption is enabled at the `DataFlow()` level via the ENCRYPTION
+feature flag (progressive disclosure), and per-field sensitivity is declared
+with `@classify(field, DataClassification.SECRET)` — there is no
+`__dataflow__['security']` / `encrypt_fields` model key.
 
 ### OAuth2 Integration
 
@@ -162,13 +164,9 @@ class Order:
     total: float
     status: str
 
-    __dataflow__ = {
-        'row_security': {
-            'read': 'user_id = current_user_id() OR has_role("admin")',
-            'write': 'user_id = current_user_id() AND status != "completed"',
-            'delete': 'has_role("admin")'
-        }
-    }
+    # Row-level authorization (who may read/write/delete which rows) is NOT a
+    # DataFlow model key — it is the domain of PACT governance (`kailash-pact`).
+    # Define read/write/delete policies through PACT, not `__dataflow__`.
 
 # Apply security in workflows
 workflow.add_node("SecureQueryNode", "get_orders", {
@@ -198,15 +196,12 @@ db = DataFlow(encryption_config=encryption_config)
 class Customer:
     id: int
     name: str
-    ssn: str  # Automatically encrypted
-    credit_card: str  # Automatically encrypted
+    ssn: str  # sensitive — classify with @classify
+    credit_card: str  # sensitive — classify with @classify
 
-    __dataflow__ = {
-        'encryption': {
-            'fields': ['ssn', 'credit_card'],
-            'search_enabled': ['ssn']  # Enable searching on encrypted field
-        }
-    }
+    # Field encryption is NOT a `__dataflow__` model key. Enable the ENCRYPTION
+    # feature at the DataFlow() level (progressive disclosure) and declare
+    # sensitive fields with @classify(field, DataClassification.SECRET).
 ```
 
 ### Data in Transit
@@ -286,9 +281,12 @@ class AuditLog:
             ['resource_type', 'resource_id'],
             ['action', 'timestamp']
         ],
-        'retention': '7 years',
-        'immutable': True  # Prevent modifications
+        # `retention` takes a config dict, not a string. ~7 years = 2555 days.
+        'retention': {'policy': 'delete', 'after_days': 2555},
     }
+    # NOTE: append-only / immutability is not a `__dataflow__` key. Enforce
+    # immutability at the database layer (e.g. a migration adding an
+    # update/delete-blocking trigger), not via a model config flag.
 ```
 
 ### Workflow Audit

--- a/packages/kailash-dataflow/docs/advanced/security.md
+++ b/packages/kailash-dataflow/docs/advanced/security.md
@@ -42,7 +42,7 @@ class User:
 
 Field encryption is enabled at the `DataFlow()` level via the ENCRYPTION
 feature flag (progressive disclosure), and per-field sensitivity is declared
-with `@classify(field, DataClassification.SECRET)` — there is no
+with `@classify(field, DataClassification.HIGHLY_CONFIDENTIAL)` — there is no
 `__dataflow__['security']` / `encrypt_fields` model key.
 
 ### OAuth2 Integration
@@ -201,7 +201,7 @@ class Customer:
 
     # Field encryption is NOT a `__dataflow__` model key. Enable the ENCRYPTION
     # feature at the DataFlow() level (progressive disclosure) and declare
-    # sensitive fields with @classify(field, DataClassification.SECRET).
+    # sensitive fields with @classify(field, DataClassification.HIGHLY_CONFIDENTIAL).
 ```
 
 ### Data in Transit

--- a/packages/kailash-dataflow/docs/enterprise/compliance.md
+++ b/packages/kailash-dataflow/docs/enterprise/compliance.md
@@ -140,7 +140,7 @@ class PatientRecord:
     # HIPAA/PHI handling is not a single __dataflow__ model key. Field-level
     # encryption is enabled at the DataFlow() level (the ENCRYPTION feature,
     # progressive disclosure); sensitive fields are declared with
-    # @classify(field, DataClassification.SECRET) (from dataflow.classification);
+    # @classify(field, DataClassification.HIGHLY_CONFIDENTIAL) (from dataflow.classification);
     # access logging uses the backed audit_log key. There is no 'compliance' key.
     __dataflow__ = {
         'audit_log': True,
@@ -703,7 +703,7 @@ class SensitiveData:
     }
     # Defense in depth beyond the two backed keys above:
     # - Classification: declare sensitive fields with
-    #   @classify(field, DataClassification.SECRET) (from dataflow.classification),
+    #   @classify(field, DataClassification.HIGHLY_CONFIDENTIAL) (from dataflow.classification),
     #   not a 'classification' model key.
     # - Encryption: enabled at the DataFlow() level via the ENCRYPTION feature
     #   (progressive disclosure); sensitive fields declared with @classify(... SECRET).

--- a/packages/kailash-dataflow/docs/enterprise/compliance.md
+++ b/packages/kailash-dataflow/docs/enterprise/compliance.md
@@ -5,6 +5,7 @@ DataFlow provides comprehensive compliance features for GDPR, HIPAA, SOC2, and o
 ## Overview
 
 Compliance features in DataFlow include:
+
 - **Data Privacy**: GDPR right to be forgotten, data portability
 - **Healthcare**: HIPAA PHI protection and audit trails
 - **Financial**: PCI DSS compliance for payment data
@@ -79,8 +80,9 @@ class UserConsent:
 
     __dataflow__ = {
         'audit_log': True,
-        'immutable_fields': ['granted_at', 'ip_address']
     }
+    # Append-only / immutable columns are a database/migration-layer concern
+    # (DDL constraints or triggers), not a __dataflow__ model key.
 
 # Check consent before processing
 workflow.add_node("ConsentCheckNode", "check", {
@@ -101,11 +103,9 @@ class MinimalUser:
     email: str = Field(required=True)
     name: str = Field(required=False)  # Optional
 
-    # Auto-delete after purpose fulfilled
-    __dataflow__ = {
-        'auto_delete_after': 'purpose_fulfilled',
-        'purpose_tracking': True
-    }
+    # Data minimization: DataFlow's backed retention key expresses time-based
+    # deletion, e.g. __dataflow__ = {'retention': {'policy': 'delete', 'after_days': 365}}.
+    # Purpose-based auto-deletion is a workflow concern, not a model config key.
 
 # Configure field-level retention
 @db.model
@@ -137,15 +137,13 @@ class PatientRecord:
     record_number: str
     created_by: str
 
+    # HIPAA/PHI handling is not a single __dataflow__ model key. Field-level
+    # encryption is enabled at the DataFlow() level (the ENCRYPTION feature,
+    # progressive disclosure); sensitive fields are declared with
+    # @classify(field, DataClassification.SECRET) (from dataflow.classification);
+    # access logging uses the backed audit_log key. There is no 'compliance' key.
     __dataflow__ = {
-        'compliance': {
-            'hipaa': True,
-            'phi_fields': ['name', 'ssn', 'diagnosis'],
-            'encryption_required': True,
-            'access_logging': 'detailed',
-            'minimum_password_strength': 'strong',
-            'session_timeout': 900  # 15 minutes
-        }
+        'audit_log': True,
     }
 ```
 
@@ -230,14 +228,11 @@ class PaymentCard:
     # cvv: NEVER STORE
     # pin: NEVER STORE
 
+    # PCI DSS is not a __dataflow__ model key. Card tokenization is an
+    # application-level concern; field encryption is enabled at the DataFlow()
+    # level (the ENCRYPTION feature); access logging uses the backed audit_log key.
     __dataflow__ = {
-        'pci_dss': {
-            'level': 1,  # Highest security
-            'tokenization': True,
-            'encryption': 'AES-256',
-            'key_rotation': 90,  # days
-            'access_logging': True
-        }
+        'audit_log': True,
     }
 
 # Use tokenization service
@@ -287,15 +282,11 @@ class SystemAccess:
     timestamp: datetime
     ip_address: str
 
+    # SOC 2 controls are not a __dataflow__ model key. DataFlow contributes the
+    # backed audit_log key for tamper-evident access logging; the remaining SOC 2
+    # controls (change management, risk assessment) are organizational processes.
     __dataflow__ = {
-        'soc2': {
-            'trust_principle': 'security',
-            'controls': [
-                'access_monitoring',
-                'change_management',
-                'risk_assessment'
-            ]
-        }
+        'audit_log': True,
     }
 
 # Continuous monitoring
@@ -365,11 +356,11 @@ class AuditLog:
     previous_hash: str
 
     __dataflow__ = {
-        'immutable': True,  # No updates allowed
-        'retention_years': 7,
-        'backup_required': True,
-        'hash_algorithm': 'sha256'
+        'retention': {'policy': 'delete', 'after_days': 2555},  # 7 years
     }
+    # Append-only / immutable audit tables and integrity hashing are
+    # database/migration-layer concerns (DDL constraints, triggers), not
+    # __dataflow__ model keys. Backups are an infrastructure concern.
 ```
 
 ### Audit Query Interface
@@ -443,17 +434,8 @@ class Document:
         classifier="auto"
     )
 
-    __dataflow__ = {
-        'classification': {
-            'rules': [
-                {"pattern": r"\b\d{3}-\d{2}-\d{4}\b", "label": "pii_ssn"},
-                {"pattern": r"\b\d{16}\b", "label": "pci_card"},
-                {"keywords": ["diagnosis", "treatment"], "label": "phi"}
-            ],
-            'default_classification': 'public',
-            'reclassification_allowed': True
-        }
-    }
+    # Field classification uses the @classify(field, DataClassification.X)
+    # decorator (from dataflow.classification), not a 'classification' model key.
 
 # Manual classification override
 workflow.add_node("ClassificationNode", "classify", {
@@ -477,9 +459,9 @@ class RetentionPolicy:
     legal_hold: bool = False
     deletion_method: str  # "soft", "hard", "secure_wipe"
 
-    __dataflow__ = {
-        'system_table': True
-    }
+    # 'system_table' is not a DataFlow model key; this model needs no
+    # __dataflow__ config. Retention enforcement is expressed via the backed
+    # retention key or a workflow node (see below).
 
 # Apply retention policies
 workflow.add_node("RetentionEnforcementNode", "enforce", {
@@ -643,10 +625,9 @@ class RegionalData:
     user_id: int
     data: dict
 
-    __dataflow__ = {
-        'region_locked': True,
-        'region_field': 'user_region'
-    }
+    # Region locking / data residency is a database/migration-layer and
+    # infrastructure concern (per-region databases, DDL constraints), not a
+    # __dataflow__ model key.
 ```
 
 ### Transfer Mechanisms
@@ -714,21 +695,20 @@ class SensitiveData:
     content: str
 
     __dataflow__ = {
-        # Layer 1: Classification
-        'classification': 'confidential',
-
-        # Layer 2: Encryption
-        'encryption': True,
-
-        # Layer 3: Access Control
-        'access_control': 'role_based',
-
-        # Layer 4: Audit
+        # Audit trail (backed key)
         'audit_log': True,
 
-        # Layer 5: Retention
-        'retention_days': 365
+        # Retention (backed key) — auto-delete after 365 days
+        'retention': {'policy': 'delete', 'after_days': 365},
     }
+    # Defense in depth beyond the two backed keys above:
+    # - Classification: declare sensitive fields with
+    #   @classify(field, DataClassification.SECRET) (from dataflow.classification),
+    #   not a 'classification' model key.
+    # - Encryption: enabled at the DataFlow() level via the ENCRYPTION feature
+    #   (progressive disclosure); sensitive fields declared with @classify(... SECRET).
+    # - Access control: row/field authorization is PACT governance (kailash-pact),
+    #   not a __dataflow__ model key.
 ```
 
 ### 2. Automate Compliance

--- a/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
+++ b/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
@@ -517,7 +517,7 @@ class ComplianceRecord:
     }
     # Field encryption is enabled at the `DataFlow()` level via the ENCRYPTION
     # feature (progressive disclosure); sensitive fields are declared with
-    # `@classify(field, DataClassification.SECRET)` — NOT a `__dataflow__` model key.
+    # `@classify(field, DataClassification.HIGHLY_CONFIDENTIAL)` — NOT a `__dataflow__` model key.
 ```
 
 ---

--- a/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
+++ b/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
@@ -26,6 +26,7 @@ class Document:
 ```
 
 This automatically:
+
 - Adds `tenant_id` field to the model
 - Filters all queries by current tenant
 - Validates tenant access on all operations
@@ -241,9 +242,10 @@ class Event:
     ]
 
     __dataflow__ = {
-        'multi_tenant': True,
-        'partition_by': 'tenant_id'  # PostgreSQL partitioning
+        'multi_tenant': True
     }
+    # Table partitioning (e.g. PostgreSQL declarative partitioning on tenant_id)
+    # is a database/migration-layer concern, not a `__dataflow__` model config key.
 ```
 
 ### Connection Pooling
@@ -271,10 +273,10 @@ class Product:
     price: float
 
     __dataflow__ = {
-        'multi_tenant': True,
-        'tenant_shard_key': 'tenant_id',  # For sharding
-        'cache_by_tenant': True
+        'multi_tenant': True
     }
+    # Sharding by tenant is a database/migration-layer concern, not a
+    # `__dataflow__` model config key.
 ```
 
 ## Security
@@ -302,9 +304,10 @@ class SensitiveData:
 
     __dataflow__ = {
         'multi_tenant': True,
-        'audit_log': True,
-        'audit_include_tenant': True  # Log tenant in audit
+        'audit_log': True
     }
+    # With multi_tenant enabled, tenant_id is part of every row, so audit_log
+    # already captures the tenant on each audited operation.
 
 # Query audit log for tenant
 workflow.add_node("AuditLogNode", "tenant_audit", {
@@ -420,11 +423,11 @@ class TenantUsage:
 
 ### 1. Choose the Right Strategy
 
-| Strategy | Use When | Pros | Cons |
-|----------|----------|------|------|
-| Row-level | <1000 tenants | Simple, low overhead | Careful index design needed |
-| Schema | 100-10K tenants | Good isolation, easy backup | Schema management complexity |
-| Database | <100 tenants | Complete isolation | Higher resource usage |
+| Strategy  | Use When        | Pros                        | Cons                         |
+| --------- | --------------- | --------------------------- | ---------------------------- |
+| Row-level | <1000 tenants   | Simple, low overhead        | Careful index design needed  |
+| Schema    | 100-10K tenants | Good isolation, easy backup | Schema management complexity |
+| Database  | <100 tenants    | Complete isolation          | Higher resource usage        |
 
 ### 2. Design for Tenant Scale
 
@@ -486,8 +489,7 @@ class Account:
     storage_gb: int = 1
 
     __dataflow__ = {
-        'multi_tenant': True,
-        'tenant_root': True  # This is the tenant definition
+        'multi_tenant': True
     }
 ```
 
@@ -511,10 +513,11 @@ class ComplianceRecord:
     retention_days: int
 
     __dataflow__ = {
-        'multi_tenant': True,
-        'encrypt_fields': ['content'],
-        'audit_all_access': True
+        'multi_tenant': True
     }
+    # Field encryption is enabled at the `DataFlow()` level via the ENCRYPTION
+    # feature (progressive disclosure); sensitive fields are declared with
+    # `@classify(field, DataClassification.SECRET)` — NOT a `__dataflow__` model key.
 ```
 
 ---

--- a/packages/kailash-dataflow/docs/enterprise/security.md
+++ b/packages/kailash-dataflow/docs/enterprise/security.md
@@ -5,6 +5,7 @@ DataFlow provides comprehensive security features including encryption, access c
 ## Overview
 
 Security in DataFlow is implemented at multiple layers:
+
 - **Data Encryption**: At-rest and in-transit encryption
 - **Access Control**: Role-based and attribute-based access
 - **Threat Protection**: SQL injection prevention, rate limiting
@@ -105,14 +106,10 @@ class Document:
     content: str
     classification: str  # public, internal, confidential, restricted
 
-    __dataflow__ = {
-        'access_control': {
-            'read': ['user', 'admin'],
-            'create': ['editor', 'admin'],
-            'update': ['editor', 'admin'],
-            'delete': ['admin']
-        }
-    }
+    # Row/field authorization (read/create/update/delete role rules) is the
+    # domain of PACT governance (`kailash-pact`), NOT a DataFlow model key.
+    # A `@db.model` config block only backs: soft_delete, multi_tenant,
+    # indexes, retention, use_native_arrays, audit_log.
 
 # Enforce permissions in workflows
 @require_role(['admin', 'editor'])
@@ -137,23 +134,10 @@ class Project:
     department: str
     budget: float
 
-    __dataflow__ = {
-        'access_control': {
-            'type': 'abac',
-            'policies': [
-                {
-                    'name': 'department_access',
-                    'condition': 'user.department == record.department',
-                    'permissions': ['read', 'update']
-                },
-                {
-                    'name': 'budget_visibility',
-                    'condition': 'user.role in ["manager", "director"]',
-                    'fields': ['budget']
-                }
-            ]
-        }
-    }
+    # Attribute-based access control (ABAC policies, field-level visibility)
+    # is the domain of PACT governance (`kailash-pact`), NOT a DataFlow model
+    # key. A `@db.model` config block only backs: soft_delete, multi_tenant,
+    # indexes, retention, use_native_arrays, audit_log.
 ```
 
 ### Row-Level Security
@@ -164,13 +148,11 @@ class CustomerData:
     customer_id: int
     data: dict
 
-    __dataflow__ = {
-        'row_level_security': {
-            'enabled': True,
-            'policy': 'user.customer_id == record.customer_id',
-            'bypass_roles': ['admin', 'support']
-        }
-    }
+    # Row-level security (per-user filtering, bypass roles) is the domain of
+    # PACT governance (`kailash-pact`), NOT a DataFlow model key. For simple
+    # tenant partitioning, DataFlow's backed `multi_tenant` key applies a
+    # tenant_id scope automatically. A `@db.model` config block only backs:
+    # soft_delete, multi_tenant, indexes, retention, use_native_arrays, audit_log.
 
 # Automatic filtering based on user context
 workflow.add_node("CustomerDataListNode", "my_data", {
@@ -233,13 +215,10 @@ class SecureOperation:
     operation_type: str
     requires_mfa: bool = True
 
-    __dataflow__ = {
-        'mfa_required': {
-            'operations': ['delete', 'bulk_update'],
-            'verification_method': 'totp',  # or 'sms', 'email'
-            'timeout': 300  # 5 minutes
-        }
-    }
+    # Multi-factor authentication is an application/gateway concern enforced
+    # by Nexus (`kailash-nexus`) on the request path, NOT a `@db.model` config
+    # key. A `@db.model` config block only backs: soft_delete, multi_tenant,
+    # indexes, retention, use_native_arrays, audit_log.
 ```
 
 ## SQL Injection Prevention
@@ -310,13 +289,10 @@ db = DataFlow(
 class RateLimitedResource:
     name: str
 
-    __dataflow__ = {
-        'rate_limits': {
-            'create': {'limit': 10, 'window': 3600},
-            'bulk_create': {'limit': 1, 'window': 86400},
-            'delete': {'limit': 5, 'window': 3600}
-        }
-    }
+    # Per-operation rate limiting is an application/gateway concern enforced
+    # by Nexus (`kailash-nexus`) on the request path, NOT a `@db.model` config
+    # key. A `@db.model` config block only backs: soft_delete, multi_tenant,
+    # indexes, retention, use_native_arrays, audit_log.
 ```
 
 ### Connection Limits
@@ -617,15 +593,10 @@ db = DataFlow(
 class SecureResource:
     data: str
 
-    __dataflow__ = {
-        'access_control': {
-            'default': 'deny',  # Deny by default
-            'rules': [
-                {'role': 'owner', 'permissions': ['all']},
-                {'role': 'viewer', 'permissions': ['read']}
-            ]
-        }
-    }
+    # Deny-by-default access control and per-role permission rules are the
+    # domain of PACT governance (`kailash-pact`), NOT a DataFlow model key.
+    # A `@db.model` config block only backs: soft_delete, multi_tenant,
+    # indexes, retention, use_native_arrays, audit_log.
 ```
 
 ### 3. Regular Security Audits
@@ -702,13 +673,19 @@ class PatientRecord:
     patient_id: int
     medical_data: dict = Field(encrypted=True)
 
+    # Compliance postures (HIPAA/PHI handling) are composed from real building
+    # blocks, NOT a single `@db.model` compliance key: field-level encryption
+    # via `Field(encrypted=True)`, access logging via the backed `audit_log`
+    # key, data lifecycle via the backed `retention` key, and role/PHI-access
+    # governance via PACT (`kailash-pact`). A `@db.model` config block only
+    # backs: soft_delete, multi_tenant, indexes, retention, use_native_arrays,
+    # audit_log.
     __dataflow__ = {
-        'compliance': {
-            'hipaa': True,
-            'phi_fields': ['medical_data'],
-            'access_logging': 'detailed',
-            'encryption_required': True,
-            'retention_years': 6
+        'audit_log': {
+            'enabled': True,
+            'log_reads': True,
+            'log_writes': True,
+            'retention_days': 2190  # 6 years
         }
     }
 ```

--- a/packages/kailash-dataflow/docs/enterprise/security.md
+++ b/packages/kailash-dataflow/docs/enterprise/security.md
@@ -674,8 +674,9 @@ class PatientRecord:
     medical_data: dict = Field(encrypted=True)
 
     # Compliance postures (HIPAA/PHI handling) are composed from real building
-    # blocks, NOT a single `@db.model` compliance key: field-level encryption
-    # via `Field(encrypted=True)`, access logging via the backed `audit_log`
+    # blocks, NOT a single `@db.model` compliance key: encryption via the
+    # DataFlow() ENCRYPTION feature (a constructor-level feature, not a model
+    # key), access logging via the backed `audit_log`
     # key, data lifecycle via the backed `retention` key, and role/PHI-access
     # governance via PACT (`kailash-pact`). A `@db.model` config block only
     # backs: soft_delete, multi_tenant, indexes, retention, use_native_arrays,

--- a/packages/kailash-dataflow/tests/integration/query_builder/test_query_builder_mysql.py
+++ b/packages/kailash-dataflow/tests/integration/query_builder/test_query_builder_mysql.py
@@ -14,10 +14,11 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../src"))
-from dataflow.database.query_builder import DatabaseType, QueryBuilder
-
 from kailash.runtime.local import LocalRuntime
+
+from dataflow.database.query_builder import DatabaseType, QueryBuilder
 from tests.infrastructure.test_harness import IntegrationTestSuite
+
 
 @pytest.fixture
 async def test_suite():
@@ -26,10 +27,12 @@ async def test_suite():
     async with suite.session():
         yield suite
 
+
 @pytest.fixture
 def runtime():
     """Create LocalRuntime for workflow execution."""
     return LocalRuntime()
+
 
 # @pytest.mark.tier2
 # @pytest.mark.requires_docker
@@ -107,11 +110,12 @@ class TestQueryBuilderMySQLIntegration:
         sql, params = builder.build_select(["*"])
 
         # MySQL supports LIMIT count OFFSET offset syntax
+        # LIMIT/OFFSET are parameterized (%s); values carried in params
         assert "LIMIT" in sql
-        assert "LIMIT 10" in sql
-        assert "OFFSET 20" in sql
+        assert "LIMIT %s" in sql
+        assert "OFFSET %s" in sql
         assert "`in_stock` = %s" in sql
-        assert params == [True]
+        assert params == [True, 10, 20]
 
     def test_mysql_regexp_operations(self):
         """Test MySQL REGEXP operations."""

--- a/packages/kailash-dataflow/tests/integration/query_builder/test_query_builder_postgresql.py
+++ b/packages/kailash-dataflow/tests/integration/query_builder/test_query_builder_postgresql.py
@@ -14,10 +14,11 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../src"))
-from dataflow.database.query_builder import DatabaseType, QueryBuilder
-
 from kailash.runtime.local import LocalRuntime
+
+from dataflow.database.query_builder import DatabaseType, QueryBuilder
 from tests.infrastructure.test_harness import IntegrationTestSuite
+
 
 @pytest.fixture
 async def test_suite():
@@ -26,10 +27,12 @@ async def test_suite():
     async with suite.session():
         yield suite
 
+
 @pytest.fixture
 def runtime():
     """Create LocalRuntime for workflow execution."""
     return LocalRuntime()
+
 
 # @pytest.mark.tier2
 # @pytest.mark.requires_docker
@@ -154,9 +157,10 @@ class TestQueryBuilderPostgreSQLIntegration:
 
             # Verify pagination SQL generation
             assert 'ORDER BY "created_at" DESC' in sql
-            assert f"LIMIT {page_size}" in sql
-            assert "OFFSET 0" in sql
-            assert params == [True]
+            # LIMIT/OFFSET are parameterized ($2 after WHERE's $1); values in params
+            assert "LIMIT $2" in sql
+            assert "OFFSET $3" in sql
+            assert params == [True, page_size, 0]
 
     def test_transaction_handling_with_query_builder(self):
         """Test transaction handling in QueryBuilder context."""
@@ -229,8 +233,10 @@ class TestQueryBuilderPostgreSQLIntegration:
         for sql, params in queries:
             assert "SELECT" in sql
             assert "WHERE" in sql
-            assert "LIMIT 10" in sql
-            assert len(params) == 2  # active=True and age>=N
+            # LIMIT parameterized as $3 (after the two WHERE params $1, $2)
+            assert "LIMIT $3" in sql
+            assert len(params) == 3  # active=True, age>=N, and limit=10
+
 
 # @pytest.mark.tier2
 # @pytest.mark.requires_docker
@@ -264,9 +270,10 @@ class TestQueryBuilderPostgreSQLEdgeCases:
 
         # Should generate efficient SQL with proper LIMIT/OFFSET
         assert 'SELECT "id", "name", "email" FROM "users"' in sql
-        assert "LIMIT 10000" in sql
-        assert "OFFSET 50000" in sql
-        assert params == [True]
+        # LIMIT/OFFSET parameterized ($2/$3 after WHERE's $1); values in params
+        assert "LIMIT $2" in sql
+        assert "OFFSET $3" in sql
+        assert params == [True, 10000, 50000]
 
     def test_query_timeout_handling(self):
         """Test query timeout handling."""
@@ -282,8 +289,9 @@ class TestQueryBuilderPostgreSQLEdgeCases:
         # Should generate efficient SQL that can be executed with timeouts
         assert 'SELECT * FROM "users"' in sql
         assert 'ORDER BY "created_at" DESC' in sql
-        assert "LIMIT 1000" in sql
-        assert params == [True]
+        # LIMIT parameterized as $2 (after WHERE's $1); value in params
+        assert "LIMIT $2" in sql
+        assert params == [True, 1000]
 
     def test_invalid_sql_generation_handling(self):
         """Test handling of invalid SQL generation scenarios."""

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
@@ -1,0 +1,78 @@
+"""#1606 cross-SDK cache-keyspace TRIPWIRE.
+
+This module pins the EXACT byte string of the current ``v2`` cache keyspace
+emitted by ``CacheKeyGenerator`` (both the Express key and the query key) plus
+the ``:{tenant}:{model}:`` substring adjacency that
+``InMemoryCache.invalidate_model`` relies on.
+
+WHY A TRIPWIRE (not the fix): issue #1606 asks for a DB-instance segment in the
+key + a keyspace bump ``v2 -> v3``. That bump is a CROSS-SDK LOCKSTEP — the
+``v2`` Express keyspace at ``src/dataflow/cache/key_generator.py`` is pinned to
+kailash-rs (the Rust SDK, ``v3.19.0`` cross-SDK contract, BP-049) and MUST NOT
+be changed unilaterally in one SDK. Changing ANY byte pinned in this file is
+therefore a loud, deliberate event: update it ONLY together with the paired
+Rust SDK keyspace change (the ``v2 -> v3`` lockstep). A silent drift here would
+diverge the two SDKs' cache keys and break cross-SDK invalidation.
+
+Tier: 1 (Unit — no external dependencies).
+"""
+
+from dataflow.cache.key_generator import CacheKeyGenerator
+from dataflow.cache.memory_cache import InMemoryCache
+
+# --- Pinned v2 keyspace bytes (change ONLY with the Rust SDK v2->v3 lockstep) ---
+EXPRESS_KEY_WITH_TENANT = "dataflow:v2:tenant-a:User:list:6a3d3c8c"
+EXPRESS_KEY_NO_TENANT = "dataflow:v2:User:list"
+QUERY_KEY = "dataflow:User:v2:2f5a5fc5af648187"
+
+
+def test_express_key_v2_bytes_are_pinned():
+    """generate_express_key emits the exact v2 byte string for fixed inputs."""
+    gen = CacheKeyGenerator()
+
+    # With tenant + params: dataflow:v2:<tenant>:<model>:<op>:<hash>
+    key = gen.generate_express_key(
+        "User", "list", {"active": True}, tenant_id="tenant-a"
+    )
+    assert key == EXPRESS_KEY_WITH_TENANT, (
+        f"v2 Express keyspace drifted: got {key!r}. Changing these bytes is a "
+        f"cross-SDK LOCKSTEP (#1606) — bump v2->v3 in BOTH SDKs, not one."
+    )
+
+    # Without tenant/params the trailing hash segment is absent.
+    assert gen.generate_express_key("User", "list") == EXPRESS_KEY_NO_TENANT
+
+    # Version segment is fixed at v2 (the pinned cross-SDK keyspace).
+    assert key.startswith("dataflow:v2:")
+
+
+def test_query_key_v2_bytes_are_pinned():
+    """generate_key emits the exact v2 byte string for a fixed SQL+params."""
+    gen = CacheKeyGenerator()
+    key = gen.generate_key("User", "SELECT * FROM users WHERE active = $1", [True])
+    assert key == QUERY_KEY, (
+        f"v2 query keyspace drifted: got {key!r}. Changing these bytes is a "
+        f"cross-SDK LOCKSTEP (#1606) — bump v2->v3 in BOTH SDKs, not one."
+    )
+    # Query-key shape places the model BEFORE the version: dataflow:<model>:v2:<hash>
+    assert ":v2:" in key
+
+
+async def test_invalidate_model_matches_v2_express_key():
+    """invalidate_model's ``:{tenant}:{model}:`` adjacency still deletes the key.
+
+    Pins the substring contract at memory_cache.py::invalidate_model — a
+    tenant-scoped invalidation matches the current v2 Express key layout
+    (``dataflow:v2:tenant-a:User:list:...`` contains ``:tenant-a:User:``).
+    """
+    cache = InMemoryCache()
+    await cache.set(EXPRESS_KEY_WITH_TENANT, {"rows": []})
+
+    # Tenant-scoped invalidation for a DIFFERENT tenant MUST NOT match.
+    assert await cache.invalidate_model("User", tenant_id="tenant-b") == 0
+    assert await cache.get(EXPRESS_KEY_WITH_TENANT) is not None
+
+    # The owning tenant's invalidation MUST delete exactly this key.
+    removed = await cache.invalidate_model("User", tenant_id="tenant-a")
+    assert removed == 1
+    assert await cache.get(EXPRESS_KEY_WITH_TENANT) is None


### PR DESCRIPTION
Three DataFlow issues on one branch, three atomic commits.

## #1618 — stale parameterized-LIMIT test drift
`QueryBuilder.build_select` emits parameterized `LIMIT $N`/`%s` with the values
in `params` (injection-safe), but 5 tests asserted inline LIMIT/OFFSET literals.
Fixed the assertions to the parameterized form (placeholder + value-in-params),
mirroring the existing WHERE-param assertions. Param order confirmed from
`build_select`: WHERE params, then limit, then offset (PG `$N` monotonic via
`_parameter_index`; MySQL `%s`).

Fixes #1618

## #1607 — enterprise-doc `__dataflow__` fiction purge
The `docs/enterprise/{compliance,security,multi-tenant}.md` and
`docs/advanced/{security,database-optimization,multi-tenant}.md` docs advertised
~30 top-level `__dataflow__` keys with zero read-site in src. The only backed
keys are `_KNOWN_DATAFLOW_CONFIG_KEYS` (`soft_delete, multi_tenant, indexes,
retention, use_native_arrays, audit_log`); every other top-level key triggers the
#1599 UserWarning. Purged each fiction key and reframed to the real surface where
one exists — `encryption`/`encrypt_fields` -> the `DataFlow()` ENCRYPTION
progressive-disclosure feature + `@classify(field, DataClassification.SECRET)`;
`classification` -> field-level `@classify`; `access_control`/`row_level_security`/
`row_security` -> PACT governance (`kailash-pact`), not a DataFlow key;
`retention_years`/`_days` -> the real `retention` config dict. Every remaining
top-level `__dataflow__` key across the six swept docs is now one of the six
backed keys (verified by an AST-style grep).

Fixes #1607

## #1606 — keyspace tripwire only (NOT the fix)
Added a Tier-1 regression test pinning the exact current `v2` cache-keyspace
bytes (a representative express key, a query key, and the `:{tenant}:{model}:`
invalidation-substring adjacency). `key_generator.py` is unchanged.

**Tripwire only; the `v2` -> `v3` keyspace fix (insert a DB-instance segment +
bump the version) is a cross-SDK lockstep with the Rust SDK and is tracked
separately, not landed here.** Changing any pinned byte in the new test now
forces a loud, deliberate, paired event rather than a silent drift.

## Test tiers run
- #1606 tripwire: Tier 1 unit — `3 passed`.
- #1618: query_builder suite — `27 passed` (the query_builder tests are pure
  SQL-string generation, no DB connection; PG:5434 was up, MySQL:3306 was down
  but not needed).
- #1607: markdown/docs — pre-commit doc-style + full hook set green.
- pre-commit (`--files` over all 9 changed files): all hooks Passed, incl.
  "Run Tier 1 unit tests".