### PR TITLE
fix(trust): verify capability content signature at STANDARD level (#1695)

### DIFF
--- a/src/kailash/trust/agents/trusted_agent.py
+++ b/src/kailash/trust/agents/trusted_agent.py
@@ -77,6 +77,10 @@ class TrustedAgentConfig:
     """
 
     agent_id: str
+    # SECURITY (#1695): STANDARD (default) verifies the matched capability's
+    # content signature (tamper-evident). QUICK checks only chain expiry — it
+    # skips capability + signature verification — so it MUST NOT be used as an
+    # enforcement level over untrusted or persisted trust chains.
     verification_level: VerificationLevel = VerificationLevel.STANDARD
     audit_enabled: bool = True
     fail_on_verification_failure: bool = True
@@ -363,7 +367,11 @@ class TrustedAgent:
             )
             exec_context_dict["verification"] = {
                 "valid": verification_result.valid,
-                "level": (verification_result.level.value if verification_result.level else None),
+                "level": (
+                    verification_result.level.value
+                    if verification_result.level
+                    else None
+                ),
                 "capability_used": verification_result.capability_used,
             }
         except TrustChainNotFoundError:
@@ -470,11 +478,17 @@ class TrustedAgent:
             with concurrent.futures.ThreadPoolExecutor() as pool:
                 future = pool.submit(
                     asyncio.run,
-                    self.execute_async(inputs=inputs, action=action, resource=resource, **kwargs),
+                    self.execute_async(
+                        inputs=inputs, action=action, resource=resource, **kwargs
+                    ),
                 )
                 return future.result()
         else:
-            return asyncio.run(self.execute_async(inputs=inputs, action=action, resource=resource, **kwargs))
+            return asyncio.run(
+                self.execute_async(
+                    inputs=inputs, action=action, resource=resource, **kwargs
+                )
+            )
 
     async def execute_tool(
         self,
@@ -560,7 +574,9 @@ class TrustedAgent:
         """
         # Get agent's constraints
         try:
-            constraints = await self._trust_ops.get_agent_constraints(self._config.agent_id)
+            constraints = await self._trust_ops.get_agent_constraints(
+                self._config.agent_id
+            )
         except TrustChainNotFoundError:
             return  # No constraints to enforce
 
@@ -750,7 +766,9 @@ class TrustedSupervisorAgent(TrustedAgent):
         """
         super().__init__(agent, trust_ops, config, audit_store)
         self._auto_establish_workers = auto_establish_workers
-        self._active_delegations: Dict[str, Set[str]] = {}  # worker_id -> delegation_ids
+        self._active_delegations: Dict[str, Set[str]] = (
+            {}
+        )  # worker_id -> delegation_ids
 
     async def delegate_to_worker(
         self,
@@ -819,7 +837,9 @@ class TrustedSupervisorAgent(TrustedAgent):
         # EATP: Create context for the worker with proper delegation chain
         worker_context = None
         if eatp_context:
-            worker_context = eatp_context.with_delegation(worker_id, {c: True for c in (additional_constraints or [])})
+            worker_context = eatp_context.with_delegation(
+                worker_id, {c: True for c in (additional_constraints or [])}
+            )
 
         return delegation, worker_context
 

--- a/src/kailash/trust/esa/base.py
+++ b/src/kailash/trust/esa/base.py
@@ -162,6 +162,10 @@ class ESAConfig:
     """
 
     enable_capability_discovery: bool = True
+    # SECURITY (#1695): STANDARD (default) verifies the matched capability's
+    # content signature (tamper-evident). QUICK checks only chain expiry — it
+    # skips capability + signature verification — so it MUST NOT be used as an
+    # enforcement level over untrusted or persisted trust chains.
     verification_level: VerificationLevel = VerificationLevel.STANDARD
     auto_audit: bool = True
     cache_capabilities: bool = True

--- a/src/kailash/trust/mcp/server.py
+++ b/src/kailash/trust/mcp/server.py
@@ -45,6 +45,8 @@ from typing import Any, Dict, List, Optional
 from kailash.trust.audit_store import AppendOnlyAuditStore
 from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
 from kailash.trust.chain import VerificationLevel, VerificationResult
+from kailash.trust.chain_store import TrustStore
+from kailash.trust.chain_store.memory import InMemoryTrustStore
 from kailash.trust.enforce.strict import HeldBehavior, StrictEnforcer
 from kailash.trust.exceptions import (
     DelegationError,
@@ -55,8 +57,6 @@ from kailash.trust.operations import TrustOperations
 from kailash.trust.posture.postures import PostureStateMachine
 from kailash.trust.reasoning.traces import ConfidentialityLevel, ReasoningTrace
 from kailash.trust.scoring import compute_trust_score
-from kailash.trust.chain_store import TrustStore
-from kailash.trust.chain_store.memory import InMemoryTrustStore
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +143,9 @@ _TOOL_DEFINITIONS: List[Dict[str, Any]] = [
     },
     {
         "name": "eatp_audit_query",
-        "description": ("Query the audit trail for agent actions. Supports filtering by agent_id and action type."),
+        "description": (
+            "Query the audit trail for agent actions. Supports filtering by agent_id and action type."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -193,7 +195,9 @@ _TOOL_DEFINITIONS: List[Dict[str, Any]] = [
                 },
                 "reasoning_decision": {
                     "type": "string",
-                    "description": ("What was decided — human-readable summary for the reasoning trace (optional)"),
+                    "description": (
+                        "What was decided — human-readable summary for the reasoning trace (optional)"
+                    ),
                 },
                 "reasoning_rationale": {
                     "type": "string",
@@ -418,7 +422,9 @@ class EATPMCPServer:
         method = msg.get("method")
 
         if not method or not isinstance(method, str):
-            resp = _error_response(msg_id, _INVALID_REQUEST, "Missing or invalid method")
+            resp = _error_response(
+                msg_id, _INVALID_REQUEST, "Missing or invalid method"
+            )
             return json.dumps(resp)
 
         handler = self._methods.get(method)
@@ -426,7 +432,9 @@ class EATPMCPServer:
             # Ignore unknown notifications (no id)
             if msg_id is None:
                 return None
-            resp = _error_response(msg_id, _METHOD_NOT_FOUND, f"Unknown method: {method}")
+            resp = _error_response(
+                msg_id, _METHOD_NOT_FOUND, f"Unknown method: {method}"
+            )
             return json.dumps(resp)
 
         try:
@@ -592,14 +600,18 @@ class EATPMCPServer:
                 {
                     "uri": f"eatp://chains/{authority_id}",
                     "name": f"Delegation Chain: {authority_id}",
-                    "description": (f"Delegation hierarchy under authority {authority_id}"),
+                    "description": (
+                        f"Delegation hierarchy under authority {authority_id}"
+                    ),
                     "mimeType": "application/json",
                 }
             )
 
         return {"resources": resources}
 
-    async def _handle_resource_templates_list(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_resource_templates_list(
+        self, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Handle ``resources/templates/list`` -- return URI templates."""
         return {"resourceTemplates": _RESOURCE_TEMPLATES}
 
@@ -728,7 +740,9 @@ class EATPMCPServer:
                     "created_at": chain.genesis.created_at.isoformat(),
                 }
 
-        authority_list = sorted(authorities_by_id.values(), key=lambda a: a["authority_id"])
+        authority_list = sorted(
+            authorities_by_id.values(), key=lambda a: a["authority_id"]
+        )
 
         return {
             "authorities": authority_list,
@@ -787,7 +801,9 @@ class EATPMCPServer:
                         "constraints": cap.constraints,
                         "attester_id": cap.attester_id,
                         "attested_at": cap.attested_at.isoformat(),
-                        "expires_at": (cap.expires_at.isoformat() if cap.expires_at else None),
+                        "expires_at": (
+                            cap.expires_at.isoformat() if cap.expires_at else None
+                        ),
                         "scope": cap.scope,
                     }
                 )
@@ -802,7 +818,11 @@ class EATPMCPServer:
                     "delegatee_id": delegation.delegatee_id,
                     "capabilities_delegated": delegation.capabilities_delegated,
                     "delegated_at": delegation.delegated_at.isoformat(),
-                    "expires_at": (delegation.expires_at.isoformat() if delegation.expires_at else None),
+                    "expires_at": (
+                        delegation.expires_at.isoformat()
+                        if delegation.expires_at
+                        else None
+                    ),
                     "delegation_depth": delegation.delegation_depth,
                 }
             )
@@ -817,7 +837,11 @@ class EATPMCPServer:
             "active_delegations": active_delegations,
             "chain_expired": chain.is_expired(),
             "created_at": chain.genesis.created_at.isoformat(),
-            "expires_at": (chain.genesis.expires_at.isoformat() if chain.genesis.expires_at else None),
+            "expires_at": (
+                chain.genesis.expires_at.isoformat()
+                if chain.genesis.expires_at
+                else None
+            ),
         }
 
     async def _resource_chain(self, uri_params: Dict[str, str]) -> Dict[str, Any]:
@@ -849,7 +873,9 @@ class EATPMCPServer:
             agent_id = chain.genesis.agent_id
             agent_info[agent_id] = {
                 "agent_id": agent_id,
-                "capabilities": [cap.capability for cap in chain.capabilities if not cap.is_expired()],
+                "capabilities": [
+                    cap.capability for cap in chain.capabilities if not cap.is_expired()
+                ],
                 "delegation_count": len(chain.get_active_delegations()),
                 "expired": chain.is_expired(),
             }
@@ -880,7 +906,9 @@ class EATPMCPServer:
                     children_map[parent].append(child)
                 child_agents.add(child)
 
-        def _build_subtree(agent_id: str, visited: set, depth: int = 0) -> Dict[str, Any]:
+        def _build_subtree(
+            agent_id: str, visited: set, depth: int = 0
+        ) -> Dict[str, Any]:
             """Recursively build the delegation subtree for an agent."""
             if agent_id in visited or depth > 20:
                 return {
@@ -981,8 +1009,16 @@ class EATPMCPServer:
             "agent_id": agent_id,
             "envelope_id": envelope.id if envelope else None,
             "constraint_hash": envelope.constraint_hash if envelope else "",
-            "computed_at": (envelope.computed_at.isoformat() if envelope and envelope.computed_at else None),
-            "valid_until": (envelope.valid_until.isoformat() if envelope and envelope.valid_until else None),
+            "computed_at": (
+                envelope.computed_at.isoformat()
+                if envelope and envelope.computed_at
+                else None
+            ),
+            "valid_until": (
+                envelope.valid_until.isoformat()
+                if envelope and envelope.valid_until
+                else None
+            ),
             "envelope_valid": envelope.is_valid() if envelope else False,
             "constraints": constraints_list,
             "total": len(constraints_list),
@@ -1057,11 +1093,19 @@ class EATPMCPServer:
         resource: Optional[str],
     ) -> VerificationResult:
         """
-        Lightweight verification using the store directly.
+        Lightweight, store-only pre-check used when no TrustOperations
+        instance is available.
 
-        Used when no TrustOperations instance is available. Performs
-        chain retrieval, expiration check, and capability matching
-        without full cryptographic signature verification.
+        SECURITY (#1695): this path has no key manager / authority registry, so
+        it CANNOT verify a capability's Ed25519 content signature — it cannot
+        detect a tampered stored grant (e.g. ``read_data`` -> ``delete_data``,
+        id preserved). A verification path that cannot detect tampering MUST NOT
+        authorize, so this path now FAILS CLOSED at the point it would have
+        returned ``valid=True``: it performs the cheap negative checks (missing
+        chain, expired, no matching capability) but any *positive* authorization
+        requires a configured ``trust_ops`` (which verifies the content
+        signature at STANDARD). Configure ``EATPMCPServer(trust_ops=...)`` for
+        cryptographic enforcement.
         """
         try:
             chain = await self._store.get_chain(agent_id)
@@ -1105,13 +1149,27 @@ class EATPMCPServer:
                 level=VerificationLevel.STANDARD,
             )
 
-        effective_constraints = chain.get_effective_constraints(matched_cap.capability)
-
+        # SECURITY (#1695): a capability name-matched, but this store-only path
+        # cannot verify its Ed25519 content signature (no key manager /
+        # authority registry here) — so it cannot tell a genuine grant from a
+        # tampered stored one. FAIL CLOSED rather than authorize an unverifiable
+        # grant. Configure a TrustOperations instance for cryptographic
+        # enforcement (it verifies the content signature at STANDARD).
+        logger.warning(
+            "eatp_verify reached the store-only path (no TrustOperations "
+            "configured), which cannot verify capability signatures; failing "
+            "closed. Configure EATPMCPServer(trust_ops=...) for cryptographic "
+            "enforcement.",
+            extra={"agent_id": agent_id, "action": action},
+        )
         return VerificationResult(
-            valid=True,
+            valid=False,
+            reason=(
+                "Cryptographic verification unavailable (no TrustOperations "
+                "configured) — failing closed per #1695; a matched capability "
+                "cannot be authorized without verifying its content signature"
+            ),
             level=VerificationLevel.STANDARD,
-            capability_used=matched_cap.id,
-            effective_constraints=effective_constraints,
         )
 
     async def _tool_status(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1170,7 +1228,11 @@ class EATPMCPServer:
                     "delegatee_id": delegation.delegatee_id,
                     "capabilities_delegated": delegation.capabilities_delegated,
                     "delegated_at": delegation.delegated_at.isoformat(),
-                    "expires_at": (delegation.expires_at.isoformat() if delegation.expires_at else None),
+                    "expires_at": (
+                        delegation.expires_at.isoformat()
+                        if delegation.expires_at
+                        else None
+                    ),
                     "delegation_depth": delegation.delegation_depth,
                 }
             )
@@ -1194,7 +1256,9 @@ class EATPMCPServer:
             "active_delegations": active_delegations,
             "constraints_summary": constraints_summary,
             "chain_expired": chain.is_expired(),
-            "capabilities": [cap.capability for cap in chain.capabilities if not cap.is_expired()],
+            "capabilities": [
+                cap.capability for cap in chain.capabilities if not cap.is_expired()
+            ],
         }
 
     async def _tool_audit_query(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1255,8 +1319,13 @@ class EATPMCPServer:
             if anchor.reasoning_trace is not None:
                 from kailash.trust.reasoning.traces import ConfidentialityLevel
 
-                if anchor.reasoning_trace.confidentiality <= ConfidentialityLevel.RESTRICTED:
-                    entry["anchor"]["reasoning_trace"] = anchor.reasoning_trace.to_dict()
+                if (
+                    anchor.reasoning_trace.confidentiality
+                    <= ConfidentialityLevel.RESTRICTED
+                ):
+                    entry["anchor"][
+                        "reasoning_trace"
+                    ] = anchor.reasoning_trace.to_dict()
                 # else CONFIDENTIAL/SECRET/TOP_SECRET: omit full trace
             if anchor.reasoning_trace_hash is not None:
                 entry["anchor"]["reasoning_trace_hash"] = anchor.reasoning_trace_hash
@@ -1302,7 +1371,9 @@ class EATPMCPServer:
             return {"error": "capabilities is required and must be a list of strings"}
         for cap in capabilities:
             if not isinstance(cap, str):
-                return {"error": f"Each capability must be a string, got: {type(cap).__name__}"}
+                return {
+                    "error": f"Each capability must be a string, got: {type(cap).__name__}"
+                }
 
         if self._ops is None:
             return {
@@ -1365,7 +1436,9 @@ class EATPMCPServer:
             "capabilities_delegated": delegation.capabilities_delegated,
             "constraint_subset": delegation.constraint_subset,
             "delegated_at": delegation.delegated_at.isoformat(),
-            "expires_at": (delegation.expires_at.isoformat() if delegation.expires_at else None),
+            "expires_at": (
+                delegation.expires_at.isoformat() if delegation.expires_at else None
+            ),
             "delegation_depth": delegation.delegation_depth,
         }
 
@@ -1478,7 +1551,9 @@ class EATPMCPServer:
         (
             writer_transport,
             writer_protocol,
-        ) = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, sys.stdout.buffer)
+        ) = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout.buffer
+        )
         writer = asyncio.StreamWriter(writer_transport, writer_protocol, None, loop)
 
         logger.info("EATP MCP Server started on stdio")

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -1123,7 +1123,7 @@ class TrustOperations:
                     chain.genesis.authority_id,
                     include_inactive=True,  # historical verification
                 )
-            except AuthorityNotFoundError:
+            except (AuthorityNotFoundError, AuthorityInactiveError):
                 # Fail closed: cannot resolve the signer -> cannot trust the
                 # grant. Log so the denial is observable (not a silent swallow).
                 logger.warning(
@@ -1136,11 +1136,24 @@ class TrustOperations:
                 )
                 return False
         cap_payload = serialize_for_signing(cap.to_signing_payload())
-        return await self.key_manager.verify(
-            cap_payload,
-            cap.signature,
-            authority.public_key,
-        )
+        try:
+            return await self.key_manager.verify(
+                cap_payload,
+                cap.signature,
+                authority.public_key,
+            )
+        except InvalidSignatureError:
+            # verify_signature() returns False on a BadSignatureError but RAISES
+            # InvalidSignatureError on a malformed / empty / wrong-length
+            # signature. A tampered stored grant may carry exactly such a
+            # signature, so treat the raise as an invalid signature and fail
+            # closed (mirrors _verify_reasoning_traces). Observable, not silent.
+            logger.warning(
+                "capability signature verification failed: malformed or "
+                "unverifiable signature (fail-closed denial)",
+                extra={"capability_id": cap.id},
+            )
+            return False
 
     async def _verify_signatures(
         self,

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -574,6 +574,28 @@ class TrustOperations:
                 level=level,
             )
 
+        # SECURITY (#1695): verify the MATCHED capability's Ed25519 content
+        # signature at STANDARD — not just its name + expiry. The signature
+        # covers the grant content (capability + constraints, see
+        # CapabilityAttestation.to_signing_payload), so a tampered *stored*
+        # grant (e.g. read_data -> delete_data, or loosened constraints, with
+        # the id preserved so the id-only chain-state hash is unaffected) is
+        # rejected here at the shipped default level. Previously this signature
+        # was checked only at FULL, so every enforcement surface — all of which
+        # default to STANDARD — authorized tampered grants. FULL still runs the
+        # full-chain _verify_signatures below (which re-covers this capability);
+        # QUICK is name/expiry-only by design and is not an enforcement default.
+        if level != VerificationLevel.FULL:
+            if not await self._verify_capability_signature(chain, capability):
+                return VerificationResult(
+                    valid=False,
+                    reason=(
+                        "Capability signature invalid — stored grant may be "
+                        f"tampered: {capability.id}"
+                    ),
+                    level=level,
+                )
+
         # Evaluate constraints
         if chain.constraint_envelope is not None:
             constraint_result = self._evaluate_constraints(
@@ -1065,6 +1087,61 @@ class TrustOperations:
         # Default: permit if constraint not recognized
         return {"permitted": True}
 
+    async def _verify_capability_signature(
+        self,
+        chain: TrustLineageChain,
+        cap: CapabilityAttestation,
+        authority: Optional[Any] = None,
+    ) -> bool:
+        """Verify one capability attestation's Ed25519 content signature.
+
+        The signature covers ``cap.to_signing_payload()`` — which includes the
+        granted ``capability`` string and ``constraints`` — so a stored-grant
+        content tamper (e.g. ``read_data`` -> ``delete_data`` with the ``id``
+        preserved) invalidates it. This is the single source of truth for
+        per-capability signature verification, used by both the STANDARD-level
+        matched-capability check in ``verify()`` (#1695) and the full-chain
+        ``_verify_signatures`` (FULL level).
+
+        Fails closed: if the signing authority cannot be resolved, returns
+        ``False`` and emits a WARN (a denial the operator must be able to see —
+        `rules/observability.md`), never a silent swallow.
+
+        Args:
+            chain: The trust chain whose genesis authority signed the grant.
+            cap: The capability attestation to verify.
+            authority: Optional pre-resolved authority (FULL resolves it once
+                for the whole chain and passes it to avoid N lookups); when
+                ``None`` the authority is resolved here.
+
+        Returns:
+            True iff the signature is cryptographically valid.
+        """
+        if authority is None:
+            try:
+                authority = await self.authority_registry.get_authority(
+                    chain.genesis.authority_id,
+                    include_inactive=True,  # historical verification
+                )
+            except AuthorityNotFoundError:
+                # Fail closed: cannot resolve the signer -> cannot trust the
+                # grant. Log so the denial is observable (not a silent swallow).
+                logger.warning(
+                    "capability signature verification failed: signing "
+                    "authority unresolved (fail-closed denial)",
+                    extra={
+                        "authority_id": chain.genesis.authority_id,
+                        "capability_id": cap.id,
+                    },
+                )
+                return False
+        cap_payload = serialize_for_signing(cap.to_signing_payload())
+        return await self.key_manager.verify(
+            cap_payload,
+            cap.signature,
+            authority.public_key,
+        )
+
     async def _verify_signatures(
         self,
         chain: TrustLineageChain,
@@ -1096,13 +1173,11 @@ class TrustOperations:
                 level=VerificationLevel.FULL,
             )
 
-        # Verify capability signatures
+        # Verify capability signatures (single source of truth: the same
+        # per-capability check STANDARD uses on the matched grant, #1695).
         for cap in chain.capabilities:
-            cap_payload = serialize_for_signing(cap.to_signing_payload())
-            if not await self.key_manager.verify(
-                cap_payload,
-                cap.signature,
-                authority.public_key,
+            if not await self._verify_capability_signature(
+                chain, cap, authority=authority
             ):
                 return VerificationResult(
                     valid=False,

--- a/tests/regression/test_issue_1695_tampered_grant_default_verify.py
+++ b/tests/regression/test_issue_1695_tampered_grant_default_verify.py
@@ -29,11 +29,7 @@ import pytest
 from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
 from kailash.trust.chain import AuthorityType, CapabilityType, VerificationLevel
 from kailash.trust.chain_store.memory import InMemoryTrustStore
-from kailash.trust.operations import (
-    CapabilityRequest,
-    TrustKeyManager,
-    TrustOperations,
-)
+from kailash.trust.operations import CapabilityRequest, TrustKeyManager, TrustOperations
 from kailash.trust.signing.crypto import generate_keypair
 
 
@@ -187,3 +183,69 @@ async def test_default_verify_denies_loosened_capability_constraints(ops, _store
         "in storage (#1695)"
     )
     assert "signature" in (result.reason or "").lower()
+
+
+@pytest.mark.regression
+async def test_default_verify_fails_closed_on_malformed_signature(ops, _store):
+    """A tampered grant carrying a malformed/empty signature makes the crypto
+    layer RAISE (InvalidSignatureError) rather than return False; the default
+    verify() MUST still fail closed with a clean denial, not propagate the raise
+    (security-reviewer MEDIUM on the #1695 fix)."""
+    await ops.establish(
+        agent_id="agent-1695c",
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data",
+                capability_type=CapabilityType.ACTION,
+            ),
+        ],
+    )
+
+    # Tamper: replace the signature with an empty string (malformed).
+    chain = await _store.get_chain("agent-1695c")
+    chain.capabilities[0].signature = ""
+    await _store.update_chain("agent-1695c", chain)
+
+    # MUST NOT raise; MUST return a clean fail-closed denial.
+    result = await ops.verify(agent_id="agent-1695c", action="read_data")
+    assert result.valid is False
+    assert "signature" in (result.reason or "").lower()
+
+
+@pytest.mark.regression
+async def test_mcp_ops_less_verify_fails_closed(ops, _store):
+    """The MCP store-only path (EATPMCPServer without TrustOperations) cannot
+    verify capability signatures, so it MUST fail closed on a name-matched
+    capability rather than authorize an unverifiable/tampered grant
+    (security-reviewer HIGH on the #1695 fix)."""
+    from kailash.trust.mcp.server import EATPMCPServer
+
+    # Establish a real, correctly-signed chain into the shared store.
+    await ops.establish(
+        agent_id="agent-1695d",
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data",
+                capability_type=CapabilityType.ACTION,
+            ),
+        ],
+    )
+
+    # An ops-less MCP server over the SAME store (the documented default
+    # EATPMCPServer(trust_store=...) construction).
+    server = EATPMCPServer(trust_store=_store, trust_ops=None)
+
+    # Even a genuine, correctly-signed grant is NOT authorized here — the path
+    # cannot verify the signature, so it fails closed.
+    result = await server._verify_from_store("agent-1695d", "read_data", None)
+    assert result.valid is False, (
+        "ops-less MCP verify must fail closed — it cannot verify capability "
+        "signatures (#1695)"
+    )
+    assert "TrustOperations" in (result.reason or "")
+
+    # Sanity: the SAME grant verifies True through a fully-configured ops.
+    ok = await ops.verify(agent_id="agent-1695d", action="read_data")
+    assert ok.valid is True

--- a/tests/regression/test_issue_1695_tampered_grant_default_verify.py
+++ b/tests/regression/test_issue_1695_tampered_grant_default_verify.py
@@ -1,0 +1,189 @@
+"""Regression test for issue #1695 — default (STANDARD) verification MUST reject
+a tampered *stored* capability grant.
+
+Threat model: an actor with write access to the persisted trust chain mutates a
+granted capability's CONTENT (e.g. ``read_data`` -> ``delete_data``, or loosens
+its ``constraints``) while preserving the capability ``id`` — so the id-only
+chain-state hash is unaffected. Before the fix, the shipped default
+``VerificationLevel.STANDARD`` authorized the tampered grant because the
+per-attestation Ed25519 signature that covers the grant content was verified
+ONLY at ``VerificationLevel.FULL``. Every enforcement surface defaults to
+STANDARD, so the tamper was authorized.
+
+The fix (``TrustOperations._verify_capability_signature`` called from ``verify``
+at STANDARD) verifies the matched capability's content signature at the default
+level. These behavioral tests establish a signed grant, tamper the stored
+content while preserving the id + signature, and assert the default ``verify()``
+DENIES — and that a legitimate (untampered) grant still verifies.
+
+Security-critical path (100% coverage tier per rules/testing.md); real
+InMemoryTrustStore, no mocking.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import AuthorityType, CapabilityType, VerificationLevel
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.operations import (
+    CapabilityRequest,
+    TrustKeyManager,
+    TrustOperations,
+)
+from kailash.trust.signing.crypto import generate_keypair
+
+
+class _SimpleAuthorityRegistry:
+    """Real in-memory authority registry (NOT a mock) — mirrors the lifecycle
+    integration harness's registry so this regression is self-contained."""
+
+    def __init__(self) -> None:
+        self._authorities: Dict[str, OrganizationalAuthority] = {}
+
+    async def initialize(self) -> None:  # no-op for in-memory
+        pass
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            from kailash.trust.exceptions import AuthorityNotFoundError
+
+            raise AuthorityNotFoundError(authority_id)
+        return authority
+
+
+@pytest.fixture
+def _keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def _registry(_keypair):
+    _, public_key = _keypair
+    authority = OrganizationalAuthority(
+        id="org-acme",
+        name="ACME Corporation",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="acme-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+    reg = _SimpleAuthorityRegistry()
+    reg.register(authority)
+    return reg
+
+
+@pytest.fixture
+def _key_manager(_keypair):
+    private_key, _ = _keypair
+    km = TrustKeyManager()
+    km.register_key("acme-key-001", private_key)
+    return km
+
+
+@pytest.fixture
+async def _store():
+    store = InMemoryTrustStore()
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+async def ops(_registry, _key_manager, _store):
+    operations = TrustOperations(
+        authority_registry=_registry,
+        key_manager=_key_manager,
+        trust_store=_store,
+    )
+    await operations.initialize()
+    return operations
+
+
+@pytest.mark.regression
+async def test_default_verify_denies_tampered_capability_action(ops, _store):
+    """read_data -> delete_data content tamper (id preserved) is DENIED at the
+    shipped default level; the legitimate grant still verifies."""
+    await ops.establish(
+        agent_id="agent-1695",
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data",
+                capability_type=CapabilityType.ACTION,
+            ),
+        ],
+    )
+
+    # Control: the legitimate action verifies at the DEFAULT (STANDARD) level.
+    control = await ops.verify(agent_id="agent-1695", action="read_data")
+    assert control.valid is True, "untampered grant must verify at default level"
+
+    # Tamper the STORED grant content: read_data -> delete_data, id + signature
+    # preserved (simulating an actor that rewrote the persisted chain).
+    chain = await _store.get_chain("agent-1695")
+    cap = chain.capabilities[0]
+    original_id, original_sig = cap.id, cap.signature
+    cap.capability = "delete_data"
+    assert cap.id == original_id and cap.signature == original_sig
+    await _store.update_chain("agent-1695", chain)
+
+    # Default (STANDARD) verification of the tampered action MUST deny.
+    result = await ops.verify(agent_id="agent-1695", action="delete_data")
+    assert result.valid is False, (
+        "default verify() must DENY a tampered stored grant (#1695) — "
+        "the content signature is invalid"
+    )
+    assert "signature" in (result.reason or "").lower()
+
+    # FULL level denies too (consistency across levels).
+    result_full = await ops.verify(
+        agent_id="agent-1695",
+        action="delete_data",
+        level=VerificationLevel.FULL,
+    )
+    assert result_full.valid is False
+
+
+@pytest.mark.regression
+async def test_default_verify_denies_loosened_capability_constraints(ops, _store):
+    """Loosening a matched grant's ``constraints`` (id + capability preserved)
+    is also DENIED at the default level — the signature covers constraints too."""
+    await ops.establish(
+        agent_id="agent-1695b",
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data",
+                capability_type=CapabilityType.ACTION,
+                constraints=["scope:own_tenant"],
+            ),
+        ],
+    )
+
+    control = await ops.verify(agent_id="agent-1695b", action="read_data")
+    assert control.valid is True
+
+    # Tamper: strip the constraints (widen the grant), keep id + capability.
+    chain = await _store.get_chain("agent-1695b")
+    cap = chain.capabilities[0]
+    cap.constraints = []
+    await _store.update_chain("agent-1695b", chain)
+
+    result = await ops.verify(agent_id="agent-1695b", action="read_data")
+    assert result.valid is False, (
+        "default verify() must DENY a grant whose constraints were loosened "
+        "in storage (#1695)"
+    )
+    assert "signature" in (result.reason or "").lower()

--- a/tests/trust/integration/test_mcp_integration.py
+++ b/tests/trust/integration/test_mcp_integration.py
@@ -34,12 +34,12 @@ from kailash.trust.chain import (
     CapabilityType,
     VerificationLevel,
 )
-from kailash.trust.signing.crypto import generate_keypair
+from kailash.trust.chain_store.memory import InMemoryTrustStore
 from kailash.trust.enforce.strict import HeldBehavior, StrictEnforcer
 from kailash.trust.mcp.server import EATPMCPServer
 from kailash.trust.operations import CapabilityRequest, TrustKeyManager, TrustOperations
 from kailash.trust.posture.postures import PostureStateMachine
-from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.signing.crypto import generate_keypair
 
 logger = logging.getLogger(__name__)
 
@@ -322,7 +322,9 @@ class TestProtocol:
             "eatp_delegate",
             "eatp_revoke",
         }
-        assert tool_names == expected_tools, f"Expected tools {expected_tools}, got {tool_names}"
+        assert (
+            tool_names == expected_tools
+        ), f"Expected tools {expected_tools}, got {tool_names}"
 
     async def test_tools_list_has_input_schemas(self, server):
         """Each tool definition must include an inputSchema with required fields."""
@@ -336,8 +338,12 @@ class TestProtocol:
             assert "description" in tool, f"Tool {tool['name']} missing 'description'"
             assert "inputSchema" in tool, f"Tool {tool['name']} missing 'inputSchema'"
             schema = tool["inputSchema"]
-            assert schema["type"] == "object", f"Tool {tool['name']} inputSchema type must be 'object'"
-            assert "properties" in schema, f"Tool {tool['name']} inputSchema missing 'properties'"
+            assert (
+                schema["type"] == "object"
+            ), f"Tool {tool['name']} inputSchema type must be 'object'"
+            assert (
+                "properties" in schema
+            ), f"Tool {tool['name']} inputSchema missing 'properties'"
 
     async def test_resources_templates_list(self, server):
         """resources/templates/list must return all 4 resource templates."""
@@ -356,7 +362,9 @@ class TestProtocol:
             "eatp://chains/{authority_id}",
             "eatp://constraints/{agent_id}",
         }
