### PR TITLE
feat(kaizen): DeepSeek first-class LlmProvider (#1609)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/__init__.py
@@ -45,6 +45,7 @@ from kaizen.llm.grammar.bedrock import (
     BedrockTitanGrammar,
 )
 from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
+from kaizen.llm.provider import LlmProvider, UnknownModelProvider
 from kaizen.llm.reasoning import (
     CapabilityMatchAgent,
     CapabilityMatchSignature,
@@ -84,6 +85,9 @@ __all__ = [
     "StreamingConfig",
     "RetryConfig",
     "LlmClient",
+    # Model-identifier → provider resolution (#1609)
+    "LlmProvider",
+    "UnknownModelProvider",
     # Auth strategies
     "AuthStrategy",
     "Custom",

--- a/packages/kailash-kaizen/src/kaizen/llm/from_env.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/from_env.py
@@ -55,6 +55,10 @@ LEGACY_KEY_ORDER = [
     ("AZURE_OPENAI_API_KEY", "azure_openai"),
     ("ANTHROPIC_API_KEY", "anthropic"),
     ("GOOGLE_API_KEY", "google"),
+    # DeepSeek (OpenAI-compatible) — placed last so it never displaces an
+    # existing provider's precedence; a bare DEEPSEEK_API_KEY (no URI/selector)
+    # resolves to the deepseek preset. (#1609)
+    ("DEEPSEEK_API_KEY", "deepseek"),
 ]
 
 # Strict per-field regexes for URI parsing -- defense-in-depth before
@@ -261,6 +265,13 @@ def _call_preset_from_env(selector: str, factory: Any) -> LlmDeployment:
         api_key = _require_env("GOOGLE_API_KEY", "GEMINI_API_KEY")
         model = _require_env("GOOGLE_MODEL", "GEMINI_MODEL")
         return factory(api_key, model=model)
+    if selector == "deepseek":
+        # DeepSeek (OpenAI-compatible). The preset carries the DeepSeek
+        # base_url intrinsically, so no base_url override is needed here
+        # (#1609). Model env precedence matches `_FROM_ENV_PROVIDERS`.
+        api_key = _require_env("DEEPSEEK_API_KEY")
+        model = _require_env("DEEPSEEK_PROD_MODEL", "DEEPSEEK_MODEL")
+        return factory(api_key, model=model)
     if selector == "bedrock_claude":
         token = _require_env("AWS_BEARER_TOKEN_BEDROCK")
         region = _require_env("AWS_REGION")
@@ -287,6 +298,7 @@ def _build_from_legacy(legacy_key: str) -> LlmDeployment:
     from kaizen.llm.presets import (
         anthropic_preset,
         azure_openai_preset,
+        deepseek_preset,
         google_preset,
         openai_preset,
     )
@@ -311,6 +323,13 @@ def _build_from_legacy(legacy_key: str) -> LlmDeployment:
         api_key = os.environ["GOOGLE_API_KEY"]
         model = _require_env("GOOGLE_MODEL", "GEMINI_MODEL")
         return google_preset(api_key, model=model)
+    if legacy_key == "DEEPSEEK_API_KEY":
+        # DeepSeek (OpenAI-compatible) — the preset carries the DeepSeek
+        # base_url; from_env selects it when only DEEPSEEK_API_KEY is set
+        # (no URI / selector tier). (#1609)
+        api_key = os.environ["DEEPSEEK_API_KEY"]
+        model = _require_env("DEEPSEEK_PROD_MODEL", "DEEPSEEK_MODEL")
+        return deepseek_preset(api_key, model=model)
     raise LlmClientError(f"Unhandled legacy key: {legacy_key}")
 
 

--- a/packages/kailash-kaizen/src/kaizen/llm/provider.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/provider.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-identifier → provider resolution (`LlmProvider.from_model`).
+
+The four-axis `LlmDeployment` (`deployment.py` + `presets.py`) is the
+canonical description of HOW to talk to a provider (wire protocol,
+endpoint, auth). `LlmProvider` is the thin, immutable *identity* layer
+above it: given a model name (`"deepseek-chat"`, `"gpt-4o"`), which
+provider serves it, and what are that provider's public coordinates —
+`display_name`, `base_url`, `api_key_env_vars`, `capabilities`.
+
+Cross-SDK parity: this is the Python equivalent of the Rust SDK's
+`LlmProvider::from_model` (EATP D6 — matching semantics, idiomatic
+implementation). `from_model` fails closed on an unrecognised prefix
+with a typed `UnknownModelProvider(ValueError)` rather than silently
+routing to a default provider.
+
+Single-source-of-truth discipline (no parallel data):
+
+* `capabilities` delegates to `kaizen.llm.capabilities.for_preset(name)`
+  — the same table `LlmDeployment.supports()` reads.
+* `api_key_env_vars` is pinned byte-for-byte to
+  `presets.py::_FROM_ENV_PROVIDERS` by a cross-check invariant test.
+* `base_url` is pinned to the matching `<provider>_preset` default
+  endpoint by a cross-check invariant test.
+* `deployment(...)` bridges to the registered preset factory via
+  `presets.get_preset(name)` — it does NOT re-implement wire/auth/endpoint
+  assembly, so a `from_model(...)` result has a real production path into
+  an `LlmDeployment` (orphan-detection Rule 1).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from kaizen.llm.capabilities import for_preset
+from kaizen.llm.errors import MissingCredential
+
+if TYPE_CHECKING:  # avoid importing the heavy presets module at import time
+    from kaizen.llm.deployment import LlmDeployment
+
+
+# Canonical per-provider base URLs. These are provider *identity*
+# coordinates (stable infrastructure endpoints), NOT model names, so they
+# are not an `env-models.md` violation. Each value is pinned to the
+# matching `<provider>_preset` default endpoint by a cross-check test in
+# `tests/unit/llm/test_llm_provider_from_model.py`.
+OPENAI_BASE_URL = "https://api.openai.com"
+ANTHROPIC_BASE_URL = "https://api.anthropic.com"
+GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com"
+DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+
+
+class UnknownModelProvider(ValueError):
+    """No provider could be resolved from a model identifier.
+
+    Raised by :meth:`LlmProvider.from_model` when the model name matches
+    no registered provider prefix. Fails closed (a `ValueError`) rather
+    than routing to an arbitrary default — a silent default route is the
+    exact fail-open the DeepSeek issue (#1609) reported (`from_model`
+    raised `unknown prefix` before DeepSeek was registered).
+    """
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        super().__init__(
+            f"LLM provider detection failed for model {model!r}: unknown prefix. "
+            f"Registered prefixes: {sorted(_PREFIX_TO_NAME)}."
+        )
+
+
+@dataclass(frozen=True)
+class LlmProvider:
+    """Immutable provider identity resolved from a model name.
+
+    Construct via :meth:`from_model` / :meth:`from_name`, never directly —
+    the registry (`_REGISTRY`) is the single source of provider entries.
+    """
+
+    name: str
+    """Canonical preset literal — matches `LlmDeployment.preset_name` and
+    the `presets.get_preset(name)` registry key (e.g. ``"deepseek"``)."""
+
+    display_name: str
+    """Human-readable provider name (e.g. ``"DeepSeek"``)."""
+
+    base_url: str
+    """Provider's public API base URL (no trailing slash)."""
+
+    openai_compatible: bool
+    """True when the provider speaks the OpenAI chat-completions wire
+    schema (`WireProtocol.OpenAiChat`) — DeepSeek and OpenAI itself."""
+
+    # Stored as tuples for immutability; exposed as fresh lists via the
+    # public properties below so the frozen value object cannot be mutated
+    # through its own accessors and each caller gets an independent copy.
+    _api_key_env_vars: Tuple[str, ...]
+    _model_prefixes: Tuple[str, ...]
+
+    @property
+    def api_key_env_vars(self) -> List[str]:
+        """Env var names carrying this provider's API key, in precedence
+        order. A fresh list per access (mutating it does not affect the
+        registry)."""
+        return list(self._api_key_env_vars)
+
+    @property
+    def model_prefixes(self) -> List[str]:
+        """Model-name prefixes this provider serves (e.g. ``["deepseek-"]``)."""
+        return list(self._model_prefixes)
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        """Capability matrix for this provider.
+
+        `chat` and `streaming` are True for every registered provider
+        (all are chat-completions endpoints with SSE streaming). The
+        deployment-surface capabilities (`tools`, `vision`, `batch`,
+        `caching`, `audio`) delegate to
+        :func:`kaizen.llm.capabilities.for_preset` — the single source of
+        truth also read by :meth:`LlmDeployment.supports`. `openai_compatible`
+        echoes the wire-schema flag. Returns a fresh dict per call.
+        """
+        caps: Dict[str, bool] = {
+            "chat": True,
+            "streaming": True,
+            "openai_compatible": self.openai_compatible,
+        }
+        caps.update(for_preset(self.name))
+        return caps
+
+    @classmethod
+    def from_model(cls, model: str) -> "LlmProvider":
+        """Resolve the provider serving ``model`` by prefix, or raise.
+
+        Matching is case-insensitive on the model-name prefix
+        (``"deepseek-chat"`` / ``"deepseek-reasoner"`` → DeepSeek;
+        ``"gpt-4o"`` → OpenAI; ``"claude-3"`` → Anthropic). An
+        unrecognised prefix raises :class:`UnknownModelProvider` (fail
+        closed) rather than defaulting.
+        """
+        if not isinstance(model, str) or not model.strip():
+            raise UnknownModelProvider(model)
+        lowered = model.strip().lower()
+        for prefix, name in _PREFIX_TO_NAME.items():
+            if lowered.startswith(prefix):
+                return _REGISTRY[name]
+        raise UnknownModelProvider(model)
+
+    @classmethod
+    def from_name(cls, name: str) -> "LlmProvider":
+        """Look up a provider by its canonical preset literal (`"deepseek"`)."""
+        try:
+            return _REGISTRY[name]
+        except KeyError as exc:
+            raise UnknownModelProvider(name) from exc
+
+    @classmethod
+    def all(cls) -> Tuple["LlmProvider", ...]:
+        """Every registered provider, in registration order."""
+        return tuple(_REGISTRY.values())
+
+    def deployment(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: str,
+    ) -> "LlmDeployment":
+        """Build a concrete :class:`LlmDeployment` for this provider.
+
+        Bridges to the registered preset factory
+        (`presets.get_preset(self.name)`) — no wire/auth/endpoint logic is
+        re-implemented here. ``api_key`` defaults to the first non-empty
+        value among :attr:`api_key_env_vars`; if none is set a typed
+        :class:`MissingCredential` is raised (never a silent unauthenticated
+        client). ``model`` is required and is validated by the preset.
+        """
+        from kaizen.llm.presets import get_preset
+
+        resolved_key = api_key
+        if resolved_key is None:
+            for var in self._api_key_env_vars:
+                val = os.environ.get(var, "").strip()
+                if val:
+                    resolved_key = val
+                    break
+        if not resolved_key:
+            raise MissingCredential(" or ".join(self._api_key_env_vars))
+
+        factory = get_preset(self.name)
+        return factory(resolved_key, model=model)
+
+
+# ---------------------------------------------------------------------------
+# Registry — the single source of provider identity entries.
+# ---------------------------------------------------------------------------
+#
+# `name` MUST match a `presets.get_preset(name)` registry key AND the
+# capability-table literal in `capabilities.py`. `_api_key_env_vars` is
+# pinned to `_FROM_ENV_PROVIDERS`; `base_url` to the preset default — both
+# by cross-check tests. New providers: add a row here + the matching preset
+# + capability row (all three verified by the parity tests).
+_REGISTRY: Dict[str, LlmProvider] = {
+    "openai": LlmProvider(
+        name="openai",
+        display_name="OpenAI",
+        base_url=OPENAI_BASE_URL,
+        openai_compatible=True,
+        _api_key_env_vars=("OPENAI_API_KEY",),
+        _model_prefixes=("gpt-", "o1-", "o3-", "o4-"),
+    ),
+    "anthropic": LlmProvider(
+        name="anthropic",
+        display_name="Anthropic",
+        base_url=ANTHROPIC_BASE_URL,
+        openai_compatible=False,
+        _api_key_env_vars=("ANTHROPIC_API_KEY",),
+        _model_prefixes=("claude-",),
+    ),
+    "google": LlmProvider(
+        name="google",
+        display_name="Google",
+        base_url=GOOGLE_BASE_URL,
+        openai_compatible=False,
+        _api_key_env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        _model_prefixes=("gemini-",),
+    ),
+    "deepseek": LlmProvider(
+        name="deepseek",
+        display_name="DeepSeek",
+        base_url=DEEPSEEK_BASE_URL,
+        openai_compatible=True,
+        _api_key_env_vars=("DEEPSEEK_API_KEY",),
+        _model_prefixes=("deepseek-",),
+    ),
+}
+
+# Prefix → provider-name lookup, built from the registry so it can never
+# drift from `_REGISTRY`. Longer prefixes are naturally distinct here
+# (no registered prefix is a prefix of another).
+_PREFIX_TO_NAME: Dict[str, str] = {
+    prefix: provider.name
+    for provider in _REGISTRY.values()
+    for prefix in provider._model_prefixes
+}
+
+
+__all__ = [
+    "LlmProvider",
+    "UnknownModelProvider",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_BASE_URL",
+    "GOOGLE_BASE_URL",
+    "DEEPSEEK_BASE_URL",
+]

--- a/packages/kailash-kaizen/tests/integration/llm/test_deepseek_live.py
+++ b/packages/kailash-kaizen/tests/integration/llm/test_deepseek_live.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-3 LIVE verification of DeepSeek chat + streaming (issue #1609 AC 4).
+
+Real API, NO mocking (per `rules/testing.md` Tier 2/3). DeepSeek is
+OpenAI-compatible, so the live chat/stream path runs through the framework's
+`OpenAIProvider` pointed at the DeepSeek endpoint — the same wire schema
+(`WireProtocol.OpenAiChat`) the `deepseek_preset` / `LlmProvider` describe.
+(`LlmClient.complete()` is still stubbed — see `test_llmclient_openai_wiring.py`
+— so provider-level chat is the current live surface.)
+
+**Key-gated skip (test-skip-discipline):** this test is SKIPPED — never faked —
+when `DEEPSEEK_API_KEY` is absent. An absent credential is an "unable to
+execute" skip, NOT a broken system. Both the endpoint (`base_url`) and the
+model come from the framework / environment; nothing is hardcoded
+(`rules/env-models.md`).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kaizen.llm import LlmProvider
+from kaizen.providers.llm.openai import OpenAIProvider
+
+
+def _deepseek_model() -> str:
+    """Resolve the DeepSeek model from env (no hardcoded model name)."""
+    for var in ("DEEPSEEK_PROD_MODEL", "DEEPSEEK_MODEL"):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val
+    pytest.skip(
+        "DEEPSEEK_PROD_MODEL / DEEPSEEK_MODEL not set; live DeepSeek test "
+        "needs a model from .env (rules/env-models.md — no hardcoded model)."
+    )
+
+
+def _deepseek_credentials() -> tuple[str, str, str]:
+    """Return (api_key, base_url, model) or skip when the credential is absent."""
+    api_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+    if not api_key:
+        pytest.skip(
+            "DEEPSEEK_API_KEY not set; live chat + streaming verification is "
+            "pending the credential (unable-to-execute skip, not a failure)."
+        )
+    # base_url derived from the framework provider metadata + the preset's
+    # OpenAI-compatible `/v1` path prefix — not a hardcoded literal.
+    base_url = LlmProvider.from_name("deepseek").base_url + "/v1"
+    return api_key, base_url, _deepseek_model()
+
+
+@pytest.mark.integration_llm
+def test_deepseek_live_chat() -> None:
+    """A real DeepSeek chat completion returns non-empty content."""
+    api_key, base_url, model = _deepseek_credentials()
+
+    provider = OpenAIProvider()
+    result = provider.chat(
+        [{"role": "user", "content": "Reply with exactly the word: ok"}],
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        generation_config={"max_completion_tokens": 8, "temperature": 0.0},
+    )
+
+    assert isinstance(result, dict)
+    assert result["content"], "DeepSeek returned empty chat content"
+    assert result["finish_reason"] is not None
+    assert result["usage"]["total_tokens"] > 0
+
+
+@pytest.mark.integration_llm
+@pytest.mark.asyncio
+async def test_deepseek_live_streaming() -> None:
+    """A real DeepSeek streaming completion emits deltas + a terminal event."""
+    api_key, base_url, model = _deepseek_credentials()
+
+    provider = OpenAIProvider(use_async=True)
+    deltas: list[str] = []
+    done_seen = False
+    accumulated = ""
+
+    async for event in provider.stream_chat(
+        [{"role": "user", "content": "Count: one two three"}],
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        generation_config={"max_completion_tokens": 16, "temperature": 0.0},
+    ):
+        if event.event_type == "text_delta":
+            deltas.append(event.delta_text)
+            accumulated = event.content
+        elif event.event_type == "done":
+            done_seen = True
+            assert event.finish_reason is not None
+
+    assert done_seen, "streaming never emitted a terminal 'done' event"
+    assert any(d for d in deltas), "streaming produced no text deltas"
+    assert accumulated, "streaming accumulated no content"

--- a/packages/kailash-kaizen/tests/unit/llm/test_from_env.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_from_env.py
@@ -6,15 +6,12 @@
 from __future__ import annotations
 
 import logging
+
 import pytest
 
 from kaizen.llm.client import LlmClient
 from kaizen.llm.deployment import LlmDeployment
-from kaizen.llm.errors import (
-    InvalidUri,
-    MissingCredential,
-    NoKeysConfigured,
-)
+from kaizen.llm.errors import InvalidUri, MissingCredential, NoKeysConfigured
 from kaizen.llm.from_env import (
     ENV_DEPLOYMENT_URI,
     ENV_SELECTOR,
@@ -22,7 +19,6 @@ from kaizen.llm.from_env import (
     SUPPORTED_SCHEMES,
     resolve_env_deployment,
 )
-
 
 # ---------------------------------------------------------------------------
 # No-config -> NoKeysConfigured
@@ -219,13 +215,19 @@ def test_env_var_names_stable() -> None:
 
 
 def test_legacy_key_order_matches_autoselect() -> None:
-    """Legacy tier ordering: OpenAI > Azure > Anthropic > Google."""
+    """Legacy tier ordering: OpenAI > Azure > Anthropic > Google > DeepSeek.
+
+    DeepSeek (OpenAI-compatible, #1609) is appended LAST so it never displaces
+    an existing provider's precedence — a bare DEEPSEEK_API_KEY resolves to it
+    only when none of the four canonical keys are set.
+    """
     names = [v for v, _ in LEGACY_KEY_ORDER]
     assert names == [
         "OPENAI_API_KEY",
         "AZURE_OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "GOOGLE_API_KEY",
+        "DEEPSEEK_API_KEY",
     ]
 
 

--- a/packages/kailash-kaizen/tests/unit/llm/test_llm_provider_from_model.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_llm_provider_from_model.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-1 unit tests for `LlmProvider.from_model` + DeepSeek first-class support.
+
+Covers issue #1609 acceptance criteria (network-free):
+
+* `LlmProvider.from_model("deepseek-chat")` / `("deepseek-reasoner")` resolve
+  to a DeepSeek provider.
+* The DeepSeek provider exposes `api_key_env_vars == ["DEEPSEEK_API_KEY"]`,
+  `base_url == "https://api.deepseek.com"`, and correct `capabilities`.
+* `LlmClient.from_env()` selects DeepSeek when a `deepseek-*` model +
+  `DEEPSEEK_API_KEY` are configured (legacy tier AND selector tier).
+* Single-source-of-truth cross-checks: the provider's `base_url` matches the
+  `deepseek_preset` default endpoint; its `api_key_env_vars` matches
+  `presets._FROM_ENV_PROVIDERS`.
+
+The live chat + streaming verification against the real DeepSeek
+OpenAI-compatible API is key-gated in
+`tests/integration/llm/test_deepseek_live.py` (skipped without
+`DEEPSEEK_API_KEY`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm import LlmProvider, UnknownModelProvider
+from kaizen.llm.client import LlmClient
+from kaizen.llm.deployment import LlmDeployment
+from kaizen.llm.errors import MissingCredential
+from kaizen.llm.presets import deepseek_preset
+
+# ---------------------------------------------------------------------------
+# from_model — DeepSeek (the #1609 headline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", ["deepseek-chat", "deepseek-reasoner"])
+def test_from_model_deepseek_resolves_deepseek_provider(model: str) -> None:
+    provider = LlmProvider.from_model(model)
+    assert provider.name == "deepseek"
+    assert provider.display_name == "DeepSeek"
+
+
+def test_deepseek_provider_exposes_expected_coordinates() -> None:
+    provider = LlmProvider.from_model("deepseek-chat")
+    # AC: exact list equality (mirrors the Rust `LlmProvider` Vec shape).
+    assert provider.api_key_env_vars == ["DEEPSEEK_API_KEY"]
+    assert provider.base_url == "https://api.deepseek.com"
+    assert provider.openai_compatible is True
+
+
+def test_deepseek_capabilities_chat_streaming_openai_compatible() -> None:
+    caps = LlmProvider.from_model("deepseek-reasoner").capabilities
+    # OpenAI-compatible chat + streaming per the AC.
+    assert caps["chat"] is True
+    assert caps["streaming"] is True
+    assert caps["openai_compatible"] is True
+    # Deployment surface (delegated to the capabilities table): DeepSeek's
+    # OpenAI-compatible endpoint serves text-only tool-calling, no vision.
+    assert caps["tools"] is True
+    assert caps["vision"] is False
+
+
+def test_api_key_env_vars_is_independent_list_copy() -> None:
+    provider = LlmProvider.from_name("deepseek")
+    a = provider.api_key_env_vars
+    a.append("MUTATED")
+    # Mutating the returned list does not leak into the registry.
+    assert provider.api_key_env_vars == ["DEEPSEEK_API_KEY"]
+
+
+# ---------------------------------------------------------------------------
+# from_model — sibling providers (the #1609 repro's working cases)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-4o", "openai"),
+        ("o1-preview", "openai"),
+        ("claude-3-5-sonnet", "anthropic"),
+        ("gemini-2.0-flash", "google"),
+        ("DeepSeek-Chat", "deepseek"),  # case-insensitive prefix match
+    ],
+)
+def test_from_model_prefix_resolution(model: str, expected: str) -> None:
+    assert LlmProvider.from_model(model).name == expected
+
+
+@pytest.mark.parametrize("bad", ["mystery-model-x", "", "   ", "llama3.2"])
+def test_from_model_unknown_prefix_fails_closed(bad: str) -> None:
+    # Fail-closed: unknown prefix raises (a ValueError subclass), never a
+    # silent default provider route.
+    with pytest.raises(UnknownModelProvider):
+        LlmProvider.from_model(bad)
+    assert issubclass(UnknownModelProvider, ValueError)
+
+
+def test_from_name_unknown_raises() -> None:
+    with pytest.raises(UnknownModelProvider):
+        LlmProvider.from_name("not-a-provider")
+
+
+# ---------------------------------------------------------------------------
+# Single-source-of-truth cross-checks (guard against data drift)
+# ---------------------------------------------------------------------------
+
+
+def test_deepseek_base_url_matches_preset_default() -> None:
+    # The provider's base_url MUST equal the deepseek_preset default endpoint;
+    # if a future edit changes one without the other, this fails loudly.
+    provider = LlmProvider.from_name("deepseek")
+    dep = deepseek_preset("k", model="deepseek-chat")
+    assert provider.base_url == str(dep.endpoint.base_url).rstrip("/")
+
+
+def test_deepseek_api_key_env_vars_match_from_env_registry() -> None:
+    # Pin the provider's api_key_env_vars to presets._FROM_ENV_PROVIDERS so
+    # the two registries cannot drift.
+    from kaizen.llm.presets import _FROM_ENV_PROVIDERS
+
+    spec = next(s for s in _FROM_ENV_PROVIDERS if s[0] == "deepseek")
+    _name, api_key_env, _model_vars = spec
+    assert LlmProvider.from_name("deepseek").api_key_env_vars == [api_key_env]
+
+
+def test_every_registered_provider_name_is_a_known_preset() -> None:
+    # Each provider name MUST resolve to a real preset factory (so
+    # `.deployment()` can never reference a missing preset).
+    from kaizen.llm.presets import get_preset
+
+    for provider in LlmProvider.all():
+        assert callable(get_preset(provider.name))
+
+
+# ---------------------------------------------------------------------------
+# deployment() bridge — real LlmDeployment, no re-implemented wire/auth
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_bridges_to_preset() -> None:
+    dep = LlmProvider.from_model("deepseek-chat").deployment(
+        api_key="k", model="deepseek-chat"
+    )
+    assert isinstance(dep, LlmDeployment)
+    assert dep.preset_name == "deepseek"
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.deepseek.com"
+    assert dep.wire.name == "OpenAiChat"
+
+
+def test_deployment_reads_api_key_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-key")
+    dep = LlmProvider.from_name("deepseek").deployment(model="deepseek-chat")
+    assert dep.preset_name == "deepseek"
+
+
+def test_deployment_missing_key_raises_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    with pytest.raises(MissingCredential):
+        LlmProvider.from_name("deepseek").deployment(model="deepseek-chat")
+
+
+# ---------------------------------------------------------------------------
+# LlmClient.from_env() — DeepSeek selection (legacy + selector tiers)
+# ---------------------------------------------------------------------------
+
+
+def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in [
+        "KAILASH_LLM_DEPLOYMENT",
+        "KAILASH_LLM_PROVIDER",
+        "OPENAI_API_KEY",
+        "OPENAI_PROD_MODEL",
+        "OPENAI_MODEL",
+        "AZURE_OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_MODEL",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_MODEL",
+        "GEMINI_MODEL",
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_PROD_MODEL",
+        "DEEPSEEK_MODEL",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_from_env_legacy_tier_selects_deepseek(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Bare DEEPSEEK_API_KEY (no URI, no selector) → deepseek preset, with the
+    # DeepSeek base_url flowing through intrinsically (#1609).
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.setenv("DEEPSEEK_PROD_MODEL", "deepseek-chat")
+
+    client = LlmClient.from_env()
+    dep = client.deployment
+    assert dep is not None
+    assert dep.preset_name == "deepseek"
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.deepseek.com"
+    assert dep.default_model == "deepseek-chat"
+
+
+def test_from_env_selector_tier_selects_deepseek(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("KAILASH_LLM_PROVIDER", "deepseek")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.setenv("DEEPSEEK_MODEL", "deepseek-reasoner")
+
+    dep = LlmClient.from_env().deployment
+    assert dep is not None
+    assert dep.preset_name == "deepseek"
+    assert dep.default_model == "deepseek-reasoner"
+
+
+def test_from_env_openai_still_wins_over_deepseek(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # DeepSeek is appended LAST in LEGACY_KEY_ORDER — it must never displace
+    # an existing provider's precedence.
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek")
+    monkeypatch.setenv("DEEPSEEK_PROD_MODEL", "deepseek-chat")
+
+    assert LlmClient.from_env().deployment.preset_name == "openai"
+
+
+def test_from_env_deepseek_missing_model_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Key set, model unset → typed MissingCredential (no silent unauthenticated
+    # or model-less deployment).
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    with pytest.raises(MissingCredential):
+        LlmClient.from_env()


### PR DESCRIPTION
## Summary

Makes **DeepSeek** a first-class Kaizen LLM provider reachable through the standard framework resolution surfaces, instead of only as a low-level `LlmDeployment` preset.

Before this change:
- `LlmProvider.from_model(...)` did not exist (the issue repro is written in the Rust SDK idiom; Python had no equivalent identity surface).
- `LlmClient.from_env()` could route neither a bare `DEEPSEEK_API_KEY` (legacy tier) nor a `KAILASH_LLM_PROVIDER=deepseek` selector — so a consumer had to hand-roll an OpenAI-compatible adapter and bypass the framework (framework-first violation).

## What changed

- **New leaf module `kaizen/llm/provider.py`** — an immutable `LlmProvider` identity value object:
  - `LlmProvider.from_model(model)` resolves a model prefix → provider, **fail-closed** (`UnknownModelProvider(ValueError)`) on an unknown prefix.
  - Exposes `name` / `display_name` / `base_url` / `api_key_env_vars` / `capabilities` / `openai_compatible`.
  - `.deployment(api_key=None, *, model=...)` bridges to the registered preset factory (no re-implemented wire/auth — the `from_model` result has a real path into an `LlmDeployment`).
  - Backed by the existing single-sources-of-truth: `capabilities.for_preset`, `presets.get_preset`, `presets._FROM_ENV_PROVIDERS` — with cross-check invariant tests pinning `base_url` and `api_key_env_vars` so the registries cannot drift.
- **`kaizen/llm/from_env.py`** — DeepSeek wired into the legacy tier (`LEGACY_KEY_ORDER`, appended LAST so it never displaces an existing provider) and the selector tier (`_call_preset_from_env`). The DeepSeek `base_url` is intrinsic to `deepseek_preset`, so it flows through env-driven resolution — **no new `base_url` override was needed** (this answers the issue's note about `from_env()` exposing no base_url override).
- Exported `LlmProvider` / `UnknownModelProvider` from `kaizen.llm`.

## Acceptance criteria

- [x] `LlmProvider.from_model("deepseek-chat")` and `("deepseek-reasoner")` return a DeepSeek provider.
- [x] Provider exposes `api_key_env_vars == ["DEEPSEEK_API_KEY"]`, `base_url == "https://api.deepseek.com"`, correct `capabilities` (chat + streaming, OpenAI-compatible; vision=False).
- [x] `LlmClient.from_env()` selects DeepSeek for a `deepseek-*` model + `DEEPSEEK_API_KEY` (legacy AND selector tiers).
- [ ] **Chat + streaming verified against the live DeepSeek API — key-gated, see below.**
- [x] Semantics match the Rust SDK equivalent (EATP D6): model→provider resolution + OpenAI-compatible wire.

## Test status (tiers run)

- **Tier-1 unit** (`test_llm_provider_from_model.py`, `test_from_env.py`) — **PASS**. `1040 passed, 2 skipped` across `tests/unit/llm/` on the worktree source.
- **Tier-3 live chat + streaming** (`test_deepseek_live.py`) — **SKIPPED / PENDING CREDENTIAL**. `DEEPSEEK_API_KEY` is not present in this repo's `.env`, so the live test cannot execute; it is written (real API, no mocking) and gated to skip with an "unable-to-execute" reason per test-skip-discipline. It runs automatically once `DEEPSEEK_API_KEY` + `DEEPSEEK_PROD_MODEL`/`DEEPSEEK_MODEL` are set. The endpoint (`base_url`) and model both come from the framework/env — nothing hardcoded.

`pre-commit run --files <changed>` — all hooks pass (Black, isort, Ruff, type-annotations, Tier-1 unit tests).

## Scope note

`nodes/_env_model.py::detect_provider` (the separate agent-config model→provider resolver feeding `config.providers`) is intentionally NOT extended here: `config.providers` has no DeepSeek config function, so adding a `deepseek` return there would ripple into a different surface out of this issue's scope. The AC is fully met by the `LlmProvider` + `from_env` surfaces.

## Related issues

Fixes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)