### PR TITLE
chore(workspace): re-sweep confirmation + wrapup fragment refresh

### DIFF
--- a/.session-notes.d/esperie.md
+++ b/.session-notes.d/esperie.md
@@ -5,7 +5,7 @@
 
 ---
 
-last_reconciled_sha: e67304453
+last_reconciled_sha: 69c44a2e5
 migrated_from: .session-notes
 ---
 
@@ -49,3 +49,4 @@ Reconciled off root: F20 #1607 / F21 #1614 / F22 #1601 (verified CLOSED via gh, 
 - **venv tool shebangs are stale** (repo moved from `~/repos/loom/kailash-py`): use `.venv/bin/python -m black|isort|pre_commit`, not the bare binaries.
 - **#1532 grant is RECORDED, not standing licence** — restate+confirm+journal-before-acting per cross-repo read (`repo-scope-discipline` conds 3+4). Align to SPECS, not kailash-rs.
 - **rs#1765 / rs#1771** on-remote state never verified from here (repo-scope) — spot-check from a kailash-rs-scoped session before citing as existing.
+- **`/clean-instantiate` is NOT for this repo.** It ran as a dry-run this session and correctly flagged kailash-py as **canon** (origin = `terrene-foundation/kailash-py`, 0 canon-identity tokens, already ships un-enrolled) — NOT applied. It is only ever for a _client's own clone_ before _their_ `/ecosystem-init`. Applying it here would be purely destructive (deletes journal, `--reset-history` discards ~4.8k commits).

--- a/workspaces/sdk-backlog/04-validate/sweep-2026-07-12.md
+++ b/workspaces/sdk-backlog/04-validate/sweep-2026-07-12.md
@@ -96,3 +96,12 @@ cannot distinguish loom-routed from SDK-forest rows.
    grant — a dedicated-session pick when the human wants it.
 3. **Config hygiene (LOW):** declare `role: build` in this clone's loom-links config so Sweep 9
    self-suppresses (removes the manual-suppression step every sweep).
+
+## Re-sweep confirmation (later same session, after clean-instantiate dry-run)
+
+Re-ran all 9 sweeps at `main @ 69c44a2e5` — **no delta**. Board clean: 0 todos, 0 pending journal,
+0 open PRs, 0 orphan branches; forest `--aggregate` clean; tree clean, 0/0 vs origin; no unreleased
+shippable work. Open issues unchanged (#1532 F13 deferred, #1694 loom-side). Between sweeps only a
+`/clean-instantiate` **dry-run** ran — correctly identified this as **canon** (not a client clone),
+found **0 canon-identity tokens**, and was **NOT applied** (would have been purely destructive on
+canon). Every finding/disposition above still stands.


### PR DESCRIPTION
Session-notes-only (build-repo-release-discipline §1a carve-out — no source/config/spec, no release).

- Re-ran all 9 sweeps at `main@69c44a2e5` — **no delta** since PR #1702; board clean, forest `--aggregate` clean.
- Appended a re-sweep confirmation to `sweep-2026-07-12.md`.
- Refreshed the root wrapup fragment `.session-notes.d/esperie.md` (`last_reconciled_sha`→`69c44a2e5`; added a `/clean-instantiate` trap — it dry-ran, correctly flagged this repo as **canon**, and was NOT applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)