### PR TITLE
Release v2.14.6 — cross-DB cache bleed fix + fabric tenant-scope interceptor

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.14.6] — 2026-07-10 — cross-DB query-cache bleed fix (#1606) + fabric tenant-scope interceptor (#1654)
+
+### Security
+
+- **Query cache keyspace now segments by database-instance identity (#1606).** The cache key now incorporates a credential-free hash of the masked DSN, with a component-config fallback, a loud WARN when isolation is inactive, and a credential-stripped component host in diagnostics. The Express v2 keyspace is a cross-SDK byte contract and is deliberately left untouched by this fix — the Express hot-path bleed remains open pending the coordinated cross-SDK keyspace lockstep (`cross-sdk-inspection.md` Rule 4b).
+
+### Added
+
+- **Fail-closed tenant-scoping `QueryInterceptor` on the fabric data-product read path (#1654).** The interceptor requires a resolvable tenant scope and proves the tenant predicate was actually applied to the executed query before rows return — list/count predicate-proof, a read post-fetch check, a filter-shape + kwarg allowlist, empty-tenant fail-closed, and a registration-time WARN when `multi_tenant=False` is declared over a model that carries a tenant column. The fabric cache is tenant-keyed. Follow-ups #1658 (`ctx.source` scoping) and #1659 (write-path guard) are tracked and not yet closed.
+
 ## [2.14.5] — 2026-07-10 — cross-tenant upsert write-breach fix (#1650/#1526)
 
 ### Security

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.14.5"
+version = "2.14.6"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.14.5"
+__version__ = "2.14.6"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Release PR for kailash-dataflow 2.14.5 → 2.14.6. Metadata-only release-prep diff — the underlying feature/security commits (#1606, #1654) are already on main.

- Atomic version bump: `packages/kailash-dataflow/pyproject.toml` + `packages/kailash-dataflow/src/dataflow/__init__.py` (zero-tolerance Rule 5)
- CHANGELOG populated with verified [2.14.6] entry:
  - Security: cross-DB query-cache bleed fix (#1606) — cache key segments by a credential-free masked-DSN hash, component-config fallback, loud WARN on inactive isolation; Express v2 keyspace deliberately untouched (cross-SDK byte contract)
  - Added: fail-closed tenant-scoping QueryInterceptor on the fabric data-product read path (#1654), with predicate-proof, allowlist, and fail-closed empty-tenant handling. Follow-ups #1658/#1659 tracked

## Test plan

- [x] CI green on this branch (release/v* auto-skips the heavy PR-gate matrix)
- [ ] Admin-merge, then push tag `dataflow-v2.14.6` on the merge commit
- [ ] Verify publish-pypi.yml run succeeds
- [ ] Verify `kailash-dataflow==2.14.6` live on PyPI + importable in a clean venv

## Related issues

Relates to #1606, #1654, #1658, #1659