### PR TITLE
feat(governance): BH2 fail-closed HITL reviewer authority (#1510 legs 2-3)

### DIFF
--- a/src/kailash/trust/enforce/__init__.py
+++ b/src/kailash/trust/enforce/__init__.py
@@ -31,9 +31,12 @@ from kailash.trust.enforce.held import (
     HeldAction,
     HeldActionStore,
     MemoryHeldActionStore,
+    ReviewDecisionError,
+    ReviewerDecision,
     SqliteHeldActionStore,
     new_hold_id,
     resolve_expiry_verdict,
+    resolve_review_verdict,
     resolve_timeout_seconds,
     verdict_rank,
 )
@@ -84,6 +87,10 @@ __all__ = [
     "resolve_expiry_verdict",
     "resolve_timeout_seconds",
     "verdict_rank",
+    # Reviewer decision authority (HITL, BH2 leg 3)
+    "ReviewerDecision",
+    "ReviewDecisionError",
+    "resolve_review_verdict",
     # Challenge-response
     "ChallengeProtocol",
     "ChallengeRequest",

--- a/src/kailash/trust/enforce/_types.py
+++ b/src/kailash/trust/enforce/_types.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Shared enforcement value types — the cycle-free base for ``strict`` + ``held``.
+
+``Verdict`` and ``EnforcementRecord`` are consumed at RUNTIME by BOTH
+``kailash.trust.enforce.strict`` (the enforcer) and
+``kailash.trust.enforce.held`` (the HITL hold store). Defining them here — a
+leaf module that imports neither — breaks the ``strict`` <-> ``held``
+module-level import cycle (CodeQL ``py/unsafe-cyclic-import``): both modules
+import these types from here, and neither imports the other at module scope
+for them. ``strict`` re-exports both (module-level import + ``__all__``), so
+every existing ``from kailash.trust.enforce.strict import Verdict`` /
+``EnforcementRecord`` path still resolves unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict
+
+from kailash.trust.chain import VerificationResult
+
+__all__ = ["EnforcementRecord", "Verdict"]
+
+
+class Verdict(Enum):
+    """Enforcement verdict for a verification result."""
+
+    AUTO_APPROVED = "auto_approved"  # Valid, no issues
+    FLAGGED = "flagged"  # Valid but has warnings (constraint near limits)
+    HELD = "held"  # Requires human review before proceeding
+    BLOCKED = "blocked"  # Denied, action must not proceed
+
+
+@dataclass(frozen=True)
+class EnforcementRecord:
+    """Record of an enforcement decision.
+
+    Frozen to prevent post-creation tampering of audit records.
+    """
+
+    agent_id: str
+    action: str
+    verdict: Verdict
+    verification_result: VerificationResult
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -44,7 +44,12 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from kailash.trust._locking import secure_sqlite_files, validate_id
-from kailash.trust.enforce.strict import EnforcementRecord, Verdict
+
+# Import the shared value types from the leaf ``_types`` module, NOT from
+# ``strict`` — importing ``strict`` here would recreate the strict<->held
+# module-level cycle CodeQL py/unsafe-cyclic-import flagged. ``_types`` imports
+# neither module, so this edge is one-way (held -> _types).
+from kailash.trust.enforce._types import EnforcementRecord, Verdict
 
 if TYPE_CHECKING:
     from kailash.trust.governance.models import ApprovalPolicyModel
@@ -318,15 +323,19 @@ def new_hold_id() -> str:
 
 @runtime_checkable
 class HeldActionStore(Protocol):
-    """Persistence protocol for pending human-review holds with timeouts."""
+    """Persistence protocol for pending human-review holds with timeouts.
+
+    The method bodies are the docstring alone (no ``...`` placeholder): a bare
+    ``...`` expression statement is an ineffectual statement CodeQL
+    py/ineffectual-statement flags, and the docstring is a complete, valid
+    body for a Protocol method (which is never executed).
+    """
 
     def add(self, held: HeldAction) -> None:
         """Register a pending hold for timeout tracking."""
-        ...
 
     def pop_expired(self, now: datetime) -> List[HeldAction]:
         """Atomically remove and return every hold expired as of ``now``."""
-        ...
 
     def pop(self, hold_id: str) -> Optional[HeldAction]:
         """Atomically remove and return the hold with ``hold_id``, else None.
@@ -334,15 +343,12 @@ class HeldActionStore(Protocol):
         Used by reviewer-decision resolution (BH2 leg 3) to claim a specific
         pending hold. Returns ``None`` when no such hold is tracked.
         """
-        ...
 
     def pending(self) -> List[HeldAction]:
         """Return all currently-pending holds."""
-        ...
 
     def clear(self) -> None:
         """Remove all pending holds."""
-        ...
 
 
 class MemoryHeldActionStore:

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -161,9 +161,11 @@ class ReviewerDecision(Enum):
 class ReviewDecisionError(ValueError):
     """Raised when a reviewer decision cannot be applied (fail-closed).
 
-    Covers a missing/unknown ``hold_id``, a ``MODIFY`` without an explicit
-    modified verdict, and an unrecognized decision — every path fails closed
-    with a typed error rather than silently permitting an action.
+    Covers a missing/unknown ``hold_id``, an over-length ``reviewer_id``, a
+    ``MODIFY`` without an explicit modified verdict, an ``APPROVE``/``DECLINE``
+    carrying a (contradictory) modified verdict, and an unrecognized decision —
+    every path fails closed with a typed error rather than silently permitting
+    an action or silently dropping an argument.
     """
 
 
@@ -186,11 +188,22 @@ def resolve_review_verdict(
       ``BLOCKED``. This reuses the single ``_VERDICT_RANK`` ordering that
       :func:`resolve_expiry_verdict` uses — the restrictiveness function is not
       reinvented.
+    - ``APPROVE`` / ``DECLINE`` with ``modified_verdict`` set is AMBIGUOUS input
+      (a modified verdict is meaningful only for ``MODIFY``); it raises
+      :class:`ReviewDecisionError` rather than silently ignoring the argument.
     - An unrecognized ``decision`` raises :class:`ReviewDecisionError`.
 
     Only ``APPROVE`` may resolve below ``HELD``; it is the reviewer's explicit,
     authorized sanction of the hold, NOT an automatic widening.
     """
+    # Ambiguous-input guard (Finding 3b): modified_verdict is meaningful ONLY
+    # for MODIFY. Passing it with APPROVE/DECLINE is a contradictory request
+    # (approve-but-also-change-to-X); fail closed rather than silently drop it.
+    if modified_verdict is not None and decision is not ReviewerDecision.MODIFY:
+        raise ReviewDecisionError(
+            f"modified_verdict is only valid with MODIFY, not "
+            f"{decision.value!r} — fail-closed on ambiguous input"
+        )
     if decision is ReviewerDecision.DECLINE:
         return Verdict.BLOCKED
     if decision is ReviewerDecision.APPROVE:

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -80,6 +80,12 @@ class ExpiryDisposition(Enum):
     """
 
     DENY = "deny"  # -> BLOCKED (fail-safe default)
+    # RESIDUAL (known feature-completeness gap, out of BH2 legs-2-3 scope): on
+    # expiry ESCALATE_TO_SENIOR emits a HELD expiry record but does NOT
+    # re-register a fresh reviewable hold — a functional dead-end (the action
+    # stays parked with no new review window). It is fail-CLOSED (HELD >= HELD;
+    # never proceeds / never auto-approves), so it is safe as-is; wiring the
+    # re-registration is future work.
     ESCALATE_TO_SENIOR = "escalate_to_senior"  # -> HELD (re-held for senior review)
 
 
@@ -347,6 +353,16 @@ class MemoryHeldActionStore:
         self._holds: "OrderedDict[str, HeldAction]" = OrderedDict()
         self._maxlen = maxlen
 
+    @property
+    def capacity(self) -> int:
+        """Max holds retained before FIFO eviction (admission-control bound).
+
+        Consumed by ``StrictEnforcer`` to verify the store can retain every
+        timeout-bearing queued hold so none is evicted-while-still-queued and
+        silently escapes expiry (BH2 leg 2, Finding 2).
+        """
+        return self._maxlen
+
     def add(self, held: HeldAction) -> None:
         with self._lock:
             self._holds[held.hold_id] = held
@@ -403,6 +419,21 @@ class SqliteHeldActionStore:
         self._max_records = max_records
         self._lock = threading.Lock()
 
+        self._init_connection()
+
+    @property
+    def capacity(self) -> int:
+        """Max rows retained before oldest-by-expiry eviction (admission bound).
+
+        Consumed by ``StrictEnforcer`` to verify the store can retain every
+        timeout-bearing queued hold so none is evicted-while-still-queued and
+        silently escapes expiry (BH2 leg 2, Finding 2).
+        """
+        return self._max_records
+
+    def _init_connection(self) -> None:
+        """Open the connection, apply PRAGMAs, create the table, harden perms."""
+        db_path = self._db_path
         if not db_path.startswith(":memory:") and not os.path.exists(db_path):
             open(db_path, "a").close()
 

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -599,8 +599,25 @@ class SqliteHeldActionStore:
 
         agent_id = _safe_str(1)
         action = _safe_str(2)
-        original_hold_id = repr(row[0])[:200] if row else "unknown"
+        # The sentinel is minted with a FRESH hold_id (below), but the ORIGINAL
+        # hold_id column is needed to reconcile the passive review queue on
+        # expiry (StrictEnforcer.expire_holds): a corrupt row is typically
+        # corrupt in a NON-hold_id column (e.g. on_expiry), so row[0] is a
+        # clean, matchable id. Trust it ONLY as a plain str reconcile KEY —
+        # never for control flow (the disposition is always DENY -> BLOCKED). A
+        # garbage / non-str value yields None (no queue match; still fail-safe).
+        try:
+            raw_hold_id: Any = row[0] if row else None
+        except Exception:
+            raw_hold_id = None
+        original_hold_id = raw_hold_id if isinstance(raw_hold_id, str) else None
+        original_hold_id_repr = repr(raw_hold_id)[:200] if row else "unknown"
 
+        metadata: Dict[str, Any] = {
+            "corrupt_row": True,
+            "original_hold_id": original_hold_id,
+            "original_hold_id_repr": original_hold_id_repr,
+        }
         vr = VerificationResult(
             valid=False,
             reason="corrupt held-action row — fail-closed BLOCKED",
@@ -612,7 +629,7 @@ class SqliteHeldActionStore:
             verdict=Verdict.HELD,
             verification_result=vr,
             timestamp=now,
-            metadata={"corrupt_row": True, "original_hold_id": original_hold_id},
+            metadata=dict(metadata),
         )
         return HeldAction(
             hold_id=new_hold_id(),
@@ -622,5 +639,5 @@ class SqliteHeldActionStore:
             timeout_seconds=0.0,
             on_expiry=ExpiryDisposition.DENY,
             record=record,
-            metadata={"corrupt_row": True, "original_hold_id": original_hold_id},
+            metadata=dict(metadata),
         )

--- a/src/kailash/trust/enforce/held.py
+++ b/src/kailash/trust/enforce/held.py
@@ -41,7 +41,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from kailash.trust._locking import secure_sqlite_files, validate_id
 from kailash.trust.enforce.strict import EnforcementRecord, Verdict
@@ -57,9 +57,12 @@ __all__ = [
     "HeldAction",
     "HeldActionStore",
     "MemoryHeldActionStore",
+    "ReviewDecisionError",
+    "ReviewerDecision",
     "SqliteHeldActionStore",
     "new_hold_id",
     "resolve_expiry_verdict",
+    "resolve_review_verdict",
     "resolve_timeout_seconds",
     "verdict_rank",
 ]
@@ -131,6 +134,80 @@ def resolve_expiry_verdict(disposition: ExpiryDisposition) -> Verdict:
         # than the hold it replaces. Clamp to BLOCKED (never auto-approve).
         return Verdict.BLOCKED
     return verdict
+
+
+class ReviewerDecision(Enum):
+    """A human reviewer's disposition of a pending HITL hold (BH2 leg 3).
+
+    A held action parks pending human review; this enum is the authority a
+    reviewer exercises over it. The three members resolve — via the single
+    monotonic :func:`resolve_review_verdict` — to concrete verdicts:
+
+    - ``APPROVE`` sanctions the *originally-held* action to proceed
+      (``AUTO_APPROVED``). This is the reviewer's authorized resolution of the
+      hold; it grants exactly the held action and NEVER escalates authority
+      beyond the original request.
+    - ``DECLINE`` denies the action (``BLOCKED``).
+    - ``MODIFY`` substitutes a reviewer-chosen verdict, constrained to
+      *monotonic-tightening only* — a MODIFY may never WIDEN authority below
+      ``HELD`` (see :func:`resolve_review_verdict`).
+    """
+
+    APPROVE = "approve"  # -> AUTO_APPROVED (sanction the originally-held action)
+    MODIFY = "modify"  # -> monotonic-tightening only (never widens below HELD)
+    DECLINE = "decline"  # -> BLOCKED
+
+
+class ReviewDecisionError(ValueError):
+    """Raised when a reviewer decision cannot be applied (fail-closed).
+
+    Covers a missing/unknown ``hold_id``, a ``MODIFY`` without an explicit
+    modified verdict, and an unrecognized decision — every path fails closed
+    with a typed error rather than silently permitting an action.
+    """
+
+
+def resolve_review_verdict(
+    decision: ReviewerDecision,
+    *,
+    modified_verdict: Optional[Verdict] = None,
+) -> Verdict:
+    """Resolve a reviewer decision to a concrete, monotonic-guarded verdict.
+
+    Fail-closed on every axis (pact-governance.md Rule 4/6):
+
+    - ``DECLINE`` -> ``BLOCKED``.
+    - ``APPROVE`` -> ``AUTO_APPROVED`` (the authorized resolution of the hold;
+      grants the originally-held action, no more — no authority escalation).
+    - ``MODIFY`` requires an explicit ``modified_verdict`` (else
+      :class:`ReviewDecisionError`) and is *monotonic-tightening only*: a
+      modified verdict less restrictive than ``HELD`` (i.e. ``AUTO_APPROVED`` /
+      ``FLAGGED`` — a WIDENING of authority) is clamped fail-closed to
+      ``BLOCKED``. This reuses the single ``_VERDICT_RANK`` ordering that
+      :func:`resolve_expiry_verdict` uses — the restrictiveness function is not
+      reinvented.
+    - An unrecognized ``decision`` raises :class:`ReviewDecisionError`.
+
+    Only ``APPROVE`` may resolve below ``HELD``; it is the reviewer's explicit,
+    authorized sanction of the hold, NOT an automatic widening.
+    """
+    if decision is ReviewerDecision.DECLINE:
+        return Verdict.BLOCKED
+    if decision is ReviewerDecision.APPROVE:
+        return Verdict.AUTO_APPROVED
+    if decision is ReviewerDecision.MODIFY:
+        if modified_verdict is None:
+            raise ReviewDecisionError(
+                "MODIFY requires an explicit modified_verdict (fail-closed)"
+            )
+        rank = _VERDICT_RANK.get(modified_verdict)
+        if rank is None or rank < _VERDICT_RANK[Verdict.HELD]:
+            # Monotonic-tightening guard: a MODIFY may not widen authority
+            # below HELD. An unknown verdict OR a sub-HELD verdict is clamped
+            # fail-closed to BLOCKED (never AUTO_APPROVED/FLAGGED).
+            return Verdict.BLOCKED
+        return modified_verdict
+    raise ReviewDecisionError(f"unknown reviewer decision: {decision!r}")
 
 
 def resolve_timeout_seconds(policy: "ApprovalPolicyModel") -> float:
@@ -232,6 +309,14 @@ class HeldActionStore(Protocol):
         """Atomically remove and return every hold expired as of ``now``."""
         ...
 
+    def pop(self, hold_id: str) -> Optional[HeldAction]:
+        """Atomically remove and return the hold with ``hold_id``, else None.
+
+        Used by reviewer-decision resolution (BH2 leg 3) to claim a specific
+        pending hold. Returns ``None`` when no such hold is tracked.
+        """
+        ...
+
     def pending(self) -> List[HeldAction]:
         """Return all currently-pending holds."""
         ...
@@ -262,6 +347,11 @@ class MemoryHeldActionStore:
             for h in expired:
                 del self._holds[h.hold_id]
             return expired
+
+    def pop(self, hold_id: str) -> Optional[HeldAction]:
+        validate_id(hold_id)
+        with self._lock:
+            return self._holds.pop(hold_id, None)
 
     def pending(self) -> List[HeldAction]:
         with self._lock:
@@ -391,6 +481,34 @@ class SqliteHeldActionStore:
                 )
                 result.append(self._corrupt_sentinel(row, now))
         return result
+
+    def pop(self, hold_id: str) -> Optional[HeldAction]:
+        validate_id(hold_id)
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT hold_id, agent_id, action, held_at, timeout_seconds, "
+                "on_expiry, reason, violations_json, metadata_json "
+                "FROM held_actions WHERE hold_id = ?",
+                (hold_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            self._conn.execute("DELETE FROM held_actions WHERE hold_id = ?", (hold_id,))
+            self._conn.commit()
+        # Fail-closed conversion for a corrupt/tampered row: the row is already
+        # deleted+committed above, so a raw exception would silently drop the
+        # hold with no verdict; instead yield the DENY sentinel (-> BLOCKED).
+        try:
+            return self._row_to_held(row)
+        except Exception:
+            logger.warning(
+                "[HELD] corrupt held-action row on pop — fail-closed BLOCKED "
+                "(hold_id=%r)",
+                hold_id,
+                exc_info=True,
+            )
+            return self._corrupt_sentinel(row, datetime.now(timezone.utc))
 
     def pending(self) -> List[HeldAction]:
         with self._lock:

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from kailash.trust.chain import VerificationLevel, VerificationResult
 
 if TYPE_CHECKING:
-    from kailash.trust.enforce.held import ExpiryDisposition, HeldActionStore
+    from kailash.trust.enforce.held import (
+        ExpiryDisposition,
+        HeldActionStore,
+        ReviewerDecision,
+    )
     from kailash.trust.governance.models import ApprovalPolicyModel
     from kailash.trust.hooks import HookRegistry
 
@@ -117,6 +121,7 @@ class StrictEnforcer:
         hook_registry: Optional[HookRegistry] = None,
         held_store: Optional[HeldActionStore] = None,
         default_expiry: Optional[ExpiryDisposition] = None,
+        max_pending_holds: int = 1000,
     ):
         """Initialize strict enforcer.
 
@@ -137,11 +142,29 @@ class StrictEnforcer:
                 timeout but no explicit ``on_expiry``. Defaults to the fail-safe
                 ``ExpiryDisposition.DENY`` (a hold with no configured expiry
                 disposition denies on timeout — it NEVER auto-approves).
+            max_pending_holds: Reviewer-capacity admission-control bound (BH2
+                leg 2). When the pending review queue is saturated to this
+                many holds, a NEW QUEUE-behavior escalation FAILS CLOSED —
+                it is DENIED (``BLOCKED``, ``EATPBlockedError``), never
+                silently dropped. The default is a safe, finite bound; it is
+                distinct from ``maxlen`` (a memory-only FIFO backstop). MUST
+                be a positive integer.
         """
         from kailash.trust.enforce.held import (
             DEFAULT_EXPIRY_DISPOSITION,
             MemoryHeldActionStore,
         )
+
+        if not isinstance(max_pending_holds, int) or isinstance(
+            max_pending_holds, bool
+        ):
+            raise ValueError(
+                f"max_pending_holds must be an int, got {type(max_pending_holds).__name__}"
+            )
+        if max_pending_holds < 1:
+            raise ValueError(
+                f"max_pending_holds must be >= 1, got {max_pending_holds!r}"
+            )
 
         self._on_held = on_held
         self._held_callback = held_callback
@@ -158,6 +181,7 @@ class StrictEnforcer:
         self._default_expiry: ExpiryDisposition = (
             default_expiry if default_expiry is not None else DEFAULT_EXPIRY_DISPOSITION
         )
+        self._max_pending_holds = max_pending_holds
 
         if on_held == HeldBehavior.CALLBACK and held_callback is None:
             raise ValueError("held_callback required when on_held is CALLBACK")
@@ -379,8 +403,59 @@ class StrictEnforcer:
             )
 
         if self._on_held == HeldBehavior.QUEUE:
+            # Capacity gate (BH2 leg 2): fail-closed admission control. When the
+            # pending review queue is saturated to reviewer capacity, a NEW
+            # escalation is DENIED (BLOCKED) — never silently dropped and never
+            # unbounded-queued. This is distinct from the ``maxlen`` FIFO trim
+            # below (a memory-only backstop that silently evicts oldest holds);
+            # the capacity gate is real admission control that fails closed.
+            if len(self._review_queue) >= self._max_pending_holds:
+                denial_record = EnforcementRecord(
+                    agent_id=agent_id,
+                    action=action,
+                    verdict=Verdict.BLOCKED,
+                    verification_result=result,
+                    metadata={
+                        **dict(record.metadata),
+                        "admission_denied": True,
+                        "pending_holds": len(self._review_queue),
+                        "max_pending_holds": self._max_pending_holds,
+                    },
+                )
+                self._records.append(denial_record)
+                if len(self._records) > self._max_records:
+                    trim_count = self._max_records // 10
+                    self._records = self._records[trim_count:]
+                logger.warning(
+                    "[ENFORCE] HELD escalation DENIED — review queue saturated "
+                    "(pending=%d capacity=%d): agent=%s action=%s",
+                    len(self._review_queue),
+                    self._max_pending_holds,
+                    agent_id,
+                    action,
+                )
+                raise EATPBlockedError(
+                    agent_id=agent_id,
+                    action=action,
+                    reason=(
+                        f"Review queue saturated "
+                        f"({len(self._review_queue)}/{self._max_pending_holds}) "
+                        f"— escalation denied (fail-closed)"
+                    ),
+                    violations=result.violations,
+                )
+
+            from kailash.trust.enforce.held import new_hold_id
+
+            hold_id = new_hold_id()
+            # Correlate the passive review-queue entry with its store hold so a
+            # reviewer can address the exact hold by id (apply_review_decision).
+            # record.metadata is a mutable dict; the dataclass freeze only
+            # blocks field reassignment, not mutation of the dict's contents.
+            record.metadata["hold_id"] = hold_id
             logger.info(
-                f"[ENFORCE] HELD: agent={agent_id} action={action} — queued for review"
+                f"[ENFORCE] HELD: agent={agent_id} action={action} "
+                f"hold_id={hold_id} — queued for review"
             )
             self._review_queue.append(record)
             # Bounded memory for review queue
@@ -395,6 +470,7 @@ class StrictEnforcer:
                 agent_id,
                 action,
                 record,
+                hold_id=hold_id,
                 timeout=timeout,
                 on_expiry=on_expiry,
                 approval_policy=approval_policy,
@@ -428,6 +504,7 @@ class StrictEnforcer:
         action: str,
         record: EnforcementRecord,
         *,
+        hold_id: str,
         timeout: Optional[float],
         on_expiry: Optional[ExpiryDisposition],
         approval_policy: Optional[ApprovalPolicyModel],
@@ -442,7 +519,6 @@ class StrictEnforcer:
         """
         from kailash.trust.enforce.held import (
             HeldAction,
-            new_hold_id,
             resolve_timeout_seconds,
         )
 
@@ -454,7 +530,7 @@ class StrictEnforcer:
 
         disposition = on_expiry if on_expiry is not None else self._default_expiry
         hold = HeldAction(
-            hold_id=new_hold_id(),
+            hold_id=hold_id,
             agent_id=agent_id,
             action=action,
             held_at=record.timestamp,
@@ -531,6 +607,118 @@ class StrictEnforcer:
             )
 
         return expiry_records
+
+    def apply_review_decision(
+        self,
+        hold_id: str,
+        decision: "ReviewerDecision",
+        reviewer_id: str,
+        *,
+        modified_verdict: Optional[Verdict] = None,
+    ) -> EnforcementRecord:
+        """Apply a human reviewer's decision to a pending HITL hold (BH2 leg 3).
+
+        Resolves a held action addressed by ``hold_id`` to a concrete verdict
+        under the reviewer's authority, binding ``reviewer_id`` into the
+        resulting audit record. Monotonic-guarded and fail-closed:
+
+        - ``DECLINE`` -> ``BLOCKED``.
+        - ``APPROVE`` -> ``AUTO_APPROVED`` — sanctions the originally-held
+          action to proceed, WITHOUT escalating authority beyond the original
+          request.
+        - ``MODIFY`` -> the supplied ``modified_verdict``, clamped to
+          monotonic-tightening only; a verdict less restrictive than ``HELD``
+          (a widening) is clamped fail-closed to ``BLOCKED``. ``MODIFY``
+          without a ``modified_verdict`` raises ``ReviewDecisionError``.
+
+        The reviewed hold is removed from BOTH the passive review queue and the
+        timeout-tracking store, so it can neither be re-reviewed nor expire.
+
+        Args:
+            hold_id: Identifier of the pending hold to resolve.
+            decision: The reviewer's disposition (APPROVE / MODIFY / DECLINE).
+            reviewer_id: Identifier of the reviewer, bound into the audit
+                record's metadata. An identifier, NOT a credential.
+            modified_verdict: Required for ``MODIFY`` — the reviewer's target
+                verdict, subject to the monotonic-tightening clamp.
+
+        Returns:
+            The ``EnforcementRecord`` for the reviewer decision (verdict +
+            ``reviewer_id`` bound), also appended to the enforcer's audit sink.
+
+        Raises:
+            ReviewDecisionError: If ``hold_id`` is unknown/missing, or a
+                ``MODIFY`` omits ``modified_verdict`` (both fail-closed).
+            ValueError: If ``hold_id`` is not a safe identifier.
+        """
+        from kailash.trust._locking import validate_id
+        from kailash.trust.enforce.held import (
+            ReviewDecisionError,
+            resolve_review_verdict,
+        )
+
+        validate_id(hold_id)
+
+        # The passive review queue is the source of truth for pending holds
+        # (every QUEUE escalation lands here with its hold_id); the store only
+        # tracks the timeout-bearing subset. Claim from both, fail closed if
+        # the hold is in neither (unknown/missing hold_id).
+        matched: Optional[EnforcementRecord] = None
+        remaining: List[EnforcementRecord] = []
+        for queued in self._review_queue:
+            if matched is None and queued.metadata.get("hold_id") == hold_id:
+                matched = queued
+            else:
+                remaining.append(queued)
+
+        stored = self._held_store.pop(hold_id)
+
+        if matched is None and stored is None:
+            raise ReviewDecisionError(
+                f"apply_review_decision: unknown or already-resolved hold_id "
+                f"{hold_id!r} — fail-closed"
+            )
+
+        self._review_queue = remaining
+
+        verdict = resolve_review_verdict(decision, modified_verdict=modified_verdict)
+
+        base = matched if matched is not None else stored.record
+        decision_metadata: Dict[str, Any] = {
+            **dict(base.metadata),
+            "hold_id": hold_id,
+            "reviewer_id": reviewer_id,
+            "reviewer_decision": decision.value,
+            "review_of_verdict": Verdict.HELD.value,
+        }
+        if modified_verdict is not None:
+            decision_metadata["modified_verdict_requested"] = modified_verdict.value
+
+        decision_record = EnforcementRecord(
+            agent_id=base.agent_id,
+            action=base.action,
+            verdict=verdict,
+            verification_result=base.verification_result,
+            metadata=decision_metadata,
+        )
+        self._records.append(decision_record)
+        if len(self._records) > self._max_records:
+            trim_count = self._max_records // 10
+            self._records = self._records[trim_count:]
+
+        logger.info(
+            "[ENFORCE] REVIEW %s by reviewer=%s hold_id=%s -> %s",
+            decision.value,
+            reviewer_id,
+            hold_id,
+            verdict.value,
+        )
+        return decision_record
+
+    @property
+    def max_pending_holds(self) -> int:
+        """Reviewer-capacity admission-control bound (BH2 leg 2)."""
+        return self._max_pending_holds
 
     @property
     def held_store(self) -> "HeldActionStore":

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -632,13 +632,17 @@ class StrictEnforcer:
           without a ``modified_verdict`` raises ``ReviewDecisionError``.
 
         The reviewed hold is removed from BOTH the passive review queue and the
-        timeout-tracking store, so it can neither be re-reviewed nor expire.
+        timeout-tracking store, so it can neither be re-reviewed nor expire. A
+        hold recovered from the store as a corrupt fail-closed sentinel forces
+        ``BLOCKED`` regardless of the decision (invariant 5).
 
         Args:
             hold_id: Identifier of the pending hold to resolve.
             decision: The reviewer's disposition (APPROVE / MODIFY / DECLINE).
             reviewer_id: Identifier of the reviewer, bound into the audit
-                record's metadata. An identifier, NOT a credential.
+                record's metadata. An identifier, NOT a credential. Validated
+                through ``validate_id`` (rejects newline / control-char /
+                path-traversal injection) before it is bound or logged.
             modified_verdict: Required for ``MODIFY`` — the reviewer's target
                 verdict, subject to the monotonic-tightening clamp.
 
@@ -648,8 +652,11 @@ class StrictEnforcer:
 
         Raises:
             ReviewDecisionError: If ``hold_id`` is unknown/missing, or a
-                ``MODIFY`` omits ``modified_verdict`` (both fail-closed).
-            ValueError: If ``hold_id`` is not a safe identifier.
+                ``MODIFY`` omits ``modified_verdict`` (both fail-closed). A bad
+                decision raises BEFORE the hold is consumed, so the hold
+                survives for a corrected retry.
+            ValueError: If ``hold_id`` or ``reviewer_id`` is not a safe
+                identifier.
         """
         from kailash.trust._locking import validate_id
         from kailash.trust.enforce.held import (
@@ -657,12 +664,26 @@ class StrictEnforcer:
             resolve_review_verdict,
         )
 
+        # Validate BOTH identifiers before any state mutation. hold_id gates
+        # path-traversal; reviewer_id is bound into the audit record AND logged,
+        # so a newline / control-char / null-byte reviewer_id is an audit-log
+        # line-injection vector — route it through the same validate_id as
+        # hold_id (symmetric charset floor).
         validate_id(hold_id)
+        validate_id(reviewer_id)
+
+        # Resolve the decision FIRST. resolve_review_verdict is pure and
+        # side-effect-free but VALIDATES the decision — a MODIFY without a
+        # modified_verdict, or a malformed decision, raises HERE. It MUST run
+        # BEFORE any hold is consumed so a bad decision leaves the hold intact
+        # and re-resolvable on a corrected retry (no state advance before the
+        # validating step, per eatp.md § Signed-Audit-Emits-BEFORE-State-Advance).
+        verdict = resolve_review_verdict(decision, modified_verdict=modified_verdict)
 
         # The passive review queue is the source of truth for pending holds
         # (every QUEUE escalation lands here with its hold_id); the store only
-        # tracks the timeout-bearing subset. Claim from both, fail closed if
-        # the hold is in neither (unknown/missing hold_id).
+        # tracks the timeout-bearing subset. Compute the surviving queue WITHOUT
+        # reassigning it yet, then claim the timeout-tracked hold from the store.
         matched: Optional[EnforcementRecord] = None
         remaining: List[EnforcementRecord] = []
         for queued in self._review_queue:
@@ -674,16 +695,31 @@ class StrictEnforcer:
         stored = self._held_store.pop(hold_id)
 
         if matched is None and stored is None:
+            # Unknown / already-resolved hold_id — fail closed. The pop above
+            # was a no-op (the id is in neither surface), so nothing was
+            # consumed and the reviewer can retry.
             raise ReviewDecisionError(
                 f"apply_review_decision: unknown or already-resolved hold_id "
                 f"{hold_id!r} — fail-closed"
             )
 
+        # Commit the queue mutation only now that the decision is valid AND the
+        # hold exists.
         self._review_queue = remaining
 
-        verdict = resolve_review_verdict(decision, modified_verdict=modified_verdict)
-
         base = matched if matched is not None else stored.record
+
+        # A hold recovered from the store as a CORRUPT sentinel carries
+        # verification_result.valid == False (the fail-closed DENY sentinel from
+        # SqliteHeldActionStore.pop). An APPROVE/MODIFY over corrupt state MUST
+        # NOT resolve to a permissive verdict — force BLOCKED, symmetric with
+        # the expiry path's corrupt-row handling. A well-formed HELD record is
+        # always valid=True (classify() only yields HELD for valid results), so
+        # this never false-positives on a genuine hold (invariant 5).
+        corrupt_hold = base.verification_result.valid is False
+        if corrupt_hold:
+            verdict = Verdict.BLOCKED
+
         decision_metadata: Dict[str, Any] = {
             **dict(base.metadata),
             "hold_id": hold_id,
@@ -693,6 +729,8 @@ class StrictEnforcer:
         }
         if modified_verdict is not None:
             decision_metadata["modified_verdict_requested"] = modified_verdict.value
+        if corrupt_hold:
+            decision_metadata["corrupt_hold"] = True
 
         decision_record = EnforcementRecord(
             agent_id=base.agent_id,

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -13,12 +13,18 @@ from __future__ import annotations
 import logging
 import math
 import threading
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from kailash.trust.chain import VerificationLevel, VerificationResult
+
+# Verdict + EnforcementRecord live in the leaf ``_types`` module so ``held`` can
+# import them WITHOUT importing ``strict`` (breaking the strict<->held
+# module-level cycle CodeQL py/unsafe-cyclic-import flagged). Re-exported here
+# (import + ``__all__``) so every ``from kailash.trust.enforce.strict import
+# Verdict / EnforcementRecord`` caller keeps resolving unchanged.
+from kailash.trust.enforce._types import EnforcementRecord, Verdict
 
 # Reviewer identifiers are bound into audit records and logged; cap the length
 # so a multi-megabyte reviewer_id cannot flood the log/audit sink (BH2 leg 3,
@@ -36,15 +42,6 @@ if TYPE_CHECKING:
     from kailash.trust.hooks import HookRegistry
 
 logger = logging.getLogger(__name__)
-
-
-class Verdict(Enum):
-    """Enforcement verdict for a verification result."""
-
-    AUTO_APPROVED = "auto_approved"  # Valid, no issues
-    FLAGGED = "flagged"  # Valid but has warnings (constraint near limits)
-    HELD = "held"  # Requires human review before proceeding
-    BLOCKED = "blocked"  # Denied, action must not proceed
 
 
 class HeldBehavior(Enum):
@@ -91,21 +88,6 @@ class EATPHeldError(PermissionError):
         super().__init__(
             f"EATP HELD: Agent '{agent_id}' action '{action}' requires review: {reason}"
         )
-
-
-@dataclass(frozen=True)
-class EnforcementRecord:
-    """Record of an enforcement decision.
-
-    Frozen to prevent post-creation tampering of audit records.
-    """
-
-    agent_id: str
-    action: str
-    verdict: Verdict
-    verification_result: VerificationResult
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class StrictEnforcer:

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -191,11 +191,14 @@ class StrictEnforcer:
         self._max_pending_holds = max_pending_holds
         # Serializes every _review_queue / _records mutation so the review-queue
         # lifecycle is single-winner: the capacity-gate read+append, the
-        # apply_review_decision scan→pop→reassign, and the expire_holds
-        # pop+queue-reconcile are each atomic and mutually exclusive. Reentrant
-        # (RLock) because enforce() holds it across the _handle_held call which
-        # re-acquires it. Lock ordering is always enforcer-lock THEN store-lock
-        # (never the reverse) so no deadlock with the store's own lock.
+        # apply_review_decision scan→pop→reassign, the expire_holds
+        # pop+audit-emit+queue-reconcile, and the clear_* resets are each atomic
+        # and mutually exclusive. Reentrant (RLock) DEFENSIVELY — no current path
+        # re-acquires it on the same thread (enforce() releases it before calling
+        # _handle_held, which re-acquires fresh), but RLock keeps a future
+        # guarded-method-calling-a-guarded-method refactor from self-deadlocking.
+        # Lock ordering is always enforcer-lock THEN store-lock (never the
+        # reverse) so no deadlock with the store's own lock.
         self._lock = threading.RLock()
 
         if on_held == HeldBehavior.CALLBACK and held_callback is None:
@@ -595,18 +598,21 @@ class StrictEnforcer:
         with self._lock:
             expired = self._held_store.pop_expired(evaluated_at)
 
-            # Reconcile the review queue: drop every entry whose hold_id was
-            # just expired, so an expired hold is absent from both surfaces and
-            # a late apply_review_decision hits the both-None guard (fail-closed
-            # ReviewDecisionError). Matched by the record's metadata["hold_id"],
-            # the same id _handle_held stamped and _register_hold shared.
+            # The set of ids to drop from the passive review queue on expiry.
+            # For a NORMAL expired hold this is hold.hold_id (== the id
+            # _handle_held stamped + _register_hold shared). For a CORRUPT row
+            # recovered as the fail-closed sentinel, hold.hold_id is a FRESH id
+            # that matches no queue entry — so the ORIGINAL id (preserved by
+            # _corrupt_sentinel as metadata["original_hold_id"]) is unioned in.
+            # Without this union a corrupt-row expiry leaves the original queue
+            # entry (valid=True HELD) live, and a late apply_review_decision(H,
+            # APPROVE) resurrects an already-BLOCKED action to AUTO_APPROVED.
             expired_ids = {hold.hold_id for hold in expired}
-            if expired_ids:
-                self._review_queue = [
-                    queued
-                    for queued in self._review_queue
-                    if queued.metadata.get("hold_id") not in expired_ids
-                ]
+            expired_ids |= {
+                hold.metadata.get("original_hold_id")
+                for hold in expired
+                if hold.metadata.get("original_hold_id")
+            }
 
             for hold in expired:
                 verdict = resolve_expiry_verdict(hold.on_expiry)
@@ -650,6 +656,19 @@ class StrictEnforcer:
                     hold.on_expiry.value,
                     verdict.value,
                 )
+
+            # State advance AFTER the audit emit (eatp.md § Signed-Audit-Emits-
+            # BEFORE-State-Advance): every BLOCKED expiry record is appended to
+            # the audit sink above BEFORE the review-queue is rebound here, so a
+            # sink that raises can never leave a rebound queue with a hole in the
+            # audit chain. (The store deletion inside pop_expired is unavoidably
+            # first; the queue rebind is the state advance ordered to follow.)
+            if expired_ids:
+                self._review_queue = [
+                    queued
+                    for queued in self._review_queue
+                    if queued.metadata.get("hold_id") not in expired_ids
+                ]
 
         return expiry_records
 
@@ -841,11 +860,13 @@ class StrictEnforcer:
 
     def clear_records(self) -> None:
         """Clear enforcement records."""
-        self._records.clear()
+        with self._lock:
+            self._records.clear()
 
     def clear_review_queue(self) -> None:
         """Clear the review queue."""
-        self._review_queue.clear()
+        with self._lock:
+            self._review_queue.clear()
 
 
 __all__ = [

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -11,12 +11,19 @@ unauthorized actions must be blocked.
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from kailash.trust.chain import VerificationLevel, VerificationResult
+
+# Reviewer identifiers are bound into audit records and logged; cap the length
+# so a multi-megabyte reviewer_id cannot flood the log/audit sink (BH2 leg 3,
+# Finding 3a). validate_id() guards the charset (no newline/control/traversal);
+# this floor guards the size. 256 chars is generous for any real identifier.
+_MAX_REVIEWER_ID_LEN = 256
 
 if TYPE_CHECKING:
     from kailash.trust.enforce.held import (
@@ -182,6 +189,14 @@ class StrictEnforcer:
             default_expiry if default_expiry is not None else DEFAULT_EXPIRY_DISPOSITION
         )
         self._max_pending_holds = max_pending_holds
+        # Serializes every _review_queue / _records mutation so the review-queue
+        # lifecycle is single-winner: the capacity-gate read+append, the
+        # apply_review_decision scan→pop→reassign, and the expire_holds
+        # pop+queue-reconcile are each atomic and mutually exclusive. Reentrant
+        # (RLock) because enforce() holds it across the _handle_held call which
+        # re-acquires it. Lock ordering is always enforcer-lock THEN store-lock
+        # (never the reverse) so no deadlock with the store's own lock.
+        self._lock = threading.RLock()
 
         if on_held == HeldBehavior.CALLBACK and held_callback is None:
             raise ValueError("held_callback required when on_held is CALLBACK")
@@ -329,12 +344,12 @@ class StrictEnforcer:
             verification_result=result,
             metadata=record_metadata,
         )
-        self._records.append(record)
-
-        # Bounded memory: trim oldest 10% when exceeding maxlen
-        if len(self._records) > self._max_records:
-            trim_count = self._max_records // 10
-            self._records = self._records[trim_count:]
+        with self._lock:
+            self._records.append(record)
+            # Bounded memory: trim oldest 10% when exceeding maxlen
+            if len(self._records) > self._max_records:
+                trim_count = self._max_records // 10
+                self._records = self._records[trim_count:]
 
         if verdict == Verdict.BLOCKED:
             reason = result.reason or "Verification failed"
@@ -403,78 +418,84 @@ class StrictEnforcer:
             )
 
         if self._on_held == HeldBehavior.QUEUE:
