### PR TITLE
feat(governance): confidence/evidence-quality threshold routing (#1516 leg b)

### DIFF
--- a/src/kailash/trust/pact/config.py
+++ b/src/kailash/trust/pact/config.py
@@ -22,7 +22,7 @@ import logging
 import math
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -236,6 +236,86 @@ class CommunicationConstraintConfig(BaseModel):
     )
 
 
+class ConfidenceThresholdConfig(BaseModel):
+    """Evidence-quality (confidence) disposition gate (#1516 leg b).
+
+    A configurable minimum confidence for an action to auto-proceed. An action
+    whose ``ctx["confidence"]`` (0.0-1.0, e.g. a ``ReasoningTrace.confidence``)
+    is BELOW the applicable threshold is escalated to ``held`` (human review)
+    REGARDLESS of value / limit-proximity, composed monotonically via
+    :func:`~kailash.trust.pact.risk_factors.combine_levels` so this gate can
+    only TIGHTEN a verdict, never loosen one.
+
+    Fail-closed (``pact-governance.md`` Rule 4 / Rule 6): when a threshold
+    applies to an action but ``ctx`` carries no confidence, or the confidence is
+    ``NaN`` / ``Inf`` / out-of-``[0, 1]``, the action is treated as
+    below-threshold and held -- a low-evidence action never silently
+    auto-proceeds.
+
+    Per-action-class overrides: ``per_action`` maps an action string to its own
+    threshold, falling back to ``default_threshold`` for unlisted actions. A
+    resolved threshold of ``None`` means the gate is INACTIVE for that action
+    (backward-compatible: ``ctx["confidence"]`` is ignored, verdict unchanged).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    default_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum confidence (0.0-1.0) for an action to auto-proceed. None "
+            "disables the gate for any action with no per_action override."
+        ),
+    )
+    per_action: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Per-action-class confidence thresholds (0.0-1.0), each overriding "
+            "default_threshold for the named action."
+        ),
+    )
+
+    @field_validator("default_threshold")
+    @classmethod
+    def _reject_non_finite_default(cls, v: float | None) -> float | None:
+        """Reject NaN/Inf -- they bypass the ``<`` comparison (Rule 6)."""
+        if v is not None and not math.isfinite(v):
+            raise ValueError(
+                f"default_threshold must be finite, got {v!r}. "
+                f"NaN/Inf values bypass governance checks."
+            )
+        return v
+
+    @field_validator("per_action")
+    @classmethod
+    def _validate_per_action(cls, v: dict[str, float]) -> dict[str, float]:
+        """Every per-action threshold MUST be finite and in ``[0, 1]``."""
+        for action, threshold in v.items():
+            if not math.isfinite(threshold):
+                raise ValueError(
+                    f"per_action[{action!r}] must be finite, got {threshold!r}. "
+                    f"NaN/Inf values bypass governance checks."
+                )
+            if not (0.0 <= threshold <= 1.0):
+                raise ValueError(
+                    f"per_action[{action!r}] must be in [0.0, 1.0], "
+                    f"got {threshold!r}."
+                )
+        return v
+
+    def threshold_for(self, action: str) -> float | None:
+        """Resolve the confidence threshold for ``action``.
+
+        Returns the per-action override when present, else
+        ``default_threshold``, else ``None`` (gate inactive for this action).
+        """
+        if action in self.per_action:
+            return self.per_action[action]
+        return self.default_threshold
+
+
 class ConstraintEnvelopeConfig(BaseModel):
     """A complete constraint envelope across all five CARE dimensions.
 
