### PR TITLE
feat(governance): configurable HITL timeout + fail-safe default disposition on holds (#1515)

### DIFF
--- a/src/kailash/trust/_locking.py
+++ b/src/kailash/trust/_locking.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import stat
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -155,6 +156,34 @@ def validate_id(identifier: str, prefix: str = "") -> None:
         )
     if prefix and not identifier.startswith(prefix):
         raise ValueError(f"Invalid identifier: must start with '{prefix}'")
+
+
+def secure_sqlite_files(db_path: str) -> None:
+    """Restrict a SQLite DB and its WAL/SHM sidecars to owner-only (0o600).
+
+    WAL journal mode creates ``<db>-wal`` and ``<db>-shm`` sidecar files on
+    first write; these hold the SAME governance data as the main DB (agent
+    ids, actions, reasons, metadata) but are created under the process umask
+    (typically 0o644 = world-readable). trust-plane-security.md Rule 6 requires
+    the whole set to be owner-only.
+
+    Best-effort per file: a missing sidecar (not yet created by a write) or a
+    non-POSIX filesystem is tolerated silently — the guard hardens whatever
+    exists. In-memory databases (``:memory:``) are skipped.
+
+    Args:
+        db_path: Path to the main SQLite database file.
+    """
+    if db_path.startswith(":memory:"):
+        return
+    for suffix in ("", "-wal", "-shm"):
+        target = db_path + suffix
+        try:
+            os.chmod(target, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            # Sidecar may not exist yet (created on first write) or the
+            # filesystem is non-POSIX; harden what exists, skip the rest.
+            continue
 
 
 # Maximum length for tenant IDs

--- a/src/kailash/trust/enforce/__init__.py
+++ b/src/kailash/trust/enforce/__init__.py
@@ -25,6 +25,18 @@ from kailash.trust.enforce.challenge import (
     ChallengeResponse,
 )
 from kailash.trust.enforce.decorators import audited, shadow, verified
+from kailash.trust.enforce.held import (
+    DEFAULT_EXPIRY_DISPOSITION,
+    ExpiryDisposition,
+    HeldAction,
+    HeldActionStore,
+    MemoryHeldActionStore,
+    SqliteHeldActionStore,
+    new_hold_id,
+    resolve_expiry_verdict,
+    resolve_timeout_seconds,
+    verdict_rank,
+)
 from kailash.trust.enforce.proximity import (
     CONSERVATIVE_PROXIMITY,
     ProximityAlert,
@@ -61,6 +73,17 @@ __all__ = [
     "ShadowStore",
     "MemoryShadowStore",
     "SqliteShadowStore",
+    # Held-action timeout + fail-safe expiry (HITL)
+    "ExpiryDisposition",
+    "DEFAULT_EXPIRY_DISPOSITION",
+    "HeldAction",
+    "HeldActionStore",
+    "MemoryHeldActionStore",
+    "SqliteHeldActionStore",
+    "new_hold_id",
+    "resolve_expiry_verdict",
+    "resolve_timeout_seconds",
+    "verdict_rank",
     # Challenge-response
     "ChallengeProtocol",
     "ChallengeRequest",

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -1,0 +1,422 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Human-in-the-loop (HITL) hold timeout + fail-safe expiry disposition.
+
+A HELD verdict parks an action pending human review. Without a bounded
+response window a hold is oversight-theatre — it blocks forever, or worse,
+some caller silently lets it through. This module gives the HELD machinery
+a configurable timeout and a *deterministic, fail-safe* expiry disposition.
+
+Design invariants (SAFR BH2 / GitHub #1515):
+
+1. A held action carries a ``timeout`` (seconds) + an ``on_expiry``
+   disposition (:class:`ExpiryDisposition`).
+2. On expiry the configured disposition fires deterministically and is
+   recorded to the enforcer's audit sink.
+3. The UNSET ``on_expiry`` default is fail-safe = ``DENY`` — a hold with no
+   configured expiry disposition denies on timeout; it NEVER auto-approves.
+4. Timeout windows are configurable per capability / action-class via the
+   existing :class:`~kailash.trust.governance.models.ApprovalPolicyModel`
+   ``approval_timeout_seconds`` field (see :func:`resolve_timeout_seconds`).
+5. Expiry is MONOTONIC — the resolved outcome is at least as restrictive as
+   the hold itself (never less restrictive than ``HELD``).
+
+Security (trust-plane-security.md):
+- ``timeout`` is validated with ``math.isfinite()`` and rejected if negative.
+- Hold IDs are ``validate_id()``-checked before use in any file path.
+- The SQLite store uses parameterized SQL, 0o600 perms, bounded rows.
+- Collections are bounded (``maxlen``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import sqlite3
+import stat
+import threading
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Protocol, runtime_checkable
+
+from kailash.trust._locking import validate_id
+from kailash.trust.enforce.strict import EnforcementRecord, Verdict
+
+if TYPE_CHECKING:
+    from kailash.trust.governance.models import ApprovalPolicyModel
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ExpiryDisposition",
+    "DEFAULT_EXPIRY_DISPOSITION",
+    "HeldAction",
+    "HeldActionStore",
+    "MemoryHeldActionStore",
+    "SqliteHeldActionStore",
+    "new_hold_id",
+    "resolve_expiry_verdict",
+    "resolve_timeout_seconds",
+    "verdict_rank",
+]
+
+
+class ExpiryDisposition(Enum):
+    """Default disposition applied when a human-review hold times out.
+
+    Every member MUST resolve (via :data:`_DISPOSITION_VERDICT`) to a verdict
+    that is at least as restrictive as ``HELD`` — an expired hold can escalate
+    to a denial or a re-hold, NEVER relax to auto-approval. This closed set is
+    the monotonic guarantee (invariant 5); a member that resolves below
+    ``HELD`` is a fail-open regression that :func:`resolve_expiry_verdict`
+    clamps closed and ``test_held_timeout_failsafe`` pins.
+    """
+
+    DENY = "deny"  # -> BLOCKED (fail-safe default)
+    ESCALATE_TO_SENIOR = "escalate_to_senior"  # -> HELD (re-held for senior review)
+
+
+# The unset-on_expiry fail-safe default (invariant 3). A hold with no
+# configured expiry disposition denies on timeout — it never auto-approves.
+DEFAULT_EXPIRY_DISPOSITION = ExpiryDisposition.DENY
+
+
+# Restrictiveness ordering. Monotonic escalation only, matching the trust
+# model AUTO_APPROVED -> FLAGGED -> HELD -> BLOCKED (eatp.md § Trust Model).
+_VERDICT_RANK: Dict[Verdict, int] = {
+    Verdict.AUTO_APPROVED: 0,
+    Verdict.FLAGGED: 1,
+    Verdict.HELD: 2,
+    Verdict.BLOCKED: 3,
+}
+
+# The single shared disposition -> verdict mapping. Both members resolve at
+# or above HELD; :func:`resolve_expiry_verdict` fail-closes any value not
+# present here (and any future member that would resolve below HELD).
+_DISPOSITION_VERDICT: Dict[ExpiryDisposition, Verdict] = {
+    ExpiryDisposition.DENY: Verdict.BLOCKED,
+    ExpiryDisposition.ESCALATE_TO_SENIOR: Verdict.HELD,
+}
+
+
+def verdict_rank(verdict: Verdict) -> int:
+    """Return the monotonic restrictiveness rank of a verdict (higher = tighter)."""
+    return _VERDICT_RANK[verdict]
+
+
+def resolve_expiry_verdict(disposition: ExpiryDisposition) -> Verdict:
+    """Resolve an expiry disposition to a concrete, monotonic verdict.
+
+    Fail-closed on every axis:
+
+    - An unrecognized / unmapped disposition resolves to ``BLOCKED`` (the
+      tightest verdict) rather than leaking through.
+    - A mapping that would resolve *below* ``HELD`` (a fail-open regression
+      introduced by a future enum member) is clamped up to ``BLOCKED``.
+
+    This is the sole restrictiveness function for the expiry surface — invariant
+    5 (monotonic expiry) holds because this function can only ever return a
+    verdict with rank >= ``HELD``.
+    """
+    verdict = _DISPOSITION_VERDICT.get(disposition)
+    if verdict is None:
+        # Unknown disposition — deny (fail-closed, pact-governance.md Rule 4).
+        return Verdict.BLOCKED
+    if _VERDICT_RANK[verdict] < _VERDICT_RANK[Verdict.HELD]:
+        # Monotonic guard: an expiry outcome may never be less restrictive
+        # than the hold it replaces. Clamp to BLOCKED (never auto-approve).
+        return Verdict.BLOCKED
+    return verdict
+
+
+def resolve_timeout_seconds(policy: "ApprovalPolicyModel") -> float:
+    """Resolve the per-capability hold timeout from an approval policy.
+
+    This is the live consumer of
+    :attr:`~kailash.trust.governance.models.ApprovalPolicyModel.approval_timeout_seconds`
+    — the field that previously had no consumer (invariant 4). Timeout windows
+    are therefore configurable per capability / action-class through the
+    existing policy model rather than a parallel constant.
+
+    Args:
+        policy: An ``ApprovalPolicyModel`` (or any object exposing
+            ``approval_timeout_seconds``).
+
+    Returns:
+        The timeout in seconds as a float.
+
+    Raises:
+        ValueError: If the timeout is non-finite (NaN/Inf) or negative.
+    """
+    raw = getattr(policy, "approval_timeout_seconds")
+    timeout = float(raw)
+    if not math.isfinite(timeout):
+        raise ValueError(f"approval_timeout_seconds must be finite, got {raw!r}")
+    if timeout < 0:
+        raise ValueError(f"approval_timeout_seconds must be non-negative, got {raw!r}")
+    return timeout
+
+
+@dataclass(frozen=True)
+class HeldAction:
+    """A parked human-review hold with a bounded expiry window.
+
+    Frozen to prevent post-creation tampering of the tracked deadline —
+    a mutable ``expires_at`` would let a compromised path extend its own
+    review window indefinitely.
+    """
+
+    hold_id: str
+    agent_id: str
+    action: str
+    held_at: datetime
+    timeout_seconds: float
+    on_expiry: ExpiryDisposition
+    record: EnforcementRecord
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        validate_id(self.hold_id)
+        if not math.isfinite(self.timeout_seconds):
+            raise ValueError(
+                f"timeout_seconds must be finite, got {self.timeout_seconds!r}"
+            )
+        if self.timeout_seconds < 0:
+            raise ValueError(
+                f"timeout_seconds must be non-negative, got {self.timeout_seconds!r}"
+            )
+
+    @property
+    def expires_at(self) -> datetime:
+        """The deterministic deadline: ``held_at + timeout_seconds``."""
+        return self.held_at + timedelta(seconds=self.timeout_seconds)
+
+    def is_expired(self, now: datetime) -> bool:
+        """True when ``now`` is at or past the deadline."""
+        return now >= self.expires_at
+
+
+def new_hold_id() -> str:
+    """Generate a fresh, ``validate_id``-safe hold identifier."""
+    return f"hold-{uuid.uuid4().hex}"
+
+
+# ---------------------------------------------------------------------------
+# Store protocol + implementations
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class HeldActionStore(Protocol):
+    """Persistence protocol for pending human-review holds with timeouts."""
+
+    def add(self, held: HeldAction) -> None:
+        """Register a pending hold for timeout tracking."""
+        ...
+
+    def pop_expired(self, now: datetime) -> List[HeldAction]:
+        """Atomically remove and return every hold expired as of ``now``."""
+        ...
+
+    def pending(self) -> List[HeldAction]:
+        """Return all currently-pending holds."""
+        ...
+
+    def clear(self) -> None:
+        """Remove all pending holds."""
+        ...
+
+
+class MemoryHeldActionStore:
+    """In-memory held-action store. Thread-safe, bounded (FIFO eviction)."""
+
+    def __init__(self, maxlen: int = 10_000) -> None:
+        self._lock = threading.Lock()
+        self._holds: "OrderedDict[str, HeldAction]" = OrderedDict()
+        self._maxlen = maxlen
+
+    def add(self, held: HeldAction) -> None:
+        with self._lock:
+            self._holds[held.hold_id] = held
+            # Bounded: evict oldest (FIFO) beyond maxlen.
+            while len(self._holds) > self._maxlen:
+                self._holds.popitem(last=False)
+
+    def pop_expired(self, now: datetime) -> List[HeldAction]:
+        with self._lock:
+            expired = [h for h in self._holds.values() if h.is_expired(now)]
+            for h in expired:
+                del self._holds[h.hold_id]
+            return expired
+
+    def pending(self) -> List[HeldAction]:
+        with self._lock:
+            return list(self._holds.values())
+
+    def clear(self) -> None:
+        with self._lock:
+            self._holds.clear()
+
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS held_actions (
+    hold_id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    held_at TEXT NOT NULL,
+    timeout_seconds REAL NOT NULL,
+    expires_at TEXT NOT NULL,
+    on_expiry TEXT NOT NULL,
+    reason TEXT NOT NULL DEFAULT '',
+    violations_json TEXT NOT NULL DEFAULT '[]',
+    metadata_json TEXT NOT NULL DEFAULT '{}'
+)
+"""
+
+
+class SqliteHeldActionStore:
+    """SQLite-backed held-action store (persists across restarts).
+
+    Follows the shadow-store conventions: 0o600 file perms, parameterized
+    SQL, bounded rows, thread-safe via a lock + WAL.
+    """
+
+    def __init__(self, db_path: str, max_records: int = 100_000) -> None:
+        self._db_path = db_path
+        self._max_records = max_records
+        self._lock = threading.Lock()
+
+        if not db_path.startswith(":memory:"):
+            if not os.path.exists(db_path):
+                open(db_path, "a").close()
+            try:
+                os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                logger.warning(
+                    "Could not set permissions on %s (non-POSIX system?)", db_path
+                )
+
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.execute(_CREATE_TABLE_SQL)
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_held_expires ON held_actions(expires_at)"
+        )
+        self._conn.commit()
+
+    def add(self, held: HeldAction) -> None:
+        validate_id(held.hold_id)
+        vr = held.record.verification_result
+        violations_json = json.dumps(vr.violations if vr and vr.violations else [])
+        reason = vr.reason if vr and vr.reason else ""
+        metadata_json = json.dumps(held.metadata or {})
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO held_actions "
+                "(hold_id, agent_id, action, held_at, timeout_seconds, expires_at, "
+                "on_expiry, reason, violations_json, metadata_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    held.hold_id,
+                    held.agent_id,
+                    held.action,
+                    held.held_at.isoformat(),
+                    held.timeout_seconds,
+                    held.expires_at.isoformat(),
+                    held.on_expiry.value,
+                    reason,
+                    violations_json,
+                    metadata_json,
+                ),
+            )
+            self._conn.commit()
+            # Bounded: trim oldest by expiry when exceeding max.
+            row = self._conn.execute("SELECT COUNT(*) FROM held_actions").fetchone()
+            if row and row[0] > self._max_records:
+                excess = row[0] - self._max_records
+                self._conn.execute(
+                    "DELETE FROM held_actions WHERE hold_id IN "
+                    "(SELECT hold_id FROM held_actions ORDER BY expires_at ASC LIMIT ?)",
+                    (excess,),
+                )
+                self._conn.commit()
+
+    def pop_expired(self, now: datetime) -> List[HeldAction]:
+        now_iso = now.isoformat()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT hold_id, agent_id, action, held_at, timeout_seconds, "
+                "on_expiry, reason, violations_json, metadata_json "
+                "FROM held_actions WHERE expires_at <= ?",
+                (now_iso,),
+            )
+            rows = cursor.fetchall()
+            if rows:
+                self._conn.execute(
+                    "DELETE FROM held_actions WHERE expires_at <= ?", (now_iso,)
+                )
+                self._conn.commit()
+        return [self._row_to_held(row) for row in rows]
+
+    def pending(self) -> List[HeldAction]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT hold_id, agent_id, action, held_at, timeout_seconds, "
+                "on_expiry, reason, violations_json, metadata_json FROM held_actions"
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_held(row) for row in rows]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM held_actions")
+            self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    @staticmethod
+    def _row_to_held(row: Any) -> HeldAction:
+        from kailash.trust.chain import VerificationResult
+
+        (
+            hold_id,
+            agent_id,
+            action,
+            held_at_str,
+            timeout_seconds,
+            on_expiry_str,
+            reason,
+            violations_json,
+            metadata_json,
+        ) = row
+        violations = json.loads(violations_json) if violations_json else []
+        metadata = json.loads(metadata_json) if metadata_json else {}
+        vr = VerificationResult(valid=True, reason=reason, violations=violations)
+        record = EnforcementRecord(
+            agent_id=agent_id,
+            action=action,
+            verdict=Verdict.HELD,
+            verification_result=vr,
+            timestamp=datetime.fromisoformat(held_at_str),
+            metadata=dict(metadata),
+        )
+        return HeldAction(
+            hold_id=hold_id,
+            agent_id=agent_id,
+            action=action,
+            held_at=datetime.fromisoformat(held_at_str),
+            timeout_seconds=float(timeout_seconds),
+            on_expiry=ExpiryDisposition(on_expiry_str),
+            record=record,
+            metadata=dict(metadata),
+        )

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -35,16 +35,15 @@ import logging
 import math
 import os
 import sqlite3
-import stat
 import threading
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Protocol, runtime_checkable
 
-from kailash.trust._locking import validate_id
+from kailash.trust._locking import secure_sqlite_files, validate_id
 from kailash.trust.enforce.strict import EnforcementRecord, Verdict
 
 if TYPE_CHECKING:
@@ -190,6 +189,16 @@ class HeldAction:
             raise ValueError(
                 f"timeout_seconds must be non-negative, got {self.timeout_seconds!r}"
             )
+        # Normalize a tz-naive held_at to UTC (frozen dataclass -> setattr via
+        # object). A naive held_at would make expires_at naive too, and the
+        # SQLite store compares expires_at.isoformat() lexicographically against
+        # an aware now.isoformat() (which carries a +00:00 offset) — the two
+        # forms sort differently, and is_expired() would raise TypeError on a
+        # naive-vs-aware comparison. Assume UTC for a naive caller.
+        if self.held_at.tzinfo is None:
+            object.__setattr__(
+                self, "held_at", self.held_at.replace(tzinfo=timezone.utc)
+            )
 
     @property
     def expires_at(self) -> datetime:
@@ -291,15 +300,8 @@ class SqliteHeldActionStore:
         self._max_records = max_records
         self._lock = threading.Lock()
 
-        if not db_path.startswith(":memory:"):
-            if not os.path.exists(db_path):
-                open(db_path, "a").close()
-            try:
-                os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                logger.warning(
-                    "Could not set permissions on %s (non-POSIX system?)", db_path
-                )
+        if not db_path.startswith(":memory:") and not os.path.exists(db_path):
+            open(db_path, "a").close()
 
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -311,6 +313,10 @@ class SqliteHeldActionStore:
             "CREATE INDEX IF NOT EXISTS idx_held_expires ON held_actions(expires_at)"
         )
         self._conn.commit()
+        # Harden the main DB + the WAL/SHM sidecars (created by the commit
+        # above under WAL mode) to owner-only — the sidecars hold the same
+        # governance data. Runs AFTER the first write so the sidecars exist.
+        secure_sqlite_files(db_path)
 
     def add(self, held: HeldAction) -> None:
         validate_id(held.hold_id)
@@ -364,7 +370,27 @@ class SqliteHeldActionStore:
                     "DELETE FROM held_actions WHERE expires_at <= ?", (now_iso,)
                 )
                 self._conn.commit()
-        return [self._row_to_held(row) for row in rows]
+        # Per-row fail-closed conversion. A single corrupt/tampered row (bad
+        # on_expiry string, non-finite timeout, unsafe hold_id, malformed
+        # timestamp) must NOT abort the whole batch — the rows are already
+        # deleted+committed above, so an exception here would silently drop
+        # every expired hold (including well-formed siblings) with NO BLOCKED
+        # audit record emitted. Instead, a corrupt row yields a fail-closed
+        # DENY sentinel (resolves to BLOCKED at expiry) and processing
+        # continues (user-flow-validation.md MUST-7 class (c): corrupt state).
+        result: List[HeldAction] = []
+        for row in rows:
+            try:
+                result.append(self._row_to_held(row))
+            except Exception:
+                logger.warning(
+                    "[HELD] corrupt held-action row — fail-closed BLOCKED "
+                    "(hold_id=%r)",
+                    row[0] if row else None,
+                    exc_info=True,
+                )
+                result.append(self._corrupt_sentinel(row, now))
+        return result
 
     def pending(self) -> List[HeldAction]:
         with self._lock:
@@ -419,4 +445,51 @@ class SqliteHeldActionStore:
             on_expiry=ExpiryDisposition(on_expiry_str),
             record=record,
             metadata=dict(metadata),
+        )
+
+    @staticmethod
+    def _corrupt_sentinel(row: Any, now: datetime) -> HeldAction:
+        """Build a fail-closed DENY hold for a corrupt/tampered persisted row.
+
+        Any value in the row may be garbage, so nothing from it is trusted for
+        control flow: the sentinel always denies on expiry (``DENY`` -> BLOCKED)
+        with a zero timeout (already expired). Best-effort recoverable fields
+        (agent_id / action / the original hold_id string) are surfaced in the
+        record metadata for forensics but never used to relax the disposition.
+        """
+        from kailash.trust.chain import VerificationResult
+
+        def _safe_str(index: int) -> str:
+            try:
+                value = row[index]
+            except Exception:
+                return "unknown"
+            return str(value) if value else "unknown"
+
+        agent_id = _safe_str(1)
+        action = _safe_str(2)
+        original_hold_id = repr(row[0])[:200] if row else "unknown"
+
+        vr = VerificationResult(
+            valid=False,
+            reason="corrupt held-action row — fail-closed BLOCKED",
+            violations=[],
+        )
+        record = EnforcementRecord(
+            agent_id=agent_id,
+            action=action,
+            verdict=Verdict.HELD,
+            verification_result=vr,
+            timestamp=now,
+            metadata={"corrupt_row": True, "original_hold_id": original_hold_id},
+        )
+        return HeldAction(
+            hold_id=new_hold_id(),
+            agent_id=agent_id,
+            action=action,
+            held_at=now,
+            timeout_seconds=0.0,
+            on_expiry=ExpiryDisposition.DENY,
+            record=record,
+            metadata={"corrupt_row": True, "original_hold_id": original_hold_id},
         )

--- a/src/kailash/trust/enforce/shadow_store.py
+++ b/src/kailash/trust/enforce/shadow_store.py
@@ -20,12 +20,12 @@ import json
 import logging
 import os
 import sqlite3
-import stat
 import threading
 from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
+from kailash.trust._locking import secure_sqlite_files
 from kailash.trust.enforce.strict import EnforcementRecord, Verdict
 
 logger = logging.getLogger(__name__)
@@ -215,17 +215,8 @@ class SqliteShadowStore:
         self._max_records = max_records
         self._lock = threading.Lock()
 
-        # Set file permissions on POSIX (trust-plane-security.md rule 6)
-        if not db_path.startswith(":memory:"):
-            if not os.path.exists(db_path):
-                # Create with restrictive permissions
-                open(db_path, "a").close()
-            try:
-                os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                logger.warning(
-                    "Could not set permissions on %s (non-POSIX system?)", db_path
-                )
+        if not db_path.startswith(":memory:") and not os.path.exists(db_path):
+            open(db_path, "a").close()
 
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -241,6 +232,11 @@ class SqliteShadowStore:
             "CREATE INDEX IF NOT EXISTS idx_shadow_agent " "ON shadow_records(agent_id)"
         )
         self._conn.commit()
+        # Harden the main DB + the WAL/SHM sidecars (created by the commit above
+        # under WAL mode) to owner-only per trust-plane-security.md rule 6 — the
+        # sidecars carry the same enforcement-record data. Runs AFTER the first
+        # write so the sidecars exist.
+        secure_sqlite_files(db_path)
 
     def append_record(self, record: EnforcementRecord) -> None:
         """Persist a record to SQLite."""

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from kailash.trust.chain import VerificationLevel, VerificationResult
 
 if TYPE_CHECKING:
+    from kailash.trust.enforce.held import ExpiryDisposition, HeldActionStore
+    from kailash.trust.governance.models import ApprovalPolicyModel
     from kailash.trust.hooks import HookRegistry
 
 logger = logging.getLogger(__name__)
@@ -113,6 +115,8 @@ class StrictEnforcer:
         flag_threshold: int = 1,
         maxlen: int = 10_000,
         hook_registry: Optional[HookRegistry] = None,
+        held_store: Optional[HeldActionStore] = None,
+        default_expiry: Optional[ExpiryDisposition] = None,
     ):
         """Initialize strict enforcer.
 
@@ -126,7 +130,19 @@ class StrictEnforcer:
                 If provided, PRE_VERIFICATION and POST_VERIFICATION hooks are
                 executed during enforce(). If None, enforce() behaves identically
                 to pre-hook versions (backward compatible).
+            held_store: Store tracking QUEUE-behavior holds that carry a timeout,
+                so expire_holds() can fire their configured disposition. Defaults
+                to an in-memory store bounded by ``maxlen``.
+            default_expiry: Disposition applied when a held action carries a
+                timeout but no explicit ``on_expiry``. Defaults to the fail-safe
+                ``ExpiryDisposition.DENY`` (a hold with no configured expiry
+                disposition denies on timeout — it NEVER auto-approves).
         """
+        from kailash.trust.enforce.held import (
+            DEFAULT_EXPIRY_DISPOSITION,
+            MemoryHeldActionStore,
+        )
+
         self._on_held = on_held
         self._held_callback = held_callback
         self._flag_threshold = flag_threshold
@@ -134,6 +150,14 @@ class StrictEnforcer:
         self._review_queue: List[EnforcementRecord] = []
         self._max_records = maxlen
         self._hook_registry = hook_registry
+        self._held_store: HeldActionStore = (
+            held_store
+            if held_store is not None
+            else MemoryHeldActionStore(maxlen=maxlen)
+        )
+        self._default_expiry: ExpiryDisposition = (
+            default_expiry if default_expiry is not None else DEFAULT_EXPIRY_DISPOSITION
+        )
 
         if on_held == HeldBehavior.CALLBACK and held_callback is None:
             raise ValueError("held_callback required when on_held is CALLBACK")
@@ -171,6 +195,10 @@ class StrictEnforcer:
         action: str,
         result: VerificationResult,
         metadata: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        on_expiry: Optional[ExpiryDisposition] = None,
+        approval_policy: Optional[ApprovalPolicyModel] = None,
     ) -> Verdict:
         """Enforce a verification result.
 
@@ -183,6 +211,17 @@ class StrictEnforcer:
             action: The action being verified
             result: The verification result
             metadata: Additional context
+            timeout: Optional human-review response window in seconds. When set
+                on a QUEUE-behavior hold, the hold is tracked so that a later
+                ``expire_holds()`` call fires its ``on_expiry`` disposition once
+                the window elapses. If ``None``, ``approval_policy`` is consulted.
+            on_expiry: Disposition applied when this hold times out. If ``None``
+                the enforcer's ``default_expiry`` (fail-safe ``DENY``) applies —
+                a hold with no configured expiry disposition denies on timeout.
+            approval_policy: Per-capability / per-action-class approval policy.
+                When ``timeout`` is ``None`` and a policy is given, the hold's
+                timeout is read from ``policy.approval_timeout_seconds`` — the
+                live consumer of that previously-orphan field.
 
         Returns:
             The enforcement verdict
@@ -190,6 +229,7 @@ class StrictEnforcer:
         Raises:
             EATPBlockedError: If the action is blocked
             EATPHeldError: If the action is held (when on_held=RAISE)
+            ValueError: If the resolved timeout is non-finite or negative.
         """
         # Run PRE_VERIFICATION hooks (if registry attached)
         if self._hook_registry is not None:
@@ -295,7 +335,15 @@ class StrictEnforcer:
             )
 
         if verdict == Verdict.HELD:
-            return self._handle_held(agent_id, action, result, record)
+            return self._handle_held(
+                agent_id,
+                action,
+                result,
+                record,
+                timeout=timeout,
+                on_expiry=on_expiry,
+                approval_policy=approval_policy,
+            )
 
         if verdict == Verdict.FLAGGED:
             logger.info(
@@ -311,6 +359,10 @@ class StrictEnforcer:
         action: str,
         result: VerificationResult,
         record: EnforcementRecord,
+        *,
+        timeout: Optional[float] = None,
+        on_expiry: Optional[ExpiryDisposition] = None,
+        approval_policy: Optional[ApprovalPolicyModel] = None,
     ) -> Verdict:
         """Handle a HELD verdict based on configured behavior."""
         reason = result.reason or "Action requires human review"
@@ -335,6 +387,18 @@ class StrictEnforcer:
             if len(self._review_queue) > self._max_records:
                 trim_count = self._max_records // 10
                 self._review_queue = self._review_queue[trim_count:]
+            # Register a timeout-tracked hold when a response window is set,
+            # either explicitly (timeout) or from the approval policy
+            # (approval_timeout_seconds). The unset on_expiry disposition is
+            # fail-safe DENY (never auto-approves) per self._default_expiry.
+            self._register_hold(
+                agent_id,
+                action,
+                record,
+                timeout=timeout,
+                on_expiry=on_expiry,
+                approval_policy=approval_policy,
+            )
             raise EATPHeldError(
                 agent_id=agent_id,
                 action=action,
@@ -357,6 +421,121 @@ class StrictEnforcer:
             reason=f"Denied by review callback: {reason}",
             violations=result.violations,
         )
+
+    def _register_hold(
+        self,
+        agent_id: str,
+        action: str,
+        record: EnforcementRecord,
+        *,
+        timeout: Optional[float],
+        on_expiry: Optional[ExpiryDisposition],
+        approval_policy: Optional[ApprovalPolicyModel],
+    ) -> None:
+        """Track a QUEUE hold for timeout expiry when a response window is set.
+
+        The timeout comes from ``timeout`` when given, else from
+        ``approval_policy.approval_timeout_seconds`` (per-capability window).
+        When neither is set, no hold is tracked (the hold has no bounded
+        response window and expire_holds() will never fire for it). The
+        ``on_expiry`` disposition defaults to the enforcer's fail-safe default.
+        """
+        from kailash.trust.enforce.held import (
+            HeldAction,
+            new_hold_id,
+            resolve_timeout_seconds,
+        )
+
+        resolved_timeout = timeout
+        if resolved_timeout is None and approval_policy is not None:
+            resolved_timeout = resolve_timeout_seconds(approval_policy)
+        if resolved_timeout is None:
+            return
+
+        disposition = on_expiry if on_expiry is not None else self._default_expiry
+        hold = HeldAction(
+            hold_id=new_hold_id(),
+            agent_id=agent_id,
+            action=action,
+            held_at=record.timestamp,
+            timeout_seconds=float(resolved_timeout),
+            on_expiry=disposition,
+            record=record,
+            metadata=dict(record.metadata),
+        )
+        self._held_store.add(hold)
+
+    def expire_holds(self, now: Optional[datetime] = None) -> List[EnforcementRecord]:
+        """Fire the configured disposition for every hold past its deadline.
+
+        Deterministic: pass ``now`` to evaluate expiry at a fixed instant.
+        Each expired hold resolves — via the single monotonic
+        ``resolve_expiry_verdict`` — to a verdict at least as restrictive as
+        ``HELD`` (fail-safe ``DENY`` -> ``BLOCKED`` for an unset disposition;
+        never ``AUTO_APPROVED``/``FLAGGED``). Each expiry is recorded to the
+        same audit sink (``self._records``) the verdict path writes to.
+
+        Args:
+            now: Instant to evaluate expiry against. Defaults to current UTC.
+
+        Returns:
+            The enforcement records created for the expired holds (one each).
+        """
+        from kailash.trust.enforce.held import resolve_expiry_verdict, verdict_rank
+
+        evaluated_at = now if now is not None else datetime.now(timezone.utc)
+        expired = self._held_store.pop_expired(evaluated_at)
+        expiry_records: List[EnforcementRecord] = []
+
+        for hold in expired:
+            verdict = resolve_expiry_verdict(hold.on_expiry)
+            # Monotonic invariant: an expiry outcome is never less restrictive
+            # than the hold it replaces. resolve_expiry_verdict guarantees
+            # rank >= HELD; this is the defense-in-depth fail-closed backstop.
+            if verdict_rank(verdict) < verdict_rank(Verdict.HELD):
+                verdict = Verdict.BLOCKED
+
+            expiry_metadata = {
+                **dict(hold.metadata),
+                "hold_expiry": True,
+                "hold_id": hold.hold_id,
+                "on_expiry": hold.on_expiry.value,
+                "original_verdict": Verdict.HELD.value,
+                "held_at": hold.held_at.isoformat(),
+                "timeout_seconds": hold.timeout_seconds,
+                "expires_at": hold.expires_at.isoformat(),
+            }
+            expiry_record = EnforcementRecord(
+                agent_id=hold.agent_id,
+                action=hold.action,
+                verdict=verdict,
+                verification_result=hold.record.verification_result,
+                timestamp=evaluated_at,
+                metadata=expiry_metadata,
+            )
+            self._records.append(expiry_record)
+            # Bounded memory: trim oldest 10% when exceeding maxlen
+            if len(self._records) > self._max_records:
+                trim_count = self._max_records // 10
+                self._records = self._records[trim_count:]
+
+            expiry_records.append(expiry_record)
+            logger.warning(
+                "[ENFORCE] HELD EXPIRED: agent=%s action=%s hold_id=%s "
+                "on_expiry=%s -> %s",
+                hold.agent_id,
+                hold.action,
+                hold.hold_id,
+                hold.on_expiry.value,
+                verdict.value,
+            )
+
+        return expiry_records
+
+    @property
+    def held_store(self) -> "HeldActionStore":
+        """The store tracking pending timeout-bounded holds."""
+        return self._held_store
 
     @property
     def records(self) -> List[EnforcementRecord]:

--- a/tests/trust/unit/test_held_action_store_wiring.py
+++ b/tests/trust/unit/test_held_action_store_wiring.py
@@ -17,6 +17,7 @@ testing.md Tier 2 + facade-manager-detection.md Rule 1):
 from __future__ import annotations
 
 import os
+import sqlite3
 import stat
 from datetime import datetime, timedelta, timezone
 
@@ -154,3 +155,113 @@ def test_monotonic_expiry_never_less_restrictive_through_facade(tmp_path):
     assert expired[0].verdict is Verdict.HELD
     assert expired[0].verdict not in (Verdict.AUTO_APPROVED, Verdict.FLAGGED)
     store.close()
+
+
+def test_wal_shm_sidecars_are_owner_only(tmp_path):
+    """HIGH: the WAL/SHM sidecars (created on first write) are also 0o600.
+
+    WAL mode writes ``<db>-wal`` and ``<db>-shm`` holding the SAME governance
+    data as the main DB; a world-readable sidecar leaks agent ids / actions /
+    reasons to any local user (trust-plane-security.md rule 6).
+    """
+    if os.name != "posix":
+        pytest.skip("POSIX-only permission check")
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    # A write forces the WAL/SHM sidecars into existence.
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-wal",
+            action="deploy",
+            result=_held_result(),
+            timeout=300.0,
+        )
+
+    checked_any = False
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path + suffix
+        if os.path.exists(sidecar):
+            checked_any = True
+            mode = stat.S_IMODE(os.stat(sidecar).st_mode)
+            assert mode == 0o600, f"{suffix} expected 0o600, got {oct(mode)}"
+    # WAL mode reliably creates -shm on the first write; assert we checked one.
+    assert checked_any, "no WAL/SHM sidecar was created — cannot verify perms"
+    store.close()
+
+
+def test_corrupt_row_fails_closed_and_processes_siblings(tmp_path):
+    """MEDIUM: a corrupt persisted row expires to a fail-closed BLOCKED record
+    AND well-formed sibling rows in the same batch still process.
+
+    user-flow-validation.md MUST-7 class (c): corrupt/partial persisted state
+    on re-entry. Without per-row isolation, one tampered row aborts the whole
+    pop_expired batch after the delete/commit — every expired hold is dropped
+    with NO audit record. With it, the corrupt row yields a BLOCKED sentinel
+    and the sibling is unaffected.
+    """
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    # A well-formed sibling hold, already expired.
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-good",
+            action="deploy",
+            result=_held_result(),
+            timeout=1.0,
+            on_expiry=ExpiryDisposition.DENY,
+        )
+    store.close()
+
+    # Tamper: insert a corrupt row directly (bad on_expiry string + a non-finite
+    # timeout stored as text), already past its deadline.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO held_actions "
+        "(hold_id, agent_id, action, held_at, timeout_seconds, expires_at, "
+        "on_expiry, reason, violations_json, metadata_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "hold-corrupt-1",
+            "agent-bad",
+            "wire_funds",
+            "2026-07-09T12:00:00+00:00",
+            10.0,
+            "2000-01-01T00:00:00+00:00",  # long past — expired
+            "totally-not-a-valid-disposition",  # ExpiryDisposition() will raise
+            "",
+            "[]",
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    # Re-open and expire both rows in one batch.
+    store2 = SqliteHeldActionStore(db_path)
+    enforcer2 = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store2)
+    expired = enforcer2.expire_holds(
+        now=datetime.now(timezone.utc) + timedelta(hours=1)
+    )
+
+    # BOTH rows processed — the corrupt one did NOT abort the batch.
+    assert len(expired) == 2
+    verdicts = [r.verdict for r in expired]
+    # Every expiry verdict is at least as restrictive as HELD; both are BLOCKED
+    # here (good row on_expiry=DENY; corrupt row fail-closed DENY).
+    assert all(v is Verdict.BLOCKED for v in verdicts)
+
+    # The corrupt row emitted a fail-closed BLOCKED audit record marked corrupt.
+    corrupt_records = [r for r in expired if r.metadata.get("corrupt_row")]
+    assert len(corrupt_records) == 1
+    assert corrupt_records[0].verdict is Verdict.BLOCKED
+    assert "corrupt held-action row" in (
+        corrupt_records[0].verification_result.reason or ""
+    )
+
+    # Both are also in the enforcer's audit sink.
+    assert store2.pending() == []
+    store2.close()

--- a/tests/trust/unit/test_held_action_store_wiring.py
+++ b/tests/trust/unit/test_held_action_store_wiring.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 wiring test for the HITL held-action store (GitHub #1515, SAFR BH2).
+
+Exercises the ``SqliteHeldActionStore`` THROUGH the ``StrictEnforcer`` facade
+against a real on-disk SQLite database (no mocking, real infrastructure per
+testing.md Tier 2 + facade-manager-detection.md Rule 1):
+
+- A QUEUE hold with a timeout persists a row to the SQLite file.
+- The row survives a "restart" (a fresh store on the same db_path).
+- ``expire_holds()`` through the enforcer fires the disposition, records the
+  expiry to the audit sink, and removes the row.
+- The DB file is created 0o600 (trust-plane-security.md rule 6).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kailash.trust.chain import VerificationResult
+from kailash.trust.enforce.held import ExpiryDisposition, SqliteHeldActionStore
+from kailash.trust.enforce.strict import (
+    EATPHeldError,
+    HeldBehavior,
+    StrictEnforcer,
+    Verdict,
+)
+from kailash.trust.governance.models import ApprovalPolicyModel
+
+pytestmark = [pytest.mark.integration, pytest.mark.tier2]
+
+
+def _held_result() -> VerificationResult:
+    return VerificationResult(
+        valid=True,
+        reason="needs human review",
+        violations=[{"field": "cost", "message": "near limit"}],
+    )
+
+
+def test_sqlite_store_persists_hold_through_enforcer_facade(tmp_path):
+    """A QUEUE hold with a timeout lands a row in the real SQLite file."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-sql",
+            action="deploy",
+            result=_held_result(),
+            timeout=300.0,
+            on_expiry=ExpiryDisposition.DENY,
+        )
+
+    # External effect: the hold is persisted and readable back.
+    pending = store.pending()
+    assert len(pending) == 1
+    assert pending[0].agent_id == "agent-sql"
+    assert pending[0].timeout_seconds == 300.0
+    assert pending[0].on_expiry is ExpiryDisposition.DENY
+    store.close()
+
+
+def test_hold_persists_across_store_restart(tmp_path):
+    """The persisted hold survives a fresh store on the same db_path (restart)."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-restart",
+            action="wire_funds",
+            result=_held_result(),
+            timeout=600.0,
+        )
+    store.close()
+
+    # Simulate a process restart: a brand-new store on the same file.
+    store2 = SqliteHeldActionStore(db_path)
+    pending = store2.pending()
+    assert len(pending) == 1
+    assert pending[0].agent_id == "agent-restart"
+    # Unset on_expiry defaulted to the fail-safe DENY at registration time.
+    assert pending[0].on_expiry is ExpiryDisposition.DENY
+    store2.close()
+
+
+def test_expire_holds_fires_and_audits_through_sqlite(tmp_path):
+    """expire_holds() through the enforcer fires DENY -> BLOCKED, audits, removes row."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    policy = ApprovalPolicyModel(
+        external_agent_id="agent-exp", approval_timeout_seconds=300
+    )
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-exp",
+            action="invoke",
+            result=_held_result(),
+            approval_policy=policy,  # timeout window from the (formerly orphan) field
+        )
+
+    # Deadline is held_at + 300s; expire well past it.
+    expired = enforcer.expire_holds(now=datetime.now(timezone.utc) + timedelta(hours=1))
+    assert len(expired) == 1
+    assert expired[0].verdict is Verdict.BLOCKED  # fail-safe deny
+
+    # Audited to the enforcer's records sink.
+    assert expired[0] in enforcer.records
+    assert expired[0].metadata["hold_expiry"] is True
+
+    # The store row is gone (popped on expiry).
+    assert store.pending() == []
+    store.close()
+
+
+def test_sqlite_db_file_permissions_are_owner_only(tmp_path):
+    """trust-plane-security.md rule 6: the DB file is 0o600 on POSIX."""
+    if os.name != "posix":
+        pytest.skip("POSIX-only permission check")
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    mode = stat.S_IMODE(os.stat(db_path).st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    store.close()
+
+
+def test_monotonic_expiry_never_less_restrictive_through_facade(tmp_path):
+    """INV-5 through the real store: escalate -> HELD, deny -> BLOCKED; never relax."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-mono",
+            action="escalate_me",
+            result=_held_result(),
+            timeout=10.0,
+            on_expiry=ExpiryDisposition.ESCALATE_TO_SENIOR,
+        )
+    expired = enforcer.expire_holds(now=datetime.now(timezone.utc) + timedelta(hours=1))
+    assert len(expired) == 1
+    # HELD is at least as restrictive as the original HELD; never AUTO_APPROVED.
+    assert expired[0].verdict is Verdict.HELD
+    assert expired[0].verdict not in (Verdict.AUTO_APPROVED, Verdict.FLAGGED)
+    store.close()

--- a/tests/trust/unit/test_held_timeout_failsafe.py
+++ b/tests/trust/unit/test_held_timeout_failsafe.py
@@ -1,0 +1,410 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-1 unit tests for HITL hold timeout + fail-safe expiry (GitHub #1515, SAFR BH2).
+
+Covers the five load-bearing invariants:
+
+1. A held action accepts ``timeout`` + ``on_expiry`` wired through the HELD path.
+2. On expiry the configured disposition fires deterministically and is audited.
+3. The UNSET ``on_expiry`` default is fail-safe = DENY (never auto-approves).
+4. Timeout windows are per-capability via ``ApprovalPolicyModel.approval_timeout_seconds``
+   (that previously-orphan field now has a live consumer).
+5. Expiry is MONOTONIC — the outcome is at least as restrictive as the hold.
+
+Plus the trust-plane security guards: math.isfinite on the timeout, validate_id
+on the hold id.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kailash.trust.chain import VerificationResult
+from kailash.trust.enforce.held import (
+    DEFAULT_EXPIRY_DISPOSITION,
+    ExpiryDisposition,
+    HeldAction,
+    MemoryHeldActionStore,
+    new_hold_id,
+    resolve_expiry_verdict,
+    resolve_timeout_seconds,
+    verdict_rank,
+)
+from kailash.trust.enforce.strict import (
+    EATPHeldError,
+    EnforcementRecord,
+    HeldBehavior,
+    StrictEnforcer,
+    Verdict,
+)
+from kailash.trust.governance.models import ApprovalPolicyModel
+
+pytestmark = pytest.mark.unit
+
+
+def _held_result() -> VerificationResult:
+    """A verification result that classifies to HELD (valid + 1 violation)."""
+    return VerificationResult(
+        valid=True,
+        reason="needs human review",
+        violations=[{"field": "cost", "message": "near limit"}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — Monotonic expiry (pure resolution)
+# ---------------------------------------------------------------------------
+
+
+def test_every_disposition_resolves_at_least_as_restrictive_as_held():
+    """INV-5: no ExpiryDisposition may resolve below HELD (never relaxes)."""
+    held_rank = verdict_rank(Verdict.HELD)
+    for disposition in ExpiryDisposition:
+        verdict = resolve_expiry_verdict(disposition)
+        assert (
+            verdict_rank(verdict) >= held_rank
+        ), f"{disposition} resolved to {verdict} which is LESS restrictive than HELD"
+        assert verdict not in (Verdict.AUTO_APPROVED, Verdict.FLAGGED)
+
+
+def test_disposition_verdict_mapping_is_explicit():
+    """INV-5: DENY -> BLOCKED (tighter than HELD); ESCALATE -> HELD (equal)."""
+    assert resolve_expiry_verdict(ExpiryDisposition.DENY) is Verdict.BLOCKED
+    assert resolve_expiry_verdict(ExpiryDisposition.ESCALATE_TO_SENIOR) is Verdict.HELD
+
+
+def test_verdict_rank_is_monotonic_escalation():
+    assert (
+        verdict_rank(Verdict.AUTO_APPROVED)
+        < verdict_rank(Verdict.FLAGGED)
+        < verdict_rank(Verdict.HELD)
+        < verdict_rank(Verdict.BLOCKED)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — Unset on_expiry is fail-safe DENY
+# ---------------------------------------------------------------------------
+
+
+def test_default_expiry_disposition_is_deny():
+    assert DEFAULT_EXPIRY_DISPOSITION is ExpiryDisposition.DENY
+
+
+def test_unset_on_expiry_denies_on_timeout_never_auto_approves():
+    """INV-3: a hold with no configured expiry disposition denies on timeout."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-1",
+            action="wire_funds",
+            result=_held_result(),
+            timeout=60.0,  # on_expiry deliberately unset
+        )
+
+    # Deterministic expiry past the deadline.
+    expired = enforcer.expire_holds(now=datetime.now(timezone.utc) + timedelta(days=1))
+    assert len(expired) == 1
+    assert expired[0].verdict is Verdict.BLOCKED  # fail-safe deny, NOT auto-approve
+    assert expired[0].verdict not in (Verdict.AUTO_APPROVED, Verdict.FLAGGED)
+    assert expired[0].metadata["on_expiry"] == ExpiryDisposition.DENY.value
+
+
+def test_enforcer_default_expiry_is_deny_property():
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    assert enforcer._default_expiry is ExpiryDisposition.DENY
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — Held action accepts timeout + on_expiry, wired through HELD path
+# ---------------------------------------------------------------------------
+
+
+def test_held_action_accepts_timeout_and_on_expiry():
+    """INV-1: enforce() threads timeout + on_expiry into a tracked hold."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-2",
+            action="deploy",
+            result=_held_result(),
+            timeout=120.0,
+            on_expiry=ExpiryDisposition.ESCALATE_TO_SENIOR,
+        )
+
+    pending = enforcer.held_store.pending()
+    assert len(pending) == 1
+    hold = pending[0]
+    assert hold.agent_id == "agent-2"
+    assert hold.action == "deploy"
+    assert hold.timeout_seconds == 120.0
+    assert hold.on_expiry is ExpiryDisposition.ESCALATE_TO_SENIOR
+
+
+def test_no_timeout_no_tracked_hold():
+    """A hold without a timeout window is not tracked for expiry (no bound)."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(agent_id="a", action="x", result=_held_result())
+    assert enforcer.held_store.pending() == []
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — Expiry fires deterministically AND is audited
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_is_deterministic_and_audited():
+    """INV-2: expiry only fires past the deadline, and lands in the audit sink."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    held_at = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+    hold = HeldAction(
+        hold_id=new_hold_id(),
+        agent_id="agent-3",
+        action="export",
+        held_at=held_at,
+        timeout_seconds=300.0,
+        on_expiry=ExpiryDisposition.DENY,
+        record=EnforcementRecord(
+            agent_id="agent-3",
+            action="export",
+            verdict=Verdict.HELD,
+            verification_result=_held_result(),
+            timestamp=held_at,
+        ),
+    )
+    enforcer.held_store.add(hold)
+
+    # Before the deadline: no expiry (deterministic).
+    before = enforcer.expire_holds(now=held_at + timedelta(seconds=299))
+    assert before == []
+    assert enforcer.held_store.pending()  # still pending
+
+    records_before = len(enforcer.records)
+    # At/after the deadline: expiry fires exactly once.
+    after = enforcer.expire_holds(now=held_at + timedelta(seconds=300))
+    assert len(after) == 1
+    exp = after[0]
+    assert exp.verdict is Verdict.BLOCKED
+
+    # Audited to the SAME sink the verdict path uses.
+    assert exp in enforcer.records
+    assert len(enforcer.records) == records_before + 1
+    assert exp.metadata["hold_expiry"] is True
+    assert exp.metadata["hold_id"] == hold.hold_id
+    assert exp.metadata["original_verdict"] == Verdict.HELD.value
+
+    # Idempotent: a second sweep finds nothing (the hold was popped).
+    assert enforcer.expire_holds(now=held_at + timedelta(days=1)) == []
+
+
+def test_escalate_disposition_expires_to_held():
+    """INV-2 + INV-5: escalate resolves to HELD (equal restrictiveness), audited."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    held_at = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+    enforcer.held_store.add(
+        HeldAction(
+            hold_id=new_hold_id(),
+            agent_id="agent-4",
+            action="approve_budget",
+            held_at=held_at,
+            timeout_seconds=10.0,
+            on_expiry=ExpiryDisposition.ESCALATE_TO_SENIOR,
+            record=EnforcementRecord(
+                agent_id="agent-4",
+                action="approve_budget",
+                verdict=Verdict.HELD,
+                verification_result=_held_result(),
+                timestamp=held_at,
+            ),
+        )
+    )
+    expired = enforcer.expire_holds(now=held_at + timedelta(seconds=11))
+    assert len(expired) == 1
+    assert expired[0].verdict is Verdict.HELD  # at least as restrictive as HELD
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — approval_timeout_seconds is now a live consumer
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_timeout_reads_approval_policy_field():
+    """INV-4: the previously-orphan field is consumed by resolve_timeout_seconds."""
+    policy = ApprovalPolicyModel(
+        external_agent_id="copilot", approval_timeout_seconds=1800
+    )
+    assert resolve_timeout_seconds(policy) == 1800.0
+
+
+def test_enforce_uses_policy_timeout_window():
+    """INV-4: enforce() derives the hold window from the policy field."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    policy = ApprovalPolicyModel(
+        external_agent_id="copilot", approval_timeout_seconds=300
+    )
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="copilot",
+            action="invoke",
+            result=_held_result(),
+            approval_policy=policy,
+        )
+    pending = enforcer.held_store.pending()
+    assert len(pending) == 1
+    assert pending[0].timeout_seconds == 300.0  # from approval_timeout_seconds
+
+
+def test_explicit_timeout_overrides_policy():
+    """An explicit timeout takes precedence over the policy field."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    policy = ApprovalPolicyModel(
+        external_agent_id="copilot", approval_timeout_seconds=3600
+    )
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="copilot",
+            action="invoke",
+            result=_held_result(),
+            timeout=42.0,
+            approval_policy=policy,
+        )
+    assert enforcer.held_store.pending()[0].timeout_seconds == 42.0
+
+
+# ---------------------------------------------------------------------------
+# Security guards (trust-plane-security.md)
+# ---------------------------------------------------------------------------
+
+
+class _Policy:
+    """Minimal duck-typed policy for adversarial timeout values."""
+
+    def __init__(self, value: float) -> None:
+        self.approval_timeout_seconds = value
+
+
+def test_resolve_timeout_rejects_nan():
+    with pytest.raises(ValueError):
+        resolve_timeout_seconds(_Policy(float("nan")))
+
+
+def test_resolve_timeout_rejects_inf():
+    with pytest.raises(ValueError):
+        resolve_timeout_seconds(_Policy(float("inf")))
+
+
+def test_resolve_timeout_rejects_negative():
+    with pytest.raises(ValueError):
+        resolve_timeout_seconds(_Policy(-1.0))
+
+
+def test_enforce_rejects_nan_timeout():
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    with pytest.raises(ValueError):
+        enforcer.enforce(
+            agent_id="a",
+            action="x",
+            result=_held_result(),
+            timeout=float("nan"),
+        )
+
+
+def test_held_action_rejects_non_finite_timeout():
+    held_at = datetime.now(timezone.utc)
+    rec = EnforcementRecord(
+        agent_id="a",
+        action="x",
+        verdict=Verdict.HELD,
+        verification_result=_held_result(),
+        timestamp=held_at,
+    )
+    with pytest.raises(ValueError):
+        HeldAction(
+            hold_id=new_hold_id(),
+            agent_id="a",
+            action="x",
+            held_at=held_at,
+            timeout_seconds=float("inf"),
+            on_expiry=ExpiryDisposition.DENY,
+            record=rec,
+        )
+
+
+def test_held_action_validates_hold_id():
+    held_at = datetime.now(timezone.utc)
+    rec = EnforcementRecord(
+        agent_id="a",
+        action="x",
+        verdict=Verdict.HELD,
+        verification_result=_held_result(),
+        timestamp=held_at,
+    )
+    with pytest.raises(ValueError):
+        HeldAction(
+            hold_id="../../etc/passwd",  # path traversal
+            agent_id="a",
+            action="x",
+            held_at=held_at,
+            timeout_seconds=1.0,
+            on_expiry=ExpiryDisposition.DENY,
+            record=rec,
+        )
+
+
+def test_new_hold_id_is_finite_and_safe():
+    hid = new_hold_id()
+    assert hid.startswith("hold-")
+    # Does not raise — validate_id accepts it inside HeldAction.__post_init__
+    HeldAction(
+        hold_id=hid,
+        agent_id="a",
+        action="x",
+        held_at=datetime.now(timezone.utc),
+        timeout_seconds=1.0,
+        on_expiry=ExpiryDisposition.DENY,
+        record=EnforcementRecord(
+            agent_id="a",
+            action="x",
+            verdict=Verdict.HELD,
+            verification_result=_held_result(),
+            timestamp=datetime.now(timezone.utc),
+        ),
+    )
+
+
+def test_memory_store_is_bounded():
+    """Bounded collection (trust-plane-security.md rule 4)."""
+    store = MemoryHeldActionStore(maxlen=5)
+    held_at = datetime.now(timezone.utc)
+    for _ in range(20):
+        store.add(
+            HeldAction(
+                hold_id=new_hold_id(),
+                agent_id="a",
+                action="x",
+                held_at=held_at,
+                timeout_seconds=1.0,
+                on_expiry=ExpiryDisposition.DENY,
+                record=EnforcementRecord(
+                    agent_id="a",
+                    action="x",
+                    verdict=Verdict.HELD,
+                    verification_result=_held_result(),
+                    timestamp=held_at,
+                ),
+            )
+        )
+    assert len(store.pending()) == 5
+
+
+def test_math_isfinite_guard_present():
+    """Sanity: the timeout finiteness guard actually uses math.isfinite semantics."""
+    assert not math.isfinite(float("nan"))
+    assert not math.isfinite(float("inf"))

