### PR TITLE
feat(dataflow-fabric): fail-closed tenant-scoping QueryInterceptor on the product read path (#1654)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/fabric/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/__init__.py
@@ -32,6 +32,7 @@ from dataflow.adapters.source_adapter import (
     CircuitBreakerConfig,
     SourceState,
 )
+from dataflow.fabric.cache import FabricTenantRequiredError, FabricTenantScopeError
 from dataflow.fabric.config import (
     ApiKeyAuth,
     BasicAuth,
@@ -68,6 +69,9 @@ __all__ = [
     # Consumer adapters
     "ConsumerFn",
     "ConsumerRegistry",
+    # Tenant-scope enforcement (issue #1654)
+    "FabricTenantRequiredError",
+    "FabricTenantScopeError",
     # Adapter base
     "BaseSourceAdapter",
     "SourceState",

--- a/packages/kailash-dataflow/src/dataflow/fabric/cache.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/cache.py
@@ -69,21 +69,36 @@ class FabricTenantRequiredError(Exception):
 
 class FabricTenantScopeError(FabricTenantRequiredError):
     """Raised when a multi-tenant fabric read cannot PROVE the tenant
-    predicate was applied to the executed query (issue #1654).
+    predicate was applied to a multi_tenant product's query (issue #1654).
 
     Distinct from :class:`FabricTenantRequiredError` (tenant scope *absent*):
-    this fires when a tenant scope IS resolved but a set-returning read on
-    the fabric product path either
+    this fires when a tenant scope IS resolved but a read on the fabric
+    product path could not be proven tenant-scoped and is refused.
 
-    * omitted the tenant predicate entirely (an *unscoped* query that would
-      materialize every tenant's rows into the caller's tenant slot), or
-    * carried a predicate for a DIFFERENT tenant (a *cross-tenant* attempt).
+    **Exact coverage (accurate scope — NOT "never returns cross-tenant rows"
+    universally):**
 
-    The fabric read path inspects the executed query's bound filter and
-    refuses BEFORE the query runs, so unscoped or cross-tenant rows are
-    never returned — the tenant filter is proven present on the executed
-    query, not merely declared on the product. It subclasses
-    ``FabricTenantRequiredError`` so existing ``except
+    * The set-returning ``ctx.express`` path (``list`` / ``count``) of a
+      ``multi_tenant`` product with a resolvable, non-empty tenant is
+      *fail-closed*: the executed query's bound ``filter`` MUST carry a
+      scalar ``tenant_id`` equal to the bound tenant, MUST NOT carry a
+      top-level ``$``-operator key, and MUST NOT pass a filtering ``**kwarg``
+      — else the query is refused BEFORE it runs.
+    * ``ctx.express.read`` (single-record PK lookup) is tenant-verified
+      *post-fetch*: a fetched row whose ``tenant_id`` does not match the
+      bound tenant is refused and NO row is returned.
+    * ``ctx.source(...)`` (external adapters) and the write path
+      (``create`` / ``update`` / ``delete`` / ``upsert``) are NOT covered
+      by this guard — external-source tenant scoping and write-path tenant
+      enforcement are tracked as separate follow-ups.
+
+    ``tenant_extractor`` (configured on ``db.start()``) is an
+    AUTHORIZATION boundary owned by the caller / Nexus, NOT this guard: a
+    client-controlled header extractor is spoofable, so proving the query
+    carried *a* tenant predicate does not authenticate *which* tenant the
+    request may act as — that remains the extractor's / gateway's job.
+
+    It subclasses ``FabricTenantRequiredError`` so existing ``except
     FabricTenantRequiredError`` handlers keep catching the whole
     tenant-isolation family while callers may catch this narrower case.
     """

--- a/packages/kailash-dataflow/src/dataflow/fabric/cache.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/cache.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "FabricCacheBackend",
     "FabricTenantRequiredError",
+    "FabricTenantScopeError",
     "InMemoryFabricCacheBackend",
     "RedisFabricCacheBackend",
     "_FabricCacheEntry",
@@ -63,6 +64,28 @@ class FabricTenantRequiredError(Exception):
     amendment A, the absence of ``tenant_id`` on a multi-tenant product is
     an invariant violation, not an operational failure. Callers must
     propagate the tenant identifier explicitly.
+    """
+
+
+class FabricTenantScopeError(FabricTenantRequiredError):
+    """Raised when a multi-tenant fabric read cannot PROVE the tenant
+    predicate was applied to the executed query (issue #1654).
+
+    Distinct from :class:`FabricTenantRequiredError` (tenant scope *absent*):
+    this fires when a tenant scope IS resolved but a set-returning read on
+    the fabric product path either
+
+    * omitted the tenant predicate entirely (an *unscoped* query that would
+      materialize every tenant's rows into the caller's tenant slot), or
+    * carried a predicate for a DIFFERENT tenant (a *cross-tenant* attempt).
+
+    The fabric read path inspects the executed query's bound filter and
+    refuses BEFORE the query runs, so unscoped or cross-tenant rows are
+    never returned — the tenant filter is proven present on the executed
+    query, not merely declared on the product. It subclasses
+    ``FabricTenantRequiredError`` so existing ``except
+    FabricTenantRequiredError`` handlers keep catching the whole
+    tenant-isolation family while callers may catch this narrower case.
     """
 
 

--- a/packages/kailash-dataflow/src/dataflow/fabric/context.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/context.py
@@ -33,6 +33,16 @@ __all__ = [
     "PipelineContext",
 ]
 
+# Non-filtering kwargs permitted on an ENFORCED multi-tenant read (issue
+# #1654). Anything outside this allowlist could carry an alternate WHERE /
+# ids / where predicate that re-admits other tenants past the top-level
+# tenant_id check, so an enforced list/count/read refuses any kwarg not
+# here (fail-closed). Pagination / ordering / cache / soft-delete kwargs
+# cannot widen the tenant set and are safe to forward.
+_ENFORCED_SAFE_KWARGS = frozenset(
+    {"limit", "offset", "order_by", "cache_ttl", "use_primary", "include_deleted"}
+)
+
 
 # ---------------------------------------------------------------------------
 # SourceHandle -- user-friendly wrapper around BaseSourceAdapter
@@ -379,10 +389,18 @@ class PipelineScopedExpress:
         returned. This is config/structural logic, never an agent
         decision path.
 
+        On an enforced read the filter MUST be a plain dict whose
+        ``tenant_field`` is a SCALAR equal to the bound tenant AND MUST NOT
+        carry any top-level boolean/operator key (``$or`` / ``$and`` /
+        ``$nor`` / any ``$``-prefixed key) — a complex tenant-ambiguating
+        filter can re-admit other tenants while the top-level ``tenant_id``
+        reads correct, so it is refused (issue #1654 finding 4).
+
         Raises:
             FabricTenantScopeError: When enforcement is active and the
-                filter omits the tenant predicate (unscoped) or carries a
-                predicate for a different tenant (cross-tenant).
+                filter omits the tenant predicate (unscoped), carries a
+                top-level operator key, carries a non-scalar tenant value,
+                or carries a predicate for a different tenant (cross-tenant).
         """
         if self._enforce_tenant is None:
             return
@@ -391,7 +409,7 @@ class PipelineScopedExpress:
         from dataflow.fabric.cache import FabricTenantScopeError
 
         tf = self._tenant_field
-        if not filter or tf not in filter:
+        if not isinstance(filter, dict) or tf not in filter:
             raise FabricTenantScopeError(
                 f"multi-tenant fabric {operation} of '{model}' did not carry "
                 f"the '{tf}' predicate; refusing to return unscoped rows "
@@ -399,11 +417,98 @@ class PipelineScopedExpress:
                 f"executed query filter was {filter!r}). Add "
                 f"filter={{'{tf}': ctx.tenant_id}} to the product read."
             )
-        if filter[tf] != self._enforce_tenant:
+        operator_keys = sorted(
+            k for k in filter if isinstance(k, str) and k.startswith("$")
+        )
+        if operator_keys:
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' carried "
+                f"top-level operator key(s) {operator_keys} on an enforced "
+                f"read; a boolean/operator filter (e.g. $or) can re-admit "
+                f"other tenants past the '{tf}' check and is refused. Use a "
+                f"plain-dict filter with a scalar '{tf}'."
+            )
+        tenant_value = filter[tf]
+        if isinstance(tenant_value, (dict, list, set, tuple)):
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' bound a "
+                f"non-scalar '{tf}'={tenant_value!r}; a complex tenant "
+                f"predicate (e.g. {{'$in': [...]}}) can span tenants and is "
+                f"refused. Bind '{tf}' to the single scalar ctx.tenant_id."
+            )
+        if tenant_value != self._enforce_tenant:
             raise FabricTenantScopeError(
                 f"cross-tenant fabric {operation} of '{model}': the executed "
-                f"query filter '{tf}'={filter[tf]!r} does not match the bound "
+                f"query filter '{tf}'={tenant_value!r} does not match the bound "
                 f"tenant scope {self._enforce_tenant!r}; refused."
+            )
+
+    def _reject_filtering_kwargs(
+        self,
+        operation: str,
+        model: str,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        """Forbid filtering-capable kwargs on an enforced read (issue #1654).
+
+        The tenant predicate is proven on the ``filter`` dict; a filtering
+        **kwarg forwarded to express (an alternate WHERE / ids / where
+        channel) could re-admit other tenants past that check. On an
+        enforced read only the non-filtering pagination/ordering/cache
+        kwargs in ``_ENFORCED_SAFE_KWARGS`` are permitted — any other kwarg
+        is refused fail-closed rather than silently forwarded.
+        """
+        if self._enforce_tenant is None:
+            return
+        unexpected = sorted(k for k in kwargs if k not in _ENFORCED_SAFE_KWARGS)
+        if unexpected:
+            from dataflow.fabric.cache import FabricTenantScopeError
+
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' passed "
+                f"non-pagination kwarg(s) {unexpected} on an enforced read; "
+                f"only {sorted(_ENFORCED_SAFE_KWARGS)} are permitted (a "
+                f"filtering kwarg could re-admit other tenants). Refused."
+            )
+
+    def _verify_row_tenant(
+        self,
+        operation: str,
+        model: str,
+        row: Any,
+    ) -> None:
+        """Post-fetch tenant check for a single-record read (issue #1654).
+
+        ``read(model, record_id)`` looks a row up by PK — it has no filter
+        to inspect BEFORE execution, so (unlike list/count) the tenant proof
+        is applied AFTER the fetch: the returned row's ``tenant_field`` MUST
+        equal the bound tenant, else the read is refused and NO row is
+        returned. A ``None`` / absent row is a normal miss and passes
+        through unchanged. This closes the global-PK cross-tenant read: a
+        multi-tenant product doing ``ctx.express.read('M', other_tenant_pk)``
+        can no longer return another tenant's row.
+
+        Raises:
+            FabricTenantScopeError: When enforcement is active and a fetched
+                row's tenant does not match the bound tenant (or the row
+                lacks the tenant field entirely).
+        """
+        if self._enforce_tenant is None or row is None:
+            return
+        tf = self._tenant_field
+        row_tenant = row.get(tf) if isinstance(row, dict) else None
+        if (
+            not isinstance(row, dict)
+            or tf not in row
+            or row_tenant != self._enforce_tenant
+        ):
+            from dataflow.fabric.cache import FabricTenantScopeError
+
+            raise FabricTenantScopeError(
+                f"cross-tenant fabric {operation} of '{model}': the fetched "
+                f"row's '{tf}'={row_tenant!r} does not match the bound tenant "
+                f"scope {self._enforce_tenant!r}; refused and no row returned "
+                f"(single-record reads are tenant-verified post-fetch)."
             )
 
     # -- Read operations (cached) -------------------------------------------
@@ -425,6 +530,7 @@ class PipelineScopedExpress:
             List of matching records.
         """
         self._require_tenant_predicate("list", model, filter)
+        self._reject_filtering_kwargs("list", model, kwargs)
         key = _cache_key("list", model, filter)
         if key not in self._read_cache:
             self._read_cache[key] = await self._express.list(
@@ -450,7 +556,12 @@ class PipelineScopedExpress:
         """
         key = _cache_key("read", model, {"id": record_id})
         if key not in self._read_cache:
-            self._read_cache[key] = await self._express.read(model, record_id, **kwargs)
+            self._reject_filtering_kwargs("read", model, kwargs)
+            row = await self._express.read(model, record_id, **kwargs)
+            # read() is a PK lookup with no filter to prove pre-execution;
+            # the tenant proof is applied post-fetch (issue #1654 finding 1).
+            self._verify_row_tenant("read", model, row)
+            self._read_cache[key] = row
         return self._read_cache[key]
 
     async def count(
@@ -470,6 +581,7 @@ class PipelineScopedExpress:
             Number of matching records.
         """
         self._require_tenant_predicate("count", model, filter)
+        self._reject_filtering_kwargs("count", model, kwargs)
         key = _cache_key("count", model, filter)
         if key not in self._read_cache:
             self._read_cache[key] = await self._express.count(
@@ -550,15 +662,21 @@ class PipelineContext(FabricContext):
     ) -> None:
         enforce_tenant: Optional[str] = None
         if enforce_tenant_scope:
-            if tenant_id is None:
-                # Fail closed: an enforcing multi-tenant context with no
-                # resolved tenant scope must never be constructed — it
-                # would otherwise silently disable the proof.
+            # Fail closed: an enforcing multi-tenant context with no resolved
+            # tenant scope must never be constructed — it would otherwise
+            # silently disable the proof. A None OR empty/whitespace-only
+            # tenant_id is treated identically (issue #1654 finding 2): a
+            # blank tenant is NOT a valid scope and must not flow through as
+            # a shared pseudo-tenant.
+            if tenant_id is None or (
+                isinstance(tenant_id, str) and not tenant_id.strip()
+            ):
                 from dataflow.fabric.cache import FabricTenantScopeError
 
                 raise FabricTenantScopeError(
-                    "enforce_tenant_scope=True requires a resolved tenant_id; "
-                    "refusing to build an unscoped multi-tenant fabric context."
+                    "enforce_tenant_scope=True requires a resolved, non-empty "
+                    f"tenant_id; refusing to build an unscoped multi-tenant "
+                    f"fabric context (received tenant_id={tenant_id!r})."
                 )
             enforce_tenant = tenant_id
         self._pipeline_read_cache: Dict[str, Any] = {}

--- a/packages/kailash-dataflow/src/dataflow/fabric/context.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/context.py
@@ -336,6 +336,9 @@ class PipelineScopedExpress:
         self,
         express: Any,
         read_cache: Optional[Dict[str, Any]] = None,
+        *,
+        enforce_tenant: Optional[str] = None,
+        tenant_field: str = "tenant_id",
     ) -> None:
         """Initialise the scoped wrapper.
 
@@ -345,9 +348,63 @@ class PipelineScopedExpress:
                 fresh dict is created.  Passing an explicit dict allows
                 the ``PipelineContext`` to inspect or clear the cache
                 externally.
+            enforce_tenant: When set (a resolved tenant scope), every
+                set-returning read (``list`` / ``count``) MUST carry the
+                tenant predicate on the executed query filter or the read
+                is refused with :class:`FabricTenantScopeError` BEFORE it
+                runs (issue #1654 fail-closed tenant scoping). ``None``
+                disables enforcement (single-tenant products — no change).
+            tenant_field: The filter key that carries the tenant predicate
+                (canonically ``"tenant_id"`` per the tenant-isolation
+                contract).
         """
         self._express = express
         self._read_cache: Dict[str, Any] = read_cache if read_cache is not None else {}
+        self._enforce_tenant = enforce_tenant
+        self._tenant_field = tenant_field
+
+    # -- Tenant-scope proof (issue #1654) -----------------------------------
+
+    def _require_tenant_predicate(
+        self,
+        operation: str,
+        model: str,
+        filter: Optional[Dict[str, Any]],
+    ) -> None:
+        """Prove the tenant predicate is present on the query about to run.
+
+        Deterministic, structural inspection of the bound filter — NOT a
+        declaration check. Fail-closed: refuse BEFORE executing an
+        unscoped or cross-tenant query so unscoped rows are never
+        returned. This is config/structural logic, never an agent
+        decision path.
+
+        Raises:
+            FabricTenantScopeError: When enforcement is active and the
+                filter omits the tenant predicate (unscoped) or carries a
+                predicate for a different tenant (cross-tenant).
+        """
+        if self._enforce_tenant is None:
+            return
+        # Local import avoids any import-order coupling with the cache
+        # module and keeps the enforcement co-located with its error type.
+        from dataflow.fabric.cache import FabricTenantScopeError
+
+        tf = self._tenant_field
+        if not filter or tf not in filter:
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' did not carry "
+                f"the '{tf}' predicate; refusing to return unscoped rows "
+                f"(tenant scope {self._enforce_tenant!r} required, but the "
+                f"executed query filter was {filter!r}). Add "
+                f"filter={{'{tf}': ctx.tenant_id}} to the product read."
+            )
+        if filter[tf] != self._enforce_tenant:
+            raise FabricTenantScopeError(
+                f"cross-tenant fabric {operation} of '{model}': the executed "
+                f"query filter '{tf}'={filter[tf]!r} does not match the bound "
+                f"tenant scope {self._enforce_tenant!r}; refused."
+            )
 
     # -- Read operations (cached) -------------------------------------------
 
@@ -367,6 +424,7 @@ class PipelineScopedExpress:
         Returns:
             List of matching records.
         """
+        self._require_tenant_predicate("list", model, filter)
         key = _cache_key("list", model, filter)
         if key not in self._read_cache:
             self._read_cache[key] = await self._express.list(
@@ -411,6 +469,7 @@ class PipelineScopedExpress:
         Returns:
             Number of matching records.
         """
+        self._require_tenant_predicate("count", model, filter)
         key = _cache_key("count", model, filter)
         if key not in self._read_cache:
             self._read_cache[key] = await self._express.count(
@@ -468,6 +527,15 @@ class PipelineContext(FabricContext):
         sources: Mapping of source name to ``BaseSourceAdapter``.
         products_cache: Mapping of product name to its cached result.
         tenant_id: Optional tenant identifier.
+        enforce_tenant_scope: When ``True`` (set by the fabric read path
+            for a ``multi_tenant=True`` product), every set-returning read
+            the product function issues via ``ctx.express`` MUST carry the
+            tenant predicate or the read is refused fail-closed with
+            :class:`FabricTenantScopeError` (issue #1654). Requires a
+            non-``None`` ``tenant_id``; building an enforcing context with
+            no bound tenant is itself refused fail-closed.
+        tenant_field: The filter key carrying the tenant predicate
+            (canonically ``"tenant_id"``).
     """
 
     def __init__(
@@ -476,9 +544,30 @@ class PipelineContext(FabricContext):
         sources: Mapping[str, BaseSourceAdapter],
         products_cache: Dict[str, Any],
         tenant_id: Optional[str] = None,
+        *,
+        enforce_tenant_scope: bool = False,
+        tenant_field: str = "tenant_id",
     ) -> None:
+        enforce_tenant: Optional[str] = None
+        if enforce_tenant_scope:
+            if tenant_id is None:
+                # Fail closed: an enforcing multi-tenant context with no
+                # resolved tenant scope must never be constructed — it
+                # would otherwise silently disable the proof.
+                from dataflow.fabric.cache import FabricTenantScopeError
+
+                raise FabricTenantScopeError(
+                    "enforce_tenant_scope=True requires a resolved tenant_id; "
+                    "refusing to build an unscoped multi-tenant fabric context."
+                )
+            enforce_tenant = tenant_id
         self._pipeline_read_cache: Dict[str, Any] = {}
-        self._scoped_express = PipelineScopedExpress(express, self._pipeline_read_cache)
+        self._scoped_express = PipelineScopedExpress(
+            express,
+            self._pipeline_read_cache,
+            enforce_tenant=enforce_tenant,
+            tenant_field=tenant_field,
+        )
         super().__init__(
             express=self._scoped_express,
             sources=sources,

--- a/packages/kailash-dataflow/src/dataflow/fabric/context.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/context.py
@@ -17,6 +17,7 @@ pre-loaded data for unit tests.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from datetime import datetime
@@ -436,7 +437,12 @@ class PipelineScopedExpress:
                 f"predicate (e.g. {{'$in': [...]}}) can span tenants and is "
                 f"refused. Bind '{tf}' to the single scalar ctx.tenant_id."
             )
-        if tenant_value != self._enforce_tenant:
+        # Normalize both sides before comparing: serving coerces the bound
+        # tenant to str, but an INT-typed tenant_id column returns an int
+        # from the DB. A same-tenant read (row 42 vs bound "42") MUST match,
+        # not fail closed (issue #1654 RT2 finding 1). tenant_value is the
+        # caller's OWN filter input, so echoing it in the message is safe.
+        if str(tenant_value) != str(self._enforce_tenant):
             raise FabricTenantScopeError(
                 f"cross-tenant fabric {operation} of '{model}': the executed "
                 f"query filter '{tf}'={tenant_value!r} does not match the bound "
@@ -497,17 +503,33 @@ class PipelineScopedExpress:
             return
         tf = self._tenant_field
         row_tenant = row.get(tf) if isinstance(row, dict) else None
+        # Normalize both sides before comparing so an INT-typed tenant_id
+        # column (row 42) matches the str-coerced bound tenant ("42") — a
+        # legit same-tenant read MUST NOT fail closed (issue #1654 RT2
+        # finding 1). A missing field still fails closed via `tf not in row`.
         if (
             not isinstance(row, dict)
             or tf not in row
-            or row_tenant != self._enforce_tenant
+            or str(row_tenant) != str(self._enforce_tenant)
         ):
             from dataflow.fabric.cache import FabricTenantScopeError
 
+            # Do NOT embed the FOREIGN tenant id verbatim — it would land in
+            # the requesting tenant's operator log (observability.md Rule 8
+            # / RT2 finding 2). Emit a sha256[:8] fingerprint for forensic
+            # correlation instead; the bound (own) tenant is safe to name.
+            if isinstance(row, dict) and tf in row:
+                foreign = (
+                    "sha256:"
+                    + hashlib.sha256(str(row_tenant).encode("utf-8")).hexdigest()[:8]
+                )
+            else:
+                foreign = "<absent>"
             raise FabricTenantScopeError(
                 f"cross-tenant fabric {operation} of '{model}': the fetched "
-                f"row's '{tf}'={row_tenant!r} does not match the bound tenant "
-                f"scope {self._enforce_tenant!r}; refused and no row returned "
+                f"record belongs to a different tenant (foreign tenant "
+                f"{foreign}), not the bound tenant scope "
+                f"{self._enforce_tenant!r}; refused and no row returned "
                 f"(single-record reads are tenant-verified post-fetch)."
             )
 

--- a/packages/kailash-dataflow/src/dataflow/fabric/products.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/products.py
@@ -177,6 +177,36 @@ def register_product(
                 f"Invalid cron expression for product '{name}': {schedule!r}"
             )
 
+    # Tenant-enforcement cross-check (issue #1654 finding 3): if a product
+    # depends on a model that HAS a tenant_id column (tenant-scoped-capable)
+    # but is declared multi_tenant=False, the fabric read path builds a
+    # NON-enforcing context and ctx.express.list(...) returns EVERY tenant's
+    # rows. A single forgotten flag silently disables tenant enforcement, so
+    # warn LOUDLY naming the product + model. WARN (not raise) because a
+    # legitimately-global product over a tenant-column model is a valid
+    # design — but the operator MUST be told enforcement is off.
+    if not multi_tenant:
+        for dep in deps:
+            model_info = models.get(dep)
+            if not isinstance(model_info, dict):
+                continue
+            model_fields = model_info.get("fields")
+            if isinstance(model_fields, dict) and "tenant_id" in model_fields:
+                logger.warning(
+                    "fabric.product.tenant_enforcement_disabled",
+                    extra={
+                        "product": name,
+                        "model": dep,
+                        "reason": (
+                            f"model '{dep}' has a 'tenant_id' column but product "
+                            f"'{name}' is declared multi_tenant=False — fabric "
+                            f"tenant enforcement is DISABLED for this product; "
+                            f"reads return ALL tenants' rows. Set "
+                            f"multi_tenant=True if this product is tenant-scoped."
+                        ),
+                    },
+                )
+
     # Build registration
     registration = ProductRegistration(
         name=name,

--- a/packages/kailash-dataflow/src/dataflow/fabric/runtime.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/runtime.py
@@ -811,10 +811,16 @@ class FabricRuntime:
     async def _prewarm_products_serial(self) -> None:
         """Pre-warm all materialized products one at a time (dev mode).
 
-        Identical to ``_prewarm_products`` but executes products serially
-        to reduce resource usage during development. This avoids parallel
+        Mirrors ``_prewarm_products`` but executes products serially to
+        reduce resource usage during development. This avoids parallel
         database connections and CPU spikes that are unnecessary in a
         single-developer environment.
+
+        Like ``_prewarm_products`` it SKIPS ``multi_tenant`` products
+        (issue #1654 finding 5): a multi-tenant product cannot be
+        pre-warmed without a bound tenant, and executing it here would run
+        an unscoped all-tenant query and cache the result under no tenant.
+        The first per-tenant request populates its cache lazily instead.
         """
         pipeline = self._pipeline
         if pipeline is None:
@@ -837,6 +843,17 @@ class FabricRuntime:
         )
 
         for name, product in materialized:
+            # Multi-tenant products cannot be pre-warmed without a tenant.
+            # Skip them (parity with _prewarm_products) — the first
+            # per-tenant request populates the cache lazily (issue #1654
+            # finding 5).
+            if product.multi_tenant:
+                logger.debug(
+                    "fabric.prewarm.serial_multi_tenant_skipped",
+                    extra={"product": name, "reason": "no_system_tenant"},
+                )
+                continue
+
             try:
                 source_adapters = {
                     n: info["adapter"]

--- a/packages/kailash-dataflow/src/dataflow/fabric/serving.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/serving.py
@@ -128,7 +128,16 @@ class FabricServingLayer:
             return None
         if tenant is None:
             return None
-        return str(tenant)
+        # Fail closed on a blank tenant (issue #1654 finding 2): a header
+        # extractor like ``req.headers.get("X-Tenant-Id", "")`` yields ""
+        # (or whitespace) when the header is absent. An empty tenant is NOT
+        # a valid scope — normalize it to None so the multi_tenant guard
+        # rejects it exactly as a missing tenant, never letting it flow
+        # through as a shared pseudo-tenant (cache key ``:product``).
+        tenant_str = str(tenant)
+        if not tenant_str.strip():
+            return None
+        return tenant_str
 
     def get_routes(self) -> List[Dict[str, Any]]:
         """Generate route definitions for all products.

--- a/packages/kailash-dataflow/src/dataflow/fabric/serving.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/serving.py
@@ -298,6 +298,8 @@ class FabricServingLayer:
                         express=self._express,
                         sources=source_adapters,
                         products_cache={},
+                        tenant_id=tenant_id,
+                        enforce_tenant_scope=product.multi_tenant,
                     )
                     result = await self._pipeline.execute_product(
                         product_name=name,
@@ -401,6 +403,8 @@ class FabricServingLayer:
                     express=self._express,
                     sources=source_adapters,
                     products_cache={},
+                    tenant_id=tenant_id,
+                    enforce_tenant_scope=product.multi_tenant,
                 )
                 result = await self._pipeline.execute_product(
                     name, product.fn, ctx, tenant_id=tenant_id
@@ -539,6 +543,8 @@ class FabricServingLayer:
                         express=self._express,
                         sources=source_adapters,
                         products_cache={},
+                        tenant_id=effective_tenant,
+                        enforce_tenant_scope=product.multi_tenant,
                     )
                     pipe_result = await self._pipeline.execute_product(
                         name, product.fn, ctx, tenant_id=effective_tenant

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
@@ -591,3 +591,151 @@ async def test_prewarm_serial_skips_multi_tenant(db_with_two_tenants):
     # The multi_tenant product was skipped: fn never ran, no cache written.
     assert executed == []
     assert await pipeline.get_cached("mt_prewarm", tenant_id=None) is None
+
+
+# ---------------------------------------------------------------------------
+# RT2 finding 1: INT-typed tenant_id column normalizes (no false refusal)
+# ---------------------------------------------------------------------------
+
+
+async def _read_org_by_id(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Read a single Org by PK (record_id arrives via params)."""
+    row = await ctx.express.read("Org", params["id"])
+    return {"org": row}
+
+
+@pytest.fixture
+async def db_int_tenant():
+    """Real DataFlow with an INT-typed tenant_id column and 2 tenants."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = Path(tmpdir) / "int_tenant.db"
+    db = DataFlow(f"sqlite:///{db_path}", auto_migrate=True)
+
+    @db.model
+    class Org:  # noqa: D401 - test model (INT tenant_id)
+        tenant_id: int
+        name: str
+
+    await db.initialize()
+    await db.express.create("Org", {"tenant_id": 42, "name": "org-a"})
+    await db.express.create("Org", {"tenant_id": 99, "name": "org-b"})
+
+    yield db
+
+    close = getattr(db, "close", None)
+    if close is not None:
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_int_tenant_column_same_tenant_read_not_refused(db_int_tenant):
+    """serving coerces the bound tenant to str; an INT tenant_id column
+    returns an int. A same-tenant read (row 42 vs bound "42") MUST return
+    the row, not fail closed; a cross-tenant read still raises."""
+    db = db_int_tenant
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    a_id = (await db.express.list("Org", filter={"tenant_id": 42}))[0]["id"]
+    b_id = (await db.express.list("Org", filter={"tenant_id": 99}))[0]["id"]
+
+    # Bind the tenant as a STRING (as the serving layer does) against the
+    # INT-typed column — the read post-fetch check must normalize both.
+    ctx_ok = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="42",
+        enforce_tenant_scope=True,
+    )
+    ok = await pipeline.execute_product(
+        "read_int_own", _read_org_by_id, ctx_ok, params={"id": a_id}, tenant_id="42"
+    )
+    assert ok.data["org"]["name"] == "org-a"  # int 42 vs str "42" → NOT refused
+
+    ctx_x = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="42",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError):
+        await pipeline.execute_product(
+            "read_int_cross",
+            _read_org_by_id,
+            ctx_x,
+            params={"id": b_id},
+            tenant_id="42",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RT2 finding 2: the refusal message does not leak the foreign tenant id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cross_tenant_read_message_does_not_leak_foreign_tenant_id(
+    db_with_two_tenants,
+):
+    """The post-fetch refusal message must NOT embed the FOREIGN tenant id
+    verbatim (it lands in the requesting tenant's operator log); it carries
+    a sha256 fingerprint instead. The bound (own) tenant may be named."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    b_id = (await db.express.list("Deal", filter={"tenant_id": "tenant-b"}))[0]["id"]
+    ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await pipeline.execute_product(
+            "read_leak",
+            _read_by_id_product,
+            ctx,
+            params={"id": b_id},
+            tenant_id="tenant-a",
+        )
+    msg = str(exc.value)
+    assert "tenant-b" not in msg  # foreign id NOT leaked verbatim
+    assert "sha256:" in msg  # forensic fingerprint present
+    assert "tenant-a" in msg  # bound (own) tenant is safe to name
+
+
+# ---------------------------------------------------------------------------
+# RT2 finding 3: pinned dialect invariant — operator tokens are '$'-prefixed
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_filter_dialect_operators_are_all_dollar_prefixed():
+    """Defense-in-depth pin: the fabric filter dialect's operator tokens are
+    ALL '$'-prefixed, so ``_require_tenant_predicate``'s top-level
+    '$'-prefix operator screen stays complete. If express/fabric ever adds
+    a NON-'$' top-level logical operator, this fails loudly — pointing at
+    the guard that would then be bypassable (issue #1654 RT2 finding 3).
+
+    Structural pin (not a prose-regex): asserts the enumerated operator
+    allowlist and exercises validate_filter's behavior directly."""
+    from dataflow.fabric.serving import ALLOWED_OPERATORS, validate_filter
+
+    assert ALLOWED_OPERATORS, "operator allowlist is empty — dialect surface moved?"
+    non_dollar = sorted(op for op in ALLOWED_OPERATORS if not op.startswith("$"))
+    assert non_dollar == [], (
+        f"fabric filter operator(s) {non_dollar} are NOT '$'-prefixed; "
+        f"_require_tenant_predicate (context.py) screens only '$'-prefixed "
+        f"top-level keys, so a non-'$' logical operator would bypass the "
+        f"tenant-predicate proof. Update the guard's operator screen."
+    )
+    # validate_filter keys its operator check on the '$'-prefix — the same
+    # marker the guard screens on. Confirm a '$'-prefixed disallowed
+    # operator is rejected (behavioral, not source-grep).
+    with pytest.raises(ValueError):
+        validate_filter({"tenant_id": {"$where": "1=1"}})

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tier 2 integration tests — fail-closed tenant-scope interceptor on the
+DataFlow fabric READ path (issue #1654).
+
+Real infrastructure only: a real DataFlow instance on file-backed SQLite,
+real ``db.express`` CRUD, a real ``PipelineExecutor``, and a real
+``PipelineContext``. NO mocking (no unittest.mock / MagicMock / @patch).
+
+The interceptor proves the tenant predicate was ACTUALLY APPLIED to the
+executed query before rows are returned — it does not merely trust the
+product's ``multi_tenant=True`` declaration. A multi-tenant product read
+that omits the tenant predicate (unscoped) or carries a predicate for a
+different tenant (cross-tenant) is REFUSED with ``FabricTenantScopeError``
+BEFORE the query runs, so unscoped / cross-tenant rows are never returned.
+
+Invariant coverage (issue #1654):
+  (1) multi_tenant product without a resolvable tenant scope -> RAISES
+      -> test_missing_tenant_scope_is_refused_fail_closed
+  (2) tenant predicate provably present on the executed query, else RAISE
+      -> test_unscoped_read_leaks_without_guard_then_is_refused (RED->GREEN)
+  (3) cross-tenant query attempt -> REFUSED (raises), NOT silently empty
+      -> test_cross_tenant_read_is_refused_not_empty
+  (4) non-multi_tenant products unaffected (no regression)
+      -> test_non_multi_tenant_product_is_unaffected
+  (5) the proof inspects the EXECUTED query/params, not the declaration
+      -> test_scoped_read_returns_only_own_tenant_rows (predicate proven +
+         only own-tenant rows returned) & the RED half of (2)
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.fabric.cache import FabricTenantRequiredError, FabricTenantScopeError
+from dataflow.fabric.context import PipelineContext
+from dataflow.fabric.pipeline import PipelineExecutor
+
+# ---------------------------------------------------------------------------
+# Product functions — real reads through ctx.express (NOT mocks)
+# ---------------------------------------------------------------------------
+
+
+async def _scoped_product(ctx: Any) -> Dict[str, Any]:
+    """Correctly-scoped multi-tenant product: filters by the bound tenant."""
+    rows = await ctx.express.list("Deal", filter={"tenant_id": ctx.tenant_id})
+    return {"deals": sorted(r["name"] for r in rows)}
+
+
+async def _unscoped_product(ctx: Any) -> Dict[str, Any]:
+    """Mis-scoped product: forgets the tenant predicate -> would leak every
+    tenant's rows into the caller's tenant cache slot."""
+    rows = await ctx.express.list("Deal")
+    return {"deals": sorted(r["name"] for r in rows)}
+
+
+async def _cross_tenant_product(ctx: Any) -> Dict[str, Any]:
+    """Adversarial product: bound to one tenant but queries another."""
+    rows = await ctx.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    return {"deals": sorted(r["name"] for r in rows)}
+
+
+# ---------------------------------------------------------------------------
+# Fixture — real DataFlow on file-backed SQLite with two tenants' rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_with_two_tenants():
+    """Real DataFlow (file-backed SQLite) with a Deal model and 2 tenants."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = Path(tmpdir) / "fabric_tenant.db"
+    db = DataFlow(f"sqlite:///{db_path}", auto_migrate=True)
+
+    @db.model
+    class Deal:  # noqa: D401 - test model
+        tenant_id: str
+        name: str
+
+    await db.initialize()
+
+    # Two tenants' rows — a genuine cross-tenant dataset.
+    await db.express.create("Deal", {"tenant_id": "tenant-a", "name": "a-deal-1"})
+    await db.express.create("Deal", {"tenant_id": "tenant-a", "name": "a-deal-2"})
+    await db.express.create("Deal", {"tenant_id": "tenant-b", "name": "b-deal-1"})
+
+    yield db
+
+    close = getattr(db, "close", None)
+    if close is not None:
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+
+
+# ---------------------------------------------------------------------------
+# Invariant (2) + (5): the proof inspects the EXECUTED query — RED -> GREEN
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_unscoped_read_leaks_without_guard_then_is_refused(db_with_two_tenants):
+    """RED->GREEN: the same mis-scoped product leaks cross-tenant rows when
+    enforcement is OFF (pre-#1654 behaviour), and is REFUSED when ON."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    # --- RED: without the interceptor the unscoped read returns EVERY
+    #     tenant's rows into tenant-a's execution (the cross-tenant leak). ---
+    leaky_ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=False,  # pre-#1654: no proof
+    )
+    leaked = await pipeline.execute_product(
+        "deals_unscoped", _unscoped_product, leaky_ctx, tenant_id="tenant-a"
+    )
+    # tenant-b's row leaked into tenant-a's product result.
+    assert "b-deal-1" in leaked.data["deals"]
+    assert leaked.data["deals"] == ["a-deal-1", "a-deal-2", "b-deal-1"]
+
+    # --- GREEN: with the interceptor the SAME unscoped read is refused
+    #     BEFORE the query runs — no unscoped rows are ever returned. ---
+    guarded_ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,  # #1654: prove the predicate
+    )
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await pipeline.execute_product(
+            "deals_unscoped", _unscoped_product, guarded_ctx, tenant_id="tenant-a"
+        )
+    # The proof cites the executed query's filter, not the declaration.
+    assert "did not carry" in str(exc.value)
+    assert "tenant_id" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Invariant (5): scoped read proves the predicate + returns only own rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scoped_read_returns_only_own_tenant_rows(db_with_two_tenants):
+    """A correctly-scoped multi-tenant product returns ONLY the bound
+    tenant's rows, and the executed query provably carried the predicate
+    (proven by the read succeeding under enforcement)."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    result = await pipeline.execute_product(
+        "deals_scoped", _scoped_product, ctx, tenant_id="tenant-a"
+    )
+    # Only tenant-a's rows — tenant-b never appears.
+    assert result.data["deals"] == ["a-deal-1", "a-deal-2"]
+    assert "b-deal-1" not in result.data["deals"]
+
+    # State-persistence read-back: the tenant-a result is cached under
+    # tenant-a's slot (per-tenant cache partition).
+    cached = await pipeline.get_cached("deals_scoped", tenant_id="tenant-a")
+    assert cached is not None
+
+
+# ---------------------------------------------------------------------------
+# Invariant (3): cross-tenant attempt is REFUSED, not silently empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cross_tenant_read_is_refused_not_empty(db_with_two_tenants):
+    """A tenant-a execution that queries tenant-b's scope RAISES — it does
+    NOT silently return an empty/filtered result."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await pipeline.execute_product(
+            "deals_cross", _cross_tenant_product, ctx, tenant_id="tenant-a"
+        )
+    assert "cross-tenant" in str(exc.value)
+    # It is a tenant-isolation failure of the shared family.
+    assert isinstance(exc.value, FabricTenantRequiredError)
+
+
+# ---------------------------------------------------------------------------
+# Invariant (1): multi_tenant product without a resolvable tenant -> RAISES
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_missing_tenant_scope_is_refused_fail_closed():
+    """Building an enforcing multi-tenant context with no resolved tenant
+    is itself refused fail-closed — the proof can never be silently
+    disabled by a missing tenant."""
+    with pytest.raises(FabricTenantScopeError):
+        PipelineContext(
+            express=None,
+            sources={},
+            products_cache={},
+            tenant_id=None,
+            enforce_tenant_scope=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant (4): non-multi_tenant products are unaffected (no regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_non_multi_tenant_product_is_unaffected(db_with_two_tenants):
+    """A single-tenant (non-multi_tenant) product reads without a tenant
+    predicate exactly as before — enforcement is OFF, no raise."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    ctx = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id=None,
+        enforce_tenant_scope=False,  # single-tenant product
+    )
+    result = await pipeline.execute_product("deals_all", _unscoped_product, ctx)
+    # Returns all rows, no raise — behaviour unchanged for single-tenant.
+    assert result.data["deals"] == ["a-deal-1", "a-deal-2", "b-deal-1"]

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_tenant_scope_interceptor.py
@@ -31,6 +31,7 @@ Invariant coverage (issue #1654):
 
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 from typing import Any, Dict
@@ -39,8 +40,12 @@ import pytest
 
 from dataflow import DataFlow
 from dataflow.fabric.cache import FabricTenantRequiredError, FabricTenantScopeError
+from dataflow.fabric.config import ProductMode, StalenessPolicy
 from dataflow.fabric.context import PipelineContext
 from dataflow.fabric.pipeline import PipelineExecutor
+from dataflow.fabric.products import ProductRegistration, register_product
+from dataflow.fabric.runtime import FabricRuntime
+from dataflow.fabric.serving import FabricServingLayer
 
 # ---------------------------------------------------------------------------
 # Product functions — real reads through ctx.express (NOT mocks)
@@ -253,3 +258,336 @@ async def test_non_multi_tenant_product_is_unaffected(db_with_two_tenants):
     result = await pipeline.execute_product("deals_all", _unscoped_product, ctx)
     # Returns all rows, no raise — behaviour unchanged for single-tenant.
     assert result.data["deals"] == ["a-deal-1", "a-deal-2", "b-deal-1"]
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 1: ctx.express.read() by PK is tenant-verified post-fetch
+# ---------------------------------------------------------------------------
+
+
+async def _read_by_id_product(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Read a single Deal by PK (the record_id arrives via params)."""
+    row = await ctx.express.read("Deal", params["id"])
+    return {"deal": row}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_read_by_pk_cross_tenant_is_refused(db_with_two_tenants):
+    """A multi_tenant product reading another tenant's row by global PK is
+    REFUSED post-fetch (no row returned); own-tenant PK read still works."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    # Raw express (no enforcement) to discover each tenant's row PK.
+    a_id = (await db.express.list("Deal", filter={"tenant_id": "tenant-a"}))[0]["id"]
+    b_id = (await db.express.list("Deal", filter={"tenant_id": "tenant-b"}))[0]["id"]
+
+    # Own-tenant PK read succeeds under enforcement.
+    ctx_ok = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    ok = await pipeline.execute_product(
+        "read_own",
+        _read_by_id_product,
+        ctx_ok,
+        params={"id": a_id},
+        tenant_id="tenant-a",
+    )
+    assert ok.data["deal"]["tenant_id"] == "tenant-a"
+
+    # Cross-tenant PK read (tenant-a fetching tenant-b's PK) → refused.
+    ctx_x = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await pipeline.execute_product(
+            "read_cross",
+            _read_by_id_product,
+            ctx_x,
+            params={"id": b_id},
+            tenant_id="tenant-a",
+        )
+    assert "post-fetch" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 2: empty / whitespace tenant is fail-closed like None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_empty_or_blank_tenant_is_refused_like_none():
+    """An empty/whitespace tenant is NOT a valid scope — refused at BOTH
+    context construction AND serving-layer extraction (issue #1654 f2)."""
+    # (a) enforcing context construction with a blank tenant → refused.
+    for blank in ("", "   ", "\t"):
+        with pytest.raises(FabricTenantScopeError):
+            PipelineContext(
+                express=None,
+                sources={},
+                products_cache={},
+                tenant_id=blank,
+                enforce_tenant_scope=True,
+            )
+
+    # (b) serving-layer extraction normalizes blank → None (so the existing
+    # multi_tenant guard rejects it as a missing tenant, never a shared
+    # pseudo-tenant).
+    serving = FabricServingLayer(
+        products={},
+        pipeline_executor=None,
+        tenant_extractor=lambda r: r.headers.get("X-Tenant-Id", ""),
+    )
+
+    class _Req:
+        def __init__(self, headers):
+            self.headers = headers
+
+    assert serving._extract_tenant(_Req({})) is None  # header absent → ""
+    assert serving._extract_tenant(_Req({"X-Tenant-Id": "  "})) is None  # blank
+    assert serving._extract_tenant(_Req({"X-Tenant-Id": "tenant-a"})) == "tenant-a"
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 3: multi_tenant=False over a tenant-column model WARNs loud
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_multi_tenant_false_over_tenant_column_model_warns(caplog):
+    """Declaring a product multi_tenant=False over a model that HAS a
+    tenant_id column emits a LOUD warning (enforcement silently disabled).
+    A model with no tenant_id column does NOT warn."""
+    db = DataFlow("sqlite:///:memory:", auto_migrate=False)
+
+    @db.model
+    class Widget:  # noqa: D401 - test model (has tenant_id)
+        tenant_id: str
+        name: str
+
+    @db.model
+    class Gadget:  # noqa: D401 - test model (NO tenant_id)
+        name: str
+
+    products: Dict[str, ProductRegistration] = {}
+
+    async def _p(ctx: Any) -> Dict[str, Any]:
+        return {}
+
+    with caplog.at_level(logging.WARNING):
+        register_product(
+            products=products,
+            models=db._models,
+            sources={},
+            name="widgets",
+            fn=_p,
+            mode="materialized",
+            depends_on=["Widget"],
+            multi_tenant=False,
+        )
+        register_product(
+            products=products,
+            models=db._models,
+            sources={},
+            name="gadgets",
+            fn=_p,
+            mode="materialized",
+            depends_on=["Gadget"],
+            multi_tenant=False,
+        )
+
+    warns = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "fabric.product.tenant_enforcement_disabled"
+    ]
+    # Exactly the tenant-column model warns; the plain model does not.
+    assert len(warns) == 1
+    assert warns[0].product == "widgets"
+    assert warns[0].model == "Widget"
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 4: $or / filtering-kwarg cannot bypass the tenant proof
+# ---------------------------------------------------------------------------
+
+
+async def _or_filter_product(ctx: Any) -> Dict[str, Any]:
+    """Correct top-level tenant_id BUT a sibling $or that can re-admit
+    other tenants."""
+    rows = await ctx.express.list(
+        "Deal",
+        filter={
+            "tenant_id": ctx.tenant_id,
+            "$or": [{"name": "a-deal-1"}, {"name": "b-deal-1"}],
+        },
+    )
+    return {"deals": [r["name"] for r in rows]}
+
+
+async def _kwarg_filter_product(ctx: Any) -> Dict[str, Any]:
+    """Correct filter BUT a filtering **kwarg forwarded to express."""
+    rows = await ctx.express.list(
+        "Deal", filter={"tenant_id": ctx.tenant_id}, where="1=1"
+    )
+    return {"deals": [r["name"] for r in rows]}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_operator_filter_and_filtering_kwarg_are_refused(db_with_two_tenants):
+    """On an enforced read, a top-level $or operator key OR a filtering
+    **kwarg is refused even when the scalar tenant_id is correct."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    ctx_or = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError) as exc_or:
+        await pipeline.execute_product(
+            "or_prod", _or_filter_product, ctx_or, tenant_id="tenant-a"
+        )
+    assert "operator" in str(exc_or.value)
+
+    ctx_kw = PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,
+    )
+    with pytest.raises(FabricTenantScopeError) as exc_kw:
+        await pipeline.execute_product(
+            "kwarg_prod", _kwarg_filter_product, ctx_kw, tenant_id="tenant-a"
+        )
+    assert "kwarg" in str(exc_kw.value)
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 5 (wiring): the serving-layer handler wires enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_serving_handler_wires_enforcement_for_multi_tenant_product(
+    db_with_two_tenants,
+):
+    """The real FabricServingLayer handler builds an ENFORCING context for a
+    multi_tenant product (enforce_tenant_scope=product.multi_tenant): a
+    mis-scoped product returns no rows (fail-closed), a correctly-scoped one
+    returns only its own tenant's rows."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    def _extractor(req: Any) -> Any:
+        return getattr(req, "tenant", None)
+
+    class _Req:
+        def __init__(self, query_params, tenant):
+            self.query_params = query_params
+            self.tenant = tenant
+
+    # (a) mis-scoped multi_tenant product, forced fresh via ?refresh=true.
+    reg_bad = ProductRegistration(
+        name="deals_unscoped_serve",
+        fn=_unscoped_product,
+        mode=ProductMode.MATERIALIZED,
+        depends_on=["Deal"],
+        staleness=StalenessPolicy(),
+        multi_tenant=True,
+    )
+    serving_bad = FabricServingLayer(
+        products={"deals_unscoped_serve": reg_bad},
+        pipeline_executor=pipeline,
+        express=db.express,
+        sources={},
+        tenant_extractor=_extractor,
+    )
+    handler_bad = serving_bad._make_product_handler("deals_unscoped_serve", reg_bad)
+    resp_bad = await handler_bad(request=_Req({"refresh": "true"}, "tenant-a"))
+    # Enforcement fired inside execute_product → refresh failed → 500, NO
+    # rows. Without the wiring this would be 200 with all-tenant data.
+    assert resp_bad["_status"] == 500
+    assert "data" not in resp_bad
+
+    # (b) correctly-scoped multi_tenant product → 200 with only own rows.
+    reg_ok = ProductRegistration(
+        name="deals_scoped_serve",
+        fn=_scoped_product,
+        mode=ProductMode.MATERIALIZED,
+        depends_on=["Deal"],
+        staleness=StalenessPolicy(),
+        multi_tenant=True,
+    )
+    serving_ok = FabricServingLayer(
+        products={"deals_scoped_serve": reg_ok},
+        pipeline_executor=pipeline,
+        express=db.express,
+        sources={},
+        tenant_extractor=_extractor,
+    )
+    handler_ok = serving_ok._make_product_handler("deals_scoped_serve", reg_ok)
+    resp_ok = await handler_ok(request=_Req({"refresh": "true"}, "tenant-a"))
+    assert resp_ok["_status"] == 200
+    assert resp_ok["data"]["deals"] == ["a-deal-1", "a-deal-2"]
+
+
+# ---------------------------------------------------------------------------
+# Redteam finding 5 (prewarm): _prewarm_products_serial skips multi_tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_prewarm_serial_skips_multi_tenant(db_with_two_tenants):
+    """Dev-mode serial pre-warm SKIPS multi_tenant products — it never runs
+    their unscoped all-tenant query nor writes an untenanted cache entry."""
+    db = db_with_two_tenants
+    pipeline = PipelineExecutor(dataflow=db, dev_mode=True)
+
+    executed: list[str] = []
+
+    async def _recording_product(ctx: Any) -> Dict[str, Any]:
+        executed.append("ran")
+        rows = await ctx.express.list("Deal")  # unscoped — would leak if run
+        return {"deals": [r["name"] for r in rows]}
+
+    reg = ProductRegistration(
+        name="mt_prewarm",
+        fn=_recording_product,
+        mode=ProductMode.MATERIALIZED,
+        depends_on=["Deal"],
+        staleness=StalenessPolicy(),
+        multi_tenant=True,
+    )
+    runtime = FabricRuntime(
+        dataflow=db,
+        sources={},
+        products={"mt_prewarm": reg},
+        dev_mode=True,
+        tenant_extractor=lambda r: None,
+    )
+    runtime._pipeline = pipeline
+
+    await runtime._prewarm_products_serial()
+
+    # The multi_tenant product was skipped: fn never ran, no cache written.
+    assert executed == []
+    assert await pipeline.get_cached("mt_prewarm", tenant_id=None) is None


### PR DESCRIPTION
## Summary
Implements #1654: a **fail-closed** tenant-scoping guard on the DataFlow fabric data-product read path (`@db.product` / `ctx.express`). Before rows return from a `multi_tenant` product, the guard requires a resolvable tenant scope AND proves the tenant predicate was applied to the executed query — raising `FabricTenantScopeError` otherwise, never returning unscoped/cross-tenant rows.

## The gap it closes
The fabric layer partitioned the **cache** by tenant but never passed `tenant_id` into the `PipelineContext` nor proved product queries filtered by it — so a `multi_tenant` product calling `ctx.express.list("Deal")` returned **every** tenant's rows (RED→GREEN test proves the pre-fix leak).

## What's covered (read path)
- `list` / `count` — predicate-proof on the executed filter (scalar tenant match; rejects top-level `$`-operator filters; kwarg allowlist blocks alternate filtering channels)
- `read` by PK — post-fetch tenant check (raises on a cross-tenant / tenant-field-missing row)
- Fail-closed on: missing / empty / blank tenant; non-multi_tenant products unaffected
- Registration-time WARN when a model with a `tenant_id` column is declared `multi_tenant=False` (silent-enforcement-disable guard)
- Dev-mode `_prewarm_products_serial` skips multi_tenant products (parity with the parallel path)
- Cache is tenant-keyed (composes with the #1606 keyspace work — no cross-tenant cache bleed)

## Security depth
reviewer + security-reviewer + 2 adversarial redteam rounds. Round 1 refuted the initial "never" claim on 5 axes (all fixed: read-by-PK, empty-tenant, declaration-only enforcement, `$or`/kwarg channel, serial-prewarm); round 2 confirmed the fixes safe with no new bypass/over-block; 3 LOW residuals closed (int-tenant `str`-normalize, foreign-id log-hygiene fingerprint, dialect-pin regression). 14 Tier-2 real-infra tests (no mocking), incl. a serving-layer wiring test.

## Out of scope (tracked follow-ups)
- **#1658** — `ctx.source()` tenant scoping (external-adapter reads uncovered)
- **#1659** — fabric **write** path (`create`/`update`/`delete`/`upsert`) cross-tenant guard (HIGH — write analogue of the #1650 bulk_upsert breach)
- `tenant_extractor` is an authorization boundary owned by the caller/Nexus (documented).

Ships in **kailash-dataflow 2.14.6**.

## Related issues
Fixes #1654 (the read-path interceptor). Follow-ups #1658, #1659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)