@@ -357,7 +437,7 @@ class DimensionThresholds(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def ordered(self) -> "DimensionThresholds":
+    def ordered(self) -> Self:
         """Enforce auto_approve <= flag <= hold ordering."""
         if not (
             self.auto_approve_threshold <= self.flag_threshold <= self.hold_threshold
@@ -682,7 +762,7 @@ class OrgDefinition(BaseModel):
     workspaces: list[WorkspaceConfig] = Field(
         default_factory=list, description="All workspace definitions"
     )
-    roles: list = Field(
+    roles: list[Any] = Field(
         default_factory=list,
         description="All role definitions (first-class PACT nodes, list of RoleDefinition)",
     )
@@ -1052,9 +1132,9 @@ class OrgDefinition(BaseModel):
             gradient = getattr(agent, "verification_gradient", None)
             # Fall back to team gradient if agent has none
             if not gradient or not gradient.rules:
-                team = agent_to_team.get(agent.id)
-                if team:
-                    gradient = getattr(team, "verification_gradient", None)
+                agent_team = agent_to_team.get(agent.id)
+                if agent_team:
+                    gradient = getattr(agent_team, "verification_gradient", None)
             if gradient and gradient.rules:
                 rule_patterns = [r.pattern for r in gradient.rules]
                 for cap in getattr(agent, "capabilities", []) or []:
@@ -1434,8 +1514,8 @@ class OrgDefinition(BaseModel):
 
         # Check department -> team tightening
         for team in self.teams:
-            dept = team_dept_lookup.get(team.id)
-            if dept is None or dept.envelope is None:
+            team_dept = team_dept_lookup.get(team.id)
+            if team_dept is None or team_dept.envelope is None:
                 continue
             lead_id = team.team_lead
             if lead_id and lead_id in agent_index:
@@ -1444,9 +1524,9 @@ class OrgDefinition(BaseModel):
                 if lead_env:
                     _check_envelope_tightening(
                         child_env=lead_env,
-                        parent_env=dept.envelope,
+                        parent_env=team_dept.envelope,
                         child_label=f"Team '{team.id}'",
-                        parent_label=f"department '{dept.department_id}'",
+                        parent_label=f"department '{team_dept.department_id}'",
                         code="TEAM_DEPT_TIGHTENING",
                     )
 
@@ -1512,6 +1592,8 @@ __all__ = [
     "DataAccessConstraintConfig",
     "CommunicationConstraintConfig",
     "ConstraintEnvelopeConfig",
+    # Confidence / evidence-quality disposition gate (#1516 leg b)
+    "ConfidenceThresholdConfig",
     # Verification gradient
     "GradientRuleConfig",
     "VerificationGradientConfig",

--- a/src/kailash/trust/pact/engine.py
+++ b/src/kailash/trust/pact/engine.py
@@ -52,6 +52,7 @@ from kailash.trust.pact.compilation import (
     compile_org,
 )
 from kailash.trust.pact.config import (
+    ConfidenceThresholdConfig,
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
     TrustPostureLevel,
@@ -242,6 +243,9 @@ class GovernanceEngine:
         vacancy_deadline_hours: int = 24,  # Section 5.5 configurable deadline
         require_bilateral_consent: bool = False,  # Section 4.4 bilateral consent
         risk_factor_registry: RiskFactorRegistry | None = None,  # risk-factor seam
+        confidence_threshold_config: (
+            ConfidenceThresholdConfig | None
+        ) = None,  # #1516 leg b: evidence-quality gate
     ) -> None:
         self._lock = threading.Lock()
 
@@ -249,6 +253,16 @@ class GovernanceEngine:
         # None -> use the process-wide GLOBAL_RISK_FACTOR_REGISTRY so factors
         # registered anywhere are picked up without editing the engine core.
         self._risk_factor_registry: RiskFactorRegistry | None = risk_factor_registry
+
+        # Confidence / evidence-quality disposition gate (#1516 leg b). None ->
+        # gate INACTIVE (backward-compatible: ctx["confidence"] is ignored, the
+        # verdict is byte-unchanged from the pre-gate engine). When set, an
+        # action whose confidence is below the configured threshold is escalated
+        # to `held` regardless of value/limit-proximity, composed monotonically
+        # via combine_levels (tighten-only), fail-closed on missing/NaN.
+        self._confidence_config: ConfidenceThresholdConfig | None = (
+            confidence_threshold_config
+        )
 
         # Stateful sliding-window rate-limit enforcer (#1516 leg a). Tallies
         # REAL verify_action calls per (role, action, window) and blocks on
@@ -848,6 +862,25 @@ class GovernanceEngine:
                     level = combined
                     reason = rate_reason
 
+        # Step 3.6: Confidence / evidence-quality threshold (#1516 leg b).
+        # A disposition input on the action's EVIDENCE QUALITY, independent of
+        # value / limit-proximity / risk factors / rate: an action whose
+        # ctx["confidence"] is below the configured threshold is escalated to
+        # `held` (human review) REGARDLESS of how cheap or in-limit it is.
+        # Composed MONOTONICALLY via combine_levels (tighten-only), and -- like
+        # risk factors -- it runs even with NO envelope, because evidence
+        # quality is intrinsic to the action, not to any envelope constraint.
+        # Fail-closed (pact-governance.md Rule 4/6): a configured threshold with
+        # a missing / NaN / out-of-[0,1] confidence is treated as below-threshold.
+        # conf_detail is None when no threshold governs this action (gate
+        # inactive) -> the audit trail is byte-unchanged for un-configured engines.
+        conf_level, conf_reason, conf_detail = self._evaluate_confidence(action, ctx)
+        if conf_level != "auto_approved" and level != "blocked":
+            combined = combine_levels(level, conf_level)
+            if combined != level:
+                level = combined
+                reason = conf_reason
+
         # Multi-level VERIFY: walk accountability chain and check each ancestor's
         # effective envelope. Most restrictive verdict wins. This prevents a role
         # from executing an action that is allowed at the leaf but blocked by
@@ -925,6 +958,13 @@ class GovernanceEngine:
         # verdict, for audit. Present only when the action carried risk_factors.
         if risk_eval is not None and risk_eval.present:
             audit_details["risk_factors"] = risk_eval.to_dict()
+        # Record the confidence gate's evaluation + whether it escalated the
+        # verdict (#1516 leg b, invariant 4). Present ONLY when a threshold
+        # governs this action (conf_detail is None otherwise) so an un-configured
+        # engine's audit trail is byte-unchanged.
+        if conf_detail is not None:
+            conf_detail["escalated"] = conf_level != "auto_approved"
+            audit_details["confidence"] = conf_detail
 
         verdict = GovernanceVerdict(
             level=level,
@@ -1099,6 +1139,109 @@ class GovernanceEngine:
             f"'{combined}' (driving: {driving})"
         )
         return (combined, reason, risk_eval)
+
+    def _evaluate_confidence(
+        self, action: str, ctx: dict[str, Any]
+    ) -> tuple[str, str, dict[str, Any] | None]:
+        """Evaluate the action's evidence quality against the confidence gate.
+
+        A disposition input on the action's EVIDENCE QUALITY (#1516 leg b),
+        independent of value / limit-proximity / risk factors / rate. When a
+        threshold applies to ``action`` and ``ctx["confidence"]`` is below it,
+        the returned level is ``"held"`` (human review) -- the caller composes
+        it via :func:`combine_levels` so it can only TIGHTEN the verdict.
+
+        Fail-closed (``pact-governance.md`` Rule 4 / Rule 6): a configured
+        threshold with a MISSING confidence, a NON-NUMERIC confidence, or a
+        ``NaN`` / ``Inf`` / out-of-``[0, 1]`` confidence is treated as
+        below-threshold (``"held"``) -- a low-evidence action never silently
+        auto-proceeds.
+
+        Returns:
+            ``(level, reason, audit_detail)``. ``level`` is ``"held"`` when the
+            gate applies and confidence is below-threshold / missing / invalid,
+            else ``"auto_approved"``. ``audit_detail`` is ``None`` when NO
+            threshold applies to this action (gate inactive) -- so an
+            un-configured engine's audit trail is byte-unchanged. When present,
+            it never carries a non-finite float (invalid values are recorded via
+            ``value_repr`` so the audit dict stays JSON/finite-safe).
+        """
+        config = self._confidence_config
+        if config is None:
+            return ("auto_approved", "", None)
+        threshold = config.threshold_for(action)
+        if threshold is None:
+            # No threshold governs this action -> gate inactive, verdict
+            # unchanged, audit trail unchanged (backward-compat).
+            return ("auto_approved", "", None)
+
+        detail: dict[str, Any] = {"threshold": threshold}
+
+        # Fail-closed: a threshold is configured but ctx carries no confidence.
+        # `is None` covers both an absent key and an explicit None.
+        raw = ctx.get("confidence")
+        if raw is None:
+            detail.update({"value": None, "below_threshold": True, "reason": "missing"})
+            return (
+                "held",
+                f"Confidence absent but a threshold ({threshold:.2f}) is "
+                f"configured for action '{action}' -- held for human review "
+                f"(fail-closed)",
+                detail,
+            )
+
+        # Finite + range guard (pact-governance.md Rule 6): a NaN/Inf/out-of-
+        # range value must NOT vacuously pass the `<` comparison. A non-finite
+        # float is recorded via value_repr, never stored raw in the audit dict.
+        try:
+            conf = float(raw)
+        except (TypeError, ValueError):
+            detail.update(
+                {
+                    "value": None,
+                    "value_repr": repr(raw),
+                    "below_threshold": True,
+                    "reason": "non_numeric",
+                }
+            )
+            return (
+                "held",
+                f"Confidence value is not numeric for action '{action}' -- "
+                f"held for human review (fail-closed)",
+                detail,
+            )
+
+        if not math.isfinite(conf) or not (0.0 <= conf <= 1.0):
+            detail.update(
+                {
+                    "value": None,
+                    "value_repr": repr(conf),
+                    "below_threshold": True,
+                    "reason": "out_of_range",
+                }
+            )
+            return (
+                "held",
+                f"Confidence value ({conf!r}) is NaN/Inf/out-of-[0,1] for "
+                f"action '{action}' -- held for human review (fail-closed)",
+                detail,
+            )
+
+        if conf < threshold:
+            detail.update(
+                {"value": conf, "below_threshold": True, "reason": "below_threshold"}
+            )
+            return (
+                "held",
+                f"Confidence {conf:.2f} is below the required threshold "
+                f"{threshold:.2f} for action '{action}' -- held for human review",
+                detail,
+            )
+
+        detail.update(
+            {"value": conf, "below_threshold": False, "reason": "above_threshold"}
+        )
+        return ("auto_approved", "", detail)
 
     def _evaluate_rate_limits(
         self,

--- a/tests/trust/pact/unit/test_engine_confidence_threshold.py
+++ b/tests/trust/pact/unit/test_engine_confidence_threshold.py
@@ -1,0 +1,410 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Engine-integration tests for the confidence/evidence-quality gate (#1516 leg b).
+
+These exercise ``GovernanceEngine.verify_action`` end-to-end and pin the 4
+load-bearing invariants of wiring an evidence-quality disposition input into the
+verdict path, composed MONOTONICALLY via ``combine_levels`` alongside the merged
+risk-factor seam (#1514) and rate-limit step (#1516-a):
+
+1. An action whose ``ctx["confidence"]`` is BELOW the configured threshold is
+   escalated to ``held`` (human review) REGARDLESS of value / limit-proximity --
+   even an otherwise-``auto_approved`` action. Composed via ``combine_levels`` so
+   it can only TIGHTEN, never de-escalate.
+2. A configured threshold with confidence ABSENT fails CLOSED to ``held`` (never
+   a silent pass) -- pact-governance.md Rule 4 / zero-tolerance Rule 3.
+3. A NaN / Inf / out-of-[0,1] / non-numeric confidence fails CLOSED to ``held``
+   (math.isfinite + range guard) -- pact-governance.md Rule 6.
+4. The confidence value + the fact it drove the verdict are recorded in the
+   audit trail (``verdict.audit_details["confidence"]``).
+
+Backward-compat: an engine with NO confidence config configured behaves EXACTLY
+as before -- ``ctx["confidence"]`` is ignored and the audit trail carries no
+``confidence`` key.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge
+from kailash.trust.pact.clearance import RoleClearance
+from kailash.trust.pact.compilation import CompiledOrg
+from kailash.trust.pact.config import (
+    ConfidenceThresholdConfig,
+    ConstraintEnvelopeConfig,
+    FinancialConstraintConfig,
+    OperationalConstraintConfig,
+)
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.envelopes import RoleEnvelope
+from kailash.trust.pact.store import MemoryAccessPolicyStore, MemoryClearanceStore
+from pact.examples.university.barriers import (
+    create_university_bridges,
+    create_university_ksps,
+)
+from pact.examples.university.clearance import create_university_clearances
+from pact.examples.university.org import create_university_org
+
+_ROLE = "D1-R1-D1-R1-D1-R1-T1-R1"  # CS Chair
+_DEFINER = "D1-R1-D1-R1-D1-R1"  # Dean
+
+# A factory that builds a fresh engine with an optional confidence config.
+EngineFactory = Callable[[ConfidenceThresholdConfig | None], GovernanceEngine]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_engine_rate_limit.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def university_compiled() -> tuple[CompiledOrg, Any]:
+    return create_university_org()
+
+
+@pytest.fixture
+def compiled_org(university_compiled: tuple[CompiledOrg, Any]) -> CompiledOrg:
+    return university_compiled[0]
+
+
+@pytest.fixture
+def clearances(compiled_org: CompiledOrg) -> dict[str, RoleClearance]:
+    return create_university_clearances(compiled_org)
+
+
+@pytest.fixture
+def bridges() -> list[PactBridge]:
+    return create_university_bridges()
+
+
+@pytest.fixture
+def ksps() -> list[KnowledgeSharePolicy]:
+    return create_university_ksps()
+
+
+@pytest.fixture
+def engine_factory(
+    compiled_org: CompiledOrg,
+    clearances: dict[str, RoleClearance],
+    bridges: list[PactBridge],
+    ksps: list[KnowledgeSharePolicy],
+) -> EngineFactory:
+    """Return a builder that stamps out engines with a given confidence config."""
+
+    def _build(
+        confidence_config: ConfidenceThresholdConfig | None = None,
+    ) -> GovernanceEngine:
+        clearance_store = MemoryClearanceStore()
+        for clr in clearances.values():
+            clearance_store.grant_clearance(clr)
+        access_store = MemoryAccessPolicyStore()
+        for bridge in bridges:
+            access_store.save_bridge(bridge)
+        for ksp in ksps:
+            access_store.save_ksp(ksp)
+        return GovernanceEngine(
+            compiled_org,
+            clearance_store=clearance_store,
+            access_policy_store=access_store,
+            confidence_threshold_config=confidence_config,
+        )
+
+    return _build
+
+
+def _set_envelope(
+    engine: GovernanceEngine,
+    *,
+    max_spend: float = 10_000.0,
+    approval_above: float | None = None,
+    allowed: list[str] | None = None,
+) -> None:
+    """Attach an envelope that AUTO-APPROVES a cheap in-list action, so the only
+    thing that can escalate the verdict is the confidence gate under test."""
+    envelope = ConstraintEnvelopeConfig(
+        id="env-conf-test",
+        description="confidence-threshold test envelope",
+        financial=FinancialConstraintConfig(
+            max_spend_usd=max_spend, requires_approval_above_usd=approval_above
+        ),
+        operational=OperationalConstraintConfig(
+            allowed_actions=allowed or ["read", "write", "deploy", "delete"],
+        ),
+    )
+    engine.set_role_envelope(
+        RoleEnvelope(
+            id="re-conf-test",
+            defining_role_address=_DEFINER,
+            target_role_address=_ROLE,
+            envelope=envelope,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 -- below-threshold confidence -> held, regardless of value
+# ---------------------------------------------------------------------------
+
+
+class TestInvariant1_BelowThresholdHeld:
+    def test_below_threshold_escalates_auto_approved_to_held(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        # A cheap, in-limit, allowed action -> base verdict is auto_approved.
+        # Low confidence escalates it to held REGARDLESS of the cheap cost.
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.5})
+        assert verdict.level == "held"
+        assert "below the required threshold" in verdict.reason
+
+    def test_at_or_above_threshold_passes(self, engine_factory: EngineFactory) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        # confidence == threshold is NOT below -> passes.
+        assert (
+            engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.7}).level
+            == "auto_approved"
+        )
+        assert (
+            engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.99}).level
+            == "auto_approved"
+        )
+
+    def test_held_regardless_of_high_value_in_limit(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        # Even a high-but-in-limit spend (which alone would only FLAG, near the
+        # 80% boundary) is escalated to HELD by low confidence -- confidence is
+        # orthogonal to value.
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.8))
+        _set_envelope(engine, max_spend=100.0)
+        verdict = engine.verify_action(
+            _ROLE, "write", {"cost": 90.0, "confidence": 0.4}
+        )
+        # combine_levels(flagged, held) == held -- confidence tightens further.
+        assert verdict.level == "held"
+
+    def test_per_action_override_beats_default(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(
+            ConfidenceThresholdConfig(
+                default_threshold=0.7, per_action={"deploy": 0.95}
+            )
+        )
+        _set_envelope(engine)
+        # 0.9 clears the 0.7 default for "read" ...
+        assert (
+            engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.9}).level
+            == "auto_approved"
+        )
+        # ... but is BELOW the 0.95 override for "deploy" -> held.
+        assert (
+            engine.verify_action(
+                _ROLE, "deploy", {"cost": 1.0, "confidence": 0.9}
+            ).level
+            == "held"
+        )
+
+    def test_gate_runs_even_with_no_envelope(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        # No envelope set for this role -> the base verdict is auto_approved,
+        # yet the confidence gate (intrinsic to the action) still escalates it.
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        verdict = engine.verify_action(_ROLE, "read", {"confidence": 0.2})
+        assert verdict.level == "held"
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 -- threshold set + confidence ABSENT -> held (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestInvariant2_MissingFailsClosed:
+    def test_absent_confidence_key_is_held(self, engine_factory: EngineFactory) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        # ctx carries NO confidence key at all -> fail-closed to held.
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0})
+        assert verdict.level == "held"
+        assert "absent" in verdict.reason
+        assert verdict.audit_details["confidence"]["reason"] == "missing"
+
+    def test_explicit_none_confidence_is_held(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": None})
+        assert verdict.level == "held"
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 -- NaN / Inf / out-of-range / non-numeric -> fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestInvariant3_InvalidFailsClosed:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            1.5,  # above 1.0
+            -0.1,  # below 0.0
+            2.0,
+        ],
+    )
+    def test_nan_inf_out_of_range_is_held(
+        self, engine_factory: EngineFactory, bad: float
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": bad})
+        assert verdict.level == "held", f"{bad!r} must fail closed to held"
+        # A non-finite value must NOT be stored raw in the audit dict.
+        recorded = verdict.audit_details["confidence"].get("value")
+        assert recorded is None or math.isfinite(recorded)
+
+    def test_non_numeric_confidence_is_held(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        verdict = engine.verify_action(
+            _ROLE, "read", {"cost": 1.0, "confidence": "high"}
+        )
+        assert verdict.level == "held"
+        assert verdict.audit_details["confidence"]["reason"] == "non_numeric"
+
+    def test_nan_config_threshold_is_rejected_at_construction(self) -> None:
+        # A NaN threshold cannot even be constructed (Rule 6 finite guard).
+        with pytest.raises(ValueError):
+            ConfidenceThresholdConfig(default_threshold=float("nan"))
+        with pytest.raises(ValueError):
+            ConfidenceThresholdConfig(per_action={"deploy": float("inf")})
+        with pytest.raises(ValueError):
+            ConfidenceThresholdConfig(per_action={"deploy": 1.5})
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 -- confidence + drove-the-verdict recorded in the audit trail
+# ---------------------------------------------------------------------------
+
+
+class TestInvariant4_Audited:
+    def test_below_threshold_recorded_and_escalated(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.3})
+        conf = verdict.audit_details["confidence"]
+        assert conf["value"] == 0.3
+        assert conf["threshold"] == 0.7
+        assert conf["below_threshold"] is True
+        assert conf["escalated"] is True
+
+    def test_above_threshold_recorded_not_escalated(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.9})
+        conf = verdict.audit_details["confidence"]
+        assert conf["value"] == 0.9
+        assert conf["below_threshold"] is False
+        assert conf["escalated"] is False
+
+
+# ---------------------------------------------------------------------------
+# Monotonic composition -- the gate only TIGHTENS, never de-escalates
+# ---------------------------------------------------------------------------
+
+
+class TestMonotonicComposition:
+    def test_low_confidence_never_deescalates_a_blocked_base(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        # "delete" is NOT in the allowed list -> base verdict is blocked.
+        _set_envelope(engine, allowed=["read"])
+        # Even a high OR a low confidence must leave the blocked verdict blocked
+        # (the gate can only tighten; blocked is already max-severity).
+        assert (
+            engine.verify_action(
+                _ROLE, "delete", {"cost": 1.0, "confidence": 0.9}
+            ).level
+            == "blocked"
+        )
+        assert (
+            engine.verify_action(
+                _ROLE, "delete", {"cost": 1.0, "confidence": 0.1}
+            ).level
+            == "blocked"
+        )
+
+    def test_high_confidence_does_not_relax_a_held_base(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        # Base verdict is held via the financial approval threshold; a HIGH
+        # confidence must NOT relax it back to auto_approved.
+        engine = engine_factory(ConfidenceThresholdConfig(default_threshold=0.7))
+        _set_envelope(engine, max_spend=1000.0, approval_above=100.0)
+        verdict = engine.verify_action(
+            _ROLE, "deploy", {"cost": 500.0, "confidence": 0.99}
+        )
+        assert verdict.level == "held"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat -- no threshold configured -> confidence ignored
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_no_config_ignores_confidence(self, engine_factory: EngineFactory) -> None:
+        # confidence_config=None -> gate inactive.
+        engine = engine_factory(None)
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.01})
+        assert verdict.level == "auto_approved"
+        # Audit trail is byte-unchanged: no confidence key.
+        assert "confidence" not in verdict.audit_details
+
+    def test_empty_config_ignores_confidence(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        # A config with no default and no per_action -> gate inactive for every
+        # action (threshold_for returns None).
+        engine = engine_factory(ConfidenceThresholdConfig())
+        _set_envelope(engine)
+        verdict = engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.01})
+        assert verdict.level == "auto_approved"
+        assert "confidence" not in verdict.audit_details
+
+    def test_unlisted_action_with_no_default_ignored(
+        self, engine_factory: EngineFactory
+    ) -> None:
+        # per_action gates only "deploy"; "read" has no default -> ignored.
+        engine = engine_factory(ConfidenceThresholdConfig(per_action={"deploy": 0.9}))
+        _set_envelope(engine)
+        assert (
+            engine.verify_action(_ROLE, "read", {"cost": 1.0, "confidence": 0.01}).level
+            == "auto_approved"
+        )
+        # But "deploy" IS gated.
+        assert (
+            engine.verify_action(
+                _ROLE, "deploy", {"cost": 1.0, "confidence": 0.01}
+            ).level
+            == "held"
+        )


