### PR TITLE
fix(dataflow): DB-instance identity in query cache keyspace (#1606 query-family)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/cache/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/__init__.py
@@ -15,7 +15,7 @@ Features:
 from .async_redis_adapter import AsyncRedisCacheAdapter
 from .auto_detection import CacheBackend
 from .invalidation import CacheBackendProtocol, CacheInvalidator, InvalidationPattern
-from .key_generator import CacheKeyGenerator
+from .key_generator import CacheKeyGenerator, hash_database_identity
 from .list_node_integration import (
     CacheableListNode,
     ListNodeCacheIntegration,
@@ -37,6 +37,7 @@ __all__ = [
     "CacheConfig",
     # Key generation
     "CacheKeyGenerator",
+    "hash_database_identity",
     # Invalidation
     "CacheInvalidator",
     "InvalidationPattern",

--- a/packages/kailash-dataflow/src/dataflow/cache/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/__init__.py
@@ -15,7 +15,12 @@ Features:
 from .async_redis_adapter import AsyncRedisCacheAdapter
 from .auto_detection import CacheBackend
 from .invalidation import CacheBackendProtocol, CacheInvalidator, InvalidationPattern
-from .key_generator import CacheKeyGenerator, hash_database_identity
+from .key_generator import (
+    CacheKeyGenerator,
+    DbIdentityResolution,
+    hash_database_identity,
+    resolve_db_identity,
+)
 from .list_node_integration import (
     CacheableListNode,
     ListNodeCacheIntegration,
@@ -38,6 +43,8 @@ __all__ = [
     # Key generation
     "CacheKeyGenerator",
     "hash_database_identity",
+    "resolve_db_identity",
+    "DbIdentityResolution",
     # Invalidation
     "CacheInvalidator",
     "InvalidationPattern",

--- a/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
@@ -8,8 +8,42 @@ import hashlib
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from kailash.utils.url_credentials import mask_url
+
 if TYPE_CHECKING:
     from dataflow.classification.policy import ClassificationPolicy
+
+
+def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
+    """Return a short, credential-free fingerprint of a database URL.
+
+    Used as the DB-instance identity segment in the QUERY cache keyspace
+    (issue #1606) so two DataFlow instances pointed at *different* databases
+    never collide on the same query cache key. The query keyspace hashes a
+    normalized SQL string + params, which is identical for the same
+    model+filter regardless of which database the instance targets — so
+    without this segment two instances at different DBs read each other's
+    cached query rows (cross-DB cache bleed).
+
+    The URL is FIRST routed through ``mask_url`` (credential-stripped:
+    scheme + ``***`` placeholder + host+port+dbname, NEVER user/password
+    bytes) BEFORE hashing, so no credential can ever enter the key. Redis
+    keys are an observable surface — treat like logs (``rules/security.md``
+    § "No secrets in logs"). Returns ``None`` for a falsy URL so the
+    generator falls back to the pre-#1606 keyspace shape.
+
+    NOTE: this segments the QUERY keyspace only. The Express ``v2``
+    keyspace (``generate_express_key``) is a byte-for-byte cross-SDK
+    contract pinned to kailash-rs and MUST NOT carry this segment.
+    """
+    if not database_url:
+        return None
+    # mask_url is the single credential-masking helper; its output never
+    # contains user/password bytes (only a constant ``***`` placeholder),
+    # so hashing it yields a stable per-DB fingerprint with zero credential
+    # exposure even if the digest were ever reversed.
+    masked = mask_url(database_url)
+    return hashlib.sha256(masked.encode("utf-8")).hexdigest()[:8]
 
 
 class CacheKeyGenerator:
@@ -21,6 +55,7 @@ class CacheKeyGenerator:
         namespace: Optional[str] = None,
         version: str = "v2",
         classification_policy: Optional["ClassificationPolicy"] = None,
+        db_identity: Optional[str] = None,
     ):
         """
         Initialize key generator.
@@ -38,11 +73,22 @@ class CacheKeyGenerator:
                 routed through ``format_record_id_for_event`` before
                 serialization so the raw value never appears in the JSON
                 that feeds the MD5/SHA-256 digest. See issue #520.
+            db_identity: Optional credential-free fingerprint of the
+                database this generator serves, produced by
+                ``hash_database_identity``. When set, it is inserted into
+                the QUERY keyspace (``generate_key``) — directly after the
+                model name — so two DataFlow instances at *different*
+                databases never collide on the same query cache key
+                (issue #1606: cross-DB cache bleed). It is DELIBERATELY
+                absent from ``generate_express_key``: the Express ``v2``
+                keyspace is a byte-for-byte cross-SDK contract pinned to
+                ``kailash-rs`` and MUST NOT change unilaterally.
         """
         self.prefix = prefix
         self.namespace = namespace
         self.version = version
         self._classification_policy = classification_policy
+        self.db_identity = db_identity
 
     def _safe_params(self, model_name: str, params: Any) -> Any:
         """Return a copy of ``params`` with classified PK values hashed.
@@ -111,9 +157,24 @@ class CacheKeyGenerator:
         if self.namespace:
             components.append(self.namespace)
 
-        components.extend(
-            [model_name, self.version, self._hash_query(normalized_sql, params)]
-        )
+        components.append(model_name)
+
+        # Issue #1606: DB-instance identity segment. The query keyspace
+        # hashes a normalized SQL string + params — identical for the same
+        # model+filter across every database — so without this segment two
+        # DataFlow instances at different DBs collide on one key and read
+        # each other's cached rows (cross-DB cache bleed). Placed AFTER the
+        # model name so the existing model-anchored invalidation sweeps
+        # (``{prefix}:{model}:*`` and the ``:{model}:`` substring matcher)
+        # still match BOTH old-shape (no db_identity) and new-shape keys.
+        # The query keyspace is NOT the Rust-pinned Express v2 keyspace — it
+        # diverges cross-SDK by construction (py vs rs emit different SQL),
+        # so adding this segment is a py-local change, not a cross-SDK
+        # lockstep. See ``generate_express_key`` (Rust-pinned, untouched).
+        if self.db_identity:
+            components.append(self.db_identity)
+
+        components.extend([self.version, self._hash_query(normalized_sql, params)])
 
         # Join with colons
         key = ":".join(components)

--- a/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
@@ -6,12 +6,17 @@ Generates deterministic cache keys from queries and parameters.
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 
-from kailash.utils.url_credentials import mask_url
+from kailash.utils.url_credentials import UNPARSEABLE_URL_SENTINEL, mask_url
 
 if TYPE_CHECKING:
     from dataflow.classification.policy import ClassificationPolicy
+
+
+def _hash8(material: str) -> str:
+    """Return the first 8 hex chars of sha256(material)."""
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:8]
 
 
 def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
@@ -29,8 +34,25 @@ def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
     scheme + ``***`` placeholder + host+port+dbname, NEVER user/password
     bytes) BEFORE hashing, so no credential can ever enter the key. Redis
     keys are an observable surface — treat like logs (``rules/security.md``
-    § "No secrets in logs"). Returns ``None`` for a falsy URL so the
-    generator falls back to the pre-#1606 keyspace shape.
+    § "No secrets in logs").
+
+    Returns ``None`` when the URL is falsy OR unparseable (``mask_url``
+    yields ``UNPARSEABLE_URL_SENTINEL`` — e.g. a libpq keyword/value DSN
+    ``"host=a dbname=x"`` with no ``://``). Hashing the sentinel is
+    DELIBERATELY refused: every unparseable-DSN instance would otherwise
+    share one CONSTANT identity, silently collapsing cross-DB isolation
+    (``rules/zero-tolerance.md`` Rule 3, silent fallback). Callers that
+    need the URL-vs-components-vs-none disposition (to warn the operator)
+    use ``resolve_db_identity`` instead.
+
+    SCOPE (issue #1606) — the identity keys on database LOCATION
+    (host/port/dbname), NOT on the connecting principal: ``mask_url``
+    strips userinfo to ``***``, so ``postgres://alice:pw1@h:5432/db`` and
+    ``postgres://bob:pw2@h:5432/db`` produce the SAME identity. Two
+    instances at the same database with different DB credentials share a
+    cache namespace BY DESIGN. Deployments relying on per-principal
+    DB-level row visibility (RLS / per-user GRANTs) MUST NOT share a cache
+    backend across principals.
 
     NOTE: this segments the QUERY keyspace only. The Express ``v2``
     keyspace (``generate_express_key``) is a byte-for-byte cross-SDK
@@ -43,7 +65,80 @@ def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
     # so hashing it yields a stable per-DB fingerprint with zero credential
     # exposure even if the digest were ever reversed.
     masked = mask_url(database_url)
-    return hashlib.sha256(masked.encode("utf-8")).hexdigest()[:8]
+    if masked == UNPARSEABLE_URL_SENTINEL:
+        # A non-URL DSN (or garbage) masks to a CONSTANT sentinel; hashing it
+        # would give every such instance the same identity — refuse.
+        return None
+    return _hash8(masked)
+
+
+class DbIdentityResolution(NamedTuple):
+    """Outcome of :func:`resolve_db_identity`.
+
+    Attributes:
+        identity: The credential-free DB-identity segment, or ``None`` when
+            no usable identity could be derived (the query keyspace then
+            falls back to the pre-#1606 shape and cross-DB isolation is
+            INACTIVE — the caller MUST warn).
+        source: ``"url"`` (derived from the connection URL), ``"components"``
+            (derived from host/port/dbname structured config after the URL
+            was absent or unparseable), or ``"none"`` (no usable identity).
+        url_unparseable: ``True`` when a URL string was supplied but
+            ``mask_url`` could not parse it (a keyword/value DSN or garbage).
+            The caller warns on this even when the component fallback
+            succeeds, because the supplied URL could not be used.
+    """
+
+    identity: Optional[str]
+    source: str
+    url_unparseable: bool
+
+
+def resolve_db_identity(
+    url: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[Union[int, str]] = None,
+    dbname: Optional[str] = None,
+) -> DbIdentityResolution:
+    """Resolve a credential-free DB-instance identity (issue #1606).
+
+    Tries the connection URL first; when the URL is absent OR unparseable,
+    falls back to the structured component config (``host``/``port``/
+    ``dbname``) so cross-DB isolation still HOLDS for URL-less DataFlow
+    instances (component/params config, or a lazily-populated URL). The
+    component identity is a hash of a normalized ``host:port/dbname``
+    string — host+port+dbname ONLY, NEVER any user/password field — so the
+    same credential-free contract as the URL path holds.
+
+    Returns a :class:`DbIdentityResolution`; when ``identity is None`` the
+    caller MUST emit a loud warning (cross-DB cache isolation is INACTIVE
+    on a shared cache backend). See ``rules/zero-tolerance.md`` Rule 3 —
+    silent-unprotected is the failure mode this resolution + the caller's
+    warning close.
+
+    The identity is captured ONCE at cache-integration construction; a URL
+    set on the config AFTER construction does not retroactively change it
+    (acceptable — DataFlow database URLs are set at init).
+    """
+    # 1. URL path.
+    if url:
+        masked = mask_url(url)
+        if masked != UNPARSEABLE_URL_SENTINEL:
+            return DbIdentityResolution(_hash8(masked), "url", False)
+        url_unparseable = True
+    else:
+        url_unparseable = False
+
+    # 2. Component fallback — credential-free host:port/dbname. Never hash
+    #    the unparseable sentinel (that constant would collapse isolation);
+    #    derive from structured fields instead so URL-less configs stay
+    #    isolated. host + dbname are the minimum; port is optional.
+    if host and dbname:
+        normalized = f"{host}:{port if port is not None else ''}/{dbname}"
+        return DbIdentityResolution(_hash8(normalized), "components", url_unparseable)
+
+    # 3. No usable identity — segmentation is DISABLED; the caller warns.
+    return DbIdentityResolution(None, "none", url_unparseable)
 
 
 class CacheKeyGenerator:

--- a/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
@@ -19,6 +19,37 @@ def _hash8(material: str) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:8]
 
 
+def _sanitize_component_host(host: str) -> str:
+    """Strip any credential-carrying userinfo from a component-config host.
+
+    Defense-in-depth parity (#1606): the URL identity path routes through
+    ``mask_url`` (userinfo stripped to ``***``) BEFORE hashing, so no
+    credential byte reaches the hash pre-image. The component-fallback path
+    hashes ``host:port/dbname`` directly — so if an operator mis-sets
+    ``config.database.host`` to a full DSN-with-creds (e.g.
+    ``postgres://u:pw@h/db``) AND leaves ``url`` absent, those credential
+    bytes would otherwise enter the pre-image. When ``host`` is DSN-shaped
+    (contains ``@`` or ``://``), strip the scheme and the userinfo so only a
+    credential-free host substring survives; a normal bare hostname is
+    returned BYTE-IDENTICALLY (the guard triggers ONLY on the DSN-shaped
+    case, so it never changes the identity of a correctly-configured host).
+
+    NOTE: ``host`` and ``dbname`` are assumed delimiter-free for the
+    ``host:port/dbname`` join; a literal ``:`` / ``/`` inside a component
+    field is not disambiguated (no realistic cross-DB collision is
+    constructible — the fields come from structured config, not free text).
+    """
+    if "@" not in host and "://" not in host:
+        return host
+    stripped = host
+    if "://" in stripped:
+        stripped = stripped.split("://", 1)[1]
+    if "@" in stripped:
+        # userinfo (user[:password]) precedes the last '@'; keep only the host side.
+        stripped = stripped.rsplit("@", 1)[1]
+    return stripped
+
+
 def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
     """Return a short, credential-free fingerprint of a database URL.
 
@@ -134,7 +165,13 @@ def resolve_db_identity(
     #    derive from structured fields instead so URL-less configs stay
     #    isolated. host + dbname are the minimum; port is optional.
     if host and dbname:
-        normalized = f"{host}:{port if port is not None else ''}/{dbname}"
+        # Defense-in-depth (#1606): strip any credential-carrying userinfo if
+        # host was mis-set to a DSN, so no credential byte enters the hash
+        # pre-image (parity with the URL path's mask_url step). A bare
+        # hostname is unchanged, so a correctly-configured host's identity is
+        # byte-identical to the pre-sanitize behavior.
+        safe_host = _sanitize_component_host(host)
+        normalized = f"{safe_host}:{port if port is not None else ''}/{dbname}"
         return DbIdentityResolution(_hash8(normalized), "components", url_unparseable)
 
     # 3. No usable identity — segmentation is DISABLED; the caller warns.

--- a/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
@@ -214,12 +214,18 @@ class ListNodeCacheIntegration:
 
         Issue #750 — patterns MUST match the actual cache key format produced
         by ``self.key_generator.generate_key()``: ``{prefix}:{model}:{version}:{hash}``
-        where ``{prefix}`` defaults to ``"dataflow:query"``. The previous
+        (or, since issue #1606, ``{prefix}:{model}:{db_identity}:{version}:{hash}``
+        — the DB-instance identity segment sits directly after the model
+        name). ``{prefix}`` defaults to ``"dataflow:query"``. The previous
         ``{model}:list:*`` shape never matched any real key and silently
         no-op'd every invalidation, leaving stale list/count entries served
         forever. Per ``rules/tenant-isolation.md`` Rule 3a, patterns use a
-        version-wildcard sweep (``{prefix}:{model}:*``) so v1, v2, and any
-        future keyspace bump are all swept in one call.
+        trailing wildcard sweep anchored at the model (``{prefix}:{model}:*``)
+        so v1, v2, ANY future keyspace bump, AND the #1606 DB-identity
+        segment (all of which follow the matched ``{prefix}:{model}:``
+        anchor) are swept in one call — this matches both pre-#1606
+        old-shape keys and post-#1606 new-shape keys, so no stale query-cache
+        entry survives under the old shape.
         """
         # Anchor patterns at the producer-side prefix so InMemoryCache /
         # AsyncRedisCacheAdapter substring-matchers find the real keys.

--- a/packages/kailash-dataflow/src/dataflow/cache/memory_cache.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/memory_cache.py
@@ -191,13 +191,16 @@ class InMemoryCache:
 
         - Express keys: ``dataflow:v*:{model}:{op}:...``
         - Express keys with tenant: ``dataflow:v*:{tenant}:{model}:{op}:...``
-        - SQL query keys: ``dataflow:{model}:v*:...``
+        - SQL query keys: ``dataflow:{model}:v*:...`` or, since issue #1606,
+          ``dataflow:{model}:{db_identity}:v*:...`` (the DB-instance
+          identity segment sits directly after the model name).
 
-        The ``v*`` wildcard covers legacy v1 keys (pre-BP-049) and current v2
-        keys produced by the default ``CacheKeyGenerator``. Matching is
-        version-agnostic via segment-based string search — ``:{model}:`` as
-        an exact delimiter — so the implementation survives future keyspace
-        bumps without edit (``tenant-isolation.md §3a``).
+        The ``:{model}:`` segment matcher is agnostic to BOTH the version
+        segment AND the #1606 DB-identity segment (they follow the matched
+        ``:{model}:`` delimiter), so it sweeps legacy v1 keys, pre-#1606 v2
+        keys (no db_identity), AND post-#1606 v2 keys (with db_identity) in
+        one call — the implementation survives future keyspace bumps and the
+        DB-identity addition without edit (``tenant-isolation.md §3a``).
 
         Matching strategy:
 

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -1583,7 +1583,7 @@ class DataFlow(DataFlowEventMixin):
                 CacheInvalidator,
                 CacheKeyGenerator,
                 create_cache_integration,
-                hash_database_identity,
+                resolve_db_identity,
             )
 
             # Get cache configuration
@@ -1613,17 +1613,49 @@ class DataFlow(DataFlowEventMixin):
             # Issue #1606: plumb a credential-free DB-instance fingerprint so
             # the QUERY keyspace is segmented per database — two DataFlow
             # instances at different DBs never collide on the same query
-            # cache key (cross-DB cache bleed). Sourced from the configured
-            # database URL and hashed through mask_url first, so no
-            # credential byte can enter the key. The Express v2 keyspace is
-            # Rust-pinned and does NOT receive this segment.
-            db_url = getattr(getattr(self.config, "database", None), "url", None)
-            db_identity = hash_database_identity(db_url)
+            # cache key (cross-DB cache bleed). Prefer the configured
+            # database URL; when it is absent or unparseable, fall back to
+            # the structured component config (host/port/dbname) so isolation
+            # HOLDS for URL-less instances. The identity is always a hash of
+            # a credential-free string (mask_url output, or host:port/dbname)
+            # — no user/password byte can enter the key. The Express v2
+            # keyspace is Rust-pinned and does NOT receive this segment.
+            #
+            # The identity is captured ONCE here at cache-integration
+            # construction; a URL set on the config after construction does
+            # not retroactively change it (DataFlow URLs are set at init).
+            db_conf = getattr(self.config, "database", None)
+            db_res = resolve_db_identity(
+                url=getattr(db_conf, "url", None),
+                host=getattr(db_conf, "host", None),
+                port=getattr(db_conf, "port", None),
+                dbname=getattr(db_conf, "database", None),
+            )
+            # Loud operator signal when the query keyspace cannot be
+            # segmented — silent-unprotected is the exact zero-tolerance
+            # Rule 3 failure mode this warning closes.
+            if db_res.url_unparseable:
+                logger.warning(
+                    "engine.cache.db_identity_url_unparseable: the configured "
+                    "database URL is not a parseable connection URL, so a "
+                    "per-DB cache identity could not be derived from it; "
+                    "cross-DB cache isolation relies on component config or is "
+                    "INACTIVE (#1606)"
+                )
+            if db_res.identity is None:
+                logger.warning(
+                    "engine.cache.db_identity_disabled: DB-identity segmentation "
+                    "is DISABLED (no usable database identity from URL or "
+                    "host/port/dbname component config) — cross-DB cache "
+                    "isolation is INACTIVE on a shared cache backend; two "
+                    "DataFlow instances at different databases may read each "
+                    "other's cached query rows (#1606)"
+                )
             key_generator = CacheKeyGenerator(
                 prefix=cache_key_prefix,
                 namespace=getattr(self.config, "cache_namespace", None),
                 classification_policy=getattr(self, "_classification_policy", None),
-                db_identity=db_identity,
+                db_identity=db_res.identity,
             )
 
             # Create cache invalidator

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -1583,6 +1583,7 @@ class DataFlow(DataFlowEventMixin):
                 CacheInvalidator,
                 CacheKeyGenerator,
                 create_cache_integration,
+                hash_database_identity,
             )
 
             # Get cache configuration
@@ -1608,10 +1609,21 @@ class DataFlow(DataFlowEventMixin):
             # Create key generator. BP-049 (#520): plumb the classification
             # policy so classified PKs are hashed before serialisation into
             # cache keys.
+            #
+            # Issue #1606: plumb a credential-free DB-instance fingerprint so
+            # the QUERY keyspace is segmented per database — two DataFlow
+            # instances at different DBs never collide on the same query
+            # cache key (cross-DB cache bleed). Sourced from the configured
+            # database URL and hashed through mask_url first, so no
+            # credential byte can enter the key. The Express v2 keyspace is
+            # Rust-pinned and does NOT receive this segment.
+            db_url = getattr(getattr(self.config, "database", None), "url", None)
+            db_identity = hash_database_identity(db_url)
             key_generator = CacheKeyGenerator(
                 prefix=cache_key_prefix,
                 namespace=getattr(self.config, "cache_namespace", None),
                 classification_policy=getattr(self, "_classification_policy", None),
+                db_identity=db_identity,
             )
 
             # Create cache invalidator

--- a/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_cross_db_bleed.py
+++ b/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_cross_db_bleed.py
@@ -1,0 +1,221 @@
+"""#1606 cross-DB query-cache bleed — Tier 2 (real Redis + two real SQLite DBs).
+
+Reproduces (RED) and proves closed (GREEN) the cross-database cache bleed:
+two DataFlow instances pointed at DIFFERENT databases, sharing ONE Redis cache
+backend, running the SAME model+filter, must NOT read each other's cached query
+rows.
+
+Root cause: the QUERY cache key hashes a normalized SQL string + params, which
+is identical for the same model+filter regardless of which database the
+instance targets. Without a DB-instance identity segment, both instances
+compute the SAME key on a shared Redis, so instance B reads instance A's cached
+rows. Fix (#1606): a credential-free DB-identity segment in the query keyspace
+(``dataflow:<model>:<db_identity>:v2:<hash>``).
+
+NO MOCKING (testing.md Tier 2): real Redis + two real file-backed SQLite
+databases; every assertion is a read-back through the real cache path.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from dataflow.cache.async_redis_adapter import AsyncRedisCacheAdapter
+from dataflow.cache.invalidation import CacheInvalidator
+from dataflow.cache.key_generator import CacheKeyGenerator, hash_database_identity
+from dataflow.cache.list_node_integration import ListNodeCacheIntegration
+from dataflow.cache.redis_manager import CacheConfig, RedisCacheManager
+
+# Same fixed model+SQL+params for BOTH instances — this is what makes the
+# query hash collide across databases (the bug's precondition).
+_MODEL = "User"
+_SQL = "SELECT id, name FROM users WHERE active = ?"
+_PARAMS = [1]
+
+
+def _redis_config_or_skip() -> CacheConfig:
+    """Return a CacheConfig for a reachable real Redis, or skip the test."""
+    import redis as _redis_sync
+
+    for host, port, db in (("localhost", 6380, 1), ("localhost", 6379, 1)):
+        try:
+            client = _redis_sync.Redis(host=host, port=port, db=db, socket_timeout=0.5)
+            client.ping()
+            client.close()
+            return CacheConfig(host=host, port=port, db=db)
+        except Exception:
+            continue
+    pytest.skip("No reachable Redis instance on localhost:6380 or :6379")
+
+
+def _make_sqlite_db(tmp: Path, name: str, row_name: str) -> str:
+    """Create a real file-backed SQLite DB with one users row; return its URL."""
+    db_path = tmp / f"{name}.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, active INTEGER)"
+        )
+        conn.execute("INSERT INTO users (name, active) VALUES (?, 1)", (row_name,))
+        conn.commit()
+    finally:
+        conn.close()
+    return f"sqlite:///{db_path}"
+
+
+def _executor_for(db_url: str, source_tag: str):
+    """Return a sync executor_func that runs the real SELECT against `db_url`."""
+
+    db_path = db_url[len("sqlite:///") :]
+
+    def _run():
+        conn = sqlite3.connect(db_path)
+        try:
+            cur = conn.execute("SELECT id, name FROM users WHERE active = 1")
+            rows = [{"id": r[0], "name": r[1]} for r in cur.fetchall()]
+        finally:
+            conn.close()
+        # source_db lets the test detect a bleed: a cached row from the WRONG
+        # instance carries the other instance's source tag.
+        return {"rows": rows, "source_db": source_tag}
+
+    return _run
+
+
+def _integration(cache_manager, db_url, *, with_db_identity: bool, prefix: str):
+    """Build a query-cache integration sharing `cache_manager`.
+
+    with_db_identity=False reproduces the PRE-#1606 keyspace (the bug);
+    with_db_identity=True is the POST-#1606 fixed keyspace.
+    """
+    db_identity = hash_database_identity(db_url) if with_db_identity else None
+    key_gen = CacheKeyGenerator(prefix=prefix, db_identity=db_identity)
+    invalidator = CacheInvalidator(cache_manager)
+    return ListNodeCacheIntegration(cache_manager, key_gen, invalidator)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pre_fix_shape_reproduces_cross_db_bleed():
+    """RED: without the DB-identity segment, instance B reads instance A's rows."""
+    config = _redis_config_or_skip()
+    # Unique prefix so this test's keys are isolated + cleanable on shared Redis.
+    prefix = f"df1606test:{uuid4().hex}"
+
+    cache_manager = AsyncRedisCacheAdapter(RedisCacheManager(config))
+    try:
+        with tempfile.TemporaryDirectory() as d_a, tempfile.TemporaryDirectory() as d_b:
+            url_a = _make_sqlite_db(Path(d_a), "dba", "alice-from-db-A")
+            url_b = _make_sqlite_db(Path(d_b), "dbb", "bob-from-db-B")
+
+            integ_a = _integration(
+                cache_manager, url_a, with_db_identity=False, prefix=prefix
+            )
+            integ_b = _integration(
+                cache_manager, url_b, with_db_identity=False, prefix=prefix
+            )
+
+            # Sanity: pre-fix, the two instances compute the IDENTICAL key.
+            key_a = integ_a.key_generator.generate_key(_MODEL, _SQL, _PARAMS)
+            key_b = integ_b.key_generator.generate_key(_MODEL, _SQL, _PARAMS)
+            assert key_a == key_b, "pre-fix precondition: keys must collide"
+
+            # A caches its own rows.
+            res_a = await integ_a.execute_with_cache(
+                _MODEL, _SQL, _PARAMS, _executor_for(url_a, "A")
+            )
+            assert res_a["_cache"]["hit"] is False
+            assert res_a["source_db"] == "A"
+
+            # B runs the SAME query -> HIT on A's cached entry -> BLEED.
+            res_b = await integ_b.execute_with_cache(
+                _MODEL, _SQL, _PARAMS, _executor_for(url_b, "B")
+            )
+            assert res_b["_cache"]["hit"] is True, "pre-fix: expected a cache HIT"
+            assert res_b["source_db"] == "A", (
+                "BLEED reproduced: instance B read instance A's cached rows "
+                f"({res_b['rows']!r})"
+            )
+            assert res_b["rows"] == [{"id": 1, "name": "alice-from-db-A"}]
+    finally:
+        _cleanup_redis(config, prefix)
+        await cache_manager.close_async()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_post_fix_db_identity_closes_cross_db_bleed():
+    """GREEN: with the DB-identity segment, B reads ITS OWN rows (no bleed)."""
+    config = _redis_config_or_skip()
+    prefix = f"df1606test:{uuid4().hex}"
+
+    cache_manager = AsyncRedisCacheAdapter(RedisCacheManager(config))
+    try:
+        with tempfile.TemporaryDirectory() as d_a, tempfile.TemporaryDirectory() as d_b:
+            url_a = _make_sqlite_db(Path(d_a), "dba", "alice-from-db-A")
+            url_b = _make_sqlite_db(Path(d_b), "dbb", "bob-from-db-B")
+
+            integ_a = _integration(
+                cache_manager, url_a, with_db_identity=True, prefix=prefix
+            )
+            integ_b = _integration(
+                cache_manager, url_b, with_db_identity=True, prefix=prefix
+            )
+
+            # Post-fix: the two instances compute DIFFERENT keys (the fix).
+            key_a = integ_a.key_generator.generate_key(_MODEL, _SQL, _PARAMS)
+            key_b = integ_b.key_generator.generate_key(_MODEL, _SQL, _PARAMS)
+            assert key_a != key_b, "post-fix: keys MUST differ per database"
+
+            # A caches its own rows.
+            res_a = await integ_a.execute_with_cache(
+                _MODEL, _SQL, _PARAMS, _executor_for(url_a, "A")
+            )
+            assert res_a["_cache"]["hit"] is False
+            assert res_a["source_db"] == "A"
+
+            # B runs the SAME query -> MISS (own key) -> reads ITS OWN DB.
+            res_b = await integ_b.execute_with_cache(
+                _MODEL, _SQL, _PARAMS, _executor_for(url_b, "B")
+            )
+            assert res_b["_cache"]["hit"] is False, "post-fix: B must MISS, not bleed"
+            assert res_b["source_db"] == "B"
+            assert res_b["rows"] == [
+                {"id": 1, "name": "bob-from-db-B"}
+            ], "no bleed: B reads its own database's rows"
+
+            # Read-back through the shared Redis: each key holds ITS OWN data,
+            # and A's cached entry is untouched by B.
+            back_a = await cache_manager.get(key_a)
+            back_b = await cache_manager.get(key_b)
+            assert back_a["rows"] == [{"id": 1, "name": "alice-from-db-A"}]
+            assert back_b["rows"] == [{"id": 1, "name": "bob-from-db-B"}]
+
+            # Invariant 5 restated on the real backend: a SECOND B read HITS its
+            # own key (cache still works — no over-invalidation from the fix).
+            res_b2 = await integ_b.execute_with_cache(
+                _MODEL, _SQL, _PARAMS, _executor_for(url_b, "B")
+            )
+            assert res_b2["_cache"]["hit"] is True
+            assert res_b2["source_db"] == "B"
+    finally:
+        _cleanup_redis(config, prefix)
+        await cache_manager.close_async()
+
+
+def _cleanup_redis(config: CacheConfig, prefix: str) -> None:
+    """Delete this test's keys from the shared Redis (no flushdb — shared infra)."""
+    import redis as _redis_sync
+
+    client = _redis_sync.Redis(
+        host=config.host, port=config.port, db=config.db, decode_responses=True
+    )
+    try:
+        keys = list(client.scan_iter(match=f"{prefix}*"))
+        if keys:
+            client.delete(*keys)
+    finally:
+        client.close()

--- a/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_db_identity_fallback.py
+++ b/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_db_identity_fallback.py
@@ -1,0 +1,158 @@
+"""#1606 DB-identity engine wiring — Tier 2 (real DataFlow engine, no mocking).
+
+Exercises the exact ``DataFlow._initialize_cache_integration`` path (redteam
+FINDING 1): a falsy/absent URL or a non-URL DSN MUST emit a loud operator
+warning that cross-DB cache isolation is INACTIVE, and MUST fall back to the
+credential-free component config (host/port/dbname) when available so
+isolation still holds for URL-less instances.
+
+These construct a real DataFlow engine and drive the real cache-integration
+setup; no mocks. Redis may or may not be present — irrelevant here, the
+assertions are on the key generator's db_identity + the emitted warnings.
+
+Tier: 2 (real engine wiring).
+"""
+
+import logging
+
+import pytest
+
+from dataflow import DataFlow
+
+_ENGINE_LOGGER = "dataflow.core.engine"
+_QUERY_SQL = "SELECT * FROM users WHERE active = $1"
+_QUERY_PARAMS = [True]
+
+
+def _reinit_cache(db) -> None:
+    """Re-run the cache-integration setup after mutating config.database."""
+    db._cache_integration = None
+    db._initialize_cache_integration()
+
+
+def test_falsy_db_url_warns_isolation_inactive():
+    """FINDING 1(b): absent URL + no components -> loud WARN, identity None."""
+    db = DataFlow("sqlite:///:memory:", cache_enabled=True)
+    # Simulate a config with no usable database identity at all.
+    db.config.database.url = None
+    db.config.database.database_url = None
+    db.config.database.host = None
+    db.config.database.port = None
+    db.config.database.database = None
+
+    with caplog_at_warning() as caplog:
+        _reinit_cache(db)
+
+    assert db._cache_integration is not None
+    assert db._cache_integration.key_generator.db_identity is None
+    assert "db_identity_disabled" in caplog.text
+    assert "INACTIVE" in caplog.text
+
+
+def test_falsy_db_url_with_components_uses_component_identity_no_disabled_warn():
+    """FINDING 1(a): URL-less config derives identity from host/port/dbname."""
+    db = DataFlow("sqlite:///:memory:", cache_enabled=True)
+    db.config.database.url = None
+    db.config.database.database_url = None
+    db.config.database.host = "h1"
+    db.config.database.port = 5432
+    db.config.database.database = "app_db"
+
+    with caplog_at_warning() as caplog:
+        _reinit_cache(db)
+
+    identity = db._cache_integration.key_generator.db_identity
+    assert identity is not None, "component config must yield an identity"
+    # No "disabled" warning — isolation is active via component config.
+    assert "db_identity_disabled" not in caplog.text
+
+
+def test_unparseable_dsn_warns():
+    """FINDING 1(b): a non-URL keyword/value DSN -> WARN (not a silent constant)."""
+    db = DataFlow("sqlite:///:memory:", cache_enabled=True)
+    db.config.database.url = "host=a dbname=x"  # libpq keyword DSN, no ://
+    db.config.database.database_url = "host=a dbname=x"
+    db.config.database.host = None
+    db.config.database.port = None
+    db.config.database.database = None
+
+    with caplog_at_warning() as caplog:
+        _reinit_cache(db)
+
+    # url_unparseable warning fires; with no components, identity stays None.
+    assert "db_identity_url_unparseable" in caplog.text
+    assert db._cache_integration.key_generator.db_identity is None
+
+
+def test_component_config_identity_isolates_two_urlless_instances():
+    """FINDING 1(a): two URL-less engines at different DBs -> different query keys."""
+    db_a = DataFlow("sqlite:///:memory:", cache_enabled=True)
+    db_a.config.database.url = None
+    db_a.config.database.database_url = None
+    db_a.config.database.host = "host-a"
+    db_a.config.database.port = 5432
+    db_a.config.database.database = "db_a"
+    _reinit_cache(db_a)
+
+    db_b = DataFlow("sqlite:///:memory:", cache_enabled=True)
+    db_b.config.database.url = None
+    db_b.config.database.database_url = None
+    db_b.config.database.host = "host-b"
+    db_b.config.database.port = 5432
+    db_b.config.database.database = "db_b"
+    _reinit_cache(db_b)
+
+    key_a = db_a._cache_integration.key_generator.generate_key(
+        "User", _QUERY_SQL, _QUERY_PARAMS
+    )
+    key_b = db_b._cache_integration.key_generator.generate_key(
+        "User", _QUERY_SQL, _QUERY_PARAMS
+    )
+    assert key_a != key_b, (
+        "two URL-less DataFlow instances at different databases must NOT "
+        f"collide on the same query cache key (a={key_a!r} b={key_b!r})"
+    )
+
+
+# --- caplog helper -------------------------------------------------------
+
+class _CapLog:
+    def __init__(self):
+        self.records = []
+
+    @property
+    def text(self):
+        return "\n".join(r.getMessage() for r in self.records)
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self, sink):
+        super().__init__(level=logging.WARNING)
+        self._sink = sink
+
+    def emit(self, record):
+        self._sink.records.append(record)
+
+
+class caplog_at_warning:
+    """Minimal caplog: capture WARNING+ from the engine logger during the block.
+
+    Self-contained (no pytest caplog fixture dependency) so the assertions are
+    robust to the engine's own logging configuration.
+    """
+
+    def __enter__(self):
+        self._sink = _CapLog()
+        self._handler = _ListHandler(self._sink)
+        self._logger = logging.getLogger(_ENGINE_LOGGER)
+        self._prev_level = self._logger.level
+        self._prev_propagate = self._logger.propagate
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.WARNING)
+        return self._sink
+
+    def __exit__(self, *exc):
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._prev_level)
+        self._logger.propagate = self._prev_propagate
+        return False

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_db_identity_resolver.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_db_identity_resolver.py
@@ -16,6 +16,8 @@ import hashlib
 
 from dataflow.cache.key_generator import (
     CacheKeyGenerator,
+    _hash8,
+    _sanitize_component_host,
     hash_database_identity,
     resolve_db_identity,
 )
@@ -24,8 +26,44 @@ _QUERY_SQL = "SELECT * FROM users WHERE active = $1"
 _QUERY_PARAMS = [True]
 
 
+def test_component_identity_sanitizes_dsn_shaped_host():
+    """Defense-in-depth (#1606): a DSN-with-creds mis-set as `host` enters the
+    component-identity pre-image credential-FREE; a bare hostname is unchanged.
+
+    Parity with the URL path (which routes through mask_url before hashing):
+    if an operator sets ``config.database.host`` to a full DSN with credentials
+    AND leaves ``url`` absent, no credential byte may reach the hash pre-image.
+    """
+    dsn_host = "postgres://myuser:mypassword@realhost:5432/appdb"
+
+    # The sanitized host (which feeds the hash pre-image) carries NO credential.
+    sanitized = _sanitize_component_host(dsn_host)
+    assert "mypassword" not in sanitized
+    assert "myuser" not in sanitized
+
+    # No credential byte enters the identity pre-image: the identity equals the
+    # hash of the credential-free normalized string, and DIFFERS from the naive
+    # with-credentials pre-image (proving the strip happened, not a coincidence).
+    res = resolve_db_identity(host=dsn_host, port=5432, dbname="appdb")
+    assert res.identity == _hash8(f"{sanitized}:5432/appdb")
+    assert res.identity != _hash8(f"{dsn_host}:5432/appdb")
+
+    # A userinfo-only host (no scheme) is also stripped.
+    assert "mypassword" not in _sanitize_component_host("myuser:mypassword@realhost")
+
+    # NO REGRESSION: a normal bare hostname is byte-identical (guard triggers
+    # only on DSN-shaped hosts), so a correctly-configured host's identity is
+    # unchanged from the pre-sanitize behavior.
+    assert _sanitize_component_host("realhost") == "realhost"
+    assert (
+        resolve_db_identity(host="h1", port=5432, dbname="db1").identity == "8f1d9ced"
+    )
+
+
 def test_url_path_derives_identity_credential_free():
-    res = resolve_db_identity(url="postgresql://alice:s3cret@db-a.example.com:5432/prod")
+    res = resolve_db_identity(
+        url="postgresql://alice:s3cret@db-a.example.com:5432/prod"
+    )
     assert res.identity is not None
     assert res.source == "url"
     assert res.url_unparseable is False
@@ -109,4 +147,6 @@ def test_documented_scope_same_location_different_principal_shares_identity():
     """
     alice = hash_database_identity("postgres://alice:pw1@h:5432/db")
     bob = hash_database_identity("postgres://bob:pw2@h:5432/db")
-    assert alice == bob, "same DB location, different principal -> same identity (by design)"
+    assert (
+        alice == bob
+    ), "same DB location, different principal -> same identity (by design)"

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_db_identity_resolver.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_db_identity_resolver.py
@@ -1,0 +1,112 @@
+"""#1606 DB-identity resolver — Tier 1 (no external dependencies).
+
+Covers the silent-fallback fix (redteam FINDING 1): a falsy/absent URL or a
+non-URL keyword/value DSN MUST NOT silently collapse cross-DB isolation. The
+resolver derives identity from the URL, falls back to credential-free
+component config (host/port/dbname), and reports ``identity=None`` (so the
+engine warns) only when neither yields a usable identity.
+
+Also pins the documented scope caveat (FINDING 2): identity keys on database
+LOCATION, not the connecting principal.
+
+Tier: 1 (Unit).
+"""
+
+import hashlib
+
+from dataflow.cache.key_generator import (
+    CacheKeyGenerator,
+    hash_database_identity,
+    resolve_db_identity,
+)
+
+_QUERY_SQL = "SELECT * FROM users WHERE active = $1"
+_QUERY_PARAMS = [True]
+
+
+def test_url_path_derives_identity_credential_free():
+    res = resolve_db_identity(url="postgresql://alice:s3cret@db-a.example.com:5432/prod")
+    assert res.identity is not None
+    assert res.source == "url"
+    assert res.url_unparseable is False
+    # Invariant 2 (no credentials): identity is the hash of the masked DSN.
+    from kailash.utils.url_credentials import mask_url
+
+    masked = mask_url("postgresql://alice:s3cret@db-a.example.com:5432/prod")
+    assert "alice" not in masked and "s3cret" not in masked
+    assert res.identity == hashlib.sha256(masked.encode()).hexdigest()[:8]
+
+
+def test_falsy_url_no_components_yields_none_for_engine_to_warn():
+    """No URL and no components -> identity None (engine emits the WARN)."""
+    res = resolve_db_identity(url=None)
+    assert res.identity is None
+    assert res.source == "none"
+    assert res.url_unparseable is False
+
+
+def test_falsy_url_with_components_falls_back_isolation_holds():
+    """FINDING 1(a): URL-less config still gets an identity from host/dbname."""
+    res = resolve_db_identity(url=None, host="h1", port=5432, dbname="db1")
+    assert res.identity is not None
+    assert res.source == "components"
+    assert res.url_unparseable is False
+
+
+def test_unparseable_dsn_never_hashes_the_constant_sentinel():
+    """FINDING 1(b): a non-URL DSN must NOT produce a constant identity.
+
+    ``mask_url`` returns UNPARSEABLE_URL_SENTINEL for a libpq keyword DSN;
+    hashing that constant would give every such instance the SAME identity.
+    The resolver refuses: url_unparseable=True and (absent components) None.
+    """
+    res = resolve_db_identity(url="host=a dbname=x")
+    assert res.identity is None
+    assert res.url_unparseable is True
+    # hash_database_identity likewise refuses the sentinel (no constant leak).
+    assert hash_database_identity("host=a dbname=x") is None
+
+
+def test_unparseable_dsn_with_components_rescues_but_flags_unparseable():
+    """Unparseable URL + usable components -> component identity, still flagged.
+
+    The engine warns on url_unparseable even though isolation now holds via
+    components, so the operator learns the supplied URL could not be used.
+    """
+    res = resolve_db_identity(url="host=a dbname=x", host="h1", port=5432, dbname="db1")
+    assert res.identity is not None
+    assert res.source == "components"
+    assert res.url_unparseable is True
+
+
+def test_component_identity_isolates_two_urlless_instances():
+    """FINDING 1(a): two URL-less configs at different DBs -> different keys."""
+    i1 = resolve_db_identity(host="h1", port=5432, dbname="db1").identity
+    i2 = resolve_db_identity(host="h2", port=5432, dbname="db2").identity
+    assert i1 is not None and i2 is not None and i1 != i2
+
+    g1 = CacheKeyGenerator(prefix="dataflow:query", db_identity=i1)
+    g2 = CacheKeyGenerator(prefix="dataflow:query", db_identity=i2)
+    k1 = g1.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    k2 = g2.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    assert k1 != k2, "different component-config DBs must yield different query keys"
+
+
+def test_same_host_different_dbname_differ_same_dbname_same():
+    """Component identity is keyed on host:port/dbname."""
+    a = resolve_db_identity(host="h", port=5432, dbname="db1").identity
+    b = resolve_db_identity(host="h", port=5432, dbname="db2").identity
+    c = resolve_db_identity(host="h", port=5432, dbname="db1").identity
+    assert a != b  # different dbname -> different identity
+    assert a == c  # same host+port+dbname -> same identity (cache still works)
+
+
+def test_documented_scope_same_location_different_principal_shares_identity():
+    """FINDING 2 (documented caveat): identity keys on LOCATION, not principal.
+
+    Two instances at the same host/port/dbname with DIFFERENT credentials
+    share a cache namespace BY DESIGN (mask_url strips userinfo to ``***``).
+    """
+    alice = hash_database_identity("postgres://alice:pw1@h:5432/db")
+    bob = hash_database_identity("postgres://bob:pw2@h:5432/db")
+    assert alice == bob, "same DB location, different principal -> same identity (by design)"

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
@@ -1,31 +1,61 @@
-"""#1606 cross-SDK cache-keyspace TRIPWIRE.
+"""#1606 cache-keyspace TRIPWIRE (Tier 1).
 
-This module pins the EXACT byte string of the current ``v2`` cache keyspace
-emitted by ``CacheKeyGenerator`` (both the Express key and the query key) plus
-the ``:{tenant}:{model}:`` substring adjacency that
-``InMemoryCache.invalidate_model`` relies on.
+This module pins the EXACT byte string of TWO cache keyspaces, which have
+DIFFERENT cross-SDK contracts and MUST NOT be conflated:
 
-WHY A TRIPWIRE (not the fix): issue #1606 asks for a DB-instance segment in the
-key + a keyspace bump ``v2 -> v3``. That bump is a CROSS-SDK LOCKSTEP — the
-``v2`` Express keyspace at ``src/dataflow/cache/key_generator.py`` is pinned to
-kailash-rs (the Rust SDK, ``v3.19.0`` cross-SDK contract, BP-049) and MUST NOT
-be changed unilaterally in one SDK. Changing ANY byte pinned in this file is
-therefore a loud, deliberate event: update it ONLY together with the paired
-Rust SDK keyspace change (the ``v2 -> v3`` lockstep). A silent drift here would
-diverge the two SDKs' cache keys and break cross-SDK invalidation.
+1. EXPRESS ``v2`` keyspace (``generate_express_key``) — RUST-PINNED / cross-SDK
+   LOCKSTEP. It is a byte-for-byte contract with kailash-rs (the Rust SDK,
+   ``v3.19.0``, BP-049); see ``src/dataflow/cache/key_generator.py`` docstring.
+   Changing ANY express byte pinned here diverges the two SDKs' cache keys and
+   breaks cross-SDK invalidation — it is a deliberate ``v2 -> v3`` lockstep to
+   be done in BOTH SDKs, never one. These assertions stay loud.
+
+2. QUERY keyspace (``generate_key``) — NOT Rust-pinned. It hashes a normalized
+   SQL string + params, which diverges cross-SDK by construction (the py and rs
+   query builders emit different SQL for the same model+filter). There is no
+   cross-SDK/BP-049 contract on these bytes. Issue #1606 ADDS a DB-instance
+   identity segment to this keyspace (directly after the model name) so two
+   DataFlow instances at DIFFERENT databases never collide on the same query
+   cache key (cross-DB cache bleed). This tripwire RE-PINS the new query bytes
+   (with the DB-identity segment) as a py-local tripwire — a query-key drift is
+   a loud, deliberate py-side event, NOT a cross-SDK lockstep.
 
 Tier: 1 (Unit — no external dependencies).
 """
 
-from dataflow.cache.key_generator import CacheKeyGenerator
+import hashlib
+
+from dataflow.cache.key_generator import (
+    CacheKeyGenerator,
+    hash_database_identity,
+)
 from dataflow.cache.memory_cache import InMemoryCache
 
-# --- Pinned v2 keyspace bytes (change ONLY with the Rust SDK v2->v3 lockstep) ---
+# --- Pinned EXPRESS v2 keyspace bytes (Rust-pinned — change ONLY with the ---
+# --- kailash-rs v2->v3 cross-SDK LOCKSTEP) ---------------------------------
 EXPRESS_KEY_WITH_TENANT = "dataflow:v2:tenant-a:User:list:6a3d3c8c"
 EXPRESS_KEY_NO_TENANT = "dataflow:v2:User:list"
-QUERY_KEY = "dataflow:User:v2:2f5a5fc5af648187"
+
+# --- Pinned QUERY keyspace bytes (py-local tripwire; NOT Rust-pinned) ------
+# A fixed DB-identity segment for byte-pinning. In production this is the
+# short sha256 of the credential-stripped DSN (hash_database_identity).
+_FIXED_DBID = "dbidfixd"
+# New-shape (post-#1606) query keys: the DB-identity segment sits directly
+# after the model name, BEFORE the version segment.
+QUERY_KEY_DEFAULT_PREFIX = "dataflow:User:dbidfixd:v2:2f5a5fc5af648187"
+QUERY_KEY_PROD_PREFIX = "dataflow:query:User:dbidfixd:v2:2f5a5fc5af648187"
+# Old-shape (pre-#1606, no DB-identity) — still produced when db_identity is
+# unset; kept pinned for backward-compat + invalidation coverage.
+QUERY_KEY_NO_DBID = "dataflow:User:v2:2f5a5fc5af648187"
+
+_QUERY_SQL = "SELECT * FROM users WHERE active = $1"
+_QUERY_PARAMS = [True]
 
 
+# =========================================================================
+# EXPRESS keyspace — RUST-PINNED. These assertions guard the cross-SDK
+# byte-for-byte contract and MUST stay loud + unchanged by #1606.
+# =========================================================================
 def test_express_key_v2_bytes_are_pinned():
     """generate_express_key emits the exact v2 byte string for fixed inputs."""
     gen = CacheKeyGenerator()
@@ -36,7 +66,7 @@ def test_express_key_v2_bytes_are_pinned():
     )
     assert key == EXPRESS_KEY_WITH_TENANT, (
         f"v2 Express keyspace drifted: got {key!r}. Changing these bytes is a "
-        f"cross-SDK LOCKSTEP (#1606) — bump v2->v3 in BOTH SDKs, not one."
+        f"cross-SDK LOCKSTEP (#1606/rs#1713) — bump v2->v3 in BOTH SDKs, not one."
     )
 
     # Without tenant/params the trailing hash segment is absent.
@@ -46,16 +76,138 @@ def test_express_key_v2_bytes_are_pinned():
     assert key.startswith("dataflow:v2:")
 
 
-def test_query_key_v2_bytes_are_pinned():
-    """generate_key emits the exact v2 byte string for a fixed SQL+params."""
-    gen = CacheKeyGenerator()
-    key = gen.generate_key("User", "SELECT * FROM users WHERE active = $1", [True])
-    assert key == QUERY_KEY, (
-        f"v2 query keyspace drifted: got {key!r}. Changing these bytes is a "
-        f"cross-SDK LOCKSTEP (#1606) — bump v2->v3 in BOTH SDKs, not one."
+def test_express_key_excludes_db_identity_segment():
+    """The #1606 DB-identity segment MUST NOT enter the Rust-pinned express key.
+
+    Even when the generator is constructed WITH a db_identity (as it always is
+    in production, from engine.py), generate_express_key emits byte-identical
+    output to a generator without one. This is the structural guard that the
+    #1606 change stayed in the query keyspace and never touched the express
+    (Rust-pinned) keyspace.
+    """
+    gen_with_dbid = CacheKeyGenerator(db_identity=_FIXED_DBID)
+    gen_without_dbid = CacheKeyGenerator()
+
+    key_with = gen_with_dbid.generate_express_key(
+        "User", "list", {"active": True}, tenant_id="tenant-a"
     )
-    # Query-key shape places the model BEFORE the version: dataflow:<model>:v2:<hash>
-    assert ":v2:" in key
+    key_without = gen_without_dbid.generate_express_key(
+        "User", "list", {"active": True}, tenant_id="tenant-a"
+    )
+    assert key_with == key_without == EXPRESS_KEY_WITH_TENANT, (
+        "db_identity leaked into the Rust-pinned express keyspace: "
+        f"with={key_with!r} without={key_without!r}. The #1606 segment is "
+        "query-keyspace-ONLY; express is a cross-SDK byte contract."
+    )
+
+
+# =========================================================================
+# QUERY keyspace — py-local tripwire. RE-PINS the new #1606 bytes (with the
+# DB-identity segment) + a production-prefix assertion. De-bundled from the
+# cross-SDK lockstep claim (this keyspace diverges cross-SDK by construction).
+# =========================================================================
+def test_query_key_new_bytes_with_db_identity_are_pinned():
+    """generate_key emits the exact new-shape (DB-identity) byte string.
+
+    The DB-identity segment sits directly after the model name:
+    ``dataflow:<model>:<db_identity>:v2:<sql+params hash>``. The trailing
+    SQL+params hash is unchanged from the pre-#1606 shape (only the segment
+    is inserted).
+    """
+    gen = CacheKeyGenerator(db_identity=_FIXED_DBID)
+    key = gen.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    assert key == QUERY_KEY_DEFAULT_PREFIX, (
+        f"#1606 query keyspace drifted: got {key!r}. This keyspace is py-local "
+        f"(NOT Rust-pinned) — a drift is a deliberate py-side event, but pin it "
+        f"here so the change is loud."
+    )
+    # DB-identity segment is present between model and version.
+    assert ":dbidfixd:v2:" in key
+
+
+def test_query_key_production_prefix_shape_is_pinned():
+    """Production uses the ``dataflow:query`` prefix (config.py) — pin that shape.
+
+    The prior tripwire only pinned the default (``dataflow``) prefix; production
+    keys carry the ``dataflow:query`` prefix (confirmed list_node_integration.py
+    ``_setup_invalidation_patterns`` docstring). Both the prefix AND the new
+    DB-identity segment are asserted here.
+    """
+    gen = CacheKeyGenerator(prefix="dataflow:query", db_identity=_FIXED_DBID)
+    key = gen.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    assert (
+        key == QUERY_KEY_PROD_PREFIX
+    ), f"#1606 production-prefix query keyspace drifted: got {key!r}."
+    # Production key is anchored at the ``dataflow:query:User:`` prefix so the
+    # model-anchored invalidation sweep (`{prefix}:{model}:*`) matches it.
+    assert key.startswith("dataflow:query:User:")
+
+
+def test_query_key_without_db_identity_keeps_old_shape():
+    """A generator with no db_identity keeps the pre-#1606 shape (backward-compat).
+
+    The DB-identity segment is opt-in — absent for a generator constructed
+    without one (e.g. a no-database DataFlow). This guards that #1606 did not
+    change bytes for the unset path.
+    """
+    gen = CacheKeyGenerator()
+    assert gen.generate_key("User", _QUERY_SQL, _QUERY_PARAMS) == QUERY_KEY_NO_DBID
+
+
+# =========================================================================
+# Invariant coverage (deterministic, no infra).
+# =========================================================================
+def test_db_identity_is_credential_free_and_differs_per_database():
+    """hash_database_identity strips credentials and separates databases (#1606).
+
+    Invariant 2 (no credentials in any key segment) + invariant 3 (two DBs ->
+    different identity).
+    """
+    url_a = "postgresql://alice:s3cret@db-a.example.com:5432/prod"
+    url_b = "postgresql://alice:s3cret@db-b.example.com:5432/prod"
+
+    dbid_a = hash_database_identity(url_a)
+    dbid_b = hash_database_identity(url_b)
+
+    # Invariant 3: different databases -> different identity segments.
+    assert dbid_a != dbid_b
+    # Short, opaque fingerprint (8 hex chars).
+    assert len(dbid_a) == 8 and all(c in "0123456789abcdef" for c in dbid_a)
+
+    # Invariant 2: NO credential byte enters the identity input. The digest is
+    # over the credential-stripped mask (host+port+dbname only), so the raw
+    # user/password can never be a pre-image of the segment.
+    from kailash.utils.url_credentials import mask_url
+
+    masked = mask_url(url_a)
+    assert "alice" not in masked and "s3cret" not in masked
+    assert dbid_a == hashlib.sha256(masked.encode("utf-8")).hexdigest()[:8]
+
+    # Falsy URL -> no segment (old-shape fallback).
+    assert hash_database_identity(None) is None
+    assert hash_database_identity("") is None
+
+
+def test_same_database_same_query_key_no_over_invalidation():
+    """Invariant 5: same DB + same query -> SAME key (cache still hits)."""
+    url = "postgresql://u:p@db.example.com:5432/prod"
+    dbid = hash_database_identity(url)
+
+    gen1 = CacheKeyGenerator(prefix="dataflow:query", db_identity=dbid)
+    gen2 = CacheKeyGenerator(prefix="dataflow:query", db_identity=dbid)
+
+    key1 = gen1.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    key2 = gen2.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+    assert key1 == key2, "same DB + same query must yield the same cache key"
+
+    # A DIFFERENT database yields a DIFFERENT key for the identical query.
+    other = CacheKeyGenerator(
+        prefix="dataflow:query",
+        db_identity=hash_database_identity(
+            "postgresql://u:p@other-db.example.com:5432/prod"
+        ),
+    )
+    assert other.generate_key("User", _QUERY_SQL, _QUERY_PARAMS) != key1
 
 
 async def test_invalidate_model_matches_v2_express_key():
@@ -76,3 +228,31 @@ async def test_invalidate_model_matches_v2_express_key():
     removed = await cache.invalidate_model("User", tenant_id="tenant-a")
     assert removed == 1
     assert await cache.get(EXPRESS_KEY_WITH_TENANT) is None
+
+
+async def test_invalidation_sweeps_both_old_and_new_query_shapes():
+    """Invariant 4: model-scoped invalidation sweeps old- AND new-shape query keys.
+
+    The ``:{model}:`` segment matcher (invalidate_model) and the
+    ``{prefix}:{model}:*`` clear_pattern both anchor at the model and use a
+    trailing match, so they cover the version segment AND the #1606 DB-identity
+    segment — no stale query-cache entry survives under the old shape.
+    """
+    cache = InMemoryCache()
+    await cache.set(QUERY_KEY_NO_DBID, {"rows": ["old-shape"]})  # pre-#1606
+    await cache.set(QUERY_KEY_DEFAULT_PREFIX, {"rows": ["new-shape"]})  # post-#1606
+
+    # Model-scoped invalidate_model (no tenant) sweeps BOTH via ``:User:``.
+    removed = await cache.invalidate_model("User")
+    assert removed == 2
+    assert await cache.get(QUERY_KEY_NO_DBID) is None
+    assert await cache.get(QUERY_KEY_DEFAULT_PREFIX) is None
+
+    # The producer-side clear_pattern sweep (`{prefix}:{model}:*`) also covers
+    # both shapes — re-seed and clear via the pattern the CacheInvalidator uses.
+    await cache.set(QUERY_KEY_NO_DBID, {"rows": ["old-shape"]})
+    await cache.set(QUERY_KEY_DEFAULT_PREFIX, {"rows": ["new-shape"]})
+    cleared = await cache.clear_pattern("dataflow:User:*")
+    assert cleared == 2
+    assert await cache.get(QUERY_KEY_NO_DBID) is None
+    assert await cache.get(QUERY_KEY_DEFAULT_PREFIX) is None


### PR DESCRIPTION
## Summary
Closes the **query/list/count** cache-keyspace half of #1606: two DataFlow instances at different databases sharing model+tenant on a shared Redis no longer collide on the query keyspace (cross-DB read bleed).

## Scope (IMPORTANT — partial fix)
- ✅ **Query keyspace** (`generate_key`, SQL-hashed): now carries a **credential-free DB-instance identity** segment (`hash_database_identity` = sha256 of a masked/credential-stripped DSN, or a `host:port/dbname` component fallback). This family is NOT Rust-pinned, so it lands single-SDK.
- ⏸️ **Express `v2` keyspace** (the hot `read`/`list`/`find_one`/`count` path): **byte-for-byte unchanged** — it is a cross-SDK contract pinned to `kailash-rs v3.19.0`. The express cross-DB bleed remains OPEN pending the coordinated `v2→v3` keyspace lockstep (**rs#1713**). Pinned open by `test_express_key_excludes_db_identity_segment`.

## Hardening (from redteam)
- Falsy/URL-less config → component-config identity fallback (isolation still holds) + **loud WARN** when no identity is derivable (no silent-unprotected fallback).
- DSN-shaped `host` misconfig → credential-stripped before hashing (no credential byte in the key pre-image).

## Verification
24 tests: unit tripwire (express v2 bytes pinned + new query bytes) + Tier-2 real-Redis two-DB RED→GREEN bleed reproduction/closure + resolver + fallback WARN. security-reviewer + 2 adversarial redteam rounds (credential-in-key SAFE; express unchanged; invalidation complete).

## Related issues
Refs #1606 (stays OPEN — the express-keyspace half is tracked for the rs#1713 lockstep). Do not auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)