### PR TITLE
chore(workspace): redteam fourth-pass re-convergence receipt (post-v2.48.0 codify wave)

### DIFF
--- a/workspaces/sdk-backlog/04-validate/redteam-2026-07-11-fourthpass.md
+++ b/workspaces/sdk-backlog/04-validate/redteam-2026-07-11-fourthpass.md
@@ -1,0 +1,69 @@
+# /redteam — 2026-07-11 (sdk-backlog, FOURTH-pass independent re-convergence)
+
+Repo: terrene-foundation/kailash-py (BUILD, PUBLIC). Posture: **L5_DELEGATED** (un-enrolled,
+coordination OFF/solo). Mode: parallelized under `/autonomize`, evidence-gated (an errored/empty
+reviewer return = zero evidence → re-run, never counted clean). Convergence: **2 consecutive
+clean rounds**.
+
+## Why a fourth pass
+
+The post-v2.48.0 codify wave converged three times prior (journal 0013 → PR #1682; journal 0015 →
+PR #1685; journal 0016 third-pass → PR #1686). HEAD has since advanced `e79366ab9` → `c5bc9914e`
+(the codify follow-up #1687 + wrapup #1688). Per `verify-resource-existence.md` MUST-4 a
+convergence verdict is re-DERIVED, not inherited from a prior self-report — this is an independent
+holistic re-verification across the full merged union on CURRENT main, with fresh adversarial
+lenses (baseline-slot justification, semantic cross-ref integrity, closure-parity of prior fixes).
+
+## Scope
+
+`git diff v2.48.0..HEAD` (HEAD=`c5bc9914e`) — an **artifact-only** wave, **zero `*.py` delta**.
+Durable non-workspace artifacts:
+
+- `.claude/rules/handoff-completion.md` — NEW baseline rule (116 lines)
+- `.claude/rules/cross-sdk-inspection.md` — Rule 4d + shared-ack normalization (306 lines)
+- `.claude/.proposals/latest.yaml` — BUILD→loom proposal (25 changes, pending_review)
+- `.session-notes.shared.md` + `.session-notes.d/esperie.md` — committed shared notes
+
+## Rounds (5 adversarial clusters + 1 orchestrator evidence-gate sweep; every cluster genuinely RAN)
+
+| Round | Cluster                                                          | Verdict  | Notes                                                                               |
+| ----- | ---------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| R1-A  | cc-architect — handoff-completion.md (rule-authoring + wiring)   | 0C/0H/0M | 116-line (no rationale needed); 8-field wiring complete; all xrefs resolve          |
+| R1-B  | reviewer — cross-sdk-inspection 4d + latest.yaml integrity       | 0C/0H/0M | YAML pending_review/25; esperie 9 unchanged; append-preserving; ack-normalized      |
+| R1-C  | security-reviewer — disclosure/secret/sensitivity across union   | 0C/0H    | 0 secrets; esperie 0 in both new rules; committed notes carry no operator-local     |
+| R1-∆  | orchestrator — net-widening evidence gate (Bash, closed C's gap) | 0        | `+9/−9` net 0 in latest.yaml; rules+notes added 0; HEAD absolute 9/0/0              |
+| R2-D  | general-purpose — mechanical battery + closure-parity            | 0C/0H/0M | 3 prior FIXED LOWs present on HEAD; both loom follow-ups present; no dangling xref  |
+| R2-E  | analyst — fresh-eyes holistic (semantic cross-ref integrity)     | 0C/0H/0M | 6 xrefs semantically verified vs target source; baseline slot earned; wave coherent |
+
+## Findings + dispositions
+
+| #    | Sev  | Finding                                                                                                                                                                           | Disposition                                                                                                                                                                                                                                               |
+| ---- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R2-E | —    | Q4 adversarial: `handoff-completion.md` cites `build-repo-release-discipline.md` as "done means released, not merged"; grep for that literal string matched only the citing rule. | **CLEARED** — semantic read of target (`build-repo-release-discipline.md:27/213/215`) confirms a faithful paraphrase of the rule's thesis, not a fabricated quote. The exact false-positive a grep-only check mis-flags HIGH; fresh-eyes lens cleared it. |
+| all  | LOW  | `cross-sdk-inspection.md` 306 lines with no named length-rationale (siblings carry one).                                                                                          | **SURFACED → loom Gate-1** (known; journal 0016/0017 + latest.yaml). Real fix = depth-extract to the guide; BUILD-side band-aid BLOCKED (loom-synced file; priority:10/path-scoped pays no baseline cost).                                                |
+| R1-A | LOW  | handoff-completion.md not on `self-referential-codify.md` allowlist despite MUST-2 firing on codify-class output.                                                                 | **SURFACED → loom Gate-1** — already flagged in the rule's own Origin + journal 0012; allowlist placement is a loom-side decision at land-time.                                                                                                           |
+| R1-C | INFO | Workspace journals 0015/0016/0017 carry own-org `esperie-enterprise/kailash-rs` in prose documenting the F6 finding.                                                              | **KNOWN F6, loom-bound** — own-org (not client/tenant), self-flagged to Gate-1; BUILD-side scrub corrupts the finding's own documentation. Not a new leak.                                                                                                |
+| R2-E | INFO | journal 0009 (immutable first-draft) named a dedicated trigger key for Rule 4d; shipped 4d uses `regression_within_grace`.                                                        | **ACCEPTED** — journal immutable (journal.md); draft→refined drift during convergence. Durable `latest.yaml` entry carries NO stale key claim, so loom won't ingest it.                                                                                   |
+
+## Convergence
+
+| Criterion                                                    | Status                                                                                                     |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| 1. 0 CRITICAL                                                | ✅ all rounds                                                                                              |
+| 2. 0 HIGH                                                    | ✅ all rounds                                                                                              |
+| 3. 2 consecutive clean rounds (every reviewer genuinely ran) | ✅ R1 + R2; 5 clusters + 1 orchestrator sweep returned dense ran-signals; zero errored/empty/throttled     |
+| 4. Spec 100% AST/grep                                        | N/A — artifact-only; the rule-authoring / trust-posture contract IS the spec, grep/AST-verified each round |
+| 5. New code has new tests                                    | N/A — 0 `*.py` delta                                                                                       |
+| 6. Frontend 0 mock                                           | N/A — no frontend                                                                                          |
+| 7. Eval-harness green                                        | N/A — COC-artifact wave; the 5 adversarial clusters ARE the semantic-probe layer                           |
+
+**CONVERGED.** Criteria 1–3 hold; 4–7 structurally N/A for an artifact-only codify wave. 0 new
+fixable findings; 2 items re-confirmed surfaced-to-loom-Gate-1; the potential-HIGH cross-ref
+mis-citation was adversarially probed and cleared via semantic read. The third-pass convergence is
+independently re-verified on current HEAD (`c5bc9914e`).
+
+## Open for human (surfaced, not self-authorized)
+
+- **cross-sdk-inspection 306-line length-rationale** → loom Gate-1 depth-extraction (present in latest.yaml for cascade).
+- **handoff-completion self-referential-codify allowlist** → loom Gate-1 (present in latest.yaml + journal 0012).
+- **latest.yaml own-org `esperie-enterprise`** (F6) → loom Gate-1 templatize-at-source; BUILD-side scrub BLOCKED.

--- a/workspaces/sdk-backlog/journal/0018-DECISION-redteam-fourthpass-reconvergence.md
+++ b/workspaces/sdk-backlog/journal/0018-DECISION-redteam-fourthpass-reconvergence.md
@@ -1,0 +1,55 @@
+---
+type: DECISION
+slug: redteam-fourthpass-reconvergence
+date: 2026-07-11
+phase: 04-validate
+---
+
+# DECISION — /redteam fourth-pass independent re-convergence (post-v2.48.0 codify wave)
+
+## Context
+
+Session directive: continue from prior session, run `/autonomize` + `/redteam` to convergence,
+parallelized (time-pressure framing → parallelization is the throughput response per
+`time-pressure-discipline.md`, NOT a procedure drop). The post-v2.48.0 artifact-only codify wave
+converged three times prior (journal 0013/0015/0016 → PR #1682/#1685/#1686). HEAD advanced
+`e79366ab9` → `c5bc9914e` since the third pass (codify follow-up #1687 + wrapup #1688), so per
+`verify-resource-existence.md` MUST-4 the convergence verdict was re-DERIVED on current main, not
+inherited.
+
+## What ran
+
+Scope: `git diff v2.48.0..HEAD` — artifact-only, zero `*.py`. Two rounds, 5 parallel adversarial
+clusters + 1 orchestrator evidence-gate sweep (cold-start wave of 3 per `worktree-isolation.md`
+Rule 4; each shard carried curated governance slices + explicit mechanical sweeps per `agents.md`):
+
+- **R1-A** cc-architect → handoff-completion.md (rule-authoring + 8-field wiring + manifest/cascade) — CLEAN
+- **R1-B** reviewer → cross-sdk-inspection 4d + latest.yaml integrity — CLEAN
+- **R1-C** security-reviewer → disclosure/secret/sensitivity across the wave union — CLEAN
+- **R1-∆** orchestrator (Bash) → closed C's un-runnable net-widening check: `esperie-enterprise` `+9/−9` net 0 in latest.yaml, 0 added to rules/notes (evidence-first: an un-run check is zero evidence, not clean)
+- **R2-D** general-purpose → mechanical battery + closure-parity of the third-pass fixes — CLEAN (all 3 FIXED LOWs present on HEAD; both loom follow-ups present for cascade)
+- **R2-E** analyst → fresh-eyes holistic, 6 cross-refs semantically verified vs target source — CLEAN
+
+## Decision
+
+**CONVERGED** — 2 consecutive clean rounds (R1 + R2), 0 CRIT / 0 HIGH / 0 MED, every dispatched
+reviewer returned a genuine ran-signal (zero errored/empty/throttled → evidence gate satisfied per
+`agents.md` § Redteam Reviewer Dispatch). Convergence criteria 1–3 hold; 4–7 structurally N/A for
+an artifact-only COC wave (the 5 adversarial clusters ARE the semantic-probe layer). The
+third-pass convergence is independently re-verified on `c5bc9914e`.
+
+Highest-value fresh-eyes catch (R2-E): the `build-repo-release-discipline.md` "done means released,
+not merged" cross-ref — a grep-only check false-flags it HIGH (literal string appears only in the
+citing rule); semantic read of the target cleared it as a faithful paraphrase. Confirms the wave's
+cross-refs are semantically accurate, not just file-resolvable.
+
+## Outstanding (all loom-Gate-1, surfaced not self-authorized — no BUILD-side action)
+
+- cross-sdk-inspection 306-line named length-rationale → loom depth-extract (present in latest.yaml)
+- handoff-completion self-referential-codify allowlist question → loom (present in latest.yaml + journal 0012)
+- latest.yaml own-org `esperie-enterprise` (F6) → loom templatize-at-source; BUILD scrub BLOCKED
+
+## Receipt
+
+Full report: `workspaces/sdk-backlog/04-validate/redteam-2026-07-11-fourthpass.md` (round table +
+findings + convergence matrix). No `*.py` / version / PyPI surface → `/release` N/A to this wave.


### PR DESCRIPTION
## Summary

Independent fourth-pass `/redteam` re-convergence on the post-v2.48.0 **artifact-only** codify wave, re-derived on current `main` (`c5bc9914e`) per `verify-resource-existence.md` MUST-4 — HEAD advanced `e79366ab9` → `c5bc9914e` (via #1687/#1688) since the third pass, so the verdict was re-verified, not inherited.

- 2 rounds, 5 parallel adversarial clusters + 1 orchestrator evidence-gate sweep
- **0 CRIT / 0 HIGH / 0 MED**, 2 consecutive clean rounds, every reviewer genuinely ran (evidence-gated)
- Fresh-eyes lens cleared a potential-HIGH cross-ref mis-citation via semantic read (grep-only would false-flag it)
- Orchestrator closed the read-only security agent's un-runnable net-widening check: `esperie-enterprise` net **+9/−9 = 0**, zero new leakage

## Scope

Adds two durable receipts (no code, no version, no PyPI surface → `/release` N/A):
- `workspaces/sdk-backlog/04-validate/redteam-2026-07-11-fourthpass.md`
- `workspaces/sdk-backlog/journal/0018-DECISION-redteam-fourthpass-reconvergence.md`

## Outstanding (loom-Gate-1, surfaced — no BUILD action)

`cross-sdk-inspection` 306-line length-rationale · `handoff-completion` self-referential-codify allowlist · `esperie-enterprise` own-org F6 — all present in `latest.yaml` for cascade; BUILD-side edits BLOCKED (loom-synced).

## Related issues

None (workspace redteam receipt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)