### PR TITLE
release: kailash-dataflow 2.14.5 (security — cross-tenant upsert #1650)

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -18,7 +18,7 @@
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
 | kailash (core)   | `v*`               | 2.45.5          |
-| kailash-dataflow | `dataflow-v*`      | 2.13.21         |
+| kailash-dataflow | `dataflow-v*`      | 2.14.5          |
 | kailash-kaizen   | `kaizen-v*`        | 2.28.0          |
 | kailash-nexus    | `nexus-v*`         | 2.9.0           |
 | kailash-pact     | `pact-v*`          | 0.12.1          |

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.14.5] — 2026-07-10 — cross-tenant upsert write-breach fix (#1650/#1526)
+
+### Security
+
+- **Upsert on a `multi_tenant` model with the default `conflict_on=["id"]` no longer lets one tenant overwrite and steal another tenant's row (`features/bulk.py`, `sql/dialects.py`, `nodes/bulk_upsert.py`, `core/nodes.py`, `nodes/bulk_create_pool.py`, #1650; natural-key-collision diagnostic #1526).** On a `multi_tenant` model the `id` primary key is global, so `bulk_upsert` / single `upsert` / `BulkCreatePoolNode` emitted an `ON CONFLICT (id) DO UPDATE` (PostgreSQL/SQLite) or `ON DUPLICATE KEY UPDATE` (MySQL) clause that carried **no tenant predicate** and did **not** exclude `tenant_id` from the SET list. As a result, tenant B upserting a row whose `id` was already owned by tenant A overwrote tenant A's row **and flipped its `tenant_id` to B** (full row theft), and the operation returned success — a confirmed cross-tenant WRITE breach. The fix, applied across all five upsert builders:
+  - **`tenant_id` is excluded from the SET clause** on every dialect, so a conflicting upsert can never flip an existing row's owner.
+  - **PostgreSQL/SQLite** DO-UPDATE now carries `WHERE {table}.tenant_id = EXCLUDED.tenant_id`, so the update only applies when the existing row belongs to the same tenant as the incoming row — a cross-tenant `id` collision leaves the stored row untouched.
+  - **MySQL** `ON DUPLICATE KEY UPDATE` (which admits no WHERE) guards each column with `IF(tenant_id = VALUES(tenant_id), <new_value>, <existing_col>)`, including the version/timestamp columns (`updated_at`), so a cross-tenant collision preserves every existing column value.
+  - **Guard-suppressed cross-tenant collisions route to the actionable `TenantNaturalKeyCollisionError` diagnostic** on the bulk paths (#1526): when the tenant-scoped guard suppresses a write because the only conflicting row belongs to a different tenant, the caller receives a tenant-scoped collision error instead of a silent no-op.
+  - Regression tests exercise the breach and the fix against real databases (PostgreSQL + SQLite), including a `BulkCreatePoolNode` cross-tenant theft regression (#1526 H1). Verified via holistic `/redteam` (two rounds plus a completeness sweep).
+
 ## [2.14.4] — 2026-07-08 — `Model.query_builder()` respects `__tablename__` (#1614) + query-surface table-identifier hardening
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.14.4"
+version = "2.14.5"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.14.4"
+__version__ = "2.14.5"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Metadata-only release-prep bump **kailash-dataflow 2.14.4 → 2.14.5**, a SECURITY patch carrying the cross-tenant upsert write-breach fix that already merged to main via #1650.

The fix code is already on main; this branch carries only the release anchors (`pyproject.toml`, `__init__.py::__version__`, `CHANGELOG.md`, and the `deploy/deployment-config.md` version-table row) so that pushing the `dataflow-v2.14.5` tag publishes the fixed code to PyPI via the OIDC Trusted-Publisher workflow.

## What ships (already merged in #1650)

On a `multi_tenant` model with the default `conflict_on=["id"]`, `bulk_upsert` / single `upsert` / `BulkCreatePoolNode` emitted `ON CONFLICT (id) DO UPDATE` (PG/SQLite) / `ON DUPLICATE KEY UPDATE` (MySQL) with **no tenant predicate** and did **not** exclude `tenant_id` from the SET — so tenant B upserting an id owned by tenant A overwrote A's row **and flipped its `tenant_id`** (full theft), returning success. Fixed across all five upsert builders:

- `tenant_id` excluded from the SET on every dialect (no owner flip)
- PG/SQLite DO-UPDATE carries `WHERE {table}.tenant_id = EXCLUDED.tenant_id`
- MySQL guards each column (incl. `updated_at`) with `IF(tenant_id = VALUES(tenant_id), <new>, <col>)`
- guard-suppressed cross-tenant collisions route to the actionable tenant-scoped `TenantNaturalKeyCollisionError` diagnostic on bulk paths (#1526)

Builders touched: `features/bulk.py`, `sql/dialects.py`, `nodes/bulk_upsert.py`, `core/nodes.py` (single-record), `nodes/bulk_create_pool.py`.

## Pre-tag validation (release branch)

- `test_issue_1526_bulk_multi_tenant_natural_key_collision.py` + `test_issue_1526_multi_tenant_natural_key_collision.py`: **26 passed** (18 SQLite/structural + 8 real PostgreSQL @ localhost:5434)
- `test_issue_1518_multi_tenant_upsert_tenant_id.py` (sibling, same builders): **11 passed**
- Clean `python -m build` → `kailash_dataflow-2.14.5-py3-none-any.whl` + `.tar.gz`; `twine check` **PASSED** both
- `kailash>=2.45.5` floor unchanged (dataflow-only fix, no core change)

## Related issues

Refs #1650, #1526