### PR TITLE
feat(pact): universal outbound-effect governance interceptor (#1517 leg-b)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/trust/governance/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/trust/governance/__init__.py
@@ -129,6 +129,12 @@ from kaizen.trust.governance.budget_enforcer import (
     ExternalAgentBudgetEnforcer,
 )
 from kaizen.trust.governance.budget_reset import BudgetResetService
+from kaizen.trust.governance.outbound import (
+    GovernedHTTPClient,
+    GovernedProvider,
+    GovernedToolInvoker,
+    resolve_interceptor,
+)
 
 __all__ = [
     # Cost estimation
@@ -181,4 +187,9 @@ __all__ = [
     "ApprovalPolicyModel",
     "ApprovalRequestModel",
     "ApprovalAuditLogModel",
+    # Universal outbound-effect governance wiring (#1517 leg-b)
+    "GovernedProvider",
+    "GovernedToolInvoker",
+    "GovernedHTTPClient",
+    "resolve_interceptor",
 ]

--- a/packages/kailash-kaizen/src/kaizen/trust/governance/outbound.py
+++ b/packages/kailash-kaizen/src/kaizen/trust/governance/outbound.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Transport wiring for the universal outbound-effect governance seam (#1517 leg-b).
+
+The domain-neutral interceptor core lives in
+:mod:`kailash.trust.pact.outbound`. THIS module is the production wiring that
+binds that seam to the three concrete outbound transports an agent uses:
+
+- :class:`GovernedProvider` -- LLM completions (wraps any Kaizen provider so
+  every ``chat`` / ``chat_async`` / ``stream_chat`` call is governed).
+- :class:`GovernedToolInvoker` -- tool / MCP invocations.
+- :class:`GovernedHTTPClient` -- outbound HTTP requests.
+
+Each facade is a THIN, transparent proxy over the interceptor: it builds the
+kind-specific :class:`~kailash.trust.pact.outbound.OutboundEffect` from the
+transport's own call and routes it through the interceptor. The agent's code is
+UNCHANGED -- an agent that calls ``provider.chat(messages)`` calls the governed
+provider's ``chat(messages)`` with the identical signature; the envelope is
+applied without the agent ever referencing governance.
+
+Layering: the transport-specific normalization (which call arg is the model,
+the URL, the tool name) lives HERE, at the framework seam (per
+framework-first.md: Kaizen owns the LLM/provider seam). The core stays
+transport-agnostic.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Callable
+
+from kailash.trust.pact.outbound import (
+    EffectKind,
+    OutboundEffect,
+    OutboundEffectInterceptor,
+    active_interceptor,
+    wrap_transport,
+    wrap_transport_async,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GovernedProvider",
+    "GovernedToolInvoker",
+    "GovernedHTTPClient",
+    "resolve_interceptor",
+]
+
+
+def resolve_interceptor(
+    interceptor: OutboundEffectInterceptor | None,
+) -> OutboundEffectInterceptor:
+    """Return the explicit interceptor, else the process-global one.
+
+    Fail-closed: if neither is available, raise -- an ungoverned transport MUST
+    NOT be silently constructed (that would defeat the seam).
+    """
+    resolved = interceptor if interceptor is not None else active_interceptor()
+    if resolved is None:
+        raise ValueError(
+            "No OutboundEffectInterceptor available: pass one explicitly or "
+            "install a process-global one via install_interceptor(). Refusing "
+            "to build an ungoverned transport (fail-closed)."
+        )
+    return resolved
+
+
+def _governed(
+    interceptor: OutboundEffectInterceptor,
+    effect_builder: Callable[[tuple[Any, ...], dict[str, Any]], OutboundEffect],
+    fn: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Wrap ``fn`` (sync OR async) in the governance seam, auto-detecting shape."""
+    if inspect.iscoroutinefunction(fn):
+        return wrap_transport_async(interceptor, effect_builder, fn)
+    return wrap_transport(interceptor, effect_builder, fn)
+
+
+class GovernedProvider:
+    """Transparent governance proxy around any Kaizen LLM provider.
+
+    Wrap a provider ONCE at construction/bootstrap; hand the wrapped provider to
+    an agent exactly as you would the raw one. Every outbound completion method
+    (``chat`` / ``chat_async`` / ``stream_chat`` / ``complete`` / ``generate``)
+    is routed through the interceptor before the real provider is called. Every
+    OTHER attribute (``name``, ``capabilities``, ``model``, ...) is forwarded
+    unchanged, so the proxy is a drop-in replacement -- the "no agent code
+    change" property.
+
+    Args:
+        provider: The underlying provider (any object exposing the completion
+            methods below). Not modified.
+        interceptor: The governance interceptor. If None, the process-global
+            interceptor is used; if neither exists, construction fails closed.
+        caller: The D/T/R role address (or resolved identity) of the agent
+            producing the effects. Passed to governance as ``role_address``.
+        cost_estimator: Optional callable ``(method, args, kwargs) -> float``
+            producing a per-call cost estimate for the financial envelope
+            dimension. Defaults to a zero-cost estimate.
+    """
+
+    _OUTBOUND_METHODS = frozenset(
+        {"chat", "chat_async", "stream_chat", "complete", "generate"}
+    )
+
+    def __init__(
+        self,
+        provider: Any,
+        interceptor: OutboundEffectInterceptor | None = None,
+        *,
+        caller: str,
+        cost_estimator: (
+            Callable[[str, tuple[Any, ...], dict[str, Any]], float] | None
+        ) = None,
+    ) -> None:
+        # object.__setattr__ so these land before __getattr__/__setattr__ wiring.
+        object.__setattr__(self, "_provider", provider)
+        object.__setattr__(self, "_interceptor", resolve_interceptor(interceptor))
+        object.__setattr__(self, "_caller", str(caller))
+        object.__setattr__(self, "_cost_estimator", cost_estimator)
+
+    def _target(self) -> str:
+        """Best-effort model/target label for audit (never a governance bypass)."""
+        for attr in ("model", "model_name", "name"):
+            value = getattr(self._provider, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        return type(self._provider).__name__
+
+    def _effect_builder(
+        self, method: str
+    ) -> Callable[[tuple[Any, ...], dict[str, Any]], OutboundEffect]:
+        def build(args: tuple[Any, ...], kwargs: dict[str, Any]) -> OutboundEffect:
+            cost = 0.0
+            if self._cost_estimator is not None:
+                cost = float(self._cost_estimator(method, args, kwargs))
+            return OutboundEffect(
+                kind=EffectKind.LLM,
+                operation=f"llm.{method}",
+                target=self._target(),
+                cost_estimate=cost,
+                caller=self._caller,
+            )
+
+        return build
+
+    def __getattr__(self, name: str) -> Any:
+        # __getattr__ only fires for attrs not found normally, i.e. everything
+        # that belongs to the wrapped provider.
+        attr = getattr(self._provider, name)
+        if name in self._OUTBOUND_METHODS and callable(attr):
+            return _governed(self._interceptor, self._effect_builder(name), attr)
+        return attr
+
+
+class GovernedToolInvoker:
+    """Governs tool / MCP invocations through the universal seam.
+
+    Use :meth:`wrap` to turn a bare tool callable into a governed one, or
+    :meth:`invoke` to govern a one-off call. The tool author writes an ordinary
+    callable; governance is applied at the invoker, not inside the tool.
+
+    Args:
+        interceptor: The governance interceptor. Falls back to the process-global
+            one; fails closed if neither exists.
+        caller: The D/T/R role address of the agent invoking tools.
+    """
+
+    def __init__(
+        self,
+        interceptor: OutboundEffectInterceptor | None = None,
+        *,
+        caller: str,
+    ) -> None:
+        self._interceptor = resolve_interceptor(interceptor)
+        self._caller = str(caller)
+
+    def _effect_builder(
+        self, tool_name: str, cost: float
+    ) -> Callable[[tuple[Any, ...], dict[str, Any]], OutboundEffect]:
+        def build(args: tuple[Any, ...], kwargs: dict[str, Any]) -> OutboundEffect:
+            return OutboundEffect(
+                kind=EffectKind.TOOL,
+                operation=f"tool.{tool_name}",
+                target=tool_name,
+                cost_estimate=cost,
+                caller=self._caller,
+            )
+
+        return build
+
+    def wrap(
+        self, tool_name: str, fn: Callable[..., Any], *, cost: float = 0.0
+    ) -> Callable[..., Any]:
+        """Return a governed version of tool callable ``fn`` (sync or async)."""
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            raise ValueError("tool_name must be a non-empty string")
+        return _governed(self._interceptor, self._effect_builder(tool_name, cost), fn)
+
+    def invoke(
+        self, tool_name: str, fn: Callable[[], Any], *, cost: float = 0.0
+    ) -> Any:
+        """Govern a single zero-arg tool call ``fn`` and return its result."""
+        effect = OutboundEffect(
+            kind=EffectKind.TOOL,
+            operation=f"tool.{tool_name}",
+            target=tool_name,
+            cost_estimate=cost,
+            caller=self._caller,
+        )
+        return self._interceptor.intercept(effect, fn)
+
+
+class GovernedHTTPClient:
+    """Governs outbound HTTP requests through the universal seam.
+
+    Wraps a transport-level request callable (e.g. ``httpx.Client.request`` or a
+    Nexus outbound-request dispatch) so every request is governed. The caller
+    invokes :meth:`request` with the same ``(method, url, **kwargs)`` shape as
+    the underlying transport -- no per-request governance call.
+
+    Args:
+        request_fn: The underlying request dispatch, ``request(method, url,
+            **kwargs) -> response`` (sync or async).
+        interceptor: The governance interceptor. Falls back to the process-global
+            one; fails closed if neither exists.
+        caller: The D/T/R role address of the agent issuing requests.
+        cost_estimator: Optional ``(method, url, kwargs) -> float`` cost estimate.
+    """
+
+    def __init__(
+        self,
+        request_fn: Callable[..., Any],
+        interceptor: OutboundEffectInterceptor | None = None,
+        *,
+        caller: str,
+        cost_estimator: Callable[[str, str, dict[str, Any]], float] | None = None,
+    ) -> None:
+        self._interceptor = resolve_interceptor(interceptor)
+        self._caller = str(caller)
+        self._cost_estimator = cost_estimator
+        self._request = _governed(self._interceptor, self._effect_builder, request_fn)
+
+    def _effect_builder(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> OutboundEffect:
+        # request(method, url, ...) -- method/url may be positional or keyword.
+        method = kwargs.get("method", args[0] if len(args) >= 1 else "")
+        url = kwargs.get("url", args[1] if len(args) >= 2 else "")
+        cost = 0.0
+        if self._cost_estimator is not None:
+            cost = float(self._cost_estimator(str(method), str(url), kwargs))
+        return OutboundEffect(
+            kind=EffectKind.HTTP,
+            operation=f"http.{str(method).upper()}",
+            target=str(url),
+            cost_estimate=cost,
+            caller=self._caller,
+        )
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        """Issue a governed HTTP request. Same shape as the wrapped transport."""
+        return self._request(method, url, **kwargs)

--- a/packages/kailash-kaizen/tests/integration/trust/governance/test_governed_outbound_wiring.py
+++ b/packages/kailash-kaizen/tests/integration/trust/governance/test_governed_outbound_wiring.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+"""Tier-2 wiring tests for the universal outbound-effect governance seam (#1517 leg-b).
+
+These tests exercise the production facades (GovernedProvider / GovernedToolInvoker
+/ GovernedHTTPClient) end-to-end against a REAL GovernanceEngine (no mocking of the
+system under test -- governance, interceptor, and wiring are all real). The
+"transports" (an LLM provider, a tool callable, an HTTP request callable) are real
+local callables standing in for the outbound endpoints being governed.
+
+The load-bearing assertion is the "NO agent code change" property: the SAME agent
+function that calls `provider.chat(...)` / `tool(...)` / `client.request(...)` runs
+IDENTICALLY whether the transport is raw or governance-wrapped -- the agent never
+references governance -- yet the governed variant applies the envelope and REFUSES
+an out-of-envelope caller without ever invoking the transport.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.outbound import (
+    EffectKind,
+    EngineEffectGovernor,
+    OutboundEffectInterceptor,
+    OutboundEffectRefused,
+)
+from kaizen.trust.governance import (
+    GovernedHTTPClient,
+    GovernedProvider,
+    GovernedToolInvoker,
+)
+from pact.examples.university.org import create_university_org
+
+ALLOWED_CALLER = "D1-R1-D2-R1-T1-R1"  # HR Director, no envelope -> auto_approved
+REFUSED_CALLER = "INVALID-ADDRESS-DOES-NOT-EXIST"  # fail-closed BLOCKED
+
+
+# --- real transport endpoints (the things being governed) -------------------
+
+
+class EchoProvider:
+    """A real (non-mock) LLM provider stand-in: echoes the last message."""
+
+    model = "echo-model-v1"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def chat(self, messages: list[dict], **kwargs) -> dict:
+        self.call_count += 1
+        return {"content": messages[-1]["content"], "role": "assistant"}
+
+
+def make_interceptor() -> OutboundEffectInterceptor:
+    compiled, _ = create_university_org()
+    engine = GovernanceEngine(compiled)
+    return OutboundEffectInterceptor(EngineEffectGovernor(engine))
+
+
+# --- the AGENT: references ONLY the transport, never governance -------------
+
+
+def agent_llm_turn(provider) -> dict:
+    """An 'agent' turn. Note: touches ONLY provider.chat -- no governance import."""
+    return provider.chat([{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# LLM transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGovernedProviderLLM:
+    def test_no_agent_code_change_governed_matches_raw(self) -> None:
+        raw = EchoProvider()
+        interceptor = make_interceptor()
+        governed = GovernedProvider(EchoProvider(), interceptor, caller=ALLOWED_CALLER)
+
+        # The SAME agent function runs against raw AND governed -- drop-in.
+        raw_result = agent_llm_turn(raw)
+        governed_result = agent_llm_turn(governed)
+
+        assert (
+            raw_result
+            == governed_result
+            == {
+                "content": "hello",
+                "role": "assistant",
+            }
+        )
+        # Only the governed path produced a governance audit record.
+        log = interceptor.audit_log()
+        assert len(log) == 1
+        assert log[0].effect.kind is EffectKind.LLM
+        assert log[0].effect.operation == "llm.chat"
+        assert log[0].effect.target == "echo-model-v1"
+        assert log[0].allowed is True
+
+    def test_refused_caller_never_calls_provider(self) -> None:
+        underlying = EchoProvider()
+        interceptor = make_interceptor()
+        governed = GovernedProvider(underlying, interceptor, caller=REFUSED_CALLER)
+
+        with pytest.raises(OutboundEffectRefused):
+            agent_llm_turn(governed)  # identical agent call
+
+        # Fail-closed: the real provider was NEVER invoked.
+        assert underlying.call_count == 0
+        assert interceptor.audit_log()[-1].allowed is False
+
+    def test_non_outbound_attrs_forwarded_unchanged(self) -> None:
+        interceptor = make_interceptor()
+        governed = GovernedProvider(EchoProvider(), interceptor, caller=ALLOWED_CALLER)
+        # Transparent proxy: non-outbound attributes pass through untouched.
+        assert governed.model == "echo-model-v1"
+
+    def test_cost_estimator_feeds_financial_dimension(self) -> None:
+        interceptor = make_interceptor()
+        governed = GovernedProvider(
+            EchoProvider(),
+            interceptor,
+            caller=ALLOWED_CALLER,
+            cost_estimator=lambda method, args, kwargs: 4.2,
+        )
+        agent_llm_turn(governed)
+        assert interceptor.audit_log()[-1].effect.cost_estimate == 4.2
+
+
+# ---------------------------------------------------------------------------
+# Tool transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGovernedToolInvoker:
+    def test_wrapped_tool_is_transparent_when_allowed(self) -> None:
+        interceptor = make_interceptor()
+        invoker = GovernedToolInvoker(interceptor, caller=ALLOWED_CALLER)
+
+        calls = {"n": 0}
+
+        def search(query: str) -> str:  # a plain tool callable
+            calls["n"] += 1
+            return f"results-for-{query}"
+
+        governed_search = invoker.wrap("search", search, cost=1.0)
+        # Agent calls the tool with its normal signature.
+        assert governed_search("kailash") == "results-for-kailash"
+        assert calls["n"] == 1
+        assert interceptor.audit_log()[-1].effect.kind is EffectKind.TOOL
+        assert interceptor.audit_log()[-1].effect.operation == "tool.search"
+
+    def test_wrapped_tool_refused_never_runs(self) -> None:
+        interceptor = make_interceptor()
+        invoker = GovernedToolInvoker(interceptor, caller=REFUSED_CALLER)
+        calls = {"n": 0}
+
+        def danger() -> str:
+            calls["n"] += 1
+            return "ran"
+
+        governed = invoker.wrap("danger", danger)
+        with pytest.raises(OutboundEffectRefused):
+            governed()
+        assert calls["n"] == 0
+
+    def test_invoke_one_off(self) -> None:
+        interceptor = make_interceptor()
+        invoker = GovernedToolInvoker(interceptor, caller=ALLOWED_CALLER)
+        result = invoker.invoke("ping", lambda: "pong", cost=0.0)
+        assert result == "pong"
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGovernedHTTPClient:
+    def test_request_is_transparent_when_allowed(self) -> None:
+        interceptor = make_interceptor()
+        sent = {"n": 0}
+
+        def raw_request(method: str, url: str, **kwargs) -> dict:
+            sent["n"] += 1
+            return {"status": 200, "method": method, "url": url}
+
+        client = GovernedHTTPClient(raw_request, interceptor, caller=ALLOWED_CALLER)
+        resp = client.request("GET", "https://api.example.com/v1/data")
+        assert resp["status"] == 200
+        assert sent["n"] == 1
+        rec = interceptor.audit_log()[-1]
+        assert rec.effect.kind is EffectKind.HTTP
+        assert rec.effect.operation == "http.GET"
+        assert rec.effect.target == "https://api.example.com/v1/data"
+
+    def test_request_refused_never_sends(self) -> None:
+        interceptor = make_interceptor()
+        sent = {"n": 0}
+
+        def raw_request(method: str, url: str, **kwargs) -> dict:
+            sent["n"] += 1
+            return {"status": 200}
+
+        client = GovernedHTTPClient(raw_request, interceptor, caller=REFUSED_CALLER)
+        with pytest.raises(OutboundEffectRefused):
+            client.request("POST", "https://api.example.com/charge")
+        assert sent["n"] == 0  # fail-closed: no request left the process

--- a/packages/kailash-pact/tests/unit/governance/test_outbound.py
+++ b/packages/kailash-pact/tests/unit/governance/test_outbound.py
@@ -1,0 +1,323 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+"""Tests for the universal outbound-effect governance interceptor (#1517 leg-b).
+
+Covers the domain-neutral core in kailash.trust.pact.outbound:
+- OutboundEffect validation (NaN/Inf/negative/empty-op/unknown-kind fail-closed)
+- OutboundVerdict serialization
+- OutboundEffectInterceptor allow -> invoke; refuse -> raise + invoke NOT called
+- Fail-closed when the governor raises
+- Bounded audit trail (deque maxlen)
+- wrap_transport / wrap_transport_async transparent seam
+- Process-global install registry
+- EngineEffectGovernor reusing a REAL GovernanceEngine (university org)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kailash.trust.pact.engine import GovernanceEngine
+from kailash.trust.pact.outbound import (
+    DEFAULT_MAX_AUDIT_ENTRIES,
+    EffectGovernor,
+    EffectKind,
+    EngineEffectGovernor,
+    OutboundEffect,
+    OutboundEffectInterceptor,
+    OutboundEffectRefused,
+    OutboundVerdict,
+    active_interceptor,
+    clear_interceptor,
+    install_interceptor,
+    wrap_transport,
+    wrap_transport_async,
+)
+from pact.examples.university.org import create_university_org
+
+# An HR-Director role with no envelope set -> auto_approved for any action.
+ALLOWED_CALLER = "D1-R1-D2-R1-T1-R1"
+# A grammar-valid-but-nonexistent address -> fail-closed BLOCKED at the engine.
+REFUSED_CALLER = "INVALID-ADDRESS-DOES-NOT-EXIST"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def engine() -> GovernanceEngine:
+    compiled, _ = create_university_org()
+    return GovernanceEngine(compiled)
+
+
+@pytest.fixture
+def interceptor(engine: GovernanceEngine) -> OutboundEffectInterceptor:
+    return OutboundEffectInterceptor(EngineEffectGovernor(engine))
+
+
+# ---------------------------------------------------------------------------
+# OutboundEffect validation
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundEffect:
+    def test_valid_effect_freezes_metadata(self) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.HTTP,
+            operation="http.POST",
+            target="api.example.com",
+            cost_estimate=2.5,
+            caller="D1-R1",
+            metadata={"k": "v"},
+        )
+        assert eff.kind is EffectKind.HTTP
+        assert eff.governance_context()["cost"] == 2.5
+        assert eff.governance_context()["effect_kind"] == "http"
+        # metadata is a read-only view
+        with pytest.raises(TypeError):
+            eff.metadata["x"] = 1  # type: ignore[index]
+
+    def test_nan_cost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            OutboundEffect(
+                kind=EffectKind.LLM, operation="llm.chat", cost_estimate=float("nan")
+            )
+
+    def test_inf_cost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            OutboundEffect(
+                kind=EffectKind.LLM, operation="llm.chat", cost_estimate=float("inf")
+            )
+
+    def test_negative_cost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            OutboundEffect(kind=EffectKind.TOOL, operation="tool.x", cost_estimate=-1.0)
+
+    def test_empty_operation_rejected(self) -> None:
+        with pytest.raises(ValueError, match="operation"):
+            OutboundEffect(kind=EffectKind.TOOL, operation="   ")
+
+    def test_bool_cost_rejected(self) -> None:
+        # bool is a subclass of int; a boolean cost is a type-confusion bug.
+        with pytest.raises(ValueError, match="real number"):
+            OutboundEffect(
+                kind=EffectKind.HTTP, operation="http.GET", cost_estimate=True  # type: ignore[arg-type]
+            )
+
+    def test_from_dict_roundtrip(self) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.TOOL,
+            operation="tool.search",
+            target="search",
+            cost_estimate=3.0,
+        )
+        assert OutboundEffect.from_dict(eff.to_dict()) == eff
+
+    def test_from_dict_unknown_kind_fails_closed(self) -> None:
+        with pytest.raises(ValueError, match="Unknown EffectKind"):
+            OutboundEffect.from_dict({"kind": "telepathy", "operation": "x"})
+
+
+# ---------------------------------------------------------------------------
+# OutboundVerdict
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_to_dict() -> None:
+    eff = OutboundEffect(kind=EffectKind.HTTP, operation="http.GET")
+    v = OutboundVerdict(allowed=True, level="auto_approved", reason="ok", effect=eff)
+    d = v.to_dict()
+    assert d["allowed"] is True
+    assert d["effect"]["operation"] == "http.GET"
+    assert "timestamp" in d
+
+
+# ---------------------------------------------------------------------------
+# Interceptor allow / refuse (real engine)
+# ---------------------------------------------------------------------------
+
+
+class TestInterceptorSync:
+    def test_allowed_effect_invokes_transport(
+        self, interceptor: OutboundEffectInterceptor
+    ) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.HTTP, operation="read", caller=ALLOWED_CALLER
+        )
+        ran = {"called": False}
+
+        def invoke() -> str:
+            ran["called"] = True
+            return "response-body"
+
+        result = interceptor.intercept(eff, invoke)
+        assert result == "response-body"
+        assert ran["called"] is True
+        assert interceptor.audit_log()[-1].allowed is True
+
+    def test_refused_effect_does_not_invoke_transport(
+        self, interceptor: OutboundEffectInterceptor
+    ) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.HTTP, operation="read", caller=REFUSED_CALLER
+        )
+        ran = {"called": False}
+
+        def invoke() -> str:
+            ran["called"] = True
+            return "should-never-return"
+
+        with pytest.raises(OutboundEffectRefused) as excinfo:
+            interceptor.intercept(eff, invoke)
+        # Fail-closed: transport NEVER ran.
+        assert ran["called"] is False
+        assert excinfo.value.verdict.allowed is False
+        assert interceptor.audit_log()[-1].allowed is False
+
+
+class TestInterceptorAsync:
+    def test_allowed_async_effect_invokes(
+        self, interceptor: OutboundEffectInterceptor
+    ) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.LLM, operation="read", caller=ALLOWED_CALLER
+        )
+        ran = {"called": False}
+
+        async def invoke() -> str:
+            ran["called"] = True
+            return "async-body"
+
+        result = asyncio.run(interceptor.aintercept(eff, invoke))
+        assert result == "async-body"
+        assert ran["called"] is True
+
+    def test_refused_async_effect_does_not_invoke(
+        self, interceptor: OutboundEffectInterceptor
+    ) -> None:
+        eff = OutboundEffect(
+            kind=EffectKind.LLM, operation="read", caller=REFUSED_CALLER
+        )
+        ran = {"called": False}
+
+        async def invoke() -> str:
+            ran["called"] = True
+            return "nope"
+
+        with pytest.raises(OutboundEffectRefused):
+            asyncio.run(interceptor.aintercept(eff, invoke))
+        assert ran["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed when the governor raises
+# ---------------------------------------------------------------------------
+
+
+class _RaisingGovernor(EffectGovernor):
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        raise RuntimeError("governor contract violation")
+
+
+def test_governor_raise_fails_closed() -> None:
+    interceptor = OutboundEffectInterceptor(_RaisingGovernor())
+    eff = OutboundEffect(kind=EffectKind.HTTP, operation="read", caller=ALLOWED_CALLER)
+    ran = {"called": False}
+
+    def invoke() -> str:
+        ran["called"] = True
+        return "x"
+
+    with pytest.raises(OutboundEffectRefused):
+        interceptor.intercept(eff, invoke)
+    assert ran["called"] is False  # never ran despite governor bug
+
+
+# ---------------------------------------------------------------------------
+# Bounded audit trail
+# ---------------------------------------------------------------------------
+
+
+class _AllowGovernor(EffectGovernor):
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        return OutboundVerdict(
+            allowed=True, level="auto_approved", reason="ok", effect=effect
+        )
+
+
+def test_audit_trail_is_bounded() -> None:
+    interceptor = OutboundEffectInterceptor(_AllowGovernor(), max_audit_entries=5)
+    for i in range(20):
+        interceptor.intercept(
+            OutboundEffect(kind=EffectKind.TOOL, operation=f"tool.op{i}"),
+            lambda: None,
+        )
+    log = interceptor.audit_log()
+    assert len(log) == 5  # deque(maxlen=5) capped
+    # oldest evicted; newest retained
+    assert log[-1].effect.operation == "tool.op19"
+
+
+def test_default_max_audit_positive() -> None:
+    assert DEFAULT_MAX_AUDIT_ENTRIES > 0
+
+
+def test_invalid_governor_type_rejected() -> None:
+    with pytest.raises(TypeError):
+        OutboundEffectInterceptor(object())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# wrap_transport / wrap_transport_async transparent seam
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_transport_sync_is_transparent() -> None:
+    interceptor = OutboundEffectInterceptor(_AllowGovernor())
+
+    def raw_send(method: str, url: str) -> str:
+        return f"{method} {url}"
+
+    def builder(args, kwargs):
+        return OutboundEffect(
+            kind=EffectKind.HTTP, operation=f"http.{args[0]}", target=args[1]
+        )
+
+    governed = wrap_transport(interceptor, builder, raw_send)
+    # Same signature, same result -- caller code unchanged.
+    assert governed("GET", "example.com") == "GET example.com"
+    assert interceptor.audit_log()[-1].effect.target == "example.com"
+
+
+def test_wrap_transport_async_is_transparent() -> None:
+    interceptor = OutboundEffectInterceptor(_AllowGovernor())
+
+    async def raw_send(payload: str) -> str:
+        return payload.upper()
+
+    def builder(args, kwargs):
+        return OutboundEffect(kind=EffectKind.LLM, operation="llm.chat")
+
+    governed = wrap_transport_async(interceptor, builder, raw_send)
+    assert asyncio.run(governed("hi")) == "HI"
+
+
+# ---------------------------------------------------------------------------
+# Install registry
+# ---------------------------------------------------------------------------
+
+
+def test_install_and_active_interceptor() -> None:
+    clear_interceptor()
+    assert active_interceptor() is None
+    interceptor = OutboundEffectInterceptor(_AllowGovernor())
+    install_interceptor(interceptor)
+    try:
+        assert active_interceptor() is interceptor
+    finally:
+        clear_interceptor()
+    assert active_interceptor() is None

--- a/src/kailash/trust/pact/__init__.py
+++ b/src/kailash/trust/pact/__init__.py
@@ -77,6 +77,21 @@ from kailash.trust.pact.observation import (
     Observation,
     ObservationSink,
 )
+from kailash.trust.pact.outbound import (
+    DEFAULT_MAX_AUDIT_ENTRIES,
+    EffectGovernor,
+    EffectKind,
+    EngineEffectGovernor,
+    OutboundEffect,
+    OutboundEffectInterceptor,
+    OutboundEffectRefused,
+    OutboundVerdict,
+    active_interceptor,
+    clear_interceptor,
+    install_interceptor,
+    wrap_transport,
+    wrap_transport_async,
+)
 from kailash.trust.pact.risk_factors import (
     GLOBAL_RISK_FACTOR_REGISTRY,
     RISK_LEVEL_ORDER,
@@ -201,6 +216,20 @@ __all__ = [
     "InMemoryObservationSink",
     "Observation",
     "ObservationSink",
+    # Universal outbound-effect governance interceptor (#1517 leg-b)
+    "DEFAULT_MAX_AUDIT_ENTRIES",
+    "EffectGovernor",
+    "EffectKind",
+    "EngineEffectGovernor",
+    "OutboundEffect",
+    "OutboundEffectInterceptor",
+    "OutboundEffectRefused",
+    "OutboundVerdict",
+    "active_interceptor",
+    "clear_interceptor",
+    "install_interceptor",
+    "wrap_transport",
+    "wrap_transport_async",
     # WEFT provenance event schema (EATP v3, #1591)
     "WeftKind",
     "WeftError",

--- a/src/kailash/trust/pact/outbound.py
+++ b/src/kailash/trust/pact/outbound.py
@@ -1,0 +1,543 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Universal outbound-effect governance interceptor (issue #1517 leg-b).
+
+A single, domain-neutral seam that wraps ANY outbound effect an agent produces
+-- HTTP requests, LLM completions, tool/MCP invocations -- in a governance
+envelope BEFORE the effect leaves the process. The interceptor is a SEAM, not a
+per-call API: transports install a governed dispatch callable once (via
+:func:`wrap_transport` / :func:`wrap_transport_async` or the process-global
+:func:`install_interceptor`), and every subsequent outbound call an agent makes
+is governed transparently, with NO change to the agent's own code.
+
+Design:
+
+- :class:`OutboundEffect` -- a normalized, transport-agnostic descriptor of one
+  outbound call (kind + operation + target + cost estimate + caller + metadata).
+  The transport layer knows how to build one; the governance layer never needs
+  to know which transport produced it. This is what makes the seam universal.
+- :class:`EffectGovernor` -- the pluggable "should this effect proceed?"
+  contract. :class:`EngineEffectGovernor` is the default, REUSING the canonical
+  :class:`~kailash.trust.pact.engine.GovernanceEngine` envelope/verdict
+  primitive -- it does NOT invent a parallel envelope.
+- :class:`OutboundEffectInterceptor` -- the seam itself: evaluate -> record
+  audit -> (allow) invoke transport / (refuse) raise. Fail-closed: any error in
+  evaluation refuses the effect; the transport is NEVER invoked on refusal.
+
+Security invariants (per pact-governance.md / trust-plane-security.md):
+
+1. Fail-closed -- any exception during governance evaluation REFUSES the effect
+   (the transport dispatch is never called). An effect that cannot be governed
+   is never emitted.
+2. NaN/Inf defense -- math.isfinite() on every numeric field (cost estimate) at
+   construction; non-finite values are rejected (they bypass numeric envelope
+   comparisons).
+3. Bounded audit -- the in-memory audit trail is a deque(maxlen=N); it cannot
+   grow without bound under a hostile effect stream.
+4. Frozen records -- OutboundEffect / OutboundVerdict are frozen dataclasses;
+   an audited decision cannot be mutated after the fact.
+5. Audit-before-effect -- the governance decision is recorded to the audit
+   trail (and any sink) BEFORE the transport dispatch runs, so the record
+   survives even if the effect itself crashes.
+6. No secrets in logs -- only kind/operation/target are logged; request bodies,
+   arguments, prompts, and headers are never logged.
+7. Thread-safe -- audit mutation acquires self._lock; the governor delegates to
+   GovernanceEngine which holds its own lock.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from functools import wraps
+from types import MappingProxyType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    TypeVar,
+)
+
+from kailash.trust.pact.exceptions import PactError
+
+if TYPE_CHECKING:
+    from kailash.trust.pact.engine import GovernanceEngine
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EffectKind",
+    "OutboundEffect",
+    "OutboundVerdict",
+    "OutboundEffectRefused",
+    "EffectGovernor",
+    "EngineEffectGovernor",
+    "OutboundEffectInterceptor",
+    "EffectBuilder",
+    "wrap_transport",
+    "wrap_transport_async",
+    "install_interceptor",
+    "active_interceptor",
+    "clear_interceptor",
+    "DEFAULT_MAX_AUDIT_ENTRIES",
+]
+
+T = TypeVar("T")
+
+DEFAULT_MAX_AUDIT_ENTRIES = 1000
+
+
+class EffectKind(str, Enum):
+    """The kind of outbound effect being governed.
+
+    Domain-neutral by construction: these are transport CATEGORIES, not
+    domain concepts. Every outbound effect an agent can produce maps to one of
+    these. ``OTHER`` is the catch-all for a transport not yet categorized (it is
+    still fully governed -- ``OTHER`` is not a bypass).
+    """
+
+    HTTP = "http"
+    LLM = "llm"
+    TOOL = "tool"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class OutboundEffect:
+    """Normalized, transport-agnostic descriptor of one outbound effect.
+
+    frozen=True: an effect descriptor handed to governance is an immutable
+    record. The transport builds one of these from its own call parameters; the
+    governance layer evaluates it without knowing which transport produced it.
+
+    Attributes:
+        kind: The transport category (:class:`EffectKind`).
+        operation: The governance action name evaluated against the envelope
+            (e.g. ``"http.POST"``, ``"llm.chat"``, ``"tool.search"``). This is
+            the ``action`` passed to ``GovernanceEngine.verify_action``.
+        target: The concrete destination (host, model name, tool name). Used for
+            audit/observability; never used as a bypass.
+        cost_estimate: Estimated cost of the effect for financial envelope
+            checks. MUST be finite and non-negative.
+        caller: The D/T/R role address (or resolved identity) of the effect's
+            originator. Passed to the engine as ``role_address``. Empty string
+            means "unknown caller" -- which fails closed at the engine.
+        metadata: Extra transport context forwarded into the governance context
+            dict. Never logged. Stored read-only (MappingProxyType).
+    """
+
+    kind: EffectKind
+    operation: str
+    target: str = ""
+    cost_estimate: float = 0.0
+    caller: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # --- kind ---
+        if not isinstance(self.kind, EffectKind):
+            raise ValueError(
+                f"OutboundEffect.kind must be an EffectKind, got {type(self.kind).__name__!r}"
+            )
+        # --- operation ---
+        if not isinstance(self.operation, str) or not self.operation.strip():
+            raise ValueError(
+                "OutboundEffect.operation must be a non-empty string "
+                "(it is the governance action name)"
+            )
+        if not isinstance(self.target, str):
+            raise ValueError("OutboundEffect.target must be a string")
+        if not isinstance(self.caller, str):
+            raise ValueError("OutboundEffect.caller must be a string")
+        # --- cost_estimate: NaN/Inf defense (Rule 2) ---
+        cost = self.cost_estimate
+        if isinstance(cost, bool) or not isinstance(cost, (int, float)):
+            raise ValueError(
+                f"OutboundEffect.cost_estimate must be a real number, got {cost!r}"
+            )
+        if not math.isfinite(cost):
+            raise ValueError(
+                f"OutboundEffect.cost_estimate must be finite, got {cost!r}: "
+                "NaN/Inf bypass numeric envelope comparisons."
+            )
+        if cost < 0:
+            raise ValueError(
+                f"OutboundEffect.cost_estimate must be non-negative, got {cost!r}"
+            )
+        # Freeze metadata into a read-only view (defensive; frozen dataclass).
+        object.__setattr__(
+            self, "metadata", MappingProxyType(dict(self.metadata or {}))
+        )
+
+    def governance_context(self) -> dict[str, Any]:
+        """Build the context dict passed to ``GovernanceEngine.verify_action``.
+
+        ``cost`` drives the financial envelope dimension. Transport metadata is
+        merged UNDER ``cost`` so a hostile metadata payload cannot override the
+        cost the transport computed.
+        """
+        ctx: dict[str, Any] = dict(self.metadata)
+        ctx["cost"] = self.cost_estimate
+        ctx["effect_kind"] = self.kind.value
+        ctx["effect_target"] = self.target
+        return ctx
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (metadata is NOT included -- it
+        may carry sensitive transport context; only governance-relevant fields
+        are emitted)."""
+        return {
+            "kind": self.kind.value,
+            "operation": self.operation,
+            "target": self.target,
+            "cost_estimate": self.cost_estimate,
+            "caller": self.caller,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> OutboundEffect:
+        """Reconstruct from a dict. Fail-closed on an unknown ``kind``."""
+        raw_kind = data.get("kind")
+        try:
+            kind = EffectKind(str(raw_kind))
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown EffectKind {raw_kind!r} -- fail-closed (refusing to "
+                "reconstruct an ungoverned effect)."
+            ) from exc
+        return cls(
+            kind=kind,
+            operation=str(data.get("operation", "")),
+            target=str(data.get("target", "")),
+            cost_estimate=float(data.get("cost_estimate", 0.0)),
+            caller=str(data.get("caller", "")),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+@dataclass(frozen=True)
+class OutboundVerdict:
+    """Governance decision for one outbound effect.
+
+    frozen=True: an immutable record of the decision. Wraps the underlying
+    governance level/reason so the interceptor stays decoupled from whichever
+    governor produced it.
+
+    Attributes:
+        allowed: True iff the effect may proceed (level auto_approved/flagged).
+        level: The governance gradient level (auto_approved/flagged/held/blocked).
+        reason: Human-readable explanation.
+        effect: The effect this verdict is about.
+        governance: Structured governance detail (e.g. GovernanceVerdict.to_dict()).
+        timestamp: When the verdict was issued (UTC).
+    """
+
+    allowed: bool
+    level: str
+    reason: str
+    effect: OutboundEffect
+    governance: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "level": self.level,
+            "reason": self.reason,
+            "effect": self.effect.to_dict(),
+            "governance": self.governance,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+class OutboundEffectRefused(PactError):
+    """Raised when governance refuses an outbound effect.
+
+    The transport dispatch is NEVER invoked when this is raised -- the effect
+    does not leave the process. Inherits :class:`PactError` (the PACT governance
+    error family, ``.details``-carrying) so it is caught by governance handlers.
+
+    Attributes:
+        verdict: The :class:`OutboundVerdict` that caused the refusal.
+    """
+
+    def __init__(self, verdict: OutboundVerdict) -> None:
+        self.verdict = verdict
+        super().__init__(
+            f"Outbound {verdict.effect.kind.value} effect "
+            f"'{verdict.effect.operation}' REFUSED: {verdict.reason}",
+            details={
+                "level": verdict.level,
+                "reason": verdict.reason,
+                "kind": verdict.effect.kind.value,
+                "operation": verdict.effect.operation,
+                "target": verdict.effect.target,
+                "caller": verdict.effect.caller,
+            },
+        )
+
+
+class EffectGovernor(ABC):
+    """Pluggable "should this outbound effect proceed?" contract.
+
+    Domain-neutral: an implementation maps an :class:`OutboundEffect` to an
+    :class:`OutboundVerdict` however it likes. The default
+    :class:`EngineEffectGovernor` delegates to the canonical GovernanceEngine.
+    Implementations MUST be fail-closed: on any internal error they MUST return
+    a non-allowed verdict, never raise past :meth:`evaluate`.
+    """
+
+    @abstractmethod
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        """Return a verdict for ``effect``. MUST NOT raise -- fail closed."""
+        ...
+
+
+class EngineEffectGovernor(EffectGovernor):
+    """Default governor: REUSES ``GovernanceEngine`` for the decision.
+
+    Maps every outbound effect onto ``engine.verify_action(caller, operation,
+    {"cost": ..., ...})`` -- the canonical envelope + gradient + access
+    primitive. Does NOT invent a parallel envelope model.
+
+    Args:
+        engine: The GovernanceEngine that holds the org, envelopes, and stores.
+    """
+
+    def __init__(self, engine: GovernanceEngine) -> None:
+        self._engine = engine
+
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        try:
+            verdict = self._engine.verify_action(
+                effect.caller,
+                effect.operation,
+                effect.governance_context(),
+            )
+            return OutboundVerdict(
+                allowed=verdict.allowed,
+                level=verdict.level,
+                reason=verdict.reason,
+                effect=effect,
+                governance=verdict.to_dict(),
+            )
+        except Exception:  # fail-closed: never leak an ungoverned effect
+            logger.exception(
+                "EngineEffectGovernor: verify_action raised for kind=%s "
+                "operation=%s -- fail-closed to REFUSED",
+                effect.kind.value,
+                effect.operation,
+            )
+            return OutboundVerdict(
+                allowed=False,
+                level="blocked",
+                reason="Internal error during outbound governance -- fail-closed",
+                effect=effect,
+                governance={"error": "internal_error"},
+            )
+
+
+class OutboundEffectInterceptor:
+    """The universal outbound-effect governance seam.
+
+    Wrap any transport dispatch through :meth:`intercept` (sync) or
+    :meth:`aintercept` (async). The interceptor evaluates the effect, records
+    the decision to a bounded audit trail (BEFORE the effect runs), and either
+    invokes the transport (allowed) or raises :class:`OutboundEffectRefused`
+    (refused). The transport dispatch is NEVER called on refusal.
+
+    Args:
+        governor: The :class:`EffectGovernor` that decides each effect.
+        audit_sink: Optional callable invoked with each :class:`OutboundVerdict`
+            for external audit anchoring (e.g. an EATP emitter). Sink failures
+            are logged and swallowed -- a broken sink MUST NOT crash the effect
+            path, but it also MUST NOT allow a refused effect through.
+        max_audit_entries: Bound on the in-memory audit deque.
+    """
+
+    def __init__(
+        self,
+        governor: EffectGovernor,
+        *,
+        audit_sink: Callable[[OutboundVerdict], None] | None = None,
+        max_audit_entries: int = DEFAULT_MAX_AUDIT_ENTRIES,
+    ) -> None:
+        if not isinstance(governor, EffectGovernor):
+            raise TypeError(
+                "governor must be an EffectGovernor instance, got "
+                f"{type(governor).__name__!r}"
+            )
+        if not isinstance(max_audit_entries, int) or max_audit_entries <= 0:
+            raise ValueError("max_audit_entries must be a positive int")
+        self._governor = governor
+        self._audit_sink = audit_sink
+        self._lock = threading.Lock()
+        self._audit: deque[OutboundVerdict] = deque(maxlen=max_audit_entries)
+
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        """Evaluate an effect and record the decision, WITHOUT dispatching.
+
+        Fail-closed: if the governor itself raises (contract violation), the
+        effect is refused.
+        """
+        try:
+            verdict = self._governor.evaluate(effect)
+        except Exception:
+            logger.exception(
+                "OutboundEffectInterceptor: governor raised for kind=%s "
+                "operation=%s -- fail-closed to REFUSED",
+                effect.kind.value,
+                effect.operation,
+            )
+            verdict = OutboundVerdict(
+                allowed=False,
+                level="blocked",
+                reason="Governor raised -- fail-closed",
+                effect=effect,
+                governance={"error": "governor_raised"},
+            )
+        # Audit-before-effect (Rule 5): record the decision before the transport
+        # dispatch could possibly run.
+        self._record(verdict)
+        return verdict
+
+    def _record(self, verdict: OutboundVerdict) -> None:
+        with self._lock:
+            self._audit.append(verdict)
+        if self._audit_sink is not None:
+            try:
+                self._audit_sink(verdict)
+            except Exception:
+                logger.exception(
+                    "OutboundEffectInterceptor: audit_sink raised for kind=%s "
+                    "operation=%s -- swallowed (decision already recorded)",
+                    verdict.effect.kind.value,
+                    verdict.effect.operation,
+                )
+
+    def intercept(self, effect: OutboundEffect, invoke: Callable[[], T]) -> T:
+        """Govern a SYNC outbound effect.
+
+        Args:
+            effect: The normalized effect descriptor.
+            invoke: Zero-arg callable that performs the actual transport
+                dispatch. Called ONLY if the effect is allowed.
+
+        Returns:
+            The transport dispatch result.
+
+        Raises:
+            OutboundEffectRefused: If governance refuses the effect (held or
+                blocked). ``invoke`` is not called.
+        """
+        verdict = self.evaluate(effect)
+        if not verdict.allowed:
+            raise OutboundEffectRefused(verdict)
+        return invoke()
+
+    async def aintercept(
+        self, effect: OutboundEffect, invoke: Callable[[], Awaitable[T]]
+    ) -> T:
+        """Govern an ASYNC outbound effect. Async mirror of :meth:`intercept`."""
+        verdict = self.evaluate(effect)
+        if not verdict.allowed:
+            raise OutboundEffectRefused(verdict)
+        return await invoke()
+
+    def audit_log(self) -> tuple[OutboundVerdict, ...]:
+        """Immutable snapshot of the bounded audit trail (oldest first)."""
+        with self._lock:
+            return tuple(self._audit)
+
+
+# ---------------------------------------------------------------------------
+# Transport seam binders -- turn any transport dispatch into a governed one.
+# ---------------------------------------------------------------------------
+
+# An EffectBuilder maps a transport call's (args, kwargs) to an OutboundEffect.
+# The transport layer supplies one; the core stays domain-neutral.
+EffectBuilder = Callable[[tuple[Any, ...], dict[str, Any]], OutboundEffect]
+
+
+def wrap_transport(
+    interceptor: OutboundEffectInterceptor,
+    effect_builder: EffectBuilder,
+    fn: Callable[..., T],
+) -> Callable[..., T]:
+    """Wrap a SYNC transport dispatch ``fn`` in the governance seam.
+
+    Returns a callable with the same signature as ``fn``. Every call builds an
+    :class:`OutboundEffect` via ``effect_builder`` and routes it through the
+    interceptor. The caller of the returned function (an agent) does NOT know
+    governance is happening -- that is the "no agent code change" property.
+    """
+
+    @wraps(fn)
+    def governed(*args: Any, **kwargs: Any) -> T:
+        effect = effect_builder(args, kwargs)
+        return interceptor.intercept(effect, lambda: fn(*args, **kwargs))
+
+    governed.__wrapped_governed__ = True  # type: ignore[attr-defined]
+    return governed
+
+
+def wrap_transport_async(
+    interceptor: OutboundEffectInterceptor,
+    effect_builder: EffectBuilder,
+    fn: Callable[..., Awaitable[T]],
+) -> Callable[..., Awaitable[T]]:
+    """Wrap an ASYNC transport dispatch ``fn`` in the governance seam.
+
+    Async mirror of :func:`wrap_transport`.
+    """
+
+    @wraps(fn)
+    async def governed(*args: Any, **kwargs: Any) -> T:
+        effect = effect_builder(args, kwargs)
+        return await interceptor.aintercept(effect, lambda: fn(*args, **kwargs))
+
+    governed.__wrapped_governed__ = True  # type: ignore[attr-defined]
+    return governed
+
+
+# ---------------------------------------------------------------------------
+# Process-global install registry -- transparent, no-agent-code-change install.
+# ---------------------------------------------------------------------------
+
+_active_lock = threading.Lock()
+_active_interceptor: OutboundEffectInterceptor | None = None
+
+
+def install_interceptor(interceptor: OutboundEffectInterceptor) -> None:
+    """Install a process-global interceptor.
+
+    Transports (or a bootstrap layer) call :func:`active_interceptor` to pick
+    this up, so an operator can turn governance on for every outbound effect in
+    the process WITHOUT touching any agent or transport call site.
+    """
+    if not isinstance(interceptor, OutboundEffectInterceptor):
+        raise TypeError("install_interceptor requires an OutboundEffectInterceptor")
+    global _active_interceptor
+    with _active_lock:
+        _active_interceptor = interceptor
+
+
+def active_interceptor() -> OutboundEffectInterceptor | None:
+    """Return the process-global interceptor, or None if none installed."""
+    with _active_lock:
+        return _active_interceptor
+
+
+def clear_interceptor() -> None:
+    """Remove the process-global interceptor (primarily for test isolation)."""
+    global _active_interceptor
+    with _active_lock:
+        _active_interceptor = None


### PR DESCRIPTION
## Summary
Implements **leg-b** of #1517 — a universal outbound-effect governance interceptor. Leg-a (pluggable identity resolver) shipped in #1642; this completes the issue.

Governance interception now covers **all** outbound effects — HTTP, LLM, and tool calls — so every effect can be wrapped in a governance envelope with **no agent code change**.

- **Domain-neutral interceptor core** (`src/kailash/trust/pact/outbound.py`) reusing the existing `GovernanceEngine`/`GovernanceVerdict` envelope primitive (`EngineEffectGovernor`) — no parallel envelope invented.
- **Three transport seams** (`kaizen/trust/governance/outbound.py`): `GovernedProvider` (LLM), `GovernedToolInvoker` (tool), `GovernedHTTPClient` (HTTP). Each is a `__getattr__` transparent proxy (`functools.wraps` on the wrapped dispatch), wired once at bootstrap, not in agent logic.
- **Fail-closed throughout**: an effect whose envelope can't be applied is refused (`OutboundEffectRefused`), never silently passed. `resolve_interceptor` fails closed — no ungoverned transport can be constructed.

Trust-plane invariants honored: `math.isfinite` + non-negative cost, `deque(maxlen=)` bounded audit, frozen `@dataclass` effect/verdict with `to_dict`/`from_dict` (unknown `EffectKind` fails closed), audit-recorded-before-transport-invoked, no secrets logged.

## Testing
- 29 new tests (20 core unit + 9 Tier-2 wiring): `29 passed`.
- `test_no_agent_code_change_governed_matches_raw` runs the SAME agent function against a raw vs governed provider — identical result, but only the governed path emits an audit record.
- `test_refused_caller_never_calls_provider` proves an out-of-envelope caller raises `OutboundEffectRefused` with the real provider's `call_count == 0`.
- Regression: pact governance unit `1203 passed, 7 skipped`; kaizen trust governance unit `94 passed`.
- Orphan-detection: each facade has a production seam + a Tier-2 wiring test in this PR.

## Related issues
Closes #1517