### PR TITLE
feat(kaizen-llm): four-axis completion send path + Vertex-Claude/Bedrock wire + GCP WIF (#1717)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/auth/gcp.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/auth/gcp.py
@@ -44,12 +44,19 @@ from kailash.utils.url_credentials import fingerprint_secret
 
 try:
     from google.auth import default as _google_auth_default
+    from google.auth import load_credentials_from_dict as _google_load_creds_from_dict
     from google.auth.transport.requests import Request as _GoogleAuthRequest
     from google.oauth2 import service_account as _google_service_account
 except ImportError:  # pragma: no cover - optional-extra guard
     _google_auth_default = None
+    _google_load_creds_from_dict = None
     _GoogleAuthRequest = None
     _google_service_account = None
+
+try:
+    from google.auth import compute_engine as _google_compute_engine
+except ImportError:  # pragma: no cover - optional-extra guard
+    _google_compute_engine = None
 
 from kaizen.llm.errors import AuthError, LlmClientError, MissingCredential
 from pydantic import SecretStr
@@ -127,10 +134,28 @@ class CachedToken:
 class GcpOauth:
     """OAuth2 access-token auth strategy for GCP / Vertex AI.
 
-    Construction accepts either a service-account-key dict (already-parsed
-    JSON) or a filesystem path to a service-account JSON file. `from_env()`
-    uses the standard `GOOGLE_APPLICATION_CREDENTIALS` env var per the GCP
-    convention.
+    Four credential-source modes are supported, each with a distinct
+    `auth_strategy_kind()` discriminant:
+
+    * `gcp_oauth` -- a service-account key: an already-parsed dict OR a
+      filesystem path to a service-account JSON file (the historical
+      default). A path whose JSON `type` field is `external_account` is
+      transparently routed to the WIF loader at credential-build time
+      (JSON-type dispatch), so `GOOGLE_APPLICATION_CREDENTIALS` may point
+      at either a service-account OR a workload-identity-federation file.
+    * `gcp_wif` -- an explicit `external_account` (Workload Identity
+      Federation) config: dict OR path. Routed through google-auth's
+      external-account loader, which performs the STS token exchange and,
+      when the config carries `service_account_impersonation_url`, the
+      service-account impersonation step.
+    * `gcp_metadata` -- keyless: the GCE / Cloud Run metadata server
+      (`use_metadata_server=True`).
+    * `gcp_adc` -- keyless: Application Default Credentials via
+      `google.auth.default()` (the fallback when no explicit credential
+      material is supplied).
+
+    `from_env()` reads the standard `GOOGLE_APPLICATION_CREDENTIALS` env
+    var per the GCP convention (service-account OR external-account file).
 
     `apply(request)` installs `Authorization: Bearer <access_token>` on the
     request, refreshing the cached token if it is within the
@@ -162,6 +187,9 @@ class GcpOauth:
     __slots__ = (
         "_service_account_info",
         "_service_account_path",
+        "_external_account_info",
+        "_external_account_path",
+        "_auth_mode",
         "_scopes",
         "_cached_token",
         "_refresh_lock",
@@ -170,33 +198,24 @@ class GcpOauth:
 
     def __init__(
         self,
-        service_account_key: dict | str,
+        service_account_key: dict | str | None = None,
         scopes: Optional[list[str]] = None,
+        *,
+        external_account: dict | str | None = None,
+        use_metadata_server: bool = False,
     ) -> None:
         if _google_auth_default is None:
             raise LlmClientError(
                 "google-auth is not installed; install the [vertex] extra: "
                 "pip install kailash-kaizen[vertex]"
             )
-        # Accept either an already-parsed service-account dict OR a path
-        # string to a JSON file. Path strings are resolved at refresh time
-        # so a key file rotated on disk is picked up by the next refresh.
-        if isinstance(service_account_key, dict):
-            if not service_account_key:
-                raise AuthError("GcpOauth service_account_key dict must not be empty")
-            self._service_account_info: Optional[dict] = dict(service_account_key)
-            self._service_account_path: Optional[str] = None
-        elif isinstance(service_account_key, str):
-            if not service_account_key:
-                raise AuthError(
-                    "GcpOauth service_account_key path must not be an empty string"
-                )
-            self._service_account_info = None
-            self._service_account_path = service_account_key
-        else:
-            raise TypeError(
-                "GcpOauth.service_account_key must be dict or str (file path); "
-                f"got {type(service_account_key).__name__}"
+        # A credential is sourced from AT MOST one place. A caller who
+        # supplies both a service-account key and an external-account
+        # config has an ambiguous intent -- fail loudly rather than pick
+        # one silently.
+        if service_account_key is not None and external_account is not None:
+            raise AuthError(
+                "GcpOauth accepts service_account_key OR external_account, " "not both"
             )
         # Scopes default to cloud-platform per Vertex spec. Caller may
         # narrow scopes for least-privilege deployments but cannot widen
@@ -211,6 +230,74 @@ class GcpOauth:
                     raise AuthError("GcpOauth.scopes entries must be non-empty strings")
             resolved_scopes = list(scopes)
         self._scopes: list[str] = resolved_scopes
+
+        # Credential-source slots -- exactly one branch below populates the
+        # material and sets the auth-mode discriminant. Path strings are
+        # resolved at refresh time so a key file rotated on disk is picked
+        # up by the next refresh.
+        self._service_account_info: Optional[dict] = None
+        self._service_account_path: Optional[str] = None
+        self._external_account_info: Optional[dict] = None
+        self._external_account_path: Optional[str] = None
+
+        if external_account is not None:
+            self._auth_mode: str = "gcp_wif"
+            if isinstance(external_account, dict):
+                if not external_account:
+                    raise AuthError("GcpOauth external_account dict must not be empty")
+                self._external_account_info = dict(external_account)
+            elif isinstance(external_account, str):
+                if not external_account:
+                    raise AuthError(
+                        "GcpOauth external_account path must not be an empty string"
+                    )
+                self._external_account_path = external_account
+            else:
+                raise TypeError(
+                    "GcpOauth.external_account must be dict or str (file path); "
+                    f"got {type(external_account).__name__}"
+                )
+        elif service_account_key is not None:
+            if isinstance(service_account_key, dict):
+                if not service_account_key:
+                    raise AuthError(
+                        "GcpOauth service_account_key dict must not be empty"
+                    )
+                info = dict(service_account_key)
+                # A dict whose `type` is `external_account` is a WIF config
+                # supplied through the service_account_key arg -- classify
+                # it as WIF (the dict `type` is free to read; no file IO).
+                if info.get("type") == "external_account":
+                    self._auth_mode = "gcp_wif"
+                    self._external_account_info = info
+                else:
+                    self._auth_mode = "gcp_oauth"
+                    self._service_account_info = info
+            elif isinstance(service_account_key, str):
+                if not service_account_key:
+                    raise AuthError(
+                        "GcpOauth service_account_key path must not be an empty string"
+                    )
+                # A path is NOT read at construction (existing contract: a
+                # path to a not-yet-present key file constructs cleanly).
+                # The JSON `type` dispatch (service_account vs
+                # external_account) happens at credential-build time.
+                self._auth_mode = "gcp_oauth"
+                self._service_account_path = service_account_key
+            else:
+                raise TypeError(
+                    "GcpOauth.service_account_key must be dict or str (file path); "
+                    f"got {type(service_account_key).__name__}"
+                )
+        elif use_metadata_server:
+            # Keyless: the GCE / Cloud Run metadata server mints tokens for
+            # the attached service account.
+            self._auth_mode = "gcp_metadata"
+        else:
+            # Keyless: Application Default Credentials resolution chain
+            # (google.auth.default) -- env var, gcloud SDK creds, metadata.
+            self._auth_mode = "gcp_adc"
+
         self._cached_token: Optional[CachedToken] = None
         # Lock guards single-flight refresh. Acquiring the lock before
         # checking expiry serializes the "is the token still valid?"
@@ -232,6 +319,45 @@ class GcpOauth:
             raise MissingCredential("GOOGLE_APPLICATION_CREDENTIALS")
         return cls(service_account_key=path, scopes=scopes)
 
+    @classmethod
+    def adc(cls, scopes: Optional[list[str]] = None) -> "GcpOauth":
+        """Keyless Application Default Credentials strategy.
+
+        Resolves credentials via `google.auth.default()` at refresh time --
+        the standard ADC chain (`GOOGLE_APPLICATION_CREDENTIALS`, gcloud SDK
+        user creds, attached service account). Use when no explicit key or
+        external-account config is available and the runtime environment
+        already carries ambient credentials.
+        """
+        return cls(scopes=scopes)
+
+    @classmethod
+    def metadata_server(cls, scopes: Optional[list[str]] = None) -> "GcpOauth":
+        """Keyless GCE / Cloud Run metadata-server strategy.
+
+        Mints tokens for the service account attached to the compute
+        instance via `google.auth.compute_engine.Credentials`. Use on
+        GCE / Cloud Run / GKE where the metadata server is reachable and
+        no key material should ever touch disk.
+        """
+        return cls(scopes=scopes, use_metadata_server=True)
+
+    @classmethod
+    def workload_identity(
+        cls,
+        external_account: dict | str,
+        scopes: Optional[list[str]] = None,
+    ) -> "GcpOauth":
+        """Workload Identity Federation (external_account) strategy.
+
+        `external_account` is a WIF config -- an already-parsed dict OR a
+        path to an `external_account` JSON file. Routed through
+        google-auth's external-account loader, which performs the STS
+        token exchange and, when the config carries
+        `service_account_impersonation_url`, the impersonation step.
+        """
+        return cls(external_account=external_account, scopes=scopes)
+
     @property
     def scopes(self) -> tuple[str, ...]:
         """Immutable view of the configured scopes."""
@@ -248,12 +374,61 @@ class GcpOauth:
         return self._refresh_count
 
     def _build_credentials(self) -> Any:
-        """Construct a google-auth `Credentials` object from the configured
-        service-account material.
+        """Construct a google-auth `Credentials` object for the configured mode.
 
-        Routed through google-auth's official constructors -- inlining the
-        JWT-bearer flow here is BLOCKED by zero-tolerance Rule 4. If
-        google-auth has a bug, the fix lives in google-auth.
+        Dispatches on `self._auth_mode`. Every branch is routed through a
+        google-auth official constructor -- inlining any token-fetch flow
+        here is BLOCKED by zero-tolerance Rule 4. If google-auth has a bug,
+        the fix lives in google-auth.
+        """
+        mode = self._auth_mode
+        if mode == "gcp_oauth":
+            return self._build_service_account_credentials()
+        if mode == "gcp_wif":
+            return self._build_wif_credentials()
+        if mode == "gcp_metadata":
+            return self._build_metadata_credentials()
+        if mode == "gcp_adc":
+            return self._build_adc_credentials()
+        raise AuthError(
+            f"GcpOauth has an unknown auth mode {mode!r}; this is a construction bug"
+        )
+
+    def _read_credentials_file(self, path: str) -> dict:
+        """Read + JSON-parse a credentials file, failing with a typed error.
+
+        The raw path is NEVER echoed -- only a fingerprint -- so a
+        misconfigured path cannot leak a filesystem layout into a log line.
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except FileNotFoundError as exc:
+            raise AuthError(
+                "GcpOauth credentials file not found "
+                f"(path_fingerprint={fingerprint_secret(path)})"
+            ) from exc
+        except (OSError, ValueError) as exc:
+            # ValueError covers json.JSONDecodeError.
+            raise AuthError(
+                "GcpOauth credentials file is unreadable or not valid JSON "
+                f"(path_fingerprint={fingerprint_secret(path)})"
+            ) from exc
+        if not isinstance(data, dict):
+            raise AuthError(
+                "GcpOauth credentials file must contain a JSON object "
+                f"(path_fingerprint={fingerprint_secret(path)})"
+            )
+        return data
+
+    def _build_service_account_credentials(self) -> Any:
+        """`gcp_oauth` mode: service-account key (dict or path).
+
+        A path is re-read on every refresh so a rotated key file is picked
+        up. JSON-`type` dispatch happens here: a path whose file declares
+        `type == "external_account"` is routed to the WIF loader, so
+        `GOOGLE_APPLICATION_CREDENTIALS` transparently supports both a
+        service-account AND a workload-identity-federation file.
         """
         if _google_service_account is None:
             raise LlmClientError(
@@ -263,17 +438,74 @@ class GcpOauth:
             return _google_service_account.Credentials.from_service_account_info(
                 self._service_account_info, scopes=list(self._scopes)
             )
-        # Path-based: re-read the file on every refresh so a rotated key
-        # file is picked up. The file is read inside the refresh lock so
-        # the read is serialized too.
         if self._service_account_path is None:
             raise AuthError(
                 "GcpOauth has neither a service-account dict nor a path; "
                 "this is a construction bug"
             )
-        return _google_service_account.Credentials.from_service_account_file(
-            self._service_account_path, scopes=list(self._scopes)
+        info = self._read_credentials_file(self._service_account_path)
+        cred_type = info.get("type")
+        if cred_type == "external_account":
+            # JSON-type dispatch: the path points at a WIF config.
+            return self._build_wif_from_info(info)
+        if cred_type == "service_account":
+            return _google_service_account.Credentials.from_service_account_file(
+                self._service_account_path, scopes=list(self._scopes)
+            )
+        raise AuthError(
+            "GcpOauth credentials file has an unsupported credential type "
+            f"(expected 'service_account' or 'external_account'; "
+            f"path_fingerprint={fingerprint_secret(self._service_account_path)})"
         )
+
+    def _build_wif_credentials(self) -> Any:
+        """`gcp_wif` mode: explicit external_account (dict or path)."""
+        if self._external_account_info is not None:
+            info = self._external_account_info
+        elif self._external_account_path is not None:
+            info = self._read_credentials_file(self._external_account_path)
+        else:
+            raise AuthError(
+                "GcpOauth WIF mode has neither an external_account dict nor "
+                "a path; this is a construction bug"
+            )
+        return self._build_wif_from_info(info)
+
+    def _build_wif_from_info(self, info: dict) -> Any:
+        """Route an external_account config through google-auth's WIF loader.
+
+        `load_credentials_from_dict` builds the correct external-account
+        subclass (identity-pool, AWS, ...), performs the STS token exchange
+        on refresh, and -- when `service_account_impersonation_url` is
+        present in the config -- wraps the result in
+        `impersonated_credentials.Credentials`. Inlining any of that is
+        BLOCKED by zero-tolerance Rule 4.
+        """
+        if _google_load_creds_from_dict is None:
+            raise LlmClientError(
+                "google-auth external_account (WIF) support is unavailable; "
+                "install the [vertex] extra"
+            )
+        creds, _project = _google_load_creds_from_dict(info, scopes=list(self._scopes))
+        return creds
+
+    def _build_metadata_credentials(self) -> Any:
+        """`gcp_metadata` mode: the GCE / Cloud Run metadata server."""
+        if _google_compute_engine is None:
+            raise LlmClientError(
+                "google-auth compute_engine (metadata-server) support is "
+                "unavailable; install the [vertex] extra"
+            )
+        return _google_compute_engine.Credentials(scopes=list(self._scopes))
+
+    def _build_adc_credentials(self) -> Any:
+        """`gcp_adc` mode: Application Default Credentials resolution."""
+        if _google_auth_default is None:
+            raise LlmClientError(
+                "google-auth is not installed; install the [vertex] extra"
+            )
+        creds, _project = _google_auth_default(scopes=list(self._scopes))
+        return creds
 
     async def _ensure_token(self) -> CachedToken:
         """Return a non-expired cached token, refreshing if needed.
@@ -308,11 +540,14 @@ class GcpOauth:
             raise LlmClientError(
                 "google-auth is not installed; install the [vertex] extra"
             )
+        # Capture into a local so the guard above narrows the type inside the
+        # deferred executor closure (a module global is not narrowed in a lambda).
+        request_factory = _GoogleAuthRequest
         loop = asyncio.get_running_loop()
         creds = await loop.run_in_executor(None, self._build_credentials)
         # Refresh runs in executor because google-auth uses requests
         # internally (blocking IO).
-        await loop.run_in_executor(None, lambda: creds.refresh(_GoogleAuthRequest()))
+        await loop.run_in_executor(None, lambda: creds.refresh(request_factory()))
         token_value = getattr(creds, "token", None)
         expiry = getattr(creds, "expiry", None)
         if not token_value:
@@ -345,7 +580,7 @@ class GcpOauth:
         logger.info(
             "gcp_oauth.token_refreshed",
             extra={
-                "auth_strategy_kind": "gcp_oauth",
+                "auth_strategy_kind": self._auth_mode,
                 "refresh_count": self._refresh_count,
                 "expiry_epoch": int(expiry_epoch),
                 "fingerprint": new_token.fingerprint,
@@ -426,7 +661,17 @@ class GcpOauth:
         )
 
     def auth_strategy_kind(self) -> str:
-        return "gcp_oauth"
+        """Stable discriminant for the configured credential source.
+
+        One of `gcp_oauth` (service-account key), `gcp_wif` (explicit
+        external_account / Workload Identity Federation), `gcp_metadata`
+        (GCE / Cloud Run metadata server), or `gcp_adc` (Application
+        Default Credentials). A path-based service-account key reports
+        `gcp_oauth` even when the file is later found to be an
+        external_account config -- the file is not read at construction, so
+        the discriminant reflects the construction API used.
+        """
+        return self._auth_mode
 
     def __repr__(self) -> str:
         # Never include service-account material or the raw token. The

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from types import TracebackType
 from typing import Any, AsyncIterator, Dict, List, Optional
 
@@ -148,6 +149,33 @@ _COMPLETE_DISPATCH: dict = {
         "streaming_path_template": "/models/{model}",
     },
 }
+
+
+# A caller-supplied ``model`` is interpolated into the URL path for the
+# ``{model}``-template wires (GoogleGenerateContent, BedrockInvoke,
+# HuggingFaceInference). Legitimate ids carry ``/`` (HuggingFace ``org/model``),
+# ``@`` (version pins), ``:`` (Bedrock version suffix ``...v2:0``), ``.`` and
+# ``-``. This shape allows those but is fail-closed against path traversal /
+# URL-control injection: it must start alphanumeric (no leading slash/dot) and
+# forbids ``%``/``?``/``#``/whitespace/control, and — checked separately — the
+# ``..`` and ``//`` sequences that alone can change host or traverse. A ``:``
+# inside a path segment cannot change the (SSRF-checked, fixed) host.
+_COMPLETION_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@/:-]{0,127}$")
+
+
+def _validate_completion_model(model: str) -> str:
+    """Fail-closed validation of a caller-controlled model before it reaches the
+    URL path. Raises ``ValueError`` on any traversal / URL-control attempt so an
+    app that routes untrusted input into ``model=`` cannot escape the provider
+    path. Byte-preserving for valid ids (no encoding — the provider sees the
+    exact id)."""
+    if not _COMPLETION_MODEL_RE.match(model) or ".." in model or "//" in model:
+        raise ValueError(
+            "model contains characters not permitted in a request path segment "
+            "(allowed: alphanumerics and _.@/:- , must start alphanumeric, no "
+            "'..' or '//'); refusing to build the request URL"
+        )
+    return model
 
 
 def _parse_stream_line(line: str, shaper: Any) -> Optional[Dict[str, Any]]:
@@ -756,6 +784,10 @@ class LlmClient:
                 "complete() requires a model — pass model=..., or construct "
                 "the deployment with a default_model."
             )
