### PR TITLE
Release v2.29.0 — outbound governance transport wiring + DeepSeek provider

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.29.0] — 2026-07-10 — outbound governance transport wiring + DeepSeek provider
+
+### Added
+
+- **Outbound governance seam wired to LLM/tool/HTTP transports** (#1517 leg-b). `GovernedProvider`, `GovernedToolInvoker`, and `GovernedHTTPClient` are transparent proxies that route every outbound call through core's outbound-effect governance interceptor, with a fail-closed `resolve_interceptor` — an unresolved interceptor refuses the call rather than passing it through ungoverned.
+- **DeepSeek is now a first-class `LlmProvider`** (#1609) — `from_model` / `from_name` resolution, plus `from_env` legacy and selector tiers.
+
+### Security
+
+- **`GovernedHTTPClient` redacts credentials from HTTP audit targets** (redteam L1). `redact_http_target` strips userinfo and query/fragment components before the URL is recorded as an audit target, so a credential-bearing outbound URL never lands in the audit trail verbatim.
+
 ## [2.28.0] — 2026-06-19 — LlmClient lifecycle: aclose() + async context manager + opt-in HTTP pooling
 
 ### Added

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.28.0"
+version = "2.29.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.28.0"
+__version__ = "2.29.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Release PR for kailash-kaizen 2.28.0 → 2.29.0. Metadata-only release-prep diff — the underlying feature/security commits (#1517 leg-b, #1609) are already on main.

- Atomic version bump: `packages/kailash-kaizen/pyproject.toml` + `packages/kailash-kaizen/src/kaizen/__init__.py` (zero-tolerance Rule 5)
- CHANGELOG populated with verified [2.29.0] entry:
  - Added: outbound governance seam wired to LLM/tool/HTTP transports (#1517 leg-b) — `GovernedProvider`/`GovernedToolInvoker`/`GovernedHTTPClient` transparent proxies, fail-closed `resolve_interceptor`; DeepSeek first-class `LlmProvider` (#1609)
  - Security: `GovernedHTTPClient` redacts credentials from HTTP audit targets (redteam L1)

## Test plan

- [x] CI green on this branch (release/v* auto-skips the heavy PR-gate matrix)
- [ ] Admin-merge, then push tag `kaizen-v2.29.0` on the merge commit
- [ ] Verify publish-pypi.yml run succeeds
- [ ] Verify `kailash-kaizen==2.29.0` live on PyPI + importable in a clean venv

## Related issues

Relates to #1517, #1609