### PR TITLE
fix(dataflow): actionable cross-tenant natural-key collision error + docs (#1526, Option B)

### DIFF
--- a/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
+++ b/packages/kailash-dataflow/docs/enterprise/multi-tenant.md
@@ -60,6 +60,64 @@ workflow.add_node("OrderListNode", "orders", {
 })
 ```
 
+#### Natural keys are globally unique under row-level isolation
+
+With row-level isolation, DataFlow keeps the model's DEFAULT single-column
+primary key `id` — the table is NOT keyed on a composite `(tenant_id, id)`. The
+`tenant_id` column is added for filtering, but `id` alone remains the primary
+key. This is intentional: under row-level isolation the `id` is a
+**globally-unique surrogate id**, so two tenants CANNOT share the same
+natural-key `id`.
+
+```python
+db = DataFlow("postgresql://…", multi_tenant=True)
+
+@db.model
+class Document:
+    id: str          # PRIMARY KEY — globally unique across ALL tenants
+    title: str
+
+db.tenant_context.register_tenant("acme", "Acme Corp")
+db.tenant_context.register_tenant("globex", "Globex Inc")
+
+with db.tenant_context.switch("acme"):
+    await db.express.create("Document", {"id": "doc-1", "title": "Acme's doc"})
+
+# A DIFFERENT tenant reusing the same natural-key id collides on the PK and
+# raises TenantNaturalKeyCollisionError (fail-closed and SAFE — no cross-tenant
+# data is exposed; the write is rejected, not merged into the other tenant's row).
+with db.tenant_context.switch("globex"):
+    await db.express.create("Document", {"id": "doc-1", "title": "Globex's doc"})
+    # dataflow.core.exceptions.TenantNaturalKeyCollisionError:
+    #   Cross-tenant natural-key collision … tenant 'globex' cannot write
+    #   id='doc-1' because that primary-key value is already owned by another
+    #   tenant. … Remediation: (1) use globally-unique ids (e.g. UUIDs); OR
+    #   (2) for tenant-LOCAL natural keys, use the schema-per-tenant strategy …
+```
+
+The error (`dataflow.core.exceptions.TenantNaturalKeyCollisionError`) names only
+your OWN active `tenant_id` and the `id` you supplied — never the other tenant's
+data. A same-tenant duplicate (the same tenant re-inserting its own `id`) is NOT
+affected; it raises the ordinary duplicate-key error.
+
+**When you need tenant-LOCAL natural keys** (each tenant reuses the same id
+space — e.g. every tenant has an invoice `INV-001`), pick one of:
+
+1. **Use globally-unique ids** (e.g. UUIDs). Each tenant's ids never collide, so
+   the surrogate-id contract holds naturally:
+
+   ```python
+   import uuid
+   await db.express.create("Document", {"id": str(uuid.uuid4()), "title": "…"})
+   ```
+
+2. **Use schema-per-tenant isolation** instead of row-level. Each tenant gets
+   its own table, so identical natural keys live in separate schemas and never
+   collide on one shared primary key. The strategy is
+   `dataflow.core.multi_tenancy.IsolationStrategy.SCHEMA`; per-tenant tables are
+   created via `SchemaIsolationStrategy.create_tenant_table`. See
+   [Schema Isolation](#2-schema-isolation) below.
+
 ### 2. Schema Isolation
 
 Each tenant gets a separate schema (PostgreSQL/MySQL):

--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -213,7 +213,7 @@ class BulkUpsertConflictTargetError(DataFlowError):
 
     def __init__(
         self,
-        conflict_on: Optional[list] = None,
+        conflict_on: Optional[list[str]] = None,
         model_name: Optional[str] = None,
         original_error: Optional[BaseException] = None,
     ) -> None:
@@ -285,7 +285,7 @@ class UpsertConflictTargetError(DataFlowError):
 
     def __init__(
         self,
-        conflict_on: Optional[list] = None,
+        conflict_on: Optional[list[str]] = None,
         model_name: Optional[str] = None,
         original_error: Optional[BaseException] = None,
     ) -> None:
@@ -305,6 +305,125 @@ class UpsertConflictTargetError(DataFlowError):
             f"schema-migration policy; it would also fail on existing duplicate "
             f"values)."
         )
+
+
+class TenantNaturalKeyCollisionError(DataFlowError):
+    """Raised when a ``multi_tenant=True`` write collides on the natural-key
+    primary key with a row another tenant already owns (issue #1526).
+
+    A ``multi_tenant=True`` DataFlow model keeps the DEFAULT single-column
+    primary key ``id`` — the schema is NOT a composite ``(tenant_id, id)``.
+    Under the default row-level tenant strategy (``QueryInterceptor`` appends a
+    ``tenant_id`` filter on reads), the ``id`` column is therefore a GLOBALLY
+    UNIQUE surrogate id: two tenants cannot both write the same natural-key
+    ``id``. When tenant B inserts an ``id`` tenant A already owns, the database
+    rejects it on the PK UNIQUE constraint (SQLite ``UNIQUE constraint failed:
+    <table>.id``; PostgreSQL ``duplicate key value violates unique constraint
+    "<table>_pkey"``; MySQL ``Duplicate entry ... for key 'PRIMARY'``).
+
+    This is fail-closed and SAFE — no cross-tenant data is exposed (the write is
+    rejected, not merged into another tenant's row) — but the raw driver message
+    never explains the surrogate-id design, so DataFlow converts it into this
+    actionable typed error.
+
+    The message names ONLY the CALLER's own values — the active ``tenant_id`` and
+    the ``id`` the caller supplied — never the other tenant's row data, so it
+    does not weaken tenant isolation (``rules/tenant-isolation.md``).
+
+    Attributes:
+        model_name: The multi_tenant model whose write collided.
+        tenant_id: The CALLER's active tenant (the one attempting the write).
+        colliding_id: The natural-key ``id`` the CALLER supplied.
+        original_error: The underlying driver exception / error string, kept for
+            local diagnosability. It is NOT interpolated into ``str(self)`` (it
+            may carry the raw driver value); attach it as ``__cause__`` via
+            ``raise ... from`` only on non-log-aggregator surfaces (see #1550).
+
+    Remediation (two supported paths — both cite real DataFlow API):
+
+    1. Use GLOBALLY-UNIQUE ids (e.g. UUIDs) so each tenant's ids never collide;
+       the surrogate-id contract then holds naturally.
+    2. For tenant-LOCAL natural keys (each tenant reuses the same id space), use
+       the schema-per-tenant isolation strategy —
+       ``dataflow.core.multi_tenancy.IsolationStrategy.SCHEMA`` /
+       ``SchemaIsolationStrategy.create_tenant_table`` — which gives each tenant
+       its own table, so identical natural keys live in separate schemas and do
+       not collide on one shared PK.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        tenant_id: str,
+        colliding_id: object,
+        original_error: Optional[BaseException] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.tenant_id = tenant_id
+        self.colliding_id = colliding_id
+        self.original_error = original_error
+
+        super().__init__(
+            f"Cross-tenant natural-key collision on multi_tenant model "
+            f"'{model_name}': tenant '{tenant_id}' cannot write id={colliding_id!r} "
+            f"because that primary-key value is already owned by another tenant. "
+            f"multi_tenant=True models keep the DEFAULT single-column primary key "
+            f"'id' (NOT a composite of (tenant_id, id)), so under the default "
+            f"row-level tenant strategy the 'id' is a GLOBALLY-UNIQUE surrogate — "
+            f"two tenants cannot share the same natural-key id. Remediation: "
+            f"(1) use globally-unique ids (e.g. UUIDs) so tenants never collide; "
+            f"OR (2) for tenant-LOCAL natural keys, use the schema-per-tenant "
+            f"isolation strategy "
+            f"(dataflow.core.multi_tenancy.IsolationStrategy.SCHEMA / "
+            f"SchemaIsolationStrategy.create_tenant_table), which gives each "
+            f"tenant its own table so identical natural keys do not collide."
+        )
+
+
+def is_pk_unique_violation(message: str, table_name: str) -> bool:
+    """True iff a driver error is a UNIQUE violation on the PRIMARY KEY ``id``
+    of ``table_name`` (issue #1526).
+
+    Detection is intentionally narrow — it matches ONLY the primary-key column
+    ``id``, never a sibling UNIQUE column (e.g. ``<table>.idempotency_key``), so
+    the caller does NOT broaden the actionable tenant-collision error onto
+    unrelated unique violations. Returns ``False`` (caller keeps the original
+    error path) for every non-PK unique violation and every other error class.
+
+    Dialect shapes matched (both raw and post-:func:`sanitize_db_error`):
+
+    * **SQLite** — ``UNIQUE constraint failed: <table>.id`` (word-bounded so
+      ``<table>.idempotency_key`` does NOT match; the clause carries no value so
+      it survives sanitization unchanged).
+    * **PostgreSQL** — ``duplicate key value violates unique constraint`` plus
+      the default PK constraint name ``<table>_pkey`` OR the ``Key (id)=`` DETAIL
+      column name (the value is redacted by ``sanitize_db_error`` but the ``id``
+      column name is preserved).
+    * **MySQL/MariaDB** — ``Duplicate entry ... for key 'PRIMARY'`` (or the
+      MySQL 8.0.19+ ``for key '<table>.PRIMARY'`` form); the ``PRIMARY`` key name
+      is preserved by ``sanitize_db_error``.
+    """
+    if not message or not table_name:
+        return False
+    m = message.lower()
+    t = table_name.lower()
+    # SQLite: word-bounded so a sibling unique column (``<table>.id_token``,
+    # ``<table>.idempotency_key``) that contains ``<table>.id`` as a prefix does
+    # NOT match — only the exact ``<table>.id`` PK column.
+    if "unique constraint failed:" in m and re.search(rf"\b{re.escape(t)}\.id\b", m):
+        return True
+    # PostgreSQL: the PK constraint (default name ``<table>_pkey``) or the
+    # ``Key (id)=`` DETAIL naming the ``id`` column.
+    if "duplicate key value violates unique constraint" in m and (
+        f"{t}_pkey" in m or "key (id)=" in m
+    ):
+        return True
+    # MySQL/MariaDB: the auto-named ``PRIMARY`` key.
+    if "duplicate entry" in m and (
+        "for key 'primary'" in m or f"for key '{t}.primary'" in m
+    ):
+        return True
+    return False
 
 
 def is_conflict_target_error(message: str) -> bool:
@@ -464,7 +583,7 @@ _MYSQL_INCORRECT_VALUE_RE = re.compile(
 # benign quoted identifiers elsewhere are untouched; greedy value bounded by a
 # lookahead requiring only closing chars ()/./whitespace) before EOS/newline (so
 # a trailing "\nHINT: …" continuation is preserved). Value redacted, phrase +
-# type name preserved.
+# the type-name preserved.
 _PG_QUOTED_VALUE_RE = re.compile(
     r'((?:invalid input syntax for (?:type )?[^\n:"]*'
     r'|invalid input value for (?:enum )?[^\n:"]*'
@@ -530,7 +649,8 @@ def sanitize_db_error(msg: str) -> str:
     msg = _MYSQL_INCORRECT_VALUE_RE.sub(r"\1: '[REDACTED]'", msg)
     msg = _PG_QUOTED_VALUE_RE.sub(r'\1: "[REDACTED]"', msg)
     # Issue #1569 red-team: PG numeric-overflow ``value "<v>" is out of range for
-    # type <t>`` (value BEFORE the descriptor — the colon-anchored sub above misses it).
+    # <t>`` where ``<t>`` is a type name (value BEFORE the descriptor — the
+    # colon-anchored sub above misses it).
     msg = _PG_VALUE_OUT_OF_RANGE_RE.sub(r'\1 "[REDACTED]"\2', msg)
     return msg
 
@@ -540,6 +660,8 @@ __all__ = [
     "MigrationNotAppliedError",
     "BulkUpsertConflictTargetError",
     "UpsertConflictTargetError",
+    "TenantNaturalKeyCollisionError",
+    "is_pk_unique_violation",
     "is_conflict_target_error",
     "sanitize_db_error",
     "DataFlowError",

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -58,7 +58,12 @@ from dataflow.cache.key_generator import CacheKeyGenerator
 from dataflow.cache.memory_cache import InMemoryCache
 from dataflow.classification.event_payload import format_record_id_for_event
 from dataflow.core.agent_context import get_current_agent_id, get_current_clearance
-from dataflow.core.exceptions import DDLFailedError, sanitize_db_error
+from dataflow.core.exceptions import (
+    DDLFailedError,
+    TenantNaturalKeyCollisionError,
+    is_pk_unique_violation,
+    sanitize_db_error,
+)
 from dataflow.core.multi_tenancy import TenantRequiredError
 from dataflow.core.protection import ProtectionViolation
 from dataflow.core.tenant_context import get_current_tenant_id
@@ -567,7 +572,97 @@ class DataFlowExpress:
             model, rows, clearance
         )
 
-    def _raise_for_failed_result(self, model: str, operation: str, result: Any) -> None:
+    async def _maybe_tenant_natural_key_collision(
+        self,
+        model: str,
+        id_value: object,
+        error_text: str,
+        original_error: Optional[BaseException] = None,
+    ) -> Optional[TenantNaturalKeyCollisionError]:
+        """Return a :class:`TenantNaturalKeyCollisionError` iff ``error_text`` is
+        a CROSS-TENANT PRIMARY-KEY collision on a ``multi_tenant`` model, else
+        ``None`` (issue #1526).
+
+        A ``multi_tenant=True`` model keeps a single-column ``id`` PK (NOT a
+        composite ``(tenant_id, id)``), so the ``id`` is a globally-unique
+        surrogate: two DIFFERENT tenants writing the same natural key collide on
+        that PK. That is fail-closed and SAFE — no cross-tenant data leaks — but
+        the raw driver message is opaque.
+
+        A same-tenant duplicate (the current tenant re-inserting its OWN ``id``)
+        produces the IDENTICAL PK-unique driver message, so the driver text alone
+        cannot distinguish the two. To avoid over-broadening (converting an
+        ordinary same-tenant duplicate into a misleading cross-tenant claim),
+        this helper disambiguates WITHOUT reading the other tenant's row: a
+        TENANT-SCOPED read for ``id_value`` returns a row IFF the CURRENT tenant
+        already owns it (→ same-tenant duplicate → keep the ordinary path). If
+        the read returns ``None`` while the PK provably exists (we are handling a
+        PK-unique violation), the colliding row belongs to ANOTHER tenant → the
+        actionable cross-tenant error. The disambiguation never reads or exposes
+        the other tenant's data (``rules/tenant-isolation.md``,
+        ``rules/security.md``); the returned error names ONLY the caller's own
+        ``tenant_id`` + supplied ``id``.
+
+        For every non-matching error it returns ``None`` so the caller keeps the
+        original error path (no over-broadening, no silent normalization —
+        zero-tolerance Rule 3). Zero-cost short-circuit for single-tenant models:
+        the multi_tenant guard returns ``None`` before any string inspection.
+        """
+        security = getattr(self._db.config, "security", None)
+        if not (security and getattr(security, "multi_tenant", False) is True):
+            return None
+        tenant_id = get_current_tenant_id()
+        if tenant_id is None:
+            return None
+        # The model must carry the tenant_id column DataFlow injects for
+        # multi_tenant instances (defends against a non-tenant model on a
+        # multi_tenant DataFlow). An introspection failure means we cannot
+        # confirm the multi_tenant shape → classification does not apply and
+        # the caller re-raises the ORIGINAL driver error (no hiding).
+        model_fields: Any = None
+        try:
+            model_fields = self._db.get_model_fields(model)
+        except Exception:
+            model_fields = None
+        if not model_fields or "tenant_id" not in model_fields:
+            return None
+        # Resolve the table name for PK-column matching; if it cannot be
+        # resolved, do not risk a false positive — keep the original path.
+        class_to_table = getattr(self._db, "_class_name_to_table_name", None)
+        table_name: Optional[str] = None
+        if callable(class_to_table):
+            try:
+                table_name = class_to_table(model)
+            except Exception:
+                table_name = None
+        if not table_name:
+            return None
+        if not is_pk_unique_violation(error_text, table_name):
+            return None
+        # Without the caller's id we cannot run the same-tenant disambiguation;
+        # decline to convert rather than assert an unverifiable cross-tenant claim.
+        if id_value is None:
+            return None
+        # Same-tenant duplicate vs cross-tenant collision. A tenant-scoped read
+        # sees ONLY the current tenant's rows (QueryInterceptor), so a hit means
+        # the current tenant already owns this id → ordinary duplicate.
+        existing = await self.read(model, str(id_value), cache_ttl=0)
+        if existing is not None:
+            return None
+        return TenantNaturalKeyCollisionError(
+            model_name=model,
+            tenant_id=tenant_id,
+            colliding_id=id_value,
+            original_error=original_error,
+        )
+
+    async def _raise_for_failed_result(
+        self,
+        model: str,
+        operation: str,
+        result: Any,
+        id_value: object = None,
+    ) -> None:
         """Convert a dict-shaped node failure into a raised typed exception.
 
         Express documents create/update/delete/upsert as raise-on-failure
@@ -603,6 +698,19 @@ class DataFlowExpress:
         if not (isinstance(result, dict) and result.get("success") is False):
             return
         error_msg = result.get("error") or "operation failed"
+        # Issue #1526: a multi_tenant write that collides on the natural-key PK
+        # with another tenant's row surfaces here as a raw ``UNIQUE constraint
+        # failed: <table>.id`` (SQLite) / ``<table>_pkey`` (PG) / ``for key
+        # 'PRIMARY'`` (MySQL). Convert THAT specific case into an actionable,
+        # caller-facing error naming the caller's own tenant_id + id and the
+        # schema-per-tenant / UUID remediation. Narrow by construction (PK-only,
+        # multi_tenant-only); every other failure keeps the DDL/RuntimeError
+        # path below (no over-broadening, no silent normalization).
+        collision = await self._maybe_tenant_natural_key_collision(
+            model, id_value, str(error_msg)
+        )
+        if collision is not None:
+            raise collision
         # Try the typed DDL classification first: the engine already
         # recorded the failed DDL via ``_record_failed_ddl`` upstream.
         # The engine records under TWO key shapes depending on the
@@ -681,6 +789,22 @@ class DataFlowExpress:
                 node._express_protection_precheck_done = True
                 result = await node.async_run(**data)
             except Exception as exc:
+                # Issue #1526: if the CreateNode RAISES a PK-unique violation
+                # (rather than returning a failure dict), convert the same
+                # multi_tenant cross-tenant collision into the actionable typed
+                # error before recording/re-raising. Non-collision errors keep
+                # the raw path unchanged.
+                collision = await self._maybe_tenant_natural_key_collision(
+                    model,
+                    data.get("id") if isinstance(data, dict) else None,
+                    str(exc),
+                    original_error=exc,
+                )
+                if collision is not None:
+                    await self._trust_record_failure(
+                        model, "create", plan, collision, query_params=data
+                    )
+                    raise collision from exc
                 await self._trust_record_failure(
                     model, "create", plan, exc, query_params=data
                 )
@@ -694,7 +818,12 @@ class DataFlowExpress:
             # the user-facing express API. See _raise_for_failed_result.
             if isinstance(result, dict) and result.get("success") is False:
                 try:
-                    self._raise_for_failed_result(model, "create", result)
+                    await self._raise_for_failed_result(
+                        model,
+                        "create",
+                        result,
+                        id_value=data.get("id") if isinstance(data, dict) else None,
+                    )
                 except Exception as exc:
                     await self._trust_record_failure(
                         model, "create", plan, exc, query_params=data
@@ -902,7 +1031,7 @@ class DataFlowExpress:
             # _raise_for_failed_result.
             if isinstance(result, dict) and result.get("success") is False:
                 try:
-                    self._raise_for_failed_result(model, "update", result)
+                    await self._raise_for_failed_result(model, "update", result)
                 except Exception as exc:
                     await self._trust_record_failure(
                         model,
@@ -989,7 +1118,7 @@ class DataFlowExpress:
             # raised typed exception before any side effect.
             if isinstance(result, dict) and result.get("success") is False:
                 try:
-                    self._raise_for_failed_result(model, "delete", result)
+                    await self._raise_for_failed_result(model, "delete", result)
                 except Exception as exc:
                     await self._trust_record_failure(
                         model,
@@ -1367,7 +1496,12 @@ class DataFlowExpress:
             # Issue #759 (DPI-A): convert dict-shaped node failure into a
             # raised typed exception before any side effect.
             if isinstance(result, dict) and result.get("success") is False:
-                self._raise_for_failed_result(model, "upsert", result)
+                await self._raise_for_failed_result(
+                    model,
+                    "upsert",
+                    result,
+                    id_value=data.get("id") if isinstance(data, dict) else None,
+                )
 
             # Model-scoped cache invalidation (TSG-104)
             await self._invalidate_model_cache(model)
@@ -1451,7 +1585,14 @@ class DataFlowExpress:
             # Issue #759 (DPI-A): convert dict-shaped node failure into a
             # raised typed exception before any side effect.
             if isinstance(result, dict) and result.get("success") is False:
-                self._raise_for_failed_result(model, "upsert_advanced", result)
+                _adv_id = None
+                if isinstance(create, dict):
+                    _adv_id = create.get("id")
+                if _adv_id is None and isinstance(where, dict):
+                    _adv_id = where.get("id")
+                await self._raise_for_failed_result(
+                    model, "upsert_advanced", result, id_value=_adv_id
+                )
 
             # Model-scoped cache invalidation (TSG-104)
             await self._invalidate_model_cache(model)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1526_multi_tenant_natural_key_collision.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1526_multi_tenant_natural_key_collision.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1526 — actionable cross-tenant natural-key error.
+
+A ``multi_tenant=True`` DataFlow model keeps the DEFAULT single-column primary
+key ``id`` (schema-gen at ``core/engine.py``), NOT a composite ``(tenant_id,
+id)``. Under the default row-level tenant strategy the ``id`` is therefore a
+GLOBALLY-UNIQUE surrogate: two tenants cannot share the same natural-key ``id``.
+When tenant B writes an ``id`` tenant A already owns, the database rejects it on
+the PK UNIQUE constraint (``UNIQUE constraint failed: <table>.id`` on SQLite;
+``<table>_pkey`` on PostgreSQL). This is fail-closed and SAFE (no cross-tenant
+data leaks — verified in #1518), but the raw driver message never explains the
+surrogate-id design.
+
+Option B (owner-selected): keep the id-alone PK (no schema change) and close the
+DX gap with an actionable typed error — :class:`TenantNaturalKeyCollisionError`
+— that names the CALLER's own ``tenant_id`` + supplied ``id`` and points to the
+schema-per-tenant / UUID alternatives.
+
+These are Tier-2 regression tests against REAL databases (no mocking): SQLite
+always, PostgreSQL when the shared Docker infra is reachable. The pure
+PK-detection helper (:func:`is_pk_unique_violation`) additionally carries Tier-1
+narrowness assertions — it MUST match ONLY the ``id`` PK, never a sibling UNIQUE
+column, so the actionable error never over-broadens onto unrelated violations.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.exceptions import (
+    TenantNaturalKeyCollisionError,
+    is_pk_unique_violation,
+)
+
+# Shared SDK Docker PostgreSQL infra (port 5434), same as the #1518 suite.
+TEST_DATABASE_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+def _uid(prefix: str = "doc") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+def _sqlite_db():
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1526_{int(time.time() * 1_000_000)}.db"
+    return DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+
+def _pg_available() -> bool:
+    import socket
+
+    host, port = "localhost", 5434
+    if TEST_DATABASE_URL.startswith("postgresql://"):
+        # Best-effort parse host:port out of the URL for the probe.
+        try:
+            after_at = TEST_DATABASE_URL.split("@", 1)[1]
+            hostport = after_at.split("/", 1)[0]
+            host = hostport.split(":", 1)[0]
+            port = int(hostport.split(":", 1)[1]) if ":" in hostport else 5432
+        except Exception:
+            pass
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tier-1: is_pk_unique_violation narrowness (PK-only, never a sibling column)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+@pytest.mark.tier1
+class TestIsPkUniqueViolation:
+    """The PK-detection helper matches ONLY the ``id`` PK across dialects and
+    NEVER a sibling UNIQUE column — the guarantee that prevents the actionable
+    error from over-broadening (issue #1526)."""
+
+    def test_sqlite_pk_violation_matches(self):
+        assert is_pk_unique_violation("UNIQUE constraint failed: docs.id", "docs")
+
+    def test_sqlite_sibling_unique_column_does_not_match(self):
+        # A sibling UNIQUE column whose name has ``id`` as a prefix MUST NOT
+        # match — only the exact ``docs.id`` PK column.
+        assert not is_pk_unique_violation(
+            "UNIQUE constraint failed: docs.idempotency_key", "docs"
+        )
+        assert not is_pk_unique_violation(
+            "UNIQUE constraint failed: docs.email", "docs"
+        )
+
+    def test_postgres_pkey_constraint_matches(self):
+        assert is_pk_unique_violation(
+            'duplicate key value violates unique constraint "docs_pkey"',
+            "docs",
+        )
+
+    def test_postgres_detail_key_id_matches(self):
+        # Even when the constraint name is redacted/absent, the DETAIL naming
+        # the ``id`` column is a positive signal (survives sanitize_db_error,
+        # which preserves the column name).
+        assert is_pk_unique_violation(
+            "duplicate key value violates unique constraint\n"
+            "DETAIL: Key (id)=([REDACTED]) already exists.",
+            "docs",
+        )
+
+    def test_postgres_sibling_unique_constraint_does_not_match(self):
+        assert not is_pk_unique_violation(
+            'duplicate key value violates unique constraint "docs_email_key"\n'
+            "DETAIL: Key (email)=([REDACTED]) already exists.",
+            "docs",
+        )
+
+    def test_mysql_primary_key_matches(self):
+        assert is_pk_unique_violation(
+            "Duplicate entry '[REDACTED]' for key 'PRIMARY'", "docs"
+        )
+        # MySQL 8.0.19+ qualified form.
+        assert is_pk_unique_violation(
+            "Duplicate entry '[REDACTED]' for key 'docs.PRIMARY'", "docs"
+        )
+
+    def test_mysql_sibling_key_does_not_match(self):
+        assert not is_pk_unique_violation(
+            "Duplicate entry '[REDACTED]' for key 'docs.email_unique'", "docs"
+        )
+
+    def test_empty_and_unrelated_inputs_return_false(self):
+        assert not is_pk_unique_violation("", "docs")
+        assert not is_pk_unique_violation("some unrelated error", "docs")
+        assert not is_pk_unique_violation("UNIQUE constraint failed: docs.id", "")
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: end-to-end through the express write path (real DB, no mocking)
+# ---------------------------------------------------------------------------
+
+
+async def _run_collision_scenario(db: DataFlow) -> None:
+    """Shared scenario body run against whichever real backend is passed in."""
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    doc_id = _uid()
+
+    # tenant-a establishes the natural key.
+    with db.tenant_context.switch("tenant-a"):
+        created = await db.express.create("Doc", {"id": doc_id, "title": "A"})
+        assert created["id"] == doc_id
+
+    # (a) tenant-b writing the SAME natural key → actionable typed error.
+    with db.tenant_context.switch("tenant-b"):
+        with pytest.raises(TenantNaturalKeyCollisionError) as excinfo:
+            await db.express.create("Doc", {"id": doc_id, "title": "B"})
+
+    err = excinfo.value
+    # Structured attributes name the CALLER's own tenant + id (never the other
+    # tenant's row data — tenant isolation preserved).
+    assert err.tenant_id == "tenant-b"
+    assert err.colliding_id == doc_id
+    assert err.model_name == "Doc"
+
+    # (c) message contains tenant_id + colliding id + surrogate-id guidance.
+    msg = str(err)
+    assert "tenant-b" in msg
+    assert doc_id in msg
+    assert "surrogate" in msg
+    assert "schema-per-tenant" in msg
+    assert "IsolationStrategy.SCHEMA" in msg
+    # Must NOT leak the other tenant's identity.
+    assert "tenant-a" not in msg
+
+    # (b) a normal SAME-tenant duplicate keeps the ordinary path — it MUST NOT
+    # be converted into the cross-tenant collision error (no over-broadening).
+    with db.tenant_context.switch("tenant-a"):
+        with pytest.raises(Exception) as dup_info:
+            await db.express.create("Doc", {"id": doc_id, "title": "A-again"})
+    assert not isinstance(dup_info.value, TenantNaturalKeyCollisionError)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_1526_cross_tenant_collision_sqlite():
+    """SQLite (always-on): cross-tenant collision raises the actionable error;
+    same-tenant duplicate keeps the ordinary path."""
+    db = _sqlite_db()
+    try:
+        await _run_collision_scenario(db)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_1526_cross_tenant_collision_postgres():
+    """PostgreSQL (when the shared Docker infra is reachable): the same
+    contract holds against the ``<table>_pkey`` violation shape."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_collision_scenario(db)
+    finally:
+        db.close()


### PR DESCRIPTION
## What

A `multi_tenant=True` DataFlow model keeps the **default single-column primary key `id`** (schema-gen keeps `PK = id` alone, not a composite `(tenant_id, id)`). Under the default row-level tenant strategy the `id` is therefore a **globally-unique surrogate**: two tenants cannot share the same natural-key `id`. When tenant B writes an `id` tenant A already owns, the database rejects it on the PK UNIQUE constraint.

This is **fail-closed and SAFE** — no cross-tenant data is exposed (the write is rejected, not merged into another tenant's row; verified in the #1518 regression) — but it surfaced only as an opaque raw `UNIQUE constraint failed: <table>.id` (SQLite) / `<table>_pkey` (PG) / `for key 'PRIMARY'` (MySQL) that never explained the surrogate-id design or the alternatives.

## Change (Option B — no schema change)

- **Actionable error** — new `TenantNaturalKeyCollisionError` naming the **caller's own** `tenant_id` + supplied `id` (never the other tenant's data), plus the two remedies: globally-unique/UUID ids, or the schema-per-tenant `IsolationStrategy.SCHEMA` / `SchemaIsolationStrategy.create_tenant_table`.
- **Narrow by construction** — a new `is_pk_unique_violation(msg, table)` matches ONLY the `id` PK across dialects (word-bounded, so a sibling unique column like `<table>.idempotency_key` never matches). Detection is multi_tenant-only and PK-only; every other error keeps its original path.
- **No over-broadening** — a same-tenant duplicate (same tenant re-inserting its own `id`) produces the identical PK-unique message, so it is disambiguated via a **tenant-scoped read** (which can never see another tenant's row) and kept on the ordinary duplicate-key path.
- Wired into the express `create` / `upsert` / `upsert_advanced` write paths (both the raised-exception and dict-failure funnels).
- **Docs** — `docs/enterprise/multi-tenant.md` documents the globally-unique-natural-key constraint + remedies; every cited symbol grep-resolves.

## Tests (real infra, no mocking)

- **Tier 2** (SQLite always; PostgreSQL when the shared Docker infra is reachable): two tenants + same natural-key id → the SECOND write raises `TenantNaturalKeyCollisionError` naming `tenant_id`; a same-tenant duplicate keeps the ordinary path; the message contains `tenant_id` + the colliding id + the surrogate-id guidance.
- **Tier 1**: `is_pk_unique_violation` narrowness across SQLite/PG/MySQL PK shapes, and rejection of sibling unique columns.

Both the SQLite and PostgreSQL Tier-2 cases ran green locally (PG infra reachable — no skips).

## Option A declined

Option A (composite `(tenant_id, id)` primary key) was **declined** for migration + cross-SDK blast radius — the id-alone PK is the intended, fail-closed-safe design; this closes the DX gap without a schema change.

Fixes #1526