+        # Fail-closed: a caller-controlled model is interpolated into the URL
+        # path for the {model}-template wires; reject traversal / URL-control
+        # injection before the request is built (security-reviewer #1717 MEDIUM).
+        _validate_completion_model(resolved_model)
         return CompletionRequest(
             model=resolved_model,
             messages=redacted,
@@ -1077,6 +1109,14 @@ class LlmClient:
                 extra={"wire": wire.name, "exception_class": type(exc).__name__},
             )
             raise Timeout() from exc
+        except httpx.HTTPError as exc:
+            # Client-layer log parity with complete(); the transport layer also
+            # logs llm.http.stream.error, but keep the wire-scoped line here too.
+            logger.error(
+                "llm.stream.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            raise
         finally:
             if owns_client:
                 await http_client.aclose()

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -160,7 +160,9 @@ _COMPLETE_DISPATCH: dict = {
 # forbids ``%``/``?``/``#``/whitespace/control, and — checked separately — the
 # ``..`` and ``//`` sequences that alone can change host or traverse. A ``:``
 # inside a path segment cannot change the (SSRF-checked, fixed) host.
-_COMPLETION_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@/:-]{0,127}$")
+# `\Z` (end-of-string), NOT `$` — Python's `$` also matches immediately before a
+# single trailing newline, which would let "model\n" slip a control char through.
+_COMPLETION_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@/:-]{0,127}\Z")
 
 
 def _validate_completion_model(model: str) -> str:
@@ -963,6 +965,15 @@ class LlmClient:
                 "llm.complete.error",
                 extra={"wire": wire.name, "exception_class": type(exc).__name__},
             )
+            if owns_client:
+                await http_client.aclose()
+            raise
+        except BaseException:
+            # A non-httpx send-phase failure — SSRF InvalidEndpoint from the
+            # transport, or a GcpOauth token-refresh error from
+            # _prepare_auth_headers — happens BEFORE `resp` exists, so it never
+            # reaches the response-phase finally below. Close the owned client
+            # here so a one-shot caller does not leak the transport (F1).
             if owns_client:
                 await http_client.aclose()
             raise

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -36,17 +36,34 @@ landed and exercised by a Tier 2 end-to-end test. Shipping a public
 
 from __future__ import annotations
 
+import json
 import logging
 from types import TracebackType
-from typing import List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 import httpx
 
-from kaizen.llm.deployment import EmbedOptions, LlmDeployment, WireProtocol
+from kaizen.llm.deployment import (
+    CompletionRequest,
+    EmbedOptions,
+    LlmDeployment,
+    WireProtocol,
+)
 from kaizen.llm.errors import InvalidResponse, ProviderError, RateLimited, Timeout
 from kaizen.llm.http_client import LlmHttpClient
 from kaizen.llm.redaction import redact_messages
-from kaizen.llm.wire_protocols import ollama_embeddings, openai_embeddings
+from kaizen.llm.wire_protocols import (
+    anthropic_messages,
+    bedrock_invoke,
+    cohere_generate,
+    google_generate_content,
+    huggingface_inference,
+    mistral_chat,
+    ollama_embeddings,
+    ollama_native,
+    openai_chat,
+    openai_embeddings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +87,96 @@ _EMBED_DISPATCH: dict = {
         "env_model_hint": "OLLAMA_EMBEDDING_MODEL",
     },
 }
+
+
+# Wire-protocol dispatch for complete() / stream(). Keyed by WireProtocol.
+# Each entry names the chat shaper and the DEFAULT URL-suffix templates used
+# when the deployment carries no `completion_routing` override (direct
+# providers). Presets that share a wire but route differently
+# (vertex_claude / vertex_gemini / bedrock_*) set `deployment.completion_routing`
+# which OVERRIDES these defaults — that override is what disambiguates the
+# three AnthropicMessages consumers (Anthropic-direct vs Vertex-Claude vs
+# Bedrock-Claude). `{model}` in a template is substituted with the resolved
+# model id; a template beginning with `:` attaches to a model-carrying
+# path_prefix without a `/` separator. This is structural dispatch on a typed
+# deployment-configuration value (rules/agent-reasoning.md permits it), not
+# keyword-matching on user input.
+_COMPLETE_DISPATCH: dict = {
+    WireProtocol.OpenAiChat: {
+        "shaper": openai_chat,
+        "path_template": "/chat/completions",
+        "streaming_path_template": "/chat/completions",
+    },
+    WireProtocol.AnthropicMessages: {
+        "shaper": anthropic_messages,
+        "path_template": "/messages",
+        "streaming_path_template": "/messages",
+    },
+    WireProtocol.GoogleGenerateContent: {
+        "shaper": google_generate_content,
+        "path_template": "/models/{model}:generateContent",
+        "streaming_path_template": "/models/{model}:streamGenerateContent",
+    },
+    WireProtocol.VertexGenerateContent: {
+        "shaper": google_generate_content,
+        "path_template": ":generateContent",
+        "streaming_path_template": ":streamGenerateContent",
+    },
+    WireProtocol.BedrockInvoke: {
+        "shaper": bedrock_invoke,
+        "path_template": "/model/{model}/invoke",
+        "streaming_path_template": "/model/{model}/invoke-with-response-stream",
+    },
+    WireProtocol.CohereGenerate: {
+        "shaper": cohere_generate,
+        "path_template": "/chat",
+        "streaming_path_template": "/chat",
+    },
+    WireProtocol.MistralChat: {
+        "shaper": mistral_chat,
+        "path_template": "/chat/completions",
+        "streaming_path_template": "/chat/completions",
+    },
+    WireProtocol.OllamaNative: {
+        "shaper": ollama_native,
+        "path_template": "/api/chat",
+        "streaming_path_template": "/api/chat",
+    },
+    WireProtocol.HuggingFaceInference: {
+        "shaper": huggingface_inference,
+        "path_template": "/models/{model}",
+        "streaming_path_template": "/models/{model}",
+    },
+}
+
+
+def _parse_stream_line(line: str, shaper: Any) -> Optional[Dict[str, Any]]:
+    """Parse one streaming line into a shaper chunk dict, or ``None`` to skip.
+
+    Handles both SSE framing (``data: {json}`` — OpenAI / Anthropic /
+    Vertex-Gemini) and bare JSONL objects (Ollama / Bedrock). Terminal SSE
+    sentinels (``[DONE]``), empty keep-alive lines, and non-JSON control
+    frames (``event:`` / ``:`` comments) are skipped by returning ``None``.
+    """
+    if not line:
+        return None
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("data:"):
+        stripped = stripped[len("data:") :].strip()
+    if not stripped or stripped == "[DONE]":
+        return None
+    if stripped[0] not in "{[":
+        # SSE control frame (event:, id:, retry:, or a `:` comment).
+        return None
+    try:
+        obj = json.loads(stripped)
+    except ValueError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return shaper.parse_response(obj)
 
 
 class LlmClient:
@@ -550,6 +657,429 @@ class LlmClient:
             prefix_norm = prefix if prefix.startswith("/") else "/" + prefix
             return f"{base}{prefix_norm}{suffix_norm}"
         return f"{base}{suffix_norm}"