--- a/tests/trust/unit/test_held_timeout_failsafe.py
+++ b/tests/trust/unit/test_held_timeout_failsafe.py
@@ -358,6 +358,62 @@ def test_held_action_validates_hold_id():
         )
 
 
+def test_held_action_normalizes_naive_held_at_to_utc():
+    """LOW-3: a tz-naive held_at is normalized to UTC (no naive/aware mismatch)."""
+    naive = datetime(2026, 7, 9, 12, 0, 0)  # no tzinfo
+    assert naive.tzinfo is None
+    rec = EnforcementRecord(
+        agent_id="a",
+        action="x",
+        verdict=Verdict.HELD,
+        verification_result=_held_result(),
+        timestamp=datetime.now(timezone.utc),
+    )
+    hold = HeldAction(
+        hold_id=new_hold_id(),
+        agent_id="a",
+        action="x",
+        held_at=naive,
+        timeout_seconds=10.0,
+        on_expiry=ExpiryDisposition.DENY,
+        record=rec,
+    )
+    # Normalized to UTC — held_at + expires_at are both aware.
+    assert hold.held_at.tzinfo is timezone.utc
+    assert hold.expires_at.tzinfo is timezone.utc
+    # is_expired() against an aware now does not raise (naive-vs-aware TypeError).
+    aware_now = datetime(2026, 7, 9, 12, 0, 30, tzinfo=timezone.utc)
+    assert hold.is_expired(aware_now) is True
+
+
+def test_naive_held_at_expires_through_enforcer():
+    """A naive-datetime-held action still expires deterministically (no TypeError)."""
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE)
+    naive_held_at = datetime(2026, 7, 9, 12, 0, 0)  # no tzinfo
+    enforcer.held_store.add(
+        HeldAction(
+            hold_id=new_hold_id(),
+            agent_id="agent-naive",
+            action="x",
+            held_at=naive_held_at,
+            timeout_seconds=5.0,
+            on_expiry=ExpiryDisposition.DENY,
+            record=EnforcementRecord(
+                agent_id="agent-naive",
+                action="x",
+                verdict=Verdict.HELD,
+                verification_result=_held_result(),
+                timestamp=datetime.now(timezone.utc),
+            ),
+        )
+    )
+    expired = enforcer.expire_holds(
+        now=datetime(2026, 7, 9, 12, 0, 10, tzinfo=timezone.utc)
+    )
+    assert len(expired) == 1
+    assert expired[0].verdict is Verdict.BLOCKED
+
+
 def test_new_hold_id_is_finite_and_safe():
     hid = new_hold_id()
     assert hid.startswith("hold-")