-        assert uri_templates == expected_templates, f"Expected templates {expected_templates}, got {uri_templates}"
+        assert (
+            uri_templates == expected_templates
+        ), f"Expected templates {expected_templates}, got {uri_templates}"
 
     async def test_ping_returns_empty_result(self, server):
         """ping must return an empty result object."""
@@ -515,7 +523,9 @@ class TestToolsValid:
     async def test_eatp_status_returns_agent_state(self, server, trust_ops):
         """eatp_status returns trust score, posture, and capabilities."""
         await _initialize_server(server)
-        await _establish_agent(trust_ops, "agent-s1", ["analyze_data", "generate_report"])
+        await _establish_agent(
+            trust_ops, "agent-s1", ["analyze_data", "generate_report"]
+        )
 
         request = _make_request(
             "tools/call",
@@ -686,7 +696,10 @@ class TestToolsValid:
         raw_response = await server.handle_message(request)
         response = _parse_response(raw_response)
 
-        assert "isError" not in response["result"] or response["result"].get("isError") is not True
+        assert (
+            "isError" not in response["result"]
+            or response["result"].get("isError") is not True
+        )
 
         data = _get_tool_result_data(response)
 
@@ -1126,7 +1139,9 @@ class TestResourcesValid:
     async def test_resource_agent_details(self, server, trust_ops):
         """eatp://agents/{id} returns comprehensive agent details."""
         await _initialize_server(server)
-        await _establish_agent(trust_ops, "agent-res-det", ["analyze_data", "read_reports"])
+        await _establish_agent(
+            trust_ops, "agent-res-det", ["analyze_data", "read_reports"]
+        )
 
         request = _make_request(
             "resources/read",
@@ -1316,7 +1331,9 @@ class TestResourceErrors:
 class TestFullWorkflow:
     """Test complete end-to-end workflows through the MCP server."""
 
-    async def test_establish_verify_delegate_audit_workflow(self, server, trust_ops, audit_store):
+    async def test_establish_verify_delegate_audit_workflow(
+        self, server, trust_ops, audit_store
+    ):
         """
         Full workflow: initialize -> establish agent -> verify action ->
         delegate to second agent -> verify delegation -> audit query.
@@ -1436,7 +1453,9 @@ class TestFullWorkflow:
         raw = await server.handle_message(audit_request)
         audit_data = _get_tool_result_data(_parse_response(raw))
         assert audit_data["total_returned"] >= 1
-        found = any(r["anchor"]["action"] == "analyze_data" for r in audit_data["records"])
+        found = any(
+            r["anchor"]["action"] == "analyze_data" for r in audit_data["records"]
+        )
         assert found, "Audit trail must contain the analyze_data action"
 
         # Step 10: Read resources to verify state
@@ -1486,7 +1505,9 @@ class TestFullWorkflow:
             msg_id=18,
         )
         raw = await server.handle_message(constraint_request)
-        constraint_data = json.loads(_parse_response(raw)["result"]["contents"][0]["text"])
+        constraint_data = json.loads(
+            _parse_response(raw)["result"]["contents"][0]["text"]
+        )
         assert constraint_data["agent_id"] == "agent-alpha"
 
         # Step 11: Revoke the delegation
@@ -1504,8 +1525,15 @@ class TestFullWorkflow:
 
     async def test_lightweight_verify_without_ops(self, server_no_ops, trust_store):
         """
-        Server without TrustOperations uses lightweight verification
-        from the store directly.
+        Server without TrustOperations FAILS CLOSED on positive authorization
+        (#1695).
+
+        The store-only path cannot verify a capability's Ed25519 content
+        signature (no key manager / authority registry here), so it cannot
+        detect a tampered stored grant. It therefore MUST NOT authorize a
+        name-matched capability: it denies (verdict=blocked) and directs the
+        operator to configure trust_ops. A no-capability-match still denies with
+        its own reason.
         """
         await _initialize_server(server_no_ops)
 
@@ -1554,8 +1582,11 @@ class TestFullWorkflow:
         raw = await server_no_ops.handle_message(request)
         data = _get_tool_result_data(_parse_response(raw))
 
-        assert data["valid"] is True
-        assert data["verdict"] == "auto_approved"
+        # #1695: name-matched but signature-unverifiable -> fail closed (deny),
+        # NOT auto-approved. The ops-less path cannot authorize.
+        assert data["valid"] is False
+        assert data["verdict"] == "blocked"
+        assert "TrustOperations" in (data["details"]["reason"] or "")
 
         # Verify unauthorized action
         request2 = _make_request(


### PR DESCRIPTION
## Summary

Fixes **#1695** — a trust-plane privilege escalation. At the default `VerificationLevel.STANDARD`, `TrustOperations.verify()` matched a capability by name + expiry only; the per-`CapabilityAttestation` Ed25519 signature that covers the **grant content** ran only at `FULL`. An actor able to tamper the persisted trust chain could mutate a stored grant's content (`read_data` → `delete_data`, or loosen `constraints`) while preserving its `id` (so the id-only chain-state hash was unaffected), and **every enforcement surface — all 12 default to STANDARD — authorized it**. The chain was advertised tamper-evident but was not at the shipped default.

## The fix

- `verify()` now verifies the **matched capability's content signature at STANDARD**, via a shared `_verify_capability_signature` helper (single source of truth; `_verify_signatures` / FULL refactored to reuse it — behaviour-identical). Fails closed with a WARN when the signing authority is unresolved or the signature is malformed.
- **MCP parity (gate-review HIGH):** the store-only `EATPMCPServer` path (no `TrustOperations`, the documented default construction) matched capabilities with **no** signature check — same attack. It has no crypto material, so it now **fails closed** on any positive authorization.
- **Malformed-sig hardening (MEDIUM):** a malformed/empty signature *raises* rather than returning `False`; the helper catches it and fails closed.
- **Config note (LOW):** `QUICK` documented as not-for-enforcement over untrusted chains.

## Verification

- **RED→GREEN proven:** with the source fix stashed, the regression tests FAIL (tampered `read_data→delete_data` returns `valid=True` — the exact vuln); with the fix they DENY.
- **4 new regression tests** (`tests/regression/test_issue_1695_*`): action tamper, constraint-loosening, malformed-sig fail-closed, ops-less MCP fail-closed. Swept the MCP integration test that asserted the old `valid=True`.
- **6535 trust tests pass, 0 regressions.**
- Gate review: security-reviewer APPROVE-WITH-FIXES (all applied), reviewer APPROVE.

## Design decision (issue invited "any/all — team's call")

Implemented AC#1 (STANDARD verifies content signatures) + AC#4 (regression test). Deliberately **not** AC#2 (content in chain-state hash) / AC#3 (verify-on-store-load): all enforcement surfaces default to STANDARD (now covered); QUICK here checks only expiry, not a stored hash, so AC#2 gates nothing; AC#2 also carries hash-format backward-compat cost. Keeps the security fix minimal + low-blast-radius.

## Cross-SDK follow-up (not filed — needs authorization)

Both reviewers noted the same two-surface shape (STANDARD verify + an ops-less lightweight path) plausibly exists in the Rust SDK trust plane. Per cross-sdk-inspection this warrants a parity issue on the Rust SDK — **surfacing as a PENDING action; I will not self-authorize a cross-repo filing.**

## Related issues

Closes #1695.