### PR TITLE
release: kailash-dataflow 2.14.7 (fabric write/source tenant guards #1659, #1658)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [2.14.7] — 2026-07-10 — fabric write-path + source-path tenant guards (#1659, #1658)
+
+### Security
+
+- **Fail-closed tenant guards on the fabric write path and `ctx.source()` read path (#1659 HIGH, #1658).** Follow-ups to the #1654 read-path interceptor, closing the two cross-tenant surfaces #1654 explicitly did not cover:
+  - **Write path (#1659):** `PipelineScopedExpress.create/update/delete/upsert` now enforce the bound tenant. `update`/`delete` refuse (raise `FabricTenantScopeError`) when the target row's `tenant_id` differs from the bound tenant; `create`/`upsert` force-inject the bound tenant on an absent value and refuse a foreign `tenant_id` — closing cross-tenant write and row-theft-by-PK for `multi_tenant` fabric products.
+  - **Source path (#1658):** `ctx.source(name)` reads for a `multi_tenant` product are refused fail-closed across every data method (fetch/fetch_all/fetch_pages/read/list/write/last_successful_data) — the fabric cannot prove an opaque external adapter applied a tenant predicate, so under enforcement it refuses rather than return unscoped rows (`tenant-isolation.md` Rule 8). The #1654 "sources are NOT covered" docstring note is removed.
+  - Both surfaces derive enforcement from the single `enforce_tenant` decision computed in `PipelineContext.__init__` (parity with the #1654 read guard). Foreign tenant ids are sha256-fingerprinted in refusal messages, never echoed. Tier-2 regression suite (real DB, no mocking): 13 tests, one direct refusal + no-leak assertion per write op and per source variant. Verified via a two-agent full-context `/redteam` (reviewer + security-reviewer, both clean).
+
 ## [2.14.6] — 2026-07-10 — cross-DB query-cache bleed fix (#1606) + fabric tenant-scope interceptor (#1654)
 
 ### Security

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.14.6"
+version = "2.14.7"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.14.6"
+__version__ = "2.14.7"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Release-prep for kailash-dataflow 2.14.7. Metadata-only (version bump + CHANGELOG) atop the merged #1665 fabric guards. Security: closes cross-tenant write (#1659 HIGH) + source-read (#1658) on the DataFlow fabric. Publishes on tag `dataflow-v2.14.7`.