-            # Capacity gate (BH2 leg 2): fail-closed admission control. When the
-            # pending review queue is saturated to reviewer capacity, a NEW
-            # escalation is DENIED (BLOCKED) — never silently dropped and never
-            # unbounded-queued. This is distinct from the ``maxlen`` FIFO trim
-            # below (a memory-only backstop that silently evicts oldest holds);
-            # the capacity gate is real admission control that fails closed.
-            if len(self._review_queue) >= self._max_pending_holds:
-                denial_record = EnforcementRecord(
-                    agent_id=agent_id,
-                    action=action,
-                    verdict=Verdict.BLOCKED,
-                    verification_result=result,
-                    metadata={
-                        **dict(record.metadata),
-                        "admission_denied": True,
-                        "pending_holds": len(self._review_queue),
-                        "max_pending_holds": self._max_pending_holds,
-                    },
-                )
-                self._records.append(denial_record)
-                if len(self._records) > self._max_records:
-                    trim_count = self._max_records // 10
-                    self._records = self._records[trim_count:]
-                logger.warning(
-                    "[ENFORCE] HELD escalation DENIED — review queue saturated "
-                    "(pending=%d capacity=%d): agent=%s action=%s",
-                    len(self._review_queue),
-                    self._max_pending_holds,
-                    agent_id,
-                    action,
-                )
-                raise EATPBlockedError(
-                    agent_id=agent_id,
-                    action=action,
-                    reason=(
-                        f"Review queue saturated "
-                        f"({len(self._review_queue)}/{self._max_pending_holds}) "
-                        f"— escalation denied (fail-closed)"
-                    ),
-                    violations=result.violations,
-                )
-
             from kailash.trust.enforce.held import new_hold_id
 