+
+    # -----------------------------------------------------------------
+    # complete() / stream() — chat-completion send-path (#1717)
+    # -----------------------------------------------------------------
+
+    def _build_completion_url(self, template: str, model: Optional[str]) -> str:
+        """Join ``base_url`` + ``path_prefix`` + a completion ``template``.
+
+        ``{model}`` in the template is substituted with ``model``. A template
+        beginning with ``:`` (a Vertex verb like ``:rawPredict``) attaches
+        directly to the model-carrying ``path_prefix`` with NO ``/``
+        separator; any other template is joined with a single ``/``. Any
+        ``endpoint.query_params`` are appended as a query string.
+        """
+        assert self._deployment is not None
+        endpoint = self._deployment.endpoint
+        base = str(endpoint.base_url).rstrip("/")
+        prefix = (endpoint.path_prefix or "").rstrip("/")
+        if prefix and not prefix.startswith("/"):
+            prefix = "/" + prefix
+        root = f"{base}{prefix}"
+        suffix = template.replace("{model}", model or "")
+        if suffix.startswith(":"):
+            url = f"{root}{suffix}"
+        else:
+            if not suffix.startswith("/"):
+                suffix = "/" + suffix
+            url = f"{root}{suffix}"
+        if endpoint.query_params:
+            from urllib.parse import urlencode
+
+            url = f"{url}?{urlencode(endpoint.query_params)}"
+        return url
+
+    def _resolve_completion_route(self, dispatch: dict, *, stream: bool) -> str:
+        """Pick the URL template: deployment routing override, else default."""
+        assert self._deployment is not None
+        routing = self._deployment.completion_routing
+        if stream:
+            if routing is not None and routing.streaming_path_template is not None:
+                return routing.streaming_path_template
+            if routing is not None and routing.path_template is not None:
+                return routing.path_template
+            return dispatch["streaming_path_template"]
+        if routing is not None and routing.path_template is not None:
+            return routing.path_template
+        return dispatch["path_template"]
+
+    def _apply_anthropic_platform_transform(
+        self, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Strip ``model`` + inject ``anthropic_version`` for platform Anthropic.
+
+        Gated on ``deployment.completion_routing.anthropic_version_body``:
+        Vertex-Claude (``"vertex-2023-10-16"``) and Bedrock-Claude
+        (``"bedrock-2023-05-31"``) carry the model in the URL and require the
+        ``anthropic_version`` body field. Anthropic-DIRECT leaves
+        ``completion_routing`` (or its ``anthropic_version_body``) ``None``,
+        so the body is returned UNCHANGED — keeping direct-Anthropic bytes
+        identical to the pre-#1717 output. Returns a new dict; input not
+        mutated.
+        """
+        assert self._deployment is not None
+        routing = self._deployment.completion_routing
+        version = routing.anthropic_version_body if routing is not None else None
+        if version is None:
+            return payload
+        transformed = dict(payload)
+        transformed.pop("model", None)
+        transformed["anthropic_version"] = version
+        return transformed
+
+    def _build_completion_request(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        model: Optional[str],
+        temperature: Optional[float],
+        top_p: Optional[float],
+        max_tokens: Optional[int],
+        stop: Optional[List[str]],
+        user: Optional[str],
+        stream: bool,
+    ) -> "CompletionRequest":
+        """Redact messages, resolve the model, build the CompletionRequest."""
+        assert self._deployment is not None
+        if not isinstance(messages, list):
+            raise TypeError(
+                f"messages must be list[dict]; got {type(messages).__name__}"
+            )
+        # Redact PII at the boundary BEFORE the request is shaped for the wire
+        # (rules/observability.md §8 / §6.5). No-op when no policy installed.
+        redacted = self.redact_request_messages(messages)
+        resolved_model = model or self._deployment.default_model
+        if not resolved_model:
+            raise ValueError(
+                "complete() requires a model — pass model=..., or construct "
+                "the deployment with a default_model."
+            )
+        return CompletionRequest(
+            model=resolved_model,
+            messages=redacted,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+            stream=stream,
+            user=user,
+        )
+
+    def _build_completion_payload_and_url(
+        self, request: "CompletionRequest", *, stream: bool
+    ) -> tuple[Dict[str, Any], str]:
+        """Shape the request body + build the URL for the deployment's wire."""
+        assert self._deployment is not None
+        wire = self._deployment.wire
+        dispatch = _COMPLETE_DISPATCH.get(wire)
+        if dispatch is None:
+            # Every wire a preset can construct is covered above; the only
+            # uncovered WireProtocol members (OpenAiCompletions, AzureOpenAi)
+            # are never emitted by a preset (Azure uses the OpenAiChat wire).
+            # A deployment reaching here was hand-assembled with an
+            # unsupported wire — a concrete configuration error, not a stub.
+            raise ValueError(
+                f"LlmClient.complete does not support wire={wire.name!r}. "
+                "Supported wires: "
+                f"{', '.join(w.name for w in _COMPLETE_DISPATCH)}. File an "
+                "issue at terrene-foundation/kailash-py referencing #1717 to "
+                "request another provider."
+            )
+        shaper = dispatch["shaper"]
+        payload = shaper.build_request_payload(request)
+        # Platform-Anthropic body transform (Vertex / Bedrock Claude). No-op
+        # for every other wire and for Anthropic-direct.
+        if wire is WireProtocol.AnthropicMessages:
+            payload = self._apply_anthropic_platform_transform(payload)
+        template = self._resolve_completion_route(dispatch, stream=stream)
+        url = self._build_completion_url(template, request.model)
+        return payload, url
+
+    async def _prepare_auth_headers(
+        self, url: str, body_bytes: bytes, *, stream: bool
+    ) -> tuple[Dict[str, str], Optional[str]]:
+        """Run the deployment auth strategy and return (headers, auth_kind).
+
+        Prefers ``apply_async`` (GcpOauth's single-flight refresh) when the
+        strategy exposes it; otherwise the sync ``apply``. The auth request
+        carries ``method`` / ``url`` / ``body`` / ``streaming`` so richer
+        strategies (AwsSigV4) that canonicalize over those fields work too.
+        Endpoint ``required_headers`` (e.g. ``anthropic-version``) merge in
+        via ``setdefault`` so auth never clobbers them.
+        """
+        assert self._deployment is not None
+        request: dict = {
+            "method": "POST",
+            "url": url,
+            "headers": {"Content-Type": "application/json"},
+            "body": body_bytes,
+            "streaming": stream,
+        }
+        auth = self._deployment.auth
+        apply_async = getattr(auth, "apply_async", None)
+        if callable(apply_async):
+            await apply_async(request)
+        else:
+            auth.apply(request)
+        for k, v in self._deployment.endpoint.required_headers.items():
+            request["headers"].setdefault(k, v)
+        auth_kind = (
+            auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
+        )
+        return request["headers"], auth_kind
+
+    async def complete(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        user: Optional[str] = None,
+        http_client: Optional[LlmHttpClient] = None,
+    ) -> Dict[str, Any]:
+        """Issue a chat completion through the configured deployment.
+
+        Mirrors :meth:`embed`: redacts prompt PII at the boundary, shapes the
+        body for the deployment's wire, dispatches through the SSRF-safe
+        ``LlmHttpClient``, maps HTTP status to the typed error taxonomy, and
+        returns the shaper's normalized dict
+        ``{text, raw_blocks?, usage, stop_reason, model}``.
+
+        Supports OpenAI (+ every OpenAI-compatible provider), Anthropic
+        (direct, Vertex-Claude, Bedrock-Claude), Google Gemini (direct +
+        Vertex), Bedrock native families, Cohere, Mistral, Ollama, and
+        HuggingFace. The per-wire URL, the platform-Anthropic body transform,
+        and the per-model temperature floor are all data-driven — no provider
+        branch in the caller path.
+
+        Raises:
+            ValueError: ``messages`` empty of a resolvable model, or no
+                deployment configured.
+            TypeError: ``messages`` not a ``list[dict]``.
+            ValueError: the deployment's ``wire`` is not supported.
+            InvalidResponse / ProviderError / RateLimited / Timeout: wire
+                failures with credential scrubbing.
+            InvalidEndpoint: SSRF guard rejected the URL at DNS-resolve time.
+        """
+        if self._deployment is None:
+            raise ValueError(
+                "LlmClient.complete requires a deployment; construct via "
+                "LlmClient.from_deployment(...) or LlmClient.from_env() first"
+            )
+        wire = self._deployment.wire
+        request = self._build_completion_request(
+            messages,
+            model=model,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+            user=user,
+            stream=False,
+        )
+        payload, url = self._build_completion_payload_and_url(request, stream=False)
+        body_bytes = json.dumps(payload).encode("utf-8")
+
+        owns_client = http_client is None
+        if owns_client and self._managed:
+            if self._http_client is None:
+                self._http_client = LlmHttpClient(
+                    deployment_preset=wire.name, timeout=60.0
+                )
+            http_client = self._http_client
+            owns_client = False
+        elif owns_client:
+            http_client = LlmHttpClient(deployment_preset=wire.name, timeout=60.0)
+        assert http_client is not None
+
+        try:
+            headers, auth_kind = await self._prepare_auth_headers(
+                url, body_bytes, stream=False
+            )
+            logger.info(
+                "llm.complete.start",
+                extra={
+                    "wire": wire.name,
+                    "auth_strategy_kind": auth_kind,
+                    "message_count": len(request.messages),
+                    "model": request.model,
+                    "source": "real",
+                    "mode": "real",
+                },
+            )
+            resp = await http_client.post(
+                url,
+                headers=headers,
+                content=body_bytes,
+                auth_strategy_kind=auth_kind,
+            )
+        except httpx.TimeoutException as exc:
+            logger.error(
+                "llm.complete.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            if owns_client:
+                await http_client.aclose()
+            raise Timeout() from exc
+        except httpx.HTTPError as exc:
+            logger.error(
+                "llm.complete.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            if owns_client:
+                await http_client.aclose()
+            raise
+
+        try:
+            if resp.status_code == 429:
+                retry_after_raw = resp.headers.get("retry-after")
+                retry_after: Optional[float] = None
+                if retry_after_raw:
+                    try:
+                        retry_after = float(retry_after_raw)
+                    except (TypeError, ValueError):
+                        retry_after = None
+                raise RateLimited(retry_after=retry_after)
+            if resp.status_code >= 400:
+                raise ProviderError(resp.status_code, body_snippet=resp.text or "")
+            try:
+                payload_json = resp.json()
+            except ValueError as exc:
+                raise InvalidResponse(
+                    f"{wire.name.lower()}_complete: response was not valid JSON"
+                ) from exc
+            dispatch = _COMPLETE_DISPATCH[wire]
+            parsed = dispatch["shaper"].parse_response(payload_json)
+            logger.info(
+                "llm.complete.ok",
+                extra={
+                    "wire": wire.name,
+                    "message_count": len(request.messages),
+                    "status_code": resp.status_code,
+                },
+            )
+            return parsed
+        finally:
+            if owns_client:
+                await http_client.aclose()
+
+    async def stream(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        user: Optional[str] = None,
+        http_client: Optional[LlmHttpClient] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Stream a chat completion as an async iterator of parsed chunks.
+
+        A REAL streaming send: routes through ``LlmHttpClient.stream_lines``
+        (httpx ``client.stream`` on the SAME SSRF-safe transport — no second
+        client, no buffering). Each yielded dict is the shaper's parse of one
+        chunk, carrying at least ``{text}``; terminal / non-JSON SSE control
+        lines (``[DONE]``, empty keep-alives) are skipped.
+
+        Consumes the deployment's :class:`StreamingConfig` — when
+        ``streaming.enabled`` is False the request is issued non-streaming and
+        a single parsed chunk is yielded, so callers can always iterate.
+
+        SSE wires (OpenAI / Anthropic / Vertex-Gemini) emit ``data: {json}``
+        lines; JSONL wires (Ollama / Bedrock) emit bare JSON objects per line.
+        Both are handled: a ``data:`` prefix is stripped when present.
+        """
+        if self._deployment is None:
+            raise ValueError(
+                "LlmClient.stream requires a deployment; construct via "
+                "LlmClient.from_deployment(...) or LlmClient.from_env() first"
+            )
+        wire = self._deployment.wire
+
+        # StreamingConfig opt-out: issue a buffered complete() and yield the
+        # single parsed result so the caller's `async for` still works.
+        if not self._deployment.streaming.enabled:
+            result = await self.complete(
+                messages,
+                model=model,
+                temperature=temperature,
+                top_p=top_p,
+                max_tokens=max_tokens,
+                stop=stop,
+                user=user,
+                http_client=http_client,
+            )
+            yield result
+            return
+
+        request = self._build_completion_request(
+            messages,
+            model=model,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+            user=user,
+            stream=True,
+        )
+        payload, url = self._build_completion_payload_and_url(request, stream=True)
+        body_bytes = json.dumps(payload).encode("utf-8")
+
+        owns_client = http_client is None
+        if owns_client and self._managed:
+            if self._http_client is None:
+                self._http_client = LlmHttpClient(
+                    deployment_preset=wire.name, timeout=60.0
+                )
+            http_client = self._http_client
+            owns_client = False
+        elif owns_client:
+            http_client = LlmHttpClient(deployment_preset=wire.name, timeout=60.0)
+        assert http_client is not None
+
+        dispatch = _COMPLETE_DISPATCH[wire]
+        shaper = dispatch["shaper"]
+        try:
+            headers, auth_kind = await self._prepare_auth_headers(
+                url, body_bytes, stream=True
+            )
+            logger.info(
+                "llm.stream.start",
+                extra={
+                    "wire": wire.name,
+                    "auth_strategy_kind": auth_kind,
+                    "message_count": len(request.messages),
+                    "model": request.model,
+                    "source": "real",
+                    "mode": "real",
+                },
+            )
+            async for line in http_client.stream_lines(
+                "POST",
+                url,
+                headers=headers,
+                content=body_bytes,
+                auth_strategy_kind=auth_kind,
+            ):
+                chunk = _parse_stream_line(line, shaper)
+                if chunk is not None:
+                    yield chunk
+        except httpx.TimeoutException as exc:
+            logger.error(
+                "llm.stream.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            raise Timeout() from exc
+        finally:
+            if owns_client:
+                await http_client.aclose()
 
     def __del__(self) -> None:
         # Emit ResourceWarning ONLY; never call aclose()/close() from the

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -268,6 +268,47 @@ class StreamingConfig(BaseModel):
     include_usage: bool = True
 
 
+class CompletionRouting(BaseModel):
+    """Per-deployment completion-path routing + platform body transform.
+
+    Carries the wire-specific pieces that CANNOT be derived from the
+    ``WireProtocol`` enum alone because SEVERAL presets share one wire but
+    route differently. The canonical example: ``bedrock_claude``,
+    ``vertex_claude`` and Anthropic-direct ALL use
+    ``WireProtocol.AnthropicMessages`` yet each needs a different URL suffix
+    (``/model/{model}/invoke`` vs ``:rawPredict`` vs ``/messages``) and a
+    different body shape (Bedrock / Vertex strip ``model`` and inject an
+    ``anthropic_version``; direct keeps ``model`` untouched).
+
+    Fields:
+
+    * ``path_template`` — non-streaming URL suffix appended after
+      ``base_url`` + ``path_prefix``. ``{model}`` is substituted with the
+      deployment's resolved model id. A template beginning with ``:`` (e.g.
+      ``:rawPredict``) is appended WITHOUT a ``/`` separator so it attaches
+      to a model-carrying ``path_prefix`` (``.../models/{model}`` +
+      ``:rawPredict``); any other template is joined with a single ``/``.
+    * ``streaming_path_template`` — the streaming variant (``:streamRawPredict``,
+      ``/model/{model}/invoke-with-response-stream``). Falls back to
+      ``path_template`` when ``None``.
+    * ``anthropic_version_body`` — when set (``"vertex-2023-10-16"`` /
+      ``"bedrock-2023-05-31"``), the completion path strips ``model`` from
+      the Anthropic body and inserts ``anthropic_version``. Left ``None`` for
+      Anthropic-direct so its body stays byte-identical to the pre-#1717
+      output.
+
+    Cross-SDK parity: the routing pieces mirror the Rust adapter's per-preset
+    URL + platform-body handling; a fixed deployment produces the same URL +
+    body bytes on both SDKs.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    path_template: Optional[str] = None
+    streaming_path_template: Optional[str] = None
+    anthropic_version_body: Optional[str] = None
+
+
 class RetryConfig(BaseModel):
     """Retry policy per deployment (backoff + cap)."""
 
@@ -313,6 +354,17 @@ class LlmDeployment(BaseModel):
     default_model: Optional[str] = None
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)
+    completion_routing: Optional[CompletionRouting] = None
+    """Per-deployment completion URL + platform-body routing.
+
+    ``None`` for presets whose completion path is fully determined by their
+    ``wire`` (OpenAI, Anthropic-direct, Cohere, Mistral, Ollama, HF, Google-
+    direct — the ``_COMPLETE_DISPATCH`` default templates cover them). Set by
+    presets that share a wire with a differently-routed sibling
+    (``vertex_claude`` / ``vertex_gemini`` / ``bedrock_*``): it disambiguates
+    the URL suffix and, for platform-hosted Anthropic, drives the
+    strip-``model`` / inject-``anthropic_version`` body transform.
+    """
     preset_name: Optional[str] = None
     """Canonical preset literal (e.g. ``"openai"``, ``"openai_compatible"``).
 
@@ -406,5 +458,6 @@ __all__ = [
     "CompletionRequest",
     "StreamingConfig",
     "RetryConfig",
+    "CompletionRouting",
     "LlmDeployment",
 ]

--- a/packages/kailash-kaizen/src/kaizen/llm/from_env.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/from_env.py
@@ -67,7 +67,10 @@ LEGACY_KEY_ORDER = [
 # GCP region shape is `us-central1`, `europe-west4`, etc. (no trailing
 # dash before the digit). The regex accepts both forms.
 _AWS_REGION_RE = re.compile(r"^[a-z]{2,3}-[a-z]+(-[a-z]+)?-\d{1,2}$")
-_GCP_REGION_RE = re.compile(r"^[a-z]{2,20}-[a-z]+\d{1,2}$")
+# GCP region shape is `us-central1`, `europe-west4`, etc. Vertex also
+# accepts the multi-region / global endpoints `us`, `eu`, and `global`
+# (NEW-B); these pass straight through (no `eu -> europe-west1` mapping).
+_GCP_REGION_RE = re.compile(r"^(?:[a-z]{2,20}-[a-z]+\d{1,2}|us|eu|global)$")
 _PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9\-]{4,28}[a-z0-9]$")
 _AZURE_RESOURCE_RE = re.compile(r"^[a-z][a-z0-9-]{1,22}[a-z0-9]$")
 
@@ -175,20 +178,23 @@ def _build_vertex_from_uri(parsed: Any) -> LlmDeployment:
         raise InvalidUri("vertex:// URI project failed regex validation")
     if not region or not _GCP_REGION_RE.match(region):
         raise InvalidUri("vertex:// URI region failed regex validation")
-    sa_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    if not sa_path:
-        raise MissingCredential(
-            "GOOGLE_APPLICATION_CREDENTIALS not set; required for vertex:// URIs"
-        )
+    # `GOOGLE_APPLICATION_CREDENTIALS` is OPTIONAL for vertex:// URIs. When
+    # set it points at either a service-account OR an external_account
+    # (Workload Identity Federation) JSON file; GcpOauth dispatches on the
+    # file's `type` at credential-build time. When UNSET, `None` flows to
+    # GcpOauth's keyless Application Default Credentials chain (ADC / GCE
+    # metadata server) rather than hard-failing -- so a Vertex deployment
+    # on GCE / Cloud Run / GKE with an attached service account needs no
+    # key file on disk.
+    sa_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    sa_key = sa_path if sa_path else None
     # Dispatch by model family prefix. Anthropic goes through vertex_claude;
     # everything else goes through vertex_gemini.
     from kaizen.llm.presets import vertex_claude_preset, vertex_gemini_preset
 
     if model.startswith("claude-"):
-        return vertex_claude_preset(
-            sa_path, project=project, region=region, model=model
-        )
-    return vertex_gemini_preset(sa_path, project=project, region=region, model=model)
+        return vertex_claude_preset(sa_key, project=project, region=region, model=model)
+    return vertex_gemini_preset(sa_key, project=project, region=region, model=model)
 
 
 def _build_azure_from_uri(parsed: Any) -> LlmDeployment:
@@ -285,6 +291,23 @@ def _call_preset_from_env(selector: str, factory: Any) -> LlmDeployment:
 
         auth = AzureEntra(api_key=api_key)
         return factory(resource, deployment, auth)
+    if selector in ("vertex_claude", "vertex_gemini"):
+        # Vertex-on-GCP without a full URI. project + region + model are
+        # REQUIRED; the service-account key is OPTIONAL -- an unset
+        # `GOOGLE_APPLICATION_CREDENTIALS` flows `None` to the preset's
+        # GcpOauth, which resolves keyless Application Default Credentials
+        # (ADC / GCE metadata server). A set value points at either a
+        # service-account OR an external_account (WIF) file; GcpOauth
+        # dispatches on the file's `type` at credential-build time.
+        project = _require_env("GOOGLE_CLOUD_PROJECT")
+        region = _require_env("VERTEX_LOCATION")
+        if selector == "vertex_claude":
+            model = _require_env("VERTEX_CLAUDE_MODEL_ID", "VERTEX_CLAUDE_MODEL")
+        else:
+            model = _require_env("VERTEX_GEMINI_MODEL_ID", "VERTEX_GEMINI_MODEL")
+        creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+        sa_key = creds if creds else None
+        return factory(sa_key, project=project, region=region, model=model)
     # Fallback: unknown selector shape. Caller MUST set URI tier instead.
     raise NoKeysConfigured(
         f"Selector '{_fingerprint_selector(selector)}' is registered but "

--- a/packages/kailash-kaizen/src/kaizen/llm/grammar/vertex.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/grammar/vertex.py
@@ -20,8 +20,13 @@ suffix convention rather than Bedrock's `-v1:0` suffix. Mapping table:
     claude-opus-4-5    -> claude-opus-4-5@latest
     claude-haiku-4-5   -> claude-haiku-4-5@latest
 
-Native passthrough: `claude-*@*` already-versioned ids are returned
-unchanged (so callers can pin a specific version explicitly).
+Open passthrough: any `claude-*` model id resolves without a catalog
+edit -- an already-versioned `claude-*@*` id is returned unchanged (so
+callers can pin a specific version explicitly), and a bare `claude-*`
+id not in the table above (e.g. a future `claude-opus-4-8`) has `@latest`
+appended so it forms a valid Vertex on-wire id. This mirrors the open
+passthrough `VertexGeminiGrammar` already has, so new Claude model names
+work the day Anthropic publishes them to Vertex.
 
 # `VertexGeminiGrammar`
 
@@ -104,8 +109,9 @@ _VERTEX_CLAUDE_MAPPING: Dict[str, str] = {
 class VertexClaudeGrammar:
     """Grammar for Anthropic Claude models served via Vertex AI.
 
-    Caller supplies a short alias (`claude-3-opus`) or an already-versioned
-    on-wire id (`claude-3-opus@20240229`). Anything else raises
+    Caller supplies a short alias (`claude-3-opus`), an already-versioned
+    on-wire id (`claude-3-opus@20240229`), or any other `claude-*` id
+    (open passthrough). A non-`claude-*` id raises
     `ModelGrammarInvalid(reason="vertex_claude_not_in_catalog")`.
 
     Distinct from `BedrockClaudeGrammar` because the on-wire id format
@@ -122,20 +128,26 @@ class VertexClaudeGrammar:
     def resolve(self, caller_model: str) -> str:
         """Translate `caller_model` into a Vertex on-wire Claude model id.
 
-        Returns the translated id, or the input unchanged if it is already
-        in `claude-*@*` shape. Raises
-        `ModelGrammarInvalid(reason="vertex_claude_not_in_catalog")` if the
-        input is neither a known alias nor a valid on-wire id.
+        Resolution order:
+
+        1. A known short alias resolves via `_VERTEX_CLAUDE_MAPPING`.
+        2. Any other `claude-*` id passes through (open passthrough): an
+           already-versioned `claude-*@*` id is returned unchanged; a bare
+           `claude-*` id (e.g. `claude-opus-4-8`) has `@latest` appended so
+           it forms a valid Vertex on-wire id without a catalog edit.
+        3. A non-`claude-*` id raises
+           `ModelGrammarInvalid(reason="vertex_claude_not_in_catalog")`.
         """
         validated = self._validate_caller_model(caller_model)
-        # 1) Short alias
+        # 1) Known short alias -- resolve to its pinned on-wire id.
         if validated in _VERTEX_CLAUDE_MAPPING:
             return _VERTEX_CLAUDE_MAPPING[validated]
-        # 2) Already-versioned passthrough -- `claude-X@<date>` or
-        # `claude-X@latest`. The `@` is the discriminator; un-suffixed
-        # `claude-3-opus` would have hit the alias table above.
-        if validated.startswith("claude-") and "@" in validated:
-            return validated
+        # 2) Open passthrough for any `claude-*` id. `@`-versioned ids pass
+        # through unchanged (explicit pin); bare ids get `@latest` so the
+        # result is always a valid Vertex on-wire id. Mirrors the open
+        # passthrough VertexGeminiGrammar has.
+        if validated.startswith("claude-"):
+            return validated if "@" in validated else f"{validated}@latest"
         raise ModelGrammarInvalid(reason="vertex_claude_not_in_catalog")
 
     def grammar_kind(self) -> str:

--- a/packages/kailash-kaizen/src/kaizen/llm/http_client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/http_client.py
@@ -63,12 +63,12 @@ import logging
 import socket
 import time
 import uuid
-from typing import Any, Mapping, Optional
+from typing import Any, AsyncIterator, Mapping, Optional
 from urllib.parse import urlparse
 
 import httpx
 
-from kaizen.llm.errors import InvalidEndpoint
+from kaizen.llm.errors import InvalidEndpoint, ProviderError, RateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -399,6 +399,106 @@ class LlmHttpClient:
 
     async def post(self, url: str, **kwargs: Any) -> httpx.Response:
         return await self.request("POST", url, **kwargs)
+
+    async def stream_lines(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        content: Any = None,
+        auth_strategy_kind: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Open a REAL streaming HTTP request and yield decoded response lines.
+
+        This is a genuine streaming send — it uses ``httpx.AsyncClient.stream``
+        which reads the response body incrementally off the socket, routed
+        through the SAME ``_SafeHttpTransport`` (SSRF resolver + no second
+        httpx client). Each decoded line (SSE ``data:`` frame for OpenAI /
+        Anthropic / Vertex-Gemini, JSONL object for Ollama / Bedrock) is
+        yielded to the caller as it arrives.
+
+        Status mapping happens BEFORE any line is yielded: a 429 raises
+        :class:`RateLimited`, any other ``>= 400`` raises
+        :class:`ProviderError` (with the error body scrubbed by
+        ``ProviderError`` itself). This mirrors the non-streaming taxonomy so
+        callers handle streaming and buffered failures identically.
+
+        Emits ``llm.http.stream.start`` / ``.ok`` / ``.error`` with the same
+        correlation fields as :meth:`request`.
+        """
+        if self._closed:
+            raise RuntimeError(
+                "LlmHttpClient is closed; cannot issue new requests "
+                "(construct a new client or avoid aclose() before reuse)"
+            )
+        request_id = str(uuid.uuid4())
+        endpoint_host = urlparse(url).hostname or "<unknown-host>"
+        t0 = time.monotonic()
+        logger.info(
+            "llm.http.stream.start",
+            extra={
+                "request_id": request_id,
+                "deployment_preset": self._deployment_preset,
+                "auth_strategy_kind": auth_strategy_kind,
+                "endpoint_host": endpoint_host,
+                "method": method,
+            },
+        )
+        try:
+            async with self._client.stream(
+                method,
+                url,
+                headers=dict(headers) if headers else None,
+                content=content,
+                **kwargs,
+            ) as resp:
+                if resp.status_code == 429:
+                    await resp.aread()
+                    retry_after_raw = resp.headers.get("retry-after")
+                    retry_after: Optional[float] = None
+                    if retry_after_raw:
+                        try:
+                            retry_after = float(retry_after_raw)
+                        except (TypeError, ValueError):
+                            retry_after = None
+                    raise RateLimited(retry_after=retry_after)
+                if resp.status_code >= 400:
+                    body = await resp.aread()
+                    raise ProviderError(
+                        resp.status_code,
+                        body_snippet=body.decode("utf-8", "replace"),
+                    )
+                async for line in resp.aiter_lines():
+                    yield line
+        except Exception as exc:
+            latency_ms = (time.monotonic() - t0) * 1000
+            logger.error(
+                "llm.http.stream.error",
+                extra={
+                    "request_id": request_id,
+                    "deployment_preset": self._deployment_preset,
+                    "auth_strategy_kind": auth_strategy_kind,
+                    "endpoint_host": endpoint_host,
+                    "method": method,
+                    "exception_class": type(exc).__name__,
+                    "latency_ms": latency_ms,
+                },
+            )
+            raise
+        latency_ms = (time.monotonic() - t0) * 1000
+        logger.info(
+            "llm.http.stream.ok",
+            extra={
+                "request_id": request_id,
+                "deployment_preset": self._deployment_preset,
+                "auth_strategy_kind": auth_strategy_kind,
+                "endpoint_host": endpoint_host,
+                "method": method,
+                "latency_ms": latency_ms,
+            },
+        )
 
     def __del__(self) -> None:
         # Emit ResourceWarning ONLY; do not call close() from finalizer.

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -40,7 +40,12 @@ from kailash.utils.url_credentials import fingerprint_secret
 from kaizen.llm.auth.aws import AwsBearerToken
 from kaizen.llm.auth.bearer import ApiKey, ApiKeyBearer, ApiKeyHeaderKind, StaticNone
 from kaizen.llm.auth.gcp import GcpOauth
-from kaizen.llm.deployment import Endpoint, LlmDeployment, WireProtocol
+from kaizen.llm.deployment import (
+    CompletionRouting,
+    Endpoint,
+    LlmDeployment,
+    WireProtocol,
+)
 from kaizen.llm.errors import MissingCredential, ModelRequired
 from kaizen.llm.grammar.bedrock import (
     BedrockClaudeGrammar,
@@ -139,9 +144,36 @@ def register_preset(name: str, factory: Callable[..., LlmDeployment]) -> None:
     logger.info("preset.registered", extra={"preset_name": validated})
 
 
+# Provider-string aliases (NEW-C). Callers reaching the registry with a
+# hyphenated / provider-style name resolve to the canonical snake_case
+# preset. Consulted BEFORE `_validate_preset_name` because aliases may carry
+# hyphens (which `_PRESET_NAME_RE` deliberately rejects), keeping the
+# canonical registry keys clean while accepting the common external spellings.
+#   * `vertex-anthropic` / `vertex_claude`  → `vertex_claude`
+#   * `vertex-gemini` / `vertex-google`     → `vertex_gemini`
+_PRESET_ALIASES: Dict[str, str] = {
+    "vertex-anthropic": "vertex_claude",
+    "vertex-claude": "vertex_claude",
+    "vertex-gemini": "vertex_gemini",
+    "vertex-google": "vertex_gemini",
+}
+
+
+def _normalize_preset_name(name: Any) -> Any:
+    """Map a provider-string alias to its canonical preset name.
+
+    Non-string / unknown inputs pass through unchanged so the downstream
+    validator produces the canonical typed error.
+    """
+    if isinstance(name, str) and name in _PRESET_ALIASES:
+        return _PRESET_ALIASES[name]
+    return name
+
+
 def get_preset(name: str) -> Callable[..., LlmDeployment]:
-    """Retrieve a preset factory by name. Validates the name first."""
-    validated = _validate_preset_name(name)
+    """Retrieve a preset factory by name. Normalizes aliases, then validates."""
+    normalized = _normalize_preset_name(name)
+    validated = _validate_preset_name(normalized)
     try:
         return _PRESETS[validated]
     except KeyError:
@@ -1022,6 +1054,15 @@ def bedrock_claude_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        completion_routing=CompletionRouting(
+            # Bedrock carries the model in the URL path; path_prefix is empty
+            # so the {model} substitution forms /model/{id}/invoke.
+            path_template="/model/{model}/invoke",
+            streaming_path_template="/model/{model}/invoke-with-response-stream",
+            # Bedrock-hosted Anthropic strips `model` from the body and
+            # injects this version literal.
+            anthropic_version_body="bedrock-2023-05-31",
+        ),
         preset_name="bedrock_claude",
     )
     logger.info(
@@ -1119,6 +1160,12 @@ def _build_bedrock_deployment(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        completion_routing=CompletionRouting(
+            # Native Bedrock invoke path; model carried in the URL, empty
+            # path_prefix so {model} forms /model/{id}/invoke.
+            path_template="/model/{model}/invoke",
+            streaming_path_template="/model/{model}/invoke-with-response-stream",
+        ),
         preset_name=preset_name,
     )
     logger.info(
@@ -1311,6 +1358,24 @@ _GRAMMAR_VERTEX_GEMINI = VertexGeminiGrammar()
 _PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9\-]{4,28}[a-z0-9]$")
 _REGION_RE = re.compile(r"^[a-z]{2,20}-[a-z]+\d{1,2}$")
 
+# NEW-B: Vertex multi-region + global location literals accepted in addition
+# to concrete regions (`us-central1`, `europe-west4`). `us` / `eu` are
+# multi-region location values that pass STRAIGHT THROUGH into the URL path
+# (`locations/us`, `locations/eu`); the host still needs a concrete regional
+# subdomain, so a concrete default is used for host derivation ONLY (eu →
+# europe-west3, NOT europe-west1). `global` uses the region-less
+# `aiplatform.googleapis.com` host with `locations/global`.
+_VERTEX_MULTI_REGIONS: frozenset[str] = frozenset({"us", "eu", "global"})
+
+# Concrete regional subdomain used to build the HOST for a multi-region
+# location value. The path `locations/<region>` still carries the multi-region
+# literal verbatim; only the `{host_region}-aiplatform.googleapis.com`
+# subdomain needs a concrete region.
+_VERTEX_MULTIREGION_HOST_DEFAULTS: Dict[str, str] = {
+    "us": "us-central1",
+    "eu": "europe-west3",
+}
+
 
 def _validate_vertex_project(project: Any) -> str:
     """Validate a GCP project id against the strict allowlist regex.
@@ -1335,32 +1400,59 @@ def _validate_vertex_project(project: Any) -> str:
 
 
 def _validate_vertex_region(region: Any) -> str:
-    """Validate a GCP region against the strict allowlist regex."""
+    """Validate a GCP region against the strict allowlist regex.
+
+    Accepts concrete regions (``us-central1``, ``europe-west4``) AND the
+    multi-region / global location literals ``us`` / ``eu`` / ``global``
+    (NEW-B). Everything else fails with a log-injection-safe fingerprint.
+    """
     if not isinstance(region, str) or not region:
         raise ValueError(
             "vertex preset requires a non-empty region string "
-            "(e.g. 'us-central1', 'europe-west4')"
+            "(e.g. 'us-central1', 'europe-west4', 'us', 'eu', 'global')"
         )
+    if region in _VERTEX_MULTI_REGIONS:
+        return region
     if not _REGION_RE.match(region):
         raise ValueError(
             "vertex region failed validation against "
-            f"^[a-z]{{2,20}}-[a-z]+\\d{{1,2}}$ "
+            f"^[a-z]{{2,20}}-[a-z]+\\d{{1,2}}$ (or one of us/eu/global) "
             f"(region_fingerprint={_fingerprint(region)})"
         )
     return region
+
+
+def _derive_vertex_host_and_location(region: str) -> tuple[str, str]:
+    """Return ``(endpoint_host, path_location)`` for a validated region.
+
+    * ``global`` → region-less host ``aiplatform.googleapis.com``, location
+      ``global``.
+    * ``us`` / ``eu`` → host uses the concrete default subdomain
+      (``us-central1`` / ``europe-west3``); the location passes THROUGH
+      as the multi-region literal so the path is ``locations/us`` /
+      ``locations/eu``.
+    * concrete region (``us-central1``) → host + location are both the region.
+    """
+    if region == "global":
+        return "aiplatform.googleapis.com", "global"
+    if region in _VERTEX_MULTIREGION_HOST_DEFAULTS:
+        host_region = _VERTEX_MULTIREGION_HOST_DEFAULTS[region]
+        return f"{host_region}-aiplatform.googleapis.com", region
+    return f"{region}-aiplatform.googleapis.com", region
 
 
 def _build_vertex_deployment(
     *,
     preset_name: str,
     publisher: str,
-    service_account_key: dict | str,
+    service_account_key: dict | str | None,
     project: str,
     region: str,
     model: str,
     env_hint: str,
     grammar: Any,
     wire: WireProtocol,
+    routing: Optional[CompletionRouting] = None,
 ) -> LlmDeployment:
     """Shared constructor for the 2 Vertex presets.
 
@@ -1384,16 +1476,15 @@ def _build_vertex_deployment(
     # platform scope per Vertex spec.
     auth = GcpOauth(service_account_key=service_account_key)
     # --- endpoint assembly --------------------------------------------------
-    endpoint_host = f"{validated_region}-aiplatform.googleapis.com"
-    # The Vertex URL embeds the model in the path (`:rawPredict` for
-    # Anthropic-on-Vertex, `:streamGenerateContent` for Gemini -- but
-    # we use `:rawPredict` for Gemini too, since the Vertex Gemini
-    # path matches the Rust SDK's choice and supports both raw + stream
-    # via the same endpoint with a query flag). path_prefix carries the
-    # full project/location/publisher/model path; the wire adapter
-    # appends `:rawPredict` at completion time.
+    # Host + path-location derive from the region: `global` uses the
+    # region-less host; `us` / `eu` multi-region literals pass through into
+    # the path while the host uses a concrete default subdomain (NEW-B).
+    endpoint_host, path_location = _derive_vertex_host_and_location(validated_region)
+    # path_prefix carries the full project/location/publisher/model path; the
+    # completion path appends the routing verb (`:rawPredict` for
+    # Anthropic-on-Vertex, `:generateContent` for Gemini) at send time.
     path_prefix = (
-        f"/v1/projects/{validated_project}/locations/{validated_region}"
+        f"/v1/projects/{validated_project}/locations/{path_location}"
         f"/publishers/{publisher}/models/{resolved_model}"
     )
     endpoint = Endpoint(
@@ -1405,6 +1496,7 @@ def _build_vertex_deployment(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        completion_routing=routing,
         preset_name=preset_name,
     )
     logger.info(
@@ -1422,7 +1514,7 @@ def _build_vertex_deployment(
 
 
 def vertex_claude_preset(
-    service_account_key: dict | str,
+    service_account_key: dict | str | None,
     project: str,
     region: str,
     model: str,
@@ -1472,11 +1564,20 @@ def vertex_claude_preset(
         env_hint="VERTEX_CLAUDE_MODEL_ID",
         grammar=_GRAMMAR_VERTEX_CLAUDE,
         wire=WireProtocol.AnthropicMessages,
+        routing=CompletionRouting(
+            # model already lives in path_prefix (.../models/{model}); the
+            # verb attaches directly (leading ':') at send time.
+            path_template=":rawPredict",
+            streaming_path_template=":streamRawPredict",
+            # Vertex-hosted Anthropic strips `model` from the body and
+            # injects this version literal.
+            anthropic_version_body="vertex-2023-10-16",
+        ),
     )
 
 
 def vertex_gemini_preset(
-    service_account_key: dict | str,
+    service_account_key: dict | str | None,
     project: str,
     region: str,
     model: str,
@@ -1510,6 +1611,11 @@ def vertex_gemini_preset(
         env_hint="VERTEX_GEMINI_MODEL_ID",
         grammar=_GRAMMAR_VERTEX_GEMINI,
         wire=WireProtocol.VertexGenerateContent,
+        routing=CompletionRouting(
+            # model already in path_prefix; verb attaches directly.
+            path_template=":generateContent",
+            streaming_path_template=":streamGenerateContent",
+        ),
     )
 
 

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/__init__.py
@@ -41,22 +41,26 @@ from __future__ import annotations
 
 from kaizen.llm.wire_protocols import (
     anthropic_messages,
+    bedrock_invoke,
     cohere_generate,
     google_generate_content,
     huggingface_inference,
     mistral_chat,
     ollama_embeddings,
     ollama_native,
+    openai_chat,
     openai_embeddings,
 )
 
 __all__ = [
     "anthropic_messages",
+    "bedrock_invoke",
     "cohere_generate",
     "google_generate_content",
     "huggingface_inference",
     "mistral_chat",
     "ollama_embeddings",
     "ollama_native",
+    "openai_chat",
     "openai_embeddings",
 ]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
@@ -61,6 +61,11 @@ def _resolve_temperature(model: str, temperature: float | None) -> float | None:
     at/above the floor passes through unchanged; a value below the floor is
     dropped so the model uses its own default instead of hard-400'ing on an
     out-of-range temperature.
+
+    Caller note: for a floor-constrained model (e.g. ``claude-opus-4-8``) an
+    explicit ``temperature=0`` is OMITTED — the request is NOT deterministic;
+    the model applies its own default sampling. A hard-400 is the only
+    alternative, so determinism is not achievable on these models via this arg.
     """
     if temperature is None:
         return None

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
@@ -30,6 +30,50 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_TOKENS = 4096
 
 
+# Per-model temperature floors (NEW-A). Some Claude models reject
+# `temperature: 0` with a hard 400 — `claude-opus-4-8` requires a minimum of
+# 1.0. This is a DATA-DRIVEN table keyed on a model-id substring so the
+# handling is model-aware without a magic branch: any resolved on-wire id
+# containing a listed substring (direct `claude-opus-4-8`, Vertex
+# `claude-opus-4-8@...`, a Bedrock inference-profile carrying the same alias)
+# gets the same floor. When a request's temperature is below the floor the
+# field is OMITTED (the model then applies its own default) rather than sent
+# and 400'd. Extend this table as providers publish new per-model minimums.
+_TEMPERATURE_MIN_BY_MODEL_SUBSTR: dict[str, float] = {
+    "claude-opus-4-8": 1.0,
+}
+
+
+def _temperature_floor_for(model: str) -> float | None:
+    """Return the temperature floor for ``model``, or ``None`` if unconstrained."""
+    if not isinstance(model, str):
+        return None
+    for substr, floor in _TEMPERATURE_MIN_BY_MODEL_SUBSTR.items():
+        if substr in model:
+            return floor
+    return None
+
+
+def _resolve_temperature(model: str, temperature: float | None) -> float | None:
+    """Apply the per-model temperature floor.
+
+    Returns the temperature to send, or ``None`` to OMIT the field. A value
+    at/above the floor passes through unchanged; a value below the floor is
+    dropped so the model uses its own default instead of hard-400'ing on an
+    out-of-range temperature.
+    """
+    if temperature is None:
+        return None
+    floor = _temperature_floor_for(model)
+    if floor is not None and temperature < floor:
+        logger.debug(
+            "anthropic_messages.temperature_omitted_below_floor",
+            extra={"floor": floor},
+        )
+        return None
+    return temperature
+
+
 def _partition_messages(
     messages: List[Dict[str, Any]],
 ) -> tuple[str | None, List[Dict[str, Any]]]:
@@ -85,8 +129,9 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     }
     if system is not None:
         payload["system"] = system
-    if request.temperature is not None:
-        payload["temperature"] = request.temperature
+    temperature = _resolve_temperature(request.model, request.temperature)
+    if temperature is not None:
+        payload["temperature"] = temperature
     if request.top_p is not None:
         payload["top_p"] = request.top_p
     if request.stop:

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWS Bedrock ``InvokeModel`` wire protocol shaper (#1717).
+
+Non-Anthropic Bedrock families (Meta Llama, Amazon Titan, Mistral, Cohere)
+speak the native Bedrock ``invoke-model`` body schema rather than the
+Anthropic Messages schema. Each family has a DIFFERENT native body shape, so
+this shaper selects the body builder from the on-wire model-id prefix that
+Bedrock's model catalogue guarantees:
+
+* ``meta.*``   → Llama:  ``{"prompt", "max_gen_len", "temperature", "top_p"}``
+* ``amazon.*`` → Titan:  ``{"inputText", "textGenerationConfig": {...}}``
+* ``mistral.*``→ Mistral:``{"prompt", "max_tokens", "temperature", "top_p", "stop"}``
+* ``cohere.*`` → Cohere: ``{"prompt", "max_tokens", "temperature", "p", "stop_sequences"}``
+
+The model id is carried in the URL path (``/model/{modelId}/invoke``), NOT
+the body — so ``build_request_payload`` reads ``request.model`` only to pick
+the family body builder.
+
+This is on-the-wire serialization (a dumb data endpoint), not agent
+reasoning: the prefix dispatch routes on a provider-catalogue-defined model
+id, exactly the structural dispatch ``rules/agent-reasoning.md`` permits.
+
+See https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List
+
+from kaizen.llm.deployment import CompletionRequest
+
+logger = logging.getLogger(__name__)
+
+# Llama / Titan cap output at model-specific ceilings; 512 is a safe
+# cross-family default when the caller did not set max_tokens.
+_DEFAULT_MAX_TOKENS = 512
+
+
+def _flatten_prompt(messages: List[Dict[str, Any]]) -> str:
+    """Render OpenAI-style messages as a single prompt string.
+
+    The native Bedrock (non-Anthropic) invoke schemas take a flat ``prompt``
+    string, not a message array. Uses the widely-supported
+    ``[ROLE] content`` convention and trails an ``[ASSISTANT]`` cue.
+    """
+    parts: List[str] = []
+    for msg in messages:
+        role = str(msg.get("role", "user")).upper()
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            text_blocks: List[str] = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text_blocks.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    text_blocks.append(block)
+            content = "".join(text_blocks)
+        parts.append(f"[{role}] {content}")
+    parts.append("[ASSISTANT] ")
+    return "\n".join(parts)
+
+
+def _build_llama(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"prompt": prompt}
+    body["max_gen_len"] = (
+        request.max_tokens if request.max_tokens is not None else _DEFAULT_MAX_TOKENS
+    )
+    if request.temperature is not None:
+        body["temperature"] = request.temperature
+    if request.top_p is not None:
+        body["top_p"] = request.top_p
+    return body
+
+
+def _build_titan(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "maxTokenCount": (
+            request.max_tokens
+            if request.max_tokens is not None
+            else _DEFAULT_MAX_TOKENS
+        )
+    }
+    if request.temperature is not None:
+        config["temperature"] = request.temperature
+    if request.top_p is not None:
+        config["topP"] = request.top_p
+    if request.stop:
+        config["stopSequences"] = list(request.stop)
+    return {"inputText": prompt, "textGenerationConfig": config}
+
+
+def _build_mistral(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"prompt": prompt}
+    if request.max_tokens is not None:
+        body["max_tokens"] = request.max_tokens
+    if request.temperature is not None:
+        body["temperature"] = request.temperature
+    if request.top_p is not None:
+        body["top_p"] = request.top_p
+    if request.stop:
+        body["stop"] = list(request.stop)
+    return body
+
+
+def _build_cohere(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
+    body: Dict[str, Any] = {"prompt": prompt}
+    if request.max_tokens is not None:
+        body["max_tokens"] = request.max_tokens
+    if request.temperature is not None:
+        body["temperature"] = request.temperature
+    if request.top_p is not None:
+        body["p"] = request.top_p
+    if request.stop:
+        body["stop_sequences"] = list(request.stop)
+    return body
+
+
+# Prefix → family body builder. Ordered longest-prefix-first is unnecessary
+# because Bedrock prefixes are disjoint namespaces.
+_FAMILY_BUILDERS: Dict[str, Callable[[CompletionRequest, str], Dict[str, Any]]] = {
+    "meta.": _build_llama,
+    "amazon.": _build_titan,
+    "mistral.": _build_mistral,
+    "cohere.": _build_cohere,
+}
+
+
+def _select_builder(
+    model: str,
+) -> Callable[[CompletionRequest, str], Dict[str, Any]]:
+    """Pick the family body builder from the on-wire model-id prefix.
+
+    Bedrock inference-profile ids may carry a region prefix
+    (``us.meta.llama3-...``); strip a leading ``<region>.`` segment before
+    matching so both native ids and inference-profile ids resolve.
+    """
+    candidate = model
+    for family_prefix, builder in _FAMILY_BUILDERS.items():
+        if (
+            candidate.startswith(family_prefix)
+            or f".{family_prefix}" in f".{candidate}"
+        ):
+            return builder
+    # Strip a single leading dotted segment (region for inference profiles)
+    # and retry once.
+    if "." in candidate:
+        stripped = candidate.split(".", 1)[1]
+        for family_prefix, builder in _FAMILY_BUILDERS.items():
+            if stripped.startswith(family_prefix):
+                return builder
+    raise ValueError(
+        "bedrock_invoke.build_request_payload: could not map model id to a "
+        "Bedrock family (expected a meta./amazon./mistral./cohere. prefix)"
+    )
+
+
+def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
+    """Build the native Bedrock ``invoke-model`` body for the model's family.
+
+    The model id (carried in the URL, not the body) selects the family body
+    builder. Raises ``ValueError`` when the id does not map to a known
+    family so a misconfigured deployment fails at the shaper boundary rather
+    than with an opaque Bedrock 400.
+    """
+    if not isinstance(request, CompletionRequest):
+        raise TypeError("build_request_payload expects a CompletionRequest")
+    prompt = _flatten_prompt(request.messages)
+    builder = _select_builder(request.model)
+    return builder(request, prompt)
+
+
+def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a native Bedrock invoke response across families.
+
+    Family response shapes:
+
+    * Llama:   ``{"generation": "...", "prompt_token_count", "generation_token_count", "stop_reason"}``
+    * Titan:   ``{"results": [{"outputText": "...", "completionReason": "..."}], "inputTextTokenCount"}``
+    * Mistral: ``{"outputs": [{"text": "...", "stop_reason": "..."}]}``
+    * Cohere:  ``{"generations": [{"text": "...", "finish_reason": "..."}]}``
+    """
+    if not isinstance(payload, dict):
+        raise TypeError("parse_response expects a dict payload")
+
+    text = ""
+    stop_reason: Any = None
+    input_tokens: Any = None
+    output_tokens: Any = None
+
+    if "generation" in payload:  # Llama
+        gen = payload.get("generation")
+        if isinstance(gen, str):
+            text = gen
+        stop_reason = payload.get("stop_reason")
+        input_tokens = payload.get("prompt_token_count")
+        output_tokens = payload.get("generation_token_count")
+    elif "results" in payload:  # Titan
+        results = payload.get("results", []) or []
+        if results and isinstance(results[0], dict):
+            first = results[0]
+            out = first.get("outputText")
+            if isinstance(out, str):
+                text = out
+            stop_reason = first.get("completionReason")
+            output_tokens = first.get("tokenCount")
+        input_tokens = payload.get("inputTextTokenCount")
+    elif "outputs" in payload:  # Mistral
+        outputs = payload.get("outputs", []) or []
+        if outputs and isinstance(outputs[0], dict):
+            first = outputs[0]
+            out = first.get("text")
+            if isinstance(out, str):
+                text = out
+            stop_reason = first.get("stop_reason")
+    elif "generations" in payload:  # Cohere
+        generations = payload.get("generations", []) or []
+        if generations and isinstance(generations[0], dict):
+            first = generations[0]
+            out = first.get("text")
+            if isinstance(out, str):
+                text = out
+            stop_reason = first.get("finish_reason")
+
+    return {
+        "text": text,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+        "stop_reason": stop_reason,
+        "model": None,
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI Chat Completions wire protocol shaper (#1717).
+
+Shapes the on-the-wire request/response for OpenAI's
+``POST /v1/chat/completions`` endpoint. Consumed by ``LlmClient.complete()``
+via its ``WireProtocol.OpenAiChat`` dispatch path.
+
+Every OpenAI-compatible provider (Groq, Together, Fireworks, OpenRouter,
+DeepSeek, Perplexity, Azure OpenAI, LM Studio, llama.cpp, Docker Model
+Runner) shares this shape — they differ only in endpoint URL + auth, not in
+the request/response body — so this single shaper serves them all.
+
+Request schema (OpenAI documented contract):
+
+* ``model`` (str)     — required; carried in the body (NOT the URL).
+* ``messages`` (list) — required; ``[{"role", "content"}, ...]`` passed
+  through verbatim so multimodal / tool blocks survive.
+* ``temperature`` / ``top_p`` / ``max_tokens`` / ``stop`` / ``stream`` /
+  ``user`` — only emitted when the caller set them, so the produced payload
+  is stable across Python dict-ordering changes.
+
+Response schema:
+
+    {
+      "choices": [{"message": {"content": "..."}, "finish_reason": "..."}],
+      "usage": {"prompt_tokens": N, "completion_tokens": M, "total_tokens": T},
+      "model": "gpt-4o-..."
+    }
+
+Cross-SDK parity: this shaper's output for a fixed input is byte-identical
+to its Rust counterpart's OpenAI chat payload builder.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from kaizen.llm.deployment import CompletionRequest
+
+
+def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
+    """Build the ``/v1/chat/completions`` request body for OpenAI.
+
+    Emits the canonical OpenAI chat shape. Optional fields are written only
+    when the caller set them so callers relying on server defaults do NOT
+    get a silent override.
+    """
+    if not isinstance(request, CompletionRequest):
+        raise TypeError("build_request_payload expects a CompletionRequest")
+
+    payload: Dict[str, Any] = {
+        "model": request.model,
+        "messages": list(request.messages),
+    }
+    if request.temperature is not None:
+        payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
+    if request.max_tokens is not None:
+        payload["max_tokens"] = request.max_tokens
+    if request.stop:
+        payload["stop"] = list(request.stop)
+    if request.stream:
+        payload["stream"] = True
+    if request.user is not None:
+        payload["user"] = request.user
+    return payload
+
+
+def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract normalized ``{text, usage, stop_reason, model}`` from a response.
+
+    Handles both the non-streaming ``choices[0].message.content`` shape and
+    the streaming ``choices[0].delta.content`` chunk shape so this same
+    parser is reusable by ``LlmClient.stream()``.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError("parse_response expects a dict payload")
+    choices = payload.get("choices", []) or []
+    text = ""
+    finish_reason: Any = None
+    if choices and isinstance(choices[0], dict):
+        first = choices[0]
+        finish_reason = first.get("finish_reason")
+        # Non-stream carries `message`; a streaming chunk carries `delta`.
+        message = first.get("message")
+        if not isinstance(message, dict):
+            message = first.get("delta", {})
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                text = content
+    usage = payload.get("usage", {}) or {}
+    return {
+        "text": text,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens"),
+            "output_tokens": usage.get("completion_tokens"),
+            "total_tokens": usage.get("total_tokens"),
+        },
+        "stop_reason": finish_reason,
+        "model": payload.get("model"),
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/tests/cross_sdk_parity/test_vertex_wire_behavior_matches_rust.py
+++ b/packages/kailash-kaizen/tests/cross_sdk_parity/test_vertex_wire_behavior_matches_rust.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-SDK parity: Vertex-Claude on-wire request shape (#1717 AC #7).
+
+Per specs/kaizen-llm-deployments.md § Cross-SDK Parity, a fixed Vertex-Claude
+deployment MUST produce byte-equivalent on-wire URL + body on both kailash-py
+and the Rust SDK (EATP D6: independent implementation, matching semantics).
+
+This pins the three load-bearing Vertex-Claude wire invariants that the Rust
+adapter's per-preset routing also enforces:
+
+* the completion verb is `:rawPredict` (unary) / `:streamRawPredict` (stream),
+  appended directly to the model-carrying path with no `/` separator;
+* the platform-Anthropic body carries the literal `anthropic_version`
+  `"vertex-2023-10-16"`;
+* `model` is STRIPPED from the body (Vertex carries it in the URL path).
+
+The assertions read the exact payload dict + URL string the send-path
+serializes, so they ARE the on-wire shape — no live GCP call is made (the
+grammar-resolved model id `claude-opus-4-8@latest` and the routing verb are
+deterministic pure-function outputs of the deployment).
+"""
+
+from __future__ import annotations
+
+from kaizen.llm import LlmClient
+from kaizen.llm.presets import vertex_claude_preset
+
+
+def _fake_sa() -> dict:
+    """Minimal service-account dict — construction only, no google-auth call."""
+    return {
+        "type": "service_account",
+        "project_id": "my-test-project",
+        "private_key_id": "k",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----",
+        "client_email": "sa@my-test-project.iam.gserviceaccount.com",
+        "client_id": "i",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+def _client_and_request(*, stream: bool):
+    dep = vertex_claude_preset(
+        _fake_sa(),
+        "my-proj-1234",
+        "us-central1",
+        "claude-opus-4-8",
+    )
+    client = LlmClient.from_deployment(dep)
+    req = client._build_completion_request(
+        [{"role": "user", "content": "hi"}],
+        model=None,
+        temperature=None,
+        top_p=None,
+        max_tokens=32,
+        stop=None,
+        user=None,
+        stream=stream,
+    )
+    return client, req
+
+
+def test_vertex_claude_unary_wire_shape_matches_rust_contract() -> None:
+    """Unary Vertex-Claude request: `:rawPredict` verb + version-stripped body."""
+    client, req = _client_and_request(stream=False)
+    payload, url = client._build_completion_payload_and_url(req, stream=False)
+
+    # Verb: `:rawPredict` appended to the model-carrying path.
+    assert url.endswith(":rawPredict")
+    assert "/publishers/anthropic/models/claude-opus-4-8" in url
+    # Platform-Anthropic body transform: version literal present, model stripped.
+    assert payload["anthropic_version"] == "vertex-2023-10-16"
+    assert "model" not in payload
+
+
+def test_vertex_claude_streaming_verb_matches_rust_contract() -> None:
+    """Streaming Vertex-Claude request routes to the `:streamRawPredict` verb."""
+    client, req = _client_and_request(stream=True)
+    _, stream_url = client._build_completion_payload_and_url(req, stream=True)
+
+    assert stream_url.endswith(":streamRawPredict")
+    # Distinct from the unary verb — a streaming send must NOT hit `:rawPredict`.
+    assert not stream_url.endswith(":rawPredict")
+    assert "/publishers/anthropic/models/claude-opus-4-8" in stream_url

--- a/packages/kailash-kaizen/tests/unit/llm/auth/test_gcp_auth_modes.py
+++ b/packages/kailash-kaizen/tests/unit/llm/auth/test_gcp_auth_modes.py
@@ -1,0 +1,326 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GcpOauth multi-mode auth completion (#1717).
+
+Covers the four credential-source modes added on top of the historical
+service-account-key path:
+
+* `gcp_wif`     -- explicit external_account (Workload Identity Federation),
+                   dict + path + impersonation
+* `gcp_metadata`-- keyless GCE / Cloud Run metadata server
+* `gcp_adc`     -- keyless Application Default Credentials
+* JSON-`type` dispatch -- a service_account_key PATH whose file declares
+                   `type == "external_account"` routes to the WIF loader at
+                   credential-build time.
+
+Construction + discriminant assertions are pure (no google-auth calls).
+Credential-build dispatch is asserted by patching the module-level
+google-auth entry points so the routing is deterministic and offline
+(Tier 1 -- mocking the google-auth boundary is permitted). Where a real
+google-auth object constructs without network IO (compute_engine, the
+external_account loader), a real-construction test runs too, guarded with
+importorskip so a venv lacking the [vertex] extra skips rather than errors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kaizen.llm.auth import gcp as gcp_mod
+from kaizen.llm.auth.gcp import DEFAULT_SCOPES, GcpOauth
+from kaizen.llm.errors import AuthError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — credential-config shapes
+# ---------------------------------------------------------------------------
+
+
+def _external_account_info(*, impersonation: bool = False) -> dict:
+    """Minimal well-formed url/file-sourced external_account (WIF) config."""
+    info = {
+        "type": "external_account",
+        "audience": (
+            "//iam.googleapis.com/projects/123456/locations/global/"
+            "workloadIdentityPools/my-pool/providers/my-provider"
+        ),
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {"file": "/var/run/secrets/token"},
+    }
+    if impersonation:
+        info["service_account_impersonation_url"] = (
+            "https://iamcredentials.googleapis.com/v1/projects/-/"
+            "serviceAccounts/wif@proj.iam.gserviceaccount.com:generateAccessToken"
+        )
+    return info
+
+
+def _service_account_info() -> dict:
+    return {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "test-key-id",
+        "private_key": (
+            "-----BEGIN PRIVATE KEY-----\nTESTKEY\n-----END PRIVATE KEY-----"
+        ),
+        "client_email": "test@test-project.iam.gserviceaccount.com",
+        "client_id": "test-client-id",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Discriminants — construction only, no google-auth calls
+# ---------------------------------------------------------------------------
+
+
+def test_keyless_default_is_adc() -> None:
+    auth = GcpOauth()
+    assert auth.auth_strategy_kind() == "gcp_adc"
+    assert auth.scopes == DEFAULT_SCOPES
+
+
+def test_adc_classmethod_discriminant() -> None:
+    assert GcpOauth.adc().auth_strategy_kind() == "gcp_adc"
+
+
+def test_metadata_server_classmethod_discriminant() -> None:
+    auth = GcpOauth.metadata_server()
+    assert auth.auth_strategy_kind() == "gcp_metadata"
+
+
+def test_use_metadata_server_kwarg_discriminant() -> None:
+    assert GcpOauth(use_metadata_server=True).auth_strategy_kind() == "gcp_metadata"
+
+
+def test_workload_identity_dict_discriminant() -> None:
+    auth = GcpOauth.workload_identity(_external_account_info())
+    assert auth.auth_strategy_kind() == "gcp_wif"
+
+
+def test_workload_identity_path_discriminant() -> None:
+    auth = GcpOauth.workload_identity("/tmp/fake-wif.json")
+    assert auth.auth_strategy_kind() == "gcp_wif"
+
+
+def test_external_account_kwarg_discriminant() -> None:
+    auth = GcpOauth(external_account=_external_account_info())
+    assert auth.auth_strategy_kind() == "gcp_wif"
+
+
+def test_service_account_key_dict_with_external_type_is_wif() -> None:
+    """A WIF config passed through the service_account_key arg (dict) is
+    classified as gcp_wif via its `type` field (free to read, no file IO)."""
+    auth = GcpOauth(service_account_key=_external_account_info())
+    assert auth.auth_strategy_kind() == "gcp_wif"
+
+
+def test_service_account_key_path_reports_gcp_oauth() -> None:
+    """A path is NOT read at construction; discriminant reflects the API used
+    (gcp_oauth). JSON-type dispatch happens at build time (tested below)."""
+    auth = GcpOauth(service_account_key="/tmp/fake-sa.json")
+    assert auth.auth_strategy_kind() == "gcp_oauth"
+
+
+def test_scopes_propagate_to_keyless_modes() -> None:
+    scope = "https://www.googleapis.com/auth/cloud-platform.read-only"
+    assert GcpOauth.adc(scopes=[scope]).scopes == (scope,)
+    assert GcpOauth.metadata_server(scopes=[scope]).scopes == (scope,)
+    assert GcpOauth.workload_identity(
+        _external_account_info(), scopes=[scope]
+    ).scopes == (scope,)
+
+
+# ---------------------------------------------------------------------------
+# Validation / error contracts
+# ---------------------------------------------------------------------------
+
+
+def test_both_key_and_external_account_raises() -> None:
+    with pytest.raises(AuthError, match=r"not both"):
+        GcpOauth(
+            service_account_key=_service_account_info(),
+            external_account=_external_account_info(),
+        )
+
+
+def test_empty_external_account_dict_raises() -> None:
+    with pytest.raises(AuthError, match=r"empty"):
+        GcpOauth(external_account={})
+
+
+def test_empty_external_account_path_raises() -> None:
+    with pytest.raises(AuthError, match=r"empty"):
+        GcpOauth(external_account="")
+
+
+def test_non_dict_non_str_external_account_raises() -> None:
+    with pytest.raises(TypeError):
+        GcpOauth(external_account=12345)  # type: ignore[arg-type]
+
+
+def test_repr_does_not_leak_external_account_material() -> None:
+    info = _external_account_info(impersonation=True)
+    auth = GcpOauth(external_account=info)
+    rendered = repr(auth)
+    assert info["audience"] not in rendered
+    assert info["service_account_impersonation_url"] not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Credential-build dispatch — patched google-auth boundary (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_build_credentials_adc_calls_google_auth_default() -> None:
+    fake_creds = MagicMock(name="adc-creds")
+    with patch.object(
+        gcp_mod, "_google_auth_default", return_value=(fake_creds, "proj")
+    ) as m_default:
+        auth = GcpOauth.adc()
+        result = auth._build_credentials()
+    assert result is fake_creds
+    m_default.assert_called_once()
+    # scopes forwarded
+    _, kwargs = m_default.call_args
+    assert kwargs["scopes"] == list(DEFAULT_SCOPES)
+
+
+def test_build_credentials_metadata_calls_compute_engine() -> None:
+    fake_ce = MagicMock(name="compute_engine")
+    with patch.object(gcp_mod, "_google_compute_engine", fake_ce):
+        auth = GcpOauth.metadata_server()
+        auth._build_credentials()
+    fake_ce.Credentials.assert_called_once()
+
+
+def test_build_credentials_wif_dict_calls_loader() -> None:
+    info = _external_account_info()
+    fake_creds = MagicMock(name="wif-creds")
+    with patch.object(
+        gcp_mod, "_google_load_creds_from_dict", return_value=(fake_creds, "proj")
+    ) as m_loader:
+        auth = GcpOauth(external_account=info)
+        result = auth._build_credentials()
+    assert result is fake_creds
+    passed_info, _ = m_loader.call_args[0], m_loader.call_args[1]
+    assert passed_info[0] == info
+
+
+def test_build_credentials_wif_path_reads_and_routes(tmp_path: Path) -> None:
+    info = _external_account_info(impersonation=True)
+    p = tmp_path / "wif.json"
+    p.write_text(json.dumps(info), encoding="utf-8")
+    fake_creds = MagicMock(name="wif-creds")
+    with patch.object(
+        gcp_mod, "_google_load_creds_from_dict", return_value=(fake_creds, None)
+    ) as m_loader:
+        auth = GcpOauth.workload_identity(str(p))
+        result = auth._build_credentials()
+    assert result is fake_creds
+    assert m_loader.call_args[0][0] == info
+
+
+# ---------------------------------------------------------------------------
+# JSON-type dispatch — a service_account_key PATH classified at build time
+# ---------------------------------------------------------------------------
+
+
+def test_sa_key_path_pointing_at_external_account_routes_to_wif(
+    tmp_path: Path,
+) -> None:
+    """GOOGLE_APPLICATION_CREDENTIALS-style path whose file is an
+    external_account config routes to the WIF loader (deliverable #4)."""
+    info = _external_account_info()
+    p = tmp_path / "creds.json"
+    p.write_text(json.dumps(info), encoding="utf-8")
+    fake_creds = MagicMock(name="wif-creds")
+    with patch.object(
+        gcp_mod, "_google_load_creds_from_dict", return_value=(fake_creds, None)
+    ) as m_loader:
+        auth = GcpOauth(service_account_key=str(p))  # discriminant stays gcp_oauth
+        result = auth._build_credentials()
+    assert result is fake_creds
+    assert m_loader.call_args[0][0] == info
+
+
+def test_sa_key_path_pointing_at_service_account_routes_to_sa(
+    tmp_path: Path,
+) -> None:
+    info = _service_account_info()
+    p = tmp_path / "creds.json"
+    p.write_text(json.dumps(info), encoding="utf-8")
+    fake_sa = MagicMock(name="service_account_module")
+    with patch.object(gcp_mod, "_google_service_account", fake_sa):
+        auth = GcpOauth(service_account_key=str(p))
+        auth._build_credentials()
+    fake_sa.Credentials.from_service_account_file.assert_called_once()
+    args, kwargs = fake_sa.Credentials.from_service_account_file.call_args
+    assert args[0] == str(p)
+    assert kwargs["scopes"] == list(DEFAULT_SCOPES)
+
+
+def test_creds_file_not_found_raises_typed_error_without_leaking_path() -> None:
+    auth = GcpOauth(service_account_key="/nonexistent/secret-layout/creds.json")
+    with pytest.raises(AuthError, match=r"not found") as exc:
+        auth._build_credentials()
+    assert "/nonexistent/secret-layout/creds.json" not in str(exc.value)
+
+
+def test_creds_file_invalid_json_raises_typed_error(tmp_path: Path) -> None:
+    p = tmp_path / "creds.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    auth = GcpOauth(service_account_key=str(p))
+    with pytest.raises(AuthError, match=r"unreadable or not valid JSON"):
+        auth._build_credentials()
+
+
+def test_creds_file_unknown_type_raises_typed_error(tmp_path: Path) -> None:
+    p = tmp_path / "creds.json"
+    p.write_text(json.dumps({"type": "authorized_user"}), encoding="utf-8")
+    auth = GcpOauth(service_account_key=str(p))
+    with pytest.raises(AuthError, match=r"unsupported credential type"):
+        auth._build_credentials()
+
+
+# ---------------------------------------------------------------------------
+# Real google-auth construction (network-free), guarded on the [vertex] extra
+# ---------------------------------------------------------------------------
+
+
+def test_real_metadata_credentials_construct() -> None:
+    pytest.importorskip("google.auth.compute_engine")
+    from google.auth.credentials import Credentials
+
+    auth = GcpOauth.metadata_server()
+    creds = auth._build_credentials()  # constructs; no network until refresh
+    assert isinstance(creds, Credentials)
+
+
+def test_real_wif_credentials_route_through_google_auth_external_account() -> None:
+    """The WIF path is REALLY wired through google-auth's external_account
+    loader (not a stub): building against a config whose subject-token file
+    is absent surfaces google-auth's typed RefreshError from the STS
+    exchange -- positive proof the identity-pool machinery ran."""
+    exc_mod = pytest.importorskip("google.auth.exceptions")
+    auth = GcpOauth(external_account=_external_account_info())
+    with pytest.raises(exc_mod.RefreshError, match=r"/var/run/secrets/token"):
+        auth._build_credentials()
+
+
+def test_real_wif_impersonation_routes_through_impersonated_credentials() -> None:
+    """With `service_account_impersonation_url` present, google-auth wraps the
+    external_account creds in `impersonated_credentials.Credentials`; the
+    refresh chain reaches the same absent subject-token file, proving the
+    impersonation wrapper is invoked (not skipped)."""
+    exc_mod = pytest.importorskip("google.auth.exceptions")
+    pytest.importorskip("google.auth.impersonated_credentials")
+    auth = GcpOauth(external_account=_external_account_info(impersonation=True))
+    with pytest.raises(exc_mod.RefreshError, match=r"/var/run/secrets/token"):
+        auth._build_credentials()

--- a/packages/kailash-kaizen/tests/unit/llm/grammar/test_vertex_claude_grammar.py
+++ b/packages/kailash-kaizen/tests/unit/llm/grammar/test_vertex_claude_grammar.py
@@ -139,12 +139,28 @@ def test_grammar_rejects_unknown_caller_model(
         grammar.resolve("gpt-4o-mini")
 
 
-def test_grammar_rejects_unversioned_unknown_claude_alias(
+def test_grammar_open_passthrough_appends_latest_for_bare_unknown_claude(
     grammar: VertexClaudeGrammar,
 ) -> None:
-    """A `claude-` prefix without `@` and not in the table must reject."""
-    with pytest.raises(ModelGrammarInvalid, match=r"vertex_claude_not_in_catalog"):
-        grammar.resolve("claude-99-fictional")
+    """Open passthrough (#498/#1717 NEW-catalog): a `claude-*` id not in the
+    table and without `@` gets `@latest` appended so it forms a valid Vertex
+    on-wire id WITHOUT a catalog edit (mirrors VertexGeminiGrammar)."""
+    assert grammar.resolve("claude-99-fictional") == "claude-99-fictional@latest"
+
+
+def test_grammar_resolves_claude_opus_4_8_via_open_passthrough(
+    grammar: VertexClaudeGrammar,
+) -> None:
+    """`claude-opus-4-8` (post-catalog model) resolves WITHOUT a mapping edit."""
+    assert grammar.resolve("claude-opus-4-8") == "claude-opus-4-8@latest"
+
+
+def test_grammar_open_passthrough_preserves_explicit_version_pin(
+    grammar: VertexClaudeGrammar,
+) -> None:
+    """An explicit `@version` on an unknown claude id is preserved (not
+    double-suffixed with @latest)."""
+    assert grammar.resolve("claude-opus-4-8@20260101") == "claude-opus-4-8@20260101"
 
 
 def test_grammar_rejects_anthropic_dot_prefix(

--- a/packages/kailash-kaizen/tests/unit/llm/test_completion_model_path_safety.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_completion_model_path_safety.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Security regression (#1717 security-review MEDIUM): a caller-controlled
+``model`` is interpolated into the outbound URL path for the ``{model}``-template
+wires (GoogleGenerateContent, BedrockInvoke, HuggingFaceInference). An app that
+routes untrusted input into ``model=`` must not be able to path-traverse or
+inject URL-control characters onto the provider host. The completion path
+validates the resolved model fail-closed before building the request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.client import _validate_completion_model
+from kaizen.llm.presets import openai_preset
+
+
+# Legitimate ids across providers MUST pass unchanged (byte-preserving).
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gemini-2.0-flash",
+        "gemini-1.5-pro-002",
+        "claude-opus-4-8",
+        "claude-opus-4-8@latest",  # Vertex version pin
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",  # Bedrock version suffix (':')
+        "us.anthropic.claude-3-5-sonnet",  # bedrock inference profile
+        "meta-llama/Llama-3-8b-Instruct",  # HuggingFace org/model needs '/'
+        "mistralai/Mistral-7B",
+    ],
+)
+def test_valid_model_ids_pass_and_are_byte_preserved(model: str) -> None:
+    assert _validate_completion_model(model) == model
+
+
+# Traversal / URL-control injection MUST be rejected fail-closed.
+@pytest.mark.parametrize(
+    "model",
+    [
+        "../../v1beta/models/other",  # path traversal
+        "../etc/passwd",
+        "a/../b",  # embedded traversal segment
+        "/etc/passwd",  # leading slash (absolute)
+        "a//b",  # empty segment
+        "//evil.com/path",  # protocol-relative host smuggle
+        "model with space",
+        "model?inject=1",  # query smuggle
+        "model#frag",
+        "model%2e%2e",  # percent-encoded dot
+        ".hidden",  # leading dot
+        "",  # empty
+        "x" * 129,  # over length
+    ],
+)
+def test_traversal_and_control_models_rejected(model: str) -> None:
+    with pytest.raises(ValueError, match="path segment"):
+        _validate_completion_model(model)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_complete_rejects_traversal_model_before_network() -> None:
+    """End-to-end: complete() raises ValueError from _build_completion_request,
+    before any transport is acquired or any byte leaves the process."""
+    dep = openai_preset(api_key="sk-test-not-real", model="gpt-4o")
+    client = LlmClient.from_deployment(dep)
+    with pytest.raises(ValueError, match="path segment"):
+        await client.complete(
+            [{"role": "user", "content": "hi"}],
+            model="../../v1beta/models/other",
+        )

--- a/packages/kailash-kaizen/tests/unit/llm/test_completion_model_path_safety.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_completion_model_path_safety.py
@@ -15,7 +15,7 @@ import pytest
 
 from kaizen.llm import LlmClient
 from kaizen.llm.client import _validate_completion_model
-from kaizen.llm.presets import openai_preset
+from kaizen.llm.presets import bedrock_claude_preset, openai_preset
 
 
 # Legitimate ids across providers MUST pass unchanged (byte-preserving).
@@ -52,6 +52,9 @@ def test_valid_model_ids_pass_and_are_byte_preserved(model: str) -> None:
         "model#frag",
         "model%2e%2e",  # percent-encoded dot
         ".hidden",  # leading dot
+        "gpt-4o\n",  # trailing newline (Python $ edge — must NOT slip through)
+        "gpt-4o\r",  # trailing carriage return
+        "model\ttab",  # embedded control
         "",  # empty
         "x" * 129,  # over length
     ],
@@ -72,4 +75,22 @@ async def test_complete_rejects_traversal_model_before_network() -> None:
         await client.complete(
             [{"role": "user", "content": "hi"}],
             model="../../v1beta/models/other",
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_complete_rejects_traversal_on_model_template_wire() -> None:
+    """End-to-end through an actual {model}-template wire (Bedrock puts the model
+    in the URL path); the guard must reject before any transport is acquired."""
+    dep = bedrock_claude_preset(
+        api_key="bedrock-token-not-real",
+        region="us-east-1",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+    client = LlmClient.from_deployment(dep)
+    with pytest.raises(ValueError, match="path segment"):
+        await client.complete(
+            [{"role": "user", "content": "hi"}],
+            model="../../foo/invoke",
         )

--- a/packages/kailash-kaizen/tests/unit/llm/test_completion_send_path.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_completion_send_path.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the four-axis completion send-path (#1717).
+
+Covers the PURE (no-HTTP) surface of `LlmClient.complete()` / `stream()`:
+
+* Per-wire URL building (OpenAI / Anthropic-direct / Google-direct /
+  Vertex-Claude / Vertex-Gemini / Bedrock-Claude / Bedrock-invoke).
+* The platform-Anthropic body transform (strip `model`, inject
+  `anthropic_version`) GATED on `completion_routing`, incl. the
+  direct-Anthropic byte-invariant.
+* NEW-A per-model temperature floor (claude-opus-4-8 omits temperature=0).
+* NEW-B Vertex region us/eu/global host + path-location derivation.
+* NEW-C provider-string aliases (vertex-anthropic / vertex-gemini / etc.).
+* openai_chat + bedrock_invoke shapers.
+* `_parse_stream_line` SSE / JSONL framing.
+
+Wire behaviour (respx round-trips) is exercised by a separate test pass; here
+we assert the deterministic shaper / transform / URL / alias logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.client import _parse_stream_line
+from kaizen.llm.deployment import CompletionRequest, WireProtocol
+from kaizen.llm.presets import (
+    anthropic_preset,
+    bedrock_claude_preset,
+    bedrock_llama_preset,
+    get_preset,
+    google_preset,
+    openai_preset,
+    vertex_claude_preset,
+    vertex_gemini_preset,
+)
+from kaizen.llm.wire_protocols import (
+    anthropic_messages,
+    bedrock_invoke,
+    openai_chat,
+)
+
+
+def _sa() -> dict:
+    return {
+        "type": "service_account",
+        "project_id": "my-test-project",
+        "private_key_id": "k",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----",
+        "client_email": "sa@my-test-project.iam.gserviceaccount.com",
+        "client_id": "i",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+def _req(
+    model: str,
+    *,
+    temperature=None,
+    max_tokens=64,
+    stream=False,
+    messages=None,
+) -> CompletionRequest:
+    return CompletionRequest(
+        model=model,
+        messages=messages or [{"role": "user", "content": "hi"}],
+        temperature=temperature,
+        max_tokens=max_tokens,
+        stream=stream,
+    )
+
+
+def _payload_and_url(dep, req, *, stream=False):
+    client = LlmClient.from_deployment(dep)
+    return client._build_completion_payload_and_url(req, stream=stream)
+
+
+# ---------------------------------------------------------------------------
+# URL building — per wire
+# ---------------------------------------------------------------------------
+
+
+def test_openai_completion_url_and_body() -> None:
+    dep = openai_preset("sk-x", "gpt-4o")
+    payload, url = _payload_and_url(dep, _req("gpt-4o"))
+    assert url == "https://api.openai.com/v1/chat/completions"
+    assert payload["model"] == "gpt-4o"
+    assert payload["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_anthropic_direct_url() -> None:
+    dep = anthropic_preset("sk-ant", "claude-3-5-sonnet-20241022")
+    _, url = _payload_and_url(dep, _req("claude-3-5-sonnet-20241022"))
+    assert url == "https://api.anthropic.com/v1/messages"
+
+
+def test_google_direct_url_carries_model_and_verb() -> None:
+    dep = google_preset("k", "gemini-2.0-flash")
+    _, url = _payload_and_url(dep, _req("gemini-2.0-flash"))
+    assert url == (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-2.0-flash:generateContent"
+    )
+    _, surl = _payload_and_url(dep, _req("gemini-2.0-flash", stream=True), stream=True)
+    assert surl.endswith(":streamGenerateContent")
+
+
+def test_vertex_claude_url_appends_rawpredict_verb() -> None:
+    dep = vertex_claude_preset(
+        _sa(), "my-proj-1234", "us-central1", "claude-3-5-sonnet"
+    )
+    _, url = _payload_and_url(dep, _req(dep.default_model))
+    assert url.endswith(":rawPredict")
+    assert "/publishers/anthropic/models/" in url
+    _, surl = _payload_and_url(dep, _req(dep.default_model, stream=True), stream=True)
+    assert surl.endswith(":streamRawPredict")
+
+
+def test_vertex_gemini_url_appends_generatecontent_verb() -> None:
+    dep = vertex_gemini_preset(_sa(), "my-proj-1234", "us-central1", "gemini-2.0-flash")
+    _, url = _payload_and_url(dep, _req(dep.default_model))
+    assert url.endswith(":generateContent")
+    assert "/publishers/google/models/" in url
+
+
+def test_bedrock_claude_url_forms_model_invoke_path() -> None:
+    dep = bedrock_claude_preset("tok", "us-east-1", "claude-sonnet-4-6")
+    _, url = _payload_and_url(dep, _req(dep.default_model))
+    assert url.startswith("https://bedrock-runtime.us-east-1.amazonaws.com/model/")
+    assert url.endswith("/invoke")
+    _, surl = _payload_and_url(dep, _req(dep.default_model, stream=True), stream=True)
+    assert surl.endswith("/invoke-with-response-stream")
+
+
+def test_bedrock_llama_invoke_url_and_native_body() -> None:
+    dep = bedrock_llama_preset("tok", "us-east-1", "llama-3.1-8b")
+    payload, url = _payload_and_url(dep, _req(dep.default_model))
+    assert url.endswith("/invoke")
+    # Llama native body shape (prompt + max_gen_len), NOT anthropic messages.
+    assert "prompt" in payload and "max_gen_len" in payload
+    assert "messages" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Platform-Anthropic body transform
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_direct_body_keeps_model_no_version() -> None:
+    dep = anthropic_preset("sk-ant", "claude-3-5-sonnet-20241022")
+    payload, _ = _payload_and_url(
+        dep, _req("claude-3-5-sonnet-20241022", temperature=0.7)
+    )
+    assert payload["model"] == "claude-3-5-sonnet-20241022"
+    assert "anthropic_version" not in payload
+
+
+def test_direct_anthropic_body_byte_invariant() -> None:
+    """The completion path must not alter direct-Anthropic body vs the raw shaper."""
+    dep = anthropic_preset("sk-ant", "claude-3-5-sonnet-20241022")
+    req = _req("claude-3-5-sonnet-20241022", temperature=0.7, max_tokens=128)
+    via_path, _ = _payload_and_url(dep, req)
+    raw = anthropic_messages.build_request_payload(req)
+    assert via_path == raw
+
+
+def test_vertex_claude_body_strips_model_injects_version() -> None:
+    dep = vertex_claude_preset(
+        _sa(), "my-proj-1234", "us-central1", "claude-3-5-sonnet"
+    )
+    payload, _ = _payload_and_url(dep, _req(dep.default_model, temperature=0.4))
+    assert "model" not in payload
+    assert payload["anthropic_version"] == "vertex-2023-10-16"
+
+
+def test_bedrock_claude_body_strips_model_injects_version() -> None:
+    dep = bedrock_claude_preset("tok", "us-east-1", "claude-sonnet-4-6")
+    payload, _ = _payload_and_url(dep, _req(dep.default_model, temperature=0.4))
+    assert "model" not in payload
+    assert payload["anthropic_version"] == "bedrock-2023-05-31"
+
+
+# ---------------------------------------------------------------------------
+# NEW-A — per-model temperature floor
+# ---------------------------------------------------------------------------
+
+
+def test_opus_4_8_omits_temperature_zero() -> None:
+    payload = anthropic_messages.build_request_payload(
+        _req("claude-opus-4-8", temperature=0.0)
+    )
+    assert "temperature" not in payload
+
+
+def test_opus_4_8_versioned_id_also_omits_temperature_zero() -> None:
+    payload = anthropic_messages.build_request_payload(
+        _req("claude-opus-4-8@latest", temperature=0.0)
+    )
+    assert "temperature" not in payload
+
+
+def test_opus_4_8_keeps_temperature_at_or_above_floor() -> None:
+    payload = anthropic_messages.build_request_payload(
+        _req("claude-opus-4-8", temperature=1.0)
+    )
+    assert payload["temperature"] == 1.0
+
+
+def test_non_opus_model_keeps_temperature_zero() -> None:
+    payload = anthropic_messages.build_request_payload(
+        _req("claude-3-5-sonnet-20241022", temperature=0.0)
+    )
+    assert payload["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# NEW-B — Vertex region us / eu / global
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_global_region_uses_regionless_host() -> None:
+    dep = vertex_gemini_preset(_sa(), "my-proj-1234", "global", "gemini-2.0-flash")
+    assert str(dep.endpoint.base_url).startswith("https://aiplatform.googleapis.com")
+    assert "/locations/global/" in dep.endpoint.path_prefix
+
+
+def test_vertex_eu_region_passes_through_with_concrete_host() -> None:
+    dep = vertex_gemini_preset(_sa(), "my-proj-1234", "eu", "gemini-2.0-flash")
+    # eu → concrete host europe-west3 (NOT europe-west1), location stays `eu`.
+    assert "europe-west3-aiplatform" in str(dep.endpoint.base_url)
+    assert "europe-west1" not in str(dep.endpoint.base_url)
+    assert "/locations/eu/" in dep.endpoint.path_prefix
+
+
+def test_vertex_us_region_passes_through_with_concrete_host() -> None:
+    dep = vertex_gemini_preset(_sa(), "my-proj-1234", "us", "gemini-2.0-flash")
+    assert "us-central1-aiplatform" in str(dep.endpoint.base_url)
+    assert "/locations/us/" in dep.endpoint.path_prefix
+
+
+def test_vertex_concrete_region_unchanged() -> None:
+    dep = vertex_gemini_preset(
+        _sa(), "my-proj-1234", "europe-west4", "gemini-2.0-flash"
+    )
+    assert "europe-west4-aiplatform" in str(dep.endpoint.base_url)
+    assert "/locations/europe-west4/" in dep.endpoint.path_prefix
+
+
+def test_vertex_bogus_region_rejected() -> None:
+    with pytest.raises(ValueError):
+        vertex_gemini_preset(_sa(), "my-proj-1234", "not a region", "gemini-2.0-flash")
+
+
+# ---------------------------------------------------------------------------
+# NEW-C — provider-string aliases
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_anthropic_alias_resolves_to_vertex_claude() -> None:
+    assert get_preset("vertex-anthropic") is get_preset("vertex_claude")
+
+
+def test_vertex_gemini_and_google_aliases_resolve() -> None:
+    assert get_preset("vertex-gemini") is get_preset("vertex_gemini")
+    assert get_preset("vertex-google") is get_preset("vertex_gemini")
+
+
+def test_unknown_alias_still_raises() -> None:
+    with pytest.raises(ValueError):
+        get_preset("vertex-nonsense")
+
+
+# ---------------------------------------------------------------------------
+# openai_chat + bedrock_invoke shapers
+# ---------------------------------------------------------------------------
+
+
+def test_openai_chat_shaper_optional_fields_omitted() -> None:
+    payload = openai_chat.build_request_payload(_req("gpt-4o", temperature=None))
+    assert payload == {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+    }
+
+
+def test_openai_chat_parse_response_message_and_delta() -> None:
+    non_stream = {
+        "choices": [{"message": {"content": "hello"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+        "model": "gpt-4o",
+    }
+    parsed = openai_chat.parse_response(non_stream)
+    assert parsed["text"] == "hello"
+    assert parsed["stop_reason"] == "stop"
+    assert parsed["usage"]["input_tokens"] == 3
+    delta = {"choices": [{"delta": {"content": "he"}}]}
+    assert openai_chat.parse_response(delta)["text"] == "he"
+
+
+def test_bedrock_invoke_titan_body_and_parse() -> None:
+    payload = bedrock_invoke.build_request_payload(
+        _req("amazon.titan-text-express-v1", temperature=0.5)
+    )
+    assert "inputText" in payload
+    assert payload["textGenerationConfig"]["temperature"] == 0.5
+    parsed = bedrock_invoke.parse_response(
+        {"results": [{"outputText": "yo", "completionReason": "FINISH"}]}
+    )
+    assert parsed["text"] == "yo"
+    assert parsed["stop_reason"] == "FINISH"
+
+
+def test_bedrock_invoke_unknown_family_raises() -> None:
+    with pytest.raises(ValueError):
+        bedrock_invoke.build_request_payload(_req("acme.unknown-model"))
+
+
+# ---------------------------------------------------------------------------
+# _parse_stream_line — SSE / JSONL framing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stream_line_sse_data_prefix() -> None:
+    chunk = _parse_stream_line(
+        'data: {"choices": [{"delta": {"content": "hi"}}]}', openai_chat
+    )
+    assert chunk is not None and chunk["text"] == "hi"
+
+
+def test_parse_stream_line_skips_done_and_blanks() -> None:
+    assert _parse_stream_line("data: [DONE]", openai_chat) is None
+    assert _parse_stream_line("", openai_chat) is None
+    assert _parse_stream_line("   ", openai_chat) is None
+    assert _parse_stream_line(": keep-alive comment", openai_chat) is None
+
+
+def test_parse_stream_line_bare_jsonl_for_ollama_shape() -> None:
+    from kaizen.llm.wire_protocols import ollama_native
+
+    chunk = _parse_stream_line(
+        '{"message": {"content": "tok"}, "done": false}', ollama_native
+    )
+    assert chunk is not None and chunk["text"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch coverage + guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_complete_dispatch_covers_every_preset_wire() -> None:
+    from kaizen.llm.client import _COMPLETE_DISPATCH
+
+    # Every wire that a preset can emit MUST be routable.
+    preset_wires = {
+        WireProtocol.OpenAiChat,
+        WireProtocol.AnthropicMessages,
+        WireProtocol.GoogleGenerateContent,
+        WireProtocol.VertexGenerateContent,
+        WireProtocol.BedrockInvoke,
+        WireProtocol.CohereGenerate,
+        WireProtocol.MistralChat,
+        WireProtocol.OllamaNative,
+        WireProtocol.HuggingFaceInference,
+    }
+    assert preset_wires <= set(_COMPLETE_DISPATCH)
+
+
+@pytest.mark.asyncio
+async def test_complete_requires_deployment() -> None:
+    with pytest.raises(ValueError):
+        await LlmClient().complete([{"role": "user", "content": "hi"}])

--- a/packages/kailash-kaizen/tests/unit/llm/test_completion_wire_respx.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_completion_wire_respx.py
@@ -22,15 +22,23 @@ tests); everything else is the production path.
 from __future__ import annotations
 
 import json
+import time
 
 import httpx
 import pytest
 import respx
+from pydantic import SecretStr
 
 from kaizen.llm import LlmClient
+from kaizen.llm.auth.gcp import CachedToken
 from kaizen.llm.errors import ProviderError, RateLimited
 from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
-from kaizen.llm.presets import bedrock_claude_preset, openai_preset
+from kaizen.llm.presets import (
+    bedrock_claude_preset,
+    openai_preset,
+    vertex_claude_preset,
+    vertex_gemini_preset,
+)
 
 
 class _AllowAllResolver(SafeDnsResolver):
@@ -45,6 +53,41 @@ class _AllowAllResolver(SafeDnsResolver):
 def _client(dep):
     http = LlmHttpClient(deployment_preset=dep.wire.name, resolver=_AllowAllResolver())
     return LlmClient.from_deployment(dep), http
+
+
+def _fake_sa() -> dict:
+    """Minimal service-account dict — never used for a real google-auth call.
+
+    Every Vertex test below pre-seeds the deployment's ``GcpOauth`` token cache
+    (``_seed_gcp_token``) so ``apply_async`` takes the fast-path cache read and
+    ``_build_credentials`` / the google-auth refresh never runs. The dict only
+    has to satisfy ``GcpOauth.__init__``'s "non-empty, not external_account"
+    shape check.
+    """
+    return {
+        "type": "service_account",
+        "project_id": "my-test-project",
+        "private_key_id": "k",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----",
+        "client_email": "sa@my-test-project.iam.gserviceaccount.com",
+        "client_id": "i",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+def _seed_gcp_token(dep, token: str = "faketoken") -> None:
+    """Pre-seed the deployment's GcpOauth cache with a known, non-expired token.
+
+    This is the token-faking seam: `apply_async` calls `_ensure_token()`, whose
+    fast-path returns the cached token WITHOUT acquiring the refresh lock or
+    calling google-auth when the cache is populated and unexpired. `expiry` is
+    now + 3600s so `is_expired()` (60s lead window) reports False. The header
+    installed on the wire is therefore `Bearer <token>` with zero real GCP IO.
+    """
+    dep.auth._cached_token = CachedToken(
+        token=SecretStr(token),
+        expiry_epoch=time.time() + 3600.0,
+    )
 
 
 @pytest.mark.asyncio
@@ -177,3 +220,208 @@ async def test_stream_openai_yields_incremental_chunks() -> None:
     finally:
         await http.aclose()
     assert chunks == ["he", "llo"]
+
+
+# ---------------------------------------------------------------------------
+# Vertex-Claude / Vertex-Gemini wire round-trips (#1717 AC #1, #2, #3)
+#
+# These are the HEADLINE acceptance criteria: they prove the FULL send-path
+# for the platform-hosted providers reaches the socket with the right verb,
+# the right transformed body, and the GcpOauth bearer header installed. The
+# token is faked by pre-seeding the deployment's GcpOauth cache
+# (`_seed_gcp_token`) so no real google-auth call fires.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_vertex_claude_wire_rawpredict_bearer_stripped_body() -> None:
+    """AC #1 (headline): Vertex-Claude complete() reaches the wire correctly.
+
+    Constructs the deployment via the PUBLIC `vertex_claude_preset(...)` path
+    with a fake SA dict + a pre-seeded GcpOauth token, then intercepts the
+    outbound request and pins the on-wire verb, body transform, and auth header.
+    """
+    dep = vertex_claude_preset(
+        _fake_sa(),
+        "my-proj-1234",
+        "us-central1",
+        "claude-opus-4-8",
+    )
+    _seed_gcp_token(dep, "faketoken")
+    client, http = _client(dep)
+    # Build the exact URL respx must match from the deployment itself (the
+    # resolved model is `claude-opus-4-8@latest`, so the on-wire path carries
+    # the `@latest` suffix — build it rather than hardcode it).
+    req = client._build_completion_request(
+        [{"role": "user", "content": "hi"}],
+        model=None,
+        temperature=None,
+        top_p=None,
+        max_tokens=32,
+        stop=None,
+        user=None,
+        stream=False,
+    )
+    _, url = client._build_completion_payload_and_url(req, stream=False)
+    route = respx.post(url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "content": [{"type": "text", "text": "vertex-ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+                "model": "claude-opus-4-8@latest",
+            },
+        )
+    )
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "hi"}], http_client=http, max_tokens=32
+        )
+    finally:
+        await http.aclose()
+
+    sent = route.calls.last.request
+    sent_url = str(sent.url)
+    # (1) Vertex-Claude verb: the URL path ends with the `:rawPredict` verb.
+    assert sent_url.endswith(":rawPredict")
+    # (2) Anthropic publisher + resolved model live in the URL path (model is
+    #     URL-carried on Vertex, resolved to `claude-opus-4-8@latest`).
+    assert "/publishers/anthropic/models/claude-opus-4-8" in sent_url
+    # (3) Platform-Anthropic body transform reached the socket.
+    body = json.loads(sent.content)
+    assert body["anthropic_version"] == "vertex-2023-10-16"
+    assert "model" not in body
+    # (4) GcpOauth bearer header installed on the wire.
+    assert sent.headers["authorization"] == "Bearer faketoken"
+    # (5) Response parses to the normalized `{text, ...}` shape.
+    assert result["text"] == "vertex-ok"
+    assert result["stop_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_vertex_gemini_wire_generatecontent_bearer() -> None:
+    """AC #2: Vertex-Gemini complete() reaches the wire with the right verb/body.
+
+    Gemini uses the `VertexGenerateContent` wire (NOT AnthropicMessages), so
+    NO anthropic transform runs: the body carries `contents` + `generationConfig`
+    and the model is URL-carried, never in the body.
+    """
+    dep = vertex_gemini_preset(
+        _fake_sa(),
+        "my-proj-1234",
+        "us-central1",
+        "gemini-2.0-flash",
+    )
+    _seed_gcp_token(dep, "faketoken")
+    client, http = _client(dep)
+    req = client._build_completion_request(
+        [{"role": "user", "content": "hi"}],
+        model=None,
+        temperature=0.5,
+        top_p=None,
+        max_tokens=48,
+        stop=None,
+        user=None,
+        stream=False,
+    )
+    _, url = client._build_completion_payload_and_url(req, stream=False)
+    route = respx.post(url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "gemini-ok"}]},
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 4,
+                    "candidatesTokenCount": 2,
+                },
+                "modelVersion": "gemini-2.0-flash",
+            },
+        )
+    )
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "hi"}],
+            http_client=http,
+            temperature=0.5,
+            max_tokens=48,
+        )
+    finally:
+        await http.aclose()
+
+    sent = route.calls.last.request
+    sent_url = str(sent.url)
+    assert sent_url.endswith(":generateContent")
+    assert "/publishers/google/models/gemini-2.0-flash" in sent_url
+    # Gemini body shape: model is URL-carried, body carries contents +
+    # generationConfig (no `model` key, no anthropic_version).
+    body = json.loads(sent.content)
+    assert "model" not in body
+    assert "anthropic_version" not in body
+    assert body["contents"] == [{"role": "user", "parts": [{"text": "hi"}]}]
+    assert body["generationConfig"]["temperature"] == 0.5
+    assert body["generationConfig"]["maxOutputTokens"] == 48
+    assert sent.headers["authorization"] == "Bearer faketoken"
+    assert result["text"] == "gemini-ok"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_vertex_claude_uses_streamrawpredict_verb() -> None:
+    """AC #3: streaming over Vertex-Claude uses the `:streamRawPredict` verb.
+
+    Drives the REAL `LlmClient.stream(...)` send-path (httpx `client.stream`
+    over the SSRF-safe transport) and asserts the intercepted request URL ends
+    with the STREAMING verb, distinct from the non-streaming `:rawPredict`.
+    """
+    dep = vertex_claude_preset(
+        _fake_sa(),
+        "my-proj-1234",
+        "us-central1",
+        "claude-opus-4-8",
+    )
+    _seed_gcp_token(dep, "faketoken")
+    client, http = _client(dep)
+    req = client._build_completion_request(
+        [{"role": "user", "content": "hi"}],
+        model=None,
+        temperature=None,
+        top_p=None,
+        max_tokens=32,
+        stop=None,
+        user=None,
+        stream=True,
+    )
+    _, stream_url = client._build_completion_payload_and_url(req, stream=True)
+    # Builder-level guard: the streaming route resolves to the STREAM verb.
+    assert stream_url.endswith(":streamRawPredict")
+
+    sse = 'data: {"content": [{"type": "text", "text": "hi"}]}\n\n' "data: [DONE]\n\n"
+    route = respx.post(stream_url).mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=sse
+        )
+    )
+    chunks = []
+    try:
+        async for chunk in client.stream(
+            [{"role": "user", "content": "hi"}], http_client=http, max_tokens=32
+        ):
+            chunks.append(chunk["text"])
+    finally:
+        await http.aclose()
+
+    sent = route.calls.last.request
+    sent_url = str(sent.url)
+    # The intercepted wire URL uses the STREAMING verb, not the unary verb.
+    assert sent_url.endswith(":streamRawPredict")
+    assert not sent_url.endswith(":rawPredict")
+    assert sent.headers["authorization"] == "Bearer faketoken"
+    assert chunks == ["hi"]

--- a/packages/kailash-kaizen/tests/unit/llm/test_completion_wire_respx.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_completion_wire_respx.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end wire tests for `LlmClient.complete()` / `stream()` (#1717).
+
+These exercise the FULL send-path (auth header injection → URL → body
+serialization → HTTP round-trip → status taxonomy → response parse) against a
+respx-mocked backend, so the completion facade is not shipped untested. The
+broader per-provider respx matrix is a separate test pass; this file pins the
+load-bearing behaviours that the pure-helper tests cannot reach:
+
+* auth header actually installed on the wire,
+* the platform-Anthropic body transform reaches the socket for Bedrock,
+* error status → typed error,
+* a REAL streaming send yields incremental parsed chunks.
+
+A no-op resolver subclass is injected so the SSRF DNS guard does not perform a
+real lookup against the mock host (the guard itself is covered by its own
+tests); everything else is the production path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from kaizen.llm import LlmClient
+from kaizen.llm.errors import ProviderError, RateLimited
+from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
+from kaizen.llm.presets import bedrock_claude_preset, openai_preset
+
+
+class _AllowAllResolver(SafeDnsResolver):
+    """SafeDnsResolver that skips the real DNS lookup (test-only)."""
+
+    __slots__ = ()
+
+    def check_host(self, host: str) -> None:  # noqa: D401 - test stub resolver
+        return None
+
+
+def _client(dep):
+    http = LlmHttpClient(deployment_preset=dep.wire.name, resolver=_AllowAllResolver())
+    return LlmClient.from_deployment(dep), http
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_openai_happy_path_installs_auth_and_parses() -> None:
+    route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                "model": "gpt-4o",
+            },
+        )
+    )
+    dep = openai_preset("sk-secret", "gpt-4o")
+    client, http = _client(dep)
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "ping"}], http_client=http, max_tokens=16
+        )
+    finally:
+        await http.aclose()
+    assert result["text"] == "pong"
+    assert result["stop_reason"] == "stop"
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == "Bearer sk-secret"
+    body = json.loads(sent.content)
+    assert body["model"] == "gpt-4o"
+    assert body["messages"] == [{"role": "user", "content": "ping"}]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_bedrock_claude_sends_transformed_body_on_wire() -> None:
+    dep = bedrock_claude_preset("tok", "us-east-1", "claude-sonnet-4-6")
+    # Build the exact URL respx must match from the deployment itself.
+    client, http = _client(dep)
+    req = client._build_completion_request(
+        [{"role": "user", "content": "hi"}],
+        model=None,
+        temperature=0.5,
+        top_p=None,
+        max_tokens=32,
+        stop=None,
+        user=None,
+        stream=False,
+    )
+    _, url = client._build_completion_payload_and_url(req, stream=False)
+    route = respx.post(url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 1},
+                "model": "claude-sonnet-4-6",
+            },
+        )
+    )
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "hi"}],
+            http_client=http,
+            temperature=0.5,
+            max_tokens=32,
+        )
+    finally:
+        await http.aclose()
+    assert result["text"] == "ok"
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == "Bearer tok"
+    body = json.loads(sent.content)
+    # Platform transform reached the wire: no `model`, anthropic_version present.
+    assert "model" not in body
+    assert body["anthropic_version"] == "bedrock-2023-05-31"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_maps_429_to_ratelimited() -> None:
+    respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(429, headers={"retry-after": "3"}, json={})
+    )
+    dep = openai_preset("sk-x", "gpt-4o")
+    client, http = _client(dep)
+    try:
+        with pytest.raises(RateLimited):
+            await client.complete([{"role": "user", "content": "hi"}], http_client=http)
+    finally:
+        await http.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_maps_500_to_provider_error() -> None:
+    respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(500, text="upstream boom")
+    )
+    dep = openai_preset("sk-x", "gpt-4o")
+    client, http = _client(dep)
+    try:
+        with pytest.raises(ProviderError):
+            await client.complete([{"role": "user", "content": "hi"}], http_client=http)
+    finally:
+        await http.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_openai_yields_incremental_chunks() -> None:
+    sse = (
+        'data: {"choices": [{"delta": {"content": "he"}}]}\n\n'
+        'data: {"choices": [{"delta": {"content": "llo"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=sse
+        )
+    )
+    dep = openai_preset("sk-x", "gpt-4o")
+    client, http = _client(dep)
+    chunks = []
+    try:
+        async for chunk in client.stream(
+            [{"role": "user", "content": "hi"}], http_client=http
+        ):
+            chunks.append(chunk["text"])
+    finally:
+        await http.aclose()
+    assert chunks == ["he", "llo"]

