### PR TITLE
chore(workspace): cross-repo read grant + verified rs# forest status

### DIFF
--- a/workspaces/sdk-backlog/.session-notes
+++ b/workspaces/sdk-backlog/.session-notes
@@ -22,13 +22,14 @@ Phase 05-codify; un-enrolled PUBLIC repo, coordination OFF (solo).
 
 - **PR #1675** disposed: owner closed (verified `state=CLOSED` @ 2026-07-11T13:02:14Z) + blocked account + filed GitHub spam report. Non-security assessment recorded in `0021`.
 - Cleaned 6 superseded `journal/.pending/` auto-capture stubs (all already promoted to `0010`–`0019`).
+- **User-authorized cross-repo read** (`journal/0022` grant): verified 6 rs# issues on kailash-rs read-only. Live forest = **3 OPEN** (rs#1713/F2, rs#1729/F3, rs#1732/BH5); **3 CLOSED** (rs#1712, rs#1667, rs#1707 — incl. rs#1707 BH3 status-change vs `0008`). None blocks this repo; all actionable only in a kailash-rs session.
 
 ## Outstanding ledger (forest — NONE actionable from this repo)
 
 | ID | Item | Value-anchor (MUST-1 source) | Status |
 | -- | ---- | ---------------------------- | ------ |
-| F2 | #1606 express `v2` keyspace (rs#1713) | #1606 — Rust-pinned v2 keyspace | BLOCKED — land py+rs together |
-| F3 | #1601 soft_delete parity (rs#1729) | #1601 — py done; fix Rust-side | in-flight — close when rs lands |
+| F2 | #1606 express `v2` keyspace (rs#1713) | #1606 — Rust-pinned v2 keyspace | rs#1713 **OPEN** (verified 07-11) — land py+rs together |
+| F3 | #1601 soft_delete parity (rs#1729) | #1601 — py done; fix Rust-side | rs#1729 **OPEN** (verified 07-11) — close when rs lands |
 | F4 | #1532 delegate-connectors → contrib/ | #1532 — consolidate adapter layer | DEFERRED — dedicated session |
 | F5 | handoff-completion → loom eval-harness validation | `journal/0010` co-owner directive | pending-loom Gate-1 |
 | F6 | latest.yaml own-org `esperie-enterprise` | `journal/0015` PUBLIC-repo disclosure | pending-loom Gate-1 templatize-at-source |

--- a/workspaces/sdk-backlog/journal/0022-cross-repo-grant-rust-sdk-read-verify.md
+++ b/workspaces/sdk-backlog/journal/0022-cross-repo-grant-rust-sdk-read-verify.md
@@ -1,0 +1,41 @@
+# 0022 — GRANT: cross-repo read-only status-verify (kailash-rs)
+
+**Date:** 2026-07-11 · **Type:** DECISION · **Phase:** 05-codify · **Posture:** L5_DELEGATED
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Grant (per repo-scope-discipline § User-Authorized Exception — all five conditions)
+
+- **Requester / authorizer:** jack@terrene.foundation (repo owner), this session.
+- **Verbatim instruction:** "i approve your cross repo read" — approving the agent-proposed,
+  agent-restated read-only status check named in the prior turn.
+- **Target:** `esperie-enterprise/kailash-rs` (private).
+- **Action (bounded, read-only):** `gh issue view <N> --repo esperie-enterprise/kailash-rs`
+  for the exact set the workspace records reference — **rs#1713, rs#1729, rs#1732, rs#1712,
+  rs#1667, rs#1707** — to report each issue's open/closed status. NO writes, NO comments,
+  NO browsing, NO other repos, NO loom reads (F5–F8 are proposal/Gate-1 items, not issues).
+- **Timestamp (grant, pre-action):** 2026-07-11T13:29:03Z.
+- **Scope guarantee:** only the named `gh issue view` calls against only the named repo/issues;
+  any incidental read beyond this set is out of scope and not performed.
+
+## Why
+
+The workspace forest ledger (F2/F3) and prior filing receipts (`journal/0004/0008/0011`) reference
+these rs# numbers as carried-forward prose. Per `handoff-completion` MUST-2 + `verify-claims-before-write`,
+their live status was UNVERIFIED. This grant authorizes the one bounded read that converts the
+carried-forward references into a verified status table.
+
+## Verified results (read-only, 2026-07-11T13:29Z)
+
+| Issue   | State    | Note                                                                                                                                                                |
+| ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rs#1713 | **OPEN** | cache keys omit DB-instance identity → cross-DB bleed (F2, mirrors py #1606); updated 2026-07-10                                                                    |
+| rs#1729 | **OPEN** | verify soft_delete/versioned parity (F3, mirrors py #1601); updated 2026-07-10                                                                                      |
+| rs#1732 | **OPEN** | BH5 trip-and-hold governance circuit-breaker (parity w/ py 2.48.0); updated 2026-07-11                                                                              |
+| rs#1712 | CLOSED   | cross-tenant upsert guard — done rs-side (2026-07-10)                                                                                                               |
+| rs#1667 | CLOSED   | RFC 8785 JCS subject_hash — done rs-side (2026-07-11)                                                                                                               |
+| rs#1707 | CLOSED   | BH3 origin-authentication — done rs-side (2026-07-11); STATUS CHANGE vs `journal/0008` ("not yet posted, py-side implementing first") — handoff has since completed |
+
+**Disposition:** 3 open (rs#1713/F2, rs#1729/F3, rs#1732/BH5) = the live cross-SDK forest, actionable
+ONLY in a kailash-rs session (py side done + merged; none blocks this repo). 3 closed = handled rs-side.
+Forest ledger in `.session-notes` updated carried-forward → verified.


### PR DESCRIPTION
## What

Records a **user-authorized read-only** verification of the 6 carried-forward `rs#` references against `esperie-enterprise/kailash-rs`, per `repo-scope-discipline` User-Authorized Exception (grant journaled pre-action in `journal/0022`). Docs-only.

## Verified status (2026-07-11)

- **OPEN (live cross-SDK forest, rs-side only):** rs#1713 (F2, mirrors py #1606), rs#1729 (F3, mirrors py #1601), rs#1732 (BH5 parity w/ py 2.48.0)
- **CLOSED (done rs-side):** rs#1712, rs#1667, rs#1707 (rs#1707 is a status-change vs `journal/0008`)

Forest ledger updated carried-forward → verified. Nothing blocks this repo.

## Related issues

None (read-only cross-repo status verification).