--- a/tests/trust/unit/test_shadow_stores.py
+++ b/tests/trust/unit/test_shadow_stores.py
@@ -29,7 +29,6 @@ from kailash.trust.enforce.shadow_store import (
 )
 from kailash.trust.enforce.strict import EnforcementRecord, Verdict
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -333,6 +332,28 @@ class TestSqliteShadowStore:
         if os.name == "posix":
             mode = os.stat(db_path).st_mode & 0o777
             assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_wal_shm_sidecar_permissions(self, db_path: str) -> None:
+        """WAL/SHM sidecars (created on first write) are also 0o600 on POSIX.
+
+        trust-plane-security.md rule 6: the sidecars carry the same
+        enforcement-record data as the main DB; a world-readable sidecar leaks
+        it. A write forces the sidecars into existence.
+        """
+        if os.name != "posix":
+            pytest.skip("POSIX-only permission check")
+        store = SqliteShadowStore(db_path)
+        store.append_record(_make_record())  # forces -wal / -shm into existence
+
+        checked_any = False
+        for suffix in ("-wal", "-shm"):
+            sidecar = db_path + suffix
+            if os.path.exists(sidecar):
+                checked_any = True
+                mode = os.stat(sidecar).st_mode & 0o777
+                assert mode == 0o600, f"{suffix} expected 0o600, got {oct(mode)}"
+        assert checked_any, "no WAL/SHM sidecar was created — cannot verify perms"
+        store.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a configurable human-in-the-loop (HITL) **hold timeout** and a **deterministic, fail-safe expiry disposition** to the existing EATP HELD machinery (`StrictEnforcer`). A hold with no bounded response window is oversight-theatre — it blocks forever, or worse, some path silently lets it through. This gives every hold a deadline and a governed on-timeout outcome, without building a parallel approval system.

