### PR TITLE
fix(security): consolidate + expand sensitive URL credential masking

### DIFF
--- a/src/kailash/config/database_config.py
+++ b/src/kailash/config/database_config.py
@@ -150,6 +150,8 @@ class DatabaseConfig:
         """
         from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+        from kailash.utils.url_credentials import is_sensitive_query_key
+
         connection_string = self.connection_string
         try:
             parsed = urlparse(connection_string)
@@ -157,25 +159,15 @@ class DatabaseConfig:
             return connection_string
 
         has_userinfo = bool(parsed.username or parsed.password)
-        # Must match the set in dataflow/utils/masking.py::_SENSITIVE_QUERY_KEYS
-        # AND both Redis rate-limit _sanitize_url helpers
-        # (src/kailash/trust/rate_limit/backends/redis.py and
-        # packages/kailash-nexus/src/nexus/auth/rate_limit/backends/redis.py).
-        # Four sites total — any divergence produces a leak path the
-        # other maskers would have caught. If you add a key here, add it
-        # to all four sites in the same commit.
-        sensitive = {
-            "password",
-            "sslpassword",
-            "sslkey",
-            "authtoken",
-            "token",
-            "apikey",
-        }
+        # Credential-bearing query keys are matched via the SINGLE canonical
+        # helper ``kailash.utils.url_credentials.is_sensitive_query_key`` —
+        # the same set ``mask_url``, the Redis rate-limit ``_sanitize_url``
+        # helpers, and ``SecureLogger`` use. No local copy: per-site copies
+        # drift and open a leak path the other maskers would have caught.
         query_has_secret = False
         if parsed.query:
             query_has_secret = any(
-                k.lower() in sensitive
+                is_sensitive_query_key(k)
                 for k, _ in parse_qsl(parsed.query, keep_blank_values=True)
             )
 
@@ -198,7 +190,7 @@ class DatabaseConfig:
         if query_has_secret:
             pairs = parse_qsl(parsed.query, keep_blank_values=True)
             masked_pairs = [
-                (k, "***" if k.lower() in sensitive else v) for k, v in pairs
+                (k, "***" if is_sensitive_query_key(k) else v) for k, v in pairs
             ]
             parsed = parsed._replace(query=urlencode(masked_pairs))
 

--- a/src/kailash/trust/rate_limit/backends/redis.py
+++ b/src/kailash/trust/rate_limit/backends/redis.py
@@ -108,20 +108,18 @@ class RedisBackend(RateLimitBackend):
         try:
             from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+            from kailash.utils.url_credentials import is_sensitive_query_key
+
             parsed = urlparse(url)
-            sensitive = {
-                "password",
-                "sslpassword",
-                "sslkey",
-                "token",
-                "authtoken",
-                "apikey",
-            }
+            # Credential-bearing query keys are matched via the SINGLE
+            # canonical helper — the same set ``mask_url``,
+            # ``DatabaseConfig.get_masked_connection_string``, and
+            # ``SecureLogger`` use. No local copy.
             has_userinfo = bool(parsed.username or parsed.password)
             query_has_secret = False
             if parsed.query:
                 query_has_secret = any(
-                    k.lower() in sensitive
+                    is_sensitive_query_key(k)
                     for k, _ in parse_qsl(parsed.query, keep_blank_values=True)
                 )
             if not has_userinfo and not query_has_secret:
@@ -134,7 +132,9 @@ class RedisBackend(RateLimitBackend):
                 parsed = parsed._replace(netloc=new_netloc)
             if query_has_secret:
                 pairs = parse_qsl(parsed.query, keep_blank_values=True)
-                masked = [(k, "***" if k.lower() in sensitive else v) for k, v in pairs]
+                masked = [
+                    (k, "***" if is_sensitive_query_key(k) else v) for k, v in pairs
+                ]
                 parsed = parsed._replace(query=urlencode(masked))
             return urlunparse(parsed)
         except Exception:

--- a/src/kailash/utils/secure_logging.py
+++ b/src/kailash/utils/secure_logging.py
@@ -10,6 +10,8 @@ import re
 from functools import wraps
 from typing import Any, Dict, List, Optional, Pattern, Set, Union
 
+from kailash.utils.url_credentials import is_sensitive_query_key
+
 
 class SecureLoggingPatterns:
     """Patterns for detecting sensitive data."""
@@ -50,7 +52,16 @@ class SecureLoggingPatterns:
         re.compile(r'["\']?secret["\']?\s*[:=]\s*["\']?([^"\']+)["\']?', re.I),
     ]
 
-    # Common PII field names
+    # Common PII field names.
+    #
+    # Credential query-key names (password / pwd / passwd / token /
+    # api_key / apikey / secret / access_token / client_secret / ...) are
+    # NOT listed here — they are owned by the SINGLE canonical set
+    # ``kailash.utils.url_credentials._SENSITIVE_QUERY_KEYS`` and matched
+    # via ``is_sensitive_query_key`` in :meth:`SecureLogger._mask_dict`,
+    # so there is no local copy to drift. This set holds only the broader
+    # PII field names (SSN, email, address, ...) plus credential-shaped
+    # field names outside the URL-query set (``pass``, ``private_key``).
     PII_FIELD_NAMES = {
         "ssn",
         "social_security",
@@ -58,14 +69,7 @@ class SecureLoggingPatterns:
         "credit_card",
         "card_number",
         "cc_number",
-        "password",
-        "pwd",
         "pass",
-        "passwd",
-        "token",
-        "api_key",
-        "apikey",
-        "secret",
         "private_key",
         "email",
         "email_address",
@@ -134,10 +138,14 @@ class SecureLogger:
         masked = {}
 
         for key, value in data.items():
-            # Check if field name indicates sensitive data
+            # Check if field name indicates sensitive data. Credential
+            # query-key names route through the single canonical helper
+            # (normalized match: ``access_token``/``client_secret``/... all
+            # covered); PII field names + custom fields use exact match.
             if (
                 key.lower() in SecureLoggingPatterns.PII_FIELD_NAMES
                 or key.lower() in self.custom_fields
+                or is_sensitive_query_key(key)
             ):
                 masked[key] = (
                     self._mask_value(str(value)) if value is not None else None

--- a/src/kailash/utils/secure_logging.py
+++ b/src/kailash/utils/secure_logging.py
@@ -55,13 +55,13 @@ class SecureLoggingPatterns:
     # Common PII field names.
     #
     # Credential query-key names (password / pwd / passwd / token /
-    # api_key / apikey / secret / access_token / client_secret / ...) are
-    # NOT listed here — they are owned by the SINGLE canonical set
-    # ``kailash.utils.url_credentials._SENSITIVE_QUERY_KEYS`` and matched
-    # via ``is_sensitive_query_key`` in :meth:`SecureLogger._mask_dict`,
-    # so there is no local copy to drift. This set holds only the broader
-    # PII field names (SSN, email, address, ...) plus credential-shaped
-    # field names outside the URL-query set (``pass``, ``private_key``).
+    # api_key / apikey / secret / access_token / client_secret /
+    # private_key / ...) are NOT listed here — they are owned by the SINGLE
+    # canonical set ``kailash.utils.url_credentials._SENSITIVE_QUERY_KEYS``
+    # and matched via ``is_sensitive_query_key`` in
+    # :meth:`SecureLogger._mask_dict`, so there is no local copy to drift.
+    # This set holds only the broader PII field names (SSN, email,
+    # address, ...) plus ``pass`` (ambiguous; outside the URL-query set).
     PII_FIELD_NAMES = {
         "ssn",
         "social_security",
@@ -70,7 +70,6 @@ class SecureLoggingPatterns:
         "card_number",
         "cc_number",
         "pass",
-        "private_key",
         "email",
         "email_address",
         "phone",

--- a/src/kailash/utils/url_credentials.py
+++ b/src/kailash/utils/url_credentials.py
@@ -57,6 +57,7 @@ __all__ = [
     "mask_url",
     "mask_secret",
     "fingerprint_secret",
+    "is_sensitive_query_key",
     "UNPARSEABLE_URL_SENTINEL",
 ]
 
@@ -67,13 +68,88 @@ __all__ = [
 # log triage can find every helper bail.
 UNPARSEABLE_URL_SENTINEL = "<unparseable url>"
 
-# Query-string parameter names that carry a secret. Matches the set
-# used by :meth:`DatabaseConfig.get_masked_connection_string` so the
-# two maskers stay in lock-step — see ``rules/security.md`` § "No
-# secrets in logs".
+# Canonical, expanded, frozen set of query-string parameter names that
+# carry a secret. This is the SINGLE SOURCE OF TRUTH for "is this URL
+# query key credential-bearing?" across the entire codebase — see
+# ``rules/security.md`` § "No secrets in logs" + § "Credential Decode
+# Helpers". Every masker (``mask_url`` here,
+# ``DatabaseConfig.get_masked_connection_string``, the Redis rate-limit
+# ``_sanitize_url`` helper, and ``SecureLogger``) MUST match against
+# this set via :func:`is_sensitive_query_key` rather than copy a local
+# list — per-site copies drift independently and open a leak path the
+# other maskers would have caught.
+#
+# Keys are stored in NORMALIZED form — lowercased with ``_`` and ``-``
+# stripped — so ``access_token``, ``access-token``, and ``accesstoken``
+# all resolve to the same entry. Match ONLY via
+# :func:`is_sensitive_query_key`, which normalizes its argument the same
+# way; membership is EXACT on the normalized form (NOT a substring
+# scan), so legitimate non-secret params — ``public_key`` (an asymmetric
+# public key is NOT a secret; ``secret_key`` / ``access_key`` ARE),
+# ``keyspace``, ``timeout``, ``sslmode``, ``sslrootcert`` (a cert PATH,
+# not a secret), ``application_name`` — are never masked.
 _SENSITIVE_QUERY_KEYS = frozenset(
-    {"password", "sslpassword", "sslkey", "authtoken", "token", "apikey"}
+    {
+        # password family
+        "password",
+        "passwd",
+        "pwd",
+        "sslpassword",
+        # secret family
+        "secret",
+        "clientsecret",  # client_secret / client-secret
+        "secretkey",  # secret_key / secret-key
+        # token family
+        "token",
+        "authtoken",  # auth_token
+        "apitoken",  # api_token
+        "accesstoken",  # access_token
+        # key family (credential keys only — NOT public_key)
+        "apikey",  # api_key
+        "accesskey",  # access_key
+        "sslkey",
+        "sslcert",  # ssl_cert (client cert material); NOT sslrootcert
+        # generic auth
+        "auth",
+    }
 )
+
+
+def _normalize_query_key(key: str) -> str:
+    """Lowercase ``key`` and strip ``_`` / ``-`` for credential matching.
+
+    ``access_token``, ``access-token``, and ``AccessToken`` all normalize
+    to ``accesstoken`` so a single canonical set entry covers every
+    common spelling variant.
+    """
+    return key.lower().replace("_", "").replace("-", "")
+
+
+def is_sensitive_query_key(key: str) -> bool:
+    """Return ``True`` if a URL query-string key carries a secret.
+
+    The SINGLE match point for credential query-key detection across
+    every masker in the codebase. ``key`` is normalized (lowercased,
+    ``_``/``-`` stripped) and tested for EXACT membership in the
+    canonical :data:`_SENSITIVE_QUERY_KEYS` set — never a substring
+    scan, so ``keyspace`` and ``public_key`` are NOT flagged while
+    ``secret_key`` and ``access_key`` ARE.
+
+    Examples:
+        >>> is_sensitive_query_key("password")
+        True
+        >>> is_sensitive_query_key("access_token")
+        True
+        >>> is_sensitive_query_key("client-secret")
+        True
+        >>> is_sensitive_query_key("public_key")
+        False
+        >>> is_sensitive_query_key("keyspace")
+        False
+        >>> is_sensitive_query_key("sslrootcert")
+        False
+    """
+    return _normalize_query_key(key) in _SENSITIVE_QUERY_KEYS
 
 
 def preencode_password_special_chars(connection_string: Optional[str]) -> str:
@@ -291,7 +367,7 @@ def mask_url(url: Optional[str]) -> str:
     query_has_secret = False
     if parsed.query:
         query_has_secret = any(
-            k.lower() in _SENSITIVE_QUERY_KEYS
+            is_sensitive_query_key(k)
             for k, _ in parse_qsl(parsed.query, keep_blank_values=True)
         )
 
@@ -316,8 +392,7 @@ def mask_url(url: Optional[str]) -> str:
         if query_has_secret:
             pairs = parse_qsl(parsed.query, keep_blank_values=True)
             masked_pairs = [
-                (k, "***" if k.lower() in _SENSITIVE_QUERY_KEYS else v)
-                for k, v in pairs
+                (k, "***" if is_sensitive_query_key(k) else v) for k, v in pairs
             ]
             parsed = parsed._replace(query=urlencode(masked_pairs))
 
@@ -367,10 +442,9 @@ def _mask_multi_host_url(url: str) -> str:
     query_mutated = False
     if q_sep and query:
         pairs = parse_qsl(query, keep_blank_values=True)
-        if any(k.lower() in _SENSITIVE_QUERY_KEYS for k, _ in pairs):
+        if any(is_sensitive_query_key(k) for k, _ in pairs):
             masked_pairs = [
-                (k, "***" if k.lower() in _SENSITIVE_QUERY_KEYS else v)
-                for k, v in pairs
+                (k, "***" if is_sensitive_query_key(k) else v) for k, v in pairs
             ]
             query = urlencode(masked_pairs)
             query_mutated = True

--- a/src/kailash/utils/url_credentials.py
+++ b/src/kailash/utils/url_credentials.py
@@ -109,6 +109,15 @@ _SENSITIVE_QUERY_KEYS = frozenset(
         "accesskey",  # access_key
         "sslkey",
         "sslcert",  # ssl_cert (client cert material); NOT sslrootcert
+        "privatekey",  # private_key (asymmetric private key IS secret; NOT public_key)
+        # cloud object-storage / presigned-URL credentials & signatures
+        # (mask_url accepts http/https, so presigned URLs can flow through it)
+        "sig",  # Azure SAS signature
+        "signature",  # generic; NOT signature_version / sig_alg (algorithm selectors)
+        "sessiontoken",  # session_token (AWS STS)
+        "xamzsignature",  # X-Amz-Signature (AWS SigV4 presigned)
+        "xamzsecuritytoken",  # X-Amz-Security-Token
+        "xamzcredential",  # X-Amz-Credential
         # generic auth
         "auth",
     }

--- a/tests/unit/utils/test_mask_url_sensitive_keys.py
+++ b/tests/unit/utils/test_mask_url_sensitive_keys.py
@@ -67,6 +67,20 @@ SENSITIVE_KEYS = [
     "sslcert",
     "ssl_cert",
     "auth",
+    # private key (asymmetric private key IS secret; public_key is NOT — pinned below)
+    "private_key",
+    "privatekey",
+    # cloud object-storage / presigned-URL credentials & signatures
+    # (mask_url accepts http/https, so presigned URLs can flow through it)
+    "sig",  # Azure SAS signature
+    "signature",
+    "session_token",  # AWS STS
+    "session-token",
+    "sessiontoken",
+    "X-Amz-Signature",  # AWS SigV4 presigned
+    "X-Amz-Security-Token",
+    "X-Amz-Credential",
+    "x_amz_signature",  # underscore spelling normalizes identically
     # mixed-case to prove case-insensitivity
     "Access_Token",
     "API_KEY",
@@ -88,6 +102,12 @@ NON_SENSITIVE_KEYS = [
     "host",
     "port",
     "dbname",
+    # signature-algorithm selectors are NOT the signature itself — must stay clear
+    "signature_version",  # normalizes to signatureversion ≠ signature
+    "signatureversion",
+    "sig_alg",  # normalizes to sigalg ≠ sig
+    "sigalg",
+    "token_type",  # normalizes to tokentype ≠ sessiontoken / token
 ]
 
 
@@ -212,9 +232,7 @@ def test_all_four_sites_mask_the_same_new_variant(key):
     assert LEAK not in str(masked_dict[key])
 
     # Site 4 — Redis rate-limit backend _sanitize_url
-    sanitized = RedisBackend._sanitize_url(
-        f"redis://cache:6379/0?{key}={LEAK}"
-    )
+    sanitized = RedisBackend._sanitize_url(f"redis://cache:6379/0?{key}={LEAK}")
     assert LEAK not in sanitized
 
 

--- a/tests/unit/utils/test_mask_url_sensitive_keys.py
+++ b/tests/unit/utils/test_mask_url_sensitive_keys.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Sensitive query-key masking — canonical set + normalized matcher.
+
+A /redteam surfaced that the "sensitive query-string key" denylist used by
+the connection-string maskers was matched by EXACT ``k.lower() in SET`` against
+a short list (``password``/``sslpassword``/``sslkey``/``authtoken``/``token``/
+``apikey``). Common credential param variants — ``access_token``, ``api_key``,
+``pwd``, ``passwd``, ``secret``, ``client_secret``, ``access_key``, ``sslcert``,
+and every underscore/hyphen spelling — were NOT masked and leaked into logs and
+errors.
+
+The fix establishes ONE canonical, expanded, frozen set plus a single
+normalized-match helper (``is_sensitive_query_key``) in
+``kailash.utils.url_credentials``. All four maskers reference it:
+
+1. ``mask_url`` (the canonical masker used at ~19 call sites)
+2. ``DatabaseConfig.get_masked_connection_string``
+3. ``SecureLogger`` (log-field masking)
+4. the Redis rate-limit backend ``_sanitize_url``
+
+These tests lock in the behavior behaviorally — every assertion calls the real
+helper / masker, never greps source (per ``rules/testing.md`` § Behavioral
+Regression Tests). They cover: the new variants ARE masked, the over-masking
+guard (legit non-secret params are NOT masked), consolidation across all four
+sites, and regression on the originally-covered keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.config.database_config import DatabaseConfig
+from kailash.trust.rate_limit.backends.redis import RedisBackend
+from kailash.utils.secure_logging import SecureLogger
+from kailash.utils.url_credentials import is_sensitive_query_key, mask_url
+
+# Value that MUST never survive masking at any surface.
+LEAK = "s3cr3t-leak-value"
+
+# Credential query-key variants that MUST be masked. Includes underscore /
+# hyphen / mixed-case spellings to prove the normalized matcher.
+SENSITIVE_KEYS = [
+    "password",
+    "passwd",
+    "pwd",
+    "sslpassword",
+    "secret",
+    "client_secret",
+    "client-secret",
+    "clientsecret",
+    "secret_key",
+    "secretkey",
+    "token",
+    "authtoken",
+    "auth_token",
+    "apitoken",
+    "api_token",
+    "access_token",
+    "access-token",
+    "accesstoken",
+    "apikey",
+    "api_key",
+    "access_key",
+    "accesskey",
+    "sslkey",
+    "sslcert",
+    "ssl_cert",
+    "auth",
+    # mixed-case to prove case-insensitivity
+    "Access_Token",
+    "API_KEY",
+]
+
+# Originally-covered keys — regression guard against the pre-fix set.
+ORIGINAL_KEYS = ["password", "token", "apikey", "sslpassword", "sslkey", "authtoken"]
+
+# Legitimate non-secret params that MUST NOT be masked (over-masking guard).
+NON_SENSITIVE_KEYS = [
+    "public_key",  # asymmetric public key is NOT a secret
+    "publickey",
+    "keyspace",  # blind "key in k" substring would wrongly mask this
+    "timeout",
+    "sslmode",
+    "sslrootcert",  # a cert PATH, not a secret; distinct from sslcert
+    "application_name",
+    "connect_timeout",
+    "host",
+    "port",
+    "dbname",
+]
+
+
+# ---------------------------------------------------------------------------
+# is_sensitive_query_key — the single match point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", SENSITIVE_KEYS)
+def test_is_sensitive_query_key_flags_credential_variants(key):
+    assert is_sensitive_query_key(key) is True, f"{key!r} should be sensitive"
+
+
+@pytest.mark.parametrize("key", NON_SENSITIVE_KEYS)
+def test_is_sensitive_query_key_allows_non_secret_params(key):
+    assert is_sensitive_query_key(key) is False, f"{key!r} should NOT be sensitive"
+
+
+def test_secret_key_masked_but_public_key_not():
+    # The deliberate, pinned distinction: secret_key / access_key ARE secrets;
+    # public_key is NOT. A blind substring match on "key" would break this.
+    assert is_sensitive_query_key("secret_key") is True
+    assert is_sensitive_query_key("access_key") is True
+    assert is_sensitive_query_key("public_key") is False
+
+
+# ---------------------------------------------------------------------------
+# mask_url — the canonical masker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", SENSITIVE_KEYS)
+def test_mask_url_masks_sensitive_query_variant(key):
+    url = f"postgresql://localhost:5432/db?{key}={LEAK}"
+    masked = mask_url(url)
+    assert LEAK not in masked, f"{key}={LEAK} leaked through mask_url: {masked}"
+    # The masked value is url-encoded '***' → '%2A%2A%2A'.
+    assert "%2A%2A%2A" in masked or "***" in masked
+
+
+@pytest.mark.parametrize("key", ORIGINAL_KEYS)
+def test_mask_url_regression_original_keys(key):
+    url = f"postgresql://localhost:5432/db?{key}={LEAK}"
+    assert LEAK not in mask_url(url)
+
+
+@pytest.mark.parametrize("key", NON_SENSITIVE_KEYS)
+def test_mask_url_does_not_mask_non_secret_params(key):
+    # A benign value on a non-secret param must round-trip unchanged.
+    benign = "benign-value-42"
+    url = f"postgresql://localhost:5432/db?{key}={benign}"
+    masked = mask_url(url)
+    assert masked == url, f"over-masked non-secret param {key!r}: {masked}"
+    assert benign in masked
+
+
+def test_mask_url_multi_host_masks_new_variant():
+    # MongoDB replica-set URL (comma-separated hosts) goes through the
+    # hand-rolled multi-host path — it MUST honor the same canonical set.
+    url = f"mongodb://h1:27017,h2:27017/db?access_token={LEAK}"
+    masked = mask_url(url)
+    assert LEAK not in masked
+
+
+def test_mask_url_mixes_masked_and_unmasked_params():
+    url = f"postgresql://localhost/db?access_token={LEAK}&sslmode=require&timeout=5"
+    masked = mask_url(url)
+    assert LEAK not in masked
+    assert "sslmode=require" in masked
+    assert "timeout=5" in masked
+
+
+# ---------------------------------------------------------------------------
+# get_masked_connection_string — Site 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", SENSITIVE_KEYS)
+def test_database_config_masks_sensitive_query_variant(key):
+    cfg = DatabaseConfig(
+        connection_string=f"postgresql://localhost:5432/db?{key}={LEAK}"
+    )
+    masked = cfg.get_masked_connection_string()
+    assert LEAK not in masked, f"{key} leaked through get_masked_connection_string"
+
+
+@pytest.mark.parametrize("key", ORIGINAL_KEYS)
+def test_database_config_regression_original_keys(key):
+    cfg = DatabaseConfig(
+        connection_string=f"postgresql://localhost:5432/db?{key}={LEAK}"
+    )
+    assert LEAK not in cfg.get_masked_connection_string()
+
+
+@pytest.mark.parametrize("key", NON_SENSITIVE_KEYS)
+def test_database_config_does_not_mask_non_secret_params(key):
+    benign = "benign-value-42"
+    conn = f"postgresql://localhost:5432/db?{key}={benign}"
+    cfg = DatabaseConfig(connection_string=conn)
+    masked = cfg.get_masked_connection_string()
+    assert masked == conn, f"over-masked non-secret param {key!r}: {masked}"
+
+
+# ---------------------------------------------------------------------------
+# Consolidation — all four sites resolve the SAME canonical set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["access_token", "api_key", "client_secret", "pwd"])
+def test_all_four_sites_mask_the_same_new_variant(key):
+    """A newly-covered variant is masked identically at every site."""
+    # Site 1 — mask_url
+    assert LEAK not in mask_url(f"redis://cache:6379/0?{key}={LEAK}")
+
+    # Site 2 — get_masked_connection_string
+    cfg = DatabaseConfig(connection_string=f"postgresql://h/db?{key}={LEAK}")
+    assert LEAK not in cfg.get_masked_connection_string()
+
+    # Site 3 — SecureLogger field masking (dict-field key match)
+    masked_dict = SecureLogger("t")._mask_dict({key: LEAK})
+    assert masked_dict[key] != LEAK
+    assert LEAK not in str(masked_dict[key])
+
+    # Site 4 — Redis rate-limit backend _sanitize_url
+    sanitized = RedisBackend._sanitize_url(
+        f"redis://cache:6379/0?{key}={LEAK}"
+    )
+    assert LEAK not in sanitized
+
+
+def test_redis_backend_sanitize_url_masks_userinfo_and_new_variant():
+    sanitized = RedisBackend._sanitize_url(
+        f"redis://user:{LEAK}@cache:6379/0?access_token={LEAK}"
+    )
+    assert LEAK not in sanitized
+    assert "***@cache" in sanitized
+
+
+def test_secure_logger_still_masks_broader_pii():
+    # Consolidation MUST NOT regress the broader PII coverage SecureLogger owns.
+    masked = SecureLogger("t")._mask_dict({"ssn": "123-45-6789", "email": "a@b.com"})
+    assert masked["ssn"] != "123-45-6789"
+    assert masked["email"] != "a@b.com"
+
+
+def test_secure_logger_does_not_mask_non_secret_field():
+    masked = SecureLogger("t")._mask_dict({"public_key": "pk-abc", "keyspace": "ks1"})
+    assert masked["public_key"] == "pk-abc"
+    assert masked["keyspace"] == "ks1"

--- a/tests/unit/utils/test_secure_logging.py
+++ b/tests/unit/utils/test_secure_logging.py
@@ -130,17 +130,31 @@ class TestSecureLoggingPatterns:
         """Test PII field name set."""
         pii_fields = SecureLoggingPatterns.PII_FIELD_NAMES
 
-        # Check common fields are included
+        # Check common (non-credential) PII fields are included
         assert "ssn" in pii_fields
         assert "credit_card" in pii_fields
-        assert "password" in pii_fields
         assert "email" in pii_fields
         assert "phone_number" in pii_fields
         assert "date_of_birth" in pii_fields
 
+        # Credential query-key names (password / token / api_key / secret /
+        # ...) are NOT in PII_FIELD_NAMES anymore — they moved to the single
+        # canonical set kailash.utils.url_credentials._SENSITIVE_QUERY_KEYS,
+        # matched via is_sensitive_query_key in SecureLogger._mask_dict. The
+        # coverage is verified behaviorally below, not by set membership.
+        assert "password" not in pii_fields
+
         # Check case sensitivity (should be lowercase)
         assert "SSN" not in pii_fields
-        assert "Password" not in pii_fields
+
+    def test_credential_field_names_masked_via_canonical_set(self):
+        """Credential keys relocated to the canonical set are still masked."""
+        masked = SecureLogger("t")._mask_dict(
+            {"password": "hunter2", "access_token": "tok-abc", "api_key": "k-123"}
+        )
+        assert masked["password"] != "hunter2"
+        assert masked["access_token"] != "tok-abc"
+        assert masked["api_key"] != "k-123"
 
 
 class TestSecureLogger:


### PR DESCRIPTION
## Summary
Closes a pre-existing **credential-in-logs** gap in core credential masking, discovered during the #1606 redteam. The connection-string maskers masked only 6 exact-match query keys, leaking common variants (`access_token`, `api_key`, `pwd`, `secret`, `client_secret`, cloud presigned/SAS signatures) into logs and error output.

## What changed
- **Consolidated** 4 duplicated sensitive-query-key sets → one canonical `_SENSITIVE_QUERY_KEYS` + `is_sensitive_query_key(key)` helper in `url_credentials.py` (normalized match: lowercase + strip `_`/`-`, then exact membership). All four sites (`mask_url`, `get_masked_connection_string`, trust `_sanitize_url`, `SecureLogger._mask_dict`) now reference the single helper — local copies deleted (grep-proven).
- **Expanded** coverage: DB-DSN variants + cloud presigned/SAS credential+signature params (`sig`, `signature`, `session_token`, `X-Amz-Signature`/`-Security-Token`/`-Credential`, `private_key`).
- **Over-masking guard** pinned: `public_key`, `keyspace`, `sslmode`, `sslrootcert`, `application_name`, algorithm-selectors stay unmasked; `secret_key`/`access_key` masked. PII masking (`ssn`/`email`/`private_key`) intact.

## Verification
Consolidation + expansion suite 259 passed; over-masking + PII + normalization-collision guards pinned. Reviewed by security-reviewer + 2 adversarial redteam rounds (no HIGH/MED; PII intact; no false-collision).

## Related
Hardens `security.md` § "No secrets in logs" / § Credential Decode Helpers. Follow-up: a 5th copy lives in the separate **kailash-nexus** distribution (`nexus/auth/rate_limit/backends/redis.py`) — to be consolidated in a kailash-nexus PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)