### PR DESCRIPTION
## Summary

Adds a confidence / evidence-quality threshold as a disposition input on the PACT governance path (`src/kailash/trust/pact/`). Before this change, `verify_action` weighed value, limit-proximity, risk factors (#1514), and rate breaches (#1516-a) — but never how well-grounded the action's own reasoning was. A low-confidence action that was cheap and in-limit auto-proceeded because **no disposition input consulted evidence-quality**.

This is **leg b** of #1516; **leg a** (stateful rate-limit enforcer, #1516-a) is already merged. Together they satisfy #1516, so this PR closes it.

## What it does

- New `ConfidenceThresholdConfig` in `trust/pact/config.py` — a `default_threshold` plus per-action-class `per_action` overrides (both finite-guarded, range `[0,1]`).
- New `GovernanceEngine(confidence_threshold_config=...)` constructor seam (mirrors the risk-factor registry seam). `None` → gate inactive.
- New Step 3.6 in the disposition path: an action whose `ctx["confidence"]` is below the applicable threshold is escalated to `held` (human review) **regardless of value/limit-proximity**, composed via the existing `combine_levels` (monotonic max-severity — the gate only TIGHTENS, never de-escalates). Runs even with no envelope (evidence quality is intrinsic to the action, like risk factors).

## Invariants (each with tests)

1. **Below-threshold → held** even for an otherwise-`auto_approved` action; per-action override beats default; runs with no envelope.
2. **Missing confidence when a threshold is set → held (fail-closed)** — never a silent pass (pact-governance Rule 4).
3. **NaN / Inf / out-of-`[0,1]` / non-numeric → fail-closed** (`math.isfinite` + range guard, Rule 6); a non-finite float is never stored raw in the audit dict.
4. **Audited** — the confidence value + `escalated` flag recorded in `verdict.audit_details["confidence"]`.
- **Backward-compat** (regression-pinned): no threshold configured → confidence ignored, verdict + audit trail byte-unchanged.

## Tests

`tests/trust/pact/unit/test_engine_confidence_threshold.py` — 22 tests, all Tier 1/2 end-to-end through `GovernanceEngine.verify_action` against the real university-org fixtures (no mocking). Full pact suite regression: **1436 passed, 8 skipped**. `mypy --strict` clean on both touched source files; pre-commit green.

Also fixes three pre-existing `config.py` type issues surfaced while touching the file (a pyright `model_validator` return-type warning + two `mypy --strict` Optional-loop-var reuses + a bare `list` annotation).

## Related issues

Fixes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)