### PR TITLE
chore(codify): tenant-isolation Rule 7 — upsert cross-tenant-write guard

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1209,3 +1209,31 @@ changes:
       GLOBAL (loom-synced onboarding suite). NOT self-referential-codify (see the 45-genesis-bootstrap
       entry above for the Rule 2 allowlist rationale). Receipt:
       workspaces/mops-onboarding/04-validate/redteam-2026-07-09-reconvergence12.md + journal/0043."
+  - type: rule_update
+    artifact: tenant-isolation
+    files:
+      - .claude/rules/tenant-isolation.md
+    classification_suggestion: global
+    context: >
+      ADDS Rule 7 ("Upsert ON CONFLICT DO UPDATE Is Tenant-Guarded And Excludes
+      tenant_id From SET") + extends the Audit Protocol grep.
+
+      Lesson: on a multi_tenant model with a global single-column id PK, every
+      upsert builder emitting `INSERT ... ON CONFLICT (id) DO UPDATE SET ...`
+      (PG/SQLite) or `ON DUPLICATE KEY UPDATE` (MySQL) MUST (a) exclude tenant_id
+      from the SET clause and (b) tenant-guard the update — PG/SQLite via
+      `WHERE {table}.tenant_id = EXCLUDED.tenant_id`, MySQL via per-column
+      `IF(tenant_id = VALUES(tenant_id), <new>, <col>)` (incl. version/timestamp).
+      A guard-suppressed cross-tenant collision routes to the actionable
+      tenant-scoped diagnostic, never a silent success/skip. ALL upsert builders
+      audited, not just the primary. DISTINCT from Rule 6 (canonical tenant source,
+      #1252): a correctly-tenant-scoped write STILL overwrites another tenant's row
+      via the un-guarded conflict path.
+
+      Evidence: PR #1650 + kailash-dataflow 2.14.5 (tag dataflow-v2.14.5, publish
+      run 29074366000 success) — holistic /redteam CONFIRMED on real SQLite +
+      PostgreSQL that bulk_upsert / single upsert / BulkCreatePoolNode overwrote
+      and reassigned another tenant's row; fixed across all 5 builders. Cross-SDK:
+      the Rust SDK's #1712 filed (shared DataFlow architecture). Canonical 8-field
+      Trust Posture Wiring present; cc-architect APPROVE. Receipts:
+      workspaces/sdk-backlog/journal/0003 (DECISION) + 0004 (DISCOVERY).

--- a/.claude/rules/tenant-isolation.md
+++ b/.claude/rules/tenant-isolation.md
@@ -180,6 +180,47 @@ tenant_id = self._tenant_context.get("tenant_id")   # stale after switch();
 
 **Trust Posture Wiring (Rule 6):** Severity `halt-and-report` at the /implement gate (reviewer mechanical sweep: every write/scope path of a `multi_tenant=True` model resolves tenant via the canonical accessor — `rg 'get_current_tenant_id|_tenant_context'` and flag any parallel source) · Grace 7 days from landing · Cumulative per `trust-posture.md` MUST-4 (3× same-rule in 30d → drop 1 posture) · Regression-within-grace → emergency downgrade (1 step) per MUST-4 · Receipt soft-gate `[ack: tenant-one-canonical-source]` IFF `posture.json::pending_verification` includes this rule_id · Detection: the Audit Protocol grep below + gate-level sweep · **Violation scope:** Rule 6 (write-path tenant-source parity) · Origin: issue #1252 (2026-06, bulk tenant-source mismatch).
 
+### 7. Upsert `ON CONFLICT DO UPDATE` Is Tenant-Guarded And Excludes `tenant_id` From SET
+
+When a `multi_tenant=True` model uses a global single-column `id` PK, EVERY upsert builder that emits `INSERT ... ON CONFLICT (id) DO UPDATE SET ...` (PostgreSQL/SQLite) or `INSERT ... ON DUPLICATE KEY UPDATE ...` (MySQL) MUST (a) EXCLUDE `tenant_id` from the SET clause AND (b) GATE the update by the row's own tenant — PG/SQLite via `WHERE {table}.tenant_id = EXCLUDED.tenant_id` appended to the `DO UPDATE`; MySQL (ODKU has no WHERE) via a per-column `IF(tenant_id = VALUES(tenant_id), <new>, <col>)` guard on EVERY updated column INCLUDING version/timestamp bumps. A guard-suppressed cross-tenant collision MUST route to the actionable tenant-scoped collision diagnostic (naming ONLY the caller's own tenant) — NEVER a silent success or silent skip. EVERY upsert builder in the codebase MUST be audited, not just the primary one.
+
+```python
+# DO — tenant-guarded DO UPDATE, tenant_id excluded from SET
+update_cols = [c for c in cols if c != "id" and not (tenant_guarded and c == "tenant_id")]
+set_parts = [f"{c} = EXCLUDED.{c}" for c in update_cols]
+where = f" WHERE {table}.tenant_id = EXCLUDED.tenant_id" if tenant_guarded else ""
+sql = f"INSERT ... ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)}{where}"
+# MySQL ODKU: f"{c} = IF(tenant_id = VALUES(tenant_id), VALUES({c}), {c})" per column
+
+# DO NOT — un-guarded DO UPDATE (cross-tenant id collision overwrites + steals the other tenant's row)
+set_parts = [f"{c} = EXCLUDED.{c}" for c in cols if c != "id"]  # tenant_id IN the SET → ownership flip
+sql = f"INSERT ... ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)}"  # no WHERE → tenant B overwrites tenant A
+```
+
+**BLOCKED rationalizations:**
+
+- "The write already reads the right tenant (Rule 6), so the upsert is safe"
+- "bulk_upsert tenant isolation is correct" (the exact pre-#1650 assumption that was false on both SQLite and PostgreSQL)
+- "`conflict_on` defaults to `id`; a cross-tenant id collision won't happen"
+- "the ON CONFLICT path returned success, so no collision occurred"
+- "I fixed the primary bulk_upsert builder; the sibling nodes are rare / opt-in"
+- "MySQL ODKU has no WHERE, so it can't be tenant-guarded" (use the per-column `IF()` guard)
+
+**Why:** A global `id` PK means a cross-tenant `id` collision IS a genuine `ON CONFLICT`; an un-guarded `DO UPDATE` resolves it by OVERWRITING the other tenant's row — and, if `tenant_id` is in the SET, flipping its ownership — while returning success, so the collision diagnostic never fires. This is DISTINCT from Rule 6 (which ensures the write reads the RIGHT tenant): a correctly-tenant-scoped write STILL overwrites another tenant's row via the un-guarded upsert-conflict path. Auditing ALL builders (not just the primary) is load-bearing — the #1650 fix found the same breach in a sibling registered node the primary fix missed.
+
+**Trust Posture Wiring (Rule 7):**
+
+- **Severity:** `halt-and-report` at gate-review (security-reviewer + reviewer mechanical sweep at `/implement` + `/redteam`: enumerate every `ON CONFLICT`/`ON DUPLICATE KEY` `DO UPDATE` builder in the DB package, confirm each `multi_tenant` path carries the tenant `WHERE`/`IF()` guard AND excludes `tenant_id` from SET); `advisory` at the hook layer (the tenant-guard property is judgment-bearing over generated SQL, not a structural tool-call signal, per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing (2026-07-10 → 2026-07-17).
+- **Cumulative posture impact:** same-class violations (a `multi_tenant` upsert builder shipped without the tenant `WHERE`/`IF()` guard, or with `tenant_id` in the SET clause) contribute to `trust-posture.md` MUST Rule 4 cumulative-window math (3× same-rule in 30d → drop 1 posture; 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** a same-class violation within the 7-day grace window routes through the GENERIC `regression_within_grace` emergency trigger per `trust-posture.md` MUST-4 (1× = drop 1 posture) — NO dedicated per-clause trigger key (an SQL-shape property is review-layer-only and judgment-bearing; minting a key would drag `trust-posture.md`, a self-referential-codify allowlist file, into a self-ref edit, and the universal `regression_within_grace` trigger already covers it).
+- **Receipt requirement:** SessionStart soft-gate `[ack: tenant-isolation]` IFF `posture.json::pending_verification` includes this rule_id.
+- **Detection mechanism:** Phase 1 (manual, gate-review) — for any `multi_tenant` upsert change, enumerate ALL `ON CONFLICT`/`ON DUPLICATE KEY` `DO UPDATE` builders (`grep -rln 'DO UPDATE SET\|ON DUPLICATE KEY UPDATE' <db-pkg>/src`), then grep each for the tenant guard (`tenant_id = EXCLUDED.tenant_id` / `IF(tenant_id =`) — a builder emitting a multi_tenant DO UPDATE with no guard is a finding; run by security-reviewer + reviewer at `/implement` + `/redteam` (the Audit Protocol grep below). Phase 2 (deferred per `trust-posture.md` § Two-Phase Rollout, after ≥3 real sessions exercise Phase 1) — no hook detector; audit fixtures land with the Phase-2 detector at `.claude/audit-fixtures/tenant-upsert-guard/` per `cc-artifacts.md` Rule 9.
+- **Violation scope:** Rule 7 (upsert `ON CONFLICT DO UPDATE` tenant-guard + `tenant_id`-excluded-from-SET) ONLY; Rules 1–6 stay grandfathered until each is itself `/codify`-touched.
+- **Origin:** See Rule 7 Origin below.
+
+Origin: #1650 / kailash-dataflow 2.14.5 (2026-07-10) — a holistic `/redteam` CONFIRMED (real SQLite + PostgreSQL) that `bulk_upsert` / single `upsert` / `BulkCreatePoolNode` on a `multi_tenant` model with the default `conflict_on=["id"]` overwrote and reassigned another tenant's row via an un-guarded `ON CONFLICT DO UPDATE`; fixed across all five upsert builders. The completeness lesson (audit ALL builders) came from the closure-parity round finding the sibling `BulkCreatePoolNode` after the primary fix.
+
 ## MUST NOT
 
 - Default missing tenant_id to a placeholder ("default", "global", "")
@@ -214,6 +255,11 @@ rg 'audit_store\.append|record_query_success|record_query_failure' .
 # Find every write/scope path; verify each resolves tenant via the canonical source (Rule 6)
 rg 'def (bulk_create|bulk_update|bulk_upsert|upsert|create|update)' .
 rg '_tenant_context\[|_tenant_context\.get' .   # any hit on a write path = HIGH (parallel source)
+
+# Find every upsert DO UPDATE builder; verify each multi_tenant path is tenant-guarded (Rule 7)
+rg -l 'DO UPDATE SET|ON DUPLICATE KEY UPDATE' .            # enumerate ALL upsert builders
+rg 'tenant_id = EXCLUDED\.tenant_id|IF\(tenant_id =' .     # the guard — a builder emitting a
+                                                          # multi_tenant DO UPDATE with NO hit here = HIGH
 ```
 
 Any match that fails the contract above is a HIGH finding.

--- a/workspaces/sdk-backlog/.session-notes
+++ b/workspaces/sdk-backlog/.session-notes
@@ -1,0 +1,75 @@
+# Session Notes — 2026-07-10 — SDK backlog sprint (CONVERGED)
+
+Direct issue-backlog work (NOT a COC-phase workspace). Durable state lives on GitHub
+(`gh pr list`, `gh issue list`); this file holds non-derivable decisions, cross-SDK
+dispositions, and the redteam convergence trail.
+
+## Read first
+- `gh pr list --state merged --search "merged:>=2026-07-10"` + PR bodies (self-documenting).
+- 4 issues remain open — all correctly BLOCKED/deferred (see below), not skippable.
+
+## MERGED THIS SESSION (5 PRs)
+- **#1647** → closed **#1516** (confidence/evidence-quality threshold routing; #1516 leg-b, completing leg-a #1644). Merge 6362eaea0.
+- **#1648** → closed **#1592** (EATP v3 additive elements: BilateralDelegation single-root atomic, ClearanceAttestation C0..C4, VERIFY_CHAIN deny-overrides, GRACEFUL/SUSPEND revocation, guarantee-tiers; dispatcher-signed ≠ non-repudiation enforced; cross-root variant fails-closed not stubbed; 11 eatp3_* vectors, PACT_VECTORS.sha256 34/34). Merge f3ff8e325.
+- **#1649** → closed **#1517** (universal outbound-effect governance interceptor, leg-b; leg-a resolver #1642 prior. GovernedProvider/ToolInvoker/HTTPClient transparent __getattr__ proxies, fail-closed, no agent code change). Merge 1e3089196.
+- **#1651** → redteam hardening M1/L1/L2 (froze 6 EATP/verify_chain/weft dataclasses; redact_http_target strips userinfo+query from audit; MappingProxyType on OutboundVerdict.governance). Merge 432b8cdc8.
+- **#1650** → **#1526 follow-up + a CRITICAL security fix** (see below). Merge acb85f5fd.
+
+## #1650 — THE SECURITY STORY (why it grew to 4 commits)
+Started as the #1526 bulk-path collision-diagnostic follow-up. The holistic /redteam
+CONFIRMED (real SQLite + real PostgreSQL, verbatim before/after) a **cross-tenant WRITE /
+row-theft breach**: `bulk_upsert(conflict_on=["id"])` on a multi_tenant model emitted
+`ON CONFLICT (id) DO UPDATE SET ...` with NO tenant predicate → tenant B overwrote tenant A's
+row AND flipped tenant_id (A→B), returned success. Pre-existing (not introduced this session),
+fixed in-session per autonomous-execution Rule 4 (same-class, in-budget, warm context).
+- Commit 60de504f5: #1526 bulk collision diagnostic.
+- Commit 8538585c8: **C1** — tenant-scoped `WHERE table.tenant_id = EXCLUDED.tenant_id`
+  (PG/SQLite) + `IF(tenant_id=...)` (MySQL) across features/bulk.py, sql/dialects.py,
+  nodes/bulk_upsert.py; tenant_id excluded from SET (no ownership flip); single-record
+  `express.upsert` sibling was ALSO breached on PG → fixed.
+- Commit df4aa632b: **HIGH residual** (redteam round 2) — MySQL version_field bump was
+  un-guarded (tested before the tenant branch) → IF()-guarded.
+- Commit fa2659490: **HIGH H1** (closure-parity round) — the sibling registered node
+  `BulkCreatePoolNode` (bulk_create_pool.py) had the same breach → guarded + real-DB
+  fail-without/pass-with regression test.
+- **Completeness sweep**: all 5 dataflow upsert builders that emit tenant-user-data DO UPDATE
+  now carry the guard (grep-verified; remaining DO-UPDATE sites are migration/registry tables +
+  capability-flag comments, not tenant data).
+
+## CONVERGENCE RECEIPTS (redteam)
+- Round 1: security-reviewer (task a383f0fe) CONFIRMED C1 CRITICAL, verified M1/L1/L2; runtime
+  verifier (a98672b1) empirical PG+SQLite theft proof.
+- Round 2: security-reviewer (a253f755) verified C1/M1/L1/L2 CLOSED, found HIGH MySQL residual;
+  closure-parity reviewer (a3d3099e) verified all 4 findings closed w/ guarding tests, found HIGH H1.
+- H1 fix + test verified by dedicated real-DB agent (a1cef526): fail-without=2 failed,
+  pass-with=4 passed (SQLite+PG), 109-test sweep clean, same-tenant upsert not broken.
+
+## OPEN ISSUES — all correctly BLOCKED (do NOT close by age)
+- **#1606** (dataflow cross-DB keyspace bleed) — BLOCKED: byte-CHANGING keyspace v2→v3, cross-SDK
+  lockstep w/ Rust. v2 tripwire landed prior (#1638). Needs paired Rust issue (human-gated) + land together.
+- **#1510** (SAFR BH3 origin-auth) — BLOCKED: byte-CHANGING signing pre-image, cross-SDK lockstep. Defer to Rust cadence.
+- **#1601** (verify soft_delete/versioned parity in Rust SDK) — py side done (#1598); fix belongs in the RUST repo. Rust-repo tracker; repo-scope bars acting here.
+- **#1532** (consolidate delegate-connectors) — CROSS-REPO migration; USER-DEFERRED (away-from-keyboard default, 2026-07-09).
+
+## DECISIONS PENDING FOR OWNER (surfaced, not acted)
+1. **Cross-SDK filing (NEW):** the dataflow cross-tenant upsert breach family (bulk_upsert /
+   single upsert / BulkCreatePoolNode ON CONFLICT DO UPDATE) is shared-architecture — the Rust
+   SDK's DataFlow very likely has the SAME breach. Filing needs explicit cross-repo authorization
+   (repo-scope-discipline; agent cannot self-authorize). NOT filed. A scrubbed draft can be prepared.
+   Same for the pre-existing #1606/#1510 paired Rust drafts.
+2. **dataflow release:** #1650 shipped a CRITICAL cross-tenant security fix on the kailash-dataflow
+   2.14.x line (also #1638/#1646 earlier). Given the security severity, recommend a dataflow /release
+   SOON (stronger than normal owner-timing). Owner call.
+3. **Codify (follow-up):** the "every multi_tenant upsert builder MUST tenant-guard its ON CONFLICT
+   DO UPDATE (WHERE tenant_id=EXCLUDED.tenant_id / IF() on MySQL) AND exclude tenant_id from SET"
+   pattern is cascade-valuable — extends tenant-isolation.md Rule 6 (currently canonical-source only,
+   not the ON-CONFLICT-guard shape). Recommend a /codify to land it as a rule clause (don't strand in memory).
+
+## TRAPS / context
+- **Server concurrency throttle** hit hard early (3-agent wave synchronized-died on the
+  `(not your usage limit)` signal). Backed off to SERIAL per worktree-isolation Rule 4 — clean thereafter.
+  Wave-of-2 recovered later in the session. No work lost (worktrees clean on death).
+- **Pyright worktree-vs-main diagnostics** are noise: new modules "unresolved" + defensive
+  isinstance-guards "unreachable" resolve against main, not the worktree. Verify via actual test runs.
+- **nexus / kailash-pact srcs** must be on PYTHONPATH for trust-plane test collection (transitive a2a→nexus import).
+- CI-check-then-merge kept SEPARATE per git.md (pinned head SHA read, then admin-merge).

--- a/workspaces/sdk-backlog/journal/0001-cross-repo-grant-rust-sdk-issues.md
+++ b/workspaces/sdk-backlog/journal/0001-cross-repo-grant-rust-sdk-issues.md
@@ -1,0 +1,14 @@
+# Cross-Repo Grant — file 2 cross-SDK issues on the Rust SDK BUILD repo
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+- **Requester:** repo owner (this session's user)
+- **Timestamp:** 2026-07-10
+- **Verbatim instruction:** "approved" (approving my offer to file the two drafted cross-SDK-parity issues on the Rust SDK BUILD repo; prior turn: "Want me to draft the two cross-SDK issues for your approval" → "approved" to draft; this turn "approved" to file).
+- **Target repo:** `esperie-enterprise/kailash-rs` (the private Rust SDK BUILD repo; per reference memory `reference_kailash_rs_repo_location.md` — NOT terrene-foundation/kailash-rs).
+- **Exact bounded action:** `gh issue create` x2 ONLY — the two paired cross-SDK-parity issues drafted this session:
+  1. `bug(dataflow): cache keys omit database-instance identity — cross-DB bleed (cross-SDK keyspace lockstep)` (#1606 pair)
+  2. `feat(eatp): origin-authentication — bind agent-declared trace to originating instruction (cross-SDK signing-payload lockstep)` (#1510/E pair)
+- **Scope:** ONLY these two issue-creates against ONLY this repo. No incidental reads, no source reads, no other writes. Issue bodies are SDK-behavior/contract-scoped, minimal-repro shape, no consumer/downstream tokens (upstream-issue-hygiene MUST-2/3), reference the py origin by bare number.
+- **Cross-reference back:** after filing, add a comment on the py-side #1606 / #1510 linking the rs issue numbers (a WRITE on the CWD repo — in-scope).
+</content>

--- a/workspaces/sdk-backlog/journal/0002-cross-repo-grant-rust-sdk-issues.md
+++ b/workspaces/sdk-backlog/journal/0002-cross-repo-grant-rust-sdk-issues.md
@@ -1,0 +1,15 @@
+# Cross-Repo Grant (session 2) — file cross-SDK issues on the Rust SDK BUILD repo
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+- **Requester:** repo owner (this session's user; genuine human turn)
+- **Timestamp:** 2026-07-10
+- **Verbatim instruction:** "approved, please release and file the issues to kailash-rs then /codify the pattern. after that /wrapup for fresh session"
+- **Target repo:** `esperie-enterprise/kailash-rs` (private Rust SDK BUILD repo, per `reference_kailash_rs_repo_location.md` — NOT terrene-foundation/kailash-rs). Existence + ADMIN access verified via `gh repo view` before this grant.
+- **Exact bounded action:** `gh issue create` ONLY, for the cross-SDK-parity issues below; plus a back-link comment on the paired py-side issue (a WRITE on the CWD repo — in-scope).
+  1. **NEW (this session's finding):** `bug(dataflow): cross-tenant WRITE via upsert ON CONFLICT DO UPDATE — no tenant predicate (cross-SDK parity)` — the cross-tenant row-theft breach fixed py-side in PR #1650. High value; shared DataFlow architecture.
+  2. **#1606 pair:** `bug(dataflow): cache keys omit database-instance identity — cross-DB bleed (cross-SDK keyspace lockstep)`.
+  3. **#1510/E pair:** `feat(eatp): origin-authentication — bind agent-declared trace to originating instruction (cross-SDK signing-payload lockstep)`.
+- **Scope:** ONLY these issue-creates against ONLY this repo + the paired py-side back-link comments. No incidental reads, no source reads, no other writes.
+- **Hygiene:** bodies are SDK-behavior/contract-scoped, minimal-repro shape, NO consumer/downstream/workspace tokens or internal paths (upstream-issue-hygiene MUST-2/3); reference py origin by bare number only.
+- **Supersedes context of 0001** (same grant, prior session; not filed then due to an account swap without a named target). This grant names the target explicitly.

--- a/workspaces/sdk-backlog/journal/0003-DECISION-tenant-upsert-guard-rule.md
+++ b/workspaces/sdk-backlog/journal/0003-DECISION-tenant-upsert-guard-rule.md
@@ -1,0 +1,37 @@
+---
+type: DECISION
+date: 2026-07-10
+author: agent
+project: sdk-backlog
+topic: Codify the upsert cross-tenant-write-guard pattern as tenant-isolation.md Rule 7
+phase: codify
+tags: [tenant-isolation, dataflow, security, upsert, codify]
+relates_to: 0004-DISCOVERY-cross-tenant-upsert-guard-pattern
+---
+
+# DECISION — tenant-isolation.md Rule 7 (upsert ON CONFLICT DO UPDATE tenant-guard)
+
+Receipt for the `/codify` the co-owner directed ("/codify the pattern") after the #1650 cross-tenant upsert write-breach fix + 2.14.5 security release.
+
+## What changed
+
+- Added **Rule 7** to `.claude/rules/tenant-isolation.md`: every `multi_tenant` upsert builder emitting `ON CONFLICT DO UPDATE` (PG/SQLite) / `ON DUPLICATE KEY UPDATE` (MySQL) MUST (a) exclude `tenant_id` from the SET clause and (b) tenant-guard the update (`WHERE {table}.tenant_id = EXCLUDED.tenant_id` / per-column `IF(tenant_id = VALUES(tenant_id),...)`); a guard-suppressed cross-tenant collision routes to the actionable tenant-scoped diagnostic; ALL builders audited, not just the primary.
+- Canonical 8-field Trust Posture Wiring (post-MUST-8-SHA, canonical-compliant); `regression_within_grace` generic trigger (no dedicated key — avoids a self-ref edit to trust-posture.md).
+- Extended the Audit Protocol grep with the Rule 7 upsert-guard sweep.
+
+## Why authored (not left in memory)
+
+Cascade-valuable per `knowledge-cascade-routing.md` MUST-1 — applies to every multi_tenant upsert in DataFlow AND cross-SDK to the Rust SDK (rs#1712 filed). Routed to a COC artifact (rule), not memory.
+
+## Distinctness
+
+Rule 7 is DISTINCT from Rule 6 (canonical-tenant-source, #1252): Rule 6 ensures the write reads the RIGHT tenant; Rule 7 blocks a correctly-scoped write from overwriting ANOTHER tenant's row via the un-guarded conflict path.
+
+## Not on the self-referential-codify allowlist
+
+tenant-isolation.md governs code behavior, not codify-class surfaces → standard cc-architect review (dispatched), not the mandatory multi-agent self-ref gate.
+
+## Receipts
+
+- Rule fix + release: PR #1650 (merge acb85f5fd) + #1652 (kailash-dataflow 2.14.5, tag dataflow-v2.14.5, publish run 29074366000 success).
+- Cross-SDK: rs#1712/#1713/#1714 filed (grant journal/0002).

--- a/workspaces/sdk-backlog/journal/0004-DISCOVERY-cross-tenant-upsert-guard-pattern.md
+++ b/workspaces/sdk-backlog/journal/0004-DISCOVERY-cross-tenant-upsert-guard-pattern.md
@@ -1,0 +1,30 @@
+---
+type: DISCOVERY
+date: 2026-07-10
+author: agent
+project: sdk-backlog
+topic: Cross-tenant upsert-conflict write breach is a distinct failure mode from tenant-source parity
+phase: codify
+tags: [tenant-isolation, dataflow, security, upsert, cross-sdk]
+relates_to: 0003-DECISION-tenant-upsert-guard-rule
+---
+
+# DISCOVERY — the un-guarded ON CONFLICT DO UPDATE tenant breach
+
+The #1650 redteam surfaced a failure mode the existing tenant-isolation rules did NOT cover: on a `multi_tenant` model with a global single-column `id` PK, an upsert with `conflict_on=["id"]` emits `ON CONFLICT (id) DO UPDATE SET ...` with no tenant predicate. A cross-tenant `id` collision is a genuine `ON CONFLICT`, so the `DO UPDATE` resolves it by overwriting the OTHER tenant's row — and, because `tenant_id` was in the SET list, reassigning ownership — while returning success. The collision diagnostic (which only fires on `success=False`) never sees it.
+
+Three properties made it invisible for a long time:
+
+1. It only bites when two tenants collide on the same `id` — rare in casual testing, guaranteed at scale with app-supplied ids.
+2. The op returns success; a tenant-scoped read of the victim's row (masked by the tenant filter) looks untouched — only a RAW cross-tenant read reveals the theft.
+3. It sits BEHIND the tenant-source-parity rule (Rule 6, #1252): the write reads the RIGHT tenant, so a Rule-6 audit passes — yet the un-guarded conflict path still overwrites another tenant's row.
+
+The completeness lesson: the primary `bulk_upsert` fix left a sibling registered node (`BulkCreatePoolNode`) with the same breach; only the closure-parity round's "audit ALL builders" sweep caught it. Five builders total needed the guard.
+
+Codified as tenant-isolation.md Rule 7 (see journal/0003). Cross-SDK: filed rs#1712 (shared DataFlow architecture).
+
+## For Discussion
+
+1. **Counterfactual:** if the sanitizer/redaction rules (`dataflow-classification.md`) had a symmetric "every mutation-return-path" discipline for WRITE-conflict paths, would this have been caught at authoring time rather than by redteam? Is there a general "every conflict-resolution path is a tenant boundary" rule hiding here, beyond upserts?
+2. **Data-specific:** the breach was invisible to `db.express.read` (tenant-scoped) and only visible to a raw cross-tenant `SELECT`. Should the Tier-2 test harness ship a standard `_raw_read_all` helper so every tenant-isolation test asserts against the unmasked table by default, not the tenant-scoped read that hides theft?
+3. **Cross-SDK:** rs#1712 assumes the Rust DataFlow shares the builder shape. If the Rust upsert path uses a composite `(tenant_id, id)` unique instead of a global `id` PK, the breach doesn't exist there — should the cross-SDK issue lead with "verify the PK shape" before "apply the guard"?


### PR DESCRIPTION
## Summary
Codifies the #1650 / kailash-dataflow 2.14.5 cross-tenant upsert write-breach fix as **tenant-isolation.md Rule 7**: every `multi_tenant` upsert builder emitting `ON CONFLICT DO UPDATE` / `ON DUPLICATE KEY UPDATE` MUST exclude `tenant_id` from SET and tenant-guard the update (PG/SQLite `WHERE tenant_id = EXCLUDED.tenant_id`; MySQL per-column `IF(tenant_id = VALUES(tenant_id),...)`); audit ALL builders.

- Distinct from Rule 6 (canonical tenant source, #1252) — a correctly-scoped write still overwrote another tenant's row via the un-guarded conflict path.
- Canonical 8-field Trust Posture Wiring; extended Audit Protocol grep. cc-architect verdict: **APPROVE**.
- BUILD→loom proposal appended (never overwriting the `pending_review` proposal).
- Journal DECISION (0003) + DISCOVERY (0004) receipts; cross-repo grant (0002) for the rs#1712/1713/1714 filings.

## Related issues
Refs #1650, #1526. Cross-SDK: the Rust SDK's #1712 (shared DataFlow architecture).