-            hold_id = new_hold_id()
-            # Correlate the passive review-queue entry with its store hold so a
-            # reviewer can address the exact hold by id (apply_review_decision).
-            # record.metadata is a mutable dict; the dataclass freeze only
-            # blocks field reassignment, not mutation of the dict's contents.
-            record.metadata["hold_id"] = hold_id
-            logger.info(
-                f"[ENFORCE] HELD: agent={agent_id} action={action} "
-                f"hold_id={hold_id} — queued for review"
-            )
-            self._review_queue.append(record)
-            # Bounded memory for review queue
-            if len(self._review_queue) > self._max_records:
-                trim_count = self._max_records // 10
-                self._review_queue = self._review_queue[trim_count:]
-            # Register a timeout-tracked hold when a response window is set,
-            # either explicitly (timeout) or from the approval policy
-            # (approval_timeout_seconds). The unset on_expiry disposition is
-            # fail-safe DENY (never auto-approves) per self._default_expiry.
-            self._register_hold(
-                agent_id,
-                action,
-                record,
-                hold_id=hold_id,
-                timeout=timeout,
-                on_expiry=on_expiry,
-                approval_policy=approval_policy,
-            )
+            # The capacity-gate READ and the queue append MUST be one atomic
+            # critical section (Finding 2): otherwise two concurrent escalations
+            # both read len < capacity and both enqueue, overrunning the bound.
+            # The lock also serializes admission vs expire_holds vs
+            # apply_review_decision on _review_queue / _records.
+            with self._lock:
+                # Capacity gate (BH2 leg 2): fail-closed admission control. When
+                # the pending review queue is saturated to reviewer capacity, a
+                # NEW escalation is DENIED (BLOCKED) — never silently dropped and
+                # never unbounded-queued. This is distinct from the ``maxlen``
+                # FIFO trim below (a memory-only backstop that silently evicts
+                # oldest holds); the capacity gate is real admission control.
+                if len(self._review_queue) >= self._max_pending_holds:
+                    denial_record = EnforcementRecord(
+                        agent_id=agent_id,
+                        action=action,
+                        verdict=Verdict.BLOCKED,
+                        verification_result=result,
+                        metadata={
+                            **dict(record.metadata),
+                            "admission_denied": True,
+                            "pending_holds": len(self._review_queue),
+                            "max_pending_holds": self._max_pending_holds,
+                        },
+                    )
+                    self._records.append(denial_record)
+                    if len(self._records) > self._max_records:
+                        trim_count = self._max_records // 10
+                        self._records = self._records[trim_count:]
+                    logger.warning(
+                        "[ENFORCE] HELD escalation DENIED — review queue "
+                        "saturated (pending=%d capacity=%d): agent=%s action=%s",
+                        len(self._review_queue),
+                        self._max_pending_holds,
+                        agent_id,
+                        action,
+                    )
+                    raise EATPBlockedError(
+                        agent_id=agent_id,
+                        action=action,
+                        reason=(
+                            f"Review queue saturated "
+                            f"({len(self._review_queue)}/{self._max_pending_holds}) "
+                            f"— escalation denied (fail-closed)"
+                        ),
+                        violations=result.violations,
+                    )
+
+                hold_id = new_hold_id()
+                # Correlate the passive review-queue entry with its store hold so
+                # a reviewer can address the exact hold by id
+                # (apply_review_decision). record.metadata is a mutable dict; the
+                # dataclass freeze blocks field reassignment, not dict mutation.
+                record.metadata["hold_id"] = hold_id
+                logger.info(
+                    f"[ENFORCE] HELD: agent={agent_id} action={action} "
+                    f"hold_id={hold_id} — queued for review"
+                )
+                self._review_queue.append(record)
+                # Bounded memory for review queue
+                if len(self._review_queue) > self._max_records:
+                    trim_count = self._max_records // 10
+                    self._review_queue = self._review_queue[trim_count:]
+                # Register a timeout-tracked hold when a response window is set,
+                # either explicitly (timeout) or from the approval policy
+                # (approval_timeout_seconds). The unset on_expiry disposition is
+                # fail-safe DENY (never auto-approves) per self._default_expiry.
+                self._register_hold(
+                    agent_id,
+                    action,
+                    record,
+                    hold_id=hold_id,
+                    timeout=timeout,
+                    on_expiry=on_expiry,
+                    approval_policy=approval_policy,
+                )
             raise EATPHeldError(
                 agent_id=agent_id,
                 action=action,
@@ -560,51 +581,75 @@ class StrictEnforcer:
         from kailash.trust.enforce.held import resolve_expiry_verdict, verdict_rank
 
         evaluated_at = now if now is not None else datetime.now(timezone.utc)
-        expired = self._held_store.pop_expired(evaluated_at)
         expiry_records: List[EnforcementRecord] = []
 
-        for hold in expired:
-            verdict = resolve_expiry_verdict(hold.on_expiry)
-            # Monotonic invariant: an expiry outcome is never less restrictive
-            # than the hold it replaces. resolve_expiry_verdict guarantees
-            # rank >= HELD; this is the defense-in-depth fail-closed backstop.
-            if verdict_rank(verdict) < verdict_rank(Verdict.HELD):
-                verdict = Verdict.BLOCKED
+        # Pop the expired holds from the store AND reconcile the passive review
+        # queue in ONE atomic critical section (Finding 1, CRITICAL). An expired
+        # hold must vanish from BOTH surfaces together: if only the store row is
+        # popped, the lingering _review_queue entry (still valid=True HELD, its
+        # hold_id intact) lets a late apply_review_decision(hold_id, APPROVE)
+        # find `matched`, skip the both-None fail-closed guard, and resurrect an
+        # already-timed-out-and-BLOCKED action to AUTO_APPROVED — a
+        # BLOCKED->AUTO_APPROVED monotonic downgrade invariant 5 forbids. The
+        # lock also serializes expire vs admission vs apply_review_decision.
+        with self._lock:
+            expired = self._held_store.pop_expired(evaluated_at)
 
-            expiry_metadata = {
-                **dict(hold.metadata),
-                "hold_expiry": True,
-                "hold_id": hold.hold_id,
-                "on_expiry": hold.on_expiry.value,
-                "original_verdict": Verdict.HELD.value,
-                "held_at": hold.held_at.isoformat(),
-                "timeout_seconds": hold.timeout_seconds,
-                "expires_at": hold.expires_at.isoformat(),
-            }
-            expiry_record = EnforcementRecord(
-                agent_id=hold.agent_id,
-                action=hold.action,
-                verdict=verdict,
-                verification_result=hold.record.verification_result,
-                timestamp=evaluated_at,
-                metadata=expiry_metadata,
-            )
-            self._records.append(expiry_record)
-            # Bounded memory: trim oldest 10% when exceeding maxlen
-            if len(self._records) > self._max_records:
-                trim_count = self._max_records // 10
-                self._records = self._records[trim_count:]
+            # Reconcile the review queue: drop every entry whose hold_id was
+            # just expired, so an expired hold is absent from both surfaces and
+            # a late apply_review_decision hits the both-None guard (fail-closed
+            # ReviewDecisionError). Matched by the record's metadata["hold_id"],
+            # the same id _handle_held stamped and _register_hold shared.
+            expired_ids = {hold.hold_id for hold in expired}
+            if expired_ids:
+                self._review_queue = [
+                    queued
+                    for queued in self._review_queue
+                    if queued.metadata.get("hold_id") not in expired_ids
+                ]
 
-            expiry_records.append(expiry_record)
-            logger.warning(
-                "[ENFORCE] HELD EXPIRED: agent=%s action=%s hold_id=%s "
-                "on_expiry=%s -> %s",
-                hold.agent_id,
-                hold.action,
-                hold.hold_id,
-                hold.on_expiry.value,
-                verdict.value,
-            )
+            for hold in expired:
+                verdict = resolve_expiry_verdict(hold.on_expiry)
+                # Monotonic invariant: an expiry outcome is never less
+                # restrictive than the hold it replaces. resolve_expiry_verdict
+                # guarantees rank >= HELD; this is the fail-closed backstop.
+                if verdict_rank(verdict) < verdict_rank(Verdict.HELD):
+                    verdict = Verdict.BLOCKED
+
+                expiry_metadata = {
+                    **dict(hold.metadata),
+                    "hold_expiry": True,
+                    "hold_id": hold.hold_id,
+                    "on_expiry": hold.on_expiry.value,
+                    "original_verdict": Verdict.HELD.value,
+                    "held_at": hold.held_at.isoformat(),
+                    "timeout_seconds": hold.timeout_seconds,
+                    "expires_at": hold.expires_at.isoformat(),
+                }
+                expiry_record = EnforcementRecord(
+                    agent_id=hold.agent_id,
+                    action=hold.action,
+                    verdict=verdict,
+                    verification_result=hold.record.verification_result,
+                    timestamp=evaluated_at,
+                    metadata=expiry_metadata,
+                )
+                self._records.append(expiry_record)
+                # Bounded memory: trim oldest 10% when exceeding maxlen
+                if len(self._records) > self._max_records:
+                    trim_count = self._max_records // 10
+                    self._records = self._records[trim_count:]
+
+                expiry_records.append(expiry_record)
+                logger.warning(
+                    "[ENFORCE] HELD EXPIRED: agent=%s action=%s hold_id=%s "
+                    "on_expiry=%s -> %s",
+                    hold.agent_id,
+                    hold.action,
+                    hold.hold_id,
+                    hold.on_expiry.value,
+                    verdict.value,
+                )
 
         return expiry_records
 
@@ -651,12 +696,17 @@ class StrictEnforcer:
             ``reviewer_id`` bound), also appended to the enforcer's audit sink.
 
         Raises:
-            ReviewDecisionError: If ``hold_id`` is unknown/missing, or a
-                ``MODIFY`` omits ``modified_verdict`` (both fail-closed). A bad
-                decision raises BEFORE the hold is consumed, so the hold
-                survives for a corrected retry.
+            ReviewDecisionError: If ``hold_id`` is unknown/missing/expired, a
+                ``MODIFY`` omits ``modified_verdict``, an ``APPROVE``/``DECLINE``
+                carries a modified_verdict (ambiguous), or ``reviewer_id``
+                exceeds the length cap — all fail-closed. A bad decision raises
+                BEFORE the hold is consumed, so the hold survives for a
+                corrected retry.
             ValueError: If ``hold_id`` or ``reviewer_id`` is not a safe
                 identifier.
+
+        Thread-safe: the scan → pop → reassign is single-winner under a lock;
+        concurrent calls on the same hold resolve exactly once.
         """
         from kailash.trust._locking import validate_id
         from kailash.trust.enforce.held import (
@@ -671,6 +721,13 @@ class StrictEnforcer:
         # hold_id (symmetric charset floor).
         validate_id(hold_id)
         validate_id(reviewer_id)
+        # Length floor (Finding 3a): validate_id caps the charset but not the
+        # size; a multi-megabyte reviewer_id would flood the audit sink + logs.
+        if len(reviewer_id) > _MAX_REVIEWER_ID_LEN:
+            raise ReviewDecisionError(
+                f"apply_review_decision: reviewer_id length {len(reviewer_id)} "
+                f"exceeds cap {_MAX_REVIEWER_ID_LEN} — fail-closed"
+            )
 
         # Resolve the decision FIRST. resolve_review_verdict is pure and
         # side-effect-free but VALIDATES the decision — a MODIFY without a
@@ -680,69 +737,78 @@ class StrictEnforcer:
         # validating step, per eatp.md § Signed-Audit-Emits-BEFORE-State-Advance).
         verdict = resolve_review_verdict(decision, modified_verdict=modified_verdict)
 
-        # The passive review queue is the source of truth for pending holds
-        # (every QUEUE escalation lands here with its hold_id); the store only
-        # tracks the timeout-bearing subset. Compute the surviving queue WITHOUT
-        # reassigning it yet, then claim the timeout-tracked hold from the store.
-        matched: Optional[EnforcementRecord] = None
-        remaining: List[EnforcementRecord] = []
-        for queued in self._review_queue:
-            if matched is None and queued.metadata.get("hold_id") == hold_id:
-                matched = queued
-            else:
-                remaining.append(queued)
+        # Scan → pop → reassign is a read-modify-write on shared state; it MUST
+        # be atomic (Finding 2) so two concurrent apply_review_decision calls on
+        # the SAME queue-only hold cannot both find `matched` and both resolve
+        # (a DECLINE + APPROVE race could otherwise emit AUTO_APPROVED after a
+        # BLOCKED). The lock makes review resolution single-winner: the first
+        # caller claims the hold, the second finds it in neither surface and
+        # fails closed. Also serializes review vs expire_holds vs admission.
+        with self._lock:
+            # The passive review queue is the source of truth for pending holds
+            # (every QUEUE escalation lands here with its hold_id); the store
+            # only tracks the timeout-bearing subset. Compute the surviving
+            # queue WITHOUT reassigning it yet, then claim the store hold.
+            matched: Optional[EnforcementRecord] = None
+            remaining: List[EnforcementRecord] = []
+            for queued in self._review_queue:
+                if matched is None and queued.metadata.get("hold_id") == hold_id:
+                    matched = queued
+                else:
+                    remaining.append(queued)
 
-        stored = self._held_store.pop(hold_id)
+            stored = self._held_store.pop(hold_id)
 
-        if matched is None and stored is None:
-            # Unknown / already-resolved hold_id — fail closed. The pop above
-            # was a no-op (the id is in neither surface), so nothing was
-            # consumed and the reviewer can retry.
-            raise ReviewDecisionError(
-                f"apply_review_decision: unknown or already-resolved hold_id "
-                f"{hold_id!r} — fail-closed"
+            if matched is None and stored is None:
+                # Unknown / already-resolved / already-expired hold_id — fail
+                # closed. The pop above was a no-op (the id is in neither
+                # surface), so nothing was consumed and the reviewer can retry.
+                raise ReviewDecisionError(
+                    f"apply_review_decision: unknown or already-resolved hold_id "
+                    f"{hold_id!r} — fail-closed"
+                )
+
+            # Commit the queue mutation only now that the decision is valid AND
+            # the hold exists.
+            self._review_queue = remaining
+
+            base = matched if matched is not None else stored.record
+
+            # A hold recovered from the store as a CORRUPT sentinel carries
+            # verification_result.valid == False (the fail-closed DENY sentinel
+            # from SqliteHeldActionStore.pop). An APPROVE/MODIFY over corrupt
+            # state MUST NOT resolve to a permissive verdict — force BLOCKED,
+            # symmetric with the expiry path's corrupt-row handling. A
+            # well-formed HELD record is always valid=True (classify() only
+            # yields HELD for valid results), so this never false-positives on a
+            # genuine hold (invariant 5).
+            corrupt_hold = base.verification_result.valid is False
+            if corrupt_hold:
+                verdict = Verdict.BLOCKED
+
+            decision_metadata: Dict[str, Any] = {
+                **dict(base.metadata),
+                "hold_id": hold_id,
+                "reviewer_id": reviewer_id,
+                "reviewer_decision": decision.value,
+                "review_of_verdict": Verdict.HELD.value,
+            }
+            if modified_verdict is not None:
+                decision_metadata["modified_verdict_requested"] = modified_verdict.value
+            if corrupt_hold:
+                decision_metadata["corrupt_hold"] = True
+
+            decision_record = EnforcementRecord(
+                agent_id=base.agent_id,
+                action=base.action,
+                verdict=verdict,
+                verification_result=base.verification_result,
+                metadata=decision_metadata,
             )
-
-        # Commit the queue mutation only now that the decision is valid AND the
-        # hold exists.
-        self._review_queue = remaining
-
-        base = matched if matched is not None else stored.record
-
-        # A hold recovered from the store as a CORRUPT sentinel carries
-        # verification_result.valid == False (the fail-closed DENY sentinel from
-        # SqliteHeldActionStore.pop). An APPROVE/MODIFY over corrupt state MUST
-        # NOT resolve to a permissive verdict — force BLOCKED, symmetric with
-        # the expiry path's corrupt-row handling. A well-formed HELD record is
-        # always valid=True (classify() only yields HELD for valid results), so
-        # this never false-positives on a genuine hold (invariant 5).
-        corrupt_hold = base.verification_result.valid is False
-        if corrupt_hold:
-            verdict = Verdict.BLOCKED
-
-        decision_metadata: Dict[str, Any] = {
-            **dict(base.metadata),
-            "hold_id": hold_id,
-            "reviewer_id": reviewer_id,
-            "reviewer_decision": decision.value,
-            "review_of_verdict": Verdict.HELD.value,
-        }
-        if modified_verdict is not None:
-            decision_metadata["modified_verdict_requested"] = modified_verdict.value
-        if corrupt_hold:
-            decision_metadata["corrupt_hold"] = True
-
-        decision_record = EnforcementRecord(
-            agent_id=base.agent_id,
-            action=base.action,
-            verdict=verdict,
-            verification_result=base.verification_result,
-            metadata=decision_metadata,
-        )
-        self._records.append(decision_record)
-        if len(self._records) > self._max_records:
-            trim_count = self._max_records // 10
-            self._records = self._records[trim_count:]
+            self._records.append(decision_record)
+            if len(self._records) > self._max_records:
+                trim_count = self._max_records // 10
+                self._records = self._records[trim_count:]
 
         logger.info(
             "[ENFORCE] REVIEW %s by reviewer=%s hold_id=%s -> %s",

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -11,6 +11,7 @@ unauthorized actions must be blocked.
 from __future__ import annotations
 
 import logging
+import math
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -189,6 +190,31 @@ class StrictEnforcer:
             default_expiry if default_expiry is not None else DEFAULT_EXPIRY_DISPOSITION
         )
         self._max_pending_holds = max_pending_holds
+
+        # Admission-control vs store-capacity invariant (BH2 leg 2, Finding 2):
+        # a timeout-bearing hold in the review queue MUST stay tracked in the
+        # store, else expire_holds never fires for it and it sits reviewer-
+        # APPROVABLE past its deadline (defeating deterministic expiry). The max
+        # number of holds simultaneously queued is min(max_pending_holds [the
+        # capacity gate], max_records [the FIFO trim]); the store MUST hold at
+        # least that many without evicting. A store exposing `capacity` is
+        # checked; a custom store that does not expose it is documented as
+        # responsible for its own sizing and skipped (fail-loud only where we
+        # can prove the misconfiguration). The internally-created default store
+        # always satisfies this (its capacity == maxlen == self._max_records).
+        store_capacity = getattr(self._held_store, "capacity", None)
+        if store_capacity is not None:
+            required = min(max_pending_holds, self._max_records)
+            if store_capacity < required:
+                raise ValueError(
+                    f"held_store capacity ({store_capacity}) is below the "
+                    f"effective pending-hold bound ({required} = "
+                    f"min(max_pending_holds={max_pending_holds}, "
+                    f"maxlen={self._max_records})); a timeout-bearing queued "
+                    f"hold could be evicted from the store and never expire. "
+                    f"Increase the store's capacity to >= {required}."
+                )
+
         # Serializes every _review_queue / _records mutation so the review-queue
         # lifecycle is single-winner: the capacity-gate read+append, the
         # apply_review_decision scan→pop→reassign, the expire_holds
@@ -423,6 +449,12 @@ class StrictEnforcer:
         if self._on_held == HeldBehavior.QUEUE:
             from kailash.trust.enforce.held import new_hold_id
 
+            # Resolve + VALIDATE the timeout BEFORE any queue mutation (Finding
+            # 3): a negative / non-finite timeout must raise here, not after the
+            # queue append — otherwise enforce(timeout=-5) leaves an orphan queue
+            # entry before HeldAction.__post_init__ would have raised.
+            resolved_timeout = self._resolve_hold_timeout(timeout, approval_policy)
+
             # The capacity-gate READ and the queue append MUST be one atomic
             # critical section (Finding 2): otherwise two concurrent escalations
             # both read len < capacity and both enqueue, overrunning the bound.
@@ -486,19 +518,24 @@ class StrictEnforcer:
                 if len(self._review_queue) > self._max_records:
                     trim_count = self._max_records // 10
                     self._review_queue = self._review_queue[trim_count:]
-                # Register a timeout-tracked hold when a response window is set,
-                # either explicitly (timeout) or from the approval policy
-                # (approval_timeout_seconds). The unset on_expiry disposition is
-                # fail-safe DENY (never auto-approves) per self._default_expiry.
-                self._register_hold(
+                # Register a timeout-tracked hold when a response window is set.
+                # The unset on_expiry disposition is fail-safe DENY (never
+                # auto-approves) per self._default_expiry. A hold that IS
+                # registered (timeout-bearing) is stamped `timeout_bearing` on
+                # its queue record so expire_holds can reconcile ONLY store-
+                # backed entries — a no-timeout queue hold (never in the store,
+                # its PK free) MUST NOT be evictable by a forged corrupt store
+                # row bearing its id (Finding 1a).
+                timeout_bearing = self._register_hold(
                     agent_id,
                     action,
                     record,
                     hold_id=hold_id,
-                    timeout=timeout,
+                    resolved_timeout=resolved_timeout,
                     on_expiry=on_expiry,
-                    approval_policy=approval_policy,
                 )
+                if timeout_bearing:
+                    record.metadata["timeout_bearing"] = True
             raise EATPHeldError(
                 agent_id=agent_id,
                 action=action,
@@ -522,6 +559,37 @@ class StrictEnforcer:
             violations=result.violations,
         )
 
+    def _resolve_hold_timeout(
+        self,
+        timeout: Optional[float],
+        approval_policy: Optional[ApprovalPolicyModel],
+    ) -> Optional[float]:
+        """Resolve + validate a hold's response window, fail-closed and early.
+
+        The window comes from ``timeout`` when given, else from
+        ``approval_policy.approval_timeout_seconds`` (per-capability). When
+        neither is set the hold has no bounded window and ``None`` is returned
+        (no store tracking; expire_holds never fires for it). A resolved window
+        MUST be finite and non-negative — validated HERE so a bad timeout raises
+        BEFORE any queue mutation (Finding 3), not later inside HeldAction.
+
+        Raises:
+            ValueError: If the resolved timeout is non-finite or negative.
+        """
+        from kailash.trust.enforce.held import resolve_timeout_seconds
+
+        resolved = timeout
+        if resolved is None and approval_policy is not None:
+            resolved = resolve_timeout_seconds(approval_policy)  # validates
+        if resolved is None:
+            return None
+        resolved = float(resolved)
+        if not math.isfinite(resolved):
+            raise ValueError(f"hold timeout must be finite, got {resolved!r}")
+        if resolved < 0:
+            raise ValueError(f"hold timeout must be non-negative, got {resolved!r}")
+        return resolved
+
     def _register_hold(
         self,
         agent_id: str,
@@ -529,28 +597,24 @@ class StrictEnforcer:
         record: EnforcementRecord,
         *,
         hold_id: str,
-        timeout: Optional[float],
+        resolved_timeout: Optional[float],
         on_expiry: Optional[ExpiryDisposition],
-        approval_policy: Optional[ApprovalPolicyModel],
-    ) -> None:
+    ) -> bool:
         """Track a QUEUE hold for timeout expiry when a response window is set.
 
