### PR TITLE
Release v2.46.0 — EATP v3 + SAFR governance-hardening epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.46.0] - 2026-07-10
+
+EATP v3 + SAFR governance-hardening epic.
+
+### Added
+
+- **Extensible risk-factor disposition calibration** (#1514 BH1).
+- **Stateful sliding-window rate-limit enforcer** in `verify_action` (#1516 leg a).
+- **Confidence/evidence-quality threshold routing** (#1516 leg b).
+- **Configurable HITL timeout** with a fail-safe DENY-on-expiry disposition.
+- **Pluggable identity resolver** — local + external DID (#1517 leg a).
+- **RFC 8785 JCS canonical encoder** + conditional `subject_hash` audit anchor (#1590).
+- **Citable WEFT provenance event schema** + conformance vectors (#1591).
+- **EATP v3 additive elements** — bilateral delegation, clearance attestation, verify-chain, revocation modes, guarantee tiers (#1592).
+- **Universal outbound-effect governance interceptor core** (#1517 leg-b).
+- **Fail-closed HITL reviewer authority + capacity gate** (#1510 BH2 legs 2-3) — `ReviewerDecision` (APPROVE/MODIFY/DECLINE, monotonic-tightening), `apply_review_decision`, `max_pending_holds` admission control, cross-surface expire/review lifecycle under a lock.
+
+### Fixed
+
+- **Ancestor-verify bypass + risk-factor fail-closed hardening** (#1514 review).
+
+### Security
+
+- **Rate-limit eviction now fails CLOSED** (rate-limit reset bypass, #1516).
+- **WAL/SHM sidecar permission hardening** + fail-closed corrupt-row expiry (#1515).
+- **`did:key` self-certification hardening** (#1517 leg a).
+- **EATP/outbound trust dataclasses frozen** + HTTP audit-target credential redaction + governance-verdict immutability (redteam M1/L1/L2).
+- **Consolidated + expanded credential-bearing URL query-key masking across 4 sites** (#1655) — single canonical `is_sensitive_query_key`, plus presigned/SAS/STS signature keys.
+- **HITL reviewer-authority multi-round redteam hardening** (#1510 BH2) — closed a CRITICAL expire/queue-desync resurrection, a HIGH corrupt-sentinel reconcile miss, and forged-row-denial/audit-poisoning/`reviewer_id`-validation gaps.
+
 ## [2.45.6] - 2026-07-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.45.6"
+version = "2.46.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.45.6"
+__version__ = "2.46.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release PR for kailash core 2.45.6 → 2.46.0. Metadata-only release-prep diff (version anchors + CHANGELOG) — the underlying feature/security commits are already on main.

- Atomic version bump: `pyproject.toml` + `src/kailash/__init__.py` (zero-tolerance Rule 5)
- CHANGELOG populated with verified [2.46.0] entry: EATP v3 + SAFR governance-hardening epic (risk-factor calibration, rate-limit + HITL timeout controls, pluggable identity resolver, RFC 8785 JCS canonical encoder, WEFT provenance schema, EATP v3 additive elements, universal outbound-effect governance interceptor core, fail-closed HITL reviewer authority + capacity gate #1510 BH2) plus security hardening (rate-limit eviction fail-closed, WAL/SHM sidecar permissions, did:key self-cert, frozen trust dataclasses, consolidated URL query-key masking #1655, multi-round HITL redteam closure)

## Test plan

- [x] CI green on this branch (release/v* auto-skips the heavy PR-gate matrix)
- [ ] Admin-merge, then push tag `v2.46.0` on the merge commit
- [ ] Verify publish-pypi.yml run succeeds
- [ ] Verify `kailash==2.46.0` live on PyPI + importable in a clean venv

## Related issues

Relates to #1514, #1515, #1516, #1517, #1590, #1591, #1592, #1510, #1655