### PR TITLE
release: kailash 2.48.1 — trust-plane security patch (#1695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.48.1] - 2026-07-12
+
+Security patch — trust-plane default-verification hardening (#1695).
+
+### Fixed
+
+- **Default verification level now detects tampered stored capability grants
+  (#1695).** At the default `VerificationLevel.STANDARD`, `TrustOperations.verify()`
+  matched a capability by name + expiry only — the per-`CapabilityAttestation`
+  Ed25519 signature covering the grant _content_ was verified only at `FULL`. An
+  actor able to tamper the persisted trust chain could mutate a stored grant's
+  content (e.g. widen `read` → `delete`, or loosen constraints) while preserving
+  its `id`, and every enforcement surface — all default to `STANDARD` — authorized
+  it. The default level now verifies the matched capability's content signature
+  (shared `_verify_capability_signature` helper; `FULL`'s full-chain check reuses
+  it), failing closed with a warning when the signing authority is unresolved or
+  the signature is malformed.
+  - The store-only MCP verification path (`EATPMCPServer` without a
+    `TrustOperations` instance) previously matched capabilities with no signature
+    verification; it now **fails closed** on positive authorization, since it has
+    no cryptographic material to detect tampering.
+  - `QUICK` is documented as expiry-only and must not be used as an enforcement
+    level over untrusted or persisted chains.
+  - Regression coverage: `tests/regression/test_issue_1695_tampered_grant_default_verify.py`.
+  - Cross-SDK parity inspection tracked on the Rust SDK.
+
 ## [2.48.0] - 2026-07-11
 
 SAFR governance-hardening: BH5 circuit-breaker (#1510) — completes the SAFR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.48.0"
+version = "2.48.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.48.0"
+__version__ = "2.48.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## What

Cuts **kailash 2.48.1**, a security patch shipping the #1695 fix (trust-plane default-verification hardening) that merged in #1697. Metadata-only (version anchors + CHANGELOG).

## Security fix shipped (#1695)

At the default `VerificationLevel.STANDARD`, tampered stored capability grants were authorized (the content signature ran only at `FULL`); every enforcement surface defaults to STANDARD. #1697 fixed it — STANDARD now verifies the matched capability's content signature, the ops-less MCP path fails closed, malformed sigs fail closed. security-reviewer CONVERGED (0 CRIT/0 HIGH); 6535 trust tests pass.

## Release checklist

- [x] security-reviewer review (mandatory) — CONVERGED
- [x] Version bumped consistently (pyproject.toml + __init__.py → 2.48.1)
- [x] CHANGELOG updated
- [x] Patch release — TestPyPI skipped with human approval (per deployment.md)
- [ ] Tag `v2.48.1` pushed → publish-pypi.yml → PyPI
- [ ] Clean-venv installability verified

## Related issues

Fixes #1695 (fix merged in #1697; this ships it).