-        The timeout comes from ``timeout`` when given, else from
-        ``approval_policy.approval_timeout_seconds`` (per-capability window).
-        When neither is set, no hold is tracked (the hold has no bounded
-        response window and expire_holds() will never fire for it). The
-        ``on_expiry`` disposition defaults to the enforcer's fail-safe default.
-        """
-        from kailash.trust.enforce.held import (
-            HeldAction,
-            resolve_timeout_seconds,
-        )
+        ``resolved_timeout`` is the already-resolved-and-validated window from
+        :meth:`_resolve_hold_timeout` (``None`` = no bounded window → not
+        tracked). The ``on_expiry`` disposition defaults to the enforcer's
+        fail-safe default.
 
-        resolved_timeout = timeout
-        if resolved_timeout is None and approval_policy is not None:
-            resolved_timeout = resolve_timeout_seconds(approval_policy)
+        Returns:
+            ``True`` if the hold was registered in the store (timeout-bearing),
+            ``False`` if it has no bounded window and was not tracked.
+        """
+        from kailash.trust.enforce.held import HeldAction
+
         if resolved_timeout is None:
-            return
+            return False
 
         disposition = on_expiry if on_expiry is not None else self._default_expiry
         hold = HeldAction(
@@ -564,6 +628,7 @@ class StrictEnforcer:
             metadata=dict(record.metadata),
         )
         self._held_store.add(hold)
