### PR TITLE
chore(workspace): wrapup — #1606 express-v3 fix + dataflow 2.15.0 + rs#1771 receipts

### DIFF
--- a/workspaces/sdk-backlog/.session-notes
+++ b/workspaces/sdk-backlog/.session-notes
@@ -2,48 +2,48 @@
 
 ## Where we are
 
-Shipped a trust-plane **privilege-escalation fix (#1695)** end-to-end: fixed → reviewed to
-convergence → merged (#1697) → cut security release **kailash 2.48.1** (live on PyPI, clean-venv
-verified). Also filed the cross-SDK parity issue **rs#1765**, closed py #1601 (rs#1729 done), and
-disposed of promotional-spam PR #1675 (earlier). Phase 05-codify; un-enrolled PUBLIC repo, solo.
-Board clear of ours.
+Shipped **F2 (#1606) end-to-end**: fixed the Express cross-DB cache bleed (v2→v3 keyspace
+lockstep) → reviewed to convergence (3 parallel redteam agents) → merged (#1700) → released
+**kailash-dataflow 2.15.0** (PyPI + clean-venv verified). Filed cross-SDK **rs#1771**. Phase
+05-codify; un-enrolled PUBLIC repo, solo. Board clear of ours (0 open PRs, no sibling drift).
 
 ## Read first
 
-1. `workspaces/sdk-backlog/journal/0026-DECISION-1695-fix-and-2481-release.md` — #1695 fix + 2.48.1 release receipt
-2. `workspaces/sdk-backlog/journal/0024-cross-repo-grant-rust-sdk-gap-audit-reopen.md` — rs gap-audit + v3 keyspace contract (for F2)
-3. `workspaces/sdk-backlog/journal/0025-cross-repo-grant-rust-sdk-1695-parity-filing.md` — rs#1765 filing grant
+1. `workspaces/sdk-backlog/journal/0028-DECISION-1606-express-v3-fix-and-2150-release.md` — F2 fix + 2.15.0 receipt
+2. `workspaces/sdk-backlog/journal/0027-cross-repo-grant-rust-sdk-1606-credential-dsn-parity.md` — rs#1771 grant + result
+3. `workspaces/sdk-backlog/journal/0024-cross-repo-grant-rust-sdk-gap-audit-reopen.md` — v3 keyspace contract (reference)
 
 ## In-flight state
 
-- `journal/0025`, `journal/0026`, and this notes write are uncommitted — land via a workspace-only chore PR (build-repo-release-discipline §1a carve-out; no release).
+- `journal/0027`, `journal/0028`, and this notes write are uncommitted — land via a
+  workspace-only chore PR (build-repo-release-discipline §1a carve-out; no release).
 
 ## Executed this session
 
-- **Released kailash 2.48.1** to PyPI (tag `v2.48.1`, publish-pypi success, GitHub Release) — the #1695 security fix.
-- **Filed rs#1765** on the Rust SDK (`cross-sdk`) — #1695 default-verification parity inspection (grant `journal/0025`).
+- **Released kailash-dataflow 2.15.0** (tag `dataflow-v2.15.0`, publish-pypi success, GitHub Release, clean-venv install verified).
+- **Filed rs#1771** on the Rust SDK (`cross-sdk`) — #1606 `//`-less-DSN credential-in-pre-image parity (grant `journal/0027`).
 
 ## Outstanding ledger (forest)
 
 | ID | Item | Value-anchor (MUST-1 source) | Status |
 | -- | ---- | ---------------------------- | ------ |
-| F2 | py #1606 express `v3` keyspace catch-up (mirror rs vectors) | #1606 — cross-DB cache bleed on hot path; rs#1713 v3 landed, contract in `journal/0024` | UNBLOCKED — active py impl (byte-mirror rs `dataflow-cache-keys.json`) |
 | F4 | #1532 delegate-connectors → contrib/ | #1532 — consolidate adapter layer | DEFERRED — dedicated session |
 | F5 | handoff-completion → loom eval-harness validation | `journal/0010` co-owner directive | pending-loom Gate-1 |
 | F6 | latest.yaml own-org `esperie-enterprise` | `journal/0015` PUBLIC-repo disclosure | pending-loom Gate-1 |
 | F7 | cross-sdk-inspection 306-line length-rationale | rule-authoring MUST-NOT; `journal/0016/0017` | pending-loom Gate-1 |
 | F8 | handoff-completion Rule-10 emission-budget headroom | `journal/0019` fifth-pass MED | pending-loom Gate-1 |
-| F9 | rs#1765 cross-SDK #1695 parity (Rust side) | `journal/0026` — same two-surface shape likely in rs trust plane | in-flight — rs-side; close when rs#1765 lands |
+| F9 | rs#1765 cross-SDK #1695 parity (Rust side) | `journal/0026` — trust-plane two-surface shape | in-flight — rs-side; close when rs#1765 lands |
+| F10 | rs#1771 cross-SDK #1606 `//`-less-DSN parity (Rust side) | `journal/0027` — L1 hardening mirror | in-flight — rs-side; close when rs#1771 lands |
 
-Closed this session: `F3` → py #1601 closed + rs#1729/PR#1751 (soft_delete parity); #1695 → PR #1697 + release v2.48.1 (`journal/0026`).
+Closed this session: `F2` → py #1606 Express half (PR #1700 + release `dataflow-v2.15.0`, `journal/0028`); #1606 auto-closed on merge.
 
 ## Traps
 
-- **F2 is byte-parity work**: py express `v2→v3` MUST mirror rs `test-vectors/dataflow-cache-keys.json` byte-for-byte (6 vectors incl. sentinels); db_instance algo verified in `journal/0024`. Vendor the fixture, don't re-author (cross-sdk-inspection Rule 4a).
-- `.venv/bin/pre-commit` has a stale shebang → run `.venv/bin/python -m pre_commit` instead.
-- release/* branches auto-skip the PR-gate matrix; a stale `build` duplicate shows `cancelled` (concurrency) — verify the LATEST `build` run is success on the head SHA before admin-merge.
-- codify/* + chore/* run FULL matrix; check CI pinned to head SHA, THEN merge as a separate command.
+- **venv tool shebangs are stale** (repo relocated from `~/repos/loom/kailash-py`): `.venv/bin/black`/`isort`/`pre-commit` fail "bad interpreter". Use `.venv/bin/python -m black|isort|pre_commit`.
+- **3 pre-existing `test_express_cache_wiring.py` failures** (ttl/cache_stats/auto_detect) fire ONLY when a local Redis is up on 6379 (they assume no-Redis fallback) — env artifact, green in no-Redis unit CI. Not #1606.
+- `dataflow-v<X.Y.Z>` tags → publish-pypi builds kailash-dataflow. Verify install with `uv pip install --refresh` (index-cache lag).
+- Query keyspace stays v2 (py-local); ONLY the Express keyspace is v3/Rust-pinned. Don't conflate.
 
 ## Open questions for the human
 
-- **F2 (py #1606 express keyspace)** is the highest-value in-repo work now unblocked — recommend it next. F5–F8 remain loom-Gate-1-bound.
+- F4–F8 remain loom-Gate-1-bound / deferred. No clear unblocked in-repo forest item remains — next-highest work is the human's call.

--- a/workspaces/sdk-backlog/journal/0027-cross-repo-grant-rust-sdk-1606-credential-dsn-parity.md
+++ b/workspaces/sdk-backlog/journal/0027-cross-repo-grant-rust-sdk-1606-credential-dsn-parity.md
@@ -1,0 +1,36 @@
+# 0027 — GRANT: cross-repo issue filing (kailash-rs) — #1606 //-less-DSN credential parity
+
+**Date:** 2026-07-12 · **Type:** DECISION · **Phase:** 05-codify · **Posture:** L5_DELEGATED
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Grant (per repo-scope-discipline § User-Authorized Exception — all five conditions)
+
+- **Requester / authorizer:** jack.hong@esperie.com (repo owner), this session, genuine user turn ("approved both").
+- **Confirmed:** agent asked "authorize the Rust SDK cross-SDK issue filing? (yes / skip)"; user replied "approved both". Restated target + action below before acting.
+- **Target:** `esperie-enterprise/kailash-rs` (private).
+- **Action — WRITE (bounded, single):** `gh issue create` ONE issue on `esperie-enterprise/kailash-rs`
+  with label `cross-sdk`, reporting the `//`-less credential-bearing DSN edge case in the express
+  `db_instance` fingerprint (the rs sibling of the py #1606 L1 hardening). Body is SDK-public-API-only
+  per `upstream-issue-hygiene.md` MUST-2 — no downstream/workspace context, no finding tags. NO other
+  writes, NO other repos, NO other issues.
+- **Timestamp (grant, pre-action):** 2026-07-12 (this session).
+- **Scope guarantee:** exactly one issue on the named repo; any incidental read/write beyond this is out
+  of scope.
+
+## Context
+
+The py #1606 Express v2→v3 keyspace fix (PR #1700, kailash-dataflow 2.15.0) added
+`express_db_instance_fingerprint`. A security review found that a `//`-less credential-bearing DSN
+(`postgres:user:pass@host/db`) leaves `urlparse` netloc empty with the userinfo in `path`, so the
+netloc `@`-strip never fires and credential bytes enter the SHA-256 pre-image. py hardened this to
+fail closed (return `None`). Per `cross-sdk-inspection.md` Rule 1, the rs `db_instance_fingerprint`
+(the byte-for-byte contract leader for `dataflow-cache-keys-v3`) likely shares the same parsing shape
+and should be inspected + hardened in lockstep. Exposure is low (one-way digest; malformed DSN rarely
+connects) but it breaks the "no credential byte in the pre-image" defense-in-depth guarantee.
+
+## Result
+
+Filed **rs#1771** (`esperie-enterprise/kailash-rs`, label `cross-sdk`, 2026-07-12) — the //-less-DSN
+credential-in-pre-image edge case in the express `db_instance` fingerprint, cross-referencing the py
+#1606 hardening. Body SDK-public-API-only. Action complete, in scope.

--- a/workspaces/sdk-backlog/journal/0028-DECISION-1606-express-v3-fix-and-2150-release.md
+++ b/workspaces/sdk-backlog/journal/0028-DECISION-1606-express-v3-fix-and-2150-release.md
@@ -1,0 +1,35 @@
+# 0028 — DECISION: #1606 Express v3 keyspace fix + kailash-dataflow 2.15.0 release
+
+**Date:** 2026-07-12 · **Type:** DECISION · **Phase:** 05-codify · **Posture:** L5_DELEGATED
+
+## What shipped (F2 CLOSED)
+
+Closed the **Express hot-path** half of the #1606 cross-DB cache bleed — the query half
+landed in 2.14.6; the express half was held open pending this coordinated cross-SDK re-pin.
+
+- **Express keyspace v2→v3**: inserted a credential-free `db<16hex>` database-instance segment
+  after the version (`dataflow:v3:{db_instance}:{tenant}:{model}:{op}:{hash}`), byte-identical to
+  the Rust SDK's #1713 contract (`dataflow-cache-keys-v3`).
+- **Vendored** the canonical vector fixture byte-for-byte (git-blob sha match, NOT re-authored —
+  `cross-sdk-inspection.md` Rule 4a) at `packages/kailash-dataflow/tests/fixtures/dataflow-cache-keys.json`.
+  All 6 V1–V6 vectors reproduce exactly (incl. empty-params/cross-DB/credential-strip sentinels).
+- New `express_db_instance_fingerprint()` (distinct algo+length from the query-side
+  `hash_database_identity`); query keyspace stays v2 (decoupled).
+- **Cross-DB bleed proven closed on real Redis** (RED→GREEN, two DBs, Tier 2).
+
+## Redteam findings resolved (3 parallel agents: reviewer + security-reviewer + conformance-verifier)
+
+- **M1** (my regression, caught same-session): `clear_cache(model)` pinned its glob to the
+  generator's v2 `self.version` → silently cleared 0 express entries after the bump (and never
+  matched tenant-scoped keys). Fixed → delegate to `invalidate_model` (version+db-instance-agnostic).
+- **L1** security hardening: a `//`-less credential DSN (`postgres:user:pass@host/db`) left userinfo
+  in urlparse `path` → credential bytes in the hash pre-image. Now fails closed (returns None).
+  Affects ZERO canonical vectors. → mirrored to rs as **rs#1771** (grant `journal/0027`).
+- **L3** stale invalidation docstrings updated (memory_cache + async_redis_adapter).
+
+## Release
+
+PR **#1700** (admin-merged, 20 CI checks green on head SHA) → tag **dataflow-v2.15.0** →
+publish-pypi success + GitHub Release → clean-venv install verified (2.15.0 imports, V1 fingerprint
+reproduces from the published wheel). Version bumped 2.14.7→2.15.0 (pyproject + **init**).
+No sibling-package drift (all main==PyPI). #1606 auto-closed on merge.


### PR DESCRIPTION
Workspace-only session receipts (build-repo-release-discipline §1a carve-out — no source/config/spec changes, no release).

- `journal/0027` — cross-repo grant + result for the rs#1771 filing (#1606 `//`-less-DSN parity).
- `journal/0028` — DECISION receipt: #1606 Express v2→v3 fix + kailash-dataflow 2.15.0 release.
- `.session-notes` — reconciled forest ledger (F2 closed via PR #1700 + `dataflow-v2.15.0`; F10 rs#1771 added).

## Related issues

Session wrapup for #1606 (closed via PR #1700) + rs#1771 (cross-SDK filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)