### PR TITLE
fix(dataflow-fabric): fail-closed tenant guards on write + source paths (#1659, #1658)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/fabric/cache.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/cache.py
@@ -87,10 +87,16 @@ class FabricTenantScopeError(FabricTenantRequiredError):
     * ``ctx.express.read`` (single-record PK lookup) is tenant-verified
       *post-fetch*: a fetched row whose ``tenant_id`` does not match the
       bound tenant is refused and NO row is returned.
-    * ``ctx.source(...)`` (external adapters) and the write path
-      (``create`` / ``update`` / ``delete`` / ``upsert``) are NOT covered
-      by this guard — external-source tenant scoping and write-path tenant
-      enforcement are tracked as separate follow-ups.
+    * The write path (``create`` / ``update`` / ``delete`` / ``upsert`` on
+      ``ctx.express``) is tenant-guarded (issue #1659): ``create`` / ``upsert``
+      force-or-validate the payload's ``tenant_id`` (a foreign tenant is
+      refused); ``update`` / ``delete`` (and the UPDATE half of ``upsert``)
+      tenant-verify the PK-addressed target row BEFORE mutating, so a
+      cross-tenant PK write is refused and no row is touched.
+    * ``ctx.source(...)`` (external adapters) is refused fail-closed for a
+      ``multi_tenant`` product (issue #1658): the fabric cannot prove an
+      arbitrary external adapter honored a tenant predicate, so its data
+      methods raise rather than return unscoped cross-tenant rows.
 
     ``tenant_extractor`` (configured on ``db.start()``) is an
     AUTHORIZATION boundary owned by the caller / Nexus, NOT this guard: a

--- a/packages/kailash-dataflow/src/dataflow/fabric/context.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/context.py
@@ -61,10 +61,59 @@ class SourceHandle:
 
     Attributes:
         name: Source name as registered with ``@db.source()``.
+
+    Tenant scoping (issue #1658): when this handle is handed out by a
+    ``multi_tenant`` product's enforcing context (``enforce_tenant`` set),
+    every DATA method (``fetch`` / ``fetch_all`` / ``fetch_pages`` / ``read``
+    / ``list`` / ``write`` / ``last_successful_data``) is refused
+    fail-closed with :class:`FabricTenantScopeError`. The fabric cannot
+    inject a provable tenant predicate into an arbitrary external adapter
+    (REST / file / DB) — the adapter's query semantics are opaque — so an
+    un-provable source read on a multi-tenant product returns unscoped,
+    cross-tenant rows. Per the tenant-isolation fail-closed contract
+    (unrecognized/unknown → tightest → refuse) the read is refused rather
+    than allowed to leak. Metadata properties (``name`` / ``source_type`` /
+    ``healthy`` / ``last_change_detected``) carry no row data and stay open.
+    Single-tenant products (``enforce_tenant is None``) are unaffected.
     """
 
-    def __init__(self, adapter: BaseSourceAdapter) -> None:
+    def __init__(
+        self,
+        adapter: BaseSourceAdapter,
+        *,
+        enforce_tenant: Optional[str] = None,
+    ) -> None:
         self._adapter = adapter
+        self._enforce_tenant = enforce_tenant
+
+    # -- Tenant-scope guard (issue #1658) -----------------------------------
+
+    def _refuse_if_enforced(self, operation: str) -> None:
+        """Fail-closed refusal for a source access under tenant enforcement.
+
+        Raises :class:`FabricTenantScopeError` when this handle belongs to a
+        ``multi_tenant`` product's enforcing context. The message names ONLY
+        the bound (own) tenant and the source name — never another tenant's
+        data — so the refusal is safe to land in the requesting tenant's
+        operator log (``observability.md`` Rule 8).
+        """
+        if self._enforce_tenant is None:
+            return
+        # Local import avoids import-order coupling with the cache module and
+        # keeps enforcement co-located with its error type (matches the read
+        # path in PipelineScopedExpress).
+        from dataflow.fabric.cache import FabricTenantScopeError
+
+        raise FabricTenantScopeError(
+            f"multi-tenant fabric product (tenant scope "
+            f"{self._enforce_tenant!r}) may not {operation} external source "
+            f"{self._adapter.name!r}: the fabric cannot PROVE an external "
+            f"source read is tenant-scoped (the adapter's query semantics are "
+            f"opaque), so it is refused fail-closed to avoid returning "
+            f"unscoped cross-tenant rows (issue #1658). Scope the source at "
+            f"the adapter/gateway boundary, or read it from a non-multi_tenant "
+            f"product."
+        )
 
     # -- Data retrieval (circuit-breaker protected) -------------------------
 
@@ -81,6 +130,7 @@ class SourceHandle:
         Returns:
             Parsed response data.
         """
+        self._refuse_if_enforced("fetch")
         return await self._adapter.safe_fetch(path, params)
 
     async def fetch_all(
@@ -99,6 +149,7 @@ class SourceHandle:
         Returns:
             Flat list of all records across pages.
         """
+        self._refuse_if_enforced("fetch_all")
         return await self._adapter.fetch_all(path, page_size, max_records)
 
     async def fetch_pages(
@@ -113,11 +164,13 @@ class SourceHandle:
         Yields:
             Lists of records, one per page.
         """
+        self._refuse_if_enforced("fetch_pages")
         async for page in self._adapter.fetch_pages(path, page_size):
             yield page
 
     async def read(self) -> Any:
         """Read the default resource (alias for ``fetch("")``)."""
+        self._refuse_if_enforced("read")
         return await self._adapter.safe_fetch("")
 
     async def list(self, prefix: str = "", limit: int = 1000) -> List[Any]:
@@ -127,6 +180,7 @@ class SourceHandle:
             prefix: Filter prefix.
             limit: Maximum items to return.
         """
+        self._refuse_if_enforced("list")
         return await self._adapter.list(prefix, limit)
 
     async def write(self, path: str, data: Any) -> Any:
@@ -142,6 +196,7 @@ class SourceHandle:
         Raises:
             NotImplementedError: If the source is read-only.
         """
+        self._refuse_if_enforced("write")
         return await self._adapter.write(path, data)
 
     # -- Degradation helpers ------------------------------------------------
@@ -152,6 +207,9 @@ class SourceHandle:
         When a source's circuit breaker is open, this returns the most
         recent successful fetch result (or ``None`` if there is none).
         """
+        # The cached payload is prior fetched ROW data — refused under
+        # enforcement exactly like a live fetch (issue #1658).
+        self._refuse_if_enforced("last_successful_data")
         return self._adapter.last_successful_data(path)
 
     # -- Read-only properties -----------------------------------------------
@@ -204,6 +262,12 @@ class FabricContext:
         sources: Mapping of source name to ``BaseSourceAdapter``.
         products_cache: Mapping of product name to its cached result.
         tenant_id: Optional tenant identifier for multi-tenant products.
+        enforce_tenant: When set (a resolved tenant scope for a
+            ``multi_tenant`` product), every ``SourceHandle`` handed out by
+            :meth:`source` refuses its data methods fail-closed with
+            :class:`FabricTenantScopeError` (issue #1658) — external sources
+            cannot be proven tenant-scoped. ``None`` (single-tenant / test
+            contexts) leaves sources unrestricted.
     """
 
     def __init__(
@@ -212,11 +276,14 @@ class FabricContext:
         sources: Mapping[str, BaseSourceAdapter],
         products_cache: Dict[str, Any],
         tenant_id: Optional[str] = None,
+        *,
+        enforce_tenant: Optional[str] = None,
     ) -> None:
         self._express = express
         self._sources: Mapping[str, BaseSourceAdapter] = sources
         self._products_cache = products_cache
         self._tenant_id = tenant_id
+        self._enforce_tenant = enforce_tenant
 
     @property
     def express(self) -> Any:
@@ -246,7 +313,7 @@ class FabricContext:
                 f"Source '{name}' is not registered. "
                 f"Available sources: {sorted(self._sources.keys())}"
             )
-        return SourceHandle(adapter)
+        return SourceHandle(adapter, enforce_tenant=self._enforce_tenant)
 
     def product(self, name: str) -> Any:
         """Read the cached result of another product.
@@ -334,8 +401,13 @@ class PipelineScopedExpress:
     queries within the same product function see a consistent snapshot.
 
     Write operations (``create``, ``update``, ``delete``, ``upsert``)
-    are forwarded directly to the underlying express instance without
-    caching.
+    are forwarded to the underlying express instance without caching. Under
+    multi-tenant enforcement (``enforce_tenant`` set) they are FIRST
+    tenant-guarded (issue #1659): ``create`` / ``upsert`` force-or-validate the
+    payload tenant scope, and ``update`` / ``delete`` (plus the UPDATE half of
+    ``upsert``) tenant-verify the PK-addressed target row before mutating, so a
+    multi_tenant product cannot write, overwrite, or delete another tenant's
+    row by global PK.
 
     The read cache is scoped to a single pipeline run and must be
     discarded between runs.
@@ -533,6 +605,123 @@ class PipelineScopedExpress:
                 f"(single-record reads are tenant-verified post-fetch)."
             )
 
+    # -- Write-path tenant guards (issue #1659) -----------------------------
+
+    def _guard_write_payload_tenant(
+        self,
+        operation: str,
+        model: str,
+        data: Any,
+        *,
+        force_inject: bool,
+    ) -> Any:
+        """Force or validate the tenant scope on a write payload.
+
+        Fail-closed guard for ``create`` / ``upsert`` / ``update`` payloads on
+        an enforced multi-tenant context. A payload that carries a FOREIGN
+        ``tenant_field`` (a different tenant, or a non-scalar predicate) is
+        refused — a fabric product may not create/move a row into another
+        tenant. When ``force_inject`` is True (``create`` / ``upsert``) and the
+        payload omits the tenant field, the bound tenant is injected so the row
+        lands under the caller's OWN scope; when False (``update`` — a partial
+        patch whose target row is separately tenant-verified) an absent tenant
+        field is left untouched.
+
+        The echoed ``tenant_field`` value is the caller's OWN payload input
+        (the product function supplied it), so echoing it in the refusal
+        message is safe — same reasoning as ``_require_tenant_predicate``.
+
+        Returns the (possibly tenant-injected) payload.
+        """
+        if self._enforce_tenant is None:
+            return data
+        from dataflow.fabric.cache import FabricTenantScopeError
+
+        tf = self._tenant_field
+        if not isinstance(data, dict):
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' requires a dict "
+                f"payload to carry the '{tf}' scope (tenant scope "
+                f"{self._enforce_tenant!r}); refused."
+            )
+        if tf not in data:
+            if force_inject:
+                # Row lands under the caller's OWN tenant, never unscoped.
+                return {**data, tf: self._enforce_tenant}
+            return data
+        tenant_value = data[tf]
+        if isinstance(tenant_value, (dict, list, set, tuple)):
+            raise FabricTenantScopeError(
+                f"multi-tenant fabric {operation} of '{model}' bound a "
+                f"non-scalar '{tf}'={tenant_value!r} on the write payload; a "
+                f"complex tenant predicate can span tenants and is refused. "
+                f"Bind '{tf}' to the single scalar ctx.tenant_id."
+            )
+        # Normalize both sides: an INT-typed tenant_id column vs a str-coerced
+        # bound tenant must not falsely refuse a same-tenant write.
+        if str(tenant_value) != str(self._enforce_tenant):
+            raise FabricTenantScopeError(
+                f"cross-tenant fabric {operation} of '{model}': the write "
+                f"payload '{tf}'={tenant_value!r} does not match the bound "
+                f"tenant scope {self._enforce_tenant!r}; a fabric product may "
+                f"not write a foreign tenant's row; refused."
+            )
+        return data
+
+    async def _verify_write_target_tenant(
+        self,
+        operation: str,
+        model: str,
+        record_id: Any,
+    ) -> None:
+        """Pre-write tenant check for a PK-addressed mutation.
+
+        ``update`` / ``delete`` (and the UPDATE half of ``upsert``) address a
+        row by GLOBAL primary key with no tenant predicate, so a multi_tenant
+        product could otherwise mutate another tenant's row by PK. The stored
+        row is fetched (via the unenforced underlying express) and its
+        ``tenant_field`` MUST equal the bound tenant, else the mutation is
+        refused and NO row is touched. A ``None`` / absent row is a normal miss
+        and passes through unchanged.
+
+        The FOREIGN tenant id comes from the DATABASE (another tenant's stored
+        value), so it is NEVER echoed — a sha256 fingerprint is emitted for
+        forensic correlation instead (``observability.md`` Rule 8).
+
+        Raises:
+            FabricTenantScopeError: When enforcement is active and the target
+                row belongs to a different tenant (or lacks the tenant field).
+        """
+        if self._enforce_tenant is None:
+            return
+        row = await self._express.read(model, record_id)
+        if row is None:
+            return
+        tf = self._tenant_field
+        row_tenant = row.get(tf) if isinstance(row, dict) else None
+        if (
+            not isinstance(row, dict)
+            or tf not in row
+            or str(row_tenant) != str(self._enforce_tenant)
+        ):
+            from dataflow.fabric.cache import FabricTenantScopeError
+
+            if isinstance(row, dict) and tf in row:
+                foreign = (
+                    "sha256:"
+                    + hashlib.sha256(str(row_tenant).encode("utf-8")).hexdigest()[:8]
+                )
+            else:
+                foreign = "<absent>"
+            touched = "deleted" if operation == "delete" else "modified"
+            raise FabricTenantScopeError(
+                f"cross-tenant fabric {operation} of '{model}': the target "
+                f"record belongs to a different tenant (foreign tenant "
+                f"{foreign}), not the bound tenant scope "
+                f"{self._enforce_tenant!r}; refused and no row {touched} "
+                f"(PK-addressed writes are tenant-verified pre-write)."
+            )
+
     # -- Read operations (cached) -------------------------------------------
 
     async def list(
@@ -616,23 +805,60 @@ class PipelineScopedExpress:
     async def create(
         self, model: str, data: Dict[str, Any], **kwargs: Any
     ) -> Dict[str, Any]:
-        """Create a record (not cached)."""
+        """Create a record (not cached).
+
+        Under multi-tenant enforcement the payload's tenant scope is forced
+        or validated (a foreign ``tenant_id`` is refused) before the write
+        runs (issue #1659).
+        """
+        data = self._guard_write_payload_tenant(
+            "create", model, data, force_inject=True
+        )
         return await self._express.create(model, data, **kwargs)
 
     async def update(
         self, model: str, record_id: str, data: Dict[str, Any], **kwargs: Any
     ) -> Dict[str, Any]:
-        """Update a record (not cached)."""
+        """Update a record (not cached).
+
+        Under multi-tenant enforcement the target row (addressed by global PK)
+        is tenant-verified BEFORE the write — a cross-tenant PK update is
+        refused and no row is modified — and a patch attempting to move the row
+        to a foreign tenant is refused (issue #1659).
+        """
+        await self._verify_write_target_tenant("update", model, record_id)
+        data = self._guard_write_payload_tenant(
+            "update", model, data, force_inject=False
+        )
         return await self._express.update(model, record_id, data, **kwargs)
 
     async def delete(self, model: str, record_id: str, **kwargs: Any) -> bool:
-        """Delete a record (not cached)."""
+        """Delete a record (not cached).
+
+        Under multi-tenant enforcement the target row (addressed by global PK)
+        is tenant-verified BEFORE the delete — a cross-tenant PK delete is
+        refused and no row is deleted (issue #1659).
+        """
+        await self._verify_write_target_tenant("delete", model, record_id)
         return await self._express.delete(model, record_id, **kwargs)
 
     async def upsert(
         self, model: str, data: Dict[str, Any], **kwargs: Any
     ) -> Dict[str, Any]:
-        """Upsert a record (not cached)."""
+        """Upsert a record (not cached).
+
+        Under multi-tenant enforcement the payload's tenant scope is forced or
+        validated (a foreign ``tenant_id`` is refused); and when the payload
+        carries a global PK (``id``) — so the upsert may UPDATE an existing row
+        by conflict — that target row is tenant-verified before the write, so a
+        cross-tenant ``id`` collision cannot overwrite another tenant's row
+        (issue #1659; complements the SQL-builder tenant-guard of #1650).
+        """
+        data = self._guard_write_payload_tenant(
+            "upsert", model, data, force_inject=True
+        )
+        if self._enforce_tenant is not None and isinstance(data, dict) and "id" in data:
+            await self._verify_write_target_tenant("upsert", model, data["id"])
         return await self._express.upsert(model, data, **kwargs)
 
     def clear_cache(self) -> None:
@@ -713,6 +939,9 @@ class PipelineContext(FabricContext):
             sources=sources,
             products_cache=products_cache,
             tenant_id=tenant_id,
+            # Propagate the resolved scope so ctx.source(...) is tenant-guarded
+            # for a multi_tenant product (issue #1658) — None disables it.
+            enforce_tenant=enforce_tenant,
         )
 
     @property

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_write_and_source_tenant_guards.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_write_and_source_tenant_guards.py
@@ -330,6 +330,40 @@ async def test_multi_tenant_product_source_read_is_refused_fail_closed():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_multi_tenant_product_source_write_and_degradation_are_refused():
+    """The source ``write`` (async) and ``last_successful_data`` (sync
+    degradation) paths are refused fail-closed under enforcement, exactly like
+    the read paths — one direct test per variant (issue #1658), so neither
+    one-line delegation can regress silently."""
+    crm = MockSource("crm", data={"": {"deals": ["cross-tenant-secret"]}})
+
+    ctx = PipelineContext(
+        express=None,
+        sources={"crm": crm},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,  # multi_tenant product
+    )
+    handle = ctx.source("crm")
+
+    # write (async) is refused before it can touch the adapter.
+    with pytest.raises(FabricTenantScopeError) as exc_write:
+        await handle.write("deals", {"amount": 100})
+    msg_write = str(exc_write.value)
+    assert "tenant-a" in msg_write and "crm" in msg_write
+    assert "cross-tenant-secret" not in msg_write
+    assert isinstance(exc_write.value, FabricTenantRequiredError)
+
+    # last_successful_data (sync degradation helper) is refused too — the
+    # cached payload is prior fetched row data.
+    with pytest.raises(FabricTenantScopeError) as exc_deg:
+        handle.last_successful_data()
+    assert "cross-tenant-secret" not in str(exc_deg.value)
+    assert isinstance(exc_deg.value, FabricTenantRequiredError)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_single_tenant_product_source_read_is_unaffected():
     """A single-tenant (non-enforcing) context reads the source unchanged —
     no regression for products that are not multi_tenant (issue #1658)."""

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_write_and_source_tenant_guards.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_fabric_write_and_source_tenant_guards.py
@@ -1,0 +1,348 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tier 2 integration tests — fail-closed tenant guards on the DataFlow fabric
+WRITE path (issue #1659) and external-SOURCE path (issue #1658).
+
+Real infrastructure only: a real DataFlow instance on file-backed SQLite,
+real ``db.express`` CRUD, a real enforcing ``PipelineContext``, and a real
+``MockSource`` (a ``BaseSourceAdapter`` subclass — a protocol-satisfying
+deterministic adapter, NOT a unittest.mock). NO mocking.
+
+Coverage:
+  #1659 write path — for EACH of create / update / delete / upsert:
+    * a cross-tenant attempt is REFUSED (raises FabricTenantScopeError), the
+      refusal never exposes another tenant's stored field values / ids, and a
+      read-back confirms the other tenant's row was NOT written / mutated /
+      deleted;
+    * a same-tenant op SUCCEEDS and is verified with a read-back.
+  #1658 source path — a multi_tenant product's ctx.source(...) read is
+    REFUSED fail-closed; a single-tenant (non-enforcing) context reads the
+    source unchanged.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.fabric.cache import FabricTenantRequiredError, FabricTenantScopeError
+from dataflow.fabric.context import PipelineContext
+from dataflow.fabric.testing import MockSource
+
+# ---------------------------------------------------------------------------
+# Fixture — real DataFlow on file-backed SQLite with two tenants' rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_with_two_tenants():
+    """Real DataFlow (file-backed SQLite) with a Deal model and 2 tenants."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = Path(tmpdir) / "fabric_write.db"
+    db = DataFlow(f"sqlite:///{db_path}", auto_migrate=True)
+
+    @db.model
+    class Deal:  # noqa: D401 - test model
+        tenant_id: str
+        name: str
+
+    await db.initialize()
+
+    await db.express.create("Deal", {"tenant_id": "tenant-a", "name": "a-deal-1"})
+    await db.express.create("Deal", {"tenant_id": "tenant-b", "name": "b-deal-1"})
+
+    yield db
+
+    close = getattr(db, "close", None)
+    if close is not None:
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+
+
+def _enforcing_ctx(db: DataFlow, tenant_id: str) -> PipelineContext:
+    """An enforcing multi_tenant PipelineContext bound to ``tenant_id``."""
+    return PipelineContext(
+        express=db.express,
+        sources={},
+        products_cache={},
+        tenant_id=tenant_id,
+        enforce_tenant_scope=True,
+    )
+
+
+async def _row_by_tenant(db: DataFlow, tenant_id: str) -> dict:
+    """Discover a tenant's row via the RAW (unenforced) express."""
+    rows = await db.express.list("Deal", filter={"tenant_id": tenant_id})
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# #1659 create — foreign tenant_id refused; same-tenant + force-inject work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_cross_tenant_payload_is_refused_no_leak(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await ctx.express.create("Deal", {"tenant_id": "tenant-b", "name": "intruder"})
+    msg = str(exc.value)
+    assert "cross-tenant" in msg
+    assert isinstance(exc.value, FabricTenantRequiredError)
+    # No-leak: the refusal does not expose tenant-b's STORED row values.
+    assert "b-deal-1" not in msg
+
+    # Read-back: tenant-b still has exactly its original row (nothing written).
+    b_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    assert [r["name"] for r in b_rows] == ["b-deal-1"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_same_tenant_succeeds_and_force_injects(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+
+    # Explicit own tenant → succeeds.
+    await ctx.express.create("Deal", {"tenant_id": "tenant-a", "name": "a-deal-2"})
+    # Absent tenant → forced to the bound tenant (never unscoped).
+    await ctx.express.create("Deal", {"name": "a-forced"})
+
+    # Read-back: both new rows landed under tenant-a; tenant-b untouched.
+    a_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-a"})
+    assert sorted(r["name"] for r in a_rows) == ["a-deal-1", "a-deal-2", "a-forced"]
+    assert all(r["tenant_id"] == "tenant-a" for r in a_rows)
+    b_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    assert [r["name"] for r in b_rows] == ["b-deal-1"]
+
+
+# ---------------------------------------------------------------------------
+# #1659 update — cross-tenant PK refused (no leak); same-tenant works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_cross_tenant_pk_is_refused_no_leak(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    b_id = (await _row_by_tenant(db, "tenant-b"))["id"]
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await ctx.express.update("Deal", b_id, {"name": "hijacked"})
+    msg = str(exc.value)
+    assert "cross-tenant" in msg
+    # No-leak: the FOREIGN tenant id (from the DB) is fingerprinted, not echoed.
+    assert "tenant-b" not in msg
+    assert "sha256:" in msg
+    assert "tenant-a" in msg  # bound (own) tenant is safe to name
+
+    # Read-back: tenant-b's row is unchanged.
+    assert (await _row_by_tenant(db, "tenant-b"))["name"] == "b-deal-1"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_foreign_tenant_in_patch_is_refused(db_with_two_tenants):
+    """Updating OWN row but attempting to MOVE it to a foreign tenant is refused."""
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    a_id = (await _row_by_tenant(db, "tenant-a"))["id"]
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await ctx.express.update("Deal", a_id, {"tenant_id": "tenant-b"})
+    assert "cross-tenant" in str(exc.value)
+
+    # Read-back: the row still belongs to tenant-a.
+    assert (await _row_by_tenant(db, "tenant-a"))["tenant_id"] == "tenant-a"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_same_tenant_succeeds(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    a_id = (await _row_by_tenant(db, "tenant-a"))["id"]
+
+    await ctx.express.update("Deal", a_id, {"name": "a-deal-renamed"})
+
+    # Read-back: the own-tenant update persisted.
+    assert (await _row_by_tenant(db, "tenant-a"))["name"] == "a-deal-renamed"
+
+
+# ---------------------------------------------------------------------------
+# #1659 delete — cross-tenant PK refused (no leak); same-tenant works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_delete_cross_tenant_pk_is_refused_no_leak(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    b_id = (await _row_by_tenant(db, "tenant-b"))["id"]
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await ctx.express.delete("Deal", b_id)
+    msg = str(exc.value)
+    assert "cross-tenant" in msg
+    assert "tenant-b" not in msg  # foreign id not leaked verbatim
+    assert "sha256:" in msg
+
+    # Read-back: tenant-b's row still exists.
+    b_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    assert [r["name"] for r in b_rows] == ["b-deal-1"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_delete_same_tenant_succeeds(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    a_id = (await _row_by_tenant(db, "tenant-a"))["id"]
+
+    await ctx.express.delete("Deal", a_id)
+
+    # Read-back: the own-tenant row is gone.
+    a_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-a"})
+    assert a_rows == []
+
+
+# ---------------------------------------------------------------------------
+# #1659 upsert — foreign payload + foreign-PK conflict refused; own works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_cross_tenant_payload_is_refused_no_leak(db_with_two_tenants):
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        await ctx.express.upsert("Deal", {"tenant_id": "tenant-b", "name": "x"})
+    msg = str(exc.value)
+    assert "cross-tenant" in msg
+    assert "b-deal-1" not in msg
+
+    b_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    assert [r["name"] for r in b_rows] == ["b-deal-1"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_foreign_pk_conflict_is_refused_no_leak(db_with_two_tenants):
+    """An upsert carrying another tenant's global PK (the UPDATE-by-conflict
+    half) is refused before it can overwrite that tenant's row."""
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    b_id = (await _row_by_tenant(db, "tenant-b"))["id"]
+
+    with pytest.raises(FabricTenantScopeError) as exc:
+        # tenant_id is force-injected to tenant-a, but the PK targets tenant-b.
+        await ctx.express.upsert("Deal", {"id": b_id, "name": "steal"})
+    msg = str(exc.value)
+    assert "cross-tenant" in msg
+    assert "tenant-b" not in msg
+    assert "sha256:" in msg
+
+    # Read-back: tenant-b's row is unchanged (not overwritten / reassigned).
+    b_row = await _row_by_tenant(db, "tenant-b")
+    assert b_row["name"] == "b-deal-1"
+    assert b_row["tenant_id"] == "tenant-b"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_same_tenant_own_row_by_pk_succeeds(db_with_two_tenants):
+    """A same-tenant upsert conflicting on the caller's OWN PK passes both the
+    payload guard and the target-row tenant verify, and persists. (express
+    upsert derives its conflict ``where`` from the ``id`` field.)"""
+    db = db_with_two_tenants
+    ctx = _enforcing_ctx(db, "tenant-a")
+    a_id = (await _row_by_tenant(db, "tenant-a"))["id"]
+
+    await ctx.express.upsert(
+        "Deal", {"id": a_id, "tenant_id": "tenant-a", "name": "a-ups-updated"}
+    )
+
+    # Read-back: the own-tenant upsert persisted; tenant-b untouched.
+    assert (await _row_by_tenant(db, "tenant-a"))["name"] == "a-ups-updated"
+    b_rows = await db.express.list("Deal", filter={"tenant_id": "tenant-b"})
+    assert [r["name"] for r in b_rows] == ["b-deal-1"]
+
+
+# ---------------------------------------------------------------------------
+# #1658 source — multi_tenant product's source read refused; single-tenant OK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_multi_tenant_product_source_read_is_refused_fail_closed():
+    """A multi_tenant product's ctx.source(...) data read is refused
+    fail-closed — the fabric cannot prove an external source is tenant-scoped,
+    so it never returns unscoped cross-tenant rows (issue #1658)."""
+    crm = MockSource("crm", data={"": {"deals": ["cross-tenant-secret"]}})
+
+    ctx = PipelineContext(
+        express=None,
+        sources={"crm": crm},
+        products_cache={},
+        tenant_id="tenant-a",
+        enforce_tenant_scope=True,  # multi_tenant product
+    )
+    handle = ctx.source("crm")
+
+    # Every data method is refused fail-closed.
+    for op in (
+        lambda: handle.fetch(),
+        lambda: handle.fetch_all(),
+        lambda: handle.read(),
+        lambda: handle.list(),
+    ):
+        with pytest.raises(FabricTenantScopeError) as exc:
+            await op()
+        msg = str(exc.value)
+        assert "tenant-a" in msg  # bound (own) tenant named
+        assert "crm" in msg  # source named
+        # No-leak: the un-returned source payload is never in the refusal.
+        assert "cross-tenant-secret" not in msg
+        assert isinstance(exc.value, FabricTenantRequiredError)
+
+    # fetch_pages is an async generator — refused on first iteration.
+    with pytest.raises(FabricTenantScopeError):
+        async for _ in handle.fetch_pages():
+            pass
+
+    # Metadata accessors carry no row data and stay open.
+    assert handle.name == "crm"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_single_tenant_product_source_read_is_unaffected():
+    """A single-tenant (non-enforcing) context reads the source unchanged —
+    no regression for products that are not multi_tenant (issue #1658)."""
+    crm = MockSource("crm", data={"": {"deals": [1, 2, 3]}})
+
+    ctx = PipelineContext(
+        express=None,
+        sources={"crm": crm},
+        products_cache={},
+        tenant_id=None,
+        enforce_tenant_scope=False,  # single-tenant product
+    )
+    handle = ctx.source("crm")
+
+    data = await handle.fetch()
+    assert data == {"deals": [1, 2, 3]}


### PR DESCRIPTION
## Summary
Closes the two cross-tenant breaches surfaced by the #1654 read-path security gate:

- **#1659 (HIGH)** — `PipelineScopedExpress.create/update/delete/upsert` had no tenant check. A `multi_tenant` product bound to tenant A could update/delete tenant B's row by PK, or create a row with a foreign `tenant_id`. Now: update/delete **refuse** (raise `FabricTenantScopeError`) when the target row's `tenant_id` != bound tenant; create/upsert **force or validate** `tenant_id == bound tenant`.
- **#1658 (MED)** — `ctx.source()`/`SourceHandle` delegated straight to the adapter with no tenant filter. A `multi_tenant` product's source reads returned unscoped cross-tenant rows. Now: every source data method (fetch/fetch_all/fetch_pages/read/list/write/last_successful_data) is **refused fail-closed** under enforcement (the fabric cannot prove an opaque external adapter honored a tenant predicate → tightest disposition, tenant-isolation Rule 8). The #1654 "sources are NOT covered" docstring note is removed.

Both surfaces derive from the SAME `enforce_tenant` decision computed once in `PipelineContext.__init__` (enforcement-surface parity with the #1654 read guard).

## Security invariants
- Foreign tenant ids read from the DB are sha256-fingerprinted in refusal messages, never echoed (no cross-tenant leak); only the caller's own tenant/input is named.
- Fail-closed everywhere (missing tenant, foreign tenant in payload, opaque source → refuse).
- No f-string/concat SQL introduced; tenant predicates bound as dict entries.

## Testing
- New Tier-2 regression suite (real file-backed SQLite, no mocking): **13 passed**, one direct test per write op + per source variant, each with a cross-tenant-no-leak assertion.
- Full fabric + tenancy regression surface: **440 passed, 9 skipped** (PG/Docker-gated rows).

## Redteam
reviewer + security-reviewer both converged CLEAN (full-context merge gate). LOW/informational advisories dispositioned:
- PK-existence oracle + TOCTOU window on the write-verify path — inherent to check-then-act with global PKs; no tenant identity/field leak; the atomic defense for the upsert conflict path is the #1650 SQL-builder guard.
- Source `write`/`last_successful_data` direct-test gap — **fixed in this PR** (second commit).

## Related issues
Fixes #1659
Fixes #1658
Follow-up to #1654.