+        return True
 
     def expire_holds(self, now: Optional[datetime] = None) -> List[EnforcementRecord]:
         """Fire the configured disposition for every hold past its deadline.
@@ -622,6 +687,16 @@ class StrictEnforcer:
                 if verdict_rank(verdict) < verdict_rank(Verdict.HELD):
                     verdict = Verdict.BLOCKED
 
+                # Finding 1b: a corrupt sentinel's agent_id/action are recovered
+                # from the attacker-controllable tampered row. Do NOT propagate
+                # them verbatim into the emitted audit record — redact to a
+                # sentinel so a forged row cannot poison the audit trail with
+                # attacker-chosen identifiers. corrupt_row + original_hold_id
+                # survive in the metadata (via the spread below) for forensics.
+                is_corrupt = bool(hold.metadata.get("corrupt_row"))
+                audit_agent_id = "<corrupt>" if is_corrupt else hold.agent_id
+                audit_action = "<corrupt>" if is_corrupt else hold.action
+
                 expiry_metadata = {
                     **dict(hold.metadata),
                     "hold_expiry": True,
@@ -633,8 +708,8 @@ class StrictEnforcer:
                     "expires_at": hold.expires_at.isoformat(),
                 }
                 expiry_record = EnforcementRecord(
-                    agent_id=hold.agent_id,
-                    action=hold.action,
+                    agent_id=audit_agent_id,
+                    action=audit_action,
                     verdict=verdict,
                     verification_result=hold.record.verification_result,
                     timestamp=evaluated_at,
@@ -650,8 +725,8 @@ class StrictEnforcer:
                 logger.warning(
                     "[ENFORCE] HELD EXPIRED: agent=%s action=%s hold_id=%s "
                     "on_expiry=%s -> %s",
-                    hold.agent_id,
-                    hold.action,
+                    audit_agent_id,
+                    audit_action,
                     hold.hold_id,
                     hold.on_expiry.value,
                     verdict.value,
@@ -663,11 +738,30 @@ class StrictEnforcer:
             # sink that raises can never leave a rebound queue with a hole in the
             # audit chain. (The store deletion inside pop_expired is unavoidably
             # first; the queue rebind is the state advance ordered to follow.)
+            #
+            # RESIDUAL (latent audit-reorder): self._records is an in-memory list
+            # today, so append() cannot fail and the store-delete-before-audit-
+            # append ordering is harmless. If _records is ever upgraded to a
+            # fallible signing / persisting sink, the audit emit MUST move BEFORE
+            # the pop_expired store deletion (emit-then-delete), or an emit
+            # failure leaves the store row deleted with no audit row.
+            #
+            # Finding 1a: reconcile ONLY entries that were TIMEOUT-BEARING (had a
+            # real store presence). A no-timeout queue hold (never registered in
+            # the store, its PK slot free) MUST NOT be evictable by an expire
+            # event — an attacker who forges a corrupt store row bearing that
+            # hold's id would otherwise get the sentinel's original_hold_id into
+            # expired_ids and drop the victim's legit queue entry (fail-closed
+            # denial-of-review). Genuinely timeout-bearing holds still reconcile
+            # (R2 corrupt-row behavior preserved) — only they carry the flag.
             if expired_ids:
                 self._review_queue = [
                     queued
                     for queued in self._review_queue
-                    if queued.metadata.get("hold_id") not in expired_ids
+                    if not (
+                        queued.metadata.get("timeout_bearing")
+                        and queued.metadata.get("hold_id") in expired_ids
+                    )
                 ]
 
         return expiry_records

--- a/tests/trust/unit/test_hitl_reviewer_authority.py
+++ b/tests/trust/unit/test_hitl_reviewer_authority.py
@@ -624,3 +624,134 @@ def test_corrupt_row_expiry_reconciles_queue_and_blocks_reapprove(tmp_path):
     assert corrupt_expiry[0].metadata.get("original_hold_id") == hold_id
     assert len(expiry_records) == 1
     store.close()
+
+
+# ---------------------------------------------------------------------------
+# Redteam round 3 findings (non-fail-open: DoS-of-review, audit poisoning,
+# store-bound misconfig, timeout-orphan)
+# ---------------------------------------------------------------------------
+
+
+def _forge_expired_corrupt_row(
+    db_path: str,
+    hold_id: str,
+    *,
+    agent_id: str = "agent-forged",
+    action: str = "deploy",
+) -> None:
+    """Forge an already-EXPIRED corrupt held-action row on disk (bad on_expiry,
+    PAST expires_at) bearing an attacker-chosen hold_id / agent_id / action."""
+    now = datetime.now(timezone.utc)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO held_actions "
+            "(hold_id, agent_id, action, held_at, timeout_seconds, expires_at, "
+            "on_expiry, reason, violations_json, metadata_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                hold_id,
+                agent_id,
+                action,
+                (now - timedelta(seconds=120)).isoformat(),
+                60.0,
+                (now - timedelta(seconds=60)).isoformat(),  # already expired
+                "not_a_valid_disposition",  # ExpiryDisposition(...) will raise
+                "",
+                "[]",
+                "{}",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_no_timeout_hold_survives_forged_corrupt_store_row(tmp_path):
+    """Finding 1a: a NO-TIMEOUT queue hold (never in the store, its PK free)
+    cannot be evicted by a forged corrupt store row bearing its id — the hold
+    survives in the queue and stays resolvable (no attacker denial-of-review)."""
+    enforcer, store = _enforcer(tmp_path)
+    # A queue-only hold (timeout=None) — never registered in the store.
+    victim_id = _queue_one(enforcer, agent_id="agent-victim", timeout=None)
+    assert store.pending() == []  # confirm: not in the store
+    assert enforcer.review_queue[-1].metadata["hold_id"] == victim_id
+
+    # Attacker forges an already-expired corrupt store row bearing the victim id.
+    _forge_expired_corrupt_row(str(tmp_path / "held.db"), victim_id)
+
+    enforcer.expire_holds(now=datetime.now(timezone.utc))
+
+    # The victim's queue entry SURVIVES (it was never timeout-bearing, so the
+    # forged row cannot reconcile it away).
+    assert any(r.metadata.get("hold_id") == victim_id for r in enforcer.review_queue)
+    # ...and it stays resolvable by a real reviewer.
+    record = enforcer.apply_review_decision(
+        victim_id, ReviewerDecision.APPROVE, "rev-victim"
+    )
+    assert record.verdict is Verdict.AUTO_APPROVED
+    store.close()
+
+
+def test_corrupt_expiry_audit_redacts_agent_and_action(tmp_path):
+    """Finding 1b: a corrupt-row expiry audit record carries redacted
+    agent_id/action (`<corrupt>`), never the attacker-forged identifiers."""
+    enforcer, store = _enforcer(tmp_path)
+    _forge_expired_corrupt_row(
+        str(tmp_path / "held.db"),
+        "hold-forged-audit",
+        agent_id="ATTACKER-AGENT",
+        action="ATTACKER-ACTION",
+    )
+
+    expiry_records = enforcer.expire_holds(now=datetime.now(timezone.utc))
+    assert len(expiry_records) == 1
+    rec = expiry_records[0]
+    assert rec.verdict is Verdict.BLOCKED
+    # The forged identifiers are NOT propagated into the audit record.
+    assert rec.agent_id == "<corrupt>"
+    assert rec.action == "<corrupt>"
+    assert rec.agent_id != "ATTACKER-AGENT" and rec.action != "ATTACKER-ACTION"
+    # corrupt_row survives for forensics.
+    assert rec.metadata.get("corrupt_row") is True
+    store.close()
+
+
+def test_store_bound_below_max_pending_holds_rejected(tmp_path):
+    """Finding 2: constructing StrictEnforcer with a store whose capacity is
+    below the effective pending-hold bound fails closed (typed ValueError); a
+    normal config constructs fine."""
+    db_path = str(tmp_path / "small.db")
+    small_store = SqliteHeldActionStore(db_path, max_records=50)
+    with pytest.raises(ValueError):
+        StrictEnforcer(
+            on_held=HeldBehavior.QUEUE,
+            held_store=small_store,
+            max_pending_holds=1000,
+        )
+    small_store.close()
+
+    # Normal config: store capacity >= max_pending_holds → constructs fine.
+    ok_store = SqliteHeldActionStore(str(tmp_path / "ok.db"), max_records=100_000)
+    enforcer = StrictEnforcer(
+        on_held=HeldBehavior.QUEUE, held_store=ok_store, max_pending_holds=1000
+    )
+    assert enforcer.max_pending_holds == 1000
+    ok_store.close()
+
+
+def test_negative_timeout_raises_with_no_orphan_queue_entry(tmp_path):
+    """Finding 3: enforce(timeout=-5) raises BEFORE the queue append — no orphan
+    queue entry and no store row are left behind."""
+    enforcer, store = _enforcer(tmp_path)
+    with pytest.raises(ValueError):
+        enforcer.enforce(
+            agent_id="agent-neg",
+            action="deploy",
+            result=_held_result(),
+            timeout=-5.0,
+        )
+    # No orphan on EITHER surface.
+    assert enforcer.review_queue == []
+    assert store.pending() == []
+    store.close()

--- a/tests/trust/unit/test_hitl_reviewer_authority.py
+++ b/tests/trust/unit/test_hitl_reviewer_authority.py
@@ -543,3 +543,84 @@ def test_approve_with_modified_verdict_rejected(tmp_path):
     pending = {h.hold_id for h in store.pending()}
     assert pending == {hold_a, hold_b}
     store.close()
+
+
+# ---------------------------------------------------------------------------
+# Redteam round 2 (HIGH) — corrupt-sentinel expiry must reconcile the queue
+# ---------------------------------------------------------------------------
+
+
+def _corrupt_row_on_disk(db_path: str, hold_id: str) -> None:
+    """Tamper an EXISTING held-action row so pop_expired returns the corrupt
+    fail-closed sentinel (bad on_expiry -> ExpiryDisposition(...) raises).
+
+    The hold_id column is left intact — the corruption is in a non-hold_id
+    column, mirroring the real tamper shape the sentinel machinery guards.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "UPDATE held_actions SET on_expiry = ? WHERE hold_id = ?",
+            ("not_a_valid_disposition", hold_id),
+        )
+        assert (
+            cur.rowcount == 1
+        ), f"expected to corrupt exactly one row, got {cur.rowcount}"
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_corrupt_row_expiry_reconciles_queue_and_blocks_reapprove(tmp_path):
+    """Finding (HIGH): when an expired hold is recovered as the corrupt sentinel
+    (a FRESH hold_id), expire_holds still reconciles the passive review queue via
+    the sentinel's preserved ORIGINAL id — so a late APPROVE on the original id
+    fails closed instead of resurrecting an already-BLOCKED action.
+
+    CRITICAL RED->GREEN: against pre-fix code the reconcile keyed only on the
+    fresh sentinel id, the original queue entry survived, and the late APPROVE
+    returned AUTO_APPROVED.
+    """
+    enforcer, store = _enforcer(tmp_path)
+    # timeout=0.0 -> the hold is already past its deadline; it lands in BOTH the
+    # store (under its original id H) and the review queue.
+    hold_id = _queue_one(enforcer, agent_id="agent-corrupt-expire", timeout=0.0)
+    assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
+    assert [h.hold_id for h in store.pending()] == [hold_id]
+
+    # Tamper the row so pop_expired must fall back to the fresh-id corrupt sentinel.
+    _corrupt_row_on_disk(str(tmp_path / "held.db"), hold_id)
+
+    later = datetime.now(timezone.utc) + timedelta(seconds=1)
+    expiry_records = enforcer.expire_holds(now=later)
+
+    # (i) the ORIGINAL hold_id is GONE from BOTH surfaces (reconcile matched on
+    # the sentinel's preserved original_hold_id, not its fresh id).
+    assert store.pending() == []
+    assert enforcer.review_queue == []
+    assert all(r.metadata.get("hold_id") != hold_id for r in enforcer.review_queue)
+
+    # (ii) a late reviewer decision on the original id fails CLOSED.
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(
+            hold_id, ReviewerDecision.APPROVE, "rev-corrupt-late"
+        )
+
+    # (iii) never AUTO_APPROVED — the only terminal record referencing the
+    # original id is the fail-closed BLOCKED corrupt expiry.
+    for_hold = [
+        r
+        for r in enforcer.records
+        if hold_id in (r.metadata.get("hold_id"), r.metadata.get("original_hold_id"))
+    ]
+    assert not any(r.verdict is Verdict.AUTO_APPROVED for r in for_hold)
+    corrupt_expiry = [
+        r
+        for r in for_hold
+        if r.metadata.get("hold_expiry") and r.metadata.get("corrupt_row")
+    ]
+    assert len(corrupt_expiry) == 1
+    assert corrupt_expiry[0].verdict is Verdict.BLOCKED
+    assert corrupt_expiry[0].metadata.get("original_hold_id") == hold_id
+    assert len(expiry_records) == 1
+    store.close()

