### PR TITLE
fix(dataflow): close Express cross-DB cache bleed via v2→v3 keyspace lockstep (#1606)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [2.15.0] — 2026-07-12 — Express cross-DB cache-bleed fix: v2→v3 keyspace lockstep (#1606)
+
+### Security
+
+- **Express cache keyspace now segments by database-instance identity (#1606, cross-SDK lockstep).** The Express hot-path keyspace bumps `v2` → `v3`, inserting a credential-free `db<16 hex>` database-instance segment directly after the version token: `dataflow:v3:{db_instance}:{tenant}:{model}:{op}:{params_hash}`. Two DataFlow instances pointed at **different** databases but sharing a process-wide cache backend (e.g. Redis) can no longer collide on the same Express `read`/`list`/`find_one`/`count` key — closing the cross-DB cache bleed on the hot path that the query-keyspace fix (2.14.6) deliberately left open pending this coordinated cross-SDK re-pin (`cross-sdk-inspection.md` Rule 4b).
+  - The `db_instance` fingerprint is `db` + the first 16 hex chars of SHA-256 over the **normalized** connection target (`scheme://<authority><path>`, scheme lowercased, credentials + query string + fragment stripped **before** hashing) — no credential or PII ever reaches the keyspace. Two instances at the **same** database with different DB credentials share a namespace by design (the identity keys on database _location_, not principal).
+  - This is the byte-for-byte cross-SDK equivalent of the Rust SDK's #1713 (contract `dataflow-cache-keys-v3`); the Rust SDK **leads** the contract and kailash-py mirrors its canonical byte-vectors. The vendored conformance fixture (`tests/fixtures/dataflow-cache-keys.json`, byte-identical to the Rust SDK's) pins all six V1–V6 vectors including the empty-params, cross-DB anti-collision, and credential-strip sentinels.
+  - When no usable database identity can be derived from the DataFlow URL, the Express wrapper emits a loud WARN and cross-DB isolation is INACTIVE (fail-open with signal, never a silent constant fallback).
+
+### Changed
+
+- **`generate_express_key` now emits `v3` keys.** The query keyspace (`generate_key`) is unaffected and stays `v2` — it is py-local (py and the Rust SDK emit different SQL) and versions independently. Legacy `v2` Express entries left on a shared cache after upgrade are orphaned and expire on TTL; every invalidation path (`invalidate_model`, `clear_pattern`, the Redis `v*` glob) already sweeps them version- and db-instance-agnostically, so no stale entry survives an explicit invalidation.
+
+### Added
+
+- `express_db_instance_fingerprint()` in `dataflow.cache.key_generator` — the Rust-pinned Express db-instance fingerprint (distinct algorithm + length from the query-keyspace `hash_database_identity`).
+- Byte-for-byte conformance suite (`test_issue_1606_express_v3_conformance.py`) over the vendored canonical vectors, plus a Redis-side regression proof that v3 + db-instance keys are swept by the invalidation glob.
+
 ## [2.14.7] — 2026-07-10 — fabric write-path + source-path tenant guards (#1659, #1658)
 
 ### Security

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.14.7"
+version = "2.15.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.14.7"
+__version__ = "2.15.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/async_redis_adapter.py
@@ -353,16 +353,19 @@ class AsyncRedisCacheAdapter:
         The key generator produces three key formats depending on
         whether caching runs in single- or multi-tenant mode:
 
-        - Express keys (single tenant): ``dataflow:<ver>:{model}:{op}:...``
-        - Express keys (multi-tenant): ``dataflow:<ver>:{tenant}:{model}:{op}:...``
+        - Express keys (single tenant): ``dataflow:v3:{db_instance}:{model}:{op}:...``
+        - Express keys (multi-tenant): ``dataflow:v3:{db_instance}:{tenant}:{model}:{op}:...``
         - SQL query keys: ``dataflow:{model}:<ver>:...``
 
         The version segment is matched as a wildcard (``v*``) so that
         every live keyspace version AND any stale legacy entries are
-        swept in one invalidation. This is required because the
-        default keyspace bumped ``v1 → v2`` in BP-049 (cross-SDK
-        parity with kailash-rs v3.19.0); a version-pinned invalidation
-        would leave v2 entries in place and serve stale reads.
+        swept in one invalidation. This is required because the express
+        keyspace bumped ``v1 → v2`` (BP-049) then ``v2 → v3`` (#1606,
+        which inserted the ``db_instance`` segment after the version); a
+        version-pinned invalidation would leave older entries in place and
+        serve stale reads. The greedy ``v*`` in the express globs above
+        spans the ``v3:{db_instance}`` prefix, so v3 keys (with the
+        db-instance segment) are matched without pinning it.
 
         All relevant patterns are scanned so that entries for the model
         are removed regardless of which code path created them.

--- a/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
@@ -7,11 +7,24 @@ Generates deterministic cache keys from queries and parameters.
 import hashlib
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
+from urllib.parse import urlparse
 
 from kailash.utils.url_credentials import UNPARSEABLE_URL_SENTINEL, mask_url
 
 if TYPE_CHECKING:
     from dataflow.classification.policy import ClassificationPolicy
+
+# Express (Rust-pinned) cross-SDK cache keyspace version. Bumped v2 -> v3 for
+# issue #1606 (the Rust SDK's #1713): the v3 keyspace inserts a database-instance
+# segment immediately after the version token so two DataFlow instances at
+# DIFFERENT databases sharing a process-wide cache backend (e.g. Redis) can never
+# collide on the same physical key. This is DISTINCT from
+# ``CacheKeyGenerator.version`` (the py-local QUERY keyspace, still ``v2``): the
+# express keyspace is a byte-for-byte contract with the Rust SDK and MUST move in
+# lockstep with it (canonical vectors: ``tests/fixtures/dataflow-cache-keys.json``,
+# contract ``dataflow-cache-keys-v3``); the query keyspace diverges cross-SDK by
+# construction (py vs rs emit different SQL) and versions independently.
+EXPRESS_KEYSPACE_VERSION = "v3"
 
 
 def _hash8(material: str) -> str:
@@ -85,9 +98,10 @@ def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
     DB-level row visibility (RLS / per-user GRANTs) MUST NOT share a cache
     backend across principals.
 
-    NOTE: this segments the QUERY keyspace only. The Express ``v2``
-    keyspace (``generate_express_key``) is a byte-for-byte cross-SDK
-    contract pinned to kailash-rs and MUST NOT carry this segment.
+    NOTE: this segments the QUERY keyspace only. The Express keyspace
+    (``generate_express_key``) carries its OWN cross-SDK db-instance
+    segment from ``express_db_instance_fingerprint`` (a different algorithm
+    + length); this query-side fingerprint MUST NOT be used there.
     """
     if not database_url:
         return None
@@ -101,6 +115,82 @@ def hash_database_identity(database_url: Optional[str]) -> Optional[str]:
         # would give every such instance the same identity — refuse.
         return None
     return _hash8(masked)
+
+
+def express_db_instance_fingerprint(database_url: Optional[str]) -> Optional[str]:
+    """Return the Rust-pinned ``db<16 hex>`` db-instance segment for EXPRESS v3.
+
+    This is the EXPRESS-keyspace sibling of :func:`hash_database_identity` and is
+    a DELIBERATELY DIFFERENT algorithm — it is a byte-for-byte cross-SDK contract
+    with the Rust SDK (issue #1606 / the Rust SDK's #1713, contract
+    ``dataflow-cache-keys-v3``), NOT the py-local query-keyspace fingerprint:
+
+    * ``hash_database_identity`` (QUERY keyspace) hashes ``mask_url(...)``
+      (``scheme://***@host:port/dbname``) and takes 8 hex chars. py-local shape.
+    * THIS function (EXPRESS keyspace) hashes the NORMALIZED connection target
+      ``scheme://<authority><path>`` — scheme lowercased, userinfo (credentials)
+      and query string and fragment stripped BEFORE hashing — and takes the
+      FIRST 16 hex chars (64 bits), prefixed with the literal ``db``. The two
+      MUST NOT be interchanged; the express bytes are pinned by the vendored
+      canonical vectors and any drift breaks cross-SDK cache-key parity.
+
+    The normalized pre-image carries NO credential byte (userinfo is stripped),
+    so a Redis key — an observable surface (``rules/security.md`` § "No secrets
+    in logs") — can never leak a password even if the digest were reversed. Two
+    instances at the SAME database with different DB credentials share a cache
+    namespace by design (the identity keys on database LOCATION, not principal).
+
+    Returns ``None`` when the URL is falsy OR unparseable (no scheme), OR when a
+    ``//``-less credential-bearing DSN would otherwise leak credential bytes into
+    the pre-image (see below). Callers that get ``None`` MUST emit a loud warning
+    — cross-DB cache isolation is then INACTIVE on a shared backend
+    (``rules/zero-tolerance.md`` Rule 3, no silent fallback).
+
+    KNOWN LIMITATION (cross-SDK-pinned): the identity keys on the connection
+    TARGET (``scheme://host:port/dbname``) — the query string is stripped, so two
+    instances at the SAME host/port/dbname that select a different SCHEMA via a
+    query parameter (e.g. ``?options=-csearch_path=a`` vs ``...=b``) share one
+    ``db_instance``. Deployments relying on per-schema-via-query isolation MUST
+    NOT share a cache backend across those instances. This normalization is the
+    byte-for-byte cross-SDK contract and MUST NOT be changed unilaterally
+    (``cross-sdk-inspection.md`` Rule 4b).
+
+    Examples (canonical vectors):
+        ``postgres://cache-host:5432/app_a``            -> ``dbd4e3f17d35c2bb57``
+        ``sqlite:///var/data/app_b.db``                 -> ``db5c74b84689218303``
+        ``postgres://svc_user:s3cr3t@cache-host:5432/app_a`` -> ``dbd4e3f17d35c2bb57``
+        (credentials stripped -> identical to the credential-free form)
+    """
+    if not database_url:
+        return None
+    try:
+        parsed = urlparse(database_url)
+    except Exception:
+        # urlparse is tolerant, but fail closed on any parse error rather than
+        # hashing a garbage constant that would collapse cross-DB isolation.
+        return None
+    if not parsed.scheme:
+        return None
+    netloc = parsed.netloc
+    # Fail closed on a ``//``-less credential-bearing DSN. ``urlparse`` only
+    # populates ``netloc`` for a ``scheme://authority`` URL; a
+    # ``scheme:user:pass@host/db`` form (no ``//``) leaves ``netloc`` empty and
+    # the userinfo in ``path``, so the ``@``-strip below would never fire and
+    # credential bytes would enter the hash pre-image. Refuse rather than hash a
+    # credential (defense-in-depth; the caller warns and isolation is INACTIVE).
+    # A ``//``-authority URL (``postgres://...``) always has a non-empty netloc;
+    # a sqlite file URL (``sqlite:///path``) has empty netloc but no ``@`` in the
+    # path — so this guard never fires for any valid/canonical target.
+    if not netloc and "@" in parsed.path:
+        return None
+    # Strip userinfo (user[:password]@) from the authority — only host[:port]
+    # survives, so no credential byte enters the hash pre-image.
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[1]
+    # query + fragment live in parsed.query / parsed.fragment and are excluded
+    # from the pre-image by construction (only scheme://netloc/path is joined).
+    normalized = f"{parsed.scheme.lower()}://{netloc}{parsed.path}"
+    return "db" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
 
 class DbIdentityResolution(NamedTuple):
@@ -188,6 +278,7 @@ class CacheKeyGenerator:
         version: str = "v2",
         classification_policy: Optional["ClassificationPolicy"] = None,
         db_identity: Optional[str] = None,
+        express_db_instance: Optional[str] = None,
     ):
         """
         Initialize key generator.
@@ -195,10 +286,11 @@ class CacheKeyGenerator:
         Args:
             prefix: Global prefix for all keys
             namespace: Optional namespace (e.g., tenant ID)
-            version: Cache keyspace version. Default is ``"v2"`` (BP-049
-                cross-SDK keyspace; pre-fix ``v1`` entries are orphaned on
-                upgrade and naturally expire). Cross-SDK contract matches
-                ``kailash-rs`` v3.19.0.
+            version: QUERY-keyspace version (``generate_key``). Default ``"v2"``
+                (py-local; diverges cross-SDK by construction — py vs rs emit
+                different SQL). This is NOT the express keyspace version; the
+                express keyspace is Rust-pinned at ``EXPRESS_KEYSPACE_VERSION``
+                (``v3``, issue #1606) and is not affected by this argument.
             classification_policy: Optional policy used to hash classified
                 PK values before they enter the key-material hash. When
                 provided, PKs whose model+field pair is classified are
@@ -212,15 +304,27 @@ class CacheKeyGenerator:
                 model name — so two DataFlow instances at *different*
                 databases never collide on the same query cache key
                 (issue #1606: cross-DB cache bleed). It is DELIBERATELY
-                absent from ``generate_express_key``: the Express ``v2``
-                keyspace is a byte-for-byte cross-SDK contract pinned to
-                ``kailash-rs`` and MUST NOT change unilaterally.
+                absent from ``generate_express_key`` — the express keyspace
+                carries its OWN ``express_db_instance`` segment (below), a
+                different byte-for-byte cross-SDK fingerprint; the two MUST
+                NOT be interchanged.
+            express_db_instance: Optional Rust-pinned ``db<16 hex>``
+                database-instance segment for the EXPRESS keyspace
+                (``generate_express_key``), produced by
+                ``express_db_instance_fingerprint``. When set, it is inserted
+                directly AFTER the version token (``dataflow:v3:<db_instance>:
+                ...``) so two DataFlow instances at *different* databases
+                never collide on the same express cache key (issue #1606 /
+                the Rust SDK's #1713, the v2->v3 lockstep). DISTINCT from
+                ``db_identity`` (query keyspace, different algorithm + length);
+                the two are never interchanged.
         """
         self.prefix = prefix
         self.namespace = namespace
         self.version = version
         self._classification_policy = classification_policy
         self.db_identity = db_identity
+        self.express_db_instance = express_db_instance
 
     def _safe_params(self, model_name: str, params: Any) -> Any:
         """Return a copy of ``params`` with classified PK values hashed.
@@ -235,9 +339,7 @@ class CacheKeyGenerator:
         if self._classification_policy is None or not isinstance(params, dict):
             return params
         # Lazy import avoids a cycle with features/express.py.
-        from dataflow.classification.event_payload import (
-            format_record_id_for_event,
-        )
+        from dataflow.classification.event_payload import format_record_id_for_event
 
         def _hash_id(mapping: Dict[str, Any]) -> Dict[str, Any]:
             if "id" not in mapping:
@@ -299,10 +401,11 @@ class CacheKeyGenerator:
         # model name so the existing model-anchored invalidation sweeps
         # (``{prefix}:{model}:*`` and the ``:{model}:`` substring matcher)
         # still match BOTH old-shape (no db_identity) and new-shape keys.
-        # The query keyspace is NOT the Rust-pinned Express v2 keyspace — it
+        # The query keyspace is NOT the Rust-pinned express keyspace — it
         # diverges cross-SDK by construction (py vs rs emit different SQL),
-        # so adding this segment is a py-local change, not a cross-SDK
-        # lockstep. See ``generate_express_key`` (Rust-pinned, untouched).
+        # so this segment is a py-local change, not a cross-SDK lockstep. The
+        # express keyspace has its OWN Rust-pinned db-instance segment; see
+        # ``generate_express_key`` / ``express_db_instance_fingerprint``.
         if self.db_identity:
             components.append(self.db_identity)
 
@@ -352,11 +455,15 @@ class CacheKeyGenerator:
         ``format_record_id_for_event`` BEFORE serialisation so the raw
         value never enters the hash input. See issue #520 (BP-049).
 
-        Shape (``v2`` keyspace; BP-049 cross-SDK):
+        Shape (``v3`` keyspace; issue #1606 / the Rust SDK's #1713 cross-SDK
+        lockstep). The ``db_instance`` segment sits directly after the
+        version, BEFORE the tenant, and is present in BOTH forms (it is
+        absent only when the generator was constructed without an
+        ``express_db_instance`` — a degraded no-DB fallback):
 
-        * Without tenant/namespace: ``dataflow:v2:User:list:a1b2c3d4``
-        * With tenant_id: ``dataflow:v2:tenant-a:User:list:a1b2c3d4``
-        * With namespace: ``dataflow:v2:<namespace>:User:list:a1b2c3d4``
+        * Single-tenant: ``dataflow:v3:<db_instance>:User:list:a1b2c3d4``
+        * Multi-tenant:  ``dataflow:v3:<db_instance>:tenant-a:User:list:a1b2c3d4``
+        * No db_instance (fallback): ``dataflow:v3:User:list:a1b2c3d4``
 
         The ``tenant_id`` argument takes precedence over the
         constructor ``namespace`` when both are supplied, so a
@@ -384,19 +491,58 @@ class CacheKeyGenerator:
         if not operation:
             raise ValueError("Operation is required")
 
-        parts: list[str] = [self.prefix, self.version]
+        params_hash: Optional[str] = None
+        if params is not None:
+            safe = self._safe_params(model_name, params)
+            param_str = json.dumps(safe, sort_keys=True, default=str)
+            params_hash = hashlib.md5(param_str.encode()).hexdigest()[:8]
+
+        return self._assemble_express_key(model_name, operation, params_hash, tenant_id)
+
+    def _assemble_express_key(
+        self,
+        model_name: str,
+        operation: str,
+        params_hash: Optional[str],
+        tenant_id: Optional[str],
+    ) -> str:
+        """Assemble a v3 express physical key from an already-computed hash.
+
+        This is the byte-for-byte cross-SDK assembly seam (the equivalent of
+        the Rust SDK's ``BackendKey::to_physical``): it concatenates the
+        keyspace segments in the canonical v3 order and is exercised directly
+        by the conformance test against the vendored canonical vectors
+        (``tests/fixtures/dataflow-cache-keys.json``). ``generate_express_key``
+        computes ``params_hash`` (MD5 of the serialised params) then delegates
+        here; the conformance test injects the vectors' pre-computed
+        ``params_hash`` instead.
+
+        ``params_hash`` semantics:
+
+        * ``None`` — no params were supplied; the trailing segment is OMITTED
+          (``dataflow:v3:<db_instance>:User:list``). Backward-compatible with
+          the pre-#1606 no-params shape.
+        * ``""`` (empty string) — a PRESENT-but-empty hash; the segment IS
+          appended, so the key ends in a bare ``:`` (canonical vector V4:
+          ``dataflow:v3:<db_instance>:Product:list:``). ``generate_express_key``
+          never emits this (MD5 is always 8 chars); it is a conformance-only
+          shape the assembly must reproduce to match the Rust SDK byte-for-byte.
+        """
+        parts: list[str] = [self.prefix, EXPRESS_KEYSPACE_VERSION]
+        # #1606 db-instance segment: directly after the version, before tenant.
+        # Present in every production key (a DataFlow always has a connection
+        # target); absent only in the degraded no-URL fallback, where the
+        # express wrapper has already logged that cross-DB isolation is INACTIVE.
+        if self.express_db_instance:
+            parts.append(self.express_db_instance)
         if tenant_id is not None:
             parts.append(str(tenant_id))
         elif self.namespace:
             parts.append(self.namespace)
         parts.append(model_name)
         parts.append(operation)
-
-        if params is not None:
-            safe = self._safe_params(model_name, params)
-            param_str = json.dumps(safe, sort_keys=True, default=str)
-            param_hash = hashlib.md5(param_str.encode()).hexdigest()[:8]
-            parts.append(param_hash)
+        if params_hash is not None:
+            parts.append(params_hash)
 
         return ":".join(parts)
 

--- a/packages/kailash-dataflow/src/dataflow/cache/memory_cache.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/memory_cache.py
@@ -189,17 +189,20 @@ class InMemoryCache:
         does NOT affect entries for ``"UserAudit"`` or ``"UserSession"``.
         The key generator produces two formats:
 
-        - Express keys: ``dataflow:v*:{model}:{op}:...``
-        - Express keys with tenant: ``dataflow:v*:{tenant}:{model}:{op}:...``
+        - Express keys (v3, #1606): ``dataflow:v3:{db_instance}:{model}:{op}:...``
+        - Express keys with tenant: ``dataflow:v3:{db_instance}:{tenant}:{model}:{op}:...``
+          (the ``db_instance`` segment sits directly after the version, BEFORE
+          the tenant; pre-#1606 v2 keys had no ``db_instance`` segment).
         - SQL query keys: ``dataflow:{model}:v*:...`` or, since issue #1606,
           ``dataflow:{model}:{db_identity}:v*:...`` (the DB-instance
           identity segment sits directly after the model name).
 
-        The ``:{model}:`` segment matcher is agnostic to BOTH the version
-        segment AND the #1606 DB-identity segment (they follow the matched
-        ``:{model}:`` delimiter), so it sweeps legacy v1 keys, pre-#1606 v2
-        keys (no db_identity), AND post-#1606 v2 keys (with db_identity) in
-        one call — the implementation survives future keyspace bumps and the
+        The ``:{model}:`` segment matcher is agnostic to the version segment,
+        the #1606 express ``db_instance`` segment, AND the query-keyspace
+        ``db_identity`` segment (all precede the matched ``:{model}:``
+        delimiter), so it sweeps legacy v1/v2 keys AND v3 express keys
+        (with or without ``db_instance``) in one call — the implementation
+        survives future keyspace bumps and the
         DB-identity addition without edit (``tenant-isolation.md §3a``).
 
         Matching strategy:

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -54,7 +54,10 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from dataflow.cache.auto_detection import CacheBackend
-from dataflow.cache.key_generator import CacheKeyGenerator
+from dataflow.cache.key_generator import (
+    CacheKeyGenerator,
+    express_db_instance_fingerprint,
+)
 from dataflow.cache.memory_cache import InMemoryCache
 from dataflow.classification.event_payload import format_record_id_for_event
 from dataflow.core.agent_context import get_current_agent_id, get_current_clearance
@@ -150,11 +153,31 @@ class DataFlowExpress:
         else:
             self._cache_manager = None
 
+        # Issue #1606 (the Rust SDK's #1713, v2->v3 cross-SDK lockstep):
+        # resolve this DataFlow's credential-free database-instance fingerprint
+        # and plumb it into the express keyspace so two DataFlow instances at
+        # DIFFERENT databases sharing a process-wide cache backend (e.g. Redis)
+        # never collide on the same express key (cross-DB cache bleed). The URL
+        # lives on the structured config (``config.database.url``), NOT as a
+        # ``database_url`` attribute on the DataFlow instance.
+        _db_cfg = getattr(self._db, "config", None)
+        _db_url = getattr(getattr(_db_cfg, "database", None), "url", None)
+        express_db_instance = express_db_instance_fingerprint(_db_url)
+        if express_db_instance is None:
+            logger.warning(
+                "express.cache.db_instance_disabled: no usable database "
+                "identity from the DataFlow URL — cross-DB express cache "
+                "isolation is INACTIVE on a shared cache backend; two DataFlow "
+                "instances at different databases may read each other's cached "
+                "express rows (#1606)",
+                extra={"url_present": _db_url is not None},
+            )
         # BP-049: plumb the DataFlow classification policy into the cache
         # key generator so classified PKs are hashed before serialisation
         # (issue #520). ``self._db`` holds the owning DataFlow instance.
         self._key_gen = CacheKeyGenerator(
             classification_policy=getattr(self._db, "_classification_policy", None),
+            express_db_instance=express_db_instance,
         )
 
         # Local hit/miss counters for Express-level stats
@@ -2313,9 +2336,19 @@ class DataFlowExpress:
         if self._cache_manager is None:
             return 0
         if model:
-            return await self._cache_manager.clear_pattern(
-                f"{self._key_gen.prefix}:{self._key_gen.version}:{model}:*"
-            )
+            # Version- AND db-instance-agnostic model-scoped clear. The
+            # express keyspace bumped v2->v3 (#1606) and inserted a
+            # db-instance segment directly after the version, so a
+            # version-pinned prefix glob
+            # (``{prefix}:{self._key_gen.version}:{model}:*``, pinned to the
+            # generator's query-keyspace version "v2") no longer matches the
+            # v3 express keys AND never matched tenant-scoped express keys
+            # (``...:{tenant}:{model}:...``, model after tenant) — it would
+            # silently clear 0 entries. Delegate to ``invalidate_model``,
+            # whose ``:{model}:`` segment matcher is agnostic to the version
+            # segment, the #1606 db-instance segment, AND the tenant segment
+            # (``tenant-isolation.md`` §3a), mirroring ``_invalidate_model_cache``.
+            return await self._cache_manager.invalidate_model(model)
         else:
             if isinstance(self._cache_manager, InMemoryCache):
                 count = len(self._cache_manager.cache)

--- a/packages/kailash-dataflow/tests/fixtures/dataflow-cache-keys.json
+++ b/packages/kailash-dataflow/tests/fixtures/dataflow-cache-keys.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "contract": "dataflow-cache-keys-v3",
+  "description": "Cross-SDK conformance vectors for the DataFlow Express cache keyspace (issue #1713). kailash-rs LEADS this contract: it DEFINES the v3 keyspace, generates these canonical byte-vectors, and kailash-py (#1606) MUST reproduce every `physical` string byte-for-byte for the same inputs. The v3 keyspace inserts a database-instance dimension immediately after the version token so two DataFlow instances pointed at DIFFERENT databases but sharing a process-wide cache backend (e.g. Redis) can never collide on the same physical key. The db-instance segment is `db<16 lowercase hex>` — the first 16 hex chars (64 bits) of SHA-256 over the NORMALIZED connection target (`scheme://<authority>` with credentials AND query string stripped BEFORE hashing, only the scheme lowercased). No credential or PII ever reaches the keyspace (same rationale as the v1->v2 PK-fingerprint bump). Physical key shape: `dataflow:v3:{db_instance}:{tenant}:{model}:{op}:{params_hash}` (multi-tenant) and `dataflow:v3:{db_instance}:{model}:{op}:{params_hash}` (single-tenant). Each vector's `physical` string is the exact byte output of `BackendKey::to_physical()` for the `input` row; `db_instance` is the exact output of `db_instance_fingerprint(input.db_target)`.",
+  "kailash_rs_reference": "crates/kailash-dataflow/src/cache/mod.rs::{BackendKey::to_physical, db_instance_fingerprint}",
+  "kailash_py_reference": "kailash-py #1606 (the cross-SDK equivalent — MUST mirror these bytes)",
+  "vectors": [
+    {
+      "id": "V1",
+      "description": "Single-tenant Postgres read. Baseline shape: no tenant segment; db-instance sits directly after the version.",
+      "input": {
+        "db_target": "postgres://cache-host:5432/app_a",
+        "tenant": null,
+        "model": "User",
+        "op": "read",
+        "params_hash": "abc123"
+      },
+      "db_instance": "dbd4e3f17d35c2bb57",
+      "physical": "dataflow:v3:dbd4e3f17d35c2bb57:User:read:abc123"
+    },
+    {
+      "id": "V2",
+      "description": "Multi-tenant Postgres read on `app_a`. Full shape: db-instance THEN tenant THEN model. Classified PK already fingerprinted (`sha256:deadbeef`) upstream.",
+      "input": {
+        "db_target": "postgres://cache-host:5432/app_a",
+        "tenant": "tenant-alpha",
+        "model": "Document",
+        "op": "read",
+        "params_hash": "sha256:deadbeef"
+      },
+      "db_instance": "dbd4e3f17d35c2bb57",
+      "physical": "dataflow:v3:dbd4e3f17d35c2bb57:tenant-alpha:Document:read:sha256:deadbeef"
+    },
+    {
+      "id": "V3",
+      "description": "Single-tenant SQLite list. Distinct scheme (`sqlite`) and file path produce a distinct db-instance from the Postgres vectors.",
+      "input": {
+        "db_target": "sqlite:///var/data/app_b.db",
+        "tenant": null,
+        "model": "Order",
+        "op": "list",
+        "params_hash": "filterhash01"
+      },
+      "db_instance": "db5c74b84689218303",
+      "physical": "dataflow:v3:db5c74b84689218303:Order:list:filterhash01"
+    },
+    {
+      "id": "V4",
+      "description": "SENTINEL — empty params_hash (e.g. an unfiltered `list`). The trailing segment is empty, so the physical key ends in a bare `:`. Pins that an empty filter does not collapse a segment.",
+      "input": {
+        "db_target": "postgres://cache-host:5432/app_a",
+        "tenant": null,
+        "model": "Product",
+        "op": "list",
+        "params_hash": ""
+      },
+      "db_instance": "dbd4e3f17d35c2bb57",
+      "physical": "dataflow:v3:dbd4e3f17d35c2bb57:Product:list:"
+    },
+    {
+      "id": "V5",
+      "description": "SENTINEL — cross-database anti-collision. IDENTICAL tenant+model+op+params_hash as V2 but a DIFFERENT database (`app_b` vs `app_a`). The db-instance segment differs, so the physical keys MUST differ — this is the exact #1713 bug this keyspace closes. `physical` MUST NOT equal V2.physical.",
+      "input": {
+        "db_target": "postgres://cache-host:5432/app_b",
+        "tenant": "tenant-alpha",
+        "model": "Document",
+        "op": "read",
+        "params_hash": "sha256:deadbeef"
+      },
+      "db_instance": "dbae1d263c494c6c05",
+      "physical": "dataflow:v3:dbae1d263c494c6c05:tenant-alpha:Document:read:sha256:deadbeef"
+    },
+    {
+      "id": "V6",
+      "description": "SENTINEL — credentials stripped. SAME normalized target as V1 but with `svc_user:s3cr3t@` userinfo. The credential is removed BEFORE hashing, so `db_instance` and `physical` MUST equal V1 exactly (no credential reaches the keyspace).",
+      "input": {
+        "db_target": "postgres://svc_user:s3cr3t@cache-host:5432/app_a",
+        "tenant": null,
+        "model": "User",
+        "op": "read",
+        "params_hash": "abc123"
+      },
+      "db_instance": "dbd4e3f17d35c2bb57",
+      "physical": "dataflow:v3:dbd4e3f17d35c2bb57:User:read:abc123"
+    }
+  ]
+}

--- a/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_cross_db_bleed.py
+++ b/packages/kailash-dataflow/tests/integration/cache/test_issue_1606_cross_db_bleed.py
@@ -25,7 +25,11 @@ import pytest
 
 from dataflow.cache.async_redis_adapter import AsyncRedisCacheAdapter
 from dataflow.cache.invalidation import CacheInvalidator
-from dataflow.cache.key_generator import CacheKeyGenerator, hash_database_identity
+from dataflow.cache.key_generator import (
+    CacheKeyGenerator,
+    express_db_instance_fingerprint,
+    hash_database_identity,
+)
 from dataflow.cache.list_node_integration import ListNodeCacheIntegration
 from dataflow.cache.redis_manager import CacheConfig, RedisCacheManager
 
@@ -201,6 +205,112 @@ async def test_post_fix_db_identity_closes_cross_db_bleed():
             )
             assert res_b2["_cache"]["hit"] is True
             assert res_b2["source_db"] == "B"
+    finally:
+        _cleanup_redis(config, prefix)
+        await cache_manager.close_async()
+
+
+# ---------------------------------------------------------------------------
+# EXPRESS keyspace (#1606 v2->v3) cross-DB bleed — the HOT path.
+#
+# The Express path (read/list/find_one/count) has no SQL: keys come from
+# ``generate_express_key`` (``dataflow:v3:<db_instance>:<tenant>:<model>:<op>:
+# <hash>``). Without the ``db_instance`` segment (pre-v3), two DataFlow
+# instances at DIFFERENT databases compute the IDENTICAL express key for the
+# same tenant+model+op+params and bleed across each other on a shared Redis.
+# The v3 db-instance segment closes it. Real Redis, real key generation,
+# real set/get read-back — NO MOCKING.
+# ---------------------------------------------------------------------------
+_EXPRESS_OP = "list"
+_EXPRESS_TENANT = "tenant-a"
+_EXPRESS_PARAMS = {"active": True}
+
+
+def _express_gen(db_url: str, *, with_db_instance: bool, prefix: str):
+    """Build an express key generator; with_db_instance=False = pre-v3 shape."""
+    inst = express_db_instance_fingerprint(db_url) if with_db_instance else None
+    return CacheKeyGenerator(prefix=prefix, express_db_instance=inst)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_express_pre_v3_shape_reproduces_cross_db_bleed():
+    """RED: without the db-instance segment, two DBs share ONE express key -> bleed."""
+    config = _redis_config_or_skip()
+    prefix = f"df1606expr:{uuid4().hex}"
+
+    cache_manager = AsyncRedisCacheAdapter(RedisCacheManager(config))
+    try:
+        gen_a = _express_gen(
+            "sqlite:///tmp/db_a.db", with_db_instance=False, prefix=prefix
+        )
+        gen_b = _express_gen(
+            "sqlite:///tmp/db_b.db", with_db_instance=False, prefix=prefix
+        )
+
+        key_a = gen_a.generate_express_key(
+            _MODEL, _EXPRESS_OP, _EXPRESS_PARAMS, tenant_id=_EXPRESS_TENANT
+        )
+        key_b = gen_b.generate_express_key(
+            _MODEL, _EXPRESS_OP, _EXPRESS_PARAMS, tenant_id=_EXPRESS_TENANT
+        )
+        # Pre-v3 precondition: no db-instance -> identical key across databases.
+        assert key_a == key_b, "pre-v3 precondition: express keys must collide"
+
+        # A caches its rows; B reads the SAME key -> HIT on A's data -> BLEED.
+        await cache_manager.set(key_a, {"rows": [{"id": 1, "src": "A"}]}, ttl=60)
+        bled = await cache_manager.get(key_b)
+        assert (
+            bled is not None and bled["rows"][0]["src"] == "A"
+        ), "BLEED reproduced: B read A's cached express rows via the shared key"
+    finally:
+        _cleanup_redis(config, prefix)
+        await cache_manager.close_async()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_express_v3_db_instance_closes_cross_db_bleed():
+    """GREEN: the v3 db-instance segment gives each database a DISTINCT express key."""
+    config = _redis_config_or_skip()
+    prefix = f"df1606expr:{uuid4().hex}"
+
+    cache_manager = AsyncRedisCacheAdapter(RedisCacheManager(config))
+    try:
+        with tempfile.TemporaryDirectory() as d_a, tempfile.TemporaryDirectory() as d_b:
+            url_a = _make_sqlite_db(Path(d_a), "dba", "alice-from-db-A")
+            url_b = _make_sqlite_db(Path(d_b), "dbb", "bob-from-db-B")
+
+            gen_a = _express_gen(url_a, with_db_instance=True, prefix=prefix)
+            gen_b = _express_gen(url_b, with_db_instance=True, prefix=prefix)
+
+            key_a = gen_a.generate_express_key(
+                _MODEL, _EXPRESS_OP, _EXPRESS_PARAMS, tenant_id=_EXPRESS_TENANT
+            )
+            key_b = gen_b.generate_express_key(
+                _MODEL, _EXPRESS_OP, _EXPRESS_PARAMS, tenant_id=_EXPRESS_TENANT
+            )
+            # Post-v3: distinct db-instance -> distinct express keys (the fix).
+            assert key_a != key_b, "post-v3: express keys MUST differ per database"
+            assert gen_a.express_db_instance != gen_b.express_db_instance
+
+            # A caches ITS rows under ITS key; B's key is a MISS (no bleed).
+            await cache_manager.set(
+                key_a, {"rows": [{"id": 1, "name": "alice-from-db-A"}]}, ttl=60
+            )
+            miss_b = await cache_manager.get(key_b)
+            assert (
+                miss_b is None
+            ), "post-v3: B's express key MUST miss, not bleed A's data"
+
+            # B caches its OWN rows; both keys coexist on the shared Redis.
+            await cache_manager.set(
+                key_b, {"rows": [{"id": 1, "name": "bob-from-db-B"}]}, ttl=60
+            )
+            back_a = await cache_manager.get(key_a)
+            back_b = await cache_manager.get(key_b)
+            assert back_a is not None and back_a["rows"][0]["name"] == "alice-from-db-A"
+            assert back_b is not None and back_b["rows"][0]["name"] == "bob-from-db-B"
     finally:
         _cleanup_redis(config, prefix)
         await cache_manager.close_async()

--- a/packages/kailash-dataflow/tests/integration/security/test_bp_049_classification_leaks_wiring.py
+++ b/packages/kailash-dataflow/tests/integration/security/test_bp_049_classification_leaks_wiring.py
@@ -55,11 +55,7 @@ import pytest
 
 from dataflow import DataFlow
 from dataflow.cache.key_generator import CacheKeyGenerator
-from dataflow.classification import (
-    DataClassification,
-    MaskingStrategy,
-    classify,
-)
+from dataflow.classification import DataClassification, MaskingStrategy, classify
 from dataflow.classification.policy import ClassificationPolicy
 from dataflow.classification.validation_error import (
     CLASSIFIED_FIELD_NAME_PLACEHOLDER,
@@ -68,7 +64,6 @@ from dataflow.classification.validation_error import (
 )
 from dataflow.validation.decorators import field_validator, validate_model
 from dataflow.validation.result import ValidationResult
-
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 pytestmark = [pytest.mark.integration]
@@ -301,8 +296,9 @@ def test_m2_cache_key_classified_pk_produces_stable_different_key():
     assert key_a != key_b, "Distinct raw PKs MUST produce distinct keys"
     assert "alice@leak.example" not in key_a
     assert "bob@leak.example" not in key_b
-    # v2 keyspace
-    assert ":v2:" in key_a
+    # v3 express keyspace (#1606 bumped v2->v3; bare generator has no
+    # db-instance segment, so the version token sits directly after the prefix)
+    assert ":v3:" in key_a
 
 
 def test_m2_cache_key_filter_nested_id_is_hashed():

--- a/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation.py
@@ -58,8 +58,9 @@ def mt_db():
         # these #1252 regression tests verify the BULK subsystem's tenant
         # stamping/scoping and read every write back to assert real PERSISTED
         # state. The Express query cache auto-detects a process-shared Redis
-        # whose keys (dataflow:v2:<tenant>:<model>:<op>:<hash>) carry a tenant
-        # dimension but NO database-instance dimension, so a sibling test's
+        # whose keys (pre-#1606 shape dataflow:v2:<tenant>:<model>:<op>:<hash>)
+        # carried a tenant dimension but NO database-instance dimension, so a
+        # sibling test's
         # rows for the same model+tenant in a DIFFERENT tmpdir DB bleed into
         # this test's read-backs (a stale cached ``list Feat`` returned an id
         # from another DB, which a later bulk_upsert then targeted — clobbering

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_express_v3_conformance.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_express_v3_conformance.py
@@ -1,0 +1,208 @@
+"""#1606 EXPRESS v3 cross-SDK byte-for-byte CONFORMANCE (Tier 1).
+
+The Rust SDK LEADS the express cache keyspace contract (issue #1606 / the Rust
+SDK's #1713, contract ``dataflow-cache-keys-v3``): it DEFINES the v3 keyspace,
+generates the canonical byte-vectors, and kailash-py MUST reproduce every
+``physical`` string byte-for-byte for the same inputs.
+
+Per ``rules/cross-sdk-inspection.md`` Rule 4a, the canonical fixture is
+VENDORED byte-for-byte from the Rust SDK (NOT re-authored) at
+``tests/fixtures/dataflow-cache-keys.json`` and consumed here directly. Rule 4
+requires >=3 real sibling-SDK byte vectors PLUS sentinels (empty params_hash,
+cross-DB anti-collision, credential-strip) — all six V1-V6 are exercised below.
+
+This is the exhaustive byte contract; ``test_issue_1606_keyspace_tripwire.py``
+pins the common shapes as a loud drift tripwire.
+
+Tier: 1 (Unit — no external dependencies).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dataflow.cache.key_generator import (
+    CacheKeyGenerator,
+    express_db_instance_fingerprint,
+)
+
+# The vendored canonical fixture (byte-identical to the Rust SDK's
+# test-vectors/dataflow-cache-keys.json). tests/unit/cache/ -> tests/fixtures/.
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2] / "fixtures" / "dataflow-cache-keys.json"
+)
+
+
+def _load_fixture() -> dict:
+    with _FIXTURE_PATH.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _vectors() -> list:
+    return _load_fixture()["vectors"]
+
+
+def test_fixture_is_the_vendored_v3_contract():
+    """Guards that the vendored fixture is the expected v3 contract, not drift."""
+    fixture = _load_fixture()
+    assert fixture["contract"] == "dataflow-cache-keys-v3"
+    # Rule 4 minimum: >=3 real vectors + the empty/cross-DB/credential sentinels.
+    ids = [v["id"] for v in fixture["vectors"]]
+    assert ids == ["V1", "V2", "V3", "V4", "V5", "V6"], (
+        f"canonical vector set drifted: {ids}. The fixture is vendored "
+        f"byte-for-byte from the Rust SDK — do not edit it locally; re-vendor."
+    )
+
+
+@pytest.mark.parametrize("vector", _vectors(), ids=lambda v: v["id"])
+def test_express_db_instance_fingerprint_matches_canonical(vector):
+    """express_db_instance_fingerprint reproduces the canonical db_instance."""
+    got = express_db_instance_fingerprint(vector["input"]["db_target"])
+    assert got == vector["db_instance"], (
+        f"{vector['id']}: db_instance fingerprint drifted for "
+        f"{vector['input']['db_target']!r}: got {got!r}, "
+        f"expected {vector['db_instance']!r}. This is a byte-for-byte cross-SDK "
+        f"contract — a drift breaks cross-DB cache-key parity with the Rust SDK."
+    )
+
+
+@pytest.mark.parametrize("vector", _vectors(), ids=lambda v: v["id"])
+def test_express_physical_key_matches_canonical(vector):
+    """The full v3 physical key reproduces the canonical byte-string.
+
+    Reproduces ``physical`` end-to-end from ``input``: fingerprint the
+    ``db_target``, then assemble the key with the vector's pre-computed
+    ``params_hash`` (the assembly seam ``_assemble_express_key`` is the py
+    equivalent of the Rust SDK's ``BackendKey::to_physical`` — it takes an
+    already-computed params_hash, exactly as the canonical vectors provide).
+    """
+    inp = vector["input"]
+    db_instance = express_db_instance_fingerprint(inp["db_target"])
+    gen = CacheKeyGenerator(express_db_instance=db_instance)
+
+    physical = gen._assemble_express_key(
+        inp["model"],
+        inp["op"],
+        inp["params_hash"],  # canonical pre-computed hash (incl. "" for V4)
+        inp["tenant"],
+    )
+    assert physical == vector["physical"], (
+        f"{vector['id']}: physical key drifted: got {physical!r}, "
+        f"expected {vector['physical']!r}. Changing express bytes is a cross-SDK "
+        f"LOCKSTEP (#1606/the Rust SDK's #1713) — re-pin v3 in BOTH SDKs."
+    )
+
+
+def test_v5_cross_database_anti_collision():
+    """SENTINEL V5: identical tenant+model+op+params, DIFFERENT db -> DIFFERENT key.
+
+    This is the exact #1606 bug the keyspace closes: without the db_instance
+    segment, V2 (app_a) and V5 (app_b) would collide and one tenant would read
+    the other database's cached row.
+    """
+    by_id = {v["id"]: v for v in _vectors()}
+    v2, v5 = by_id["V2"], by_id["V5"]
+
+    # Same everything except the database target.
+    assert v2["input"]["tenant"] == v5["input"]["tenant"]
+    assert v2["input"]["model"] == v5["input"]["model"]
+    assert v2["input"]["op"] == v5["input"]["op"]
+    assert v2["input"]["params_hash"] == v5["input"]["params_hash"]
+    assert v2["input"]["db_target"] != v5["input"]["db_target"]
+
+    # Distinct db_instance -> distinct physical keys (no cross-DB bleed).
+    assert express_db_instance_fingerprint(
+        v2["input"]["db_target"]
+    ) != express_db_instance_fingerprint(v5["input"]["db_target"])
+    assert v2["physical"] != v5["physical"]
+
+
+def test_v6_credentials_stripped_before_hashing():
+    """SENTINEL V6: userinfo (credentials) is stripped BEFORE hashing.
+
+    V6 has the same normalized target as V1 but with ``svc_user:s3cr3t@``
+    userinfo; the credential is removed before hashing so db_instance and the
+    physical key are byte-identical to V1 (no credential reaches the keyspace).
+    """
+    by_id = {v["id"]: v for v in _vectors()}
+    v1, v6 = by_id["V1"], by_id["V6"]
+
+    assert "svc_user" in v6["input"]["db_target"]  # credentials present in input
+    assert express_db_instance_fingerprint(
+        v6["input"]["db_target"]
+    ) == express_db_instance_fingerprint(v1["input"]["db_target"])
+    assert v6["physical"] == v1["physical"]
+    # No credential byte ever appears in the emitted key.
+    assert "svc_user" not in v6["physical"]
+    assert "s3cr3t" not in v6["physical"]
+
+
+def test_unparseable_and_empty_urls_fail_closed():
+    """A falsy or scheme-less URL yields None (caller warns; isolation INACTIVE).
+
+    Hashing a garbage constant would collapse every such instance into one
+    identity — the silent-fallback failure mode (``zero-tolerance.md`` Rule 3).
+    """
+    assert express_db_instance_fingerprint(None) is None
+    assert express_db_instance_fingerprint("") is None
+    assert express_db_instance_fingerprint("not-a-url-no-scheme") is None
+
+
+def test_query_string_and_fragment_stripped_before_hashing():
+    """py-local: query string + fragment are excluded from the fingerprint.
+
+    Not a canonical vector (the rs-led fixture pins the credential-strip
+    sentinel V6 but no query-string case). A query string can itself carry a
+    credential (``?password=...``), so it MUST NOT reach the keyspace pre-image
+    (`security.md` § No secrets in logs). Two URLs differing ONLY in query /
+    fragment therefore share ONE db-instance (same database location), and no
+    query byte appears in the fingerprint pre-image.
+    """
+    base = "postgres://cache-host:5432/app_a"
+    with_query = "postgres://cache-host:5432/app_a?sslmode=require&password=leak"
+    with_fragment = "postgres://cache-host:5432/app_a#frag"
+
+    fp_base = express_db_instance_fingerprint(base)
+    assert fp_base is not None
+    # Query string and fragment do not change the database-location identity.
+    assert express_db_instance_fingerprint(with_query) == fp_base
+    assert express_db_instance_fingerprint(with_fragment) == fp_base
+    # And it equals the canonical V1 db_instance (same normalized target).
+    assert fp_base == "dbd4e3f17d35c2bb57"
+
+
+def test_userinfo_variants_stripped_consistently():
+    """py-local: userinfo (incl. an ``@`` inside the password) is fully stripped.
+
+    The strip takes the host side of the LAST ``@`` (``rsplit("@", 1)``), so a
+    password containing ``@`` cannot leave a residual credential fragment in the
+    pre-image. All credentialed variants collapse to the credential-free form.
+    """
+    plain = "postgres://cache-host:5432/app_a"
+    fp = express_db_instance_fingerprint(plain)
+    for creds in (
+        "postgres://user:pw@cache-host:5432/app_a",
+        "postgres://user:p@ss@cache-host:5432/app_a",  # '@' inside the password
+        "postgres://user@cache-host:5432/app_a",  # user only, no password
+    ):
+        got = express_db_instance_fingerprint(creds)
+        assert got == fp, f"userinfo not fully stripped for {creds!r}: {got!r}"
+
+
+def test_scheme_only_credential_dsn_fails_closed():
+    """py-local: a `//`-less credential-bearing DSN fails closed (returns None).
+
+    ``urlparse("postgres:user:pass@host/db")`` yields an empty netloc with the
+    userinfo in ``path``, so the netloc `@`-strip cannot fire; hashing that
+    pre-image would leak credential bytes into it. The fingerprint refuses
+    (None → caller WARNs, isolation INACTIVE) rather than hash a credential.
+    A valid sqlite file URL (empty netloc, no `@` in path) is UNAFFECTED.
+    """
+    # `//`-less DSN with embedded credentials -> fail closed.
+    assert express_db_instance_fingerprint("postgres:user:s3cr3t@host/db") is None
+    # A valid sqlite file URL (empty netloc, no '@') still fingerprints (V3).
+    assert (
+        express_db_instance_fingerprint("sqlite:///var/data/app_b.db")
+        == "db5c74b84689218303"
+    )

--- a/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_issue_1606_keyspace_tripwire.py
@@ -3,12 +3,18 @@
 This module pins the EXACT byte string of TWO cache keyspaces, which have
 DIFFERENT cross-SDK contracts and MUST NOT be conflated:
 
-1. EXPRESS ``v2`` keyspace (``generate_express_key``) — RUST-PINNED / cross-SDK
-   LOCKSTEP. It is a byte-for-byte contract with kailash-rs (the Rust SDK,
-   ``v3.19.0``, BP-049); see ``src/dataflow/cache/key_generator.py`` docstring.
-   Changing ANY express byte pinned here diverges the two SDKs' cache keys and
-   breaks cross-SDK invalidation — it is a deliberate ``v2 -> v3`` lockstep to
-   be done in BOTH SDKs, never one. These assertions stay loud.
+1. EXPRESS ``v3`` keyspace (``generate_express_key``) — RUST-PINNED / cross-SDK
+   LOCKSTEP. It is a byte-for-byte contract with the Rust SDK (issue #1606 /
+   the Rust SDK's #1713, contract ``dataflow-cache-keys-v3``); see
+   ``src/dataflow/cache/key_generator.py`` docstring. The ``v2 -> v3`` bump
+   inserted a database-instance segment directly after the version so two
+   DataFlow instances at DIFFERENT databases sharing a process-wide cache
+   backend never collide. Changing ANY express byte pinned here diverges the
+   two SDKs' cache keys and breaks cross-SDK invalidation — it is a deliberate
+   lockstep to be done in BOTH SDKs, never one. The exhaustive byte-for-byte
+   conformance vectors live in ``test_issue_1606_express_v3_conformance.py``
+   (vendored canonical fixture); these assertions stay loud on the common
+   shapes. These assertions stay loud.
 
 2. QUERY keyspace (``generate_key``) — NOT Rust-pinned. It hashes a normalized
    SQL string + params, which diverges cross-SDK by construction (the py and rs
@@ -25,16 +31,20 @@ Tier: 1 (Unit — no external dependencies).
 
 import hashlib
 
-from dataflow.cache.key_generator import (
-    CacheKeyGenerator,
-    hash_database_identity,
-)
+from dataflow.cache.key_generator import CacheKeyGenerator, hash_database_identity
 from dataflow.cache.memory_cache import InMemoryCache
 
-# --- Pinned EXPRESS v2 keyspace bytes (Rust-pinned — change ONLY with the ---
-# --- kailash-rs v2->v3 cross-SDK LOCKSTEP) ---------------------------------
-EXPRESS_KEY_WITH_TENANT = "dataflow:v2:tenant-a:User:list:6a3d3c8c"
-EXPRESS_KEY_NO_TENANT = "dataflow:v2:User:list"
+# --- Pinned EXPRESS v3 keyspace bytes (Rust-pinned — change ONLY with the ---
+# --- Rust SDK v2->v3 cross-SDK LOCKSTEP, #1606/the Rust SDK's #1713) --------
+# A fixed express db-instance segment for byte-pinning. In production this is
+# the ``db<16 hex>`` fingerprint of the normalized DSN
+# (express_db_instance_fingerprint). The v3 shape places it directly after the
+# version token, BEFORE the tenant.
+_FIXED_EXPRESS_DBID = "db0011223344556677"
+EXPRESS_KEY_WITH_TENANT = (
+    f"dataflow:v3:{_FIXED_EXPRESS_DBID}:tenant-a:User:list:6a3d3c8c"
+)
+EXPRESS_KEY_NO_TENANT = f"dataflow:v3:{_FIXED_EXPRESS_DBID}:User:list"
 
 # --- Pinned QUERY keyspace bytes (py-local tripwire; NOT Rust-pinned) ------
 # A fixed DB-identity segment for byte-pinning. In production this is the
@@ -56,49 +66,67 @@ _QUERY_PARAMS = [True]
 # EXPRESS keyspace — RUST-PINNED. These assertions guard the cross-SDK
 # byte-for-byte contract and MUST stay loud + unchanged by #1606.
 # =========================================================================
-def test_express_key_v2_bytes_are_pinned():
-    """generate_express_key emits the exact v2 byte string for fixed inputs."""
-    gen = CacheKeyGenerator()
+def test_express_key_v3_bytes_are_pinned():
+    """generate_express_key emits the exact v3 byte string for fixed inputs.
 
-    # With tenant + params: dataflow:v2:<tenant>:<model>:<op>:<hash>
+    The v3 keyspace inserts the ``db<16 hex>`` db-instance segment directly
+    after the version, BEFORE the tenant (issue #1606 / the Rust SDK's #1713).
+    """
+    gen = CacheKeyGenerator(express_db_instance=_FIXED_EXPRESS_DBID)
+
+    # With db_instance + tenant + params:
+    # dataflow:v3:<db_instance>:<tenant>:<model>:<op>:<hash>
     key = gen.generate_express_key(
         "User", "list", {"active": True}, tenant_id="tenant-a"
     )
     assert key == EXPRESS_KEY_WITH_TENANT, (
-        f"v2 Express keyspace drifted: got {key!r}. Changing these bytes is a "
-        f"cross-SDK LOCKSTEP (#1606/rs#1713) — bump v2->v3 in BOTH SDKs, not one."
+        f"v3 Express keyspace drifted: got {key!r}. Changing these bytes is a "
+        f"cross-SDK LOCKSTEP (#1606/the Rust SDK's #1713) — re-pin v3 in BOTH "
+        f"SDKs, not one."
     )
 
-    # Without tenant/params the trailing hash segment is absent.
+    # Without tenant/params the trailing hash segment is absent, but the
+    # db_instance segment stays.
     assert gen.generate_express_key("User", "list") == EXPRESS_KEY_NO_TENANT
 
-    # Version segment is fixed at v2 (the pinned cross-SDK keyspace).
-    assert key.startswith("dataflow:v2:")
+    # Version segment is fixed at v3 (the pinned cross-SDK keyspace).
+    assert key.startswith("dataflow:v3:")
+    # The db-instance segment sits directly after the version.
+    assert key.startswith(f"dataflow:v3:{_FIXED_EXPRESS_DBID}:")
 
 
-def test_express_key_excludes_db_identity_segment():
-    """The #1606 DB-identity segment MUST NOT enter the Rust-pinned express key.
+def test_express_and_query_db_segments_are_decoupled():
+    """The express db_instance and the query db_identity are DISTINCT segments.
 
-    Even when the generator is constructed WITH a db_identity (as it always is
-    in production, from engine.py), generate_express_key emits byte-identical
-    output to a generator without one. This is the structural guard that the
-    #1606 change stayed in the query keyspace and never touched the express
-    (Rust-pinned) keyspace.
+    Both fingerprints coexist on one generator in production (engine.py builds
+    the query generator with ``db_identity``; express.py builds its own with
+    ``express_db_instance``). This pins that neither leaks into the other's
+    keyspace — the express key carries ONLY ``express_db_instance`` and the
+    query key carries ONLY ``db_identity``.
     """
-    gen_with_dbid = CacheKeyGenerator(db_identity=_FIXED_DBID)
-    gen_without_dbid = CacheKeyGenerator()
+    gen = CacheKeyGenerator(
+        express_db_instance=_FIXED_EXPRESS_DBID,
+        db_identity=_FIXED_DBID,
+    )
 
-    key_with = gen_with_dbid.generate_express_key(
+    express_key = gen.generate_express_key(
         "User", "list", {"active": True}, tenant_id="tenant-a"
     )
-    key_without = gen_without_dbid.generate_express_key(
-        "User", "list", {"active": True}, tenant_id="tenant-a"
+    query_key = gen.generate_key("User", _QUERY_SQL, _QUERY_PARAMS)
+
+    # Express key carries the express db_instance, NOT the query db_identity.
+    assert express_key == EXPRESS_KEY_WITH_TENANT
+    assert _FIXED_EXPRESS_DBID in express_key
+    assert _FIXED_DBID not in express_key, (
+        "query db_identity leaked into the Rust-pinned express keyspace: "
+        f"{express_key!r}"
     )
-    assert key_with == key_without == EXPRESS_KEY_WITH_TENANT, (
-        "db_identity leaked into the Rust-pinned express keyspace: "
-        f"with={key_with!r} without={key_without!r}. The #1606 segment is "
-        "query-keyspace-ONLY; express is a cross-SDK byte contract."
-    )
+
+    # Query key carries the query db_identity, NOT the express db_instance.
+    assert _FIXED_DBID in query_key
+    assert (
+        _FIXED_EXPRESS_DBID not in query_key
+    ), f"express db_instance leaked into the query keyspace: {query_key!r}"
 
 
 # =========================================================================
@@ -210,12 +238,17 @@ def test_same_database_same_query_key_no_over_invalidation():
     assert other.generate_key("User", _QUERY_SQL, _QUERY_PARAMS) != key1
 
 
-async def test_invalidate_model_matches_v2_express_key():
+async def test_invalidate_model_matches_v3_express_key():
     """invalidate_model's ``:{tenant}:{model}:`` adjacency still deletes the key.
 
-    Pins the substring contract at memory_cache.py::invalidate_model — a
-    tenant-scoped invalidation matches the current v2 Express key layout
-    (``dataflow:v2:tenant-a:User:list:...`` contains ``:tenant-a:User:``).
+    Pins the substring contract at memory_cache.py::invalidate_model against the
+    v3 Express key layout WITH the #1606 db-instance segment
+    (``dataflow:v3:<db_instance>:tenant-a:User:list:...`` still contains
+    ``:tenant-a:User:``). The db-instance segment sits BEFORE the tenant, so the
+    tenant-scoped matcher is unaffected by the v2->v3 bump — this is the
+    structural proof that the invalidation path needed NO change for v3
+    (``tenant-isolation.md §3a`` — the ``:{model}:`` matcher is version- and
+    db-instance-agnostic).
     """
     cache = InMemoryCache()
     await cache.set(EXPRESS_KEY_WITH_TENANT, {"rows": []})

--- a/packages/kailash-dataflow/tests/unit/cache/test_redis_invalidate_v2_keyspace.py
+++ b/packages/kailash-dataflow/tests/unit/cache/test_redis_invalidate_v2_keyspace.py
@@ -85,10 +85,50 @@ async def test_invalidate_model_regression_pin_v2_entries_swept() -> None:
     await adapter.invalidate_model("User", tenant_id="acme")
 
     # Sample v2 Express key (multi-tenant) as written by
-    # CacheKeyGenerator at the new default keyspace.
+    # CacheKeyGenerator at the pre-#1606 default keyspace. Legacy v2 entries
+    # left on Redis after the v3 upgrade MUST still be swept (backward-compat).
     sample_v2_key = "dataflow:v2:acme:User:list:a1b2c3d4"
     assert any(fnmatch.fnmatchcase(sample_v2_key, p) for p in captured), (
         f"v2 key {sample_v2_key!r} did not match any invalidation "
         f"pattern {captured!r} — the v1→v2 keyspace bump from BP-049 "
         f"is not being cleared on Redis."
     )
+
+
+@pytest.mark.asyncio
+async def test_invalidate_model_regression_pin_v3_db_instance_keys_swept() -> None:
+    """#1606: a v3 key WITH the inserted db-instance segment MUST be swept.
+
+    The v3 keyspace (issue #1606 / the Rust SDK's #1713) inserts a
+    ``db<16 hex>`` db-instance segment directly after the version, BEFORE the
+    tenant: ``dataflow:v3:<db_instance>:<tenant>:<model>:<op>:<hash>``. This
+    shifts every segment right by one, so this PROVES (not reasons) that the
+    ``dataflow:v*:{tenant}:{model}:*`` invalidation glob still matches — the
+    greedy ``*`` after ``v*`` spans the ``v3:<db_instance>`` prefix. Without
+    this test the v2->v3 bump could silently break Redis invalidation of every
+    express entry (``tenant-isolation.md §3a``). Behavioural via ``fnmatch``.
+    """
+    import fnmatch
+
+    adapter = AsyncRedisCacheAdapter.__new__(AsyncRedisCacheAdapter)
+    captured: list[str] = []
+
+    async def fake_clear_pattern(pattern: str) -> int:
+        captured.append(pattern)
+        return 0
+
+    adapter.clear_pattern = AsyncMock(side_effect=fake_clear_pattern)  # type: ignore[method-assign]
+
+    # Model-wide AND tenant-scoped invalidation both emit patterns.
+    await adapter.invalidate_model("User")
+    await adapter.invalidate_model("User", tenant_id="acme")
+
+    # Canonical v3 shapes (db-instance from express_db_instance_fingerprint).
+    v3_single_tenant = "dataflow:v3:dbd4e3f17d35c2bb57:User:read:abc123"
+    v3_multi_tenant = "dataflow:v3:dbd4e3f17d35c2bb57:acme:User:list:a1b2c3d4"
+    for sample in (v3_single_tenant, v3_multi_tenant):
+        assert any(fnmatch.fnmatchcase(sample, p) for p in captured), (
+            f"v3 key {sample!r} did not match any invalidation pattern "
+            f"{captured!r} — the #1606 db-instance segment broke Redis "
+            f"invalidation of express entries."
+        )

--- a/packages/kailash-dataflow/tests/unit/test_express_cache.py
+++ b/packages/kailash-dataflow/tests/unit/test_express_cache.py
@@ -20,14 +20,17 @@ class TestCacheKeyGeneratorExpress:
     """Test CacheKeyGenerator.generate_express_key()."""
 
     def test_basic_key_format(self):
-        """Key has format prefix:version:model:operation[:hash].
+        """Key format prefix:version[:db_instance][:tenant]:model:operation[:hash].
 
-        Keyspace bumped v1->v2 in commit 64167f7c (BP-049 classified-data
-        cross-SDK fix); test updated to match producer-side default.
+        Keyspace history: v1->v2 (BP-049 classified-data cross-SDK fix);
+        v2->v3 (#1606 / the Rust SDK's #1713 — inserts a db-instance segment
+        directly after the version). A bare generator (no ``express_db_instance``)
+        omits the db-instance segment, so the no-db / no-tenant / no-params shape
+        is ``dataflow:v3:User:list``.
         """
         gen = CacheKeyGenerator()
         key = gen.generate_express_key("User", "list")
-        assert key == "dataflow:v2:User:list"
+        assert key == "dataflow:v3:User:list"
 
     def test_params_produce_hash_suffix(self):
         """When params are provided a short hash is appended."""


### PR DESCRIPTION
## Summary

Closes the **Express hot-path** half of the cross-database cache bleed (#1606). Two DataFlow instances at *different* databases sharing one process-wide cache backend (e.g. Redis) could serve each other's Express `read`/`list`/`find_one`/`count` rows when they matched on `tenant+model+op+params`, because the Express cache key had no database-instance dimension. The query-keyspace half landed in 2.14.6; the Express half was held open pending this coordinated cross-SDK re-pin.

The Express keyspace bumps **v2 → v3**, inserting a credential-free `db<16hex>` segment after the version:
`dataflow:v3:{db_instance}:{tenant}:{model}:{op}:{params_hash}` — byte-identical to the Rust SDK's #1713 contract (`dataflow-cache-keys-v3`).

## Cross-SDK lockstep (byte-for-byte)

- The canonical vector fixture is **vendored byte-for-byte** from the Rust SDK (`tests/fixtures/dataflow-cache-keys.json`, git-blob sha match — not re-authored, per cross-sdk-inspection Rule 4a).
- All six V1–V6 vectors reproduce exactly, including the empty-params (V4), cross-DB anti-collision (V5), and credential-strip (V6) sentinels.
- The query keyspace stays `v2` (py-local; py and rs emit different SQL) — the two versions are decoupled.

## Security

- No credential byte reaches the cache key: userinfo + query string + fragment are stripped before hashing (Redis keys are an observable surface).
- A `//`-less credential-bearing DSN now **fails closed** (returns `None` → WARN, isolation inactive) rather than leak credential bytes into the hash pre-image.
- When no DB identity can be derived, a loud WARN fires and cross-DB isolation is inactive — never a silent constant fallback.

## Also fixed (same-class regression caught in review)

`clear_cache(model)` pinned its invalidation glob to the generator's query-keyspace version (`"v2"`) and after the bump silently cleared **zero** Express entries (and never matched tenant-scoped Express keys). Now version- and db-instance-agnostic via `invalidate_model` (tenant-isolation §3a).

## Verification

- **Byte-for-byte conformance** suite over the vendored vectors + sentinels (Tier 1).
- **Cross-DB bleed reproduced (RED) and closed (GREEN)** on real Redis with two real databases (Tier 2).
- Invalidation proven (memory substring matcher + Redis `v*` glob both sweep v3 + db-instance keys).
- Redteam: reviewer + security-reviewer + independent conformance-parity verifier — all findings resolved (M1 clear_cache + L1 //-less-DSN + L3 docstrings fixed; L2 documented).
- Version bumped `2.14.7 → 2.15.0` (pyproject + `__init__`), CHANGELOG entry.

## Related issues

Fixes #1606 (Express keyspace half; query half closed in 2.14.6).
Cross-SDK lockstep with the Rust SDK's #1713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)