Framework-first: extends the existing HELD path (`HeldBehavior` / `_handle_held` / the held store) rather than introducing a new subsystem. PACT owns the authorization decision; the timeout is a new dimension of it.

## The five load-bearing invariants

1. **Held action accepts `timeout` + `on_expiry`** — `StrictEnforcer.enforce(..., timeout=, on_expiry=, approval_policy=)` threads both through the QUEUE hold path into a tracked `HeldAction`.
2. **Expiry fires deterministically + is audited** — `expire_holds(now=...)` resolves each past-deadline hold and records an `EnforcementRecord` to the *same* audit sink (`records`) the verdict path writes to.
3. **Unset `on_expiry` is fail-safe = `deny`** — an unconfigured expiry disposition resolves to `BLOCKED` on timeout, **never** `AUTO_APPROVED`/`FLAGGED`. A hold whose reviewer never responds must not silently become an approval (zero-tolerance Rule 2/3, pact-governance.md Rule 4).
4. **Per-capability timeout windows** — consumes the existing `ApprovalPolicyModel.approval_timeout_seconds` field. That field previously had **no consumer** (an orphan config field is a stub); `resolve_timeout_seconds()` is now its live consumer.
5. **Monotonic expiry** — the on-expiry outcome is always at least as restrictive as the hold (`deny` -> `BLOCKED`, `escalate_to_senior` -> `HELD`; never less-restrictive). A single shared restrictiveness function (`resolve_expiry_verdict` / `verdict_rank`) enforces it and fail-closes any unrecognized disposition to `BLOCKED`.

