### PR TITLE
fix(pact): harden EATP + outbound trust dataclasses (redteam M1/L1/L2)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/trust/governance/outbound.py
+++ b/packages/kailash-kaizen/src/kaizen/trust/governance/outbound.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import inspect
 import logging
 from typing import Any, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 from kailash.trust.pact.outbound import (
     EffectKind,
@@ -46,7 +47,47 @@ __all__ = [
     "GovernedToolInvoker",
     "GovernedHTTPClient",
     "resolve_interceptor",
+    "redact_http_target",
 ]
+
+# Grep-safe sentinel returned when a request URL cannot be parsed -- distinct
+# from any successful redaction so it is never mistaken for a real target and a
+# malformed credential-bearing string never reaches the audit record.
+_REDACTED_URL_SENTINEL = "<redacted url>"
+
+
+def redact_http_target(url: str) -> str:
+    """Strip credentials from a request URL before it becomes an audit target.
+
+    The raw request URL flows verbatim from :class:`GovernedHTTPClient` into
+    :class:`~kailash.trust.pact.outbound.OutboundEffect`'s ``target`` field, and
+    from there into the :class:`~kailash.trust.pact.outbound.OutboundVerdict`,
+    the bounded audit deque, any ``audit_sink``, and
+    :class:`~kailash.trust.pact.outbound.OutboundEffectRefused`'s ``details``.
+    A URL carrying userinfo (``https://user:pass@host``) or a secret query
+    parameter (``?api_key=...``) would therefore write a credential into the
+    audit trail -- the ``rules/security.md`` § "No secrets in logs" failure mode.
+
+    This keeps ONLY ``scheme://host[:port]/path`` -- everything the audit trail
+    needs for observability -- and drops BOTH credential vectors: the userinfo
+    component AND the entire query string (and fragment). Fail-closed: a value
+    that cannot be parsed as a URL is reduced to :data:`_REDACTED_URL_SENTINEL`
+    rather than echoed verbatim.
+    """
+    if not isinstance(url, str) or not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname or ""
+        if ":" in host:  # IPv6 literal -- re-bracket it
+            host = f"[{host}]"
+        netloc = host
+        if parts.port:
+            netloc = f"{netloc}:{parts.port}"
+        # Drop userinfo, query, and fragment; keep scheme://host[:port]/path.
+        return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    except (ValueError, AttributeError):
+        return _REDACTED_URL_SENTINEL
 
 
 def resolve_interceptor(
@@ -255,7 +296,9 @@ class GovernedHTTPClient:
         return OutboundEffect(
             kind=EffectKind.HTTP,
             operation=f"http.{str(method).upper()}",
-            target=str(url),
+            # Redact credentials (userinfo + query) before the URL becomes the
+            # audit target -- it flows verbatim into the audit trail otherwise.
+            target=redact_http_target(str(url)),
             cost_estimate=cost,
             caller=self._caller,
         )

--- a/packages/kailash-kaizen/tests/unit/trust/governance/test_outbound_url_redaction.py
+++ b/packages/kailash-kaizen/tests/unit/trust/governance/test_outbound_url_redaction.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for L1 (LOW) -- HTTP target URL credential leak into the audit trail.
+
+Wave-2 holistic /redteam finding against #1517-b outbound governance:
+``GovernedHTTPClient._effect_builder`` set ``OutboundEffect.target`` to the RAW
+request URL, which flows verbatim into ``OutboundVerdict``, the bounded audit
+deque, any ``audit_sink``, and ``OutboundEffectRefused.details``. A URL with
+userinfo (``https://user:pass@host``) or a secret query parameter
+(``?api_key=...``) thus wrote a credential into the audit record
+(``rules/security.md`` § "No secrets in logs").
+
+Fix: redact the URL (strip userinfo AND the query string, keep
+``scheme://host[:port]/path``) before it becomes the audit target.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.trust.governance.outbound import (
+    GovernedHTTPClient,
+    redact_http_target,
+)
+from kailash.trust.pact.outbound import (
+    EffectGovernor,
+    OutboundEffect,
+    OutboundEffectInterceptor,
+    OutboundEffectRefused,
+    OutboundVerdict,
+)
+
+pytestmark = pytest.mark.regression
+
+_SECRET_URL = "https://alice:s3cr3t@api.example.com:8443/v1/users?api_key=topsecret&x=1"
+
+
+# --------------------------------------------------------------------------- #
+# Pure helper
+# --------------------------------------------------------------------------- #
+def test_redact_strips_userinfo_and_query():
+    redacted = redact_http_target(_SECRET_URL)
+    assert redacted == "https://api.example.com:8443/v1/users"
+    for leak in ("alice", "s3cr3t", "api_key", "topsecret"):
+        assert leak not in redacted
+
+
+def test_redact_keeps_clean_url_path():
+    assert redact_http_target("https://host/a/b") == "https://host/a/b"
+
+
+def test_redact_strips_query_even_without_userinfo():
+    assert redact_http_target("https://host/p?api_key=leak") == "https://host/p"
+
+
+def test_redact_handles_ipv6_host():
+    assert (
+        redact_http_target("https://u:p@[2001:db8::1]:443/p?token=x")
+        == "https://[2001:db8::1]:443/p"
+    )
+
+
+def test_redact_unparseable_url_returns_sentinel_not_verbatim():
+    # An invalid port makes urlsplit().port raise ValueError -> fail-closed sentinel.
+    out = redact_http_target("http://user:pass@host:notaport/p?api_key=leak")
+    assert out == "<redacted url>"
+    assert "pass" not in out and "leak" not in out
+
+
+def test_redact_empty_and_nonstring():
+    assert redact_http_target("") == ""
+    assert redact_http_target(None) == ""  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the governed HTTP client (audit trail + refusal details)
+# --------------------------------------------------------------------------- #
+class _AllowGovernor(EffectGovernor):
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        return OutboundVerdict(
+            allowed=True, level="auto_approved", reason="ok", effect=effect
+        )
+
+
+class _DenyGovernor(EffectGovernor):
+    def evaluate(self, effect: OutboundEffect) -> OutboundVerdict:
+        return OutboundVerdict(
+            allowed=False, level="blocked", reason="denied", effect=effect
+        )
+
+
+def test_audit_record_target_has_secret_stripped():
+    interceptor = OutboundEffectInterceptor(_AllowGovernor())
+    client = GovernedHTTPClient(
+        request_fn=lambda method, url, **kw: {"status": 200},
+        interceptor=interceptor,
+        caller="Eng-CTO",
+    )
+    client.request("GET", _SECRET_URL)
+
+    target = interceptor.audit_log()[-1].effect.target
+    assert target == "https://api.example.com:8443/v1/users"
+    for leak in ("alice", "s3cr3t", "api_key", "topsecret"):
+        assert leak not in target
+
+
+def test_refusal_details_target_has_secret_stripped():
+    interceptor = OutboundEffectInterceptor(_DenyGovernor())
+    client = GovernedHTTPClient(
+        request_fn=lambda method, url, **kw: {"status": 200},
+        interceptor=interceptor,
+        caller="Eng-CTO",
+    )
+    with pytest.raises(OutboundEffectRefused) as exc:
+        client.request("POST", _SECRET_URL)
+
+    details_target = exc.value.details["target"]
+    assert details_target == "https://api.example.com:8443/v1/users"
+    for leak in ("alice", "s3cr3t", "api_key", "topsecret"):
+        assert leak not in details_target

--- a/src/kailash/trust/pact/attestation.py
+++ b/src/kailash/trust/pact/attestation.py
@@ -91,7 +91,7 @@ def posture_can_reidentify(
     return ceiling >= required_clearance
 
 
-@dataclass
+@dataclass(frozen=True)
 class ClearanceAttestation:
     """A posture-gated re-identification attestation with a citable JCS hash.
 

--- a/src/kailash/trust/pact/bilateral.py
+++ b/src/kailash/trust/pact/bilateral.py
@@ -149,7 +149,7 @@ def _root_of(role_address: str) -> str:
     return role_address.split("-", 1)[0]
 
 
-@dataclass
+@dataclass(frozen=True)
 class PartyAnchor:
     """A citable reference to one party's audit anchor in a bilateral delegation.
 
@@ -216,7 +216,7 @@ class PartyAnchor:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class BilateralDelegation:
     """An atomic two-party delegation with a citable, JCS-hashed envelope.
 

--- a/src/kailash/trust/pact/outbound.py
+++ b/src/kailash/trust/pact/outbound.py
@@ -237,6 +237,10 @@ class OutboundVerdict:
         reason: Human-readable explanation.
         effect: The effect this verdict is about.
         governance: Structured governance detail (e.g. GovernanceVerdict.to_dict()).
+            Stored read-only (MappingProxyType): frozen=True blocks rebinding the
+            field, and the proxy blocks mutating the dict CONTENTS -- together they
+            make the guarantee "an audited decision cannot be mutated after the
+            fact" hold for the nested detail too, not just the top-level fields.
         timestamp: When the verdict was issued (UTC).
     """
 
@@ -244,8 +248,17 @@ class OutboundVerdict:
     level: str
     reason: str
     effect: OutboundEffect
-    governance: dict[str, Any] = field(default_factory=dict)
+    governance: Mapping[str, Any] = field(default_factory=dict)
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        # Freeze the governance detail into a read-only view. frozen=True already
+        # prevents rebinding self.governance; wrapping the value in a
+        # MappingProxyType additionally prevents mutating its CONTENTS after the
+        # verdict is recorded. Mirrors the OutboundEffect.metadata pattern.
+        object.__setattr__(
+            self, "governance", MappingProxyType(dict(self.governance or {}))
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -253,7 +266,9 @@ class OutboundVerdict:
             "level": self.level,
             "reason": self.reason,
             "effect": self.effect.to_dict(),
-            "governance": self.governance,
+            # Copy the read-only view back to a plain, JSON-serializable dict so
+            # to_dict() round-trips (json.dumps rejects MappingProxyType).
+            "governance": dict(self.governance),
             "timestamp": self.timestamp.isoformat(),
         }
 

--- a/src/kailash/trust/pact/verify_chain.py
+++ b/src/kailash/trust/pact/verify_chain.py
@@ -65,7 +65,7 @@ class ChainVerdict(str, Enum):
     DENY = "deny"
 
 
-@dataclass
+@dataclass(frozen=True)
 class ChainLink:
     """One link in a verification chain.
 
@@ -119,7 +119,7 @@ class ChainLink:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ChainResult:
     """The composed verdict of a :func:`verify_chain` evaluation.
 

--- a/src/kailash/trust/pact/weft.py
+++ b/src/kailash/trust/pact/weft.py
@@ -140,7 +140,7 @@ class MissingGateError(WeftError):
     """
 
 
-@dataclass
+@dataclass(frozen=True)
 class WeftEvent:
     """A single citable, hash-chained WEFT provenance event.
 

--- a/tests/regression/test_frozen_trust_dataclasses_redteam.py
+++ b/tests/regression/test_frozen_trust_dataclasses_redteam.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the wave-2 holistic /redteam trust-plane hardening.
+
+Findings hardened here (all against code merged this session -- #1592 EATP v3 +
+#1517-b outbound governance):
+
+* **M1 (MED)** -- the security-critical EATP dataclasses enforced their
+  construction-time invariants ONLY at ``__post_init__`` (cross-root federation
+  denial, re-identification clearance gate, hash-chain linkage, deny-overrides
+  verdict). Because they were plain ``@dataclass`` (mutable), an attacker could
+  construct a VALID instance and then reassign a field with NO re-validation,
+  bypassing the gate. The fix makes them ``@dataclass(frozen=True)`` (per
+  ``trust-plane-security.md`` MUST-NOT-4 / ``eatp.md``). These tests assert
+  (a) post-construction assignment raises ``FrozenInstanceError``, (b) the
+  construct-valid-then-mutate bypass now raises, and (c) ``from_dict(to_dict(x))``
+  still round-trips.
+
+* **L2 (LOW)** -- ``OutboundVerdict`` was ``frozen=True`` but its ``governance``
+  dict's CONTENTS stayed mutable, weakening the "an audited decision cannot be
+  mutated after the fact" guarantee. The fix wraps ``governance`` in a
+  ``MappingProxyType`` at construction; ``to_dict`` copies back to a plain dict.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from kailash.trust import ConfidentialityLevel
+from kailash.trust.pact.attestation import (
+    ClearanceAttestation,
+    new_clearance_attestation,
+)
+from kailash.trust.pact.audit import SCHEMA_VERSION_V3
+from kailash.trust.pact.bilateral import (
+    BilateralDelegation,
+    PartyAnchor,
+    SignerKind,
+    new_bilateral_delegation,
+)
+from kailash.trust.pact.outbound import EffectKind, OutboundEffect, OutboundVerdict
+from kailash.trust.pact.verify_chain import ChainLink, ChainVerdict
+from kailash.trust.pact.weft import WeftEvent, WeftKind
+
+pytestmark = pytest.mark.regression
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / builders
+# --------------------------------------------------------------------------- #
+def _party(addr: str, ref: str = "sha256:anchor") -> PartyAnchor:
+    return PartyAnchor(role_address=addr, anchor_ref=ref, signer_kind=SignerKind.PARTY)
+
+
+def _valid_delegation() -> BilateralDelegation:
+    return new_bilateral_delegation(
+        delegation_id="del-1",
+        root="Eng",
+        delegator=_party("Eng-CTO"),
+        delegate=_party("Eng-Dev"),
+        ts="2026-07-10T00:00:00Z",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# M1 -- PartyAnchor
+# --------------------------------------------------------------------------- #
+def test_party_anchor_is_frozen():
+    anchor = _party("Eng-CTO")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        anchor.signer_kind = SignerKind.DISPATCHER  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        anchor.anchor_ref = "sha256:forged"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# M1 -- BilateralDelegation (cross-root federation gate)
+# --------------------------------------------------------------------------- #
+def test_bilateral_delegation_is_frozen():
+    delegation = _valid_delegation()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        delegation.root = "Acme"  # type: ignore[misc]
+
+
+def test_bilateral_delegation_cross_root_gate_cannot_be_mutation_bypassed():
+    """Construct a valid single-root delegation, then try to swap the delegator
+    for a FOREIGN-root anchor. The cross-root gate only runs at construction, so
+    before the freeze this reassignment silently produced a cross-root delegation
+    that was never re-validated. Frozen=True now blocks the reassignment."""
+    delegation = _valid_delegation()
+    foreign = _party("Acme-CFO")  # different D/T/R root
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        delegation.delegator = foreign  # type: ignore[misc]
+    # The gate still fires the legitimate way -- at construction.
+    from kailash.trust.pact.bilateral import CrossRootFederationError
+
+    with pytest.raises(CrossRootFederationError):
+        BilateralDelegation(
+            schema_version=SCHEMA_VERSION_V3,
+            delegation_id="del-x",
+            root="Eng",
+            delegator=foreign,  # Acme root != Eng
+            delegate=_party("Eng-Dev"),
+            ts="2026-07-10T00:00:00Z",
+        )
+
+
+def test_bilateral_delegation_roundtrip_survives_freeze():
+    delegation = _valid_delegation()
+    assert BilateralDelegation.from_dict(delegation.to_dict()) == delegation
+
+
+# --------------------------------------------------------------------------- #
+# M1 -- ClearanceAttestation (re-identification clearance gate)
+# --------------------------------------------------------------------------- #
+def test_clearance_attestation_is_frozen():
+    att = new_clearance_attestation(
+        attestation_id="att-1",
+        subject_ref="pseudo-123",
+        required_clearance=ConfidentialityLevel.SECRET,
+        ts="2026-07-10T00:00:00Z",
+        attested_by_role_address="Eng-CTO",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        att.required_clearance = ConfidentialityLevel.PUBLIC  # type: ignore[misc]
+
+
+def test_clearance_attestation_reid_gate_cannot_be_lowered_by_mutation():
+    """The re-identification gate reads ``required_clearance``. Before the freeze,
+    an attacker could construct a SECRET-gated attestation and then lower it to
+    PUBLIC, re-identifying a subject their posture could never clear."""
+    att = new_clearance_attestation(
+        attestation_id="att-2",
+        subject_ref="pseudo-456",
+        required_clearance=ConfidentialityLevel.SECRET,
+        ts="2026-07-10T00:00:00Z",
+        attested_by_role_address="Eng-CTO",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        att.required_clearance = ConfidentialityLevel.PUBLIC  # type: ignore[misc]
+
+
+def test_clearance_attestation_roundtrip_survives_freeze():
+    att = new_clearance_attestation(
+        attestation_id="att-3",
+        subject_ref="pseudo-789",
+        required_clearance=ConfidentialityLevel.CONFIDENTIAL,
+        ts="2026-07-10T00:00:00Z",
+        attested_by_role_address="Eng-CTO",
+        payload={"k": "v"},
+    )
+    assert ClearanceAttestation.from_dict(att.to_dict()) == att
+
+
+# --------------------------------------------------------------------------- #
+# M1 -- WeftEvent (hash-chain linkage invariant)
+# --------------------------------------------------------------------------- #
+def test_weft_event_is_frozen_and_chain_link_immutable():
+    event = WeftEvent(
+        schema_version=SCHEMA_VERSION_V3,
+        kind=WeftKind.MINT,
+        ts="2026-07-10T00:00:00Z",
+        session="s-1",
+        identity_ref="Eng-CTO",
+        prev_link="sha256:parent",
+    )
+    # content_hash still computes over the (now immutable) envelope.
+    assert event.content_hash().startswith("sha256:")
+    # An attacker cannot re-thread the chain by rewriting prev_link/payload.
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        event.prev_link = "sha256:forged-parent"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        event.kind = WeftKind.DISTRIBUTE  # type: ignore[misc]
+
+
+def test_weft_event_roundtrip_survives_freeze():
+    event = WeftEvent(
+        schema_version=SCHEMA_VERSION_V3,
+        kind=WeftKind.MINT,
+        ts="2026-07-10T00:00:00Z",
+        session="s-1",
+        identity_ref="Eng-CTO",
+        payload={"a": 1},
+        prev_link=None,
+    )
+    assert WeftEvent.from_dict(event.to_dict()) == event
+
+
+# --------------------------------------------------------------------------- #
+# M1 -- ChainLink (deny-overrides verdict gate)
+# --------------------------------------------------------------------------- #
+def test_chain_link_deny_verdict_cannot_be_flipped_to_allow():
+    """A DENY link denies the whole chain (deny-overrides). Before the freeze an
+    attacker could construct a DENY link and flip ``.verdict`` to ALLOW."""
+    link = ChainLink(link_id="link-1", verdict=ChainVerdict.DENY, reason="blocked")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        link.verdict = ChainVerdict.ALLOW  # type: ignore[misc]
+
+
+def test_chain_link_roundtrip_survives_freeze():
+    link = ChainLink(link_id="link-2", verdict=ChainVerdict.ALLOW, reason="ok")
+    assert ChainLink.from_dict(link.to_dict()) == link
+
+
+# --------------------------------------------------------------------------- #
+# L2 -- OutboundVerdict.governance is deeply immutable
+# --------------------------------------------------------------------------- #
+def _verdict(governance: dict) -> OutboundVerdict:
+    return OutboundVerdict(
+        allowed=True,
+        level="auto_approved",
+        reason="ok",
+        effect=OutboundEffect(kind=EffectKind.HTTP, operation="http.GET"),
+        governance=governance,
+    )
+
+
+def test_outbound_verdict_governance_contents_are_immutable():
+    verdict = _verdict({"x": 0, "nested": {"y": 1}})
+    # frozen=True already blocks rebinding the field...
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        verdict.governance = {"evil": True}  # type: ignore[misc]
+    # ...and MappingProxyType now blocks mutating its CONTENTS.
+    with pytest.raises(TypeError):
+        verdict.governance["x"] = 1  # type: ignore[index]
+    with pytest.raises(TypeError):
+        del verdict.governance["x"]  # type: ignore[misc]
+
+
+def test_outbound_verdict_to_dict_returns_plain_mutable_dict():
+    verdict = _verdict({"x": 0})
+    d = verdict.to_dict()
+    gov = d["governance"]
+    assert type(gov) is dict  # plain dict, NOT a MappingProxyType
+    assert gov == {"x": 0}
+    # Mutating the serialized copy MUST NOT affect the verdict's frozen view.
+    gov["x"] = 99
+    assert verdict.governance["x"] == 0


### PR DESCRIPTION
## Summary
Closes three findings from this session's holistic /redteam of the EATP v3 (#1648) and outbound-governance (#1649) shards.

- **M1 (MED) — mutable security-critical trust dataclasses.** `PartyAnchor`, `BilateralDelegation`, `ClearanceAttestation`, `WeftEvent`, `ChainLink`, `ChainResult` enforced their invariants only at `__post_init__` (single-root check, clearance gate, hash-chain linkage, deny-overrides verdict) but were mutable — an attacker could construct a valid instance then reassign a field (swap `.delegator` to a foreign root, lower `.required_clearance`, flip a DENY `.verdict` to ALLOW) with no re-validation. Now `@dataclass(frozen=True)`; `to_dict`/`from_dict` round-trips preserved.
- **L1 (LOW) — credential leak in audit trail.** `GovernedHTTPClient` persisted the raw request URL as `OutboundEffect.target`, so a `https://user:pass@host/?api_key=…` URL landed verbatim in the audit deque / sink / refusal details. New `redact_http_target()` strips userinfo + query + fragment (keeps `scheme://host/path`), fail-closed sentinel on parse error.
- **L2 (LOW) — shallow-frozen governance dict.** `OutboundVerdict.governance` wrapped in `MappingProxyType` so an audited decision can't be mutated after the fact; `to_dict` still emits a plain dict.

## Testing
- 21 new tests (M1+L2: 13, L1: 8) — all pass.
- Regression: EATP v3 conformance + WEFT + core outbound = 122 passed; kaizen governed-outbound wiring = 9 passed.
- Production-code sweep confirmed nothing mutates any newly-frozen field or the governance dict at runtime.

## Related issues
Redteam hardening follow-up to #1592 / #1517.