--- a/tests/trust/unit/test_hitl_reviewer_authority.py
+++ b/tests/trust/unit/test_hitl_reviewer_authority.py
@@ -23,6 +23,7 @@ The five governance invariants (each asserted below):
 from __future__ import annotations
 
 import sqlite3
+import threading
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -397,4 +398,148 @@ def test_reviewer_id_with_control_char_is_rejected(tmp_path):
     # reviewer_id is validated before any state mutation — the hold survives.
     assert [h.hold_id for h in store.pending()] == [hold_id]
     assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface /redteam findings (BH2 legs 2-3 lifecycle)
+# ---------------------------------------------------------------------------
+
+
+def test_expired_hold_reconciled_and_cannot_be_reapproved(tmp_path):
+    """Finding 1 (CRITICAL): an expired hold is removed from BOTH the store AND
+    the review queue, so a late APPROVE fails closed instead of resurrecting an
+    already-timed-out-and-BLOCKED action to AUTO_APPROVED.
+
+    This is the CRITICAL RED->GREEN: against pre-fix code (expire_holds did NOT
+    reconcile the queue) the late APPROVE returns AUTO_APPROVED — a
+    BLOCKED->AUTO_APPROVED monotonic downgrade.
+    """
+    enforcer, store = _enforcer(tmp_path)
+    # timeout=0.0 -> the hold is already past its deadline; it lands in BOTH the
+    # store (timeout-bearing) and the review queue.
+    hold_id = _queue_one(enforcer, agent_id="agent-expire", timeout=0.0)
+    assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
+    assert [h.hold_id for h in store.pending()] == [hold_id]
+
+    later = datetime.now(timezone.utc) + timedelta(seconds=1)
+    expiry_records = enforcer.expire_holds(now=later)
+
+    # (i) the hold is GONE from BOTH surfaces (atomic reconcile).
+    assert store.pending() == []
+    assert enforcer.review_queue == []
+    assert all(r.metadata.get("hold_id") != hold_id for r in enforcer.review_queue)
+
+    # (ii) a late reviewer decision on the expired hold fails CLOSED.
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(hold_id, ReviewerDecision.APPROVE, "rev-late")
+
+    # (iii) the only TERMINAL record for that hold_id is the BLOCKED expiry —
+    # no AUTO_APPROVED resurrection anywhere in the audit trail.
+    for_hold = [r for r in enforcer.records if r.metadata.get("hold_id") == hold_id]
+    assert not any(r.verdict is Verdict.AUTO_APPROVED for r in for_hold)
+    expiry = [r for r in for_hold if r.metadata.get("hold_expiry")]
+    assert len(expiry) == 1
+    assert expiry[0].verdict is Verdict.BLOCKED
+    assert len(expiry_records) == 1
+    store.close()
+
+
+def test_concurrent_resolution_single_winner(tmp_path):
+    """Finding 2 (MED): two threads resolving the SAME queue-only hold —
+    exactly one succeeds, the other fails closed. A DECLINE + APPROVE race
+    never yields AUTO_APPROVED after a BLOCKED (single-winner under the lock).
+    """
+    enforcer, store = _enforcer(tmp_path)
+
+    # Repeat to widen the race window a missing lock would fall through.
+    for i in range(25):
+        # A queue-only hold (no timeout) — never in the store, so the queue
+        # scan is the sole arbiter and the lock is the only thing serializing.
+        hold_id = _queue_one(enforcer, agent_id=f"agent-race-{i}", timeout=None)
+
+        barrier = threading.Barrier(2)
+        outcomes: list = []
+        lock = threading.Lock()
+
+        def _resolve(decision):
+            barrier.wait()
+            try:
+                rec = enforcer.apply_review_decision(hold_id, decision, "rev-race")
+                with lock:
+                    outcomes.append(("ok", rec.verdict))
+            except ReviewDecisionError:
+                with lock:
+                    outcomes.append(("closed", None))
+
+        t1 = threading.Thread(target=_resolve, args=(ReviewerDecision.APPROVE,))
+        t2 = threading.Thread(target=_resolve, args=(ReviewerDecision.DECLINE,))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Exactly one winner; the other failed closed.
+        successes = [o for o in outcomes if o[0] == "ok"]
+        closed = [o for o in outcomes if o[0] == "closed"]
+        assert len(successes) == 1, f"iter {i}: {outcomes}"
+        assert len(closed) == 1, f"iter {i}: {outcomes}"
+
+        # The hold resolved exactly once — never a BLOCKED followed by an
+        # AUTO_APPROVED (no double-resolve).
+        decided = [
+            r
+            for r in enforcer.records
+            if r.metadata.get("hold_id") == hold_id
+            and r.metadata.get("reviewer_id") == "rev-race"
+        ]
+        assert len(decided) == 1, f"iter {i}: {[r.verdict for r in decided]}"
+        # And the review queue no longer holds it.
+        assert all(r.metadata.get("hold_id") != hold_id for r in enforcer.review_queue)
+    store.close()
+
+
+def test_reviewer_id_over_length_rejected(tmp_path):
+    """Finding 3a: a reviewer_id past the length cap fails closed (audit/log
+    flood defense) and the hold survives for a corrected retry."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-longid", timeout=300.0)
+
+    over_length = "a" * 300  # valid charset, but past the 256-char cap
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(hold_id, ReviewerDecision.APPROVE, over_length)
+
+    # Hold survives — nothing was consumed before the length check.
+    assert [h.hold_id for h in store.pending()] == [hold_id]
+    assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
+    store.close()
+
+
+def test_approve_with_modified_verdict_rejected(tmp_path):
+    """Finding 3b: APPROVE/DECLINE carrying a modified_verdict is ambiguous
+    input and fails closed rather than silently dropping the argument. MODIFY
+    still REQUIRES modified_verdict."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_a = _queue_one(enforcer, agent_id="agent-amb-a", timeout=300.0)
+
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(
+            hold_a,
+            ReviewerDecision.APPROVE,
+            "rev-amb",
+            modified_verdict=Verdict.HELD,
+        )
+
+    hold_b = _queue_one(enforcer, agent_id="agent-amb-b", timeout=300.0)
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(
+            hold_b,
+            ReviewerDecision.DECLINE,
+            "rev-amb",
+            modified_verdict=Verdict.BLOCKED,
+        )
+
+    # Both holds survive the ambiguous requests.
+    pending = {h.hold_id for h in store.pending()}
+    assert pending == {hold_a, hold_b}
     store.close()

--- a/tests/trust/unit/test_hitl_reviewer_authority.py
+++ b/tests/trust/unit/test_hitl_reviewer_authority.py
@@ -22,6 +22,7 @@ The five governance invariants (each asserted below):
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -288,4 +289,112 @@ def test_expiry_unset_still_defaults_to_deny_blocked(tmp_path):
     assert len(expiry_records) == 1
     assert expiry_records[0].verdict is Verdict.BLOCKED
     assert store.pending() == []
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Merge-gate regression coverage (BH2 legs 2-3 review findings)
+# ---------------------------------------------------------------------------
+
+
+def test_bad_decision_raises_before_hold_is_consumed(tmp_path):
+    """Finding 1: a MODIFY without modified_verdict raises BEFORE the hold is
+    popped, so the hold SURVIVES and is resolvable on a corrected retry.
+
+    Guards against state-advance-before-validation: the pure resolver runs
+    first, so a bad decision cannot destroy the hold (leaving the action stuck
+    blocked forever with no audit trail).
+    """
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-survive", timeout=300.0)
+
+    # MODIFY with no modified_verdict fails closed...
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(hold_id, ReviewerDecision.MODIFY, "rev-1")
+
+    # ...and the hold was NOT consumed: still in the store AND the review queue.
+    assert [h.hold_id for h in store.pending()] == [hold_id]
+    assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
+
+    # A corrected retry resolves the SAME hold — proving it survived intact.
+    record = enforcer.apply_review_decision(
+        hold_id,
+        ReviewerDecision.MODIFY,
+        "rev-1",
+        modified_verdict=Verdict.HELD,
+    )
+    assert record.verdict is Verdict.HELD
+    assert store.pending() == []
+    store.close()
+
+
+def _insert_corrupt_row(db_path: str, hold_id: str) -> None:
+    """Write a corrupt held-action row (bad on_expiry) straight into SQLite so
+    the store's pop() must fall back to its fail-closed DENY sentinel."""
+    now = datetime.now(timezone.utc)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO held_actions "
+            "(hold_id, agent_id, action, held_at, timeout_seconds, expires_at, "
+            "on_expiry, reason, violations_json, metadata_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                hold_id,
+                "agent-corrupt",
+                "deploy",
+                now.isoformat(),
+                300.0,
+                (now + timedelta(seconds=300)).isoformat(),
+                "not_a_valid_disposition",  # ExpiryDisposition(...) will raise
+                "",
+                "[]",
+                "{}",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_approve_over_corrupt_sentinel_fails_closed_to_blocked(tmp_path):
+    """Finding 2: an APPROVE addressed to a hold that pop() recovers as the
+    corrupt DENY sentinel resolves to BLOCKED, never AUTO_APPROVED."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(on_held=HeldBehavior.QUEUE, held_store=store)
+
+    hold_id = "hold-corrupt-sentinel"
+    _insert_corrupt_row(db_path, hold_id)
+
+    # Real SQLite round-trip: apply_review_decision pops the row, which converts
+    # to the fail-closed DENY sentinel (valid=False) inside the store.
+    record = enforcer.apply_review_decision(
+        hold_id, ReviewerDecision.APPROVE, "reviewer-corrupt"
+    )
+    # APPROVE must NOT honor a corrupt hold — forced fail-closed to BLOCKED.
+    assert record.verdict is Verdict.BLOCKED
+    assert record.metadata["corrupt_hold"] is True
+    assert record.metadata["reviewer_id"] == "reviewer-corrupt"
+    # The corrupt row was consumed by the pop (real round-trip).
+    assert store.pop(hold_id) is None
+    store.close()
+
+
+def test_reviewer_id_with_control_char_is_rejected(tmp_path):
+    """Finding 3: a newline/control-char reviewer_id (audit-log injection
+    vector) is rejected before it is bound or logged — and the hold survives."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-inject", timeout=300.0)
+
+    with pytest.raises(ValueError):
+        enforcer.apply_review_decision(
+            hold_id,
+            ReviewerDecision.DECLINE,
+            "reviewer\ninjected-audit-log-line",
+        )
+
+    # reviewer_id is validated before any state mutation — the hold survives.
+    assert [h.hold_id for h in store.pending()] == [hold_id]
+    assert enforcer.review_queue[-1].metadata["hold_id"] == hold_id
     store.close()

