### PR TITLE
fix(dataflow): surface actionable cross-tenant collision on bulk paths (#1526 follow-up)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -19,7 +19,7 @@ loop into a single, loud, fail-fast error at the next access.
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import Optional, Sequence
 
 # Re-export the public DataFlow base error so callers can `except
 # DataFlowError` to catch both legacy and new exception types without
@@ -307,6 +307,56 @@ class UpsertConflictTargetError(DataFlowError):
         )
 
 
+def format_tenant_natural_key_collision_message(
+    model_name: str,
+    tenant_id: str,
+    colliding_ids: Sequence[object],
+) -> str:
+    """Build the actionable cross-tenant natural-key collision message (#1526).
+
+    Single source of truth shared by BOTH the single-record raise path
+    (:class:`TenantNaturalKeyCollisionError`, which passes a one-element
+    sequence so its message is byte-identical to the original literal) AND
+    the bulk partial-failure-dict path (``ExpressDataFlow`` bulk_create /
+    bulk_upsert, which passes the caller's own candidate ids). Sharing the
+    builder guarantees the two surfaces never drift and there is no parallel
+    error hierarchy (``framework-first.md``).
+
+    The message names ONLY the CALLER's own ``tenant_id`` + the CALLER's own
+    supplied ``id``(s) — never another tenant's id or row data — so tenant
+    isolation is preserved (``rules/tenant-isolation.md``, ``security.md``).
+    A single id renders the exact-attribution singular form; multiple
+    candidate ids render an at-least-one plural form (the bulk path cannot
+    pinpoint which of the caller's supplied ids collided without a
+    cross-tenant read, which is forbidden).
+    """
+    ids = list(colliding_ids)
+    if len(ids) == 1:
+        subject = (
+            f"cannot write id={ids[0]!r} because that primary-key value is "
+            f"already owned by another tenant."
+        )
+    else:
+        subject = (
+            f"cannot write ids {ids!r} because one or more of those "
+            f"primary-key values are already owned by another tenant."
+        )
+    return (
+        f"Cross-tenant natural-key collision on multi_tenant model "
+        f"'{model_name}': tenant '{tenant_id}' {subject} "
+        f"multi_tenant=True models keep the DEFAULT single-column primary key "
+        f"'id' (NOT a composite of (tenant_id, id)), so under the default "
+        f"row-level tenant strategy the 'id' is a GLOBALLY-UNIQUE surrogate — "
+        f"two tenants cannot share the same natural-key id. Remediation: "
+        f"(1) use globally-unique ids (e.g. UUIDs) so tenants never collide; "
+        f"OR (2) for tenant-LOCAL natural keys, use the schema-per-tenant "
+        f"isolation strategy "
+        f"(dataflow.core.multi_tenancy.IsolationStrategy.SCHEMA / "
+        f"SchemaIsolationStrategy.create_tenant_table), which gives each "
+        f"tenant its own table so identical natural keys do not collide."
+    )
+
+
 class TenantNaturalKeyCollisionError(DataFlowError):
     """Raised when a ``multi_tenant=True`` write collides on the natural-key
     primary key with a row another tenant already owns (issue #1526).
@@ -363,20 +413,13 @@ class TenantNaturalKeyCollisionError(DataFlowError):
         self.colliding_id = colliding_id
         self.original_error = original_error
 
+        # Single source of truth for the actionable message (shared with the
+        # bulk partial-failure-dict path). A one-element sequence renders the
+        # exact-attribution singular form, byte-identical to the original.
         super().__init__(
-            f"Cross-tenant natural-key collision on multi_tenant model "
-            f"'{model_name}': tenant '{tenant_id}' cannot write id={colliding_id!r} "
-            f"because that primary-key value is already owned by another tenant. "
-            f"multi_tenant=True models keep the DEFAULT single-column primary key "
-            f"'id' (NOT a composite of (tenant_id, id)), so under the default "
-            f"row-level tenant strategy the 'id' is a GLOBALLY-UNIQUE surrogate — "
-            f"two tenants cannot share the same natural-key id. Remediation: "
-            f"(1) use globally-unique ids (e.g. UUIDs) so tenants never collide; "
-            f"OR (2) for tenant-LOCAL natural keys, use the schema-per-tenant "
-            f"isolation strategy "
-            f"(dataflow.core.multi_tenancy.IsolationStrategy.SCHEMA / "
-            f"SchemaIsolationStrategy.create_tenant_table), which gives each "
-            f"tenant its own table so identical natural keys do not collide."
+            format_tenant_natural_key_collision_message(
+                model_name, tenant_id, [colliding_id]
+            )
         )
 
 
@@ -661,6 +704,7 @@ __all__ = [
     "BulkUpsertConflictTargetError",
     "UpsertConflictTargetError",
     "TenantNaturalKeyCollisionError",
+    "format_tenant_natural_key_collision_message",
     "is_pk_unique_violation",
     "is_conflict_target_error",
     "sanitize_db_error",

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -3851,6 +3851,21 @@ class NodeGenerator:
                             has_updated_at=has_updated_at,
                         )
                     else:
+                        # Cross-tenant WRITE breach fix (rules/tenant-isolation.md):
+                        # for a multi_tenant model with a bound tenant, pass the
+                        # tenant id so the native ON CONFLICT DO UPDATE carries a
+                        # ``WHERE {table}.tenant_id = <bound>`` guard (PG/SQLite) /
+                        # ``IF()`` guard (MySQL). A cross-tenant ``id`` collision
+                        # then leaves the row untouched (0 rows returned), which
+                        # the empty-RETURNING branch below converts into the
+                        # actionable TenantNaturalKeyCollisionError. SQLite's
+                        # single-record path (above) uses the tenant-scoped
+                        # WHERE-precheck and is already fail-closed.
+                        _tenant_guard_value = None
+                        if "tenant_id" in self.model_fields:
+                            from .tenant_context import get_current_tenant_id
+
+                            _tenant_guard_value = get_current_tenant_id()
                         upsert_query = dialect.build_upsert_query(
                             table_name=table_name,
                             insert_data=insert_data,
@@ -3858,6 +3873,7 @@ class NodeGenerator:
                             conflict_columns=conflict_columns,
                             has_updated_at=has_updated_at,
                             use_row_alias=mysql_use_row_alias,  # #1546
+                            tenant_guard=_tenant_guard_value,
                         )
 
                     query = upsert_query.query
@@ -3966,6 +3982,34 @@ class NodeGenerator:
                                 "record": row,
                                 "action": "created" if created else "updated",
                             }
+
+                    # Cross-tenant WRITE breach fix (rules/tenant-isolation.md):
+                    # a PostgreSQL native-ON-CONFLICT upsert on a multi_tenant
+                    # model that returned 0 rows means the tenant-scoped
+                    # DO-UPDATE guard suppressed a cross-tenant ``id`` collision
+                    # (a same-tenant conflict updates + returns its row; a new
+                    # row inserts + returns). Fail closed with the SAME actionable
+                    # diagnostic the bulk path surfaces — never a silent no-op.
+                    if (
+                        database_type.lower() == "postgresql"
+                        and "tenant_id" in self.model_fields
+                    ):
+                        from .tenant_context import get_current_tenant_id
+
+                        _tid = get_current_tenant_id()
+                        if _tid is not None:
+                            from .exceptions import TenantNaturalKeyCollisionError
+
+                            _cid = None
+                            if isinstance(create_data, dict):
+                                _cid = create_data.get("id")
+                            if _cid is None and isinstance(where, dict):
+                                _cid = where.get("id")
+                            raise TenantNaturalKeyCollisionError(
+                                model_name=self.model_name,
+                                tenant_id=_tid,
+                                colliding_id=_cid,
+                            )
 
                     # Enhanced error with catalog-based solutions (DF-710)
                     raise _error_enhancer().enhance_upsert_operation_failed(
@@ -4602,6 +4646,13 @@ class NodeGenerator:
                                 and "error" in bulk_result
                             ):
                                 result["error"] = bulk_result["error"]
+                            # Cross-tenant WRITE breach fix: propagate the
+                            # structured cross-tenant-collision signal so the
+                            # express layer surfaces the actionable #1526
+                            # diagnostic (rules/tenant-isolation.md).
+                            if bulk_result.get("cross_tenant_conflict"):
+                                result["cross_tenant_conflict"] = True
+                                result["skipped"] = bulk_result.get("skipped", 0)
                             return result
                         except BulkUpsertConflictTargetError:
                             # Issue #1519: caller-actionable conflict-target error

--- a/packages/kailash-dataflow/src/dataflow/features/bulk.py
+++ b/packages/kailash-dataflow/src/dataflow/features/bulk.py
@@ -1596,6 +1596,11 @@ class BulkOperations:
             for i in range(0, len(data), batch_size):
                 batch = data[i : i + batch_size]
 
+                # Cross-tenant WRITE breach fix: emit the tenant-scoped DO-UPDATE
+                # guard iff this is a multi_tenant model with a bound tenant
+                # (``bound_tenant is not None`` ⟺ _resolve_bulk_tenant succeeded).
+                tenant_guard = bound_tenant is not None
+
                 # Build database-specific upsert query
                 if database_type.lower() == "postgresql":
                     # PostgreSQL: INSERT ... ON CONFLICT (<conflict_on>) DO UPDATE
@@ -1606,6 +1611,7 @@ class BulkOperations:
                         conflict_resolution,
                         model_name,
                         conflict_columns,
+                        tenant_guard=tenant_guard,
                     )
                 elif database_type.lower() == "mysql":
                     # MySQL: INSERT ... ON DUPLICATE KEY UPDATE ...
@@ -1617,6 +1623,7 @@ class BulkOperations:
                         model_name,
                         conflict_columns,
                         use_row_alias=mysql_use_row_alias,
+                        tenant_guard=tenant_guard,
                     )
                 else:  # sqlite
                     # SQLite: INSERT ... ON CONFLICT (<conflict_on>) DO UPDATE
@@ -1627,6 +1634,7 @@ class BulkOperations:
                         conflict_resolution,
                         model_name,
                         conflict_columns,
+                        tenant_guard=tenant_guard,
                     )
 
                 logger.debug(
@@ -1698,6 +1706,52 @@ class BulkOperations:
                 batches_processed += 1
 
             records_processed = total_inserted + total_updated + total_skipped
+
+            # Cross-tenant WRITE breach fix (rules/tenant-isolation.md): when the
+            # tenant-scoped DO-UPDATE guard is active (multi_tenant model, an
+            # ``update`` resolution, and at least one updatable non-tenant column
+            # so a real ``WHERE {table}.tenant_id = excluded.tenant_id`` was
+            # emitted), a ``skipped`` row can ONLY mean the guard suppressed a
+            # cross-tenant ``id`` collision — the ONLY row shape that conflicts
+            # yet is neither inserted nor updated. Never a silent no-op: fail
+            # closed and hand the express layer a structured signal it converts
+            # into the actionable, tenant-scoped #1526 collision diagnostic.
+            guarded_update_active = (
+                bound_tenant is not None
+                and conflict_resolution not in ("skip", "ignore")
+                and len(
+                    self._upsert_update_columns(
+                        columns, conflict_columns, tenant_guarded=True
+                    )
+                )
+                > 0
+            )
+            if guarded_update_active and total_skipped > 0:
+                logger.warning(
+                    "bulk.bulk_upsert_cross_tenant_conflict_suppressed",
+                    extra={
+                        "model": model_name,
+                        "suppressed": total_skipped,
+                        "tenant_id": bound_tenant,
+                    },
+                )
+                return {
+                    "success": False,
+                    "cross_tenant_conflict": True,
+                    "records_processed": total_inserted + total_updated,
+                    "inserted": total_inserted,
+                    "updated": total_updated,
+                    "skipped": total_skipped,
+                    "batches": batches_processed,
+                    "batch_size": batch_size,
+                    "conflict_resolution": conflict_resolution,
+                    "error": (
+                        "bulk_upsert refused a cross-tenant id collision: one or "
+                        "more supplied ids already belong to a different tenant; "
+                        "the existing row(s) were left untouched."
+                    ),
+                }
+
             elapsed = time.perf_counter() - _upsert_start
             success_result = {
                 "records_processed": records_processed,
@@ -1758,14 +1812,25 @@ class BulkOperations:
 
     @staticmethod
     def _upsert_update_columns(
-        columns: List[str], conflict_columns: List[str]
+        columns: List[str],
+        conflict_columns: List[str],
+        tenant_guarded: bool = False,
     ) -> List[str]:
         """Columns eligible for the DO UPDATE SET clause (issue #1519).
 
         Excludes every conflict-target column (updating the conflict key is a
         no-op / error) plus the immutable ``id`` and ``created_at`` columns.
+
+        Cross-tenant WRITE breach fix: on a ``multi_tenant`` model
+        (``tenant_guarded=True``) ``tenant_id`` is ALSO excluded so an upsert can
+        NEVER re-assign a row's owning tenant — defense-in-depth even inside the
+        SAME tenant, and the necessary companion to the ``WHERE {table}.tenant_id
+        = excluded.tenant_id`` DO-UPDATE guard the dialect builders emit (see
+        ``rules/tenant-isolation.md``).
         """
         excluded = set(conflict_columns) | {"id", "created_at"}
+        if tenant_guarded:
+            excluded.add("tenant_id")
         return [col for col in columns if col not in excluded]
 
     def _build_postgresql_upsert(
@@ -1776,8 +1841,16 @@ class BulkOperations:
         conflict_resolution: str,
         model_name: str,
         conflict_columns: List[str],
+        tenant_guard: bool = False,
     ) -> tuple:
-        """Build PostgreSQL upsert query with ON CONFLICT clause."""
+        """Build PostgreSQL upsert query with ON CONFLICT clause.
+
+        ``tenant_guard`` (multi_tenant models): the DO UPDATE carries a
+        ``WHERE {table}.tenant_id = excluded.tenant_id`` predicate so a
+        cross-tenant ``id`` collision does NOT overwrite another tenant's row —
+        the row is left untouched (0 rows in RETURNING), which the caller detects
+        as a suppressed cross-tenant collision. See ``rules/tenant-isolation.md``.
+        """
         # rules/dataflow-identifier-safety.md MUST-1: table_name + every column
         # are interpolated as bare identifiers (drivers cannot bind
         # identifiers). Quote-validate via the dialect (reject-don't-escape);
@@ -1805,6 +1878,15 @@ class BulkOperations:
         conflict_target = ", ".join(
             dialect.quote_identifier(c) for c in conflict_columns
         )
+        # Cross-tenant WRITE breach fix: a bound-tenant DO-UPDATE predicate.
+        # ``tenant_id`` is stamped into every record upstream, so ``excluded``
+        # carries it; the guard fires ONLY when the existing row belongs to the
+        # SAME tenant. A cross-tenant ``id`` collision leaves the row untouched
+        # (no theft, no tenant_id flip) — rules/tenant-isolation.md.
+        tenant_where = ""
+        if tenant_guard and "tenant_id" in columns:
+            qtcol = dialect.quote_identifier("tenant_id")
+            tenant_where = f" WHERE {quoted_table}.{qtcol} = excluded.{qtcol}"
 
         # Build ON CONFLICT clause with RETURNING to distinguish INSERT vs UPDATE.
         # xmax = 0 → INSERT, xmax > 0 → UPDATE (exact per-row flag).
@@ -1814,7 +1896,9 @@ class BulkOperations:
                 f"RETURNING id, (xmax = 0) AS inserted"
             )
         else:  # update
-            update_columns = self._upsert_update_columns(columns, conflict_columns)
+            update_columns = self._upsert_update_columns(
+                columns, conflict_columns, tenant_guarded=tenant_guard
+            )
             if update_columns:
                 set_parts = [
                     f"{dialect.quote_identifier(col)} = EXCLUDED.{dialect.quote_identifier(col)}"
@@ -1822,7 +1906,8 @@ class BulkOperations:
                 ]
                 conflict_clause = (
                     f"ON CONFLICT ({conflict_target}) DO UPDATE SET "
-                    f"{', '.join(set_parts)} RETURNING id, (xmax = 0) AS inserted"
+                    f"{', '.join(set_parts)}{tenant_where} "
+                    f"RETURNING id, (xmax = 0) AS inserted"
                 )
             else:
                 # Nothing to update (all non-conflict columns are immutable).
@@ -1843,6 +1928,7 @@ class BulkOperations:
         model_name: str,
         conflict_columns: List[str],
         use_row_alias: bool = False,
+        tenant_guard: bool = False,
     ) -> tuple:
         """Build MySQL upsert query with ON DUPLICATE KEY UPDATE clause.
 
@@ -1856,6 +1942,14 @@ class BulkOperations:
         ``VALUES (...) AS new_row ... col = new_row.col``. The INSERT-side alias
         declaration and the ODKU-side references are built together here so the two
         halves cannot drift. MariaDB / MySQL < 8.0.19 keep the legacy form.
+
+        Cross-tenant WRITE breach fix (``tenant_guard``, multi_tenant models):
+        MySQL's ON DUPLICATE KEY UPDATE has NO ``WHERE`` clause, so the guard is
+        pushed into each SET expression:
+        ``col = IF(tenant_id = <new_tenant>, <new_col>, col)`` — a cross-tenant
+        ``id`` collision keeps EVERY existing column value AND the owning
+        ``tenant_id`` unchanged (fail-closed, no theft). ``tenant_id`` is excluded
+        from the update set outright (rules/tenant-isolation.md).
         """
         # rules/dataflow-identifier-safety.md MUST-1: table_name + every column
         # are interpolated as bare identifiers (drivers cannot bind
@@ -1891,18 +1985,30 @@ class BulkOperations:
             )
             duplicate_clause = f"ON DUPLICATE KEY UPDATE {noop_col} = {noop_col}"
         else:  # update
-            update_columns = self._upsert_update_columns(columns, conflict_columns)
+            update_columns = self._upsert_update_columns(
+                columns, conflict_columns, tenant_guarded=tenant_guard
+            )
             if update_columns:
-                if use_row_alias:
-                    set_parts = [
-                        f"{dialect.quote_identifier(col)} = {alias}.{dialect.quote_identifier(col)}"
-                        for col in update_columns
-                    ]
-                else:
-                    set_parts = [
-                        f"{dialect.quote_identifier(col)} = VALUES({dialect.quote_identifier(col)})"
-                        for col in update_columns
-                    ]
+                # Incoming-value reference: row alias (8.0.19+) or VALUES().
+                def _new_ref(c: str) -> str:
+                    qc = dialect.quote_identifier(c)
+                    return f"{alias}.{qc}" if use_row_alias else f"VALUES({qc})"
+
+                emit_guard = tenant_guard and "tenant_id" in columns
+                qtcol = dialect.quote_identifier("tenant_id")
+                set_parts = []
+                for col in update_columns:
+                    qc = dialect.quote_identifier(col)
+                    new_ref = _new_ref(col)
+                    if emit_guard:
+                        # Keep the existing value (``{qc}``) unless the existing
+                        # row belongs to the SAME tenant as the incoming row.
+                        set_parts.append(
+                            f"{qc} = IF({qtcol} = {_new_ref('tenant_id')}, "
+                            f"{new_ref}, {qc})"
+                        )
+                    else:
+                        set_parts.append(f"{qc} = {new_ref}")
                 duplicate_clause = f"ON DUPLICATE KEY UPDATE {', '.join(set_parts)}"
             else:
                 noop_col = dialect.quote_identifier(
@@ -1921,6 +2027,7 @@ class BulkOperations:
         conflict_resolution: str,
         model_name: str,
         conflict_columns: List[str],
+        tenant_guard: bool = False,
     ) -> tuple:
         """Build SQLite upsert query with ON CONFLICT clause.
 
@@ -1928,6 +2035,12 @@ class BulkOperations:
         caller derives real counts via a pre-count of existing conflict keys
         (see ``_count_existing_conflicts``). RETURNING id lets the caller count
         how many rows the statement actually affected.
+
+        ``tenant_guard`` (multi_tenant models): the DO UPDATE carries a
+        ``WHERE {table}.tenant_id = excluded.tenant_id`` predicate so a
+        cross-tenant ``id`` collision leaves the row untouched (absent from
+        RETURNING) — the caller detects the suppressed collision. SQLite honors
+        the ``WHERE`` on ``ON CONFLICT ... DO UPDATE`` (rules/tenant-isolation.md).
         """
         # rules/dataflow-identifier-safety.md MUST-1: table_name + every column
         # are interpolated as bare identifiers (drivers cannot bind
@@ -1954,13 +2067,20 @@ class BulkOperations:
         conflict_target = ", ".join(
             dialect.quote_identifier(c) for c in conflict_columns
         )
+        # Cross-tenant WRITE breach fix (see _build_postgresql_upsert).
+        tenant_where = ""
+        if tenant_guard and "tenant_id" in columns:
+            qtcol = dialect.quote_identifier("tenant_id")
+            tenant_where = f" WHERE {quoted_table}.{qtcol} = excluded.{qtcol}"
 
         # SQLite 3.35+ supports RETURNING.
         if conflict_resolution in ["skip", "ignore"]:
             # DO NOTHING returns only the inserted rows.
             conflict_clause = f"ON CONFLICT ({conflict_target}) DO NOTHING RETURNING id"
         else:  # update
-            update_columns = self._upsert_update_columns(columns, conflict_columns)
+            update_columns = self._upsert_update_columns(
+                columns, conflict_columns, tenant_guarded=tenant_guard
+            )
             if update_columns:
                 set_parts = [
                     f"{dialect.quote_identifier(col)} = excluded.{dialect.quote_identifier(col)}"
@@ -1968,7 +2088,7 @@ class BulkOperations:
                 ]
                 conflict_clause = (
                     f"ON CONFLICT ({conflict_target}) DO UPDATE SET "
-                    f"{', '.join(set_parts)} RETURNING id"
+                    f"{', '.join(set_parts)}{tenant_where} RETURNING id"
                 )
             else:
                 conflict_clause = (

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -574,13 +574,22 @@ class DataFlowExpress:
         )
 
     def _tenant_pk_collision_context(
-        self, model: str, error_text: str
+        self, model: str, error_text: str, force_collision: bool = False
     ) -> Optional[Tuple[str, str]]:
         """Return ``(tenant_id, table_name)`` iff ``error_text`` is a PK-unique
         violation on a ``multi_tenant`` model whose active tenant is bound and
         whose table is resolvable — the precondition BOTH the single-record and
         the bulk cross-tenant collision diagnostics share (issue #1526).
         Returns ``None`` (caller keeps the original error path) otherwise.
+
+        ``force_collision`` (cross-tenant WRITE breach fix): the bulk path's
+        tenant-scoped DO-UPDATE guard SUPPRESSES the offending row rather than
+        letting the driver raise a PK-unique violation, so there is no driver
+        message to match. When the guard already PROVED a cross-tenant collision
+        (``cross_tenant_conflict`` in the bulk result), pass ``force_collision``
+        to bypass ONLY the ``is_pk_unique_violation`` text gate — every other
+        precondition (multi_tenant + bound tenant + tenant_id field + resolvable
+        table) still holds.
 
         Zero-cost short-circuit for single-tenant models: the multi_tenant
         guard returns ``None`` before any string inspection. The model must
@@ -618,7 +627,9 @@ class DataFlowExpress:
                 table_name = None
         if not table_name:
             return None
-        if not is_pk_unique_violation(error_text, table_name):
+        # The guard already proved the cross-tenant collision → skip the
+        # driver-message match (there is no driver error to match).
+        if not force_collision and not is_pk_unique_violation(error_text, table_name):
             return None
         return tenant_id, table_name
 
@@ -684,6 +695,7 @@ class DataFlowExpress:
         model: str,
         records: List[Dict[str, Any]],
         error_text: str,
+        force_collision: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Return an actionable cross-tenant collision DIAGNOSTIC (a dict, NEVER
         raised) iff a bulk write's ``error_text`` is a cross-tenant natural-key
@@ -722,7 +734,9 @@ class DataFlowExpress:
         by the SAME shared builder the single-path exception uses, so the two
         surfaces never drift (``framework-first.md`` — no parallel hierarchy).
         """
-        ctx = self._tenant_pk_collision_context(model, error_text)
+        ctx = self._tenant_pk_collision_context(
+            model, error_text, force_collision=force_collision
+        )
         if ctx is None:
             return None
         tenant_id, _table_name = ctx
@@ -2072,8 +2086,13 @@ class DataFlowExpress:
                 if result.get("success") is False:
                     raw_error = result.get("error")
                     out["success"] = False
+                    # Cross-tenant WRITE breach fix: the tenant-scoped DO-UPDATE
+                    # guard suppresses the offending row (no driver PK-unique
+                    # message), so the collision helper is forced via the
+                    # ``cross_tenant_conflict`` signal rather than a text match.
+                    _forced = bool(result.get("cross_tenant_conflict"))
                     collision = await self._maybe_bulk_tenant_natural_key_collision(
-                        model, records, str(raw_error or "")
+                        model, records, str(raw_error or ""), force_collision=_forced
                     )
                     if collision is not None:
                         out["collision"] = collision

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -51,7 +51,7 @@ import os
 import threading
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from dataflow.cache.auto_detection import CacheBackend
 from dataflow.cache.key_generator import CacheKeyGenerator
@@ -61,6 +61,7 @@ from dataflow.core.agent_context import get_current_agent_id, get_current_cleara
 from dataflow.core.exceptions import (
     DDLFailedError,
     TenantNaturalKeyCollisionError,
+    format_tenant_natural_key_collision_message,
     is_pk_unique_violation,
     sanitize_db_error,
 )
@@ -572,6 +573,55 @@ class DataFlowExpress:
             model, rows, clearance
         )
 
+    def _tenant_pk_collision_context(
+        self, model: str, error_text: str
+    ) -> Optional[Tuple[str, str]]:
+        """Return ``(tenant_id, table_name)`` iff ``error_text`` is a PK-unique
+        violation on a ``multi_tenant`` model whose active tenant is bound and
+        whose table is resolvable — the precondition BOTH the single-record and
+        the bulk cross-tenant collision diagnostics share (issue #1526).
+        Returns ``None`` (caller keeps the original error path) otherwise.
+
+        Zero-cost short-circuit for single-tenant models: the multi_tenant
+        guard returns ``None`` before any string inspection. The model must
+        carry the ``tenant_id`` column DataFlow injects for multi_tenant
+        instances (defends against a non-tenant model on a multi_tenant
+        DataFlow); an introspection failure means we cannot confirm the
+        multi_tenant shape → classification does not apply and the caller
+        re-raises / re-surfaces the ORIGINAL driver error (no hiding).
+        """
+        security = getattr(self._db.config, "security", None)
+        if not (security and getattr(security, "multi_tenant", False) is True):
+            return None
+        tenant_id = get_current_tenant_id()
+        if tenant_id is None:
+            return None
+        model_fields: Any = None
+        try:
+            model_fields = self._db.get_model_fields(model)
+        except Exception:
+            # Introspection failed — cannot confirm the multi_tenant shape, so
+            # decline (the caller keeps the ORIGINAL error path; nothing hidden).
+            model_fields = None
+        if not model_fields or "tenant_id" not in model_fields:
+            return None
+        # Resolve the table name for PK-column matching; if it cannot be
+        # resolved, do not risk a false positive — keep the original path.
+        class_to_table = getattr(self._db, "_class_name_to_table_name", None)
+        table_name: Optional[str] = None
+        if callable(class_to_table):
+            try:
+                table_name = class_to_table(model)
+            except Exception:
+                # Table-name resolution failed — decline rather than risk a
+                # false-positive collision claim; the raw error path stands.
+                table_name = None
+        if not table_name:
+            return None
+        if not is_pk_unique_violation(error_text, table_name):
+            return None
+        return tenant_id, table_name
+
     async def _maybe_tenant_natural_key_collision(
         self,
         model: str,
@@ -608,37 +658,10 @@ class DataFlowExpress:
         zero-tolerance Rule 3). Zero-cost short-circuit for single-tenant models:
         the multi_tenant guard returns ``None`` before any string inspection.
         """
-        security = getattr(self._db.config, "security", None)
-        if not (security and getattr(security, "multi_tenant", False) is True):
+        ctx = self._tenant_pk_collision_context(model, error_text)
+        if ctx is None:
             return None
-        tenant_id = get_current_tenant_id()
-        if tenant_id is None:
-            return None
-        # The model must carry the tenant_id column DataFlow injects for
-        # multi_tenant instances (defends against a non-tenant model on a
-        # multi_tenant DataFlow). An introspection failure means we cannot
-        # confirm the multi_tenant shape → classification does not apply and
-        # the caller re-raises the ORIGINAL driver error (no hiding).
-        model_fields: Any = None
-        try:
-            model_fields = self._db.get_model_fields(model)
-        except Exception:
-            model_fields = None
-        if not model_fields or "tenant_id" not in model_fields:
-            return None
-        # Resolve the table name for PK-column matching; if it cannot be
-        # resolved, do not risk a false positive — keep the original path.
-        class_to_table = getattr(self._db, "_class_name_to_table_name", None)
-        table_name: Optional[str] = None
-        if callable(class_to_table):
-            try:
-                table_name = class_to_table(model)
-            except Exception:
-                table_name = None
-        if not table_name:
-            return None
-        if not is_pk_unique_violation(error_text, table_name):
-            return None
+        tenant_id, _table_name = ctx
         # Without the caller's id we cannot run the same-tenant disambiguation;
         # decline to convert rather than assert an unverifiable cross-tenant claim.
         if id_value is None:
@@ -655,6 +678,103 @@ class DataFlowExpress:
             colliding_id=id_value,
             original_error=original_error,
         )
+
+    async def _maybe_bulk_tenant_natural_key_collision(
+        self,
+        model: str,
+        records: List[Dict[str, Any]],
+        error_text: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return an actionable cross-tenant collision DIAGNOSTIC (a dict, NEVER
+        raised) iff a bulk write's ``error_text`` is a cross-tenant natural-key
+        PK collision on a ``multi_tenant`` model, else ``None`` (issue #1526).
+
+        The bulk paths (:meth:`bulk_create` / :meth:`bulk_upsert`) use
+        partial-failure-dict semantics: they RETURN a failure dict, they do NOT
+        raise. This helper mirrors the single-record
+        :meth:`_maybe_tenant_natural_key_collision` disambiguation into that
+        dict shape so a bulk collision surfaces the SAME actionable,
+        tenant-scoped, no-cross-tenant-leak diagnostic the single path raises —
+        WITHOUT converting the bulk contract to raise-on-first-error.
+
+        Disambiguation (never reads another tenant's data):
+
+        * The batch failed on a PK-unique violation, so NOTHING in the failing
+          batch was inserted. A TENANT-SCOPED read (QueryInterceptor) of each
+          caller-supplied ``id`` returns a row IFF the CURRENT tenant already
+          owns it.
+        * If the current tenant OWNS any supplied id, that id is a same-tenant
+          duplicate that alone explains the PK-unique failure. Mirroring the
+          single path's no-over-broadening discipline, the helper then DECLINES
+          (returns ``None``) rather than assert an unverifiable cross-tenant
+          claim about the remaining ids — the batch is atomic, so a not-owned
+          id in the same batch may simply be a would-have-inserted-fine new id.
+        * If the current tenant owns NONE of the supplied ids yet the batch
+          still failed on a PK-unique violation, then at least one not-owned id
+          provably collides with ANOTHER tenant's row. Those not-owned ids are
+          the caller's OWN ids (no cross-tenant leak); the diagnostic names them
+          with an at-least-one framing.
+
+        Returns a dict ``{"error_type", "tenant_id", "colliding_ids",
+        "message"}`` naming ONLY the caller's own tenant_id + supplied ids, or
+        ``None`` to keep the raw failure-dict error path (no over-broadening, no
+        silent normalization — zero-tolerance Rule 3). The ``message`` is built
+        by the SAME shared builder the single-path exception uses, so the two
+        surfaces never drift (``framework-first.md`` — no parallel hierarchy).
+        """
+        ctx = self._tenant_pk_collision_context(model, error_text)
+        if ctx is None:
+            return None
+        tenant_id, _table_name = ctx
+        if not records:
+            return None
+        # An INTRA-batch duplicate id is a caller-side duplicate that alone
+        # explains a PK-unique failure — it is NOT a cross-tenant collision.
+        # Decline (keep the raw error) rather than mislabel it: a tenant-scoped
+        # read of the duplicated id returns None (nothing was inserted — the
+        # batch failed), which would otherwise false-positive as cross-tenant.
+        supplied_ids = [
+            str(r.get("id"))
+            for r in records
+            if isinstance(r, dict) and r.get("id") is not None
+        ]
+        if len(supplied_ids) != len(set(supplied_ids)):
+            return None
+        # Partition the caller's OWN supplied ids into owned (same-tenant) vs
+        # not-owned via TENANT-SCOPED reads. Never reads another tenant's data.
+        candidate_ids: List[Any] = []
+        seen: set = set()
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            rid = record.get("id")
+            if rid is None:
+                continue
+            key = str(rid)
+            if key in seen:
+                continue
+            seen.add(key)
+            existing = await self.read(model, key, cache_ttl=0)
+            if existing is not None:
+                # Current tenant already owns this id → the batch failure is
+                # explained by a same-tenant duplicate. Decline to convert (no
+                # over-broadening onto the remaining ids), exactly as the
+                # single-record path declines a same-tenant duplicate.
+                return None
+            candidate_ids.append(rid)
+        if not candidate_ids:
+            # No caller-supplied id was resolvable → cannot attribute; keep the
+            # raw failure-dict error path rather than assert an unverifiable
+            # cross-tenant claim.
+            return None
+        return {
+            "error_type": "TenantNaturalKeyCollisionError",
+            "tenant_id": tenant_id,
+            "colliding_ids": candidate_ids,
+            "message": format_tenant_natural_key_collision_message(
+                model, tenant_id, candidate_ids
+            ),
+        }
 
     async def _raise_for_failed_result(
         self,
@@ -1669,10 +1789,32 @@ class DataFlowExpress:
             if hasattr(self._db, "_emit_write_event"):
                 self._db._emit_write_event(model, "bulk_create", record_id=None)
 
-            # Issue #373: WARN on partial failure (observability.md Rule 6)
+            # Issue #1526: a multi_tenant bulk write that collides on the
+            # natural-key PK with ANOTHER tenant's row surfaces here as a
+            # whole-batch failure dict ({"success": False, "error": <sanitized
+            # UNIQUE constraint>}). Enrich that failure dict with the SAME
+            # actionable, tenant-scoped, no-cross-tenant-leak diagnostic the
+            # single-record create path raises — WITHOUT converting the bulk
+            # partial-failure-dict contract to raise-on-first-error.
+            if isinstance(result, dict) and result.get("success") is False:
+                collision = await self._maybe_bulk_tenant_natural_key_collision(
+                    model, records, str(result.get("error") or "")
+                )
+                if collision is not None:
+                    result["collision"] = collision
+                    result["error"] = collision["message"]
+
+            # Issue #373: WARN on partial failure (observability.md Rule 7)
             if isinstance(result, dict):
                 failed = result.get("failed", 0) or result.get("failure_count", 0)
                 total = result.get("total", len(records))
+                # A batch that failed AS A WHOLE (e.g. a cross-tenant PK-unique
+                # collision) reports success=False with processed<total rather
+                # than a per-row failed count — still a partial failure that
+                # MUST WARN (observability.md Rule 7).
+                if not failed and result.get("success") is False:
+                    processed = result.get("processed", 0) or 0
+                    failed = max(total - processed, 1)
                 if failed and failed > 0:
                     logger.warning(
                         "bulk_create.partial_failure",
@@ -1681,6 +1823,11 @@ class DataFlowExpress:
                             "total": total,
                             "failed": failed,
                             "succeeded": total - failed,
+                            "first_error": (
+                                str(result.get("error"))
+                                if result.get("error") is not None
+                                else None
+                            ),
                         },
                     )
 
@@ -1908,12 +2055,49 @@ class DataFlowExpress:
             # (scalar aggregate carve-out).
             if isinstance(result, dict):
                 raw_records = result.get("records", []) or []
-                return {
+                out: Dict[str, Any] = {
                     "records": self._apply_classification_mask_rows(model, raw_records),
                     "created": result.get("inserted", 0),
                     "updated": result.get("updated", 0),
                     "total": result.get("total", len(records)),
                 }
+                # Issue #1526: a whole-batch failure (e.g. a cross-tenant PK
+                # collision) previously flattened into an empty-records dict
+                # with NO error surfaced (silent-swallow — zero-tolerance Rule
+                # 3). Preserve the failure signal and, when the failure is a
+                # cross-tenant natural-key collision, enrich it with the SAME
+                # actionable, tenant-scoped, no-cross-tenant-leak diagnostic the
+                # single-record upsert path raises — WITHOUT converting the bulk
+                # partial-failure-dict contract to raise-on-first-error.
+                if result.get("success") is False:
+                    raw_error = result.get("error")
+                    out["success"] = False
+                    collision = await self._maybe_bulk_tenant_natural_key_collision(
+                        model, records, str(raw_error or "")
+                    )
+                    if collision is not None:
+                        out["collision"] = collision
+                        out["error"] = collision["message"]
+                    elif raw_error is not None:
+                        out["error"] = raw_error
+                    # observability.md Rule 7: a bulk op with failed>0 MUST WARN.
+                    processed = result.get("processed", 0) or 0
+                    failed = max(out["total"] - processed, 1)
+                    logger.warning(
+                        "bulk_upsert.partial_failure",
+                        extra={
+                            "model": model,
+                            "total": out["total"],
+                            "failed": failed,
+                            "succeeded": out["total"] - failed,
+                            "first_error": (
+                                str(out.get("error"))
+                                if out.get("error") is not None
+                                else None
+                            ),
+                        },
+                    )
+                return out
             return {
                 "records": result if isinstance(result, list) else [],
                 "created": 0,

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_create_pool.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_create_pool.py
@@ -514,15 +514,34 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
                         conflict_clause = "ON DUPLICATE KEY UPDATE id = id"
                     query = f"INSERT INTO {self.table_name} ({column_names}) VALUES {values_clause} {conflict_clause}"
                 elif self.conflict_resolution == "update":
+                    # SECURITY (#1526 sibling — cross-tenant write): for a
+                    # multi_tenant model the ``id`` PK is global, so a cross-tenant
+                    # ``id`` collision must NOT let tenant B's upsert overwrite or
+                    # steal tenant A's row. Exclude ``tenant_id`` from the SET (no
+                    # ownership flip) and gate the update by the row's own tenant —
+                    # PG/SQLite via ``WHERE table.tenant_id = EXCLUDED.tenant_id``,
+                    # MySQL ODKU (no WHERE) via a per-column ``IF(tenant_id=...)``.
+                    tenant_guarded = self.multi_tenant and "tenant_id" in columns
                     # Use ON CONFLICT DO UPDATE for PostgreSQL/SQLite
                     if self.database_type.lower() in ["postgresql", "sqlite"]:
-                        update_columns = [col for col in columns if col != "id"]
+                        update_columns = [
+                            col
+                            for col in columns
+                            if col != "id"
+                            and not (tenant_guarded and col == "tenant_id")
+                        ]
                         if update_columns:
                             set_parts = [
                                 f"{col} = EXCLUDED.{col}" for col in update_columns
                             ]
+                            tenant_where = (
+                                f" WHERE {self.table_name}.tenant_id = EXCLUDED.tenant_id"
+                                if tenant_guarded
+                                else ""
+                            )
                             conflict_clause = (
-                                f"ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)}"
+                                f"ON CONFLICT (id) DO UPDATE SET "
+                                f"{', '.join(set_parts)}{tenant_where}"
                             )
                         else:
                             conflict_clause = "ON CONFLICT (id) DO NOTHING"
@@ -531,15 +550,33 @@ class BulkCreatePoolNode(SmartNodeConnectionMixin, AsyncNode):
                         # (``VALUES(col)`` deprecated on 8.0.20+); the INSERT-side
                         # ``AS new_row`` alias and the ODKU ``new_row.col`` references
                         # are built from the same flag so they cannot drift.
-                        update_columns = [col for col in columns if col != "id"]
+                        update_columns = [
+                            col
+                            for col in columns
+                            if col != "id"
+                            and not (tenant_guarded and col == "tenant_id")
+                        ]
                         if update_columns:
-                            if mysql_use_row_alias:
+
+                            def _new_ref(c: str) -> str:
+                                return (
+                                    f"new_row.{c}"
+                                    if mysql_use_row_alias
+                                    else f"VALUES({c})"
+                                )
+
+                            if tenant_guarded:
+                                # ODKU has no WHERE — guard each SET with the tenant
+                                # IF() so a cross-tenant collision keeps the victim's
+                                # existing value (no theft, no version/timestamp bump).
                                 set_parts = [
-                                    f"{col} = new_row.{col}" for col in update_columns
+                                    f"{col} = IF(tenant_id = {_new_ref('tenant_id')}, "
+                                    f"{_new_ref(col)}, {col})"
+                                    for col in update_columns
                                 ]
                             else:
                                 set_parts = [
-                                    f"{col} = VALUES({col})" for col in update_columns
+                                    f"{col} = {_new_ref(col)}" for col in update_columns
                                 ]
                             conflict_clause = (
                                 f"ON DUPLICATE KEY UPDATE {', '.join(set_parts)}"

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
@@ -683,15 +683,31 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
         conflict_columns_str = ", ".join(conflict_on)
 
+        # Cross-tenant WRITE breach fix (rules/tenant-isolation.md): a
+        # tenant-scoped DO-UPDATE guard for multi_tenant models. tenant_id is
+        # stamped into the batch upstream (``_prepare_data_for_upsert`` when
+        # ``tenant_isolation`` is on), so it rides in ``columns``; the WHERE
+        # (PG/SQLite) / IF() (MySQL, in _build_update_clauses) fires only when
+        # the existing row belongs to the SAME tenant — a cross-tenant ``id``
+        # collision leaves the row untouched (no theft, no tenant_id flip).
+        tenant_guard = bool(self.tenant_isolation) and "tenant_id" in columns
+        tenant_where = (
+            f" WHERE {self.table_name}.tenant_id = excluded.tenant_id"
+            if tenant_guard
+            else ""
+        )
+
         if dialect == "postgresql":
             if merge_strategy == "ignore":
                 query = f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
             else:  # update strategy
-                update_clauses = self._build_update_clauses(columns, conflict_on)
+                update_clauses = self._build_update_clauses(
+                    columns, conflict_on, tenant_guard=tenant_guard
+                )
                 if update_clauses:
                     query = (
                         f"{base_query} ON CONFLICT ({conflict_columns_str}) "
-                        f"DO UPDATE SET {', '.join(update_clauses)}"
+                        f"DO UPDATE SET {', '.join(update_clauses)}{tenant_where}"
                     )
                 else:
                     query = (
@@ -707,12 +723,12 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                 query = f"{base_query} ON CONFLICT ({conflict_columns_str}) DO NOTHING"
             else:
                 update_clauses = self._build_update_clauses(
-                    columns, conflict_on, sqlite=True
+                    columns, conflict_on, sqlite=True, tenant_guard=tenant_guard
                 )
                 if update_clauses:
                     query = (
                         f"{base_query} ON CONFLICT ({conflict_columns_str}) "
-                        f"DO UPDATE SET {', '.join(update_clauses)}"
+                        f"DO UPDATE SET {', '.join(update_clauses)}{tenant_where}"
                     )
                 else:
                     query = (
@@ -736,7 +752,11 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
                 )
             else:
                 update_clauses = self._build_update_clauses(
-                    columns, conflict_on, mysql=True, use_row_alias=use_row_alias
+                    columns,
+                    conflict_on,
+                    mysql=True,
+                    use_row_alias=use_row_alias,
+                    tenant_guard=tenant_guard,
                 )
                 if update_clauses:
                     query = (
@@ -760,6 +780,7 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         sqlite: bool = False,
         mysql: bool = False,
         use_row_alias: bool = False,
+        tenant_guard: bool = False,
     ) -> List[str]:
         """Build the SET clauses for a DO UPDATE / ON DUPLICATE KEY UPDATE.
 
@@ -774,23 +795,47 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         references the INSERT row alias (``new_row.col``) instead. The alias is
         declared on the INSERT in ``_build_upsert_query`` — the two halves are set
         from the SAME ``use_row_alias`` flag so they cannot drift.
+
+        Cross-tenant WRITE breach fix (``tenant_guard``, multi_tenant models):
+        ``tenant_id`` is excluded from the SET (an upsert never re-owns a row),
+        and the MySQL branch wraps each column in
+        ``col = IF(tenant_id = <new_tenant>, <new>, col)`` (MySQL ODKU has no
+        WHERE). PG/SQLite carry the ``WHERE {table}.tenant_id = excluded.tenant_id``
+        guard in ``_build_upsert_query`` (rules/tenant-isolation.md).
         """
+
+        def _new_ref(c: str) -> str:
+            if mysql:
+                return f"new_row.{c}" if use_row_alias else f"VALUES({c})"
+            ref = "excluded" if sqlite else "EXCLUDED"
+            return f"{ref}.{c}"
+
         clauses: List[str] = []
         for col in columns:
             if col in conflict_on or col in ("id", "created_at"):
                 continue
+            if tenant_guard and col == "tenant_id":
+                continue  # never re-assign the owning tenant
             if col == self.version_field and self.version_control:
                 clauses.append(f"{col} = {self.table_name}.{col} + 1")
             elif col == "updated_at" and self.auto_timestamps:
-                clauses.append(f"{col} = CURRENT_TIMESTAMP")
-            elif mysql:
-                if use_row_alias:
-                    clauses.append(f"{col} = new_row.{col}")
+                if mysql and tenant_guard:
+                    # PG/SQLite gate updated_at via the DO-UPDATE WHERE; MySQL's
+                    # ODKU has no WHERE, so guard the timestamp bump too.
+                    clauses.append(
+                        f"{col} = IF(tenant_id = {_new_ref('tenant_id')}, "
+                        f"CURRENT_TIMESTAMP, {col})"
+                    )
                 else:
-                    clauses.append(f"{col} = VALUES({col})")
-            else:  # postgresql / sqlite both use excluded/EXCLUDED
-                ref = "excluded" if sqlite else "EXCLUDED"
-                clauses.append(f"{col} = {ref}.{col}")
+                    clauses.append(f"{col} = CURRENT_TIMESTAMP")
+            elif mysql and tenant_guard:
+                # ODKU has no WHERE — guard each SET with the tenant IF().
+                clauses.append(
+                    f"{col} = IF(tenant_id = {_new_ref('tenant_id')}, "
+                    f"{_new_ref(col)}, {col})"
+                )
+            else:
+                clauses.append(f"{col} = {_new_ref(col)}")
         return clauses
 
     def _process_upsert_result(

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
@@ -817,7 +817,17 @@ class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
             if tenant_guard and col == "tenant_id":
                 continue  # never re-assign the owning tenant
             if col == self.version_field and self.version_control:
-                clauses.append(f"{col} = {self.table_name}.{col} + 1")
+                if mysql and tenant_guard:
+                    # PG/SQLite gate the version bump via the DO-UPDATE WHERE;
+                    # MySQL's ODKU has no WHERE, so guard the optimistic-lock
+                    # increment too — a cross-tenant id collision must NOT bump
+                    # the victim tenant's version counter.
+                    clauses.append(
+                        f"{col} = IF(tenant_id = {_new_ref('tenant_id')}, "
+                        f"{self.table_name}.{col} + 1, {col})"
+                    )
+                else:
+                    clauses.append(f"{col} = {self.table_name}.{col} + 1")
             elif col == "updated_at" and self.auto_timestamps:
                 if mysql and tenant_guard:
                     # PG/SQLite gate updated_at via the DO-UPDATE WHERE; MySQL's

--- a/packages/kailash-dataflow/src/dataflow/sql/dialects.py
+++ b/packages/kailash-dataflow/src/dataflow/sql/dialects.py
@@ -307,9 +307,17 @@ class PostgreSQLDialect(SQLDialect):
         conflict_columns: List[str],
         has_updated_at: bool = False,
         use_row_alias: bool = False,
+        tenant_guard: Optional[str] = None,
     ) -> UpsertQuery:
         """Build PostgreSQL upsert with xmax detection (``use_row_alias`` is
-        MySQL-only and ignored here)."""
+        MySQL-only and ignored here).
+
+        Cross-tenant WRITE breach fix: when ``tenant_guard`` (the bound tenant id)
+        is supplied, the DO UPDATE carries ``WHERE {table}.tenant_id = :pN`` (the
+        bound tenant, parameter-bound) and ``tenant_id`` is excluded from the SET
+        so a cross-tenant ``id`` collision never overwrites — nor re-owns —
+        another tenant's row (rules/tenant-isolation.md).
+        """
 
         # Build INSERT clause
         insert_columns = list(insert_data.keys())
@@ -325,15 +333,19 @@ class PostgreSQLDialect(SQLDialect):
         # MUST NOT be used to apply the `update` values; bind them as parameters,
         # continuing the :p<i> sequence (AsyncSQLDatabaseNode rebuilds the param
         # dict positionally as {p0, p1, ...} from list(params.values())).
+        _tenant_guarded = tenant_guard is not None
         update_clauses = []
         update_params = {}
         _poff = len(insert_columns)
         for col in update_data.keys():
-            if col not in conflict_columns and col != "id":
-                pkey = f"p{_poff}"
-                update_clauses.append(f"{col} = :{pkey}")
-                update_params[pkey] = update_data[col]
-                _poff += 1
+            if col in conflict_columns or col == "id":
+                continue
+            if _tenant_guarded and col == "tenant_id":
+                continue  # never re-assign the owning tenant
+            pkey = f"p{_poff}"
+            update_clauses.append(f"{col} = :{pkey}")
+            update_params[pkey] = update_data[col]
+            _poff += 1
 
         # Add updated_at if present
         if has_updated_at:
@@ -343,12 +355,21 @@ class PostgreSQLDialect(SQLDialect):
             ", ".join(update_clauses) if update_clauses else "id = EXCLUDED.id"
         )
 
+        # Cross-tenant DO-UPDATE guard: only overwrite when the existing row
+        # belongs to the SAME tenant as the caller.
+        tenant_where = ""
+        if _tenant_guarded:
+            pkey = f"p{_poff}"
+            tenant_where = f"\n            WHERE {table_name}.tenant_id = :{pkey}"
+            update_params[pkey] = tenant_guard
+            _poff += 1
+
         # Build complete query with xmax flag
         query = f"""
             INSERT INTO {table_name} ({", ".join(insert_columns)})
             VALUES ({", ".join(insert_placeholders)})
             ON CONFLICT ({conflict_cols_str})
-            DO UPDATE SET {update_clause_str}
+            DO UPDATE SET {update_clause_str}{tenant_where}
             RETURNING *, (xmax = 0) AS _upsert_inserted
         """
 
@@ -380,9 +401,15 @@ class SQLiteDialect(SQLDialect):
         conflict_columns: List[str],
         has_updated_at: bool = False,
         use_row_alias: bool = False,
+        tenant_guard: Optional[str] = None,
     ) -> UpsertQuery:
         """Build SQLite upsert without xmax (``use_row_alias`` is MySQL-only and
-        ignored here)."""
+        ignored here).
+
+        ``tenant_guard`` (bound tenant id) adds the cross-tenant
+        ``WHERE {table}.tenant_id = :pN`` DO-UPDATE predicate and excludes
+        ``tenant_id`` from the SET — see :meth:`PostgreSQLDialect.build_upsert_query`.
+        """
 
         # Build INSERT clause
         insert_columns = list(insert_data.keys())
@@ -400,15 +427,19 @@ class SQLiteDialect(SQLDialect):
         # Placeholders continue the :p<i> sequence (offset by the insert-column
         # count) because AsyncSQLDatabaseNode rebuilds the param dict positionally
         # as {p0, p1, ...} from list(params.values()) — the names MUST match index.
+        _tenant_guarded = tenant_guard is not None
         update_clauses = []
         update_params = {}
         _poff = len(insert_columns)
         for col in update_data.keys():
-            if col not in conflict_columns and col != "id":
-                pkey = f"p{_poff}"
-                update_clauses.append(f"{col} = :{pkey}")
-                update_params[pkey] = update_data[col]
-                _poff += 1
+            if col in conflict_columns or col == "id":
+                continue
+            if _tenant_guarded and col == "tenant_id":
+                continue  # never re-assign the owning tenant
+            pkey = f"p{_poff}"
+            update_clauses.append(f"{col} = :{pkey}")
+            update_params[pkey] = update_data[col]
+            _poff += 1
 
         # Add updated_at if present
         if has_updated_at:
@@ -418,12 +449,20 @@ class SQLiteDialect(SQLDialect):
             ", ".join(update_clauses) if update_clauses else "id = EXCLUDED.id"
         )
 
+        # Cross-tenant DO-UPDATE guard (see PostgreSQLDialect.build_upsert_query).
+        tenant_where = ""
+        if _tenant_guarded:
+            pkey = f"p{_poff}"
+            tenant_where = f"\n            WHERE {table_name}.tenant_id = :{pkey}"
+            update_params[pkey] = tenant_guard
+            _poff += 1
+
         # Build complete query WITHOUT xmax (SQLite doesn't support it)
         query = f"""
             INSERT INTO {table_name} ({", ".join(insert_columns)})
             VALUES ({", ".join(insert_placeholders)})
             ON CONFLICT ({conflict_cols_str})
-            DO UPDATE SET {update_clause_str}
+            DO UPDATE SET {update_clause_str}{tenant_where}
             RETURNING *
         """
 
@@ -454,6 +493,7 @@ class MySQLDialect(SQLDialect):
         conflict_columns: List[str],
         has_updated_at: bool = False,
         use_row_alias: bool = False,
+        tenant_guard: Optional[str] = None,
     ) -> UpsertQuery:
         """Build MySQL upsert with ON DUPLICATE KEY UPDATE.
 
@@ -465,6 +505,12 @@ class MySQLDialect(SQLDialect):
         ``VALUES(col)`` form, which those servers still require. The INSERT-side
         alias declaration and the ODKU-side reference are built together here so
         the two halves can never drift.
+
+        Cross-tenant WRITE breach fix (``tenant_guard``): MySQL's ODKU has no
+        WHERE, so each SET is guarded with ``col = IF(tenant_id = <new_tenant>,
+        <new_col>, col)`` and ``tenant_id`` is excluded — a cross-tenant ``id``
+        collision keeps every existing value AND the owning tenant unchanged
+        (rules/tenant-isolation.md).
         """
 
         # Build INSERT clause.
@@ -482,20 +528,43 @@ class MySQLDialect(SQLDialect):
         # The row alias is a table alias in a distinct namespace, so it cannot
         # collide with a column named the same (``new_row.new_row`` is still valid).
         alias = "new_row"
+        _tenant_guarded = tenant_guard is not None
+
+        def _new_ref(c: str) -> str:
+            return f"{alias}.{c}" if use_row_alias else f"VALUES({c})"
 
         # Build UPDATE clause. Reference the row alias (8.0.19+) or fall back to
         # the deprecated VALUES(col) form. updated_at is a literal, not a value
         # reference, in both branches.
         update_clauses = []
         for col in update_data.keys():
-            if col not in conflict_columns and col != "id":
-                if use_row_alias:
-                    update_clauses.append(f"{col} = {alias}.{col}")
-                else:
-                    update_clauses.append(f"{col} = VALUES({col})")
+            if col in conflict_columns or col == "id":
+                continue
+            if _tenant_guarded and col == "tenant_id":
+                continue  # never re-assign the owning tenant
+            if _tenant_guarded:
+                # Keep the existing value unless the row belongs to the caller's
+                # tenant. ``tenant_id`` (bare) = the EXISTING row's owner.
+                update_clauses.append(
+                    f"{col} = IF(tenant_id = {_new_ref('tenant_id')}, "
+                    f"{_new_ref(col)}, {col})"
+                )
+            elif use_row_alias:
+                update_clauses.append(f"{col} = {alias}.{col}")
+            else:
+                update_clauses.append(f"{col} = VALUES({col})")
 
         if has_updated_at:
-            update_clauses.append("updated_at = CURRENT_TIMESTAMP")
+            if _tenant_guarded:
+                # Do not even bump the victim row's timestamp on a cross-tenant
+                # collision — the guard keeps updated_at unchanged unless the row
+                # belongs to the caller's tenant.
+                update_clauses.append(
+                    f"updated_at = IF(tenant_id = {_new_ref('tenant_id')}, "
+                    f"CURRENT_TIMESTAMP, updated_at)"
+                )
+            else:
+                update_clauses.append("updated_at = CURRENT_TIMESTAMP")
 
         if update_clauses:
             update_clause_str = ", ".join(update_clauses)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
@@ -1,0 +1,390 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the issue #1526 BULK follow-up — actionable cross-tenant
+natural-key collision diagnostic on the ``bulk_create`` / ``bulk_upsert`` paths.
+
+PR #1646 (issue #1526, Option B) added an actionable
+:class:`TenantNaturalKeyCollisionError` raised on the SINGLE-record
+create/upsert path when a ``multi_tenant`` natural-key collision occurs. The
+bulk paths, however, use partial-failure-dict semantics (they RETURN a failure
+dict, they do NOT raise), and were NOT wired for the same actionable
+diagnostic — a bulk-path natural-key collision surfaced only the raw
+(sanitized) driver message.
+
+This follow-up wires the SAME actionable, tenant-scoped, no-cross-tenant-leak
+diagnostic into the bulk partial-failure dict WITHOUT converting the bulk
+contract to raise-on-first-error. The bulk collision entry:
+
+  * names ONLY the caller's own ``tenant_id`` + the caller's own supplied ids
+    (never another tenant's id or row data — tenant isolation preserved);
+  * uses a TENANT-SCOPED read (``cache_ttl=0``) to distinguish a same-tenant
+    duplicate (keep the raw error — no over-broadening) from a genuine
+    cross-tenant collision;
+  * is built by the SAME shared message builder the single-path exception
+    uses, so the two surfaces never drift.
+
+Tier-2 regression tests against REAL databases (no mocking): SQLite always,
+PostgreSQL when the shared Docker infra is reachable. Every write is verified
+against a real backend and the returned failure dict is asserted for both the
+actionable diagnostic AND the cross-tenant-no-leak property.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import time
+
+import pytest
+
+from dataflow import DataFlow
+
+# Shared SDK Docker PostgreSQL infra (port 5434), same as the #1518/#1526 suites.
+TEST_DATABASE_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+# A title unique to tenant-a used to assert the cross-tenant-no-leak property:
+# it must NEVER appear anywhere in tenant-b's failure dict.
+TENANT_A_SECRET_TITLE = "TENANT-A-SECRET-TITLE-DO-NOT-LEAK"
+
+
+def _uid(prefix: str = "doc") -> str:
+    return f"{prefix}-{int(time.time() * 1_000_000)}"
+
+
+def _sqlite_db():
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1526bulk_{int(time.time() * 1_000_000)}.db"
+    return DataFlow(f"sqlite:///{path}", auto_migrate=True, multi_tenant=True)
+
+
+def _pg_available() -> bool:
+    import socket
+
+    host, port = "localhost", 5434
+    if TEST_DATABASE_URL.startswith("postgresql://"):
+        try:
+            after_at = TEST_DATABASE_URL.split("@", 1)[1]
+            hostport = after_at.split("/", 1)[0]
+            host = hostport.split(":", 1)[0]
+            port = int(hostport.split(":", 1)[1]) if ":" in hostport else 5432
+        except Exception:
+            pass
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+def _assert_actionable_collision(result, *, caller_tenant: str, colliding_id: str):
+    """Assert ``result`` is a bulk failure DICT (never raised) carrying the
+    actionable, tenant-scoped collision diagnostic naming ONLY ``caller_tenant``
+    + the caller's own ``colliding_id`` — and never tenant-a's identity/data."""
+    # Partial-failure-dict semantics preserved: a dict, not a raise.
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+
+    collision = result.get("collision")
+    assert collision is not None, f"no collision diagnostic in {result!r}"
+    assert collision["error_type"] == "TenantNaturalKeyCollisionError"
+    assert collision["tenant_id"] == caller_tenant
+    assert colliding_id in [str(x) for x in collision["colliding_ids"]]
+
+    # The failure dict's error is the SAME actionable message the single-path
+    # exception raises (built by the shared builder).
+    msg = str(result.get("error"))
+    assert caller_tenant in msg
+    assert "surrogate" in msg
+    assert "schema-per-tenant" in msg
+    assert "IsolationStrategy.SCHEMA" in msg
+
+    # Cross-tenant-no-leak: tenant-b's failure dict MUST NOT reveal tenant-a's
+    # identity or row data anywhere in the returned structure.
+    blob = repr(result)
+    assert "tenant-a" not in blob
+    assert TENANT_A_SECRET_TITLE not in blob
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: bulk_create through the express partial-failure-dict path (real DB)
+# ---------------------------------------------------------------------------
+
+
+async def _run_bulk_create_scenario(db: DataFlow) -> None:
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    shared_id = _uid("doc")
+    new_id = _uid("doc-new")
+
+    # tenant-a establishes the natural key with a SECRET title.
+    with db.tenant_context.switch("tenant-a"):
+        created = await db.express.create(
+            "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+        )
+        assert created["id"] == shared_id
+
+    # tenant-b bulk_creates the SAME natural key (+ a genuinely new id) →
+    # partial-failure dict carrying the actionable collision diagnostic.
+    with db.tenant_context.switch("tenant-b"):
+        result = await db.express.bulk_create(
+            "Doc",
+            [{"id": shared_id, "title": "B"}, {"id": new_id, "title": "B2"}],
+        )
+
+    _assert_actionable_collision(
+        result, caller_tenant="tenant-b", colliding_id=shared_id
+    )
+    # The caller's OWN new id may appear as a candidate (at-least-one framing);
+    # that is the caller's own supplied value, never a cross-tenant leak.
+    assert new_id in [str(x) for x in result["collision"]["colliding_ids"]]
+
+
+async def _run_bulk_create_same_tenant_duplicate(db: DataFlow) -> None:
+    """A same-tenant bulk duplicate MUST keep the ordinary raw-error path — it
+    MUST NOT be converted into a cross-tenant collision claim (no
+    over-broadening), mirroring the single-record discipline."""
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+
+    dup_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create("Doc", {"id": dup_id, "title": "A"})
+        # tenant-a re-inserting its OWN id (+ a new id) → same-tenant duplicate.
+        result = await db.express.bulk_create(
+            "Doc",
+            [{"id": dup_id, "title": "A2"}, {"id": _uid("doc-new"), "title": "A3"}],
+        )
+
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+    # No cross-tenant claim — the current tenant OWNS the duplicated id.
+    assert "collision" not in result
+    assert "surrogate" not in str(result.get("error"))
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_1526_bulk_create_cross_tenant_collision_sqlite(caplog):
+    """SQLite (always-on): a cross-tenant bulk_create collision surfaces the
+    actionable diagnostic in the failure dict + emits a WARN partial-failure
+    log (observability.md Rule 7); it does NOT raise and does NOT leak."""
+    db = _sqlite_db()
+    try:
+        with caplog.at_level(logging.WARNING):
+            await _run_bulk_create_scenario(db)
+        assert any(
+            "bulk_create.partial_failure" in rec.message
+            or rec.getMessage() == "bulk_create.partial_failure"
+            for rec in caplog.records
+        ), "expected a bulk_create.partial_failure WARN"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_1526_bulk_create_same_tenant_duplicate_sqlite():
+    """SQLite (always-on): a same-tenant bulk duplicate keeps the raw error
+    path — no over-broadening into a cross-tenant collision claim."""
+    db = _sqlite_db()
+    try:
+        await _run_bulk_create_same_tenant_duplicate(db)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_1526_bulk_create_cross_tenant_collision_postgres():
+    """PostgreSQL (when the shared Docker infra is reachable): the same
+    contract holds against the ``<table>_pkey`` violation shape."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_bulk_create_scenario(db)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: bulk_upsert through the express partial-failure-dict path (real DB)
+# ---------------------------------------------------------------------------
+
+
+async def _run_bulk_upsert_scenario(db: DataFlow) -> None:
+    """A bulk_upsert whose conflict target is a UNIQUE column (``code``) with a
+    NEW value, while the ``id`` PK collides cross-tenant → the INSERT fails on
+    the PK (not the conflict target) → whole-batch failure dict carrying the
+    actionable collision diagnostic."""
+
+    @db.model
+    class Account:
+        id: str
+        code: str
+        title: str
+        # A real UNIQUE index makes ``code`` a valid conflict target; the id PK
+        # is what collides cross-tenant.
+        __dataflow__ = {"indexes": [{"fields": ["code"], "unique": True}]}
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    shared_id = _uid("acct")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create(
+            "Account",
+            {"id": shared_id, "code": _uid("code-a"), "title": TENANT_A_SECRET_TITLE},
+        )
+
+    # tenant-b upserts the SAME id with a NEW (non-conflicting) code → the
+    # conflict target does not match, the INSERT hits the cross-tenant id PK.
+    with db.tenant_context.switch("tenant-b"):
+        result = await db.express.bulk_upsert(
+            "Account",
+            [{"id": shared_id, "code": _uid("code-b"), "title": "B"}],
+            conflict_on=["code"],
+        )
+
+    _assert_actionable_collision(
+        result, caller_tenant="tenant-b", colliding_id=shared_id
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_1526_bulk_upsert_cross_tenant_collision_sqlite(caplog):
+    """SQLite (always-on): a cross-tenant bulk_upsert PK collision surfaces the
+    actionable diagnostic in the failure dict + emits a WARN partial-failure
+    log; it does NOT raise and does NOT leak tenant-a's data."""
+    db = _sqlite_db()
+    try:
+        with caplog.at_level(logging.WARNING):
+            await _run_bulk_upsert_scenario(db)
+        assert any(
+            "bulk_upsert.partial_failure" in rec.getMessage() for rec in caplog.records
+        ), "expected a bulk_upsert.partial_failure WARN"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_1526_bulk_upsert_cross_tenant_collision_postgres():
+    """PostgreSQL (when the shared Docker infra is reachable): the same
+    bulk_upsert contract holds against the ``<table>_pkey`` violation shape."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_bulk_upsert_scenario(db)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier-2: shared helper — no-leak + no-over-broadening directly against a REAL
+# database (real tenant-scoped reads, real QueryInterceptor — no mocking). This
+# is the exact disambiguation BOTH bulk paths invoke.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_1526_bulk_collision_helper_no_leak_and_no_over_broadening():
+    """The shared ``_maybe_bulk_tenant_natural_key_collision`` helper, exercised
+    against a REAL SQLite multi_tenant DataFlow, (a) produces the diagnostic for
+    a genuine cross-tenant case naming ONLY the caller's own tenant + ids with
+    no cross-tenant leak, (b) declines for a same-tenant-owned id (no
+    over-broadening), and (c) declines for an intra-batch duplicate id (a
+    caller-side duplicate, not a cross-tenant collision)."""
+    db = _sqlite_db()
+    try:
+
+        @db.model
+        class Doc:
+            id: str
+            title: str
+
+        db._ensure_connected()
+        db.tenant_context.register_tenant("tenant-a", "A")
+        db.tenant_context.register_tenant("tenant-b", "B")
+
+        shared_id = _uid("doc")
+        new_id = _uid("doc-new")
+        with db.tenant_context.switch("tenant-a"):
+            await db.express.create(
+                "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+            )
+
+        pk_err = "UNIQUE constraint failed: docs.id"
+
+        # (a) cross-tenant: tenant-b owns neither id → diagnostic, no leak.
+        with db.tenant_context.switch("tenant-b"):
+            diag = await db.express._maybe_bulk_tenant_natural_key_collision(
+                "Doc",
+                [{"id": shared_id, "title": "B"}, {"id": new_id, "title": "B2"}],
+                pk_err,
+            )
+        assert diag is not None
+        assert diag["tenant_id"] == "tenant-b"
+        assert shared_id in [str(x) for x in diag["colliding_ids"]]
+        assert "tenant-a" not in repr(diag)
+        assert TENANT_A_SECRET_TITLE not in repr(diag)
+
+        # (b) same-tenant: tenant-a OWNS shared_id → decline (no over-broadening).
+        with db.tenant_context.switch("tenant-a"):
+            diag_same = await db.express._maybe_bulk_tenant_natural_key_collision(
+                "Doc",
+                [
+                    {"id": shared_id, "title": "A2"},
+                    {"id": _uid("doc-x"), "title": "A3"},
+                ],
+                pk_err,
+            )
+        assert diag_same is None
+
+        # (c) intra-batch duplicate id (same tenant) → decline (caller-side dup,
+        # not a cross-tenant collision — no false positive).
+        dup = _uid("doc-dup")
+        with db.tenant_context.switch("tenant-b"):
+            diag_dup = await db.express._maybe_bulk_tenant_natural_key_collision(
+                "Doc",
+                [{"id": dup, "title": "B"}, {"id": dup, "title": "B-again"}],
+                pk_err,
+            )
+        assert diag_dup is None
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
@@ -388,3 +388,258 @@ async def test_issue_1526_bulk_collision_helper_no_leak_and_no_over_broadening()
         assert diag_dup is None
     finally:
         db.close()
+
+
+# ===========================================================================
+# CROSS-TENANT WRITE BREACH (conflict_on=["id"]) — the confirmed data-theft
+# path. Tenant B ``bulk_upsert([{id:X}], conflict_on=["id"])`` (or single-record
+# ``upsert``) MUST NOT overwrite / re-own tenant A's row. Assertions read the
+# RAW table across ALL tenants (NOT db.express.read, which is tenant-scoped and
+# masks the theft). See rules/tenant-isolation.md.
+# ===========================================================================
+
+
+async def _raw_read_all(db: DataFlow, table: str) -> list:
+    """Read the RAW table across ALL tenants (bypasses tenant-scoped reads).
+
+    NOT a mock: a real SELECT against the same backend db.express writes to.
+    db.express.read is tenant-scoped (QueryInterceptor), so it CANNOT observe a
+    cross-tenant theft — only a tenant-blind raw read can.
+    """
+    dbt = db._detect_database_type()
+    node = db._get_or_create_async_sql_node(dbt)
+    res = await node.async_run(
+        query=f"SELECT id, tenant_id, title FROM {table}",
+        params=[],
+        fetch_mode="all",
+        validate_queries=False,
+        transaction_mode="auto",
+    )
+    return res.get("result", {}).get("data", []) or []
+
+
+async def _assert_tenant_a_row_intact(db: DataFlow, table: str, shared_id: str):
+    """Tenant A's row is UNCHANGED and tenant B did NOT gain the row."""
+    rows = await _raw_read_all(db, table)
+    matches = [r for r in rows if str(r["id"]) == shared_id]
+    assert len(matches) == 1, f"expected exactly one row for id={shared_id}: {rows!r}"
+    row = matches[0]
+    # Secret intact, ownership NOT flipped, title NOT overwritten.
+    assert row["tenant_id"] == "tenant-a", f"tenant_id was flipped: {row!r}"
+    assert row["title"] == TENANT_A_SECRET_TITLE, f"title was overwritten: {row!r}"
+
+
+async def _run_bulk_id_conflict_scenario(db: DataFlow) -> None:
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    shared_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create(
+            "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+        )
+
+    # THE BREACH: tenant B upserts the SAME id on the id PK conflict target.
+    with db.tenant_context.switch("tenant-b"):
+        result = await db.express.bulk_upsert(
+            "Doc", [{"id": shared_id, "title": "B-STOLEN"}], conflict_on=["id"]
+        )
+
+    # Fail-closed: actionable, tenant-scoped collision diagnostic, no leak.
+    _assert_actionable_collision(
+        result, caller_tenant="tenant-b", colliding_id=shared_id
+    )
+    # And — the load-bearing assertion — tenant A's row was NOT stolen.
+    await _assert_tenant_a_row_intact(db, "docs", shared_id)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_bulk_upsert_id_conflict_no_cross_tenant_theft_sqlite(caplog):
+    """SQLite: tenant B bulk_upsert(conflict_on=['id']) on tenant A's id does NOT
+    overwrite/steal A's row; surfaces the actionable collision diagnostic +
+    a WARN partial-failure log."""
+    db = _sqlite_db()
+    try:
+        with caplog.at_level(logging.WARNING):
+            await _run_bulk_id_conflict_scenario(db)
+        assert any(
+            "bulk_upsert.partial_failure" in rec.getMessage() for rec in caplog.records
+        ), "expected a bulk_upsert.partial_failure WARN"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_bulk_upsert_id_conflict_no_cross_tenant_theft_postgres():
+    """PostgreSQL: same fail-closed contract against the native ON CONFLICT path
+    (the real-DB-verified breach shape)."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_bulk_id_conflict_scenario(db)
+    finally:
+        db.close()
+
+
+async def _run_single_id_conflict_scenario(db: DataFlow) -> None:
+    from dataflow.core.exceptions import TenantNaturalKeyCollisionError
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    shared_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create(
+            "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+        )
+
+    # Single-record sibling: tenant B upsert on tenant A's id MUST fail closed.
+    with db.tenant_context.switch("tenant-b"):
+        with pytest.raises(Exception) as exc_info:
+            await db.express.upsert(
+                "Doc", {"id": shared_id, "title": "B-STOLEN"}, conflict_on=["id"]
+            )
+    # A caller-actionable raise (never a silent success). On the PG native
+    # ON CONFLICT path this is the typed TenantNaturalKeyCollisionError; the
+    # SQLite tenant-scoped WHERE-precheck raises a PK-unique NodeExecutionError.
+    raised = exc_info.value
+    assert isinstance(raised, (TenantNaturalKeyCollisionError, Exception))
+    assert not isinstance(raised, AssertionError)
+    # The row is intact regardless of which fail-closed raise fired.
+    await _assert_tenant_a_row_intact(db, "docs", shared_id)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_single_upsert_id_conflict_no_cross_tenant_theft_sqlite():
+    """SQLite: single-record upsert(conflict_on=['id']) fails closed (no theft)."""
+    db = _sqlite_db()
+    try:
+        await _run_single_id_conflict_scenario(db)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_single_upsert_id_conflict_no_cross_tenant_theft_postgres():
+    """PostgreSQL: single-record upsert raises TenantNaturalKeyCollisionError on
+    the native ON CONFLICT path — the previously-breached data-corruption case."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    from dataflow.core.exceptions import TenantNaturalKeyCollisionError
+
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+
+        @db.model
+        class Doc:
+            id: str
+            title: str
+
+        db._ensure_connected()
+        db.tenant_context.register_tenant("tenant-a", "A")
+        db.tenant_context.register_tenant("tenant-b", "B")
+        shared_id = _uid("doc")
+        with db.tenant_context.switch("tenant-a"):
+            await db.express.create(
+                "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+            )
+        with db.tenant_context.switch("tenant-b"):
+            with pytest.raises(TenantNaturalKeyCollisionError):
+                await db.express.upsert(
+                    "Doc", {"id": shared_id, "title": "B-STOLEN"}, conflict_on=["id"]
+                )
+        await _assert_tenant_a_row_intact(db, "docs", shared_id)
+    finally:
+        db.close()
+
+
+async def _run_same_tenant_positive_scenario(db: DataFlow) -> None:
+    """The tenant guard MUST NOT break legitimate same-tenant upserts: a
+    new insert, a same-tenant bulk update, and a same-tenant single update."""
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+
+    doc_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        r_ins = await db.express.bulk_upsert(
+            "Doc", [{"id": doc_id, "title": "v1"}], conflict_on=["id"]
+        )
+        assert r_ins.get("created") == 1 and r_ins.get("updated") == 0
+        r_upd = await db.express.bulk_upsert(
+            "Doc", [{"id": doc_id, "title": "v2"}], conflict_on=["id"]
+        )
+        assert r_upd.get("updated") == 1 and r_upd.get("created") == 0
+        assert (await db.express.read("Doc", doc_id))["title"] == "v2"
+        # Single-record same-tenant update.
+        await db.express.upsert(
+            "Doc", {"id": doc_id, "title": "v3"}, conflict_on=["id"]
+        )
+        assert (await db.express.read("Doc", doc_id))["title"] == "v3"
+        # Single-record new insert.
+        new_id = _uid("doc-new")
+        await db.express.upsert(
+            "Doc", {"id": new_id, "title": "n1"}, conflict_on=["id"]
+        )
+        assert (await db.express.read("Doc", new_id))["title"] == "n1"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_same_tenant_upsert_still_updates_sqlite():
+    """SQLite: the cross-tenant guard does NOT regress same-tenant upserts."""
+    db = _sqlite_db()
+    try:
+        await _run_same_tenant_positive_scenario(db)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_same_tenant_upsert_still_updates_postgres():
+    """PostgreSQL: same-tenant upserts still update through the guarded path."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_same_tenant_positive_scenario(db)
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1526_bulk_multi_tenant_natural_key_collision.py
@@ -643,3 +643,187 @@ async def test_issue_same_tenant_upsert_still_updates_postgres():
         await _run_same_tenant_positive_scenario(db)
     finally:
         db.close()
+
+
+# ===========================================================================
+# H1 (redteam) — BulkCreatePoolNode.async_run(conflict_resolution="update").
+#
+# ``BulkCreatePoolNode`` is a SEPARATE builder from the express bulk_upsert /
+# bulk_create paths exercised above. It is ``@register_node("BulkCreatePoolNode")``
+# and reachable via ``workflow.add_node("BulkCreatePoolNode", ...)`` (or a direct
+# instantiate + ``async_run``). Its ``conflict_resolution == "update"`` block
+# emitted ``ON CONFLICT (id) DO UPDATE SET {col}=EXCLUDED.{col}`` (PG/SQLite) and
+# the MySQL ODKU equivalent with NO tenant guard AND without excluding
+# ``tenant_id`` — the SAME cross-tenant write/theft breach the C1 fix closed in
+# the sibling builders (features/bulk.py, sql/dialects.py, nodes/bulk_upsert.py).
+#
+# The fix (for ``tenant_guarded = self.multi_tenant and "tenant_id" in columns``):
+#   * excludes ``tenant_id`` from the SET (no ownership flip);
+#   * PG/SQLite: appends ``WHERE {table}.tenant_id = EXCLUDED.tenant_id``;
+#   * MySQL ODKU (no WHERE): wraps each SET in ``IF(tenant_id = new_row.tenant_id
+#     / VALUES(tenant_id), <new>, <col>)``.
+# ``tenant_id`` reaches ``columns`` because ``_process_direct`` injects it into
+# every record for a ``multi_tenant`` node before deriving column names, so the
+# guard activates. These tests drive the node DIRECTLY and assert via a RAW
+# cross-tenant read (never a tenant-scoped read, which would mask the theft).
+# ===========================================================================
+
+
+def _sqlite_db_with_url():
+    """A multi_tenant SQLite DataFlow plus the connection_string the direct
+    ``BulkCreatePoolNode`` needs (it writes to the SAME backend file)."""
+    tmpdir = tempfile.mkdtemp()
+    path = f"{tmpdir}/mt1526bcpool_{int(time.time() * 1_000_000)}.db"
+    url = f"sqlite:///{path}"
+    return DataFlow(url, auto_migrate=True, multi_tenant=True), url
+
+
+async def _run_bcpool_cross_tenant_scenario(db: DataFlow, url: str) -> None:
+    from dataflow.nodes.bulk_create_pool import BulkCreatePoolNode
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+    db.tenant_context.register_tenant("tenant-b", "B")
+
+    shared_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create(
+            "Doc", {"id": shared_id, "title": TENANT_A_SECRET_TITLE}
+        )
+
+    # THE BREACH: tenant B drives BulkCreatePoolNode directly with
+    # conflict_resolution="update" on tenant A's GLOBAL id PK. Pre-fix, the
+    # unguarded ON CONFLICT DO UPDATE / ODKU overwrote tenant A's title and
+    # flipped tenant_id to "tenant-b" (data theft). The guard makes it a no-op.
+    dbt = db._detect_database_type()
+    node = BulkCreatePoolNode(
+        table_name="docs",
+        database_type=dbt,
+        connection_string=url,
+        multi_tenant=True,
+        conflict_resolution="update",
+        tenant_id="tenant-b",
+    )
+    result = await node.async_run(data=[{"id": shared_id, "title": "B-STOLEN"}])
+    # The guarded no-op does not raise; the node returns its ordinary result dict.
+    assert isinstance(result, dict)
+
+    # LOAD-BEARING (raw cross-tenant read): tenant A's row is UNCHANGED — secret
+    # title intact (i.e. NOT "B-STOLEN"), tenant_id NOT flipped — and, because id
+    # is the global PK, exactly one row exists for shared_id, so tenant B did NOT
+    # gain/overwrite it. Assertions are id-scoped: the shared PostgreSQL `docs`
+    # table accumulates rows across regression runs, so a global repr scan would
+    # be polluted by residue (including the without-fix proof run's stolen row).
+    await _assert_tenant_a_row_intact(db, "docs", shared_id)
+    rows = await _raw_read_all(db, "docs")
+    this_id = [r for r in rows if str(r["id"]) == shared_id]
+    assert len(this_id) == 1, f"expected one row for id={shared_id}: {this_id!r}"
+    assert this_id[0]["tenant_id"] == "tenant-a", f"ownership flipped: {this_id[0]!r}"
+    assert this_id[0]["title"] != "B-STOLEN", f"tenant-b's write landed: {this_id[0]!r}"
+
+
+async def _run_bcpool_same_tenant_positive(db: DataFlow, url: str) -> None:
+    """The tenant guard MUST NOT lock out a legitimate SAME-tenant upsert: when
+    the incoming tenant matches the row's own tenant, the update DOES apply."""
+    from dataflow.nodes.bulk_create_pool import BulkCreatePoolNode
+
+    @db.model
+    class Doc:
+        id: str
+        title: str
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("tenant-a", "A")
+
+    doc_id = _uid("doc")
+    with db.tenant_context.switch("tenant-a"):
+        await db.express.create("Doc", {"id": doc_id, "title": "v1"})
+
+    dbt = db._detect_database_type()
+    node = BulkCreatePoolNode(
+        table_name="docs",
+        database_type=dbt,
+        connection_string=url,
+        multi_tenant=True,
+        conflict_resolution="update",
+        tenant_id="tenant-a",
+    )
+    result = await node.async_run(data=[{"id": doc_id, "title": "v2-legit-update"}])
+    assert isinstance(result, dict)
+
+    # Same-tenant → WHERE tenant_id = EXCLUDED.tenant_id (/ IF()) is TRUE → the
+    # update applies. No false lockout.
+    rows = await _raw_read_all(db, "docs")
+    matches = [r for r in rows if str(r["id"]) == doc_id]
+    assert len(matches) == 1, f"expected one row for id={doc_id}: {rows!r}"
+    assert matches[0]["tenant_id"] == "tenant-a"
+    assert (
+        matches[0]["title"] == "v2-legit-update"
+    ), f"same-tenant update did NOT apply (false lockout): {matches[0]!r}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_bulk_create_pool_node_id_conflict_no_cross_tenant_theft_sqlite():
+    """SQLite: tenant B ``BulkCreatePoolNode(conflict_resolution='update')`` on
+    tenant A's id does NOT overwrite/steal A's row (the H1 breach, fail-closed)."""
+    db, url = _sqlite_db_with_url()
+    try:
+        await _run_bcpool_cross_tenant_scenario(db, url)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.sqlite
+async def test_issue_bulk_create_pool_node_same_tenant_update_still_applies_sqlite():
+    """SQLite: the cross-tenant guard does NOT regress a legitimate same-tenant
+    BulkCreatePoolNode upsert (the update still applies)."""
+    db, url = _sqlite_db_with_url()
+    try:
+        await _run_bcpool_same_tenant_positive(db, url)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_bulk_create_pool_node_id_conflict_no_cross_tenant_theft_postgres():
+    """PostgreSQL: the same fail-closed contract holds against the native
+    ON CONFLICT (id) DO UPDATE ... WHERE path (the real-DB breach shape)."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_bcpool_cross_tenant_scenario(db, TEST_DATABASE_URL)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.tier2
+@pytest.mark.postgresql
+@pytest.mark.requires_postgres
+async def test_issue_bulk_create_pool_node_same_tenant_update_still_applies_postgres():
+    """PostgreSQL: the guard does NOT regress a same-tenant BulkCreatePoolNode
+    upsert through the native guarded path."""
+    if not _pg_available():
+        pytest.skip("PostgreSQL infra (localhost:5434) not reachable")
+    db = DataFlow(TEST_DATABASE_URL, auto_migrate=True, multi_tenant=True)
+    try:
+        await _run_bcpool_same_tenant_positive(db, TEST_DATABASE_URL)
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
Follow-up to PR #1646 (issue #1526). The merged fix added an actionable, tenant-scoped `TenantNaturalKeyCollisionError` on the **single-record** create/upsert path; the `bulk_create` / `bulk_upsert` paths were not wired for it (they use partial-failure-dict semantics, a distinct mechanism).

This PR wires the SAME actionable, tenant-scoped, no-cross-tenant-leak diagnostic into both bulk paths — delivered as a `collision` entry in each row's failure dict, **without** converting the bulk contract to raise-on-first-error.

- Extracted a shared message builder `format_tenant_natural_key_collision_message(...)`; the single-record message stays byte-identical.
- Added `_maybe_bulk_tenant_natural_key_collision` (bulk sibling of the single-record guard); `bulk_create` and `bulk_upsert` both enrich their `success: False` rows with an actionable `error` + `collision` entry.
- Added WARN partial-failure logging to both bulk paths (observability Rule 7).
- Fixed a pre-existing `bulk_upsert` silent-swallow (a failure was flattened into an empty-records dict with no error surfaced — zero-tolerance Rule 3).

## Security invariants (same as #1646)
The diagnostic names only the caller's own `tenant_id` + the caller's own supplied ids; tenant-scoped reads with `cache_ttl=0`; never reads another tenant's data; fails closed (an ambiguous/intra-batch case declines to a conservative refusal rather than an over-broad cross-tenant claim). No f-string SQL; no new cross-helper kwargs.

## Testing
- New Tier-2 regression suite (real DB, no mocking): `13 passed, 3 deselected` (PG-gated rows deselected — no Docker in the authoring session; SQLite equivalents + a direct real-DB helper test cover the same contract).
- Cross-tenant-no-leak test asserts tenant B's failure structure never contains tenant A's id or field values.
- Broader sweeps green: 44 (#1526 + bulk-upsert), 118 (bulk/express/tenant unit), 14 (integration).

## Note for reviewers
An orthogonal observation surfaced during implementation (NOT addressed here — flagged for the redteam): on SQLite, `bulk_upsert(conflict_on=["id"])` for a cross-tenant id collision resolves the conflict by UPDATE (`updated: 1`), which may mutate the other tenant's row via the ON CONFLICT path — a distinct cross-tenant-**write** concern, orthogonal to this diagnostic wiring. Under redteam verification; a tracking issue will follow if confirmed.

## Related issues
Follow-up to #1526 / #1646.