--- a/packages/kailash-kaizen/tests/unit/llm/test_from_env_vertex_config.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_from_env_vertex_config.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""from_env() Vertex selector + region-config tests (#1717).
+
+Covers the env-config completion for Vertex-on-GCP:
+
+* `KAILASH_LLM_PROVIDER=vertex_claude` / `vertex_gemini` resolves WITHOUT a
+  full URI, reading GOOGLE_CLOUD_PROJECT / VERTEX_LOCATION / model env
+  (deliverable #5).
+* The service-account key is OPTIONAL -- an unset
+  GOOGLE_APPLICATION_CREDENTIALS resolves keyless ADC (deliverable #4/#5).
+* `_GCP_REGION_RE` accepts `us` / `eu` / `global` in addition to the
+  `us-central1` shape (deliverable #7).
+* The vertex catalog resolves `claude-opus-4-8` through the selector
+  end-to-end (deliverable #6, exercised via the grammar).
+
+Env-var reads go through monkeypatch with a clean-slate strip at the top of
+each test, matching the sibling `test_from_env.py` pattern for the
+KAILASH_LLM_* surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.deployment import WireProtocol
+from kaizen.llm.errors import MissingCredential
+from kaizen.llm.from_env import (
+    ENV_DEPLOYMENT_URI,
+    ENV_SELECTOR,
+    _GCP_REGION_RE,
+    resolve_env_deployment,
+)
+
+_VERTEX_ENV = (
+    ENV_DEPLOYMENT_URI,
+    ENV_SELECTOR,
+    "GOOGLE_CLOUD_PROJECT",
+    "VERTEX_LOCATION",
+    "VERTEX_CLAUDE_MODEL_ID",
+    "VERTEX_CLAUDE_MODEL",
+    "VERTEX_GEMINI_MODEL_ID",
+    "VERTEX_GEMINI_MODEL",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch):
+    for var in _VERTEX_ENV:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Region regex broadening (#7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "region", ["us", "eu", "global", "us-central1", "europe-west4", "asia-south1"]
+)
+def test_gcp_region_regex_accepts_multi_region_and_standard(region: str) -> None:
+    assert _GCP_REGION_RE.match(region) is not None
+
+
+@pytest.mark.parametrize(
+    "region",
+    ["", "US", "us_central1", "evil.com", "us-central1\r\nX", "eu-", "globalz1x"],
+)
+def test_gcp_region_regex_rejects_bad_shapes(region: str) -> None:
+    # `globalz1x` does not equal the literal `global` and does not match the
+    # `<area>-<locality><digit>` shape either -> rejected.
+    assert _GCP_REGION_RE.match(region) is None
+
+
+def test_gcp_region_regex_eu_passes_straight_through() -> None:
+    """`eu` is accepted verbatim -- NOT mapped to `europe-west1` (#7)."""
+    m = _GCP_REGION_RE.match("eu")
+    assert m is not None and m.group(0) == "eu"
+
+
+# ---------------------------------------------------------------------------
+# Vertex selector — service-account key present (#5)
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_claude_selector_with_sa_path(_clean_env, tmp_path) -> None:
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")  # not read at construction
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL_ID", "claude-3-opus")
+    _clean_env.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(sa))
+    dep = resolve_env_deployment()
+    assert dep.wire == WireProtocol.AnthropicMessages
+    assert dep.preset_name == "vertex_claude"
+    assert dep.default_model == "claude-3-opus@20240229"
+    assert dep.auth.auth_strategy_kind() == "gcp_oauth"
+
+
+def test_vertex_gemini_selector_with_sa_path(_clean_env, tmp_path) -> None:
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")
+    _clean_env.setenv(ENV_SELECTOR, "vertex_gemini")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_GEMINI_MODEL_ID", "gemini-2.0-flash")
+    _clean_env.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(sa))
+    dep = resolve_env_deployment()
+    assert dep.wire == WireProtocol.VertexGenerateContent
+    assert dep.preset_name == "vertex_gemini"
+    assert dep.default_model == "gemini-2.0-flash"
+
+
+# ---------------------------------------------------------------------------
+# Vertex selector — keyless ADC fallback (#4/#5)
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_claude_selector_keyless_falls_back_to_adc(_clean_env) -> None:
+    """GOOGLE_APPLICATION_CREDENTIALS unset -> keyless ADC, no hard-fail."""
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL_ID", "claude-sonnet-4-6")
+    dep = resolve_env_deployment()
+    assert dep.preset_name == "vertex_claude"
+    assert dep.auth.auth_strategy_kind() == "gcp_adc"
+
+
+def test_vertex_selector_legacy_model_env_fallback(_clean_env) -> None:
+    """VERTEX_CLAUDE_MODEL (no _ID suffix) is accepted when _ID is unset."""
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL", "claude-3-haiku")
+    dep = resolve_env_deployment()
+    assert dep.default_model == "claude-3-haiku@20240307"
+
+
+# ---------------------------------------------------------------------------
+# Vertex catalog: claude-opus-4-8 resolves through the selector (#6)
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_claude_selector_resolves_claude_opus_4_8(_clean_env) -> None:
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL_ID", "claude-opus-4-8")
+    dep = resolve_env_deployment()
+    assert dep.default_model == "claude-opus-4-8@latest"
+
+
+# ---------------------------------------------------------------------------
+# Missing required config -> typed MissingCredential
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_selector_missing_project_raises(_clean_env) -> None:
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL_ID", "claude-3-opus")
+    with pytest.raises(MissingCredential, match=r"GOOGLE_CLOUD_PROJECT"):
+        resolve_env_deployment()
+
+
+def test_vertex_selector_missing_region_raises(_clean_env) -> None:
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_CLAUDE_MODEL_ID", "claude-3-opus")
+    with pytest.raises(MissingCredential, match=r"VERTEX_LOCATION"):
+        resolve_env_deployment()
+
+
+def test_vertex_selector_missing_model_raises(_clean_env) -> None:
+    _clean_env.setenv(ENV_SELECTOR, "vertex_claude")
+    _clean_env.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+    _clean_env.setenv("VERTEX_LOCATION", "us-central1")
+    with pytest.raises(MissingCredential, match=r"VERTEX_CLAUDE_MODEL"):
+        resolve_env_deployment()
+
+
+# ---------------------------------------------------------------------------
+# Vertex URI keyless ADC fallback (#4)
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_uri_keyless_falls_back_to_adc(_clean_env) -> None:
+    _clean_env.setenv(
+        ENV_DEPLOYMENT_URI, "vertex://my-gcp-project/us-central1/claude-3-opus"
+    )
+    dep = resolve_env_deployment()
+    assert dep.preset_name == "vertex_claude"
+    assert dep.auth.auth_strategy_kind() == "gcp_adc"

--- a/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
@@ -130,6 +130,12 @@ def test_unmanaged_client_holds_no_transport_and_warns_nothing_at_gc() -> None:
     client = LlmClient.from_deployment(_deployment())
     assert client._http_client is None
 
+    # Drain finalizers for any unrelated garbage from prior tests BEFORE the
+    # recording window, so this assertion is scoped to THIS client only. Without
+    # the pre-drain, a sibling test that leaked a managed client would finalize
+    # inside our catch_warnings and be mis-attributed here (GC-order flake).
+    gc.collect()
+
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         del client

--- a/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_llmclient_lifecycle.py
@@ -146,3 +146,36 @@ def test_unmanaged_client_holds_no_transport_and_warns_nothing_at_gc() -> None:
         "unmanaged LlmClient emitted a ResourceWarning at GC; the additive "
         f"lifecycle must not warn for one-shot callers: {[str(w.message) for w in resource_warnings]}"
     )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_complete_closes_owned_client_on_non_httpx_send_error(
+    monkeypatch,
+) -> None:
+    """F1: a NON-httpx send-phase failure (SSRF InvalidEndpoint, or a GcpOauth
+    token-refresh error from _prepare_auth_headers) happens before `resp` exists
+    and escapes the httpx-only excepts. The owned (unmanaged) client MUST still
+    be closed — no leaked transport, no ResourceWarning at GC.
+    """
+    client = LlmClient.from_deployment(_deployment())
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated non-httpx auth-refresh failure")
+
+    # Forces the failure AFTER the owned LlmHttpClient (with a live transport) is
+    # created inside complete(), but before the response phase.
+    monkeypatch.setattr(client, "_prepare_auth_headers", _boom)
+
+    gc.collect()  # drain unrelated finalizers before the recording window
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(RuntimeError, match="simulated non-httpx"):
+            await client.complete([{"role": "user", "content": "hi"}])
+        gc.collect()
+
+    resource_warnings = [w for w in caught if issubclass(w.category, ResourceWarning)]
+    assert resource_warnings == [], (
+        "complete() leaked the owned HTTP client on a non-httpx send-phase error "
+        f"(F1): {[str(w.message) for w in resource_warnings]}"
+    )

--- a/workspaces/issue-1717-vertex-claude/journal/0001-ANALYZE-and-PLAN.md
+++ b/workspaces/issue-1717-vertex-claude/journal/0001-ANALYZE-and-PLAN.md
@@ -1,0 +1,71 @@
+# #1717 — Vertex-Claude four-axis completion send path + WIF; legacy/four-axis redundancy
+
+## Analysis (4-agent parallel deep-dive, 2026-07-13)
+
+**Reframed finding — the redundancy is inverse to the issue's framing:**
+- LEGACY `providers/llm/` is the PRIMARY and ONLY production LLM completion path.
+  `BaseAgent → AgentLoop → LLMAgentNode → get_provider().chat()` (`llm_agent.py:2189`,
+  `base_agent.py:333`). Supports tools/function-calling + structured output.
+- NEW four-axis `LlmClient` layer is ORPHANED — zero production construction sites,
+  `complete()` deliberately unexposed, only `embed()` wire-sends. `CompletionRequest`
+  has NO tools / NO structured-output fields.
+- ⇒ Four-axis CANNOT replace legacy today without regressing agent tool-calling.
+  Closing #1717's gaps is a PREREQUISITE to any consolidation, and is valuable
+  regardless of the consolidation decision. So we close all gaps now, compute the
+  exact parity delta in parallel, and surface the consolidation as a sequenced program.
+
+## Confirmed gaps (all CONFIRMED at file:line by analysis agents)
+- No `complete()`/`stream()` in four-axis layer (`client.py:28-34`). Only `embed()`.
+- Anthropic body carries `model`, no `anthropic_version` (`anthropic_messages.py:81-85`).
+- `:rawPredict`/`:streamRawPredict` verb only in comments (`presets.py:1289..1438`).
+- Bedrock-Claude reuses AnthropicMessages + empty path_prefix (`presets.py:1013-1024`);
+  needs `/model/{id}/invoke` + `anthropic_version: bedrock-2023-05-31`.
+- GCP auth SA-key-only; `google.auth.default` a presence sentinel; 0 WIF refs
+  (`auth/gcp.py:250-276,46,176`). Sync `apply()` cold-raises (`gcp.py:401-408`).
+- Region regex rejects `us`/`eu`/`global` (`presets.py:1312`, `from_env.py:70`).
+- `_VERTEX_CLAUDE_MAPPING` tops at `claude-opus-4-5`; bare `claude-opus-4-8` raises
+  (`grammar/vertex.py:89-101,139`). Gemini already passes `gemini-*` through.
+- `from_env` doesn't read `GOOGLE_CLOUD_PROJECT`/`VERTEX_LOCATION`; no vertex selector
+  branch (`from_env.py:254-293`).
+- No alias layer: `vertex-anthropic` unresolved, `vertex_claude` exact-key only.
+- Parity tests assert preset NAMES only, never on-wire bytes (`test_preset_names_match_rust.py`).
+- NEW-A: no per-model temperature constraint → HTTP 400 on `claude-opus-4-8`.
+- NEW-B: `eu`/`us`/`global` must pass through as valid Vertex locations.
+- NEW-C: both `vertex-anthropic` AND `vertex_claude` must resolve to the same preset.
+
+## Test infra
+- Mock lib: `respx` (dev dep, httpx-native). HTTP client = httpx via `LlmHttpClient`.
+- Runner: `cd packages/kailash-kaizen && python -m pytest ...`. `asyncio_mode=auto`.
+- Wire-behavior tests (URL+body+headers) are the uncovered surface to add.
+
+## Execution plan — 2 disjoint-file parallel streams + tests + gate
+
+**Stream 1 — Core completion path** (files: `deployment.py`, `presets.py`, `client.py`,
+`http_client.py`, `wire_protocols/anthropic_messages.py`, `wire_protocols/google_generate_content.py`,
+new `wire_protocols/*` if needed). Owns the full completion contract: `complete()`/`stream()`,
+`_COMPLETE_DISPATCH`, per-wire URL (`:rawPredict`/`:streamRawPredict`, bedrock `/invoke`),
+post-shaper Anthropic body transform (strip `model` + inject `anthropic_version`, GATED so
+direct paths stay byte-identical), NEW-A temperature constraint, streaming transport,
+region `us`/`eu`/`global` (NEW-B), preset aliases (NEW-C). Keep preset factory public
+signatures backward-compatible (Stream 2 calls them).
+
+**Stream 2 — Auth + env config + catalog** (files: `auth/gcp.py`, `from_env.py`,
+`grammar/vertex.py`). WIF `external_account` (STS + impersonation), metadata-server ADC,
+`google.auth.default()` ADC, creds JSON-`type` dispatch; `GOOGLE_CLOUD_PROJECT`/`VERTEX_LOCATION`
++ vertex selector branch; `claude-opus-4-8` catalog (adopt `startswith("claude-")` passthrough
+like Gemini). DISJOINT from Stream 1's files.
+
+**Stream 3 — Tests** (after 1+2 merge): respx wire tests (Vertex-Claude `:rawPredict` URL +
+`anthropic_version` body + no `model` + Bearer; Vertex-Gemini; Bedrock), cross_sdk_parity
+wire extension, streaming, auth-mode tests.
+
+**Gate:** parallel reviewer + security-reviewer → /redteam to convergence (evidence-gated).
+
+## Consolidation decision (surfaced, evidence-backed after parity-delta agent)
+Removing legacy requires four-axis to reach feature parity (tools, structured output, full
+provider coverage) THEN migrating `LLMAgentNode`+`_simple_execute_async` — a multi-session,
+high-risk hot-path program. Not a naive deletion this session (would regress agents).
+Recommendation + exact delta to be presented to the co-owner.
+
+Invariant count per stream: S1 ~6 (dispatch, URL-per-wire, body-gate, stream, temp, alias);
+S2 ~4 (WIF, metadata-ADC, default-ADC, config-env). Both within budget.

--- a/workspaces/issue-1717-vertex-claude/journal/0002-parity-delta-legacy-vs-four-axis.md
+++ b/workspaces/issue-1717-vertex-claude/journal/0002-parity-delta-legacy-vs-four-axis.md
@@ -1,0 +1,51 @@
+# Legacy vs four-axis parity delta (consolidation decision input)
+
+Source: parity-delta analyst, 2026-07-13. READ-ONLY. **Tooling caveat:** ripgrep
+absent in that agent's env → Part 4 (test surface) + full consumer enumeration are
+DIRECTIONAL; re-grep before committing the consolidation program plan:
+`grep -rn 'get_provider\|from kaizen.providers' src/`,
+`grep -rln 'providers.llm\|get_provider\|MockProvider' tests/`.
+
+## Headline
+Four-axis is a CONFIG superset (24+ presets) but a RUNTIME near-empty-set: `LlmClient`
+implements ONE send (`embed()`) for 2 of 11 wires. NO completion send path today.
+`CompletionRequest` has NO tools / structured / multimodal / reasoning / seed / logit_bias /
+BYOK-per-request. Legacy is the SOLE production completion path.
+
+## Four-axis GAPS vs legacy (block legacy deletion)
+- tools/function-calling, structured output, streaming SEND, multimodal, reasoning-param
+  filter, seed/penalties, per-request BYOK, sync+async send — ALL absent.
+- Protocols (ToolCallingProvider/StructuredOutputProvider/StreamingProvider,
+  `providers/base.py:132-179`) exist but UNWIRED.
+- NO chat shaper for OpenAiChat (most-used), Bedrock, Vertex, Azure (this session's
+  Stream 1 adds OpenAI chat + Vertex/Bedrock handling).
+- NO `mock` preset — offline tests depend on it; blocks deletion.
+- cohere/huggingface/azure EMBEDDINGS not in embed dispatch.
+
+## Consumers to migrate (5 confirmed; ~8-15 total est)
+1. `llm_agent.py:2189-2213` `_provider_llm_response` → get_provider().chat(...,tools). CRITICAL hot path, tool-loop 888-939.
+2. `base_agent.py:333-379` `_simple_execute_async` → OpenAIProvider().chat_async, multimodal. HIGH.
+3. `embedding_generator.py:661-664` → get_provider(p,"embeddings"). MEDIUM.
+4. `registry.py:206` get_streaming_provider. HIGH.
+5. `registry.py:165` get_provider_for_model.
+
+## VERIFIED counts (orchestrator re-grep, closes the ripgrep caveat)
+- Legacy-consumer src files (10): `config/__init__.py`, `config/providers.py`,
+  `core/agents.py`, `core/base_agent.py`, `nodes/ai/__init__.py`,
+  `nodes/ai/embedding_generator.py`, `nodes/ai/llm_agent.py`, `providers/__init__.py`,
+  `providers/document/provider_manager.py`, `providers/registry.py` (53 total refs).
+- Legacy-touching test files: 34. Confirms migration surface for the program plan.
+
+## Verdict — consolidation is a 6-10 session program
+(a) four-axis→parity ~4-6 sessions; (b) migrate consumers ~1-2; (c) delete legacy+tests ~1-2.
+Highest risk: streaming-with-tools delta accumulation; `_provider_llm_response` tool-loop +
+structured post-parse parity; mock-preset absence; RELEASE GATE — no four-axis quick-start
+regression exists (unit-green ≠ release-green).
+
+## Decision for THIS session
+Close ALL #1717 four-axis gaps now (prerequisite to any consolidation, valuable standalone).
+Do NOT delete legacy — naive deletion regresses agent tool-calling/structured-output.
+Recommend the ADDITIVE path: build complete() parity → dual-run behind `_provider_llm_response`
+→ migrate consumers one at a time → delete legacy LAST, gated on a four-axis quick-start
+regression being pipeline-green. Surface this sequenced program to the co-owner as the
+redundancy resolution (a structural, multi-session decision — their call to authorize scope).

--- a/workspaces/issue-1717-vertex-claude/journal/0003-redteam-convergence.md
+++ b/workspaces/issue-1717-vertex-claude/journal/0003-redteam-convergence.md
@@ -1,0 +1,41 @@
+# #1717 — redteam convergence receipt
+
+Commits: 4eeb7e7b5 (feat), 7133d4e7a (gate remediation), e1d30f7ec (redteam remediation).
+Branch: feat/1717-vertex-claude-four-axis-completion.
+
+## Gate review (over 4eeb7e7b5)
+
+- **reviewer** (gate-reviewer): CLEAN — no Critical/Important. Verified gated body
+  transform byte-identical for direct paths, redact-before-shape, real SSRF-safe
+  streaming, temperature handling, error-taxonomy parity. 3 <20-LOC minors → all
+  folded (stream() HTTPError catch parity; temperature-determinism docstring;
+  lifecycle GC pre-drain).
+- **security-reviewer** (gate-security): 1 MEDIUM — caller `model` interpolated raw
+  into URL path (Google/Bedrock/HF {model} templates). Fixed: `_validate_completion_model`
+  fail-closed in `_build_completion_request` (covers complete()+stream()). Behavioral
+  regression test. All other surfaces CLEAN (GCP cred hygiene, no-secrets-in-logs,
+  streaming SSRF, redaction).
+
+## Holistic /redteam (3 parallel, over 4eeb7e7b5 + 7133d4e7a)
+
+- **rt-closure** (general-purpose, Bash+Read): every AC (1–8) + NEW-A/B/C VERIFIED —
+  each backed by delivered code AND a passing test; NEW-B/C confirmed by live probe.
+  141 targeted tests pass, collection exit 0.
+- **rt-security** (security-reviewer): fix CLOSES THE CLASS; 1 LOW — regex `$` allows
+  a single trailing newline. Fixed `$`→`\Z` + trailing-\n/\r/\t reject cases + e2e
+  reject through a {model}-template (Bedrock) wire.
+- **rt-correct** (reviewer): cross-shard CLEAN; 1 LOW/MED (F1) — complete() leaked the
+  owned client on a non-httpx send-phase error (SSRF InvalidEndpoint / auth-refresh).
+  Fixed: catch-all send-phase clause closes owned client + re-raises (symmetry with
+  stream()). Regression test PROVEN to fail without the fix. Confirmed the 3
+  cross_sdk_parity failures are pre-existing on main (ran main in throwaway worktree:
+  list_presets()=42 vs fixture 24).
+
+## Convergence
+
+All findings remediated with regression tests. Suite: 1205 passed / 11 skipped,
+stable across runs. Remaining 3 failures = pre-existing cross_sdk_parity drift
+(registry 42 vs Rust fixture 24 + deepseek legacy-key order) — NOT introduced this
+session (verified red on base 6c8bd36d9 and on main), different bug class, NOT
+CI-gated (kaizen has no job in unified-ci.yml). Surfaced to co-owner (§ disposition
+in 0002 + issue comment): needs Rust ground truth / cross-repo grant to reconcile.


### PR DESCRIPTION
## What this delivers

Users can now send **Vertex-Claude** (and Vertex-Gemini, Bedrock-Claude) chat completions through the four-axis `LlmClient` deployment abstraction — previously only `embed()` reached the wire, and there was no Vertex-Claude send path at all. Every implementation gap in issue #1717 is closed, plus the three SDK-agnostic correctness facts (NEW-A/B/C).

### Acceptance criteria — all met
- ✅ Vertex-Claude completion on the wire: URL `…:rawPredict`, body `anthropic_version: vertex-2023-10-16` + no `model`, `Authorization: Bearer …`
- ✅ Vertex-Gemini routes through four-axis (publisher path + Bearer)
- ✅ Streaming hits `:streamRawPredict` / `:streamGenerateContent`
- ✅ GCP Workload Identity Federation (`external_account` + impersonation), metadata-server ADC, and `google.auth.default()` ADC all mint a working Bearer
- ✅ `GOOGLE_CLOUD_PROJECT` / `VERTEX_LOCATION` honored; `eu`/`us`/`global` validate; bare `claude-opus-4-8` resolves
- ✅ Bedrock-Claude gets the same body transform (`bedrock-2023-05-31`, no `model`)
- ✅ Cross-SDK parity tests assert Vertex **wire** behavior, not just preset names
- ✅ Direct-provider paths remain **byte-identical** (transforms gated on wire mode)
- ✅ NEW-A per-model temperature floor (`claude-opus-4-8` no hard-400 on `temperature=0`); NEW-B `eu` passthrough (not mapped to `europe-west1`); NEW-C `vertex-anthropic` + `vertex_claude` both resolve

### Security & correctness (redteam-hardened)
Gate review + a holistic 3-reviewer `/redteam` surfaced and fixed: a caller-`model` URL-path-injection (fail-closed validator), a regex trailing-newline edge (`$`→`\Z`), and an owned-client transport leak on non-httpx send errors. All fixed with regression tests (the leak test is proven to fail without the fix).

### User-flow walk receipt (scrubbed)
```
$ pytest tests/unit/llm/test_completion_wire_respx.py::test_complete_vertex_claude_wire_rawpredict_bearer_stripped_body -q
  # drives LlmClient.complete() over a respx-mocked backend:
  assert sent_url.endswith(":rawPredict")                                  # PASS
  assert "/publishers/anthropic/models/claude-opus-4-8" in sent_url        # PASS
  assert body["anthropic_version"] == "vertex-2023-10-16"                  # PASS
  assert "model" not in body                                              # PASS
  assert sent.headers["authorization"] == "Bearer <redacted>"             # PASS
→ 1 passed. Full suite: 1205 passed / 11 skipped.
```

## Notes
- **3 pre-existing `cross_sdk_parity` failures** (Python preset registry 42 vs Rust fixture 24 + a `deepseek` legacy-key entry) are **not introduced here** — verified red on this branch's base and on `main`, from prior merged PRs, and a different bug class (cross-SDK catalog drift). Not CI-gated (kaizen has no job in `unified-ci.yml`). Reconciling them needs Rust ground truth; surfaced separately for a co-owner decision.
- **Legacy/four-axis redundancy:** analysis (in-PR journal) shows the legacy `providers/llm/` layer is still the sole production completion path (tools + structured output); retiring it is a multi-session program gated on four-axis reaching feature parity. Presented separately — this PR is the prerequisite, not the migration.

## Related issues
Closes #1717
Cross-SDK sibling: the Rust SDK's kaizen (`anthropic_version`/WIF/temperature facts apply cross-SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)