--- a/tests/trust/unit/test_hitl_reviewer_authority.py
+++ b/tests/trust/unit/test_hitl_reviewer_authority.py
@@ -1,0 +1,291 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 wiring test for HITL reviewer authority (GitHub #1510, SAFR BH2 legs 2-3).
+
+Exercises the fail-closed reviewer-decision surface + capacity gate THROUGH the
+``StrictEnforcer`` facade against a REAL on-disk ``SqliteHeldActionStore`` (no
+mocking — testing.md Tier 2 + facade-manager-detection.md Rule 1; the store is a
+manager-shape facade, so the real SQLite round-trip is used, never a mock).
+
+The five governance invariants (each asserted below):
+
+1. A reviewer MODIFY never widens authority — a modified verdict below HELD is
+   clamped fail-closed to BLOCKED (monotonic-tightening only).
+2. Capacity saturation fails CLOSED to BLOCKED — a NEW escalation is denied
+   when the review queue is full, never queued and never silently dropped.
+3. Expiry still defaults to DENY when ``on_expiry`` is unset (BH2 leg 1
+   unchanged).
+4. Every reviewer decision binds ``reviewer_id`` into the audit record.
+5. A corrupt / missing / unsafe ``hold_id`` fails closed with a typed error.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kailash.trust.chain import VerificationResult
+from kailash.trust.enforce.held import (
+    ExpiryDisposition,
+    ReviewDecisionError,
+    ReviewerDecision,
+    SqliteHeldActionStore,
+)
+from kailash.trust.enforce.strict import (
+    EATPBlockedError,
+    EATPHeldError,
+    HeldBehavior,
+    StrictEnforcer,
+    Verdict,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.tier2]
+
+
+def _held_result() -> VerificationResult:
+    """A verification result that classifies as HELD (>= flag_threshold)."""
+    return VerificationResult(
+        valid=True,
+        reason="needs human review",
+        violations=[{"field": "cost", "message": "near limit"}],
+    )
+
+
+def _enforcer(tmp_path, *, max_pending_holds: int = 1000, default_expiry=None):
+    """A QUEUE-behavior enforcer backed by a REAL on-disk SQLite store."""
+    db_path = str(tmp_path / "held.db")
+    store = SqliteHeldActionStore(db_path)
+    enforcer = StrictEnforcer(
+        on_held=HeldBehavior.QUEUE,
+        held_store=store,
+        max_pending_holds=max_pending_holds,
+        default_expiry=default_expiry,
+    )
+    return enforcer, store
+
+
+def _queue_one(enforcer, agent_id="agent-x", action="deploy", *, timeout=300.0):
+    """Escalate one HELD action to the review queue; return its hold_id."""
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id=agent_id,
+            action=action,
+            result=_held_result(),
+            timeout=timeout,
+        )
+    return enforcer.review_queue[-1].metadata["hold_id"]
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — capacity saturation fails CLOSED (leg 2)
+# ---------------------------------------------------------------------------
+
+
+def test_capacity_saturation_denies_new_escalation_blocked(tmp_path):
+    """Fill review queue to max_pending_holds → next escalation DENIED (BLOCKED)."""
+    enforcer, store = _enforcer(tmp_path, max_pending_holds=3)
+
+    # Fill to capacity (each held → EATPHeldError, queued).
+    for i in range(3):
+        _queue_one(enforcer, agent_id=f"agent-{i}", timeout=300.0)
+    assert len(enforcer.review_queue) == 3
+
+    # The NEXT escalation is admission-denied, fail-closed to BLOCKED —
+    # NOT queued, NOT silently dropped.
+    with pytest.raises(EATPBlockedError) as excinfo:
+        enforcer.enforce(
+            agent_id="agent-overflow",
+            action="deploy",
+            result=_held_result(),
+            timeout=300.0,
+        )
+    assert "saturated" in str(excinfo.value).lower()
+
+    # The queue did NOT grow (the escalation was denied, not enqueued).
+    assert len(enforcer.review_queue) == 3
+
+    # A BLOCKED audit record was emitted for the denial (never silent).
+    denial = [
+        r
+        for r in enforcer.records
+        if r.metadata.get("admission_denied") and r.agent_id == "agent-overflow"
+    ]
+    assert len(denial) == 1
+    assert denial[0].verdict is Verdict.BLOCKED
+    assert denial[0].metadata["max_pending_holds"] == 3
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — APPROVE resolves to AUTO_APPROVED, binds reviewer_id
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_approve_resolves_to_auto_approved_binds_reviewer(tmp_path):
+    """APPROVE -> AUTO_APPROVED (original action sanctioned), reviewer_id bound."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-approve", timeout=300.0)
+
+    # The hold persisted to the REAL SQLite store; the review-queue entry and
+    # the store hold are correlated by the same hold_id.
+    pending = store.pending()
+    assert len(pending) == 1
+    assert pending[0].hold_id == hold_id
+
+    record = enforcer.apply_review_decision(
+        hold_id, ReviewerDecision.APPROVE, "reviewer-alice"
+    )
+
+    # APPROVE sanctions the originally-held action WITHOUT escalating authority.
+    assert record.verdict is Verdict.AUTO_APPROVED
+    # Invariant 4: reviewer_id bound for audit.
+    assert record.metadata["reviewer_id"] == "reviewer-alice"
+    assert record.metadata["reviewer_decision"] == ReviewerDecision.APPROVE.value
+    assert record.metadata["hold_id"] == hold_id
+    # The decision record landed in the enforcer's audit sink.
+    assert record in enforcer.records
+
+    # Real SQLite round-trip: the hold was popped from the store (cannot be
+    # re-reviewed nor expire).
+    assert store.pending() == []
+    assert enforcer.review_queue == []
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# DECLINE resolves to BLOCKED
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_decline_resolves_to_blocked(tmp_path):
+    """DECLINE -> BLOCKED (fail-closed denial by reviewer authority)."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-decline", timeout=300.0)
+
+    record = enforcer.apply_review_decision(
+        hold_id, ReviewerDecision.DECLINE, "reviewer-bob"
+    )
+    assert record.verdict is Verdict.BLOCKED
+    assert record.metadata["reviewer_id"] == "reviewer-bob"
+    assert store.pending() == []
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — MODIFY never widens authority (monotonic-tightening only)
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_modify_widening_is_clamped_to_blocked(tmp_path):
+    """MODIFY that attempts to WIDEN (AUTO_APPROVED) is clamped to BLOCKED."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-modify", timeout=300.0)
+
+    # A MODIFY targeting a verdict LESS restrictive than HELD is a widening —
+    # clamped fail-closed to BLOCKED (invariant 1).
+    record = enforcer.apply_review_decision(
+        hold_id,
+        ReviewerDecision.MODIFY,
+        "reviewer-carol",
+        modified_verdict=Verdict.AUTO_APPROVED,
+    )
+    assert record.verdict is Verdict.BLOCKED
+    assert record.metadata["reviewer_id"] == "reviewer-carol"
+    # The reviewer's (rejected) intent is preserved in the audit trail.
+    assert record.metadata["modified_verdict_requested"] == Verdict.AUTO_APPROVED.value
+    store.close()
+
+
+def test_reviewer_modify_tightening_is_allowed(tmp_path):
+    """MODIFY to a verdict >= HELD is monotonic-tightening and passes through."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-modify2", timeout=300.0)
+
+    # MODIFY -> HELD (re-hold for further review) is a valid non-widening.
+    record = enforcer.apply_review_decision(
+        hold_id,
+        ReviewerDecision.MODIFY,
+        "reviewer-dave",
+        modified_verdict=Verdict.HELD,
+    )
+    assert record.verdict is Verdict.HELD
+    store.close()
+
+
+def test_reviewer_modify_without_target_fails_closed(tmp_path):
+    """MODIFY without an explicit modified_verdict fails closed (typed error)."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-modify3", timeout=300.0)
+
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(hold_id, ReviewerDecision.MODIFY, "reviewer-eve")
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — missing / unsafe hold_id fails closed with a typed error
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_hold_id_fails_closed(tmp_path):
+    """An unknown (or already-resolved) hold_id raises the typed error."""
+    enforcer, store = _enforcer(tmp_path)
+    _queue_one(enforcer, agent_id="agent-real", timeout=300.0)
+
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(
+            "hold-does-not-exist", ReviewerDecision.APPROVE, "reviewer-x"
+        )
+    store.close()
+
+
+def test_unsafe_hold_id_rejected(tmp_path):
+    """A path-traversal-shaped hold_id is rejected before any lookup."""
+    enforcer, store = _enforcer(tmp_path)
+    with pytest.raises(ValueError):
+        enforcer.apply_review_decision(
+            "../../etc/passwd", ReviewerDecision.DECLINE, "reviewer-x"
+        )
+    store.close()
+
+
+def test_double_review_fails_closed(tmp_path):
+    """A resolved hold cannot be re-reviewed (fail-closed on the second call)."""
+    enforcer, store = _enforcer(tmp_path)
+    hold_id = _queue_one(enforcer, agent_id="agent-twice", timeout=300.0)
+
+    enforcer.apply_review_decision(hold_id, ReviewerDecision.APPROVE, "reviewer-1")
+    with pytest.raises(ReviewDecisionError):
+        enforcer.apply_review_decision(hold_id, ReviewerDecision.APPROVE, "reviewer-2")
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — expiry still defaults to DENY (leg 1 unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_unset_still_defaults_to_deny_blocked(tmp_path):
+    """A timeout-bearing hold with no on_expiry expires to BLOCKED (fail-safe DENY)."""
+    # default_expiry unset -> the fail-safe ExpiryDisposition.DENY applies.
+    enforcer, store = _enforcer(tmp_path, default_expiry=None)
+
+    # A zero-timeout hold is already past its deadline; on_expiry is unset.
+    with pytest.raises(EATPHeldError):
+        enforcer.enforce(
+            agent_id="agent-expire",
+            action="deploy",
+            result=_held_result(),
+            timeout=0.0,
+        )
+    # The persisted hold carries the fail-safe DENY disposition.
+    assert store.pending()[0].on_expiry is ExpiryDisposition.DENY
+
+    later = datetime.now(timezone.utc) + timedelta(seconds=1)
+    expiry_records = enforcer.expire_holds(now=later)
+    assert len(expiry_records) == 1
+    assert expiry_records[0].verdict is Verdict.BLOCKED
+    assert store.pending() == []
+    store.close()


### PR DESCRIPTION
## Summary
Implements **BH2 legs 2–3** of the SAFR governance-hardening umbrella (#1510): fail-closed human-in-the-loop reviewer authority in the core `kailash.trust` enforce layer. BH2 leg 1 (timeout→DENY) already shipped; this adds the reviewer decision API + capacity admission control.

## What changed
- **`ReviewerDecision` (APPROVE / MODIFY / DECLINE)** + `resolve_review_verdict` — monotonic-tightening only (MODIFY can never widen; a sub-HELD target clamps to BLOCKED). `apply_review_decision(hold_id, decision, reviewer_id)` binds the reviewer into the audit record.
- **Fail-closed capacity admission** — `max_pending_holds` denies (BLOCKED) a new escalation when the review queue is saturated, never unbounded-queues, never fail-opens.
- **Cross-surface lifecycle correctness** — `expire_holds` atomically reconciles both the store and the review queue under a lock; a timed-out (BLOCKED) hold can never be resurrected to AUTO_APPROVED by a late review.

## Security depth (4 redteam rounds)
The reviewer + security-reviewer gate and 3 adversarial redteam rounds drove the **fail-open axis to convergence**: closed a CRITICAL (expire/queue desync resurrection), a HIGH (corrupt-sentinel reconcile miss), and hardened non-fail-open refinements (forged-row denial-of-review, corrupt-sentinel audit-poisoning redaction, store-capacity vs admission-control, negative-timeout hygiene). All pinned by real-`SqliteHeldActionStore` RED→GREEN regression tests. 22 HITL tests pass under `-W error`; broader trust suite 4837 passed.

## #1510 disposition (this PR is one leg of a cross-SDK umbrella)
- ✅ BH1 (per-action independence + risk factors) — already landed (#1514)
- ✅ BH2 leg 1 (timeout→DENY) — already landed (#1515); **legs 2–3 — this PR**
- ✅ BH4 (evidence-quality confidence threshold) — already landed (#1516)
- ⏸️ BH3 (trace origin-auth, byte-lockstep) + BH5 (circuit-breaker parity, semantics-lockstep) — deferred to the Rust SDK lockstep (**rs#1714**)

## Related issues
Refs #1510 (stays OPEN — BH3/BH5 remain as the cross-SDK lockstep tracker). Do not auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)