## Trust-plane security (trust-plane-security.md)

- `math.isfinite()` guards on every timeout numeric (rejects NaN/Inf/negative) at the `enforce()`, `HeldAction`, and `resolve_timeout_seconds()` boundaries.
- `validate_id()` on every hold id (path-traversal defense).
- Bounded collections (`MemoryHeldActionStore` FIFO-evicts at `maxlen`; SQLite store trims oldest beyond `max_records`).
- `SqliteHeldActionStore` uses parameterized SQL, WAL, and 0o600 file perms — mirrors the sibling `SqliteShadowStore`.

## Tests

- **Tier 1** `tests/trust/unit/test_held_timeout_failsafe.py` (22 tests) — all five invariants + NaN/Inf/negative/hold-id security guards.
- **Tier 2** `tests/trust/unit/test_held_action_store_wiring.py` (5 tests) — exercises `SqliteHeldActionStore` through the `StrictEnforcer` facade against a real on-disk SQLite DB: persistence, restart survival, expiry+audit, 0o600 perms, monotonic expiry.

`27 passed`. Full `kailash-pact` unit suite regression: `1561 passed, 8 skipped`. Existing enforce suite: `109 passed`. `mypy --strict` clean on touched files; pre-commit (Black/isort/Ruff/type-annotations/Tier-1) green.

## Notes

- The previously-orphan `ApprovalPolicyModel.approval_timeout_seconds` now has a live consumer.
- A **cross-SDK soft-parity follow-up** is warranted: the Rust SDK trust plane has the sibling HELD machinery and should gain the same timeout + fail-safe-deny expiry dimension.

## Related issues

Fixes #1515