### PR TITLE
codify: handoff-completion redteam fixes + loom Gate-1 follow-ups

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -942,4 +942,5 @@ changes:
     \ never left implied-done in a local note; a cross-repo artifact is referenced as existing only after\
     \ created/verified this session; needs-authorization means ASK specifically, not stop at a note. Co-owner-directed\
     \ origination (BH5 session left a local rs handoff + a wrong rs#1714 ref unfiled). Rule-10 named-rationale:\
-    \ non-decomposable critical behavioral contract, authored tight (~130 lines). Origin journal/0010."
+    \ non-decomposable critical behavioral contract, authored tight (minimal load-bearing clauses; depth\
+    \ in DO/DO-NOT). Origin journal/0010."

--- a/.claude/rules/handoff-completion.md
+++ b/.claude/rules/handoff-completion.md
@@ -11,7 +11,7 @@ When a session's work is only complete once a DOWNSTREAM action happens — a cr
 
 ### 1. A Downstream-Required Action Is Executed Or Explicitly Surfaced As Pending — Never Left Implied-Done
 
-If completing a deliverable REQUIRES an action on another repo / an external surface (file an issue, open a cross-repo PR, send a handoff), the session MUST either (a) EXECUTE it this session, or (b) surface it in the wrap-up as an EXPLICIT pending action: the exact target, the exact action, and the specific authorization or input it is waiting on. Leaving it as a local artifact ("handoff prepared", "notes for the Rust SDK") with no executed action and no explicit pending-surface is BLOCKED. "The next session / the human will pick it up from the notes" is not a handoff — it is an abandonment.
+If completing a deliverable REQUIRES an action on another repo / an external surface (file an issue, open a cross-repo PR, send a handoff), the session MUST either (a) EXECUTE it this session (a cross-repo write requires ALL FIVE `repo-scope-discipline.md` User-Authorized-Exception conditions — user-initiated, explicit+specific, confirmed, journaled-before-acting, scoped-exactly — never self-authorization), or (b) surface it AT THE MOMENT THE DELIVERABLE IS CLAIMED DONE (and again at wrap-up) as an EXPLICIT pending action: the exact target, the exact action, and the specific authorization or input it is waiting on. Leaving it as a local artifact ("handoff prepared", "notes for the Rust SDK") with no executed action and no explicit pending-surface is BLOCKED. "The next session / the human will pick it up from the notes" is not a handoff — it is an abandonment.
 
 ```markdown
 # DO — either execute, or surface the exact pending action
@@ -35,6 +35,8 @@ mirror remains the cross-SDK lockstep." # no issue filed, nothing asked — # th
 - "The notes say it's pending; that's surfacing it"
 - "It needs authorization, so leaving a note is the safe default"
 - "The next session will pick it up from the session notes"
+- "I added it to the workspace todos / backlog; the next /implement will action it"
+- "It's tracked in a local issue draft, that's good enough"
 
 **Why:** A local note is invisible on the surface that actually needs the action (the other repo); nobody downstream is watching the note, so "prepared" becomes "never done" and the human discovers the gap only by asking. Executing it, or naming it as an explicit pending action with its authorization requirement, is the only disposition that closes the loop.
 
@@ -51,6 +53,14 @@ Verified rs#1732 open (filed this session). / "rs#1714" — unverified; check be
 
 "the remaining lockstep is tracked in rs#1714" # never verified; rs#1714 was # actually a DIFFERENT primitive
 ```
+
+**BLOCKED rationalizations:**
+
+- "The tracker number is in my notes, it's fine to cite it"
+- "The prior session established rs#NNNN as the tracker"
+- "It's the same primitive, the number is close enough"
+- "I referenced it last time, it must still be open"
+- "`gh issue view` is an extra step; the reference is obviously right"
 
 **Why:** An unverified downstream reference stated as fact misdirects every reader who trusts it, and hides that the artifact was never created — the exact shape that let a "prepared" handoff look done. One `gh issue view` before citing is the whole cost.
 
@@ -70,7 +80,15 @@ and I'll draft the scrubbed body, journal the grant, and file it. (y/N)"
 workspace." # never asked; the human must now discover and drive it
 ```
 
-**Why:** "It needed authorization" is the most plausible-sounding rationalization for the prepared ≠ delivered failure — it sounds disciplined while doing nothing. The discipline is to gate the ACTION behind a specific ask, not to substitute a local note for the ask.
+**BLOCKED rationalizations:**
+
+- "It needs authorization, so leaving a note is the safe default"
+- "I can't self-authorize a cross-repo write, so I've done all I can"
+- "The user has a standing 'I authorize you', a specific ask is redundant"
+- "Asking again is nagging; the note documents what's needed"
+- "Surfacing the requirement in notes IS the ask"
+
+**Why:** "It needed authorization" is the most plausible-sounding rationalization for the prepared ≠ delivered failure — it sounds disciplined while doing nothing. The discipline is to gate the ACTION behind a specific ask, not to substitute a local note for the ask. A blanket standing grant ("i already authorize you") still does not satisfy `repo-scope-discipline.md`'s per-action confirm-and-journal, so the specific ask is still required.
 
 ## MUST NOT
 
@@ -95,4 +113,4 @@ workspace." # never asked; the human must now discover and drive it
 
 ## Origin
 
-2026-07-11 — co-owner-directed origination. The BH5 session prepared a local Rust-SDK handoff doc, referenced `rs#1714` as the BH5 lockstep tracker (it was actually the BH3 tracker), and reported the cross-SDK mirror as "handoff prepared" without filing any issue on the Rust SDK repo — leaving the completion for the human to infer and drive. Verbatim directive: _"i already authorize you, if you don't specifically ask for it and just leave your notes locally and expect it to be magically done at kailash-rs or expect me to fill in the gaps for you, that's very irresponsible! please codify this unacceptable behavior and NEVER LET IT HAPPEN AGAIN!"_ Correction executed the same session: filed rs#1732 (the BH5 circuit-breaker cross-SDK parity issue), corrected the `rs#1714` misreference on py #1510, and codified this rule. Grant + receipt: `journal/0010`. Sibling of `build-repo-release-discipline.md` ("done means released, not merged") one layer out to cross-repo handoffs, and of `verify-claims-before-write.md` (MUST-2) for the unverified-reference half.
+2026-07-11 — co-owner-directed origination. The BH5 session prepared a local Rust-SDK handoff doc, referenced `rs#1714` as the BH5 lockstep tracker (it was actually the BH3 tracker), and reported the cross-SDK mirror as "handoff prepared" without filing any issue on the Rust SDK repo — leaving the completion for the human to infer and drive. Verbatim directive: _"i already authorize you, if you don't specifically ask for it and just leave your notes locally and expect it to be magically done at kailash-rs or expect me to fill in the gaps for you, that's very irresponsible! please codify this unacceptable behavior and NEVER LET IT HAPPEN AGAIN!"_ Correction executed the same session: filed rs#1732 (the BH5 circuit-breaker cross-SDK parity issue), corrected the `rs#1714` misreference on py #1510, and codified this rule. Grant + receipt: `journal/0010`. Sibling of `build-repo-release-discipline.md` ("done means released, not merged") one layer out to cross-repo handoffs; MUST-2 (unverified cross-repo reference) pairs with `verify-claims-before-write.md` MUST-2 and `verify-resource-existence.md` MUST-2 (a cross-repo issue number is a resource-existence claim). Two loom-canonical follow-ups — whether MUST-2 relocates to the path-scoped `verify-claims-before-write.md`, and whether this rule joins the `self-referential-codify.md` Rule 2 allowlist (MUST-2 fires on codify-class output) — are flagged for loom Gate-1 in the codify redteam amendment (`journal/0012`).

--- a/workspaces/sdk-backlog/journal/0012-AMENDMENT-handoff-completion-redteam-and-loom-followups.md
+++ b/workspaces/sdk-backlog/journal/0012-AMENDMENT-handoff-completion-redteam-and-loom-followups.md
@@ -1,0 +1,35 @@
+# AMENDMENT — handoff-completion redteam results + loom Gate-1 follow-ups
+
+**Date:** 2026-07-11
+**Phase:** 05-codify
+**Type:** AMENDMENT
+**relates_to:** 0011-DECISION-codify-handoff-completion-and-rs1732-receipt
+
+## Redteam (reviewer + cc-architect, parallel)
+
+- **reviewer:** SUFFICIENT-WITH-FIXES — the rule prevents the target failure; distinct from siblings; baseline scope justified (fires in completion-reporting reasoning, no file-path anchor).
+- **cc-architect:** COMPLIANT-WITH-FIXES — 8-field wiring, frontmatter pair, Rule-10 named-rationale, `global` classification all PASS.
+
+## Fixes APPLIED this amendment (in `rules/handoff-completion.md`)
+
+1. MUST-2 gained a 5-phrase BLOCKED corpus (rule-authoring Rule 2 — the clause targets a rationalizable behavior).
+2. MUST-3 gained a 5-phrase BLOCKED corpus, incl. the standing-authorization phrase ("i already authorize you" still needs the per-action ask + journal per `repo-scope-discipline.md`).
+3. MUST-1 BLOCKED list gained the local-todo/backlog variant (2 phrases).
+4. MUST-1 body: the surface obligation now attaches to the moment done is CLAIMED (not deferred to a wrap-up that may not run); option (a) EXECUTE now binds the five `repo-scope-discipline.md` User-Authorized-Exception conditions (execute ≠ self-authorize).
+5. Cross-refs: added `verify-resource-existence.md` MUST-2 alongside `verify-claims-before-write.md` for MUST-2's unverified-reference half.
+
+## Durable-claim correction (verify-claims-before-write MUST-1)
+
+The proposal context asserted the rule is "~130 lines"; verified actual is **98 lines** (pre-fix). Corrected in `.claude/.proposals/latest.yaml`. (An unverified count in a durable artifact — the exact class Rule 4d + verify-claims-before-write block; caught by cc-architect.)
+
+## Loom Gate-1 follow-ups (loom-canonical design decisions — NOT made BUILD-side)
+
+`self-referential-codify.md` + `verify-claims-before-write.md` are loom-canonical codify-discipline artifacts; their structure is loom's to decide when it ingests this proposal. Two flagged decisions:
+
+1. **MUST-2 home.** reviewer Finding 7: MUST-2 (cross-repo artifact referenced-as-existing) is a durable-write-surface claim that could relocate to the path-scoped `verify-claims-before-write.md` (recovers baseline budget) OR stay here (it is integral to the handoff failure — the `rs#1714` misreference was half the incident). Kept here BUILD-side; loom decides at Gate-1.
+2. **Self-ref allowlist membership.** cc-architect Finding 4: MUST-2 fires on codify-class output (journal/session-notes/PR bodies) — the same predicate that admitted `verify-claims-before-write.md` to the `self-referential-codify.md` Rule 2 allowlist. Genuine boundary case (center of gravity is session-completion, OUT; MUST-2 overlap points IN). Editing that allowlist is itself a self-referential codify (loom-canonical); flagged for loom to resolve explicitly at Gate-1 rather than resolved by silence.
+
+## NOT done here (surfaced, per handoff-completion itself)
+
+- **Eval-harness validation:** no rule eval-harness exists in this BUILD repo (`.claude/test-harness/` absent); it is loom-side. UNTESTED behaviorally; loom's `/codify` eval is the validation surface.
+- **Loom ingestion:** the proposal is queued (`pending_review`); loom's `/sync-from-build` → `/codify` redteam → eval → Gate-1 classify → `/sync-to-use` is the pending downstream action. Tracking issue filed to make it a real surface, not a note.


### PR DESCRIPTION
Applies reviewer + cc-architect findings to the new baseline rule (BLOCKED corpora, local-todo variant, done-claim surface timing, repo-scope binding, cross-refs; removed a drift-prone count). Two loom-canonical design decisions flagged for Gate-1 (journal/0012). 🤖 Generated with [Claude Code](https://claude.com/claude-code)