### PR TITLE
chore(codify): read-path tenant-scope guard (Rule 8) + dual-surface state reconcile

### DIFF
--- a/.claude/rules/eatp.md
+++ b/.claude/rules/eatp.md
@@ -95,4 +95,51 @@ self._audit_engine.append(event)   # next dispatch observes half-state
 - **Violation scope:** MUST 1 (emit-before-advance ordering) — structural AST sweep; MUST 2 (no-recurse FAILED helper) — structural AST sweep asserting any `*_to_failed*` function has zero calls to the module's parent audit-emit helper.
 - **Origin:** PR #1139 commit e9626a223 (2026-05-22) — pre-fix code advanced the lifecycle `phase` slot before `_audit_engine.append`; an emit failure left (phase=ACTING, no audit row) and the next dispatch raised an opaque error. Post-fix: emit-first, advance-second, plus `_advance_to_failed_no_audit` for the FAILED-path recursion guard.
 
+## MUST: Dual-Surface State Reconciles BOTH Surfaces Atomically Under One Lock; Reconcile On A Stable Id
+
+A state machine whose state spans TWO mutable surfaces (e.g. an in-memory review queue + a persisted store) MUST reconcile BOTH surfaces ATOMICALLY under ONE lock on EVERY transition (expire, resolve, review). A transition that mutates one surface without reconciling the other lets a stale entry on the un-reconciled surface be re-resolved into a monotonic DOWNGRADE — the exact inverse of the monotonic-escalation invariant above (AUTO_APPROVED → … → BLOCKED, never downgrade). Two further invariants hold the reconcile honest:
+
+- **The reconcile key MUST be STABLE.** Keying reconcile on a re-minted / mutable id (e.g. a corrupt-sentinel that mints a fresh id) misses the very entries it must remove. Carry the ORIGINAL id through the transition and reconcile on it.
+- **A single-surface entry MUST NOT be evictable by an event on the OTHER surface.** An entry present in ONLY one surface (e.g. a no-timeout hold in the queue but never written to the store) MUST NOT be removed by an event targeting the other surface — a forged / stale store row MUST NOT deny a queue-only entry.
+
+```python
+# DO — one lock, both surfaces, reconcile on the ORIGINAL id
+async def expire_holds(self, now):
+    async with self._lock:                              # ONE lock spans both surfaces
+        for h in self._store.due(now):
+            orig_id = h.id                              # stable key captured BEFORE any re-mint
+            self._store.mark_blocked(orig_id)
+            self._review_queue.discard(orig_id)         # queue reconciled in the SAME critical section
+        # a queue-only entry (never in _store) is untouched here — no store event evicts it
+
+# DO NOT — mutate one surface, leave the other stale; reconcile on a re-minted id
+async def expire_holds(self, now):
+    for h in self._store.due(now):
+        self._store.mark_blocked(h.id)                  # store advanced to BLOCKED
+    # review_queue NOT reconciled → a lingering queue entry re-resolves the
+    # already-BLOCKED hold back to AUTO_APPROVED (monotonic downgrade), and a
+    # corrupt-sentinel remint means discard(h.id) would miss it anyway
+```
+
+**BLOCKED rationalizations:**
+
+- "The store is the source of truth; the queue is just a cache" (a stale queue entry still re-resolves a terminal state — both surfaces are authoritative until reconciled)
+- "Reconcile the queue in a follow-up pass after the store write" (the un-reconciled window is where the downgrade lands; it MUST be one critical section)
+- "The corrupt-sentinel mints a clean id, that's safer" (a fresh id misses the entry the reconcile must remove — carry the original)
+- "A store row targeting this id is enough to evict the queue entry" (a queue-only entry has no store row; a forged store row must not deny it)
+- "Two locks, one per surface, is finer-grained" (an interleave between the two locks is exactly the un-reconciled window)
+
+**Why:** When a lifecycle's state lives on two mutable surfaces, a transition that advances one surface and leaves the other stale creates a re-resolution window — a lingering queue entry re-approves an already-expired-and-BLOCKED hold, a monotonic DOWNGRADE that defeats the escalation model. Atomic dual-surface reconcile under one lock, keyed on a stable id, with single-surface entries fenced from cross-surface eviction, is the structural defense; this generalizes the audit-before-state-advance clause above from the single-surface case to the two-surface case.
+
+**Trust Posture Wiring:**
+
+- **Severity:** `halt-and-report` at gate-review (security-reviewer + reviewer at `/implement` + `/redteam`: for any state machine spanning two mutable surfaces, confirm every transition reconciles BOTH under one lock, keys reconcile on a stable id, and fences single-surface entries from cross-surface eviction); `advisory` at the hook layer (the dual-surface-atomicity property is judgment-bearing over the transition's critical section, not a structural tool-call signal, per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing (2026-07-10 → 2026-07-17).
+- **Cumulative posture impact:** same-class violations (a dual-surface transition that mutates one surface without reconciling the other, reconciles on a re-minted id, or evicts a single-surface entry via a cross-surface event) contribute to `trust-posture.md` MUST Rule 4 cumulative-window math (3× same-rule in 30d → drop 1 posture; 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** a same-class violation within the 7-day grace window routes through the GENERIC `regression_within_grace` emergency trigger per `trust-posture.md` MUST-4 (1× = drop 1 posture) — NO dedicated per-clause trigger key (a dual-surface-reconcile property is review-layer-only and judgment-bearing; minting a key would drag `trust-posture.md`, a self-referential-codify allowlist file, into a self-ref edit, and the universal `regression_within_grace` trigger already covers it). Named deviation from the canonical key-per-clause shape, recorded here per `trust-posture.md` Rule 8 — the same no-dedicated-key disposition `security.md` § Enforcement-Surface Parity and `git.md` § CI-check/merge took.
+- **Receipt requirement:** SessionStart soft-gate `[ack: eatp]` IFF `posture.json::pending_verification` includes this rule_id.
+- **Detection mechanism:** Phase 1 (manual, gate-review) — for any state machine whose state spans two mutable surfaces (in-memory queue + persisted store, or equivalent), AST-walk each transition (expire / resolve / review) and confirm both surfaces mutate inside ONE lock's critical section, the reconcile key is the original (non-re-minted) id, and single-surface entries are fenced from cross-surface eviction; run by security-reviewer + reviewer at `/implement` + `/redteam`. Phase 2 (deferred per `trust-posture.md` § Two-Phase Rollout, after ≥3 real sessions exercise Phase 1) — no hook detector; audit fixtures land with the Phase-2 detector at `.claude/audit-fixtures/eatp-dual-surface-reconcile/` per `cc-artifacts.md` Rule 9.
+- **Violation scope:** this clause (dual-surface atomic reconcile + stable reconcile key + single-surface-entry eviction fence) ONLY; the pre-existing grandfathered `eatp.md` sections stay exempt until each is itself `/codify`-touched (the clause-scoped precedent set by `rule-authoring.md`'s own Wiring section + `security.md` / `git.md`).
+- **Origin:** kailash-py #1510 BH2 legs 2-3 (2026-07-10, PR #1657, kailash 2.46.0). Four adversarial `/redteam` rounds closed a CRITICAL (`expire_holds` mutated the store without reconciling the review queue → a BLOCKED→AUTO_APPROVED resurrection) plus a HIGH (reconcile keyed on the corrupt-sentinel's fresh id missed the original) plus a forged-store-row denial of a queue-only entry. Generalizes the audit-before-state-advance clause above to the two-surface case.
+
 <!-- /slot:neutral-body -->

--- a/.claude/rules/tenant-isolation.md
+++ b/.claude/rules/tenant-isolation.md
@@ -221,6 +221,69 @@ sql = f"INSERT ... ON CONFLICT (id) DO UPDATE SET {', '.join(set_parts)}"  # no 
 
 Origin: #1650 / kailash-dataflow 2.14.5 (2026-07-10) — a holistic `/redteam` CONFIRMED (real SQLite + PostgreSQL) that `bulk_upsert` / single `upsert` / `BulkCreatePoolNode` on a `multi_tenant` model with the default `conflict_on=["id"]` overwrote and reassigned another tenant's row via an un-guarded `ON CONFLICT DO UPDATE`; fixed across all five upsert builders. The completeness lesson (audit ALL builders) came from the closure-parity round finding the sibling `BulkCreatePoolNode` after the primary fix.
 
+### 8. Data-Product / Materialized-View Read-Path Tenant-Scope Guard
+
+A tenant-isolation guard on a data-product / materialized-view / cached-read surface MUST prove the tenant predicate was actually APPLIED to the EXECUTED query before rows return — NOT merely that the product is DECLARED `multi_tenant=True`. The guard MUST inspect the executed filter/params (or the tenant value bound into the pipeline context), never trust the declaration. Concretely, a compliant read-path guard MUST hold ALL of:
+
+- **Predicate-proof, not declaration-proof.** Inspect the executed filter/params; a product declared multi-tenant whose query carried no tenant predicate fails closed. Partitioning a downstream CACHE by tenant is NOT proof the QUERY filtered by tenant.
+- **Post-fetch assertion for single-record PK reads.** A single-record PK read carries no pre-execution filter to inspect, so it MUST assert AFTER fetch that the row's tenant field equals the bound tenant — type-normalized (`str(a) == str(b)`, so an INT tenant column does not over-block a str-bound tenant). A row missing the tenant field fails closed.
+- **Reject alternate filtering channels.** On an enforced read the guard MUST require a plain-dict filter with a SCALAR tenant value, REJECT top-level boolean / `$`-operator keys (`$or`, `$and`, `and`, `or`), and allowlist ONLY safe non-filtering kwargs (pagination: `limit` / `offset` / `order_by` / `cache_ttl` / …). Any other filtering-capable kwarg is refused fail-closed.
+- **Cross-check the declaration flag at registration.** Enforcement gated on a declaration flag (`multi_tenant=True`) MUST be cross-checked at model registration against the ACTUAL tenant column: a model WITH a tenant column DECLARED non-tenant MUST emit a loud WARN (or raise). A forgotten flag silently disables all enforcement — the silent-fallback failure mode (`zero-tolerance.md` Rule 3).
+- **Empty/blank tenant fails closed exactly like None** — at extraction AND at context construction.
+- **Refusal messages MUST NOT echo the FOREIGN tenant id** — use a hash/fingerprint (`observability.md` Rule 8 log hygiene).
+- **Scope is the READ path only.** Write paths and out-of-band source reads are DISTINCT surfaces requiring their own guards; a read-path guard MUST NOT claim to cover them.
+
+```python
+# DO — prove the predicate was applied to the EXECUTED query; post-fetch assert on PK reads
+def intercept_query(self, model, filt, **kwargs):
+    if not model.multi_tenant:
+        return filt
+    bound = get_current_tenant_id()
+    if not bound:                                    # None OR "" OR "  " → fail closed
+        raise TenantRequiredError(model.name)
+    unsafe = set(kwargs) - {"limit", "offset", "order_by", "cache_ttl"}
+    if unsafe or any(k in filt for k in ("$or", "$and", "and", "or")):
+        raise TenantScopeError(f"non-scalar filter channel refused for {model.name}")
+    if not isinstance(filt.get("tenant_id"), (str, int)):   # scalar predicate required
+        raise TenantScopeError(f"tenant predicate absent/non-scalar for {model.name}")
+    return {**filt, "tenant_id": bound}
+
+def assert_pk_row(self, model, row, bound):          # single-record PK read: post-fetch
+    if model.multi_tenant and str(row.get("tenant_id")) != str(bound):  # type-normalized
+        raise TenantScopeError(f"cross-tenant row for fp={_fingerprint(bound)}")  # no foreign id echoed
+
+# DO NOT — trust the declaration; partition only the cache; skip PK post-fetch
+def intercept_query(self, model, filt, **kwargs):
+    if model.multi_tenant:
+        cache.partition_by(get_current_tenant_id())  # cache scoped, QUERY unfiltered
+    return filt                                       # every tenant's rows returned
+```
+
+**BLOCKED rationalizations:**
+
+- "The product is declared `multi_tenant=True`, so its reads are scoped"
+- "The cache is partitioned by tenant, that's the isolation"
+- "PK reads are safe — the id is unique, no filter needed" (no post-fetch assert → cross-tenant PK collision leaks)
+- "`$or` in the filter is the caller's business" (a boolean channel bypasses the scalar tenant predicate)
+- "The `multi_tenant` flag is set correctly everywhere, no registration cross-check needed"
+- "Empty tenant is basically None, the None check covers it" (blank must fail closed at BOTH extraction and context construction)
+- "This read guard covers the write path too" (distinct surface; own guard required)
+
+**Why:** A product DECLARED multi-tenant whose QUERIES never carry the tenant predicate returns every tenant's rows while looking isolated — the leak is invisible until two tenants share a key, exactly `rules/tenant-isolation.md`'s neutral-body failure mode one layer up (the read surface, not the cache key). Proving the predicate reached the EXECUTED query — plus a post-fetch assert on the one read shape that has no pre-execution filter (PK), a rejected alternate-channel set, a registration cross-check catching the forgotten flag, and fail-closed blank/None handling — is the structural defense; declaration-trust is the silent fallback.
+
+**Trust Posture Wiring (Rule 8):**
+
+- **Severity:** `halt-and-report` at gate-review (security-reviewer + reviewer at `/implement` + `/redteam`: for any `multi_tenant` data-product / materialized-view / cached-read surface, confirm the read guard inspects the EXECUTED predicate — not the declaration — carries a PK post-fetch assert, rejects boolean/`$`-operator channels, cross-checks the flag at registration, and fails closed on blank/None); `advisory` at the hook layer (the predicate-was-applied property is judgment-bearing over executed queries, not a structural tool-call signal, per `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from rule landing (2026-07-10 → 2026-07-17).
+- **Cumulative posture impact:** same-class violations (a `multi_tenant` read-path surface whose guard trusts the declaration instead of proving the executed predicate, OR omits the PK post-fetch assert, OR admits an alternate filtering channel) contribute to `trust-posture.md` MUST Rule 4 cumulative-window math (3× same-rule in 30d → drop 1 posture; 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** a same-class violation within the 7-day grace window routes through the GENERIC `regression_within_grace` emergency trigger per `trust-posture.md` MUST-4 (1× = drop 1 posture) — NO dedicated per-clause trigger key (a read-path predicate-proof property is review-layer-only and judgment-bearing; minting a key would drag `trust-posture.md`, a self-referential-codify allowlist file, into a self-ref edit, and the universal `regression_within_grace` trigger already covers it). Named deviation from the canonical key-per-clause shape, recorded here per `trust-posture.md` Rule 8 — the same no-dedicated-key disposition `security.md` § Enforcement-Surface Parity and `git.md` § CI-check/merge took.
+- **Receipt requirement:** SessionStart soft-gate `[ack: tenant-isolation]` IFF `posture.json::pending_verification` includes this rule_id.
+- **Detection mechanism:** Phase 1 (manual, gate-review) — for any `multi_tenant` data-product / materialized-view / cached-read change, enumerate every read entry point over the surface and confirm each (a) inspects the executed filter/params (not the declaration flag), (b) post-fetch-asserts type-normalized tenant equality on PK reads, (c) rejects top-level boolean/`$`-operator keys and non-allowlisted filtering kwargs, (d) cross-checks `multi_tenant` against the actual tenant column at registration, (e) fails closed on blank/None; run by security-reviewer + reviewer at `/implement` + `/redteam`. Phase 2 (deferred per `trust-posture.md` § Two-Phase Rollout, after ≥3 real sessions exercise Phase 1) — no hook detector; audit fixtures land with the Phase-2 detector at `.claude/audit-fixtures/data-product-tenant-scope-guard/` per `cc-artifacts.md` Rule 9.
+- **Violation scope:** Rule 8 (data-product / materialized-view read-path tenant-scope guard) ONLY; Rules 1–6 stay grandfathered until each is itself `/codify`-touched (Rule 7 landed its own canonical Wiring this cycle).
+- **Origin:** See Rule 8 Origin below.
+
+Origin: kailash-py #1654 → kailash-dataflow 2.14.6 (2026-07-10, PR #1660). The fabric read path partitioned the CACHE by tenant but never proved product QUERIES filtered by tenant nor passed `tenant_id` into the pipeline context, so a `multi_tenant` product returned every tenant's rows (RED→GREEN proven). An adversarial `/redteam` refuted the initial "never leaks" claim on five axes — an unguarded PK read, an empty-tenant bypass, declaration-only enforcement, a `$or`/kwarg filtering channel, and a serial-prewarm path — all hardened. Follow-ups #1658 (source-path scoping) + #1659 (write-path guard) fence the distinct surfaces this read-path guard does NOT cover. Cross-SDK: the Rust SDK fabric read path likely shares the shape.
+
 ## MUST NOT
 
 - Default missing tenant_id to a placeholder ("default", "global", "")

--- a/workspaces/sdk-backlog/journal/0005-DECISION-codify-read-path-tenant-guard-and-dual-surface-lifecycle.md
+++ b/workspaces/sdk-backlog/journal/0005-DECISION-codify-read-path-tenant-guard-and-dual-surface-lifecycle.md
@@ -1,0 +1,48 @@
+# DECISION — Codify: data-product read-path tenant-scope guard + dual-surface state reconcile
+
+**Date:** 2026-07-10
+**Phase:** 05-codify
+**Type:** DECISION
+
+## What was codified
+
+Two new MUST clauses authored on branch `codify/jack-hong-2026-07-10`, distilled from
+this session's converged security work:
+
+1. **`rules/tenant-isolation.md` Rule 8 — Data-Product / Materialized-View Read-Path
+   Tenant-Scope Guard.** Generalizes the #1654 fabric tenant QueryInterceptor beyond
+   fabric: a tenant guard on a data-product / materialized-view / cached-read surface
+   MUST prove the tenant predicate was applied to the EXECUTED query (not merely that the
+   product is DECLARED `multi_tenant`); PK reads need a type-normalized post-fetch assert;
+   reject alternate filtering channels (`$`-operator keys + non-allowlisted kwargs);
+   cross-check the declaration flag against the model's actual tenant column at
+   registration; blank/None fails closed; refusals don't echo the foreign tenant id;
+   read-path scope only (write + source paths are distinct — #1658/#1659).
+
+2. **`rules/eatp.md` — Dual-Surface State Reconciles BOTH Surfaces Atomically Under One
+   Lock; Reconcile On A Stable Id.** Distilled from #1510 BH2. A state machine spanning
+   two mutable surfaces (in-memory review queue + persisted store) MUST reconcile BOTH
+   atomically under one lock on every transition; reconcile on the ORIGINAL (non-re-minted)
+   id; a single-surface entry MUST NOT be evictable by a cross-surface event. Generalizes
+   the sibling audit-before-state-advance clause from one surface to two.
+
+## Why these two (value-rank)
+
+Both are cascade-valuable security disciplines that generalize beyond the originating
+bug: any SDK with tenant-scoped read surfaces / dual-surface state machines inherits them.
+The self-referential-codify gate was checked — neither `tenant-isolation` nor `eatp` is on
+the Rule-2 allowlist (they govern CODE behavior, not codify-governance), so the mandatory
+multi-agent gate did not apply; both clauses were still cc-architect-authored + Origin-
+verified against git log + carry canonical 8-field Trust Posture Wiring.
+
+The mask_url credential-mask consolidation (this session, #1655) was NOT given a separate
+clause — `security.md` § Credential Decode Helpers + `observability.md` § 6 already mandate
+consolidation + canonical mask forms; the session's addition (presigned/SAS key variants +
+normalized matching) is an in-family extension, noted here rather than a new rule.
+
+## Receipts
+
+- tenant-isolation Rule 8 Origin: #1654 → kailash-dataflow 2.14.6, PR #1660.
+- eatp dual-surface Origin: #1510 BH2 legs 2-3 → kailash 2.46.0, PR #1657.
+- Both verified present via `grep -c '**Violation scope:**'` (wiring anchor).
+- last_codified anchor advanced from 2026-07-10T06:46:44Z.

--- a/workspaces/sdk-backlog/journal/0006-DISCOVERY-declaration-proof-is-not-predicate-proof.md
+++ b/workspaces/sdk-backlog/journal/0006-DISCOVERY-declaration-proof-is-not-predicate-proof.md
@@ -1,0 +1,45 @@
+# DISCOVERY — "Declared multi-tenant" is not "query was tenant-scoped"; dual-surface reconcile
+
+**Date:** 2026-07-10
+**Phase:** 05-codify
+**Type:** DISCOVERY
+
+## The pattern the next session should inherit
+
+### 1. Declaration-proof ≠ predicate-proof (tenant read paths)
+
+The #1654 fabric interceptor's core failure mode: the layer partitioned the **cache** by
+tenant and the product was **declared** `multi_tenant=True`, yet the product's actual
+queries carried **no tenant predicate** (and `tenant_id` was never even passed into the
+pipeline context) — so it returned every tenant's rows while looking isolated. A tenant
+guard that trusts the declaration or the cache partition is a **silent fallback**. The
+guard must inspect the **executed** filter/params.
+
+Adversarial redteam refuted the first "never leaks" claim on **five** axes that a single-
+pass review missed: (a) single-PK `read()` has no pre-execution filter → needs a POST-FETCH
+assert; (b) empty/blank tenant `""` passed the `is None` check → shared pseudo-tenant;
+(c) enforcement gated ONLY on the declaration flag → a model with a tenant column declared
+`multi_tenant=False` silently disables all enforcement; (d) a top-level `$or` / an alternate
+`**kwarg` filter channel re-admits other tenants while `filter["tenant_id"]` reads correct;
+(e) a dev-mode serial-prewarm path ran multi_tenant products unguarded. **Lesson:** a
+"prove the filter fired" guard has many bypass surfaces — enumerate every row-returning
+path, every filter channel, and the declaration-vs-reality gap.
+
+### 2. Dual-surface state machines re-resolve terminal states
+
+The #1510 BH2 CRITICAL: a lifecycle state living on TWO mutable surfaces (an in-memory
+review queue + a persisted store). `expire_holds` advanced the STORE to BLOCKED but left
+the queue entry → a late review re-resolved the already-BLOCKED hold to AUTO_APPROVED — a
+monotonic **downgrade**. The round-2 HIGH: the fix's reconcile keyed on the corrupt-sentinel's
+**re-minted** id, missing the original. **Lesson:** reconcile BOTH surfaces atomically under
+ONE lock, key on the STABLE original id, and fence single-surface entries from cross-surface
+eviction. This is the two-surface generalization of audit-before-state-advance.
+
+## Process note (for the next codegen session)
+
+Both failures were found by **adversarial redteam that tried to REFUTE**, not confirm —
+each round found a progressively narrower fail-open a per-function review could not see
+(cross-surface lifecycle, forged-row injection, declaration-vs-model gap). For any
+fail-closed security guard, budget ≥2 adversarial rounds and treat each round's finding as
+evidence the surface is trickier than the diff shows. Convergence = a round that genuinely
+refutes nothing NEW, not a clean per-function review.


### PR DESCRIPTION
## Summary
Codifies two cascade-valuable security disciplines from the SDK-backlog release session:

- **`tenant-isolation.md` Rule 8** — data-product / materialized-view read-path tenant-scope guard (prove the predicate reached the executed query, not the `multi_tenant` declaration; PK post-fetch assert; reject alternate filter channels; registration cross-check; fail-closed blank/None). Origin: #1654 → dataflow 2.14.6.
- **`eatp.md`** — dual-surface state machines reconcile BOTH surfaces atomically under one lock, keyed on a stable id (generalizes audit-before-state-advance to two surfaces). Origin: #1510 BH2 → kailash 2.46.0.

Both carry canonical 8-field Trust Posture Wiring. Self-referential-codify gate checked (neither rule is codify-governing → no mandatory multi-agent gate). cc-architect-authored + Origin-verified against git log. Journal entries 0005 (DECISION) + 0006 (DISCOVERY) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)