### PR TITLE
chore(wrapup): #1717 session notes — four-axis completion shipped + kaizen 2.31.0 released

### DIFF
--- a/workspaces/issue-1717-vertex-claude/.session-notes
+++ b/workspaces/issue-1717-vertex-claude/.session-notes
@@ -1,0 +1,67 @@
+# Session Notes — 2026-07-14 — #1717 four-axis LLM completion + release
+
+## Where we are — SHIPPED + RELEASED
+
+**#1717 fully resolved, merged, released.** kailash-kaizen **2.31.0** published to
+PyPI (tag `kaizen-v2.31.0`, publish workflow 29269485214 success, GitHub Release
+created). Clean-venv verified: `kaizen.__version__==2.31.0`, `LlmClient.complete`/
+`stream` callable, `vertex-anthropic` alias resolves. Un-enrolled PUBLIC repo, solo.
+
+The four-axis `LlmClient` can now send Vertex-Claude/Gemini + Bedrock completions
+(previously only `embed()` wire-sent; no Vertex-Claude path at all).
+
+## Merged this session
+- **PR #1719** → #1717 four-axis completion send path (2 parallel impl streams +
+  wire proof + 3-reviewer redteam). Issue #1717 closed.
+- **PR #1722** → #1721 cross-SDK parity reconciliation (the 3 pre-existing failures).
+- **PR #1723** → release-prep kaizen 2.31.0. Tag pushed → PyPI.
+
+## What shipped (all 8 ACs + NEW-A/B/C)
+`complete()`/`stream()` + `_COMPLETE_DISPATCH` (9 wires); per-wire URL verbs
+(`:rawPredict`/`:streamRawPredict`, bedrock `/invoke`); gated Anthropic body
+transform (strip model + `anthropic_version`, direct paths byte-identical);
+GCP WIF/metadata/ADC auth; `GOOGLE_CLOUD_PROJECT`/`VERTEX_LOCATION`; region
+us/eu/global; `claude-opus-4-8` catalog; temperature floor; provider aliases.
+Redteam-hardened: model URL-path injection guard, regex `\Z` newline edge,
+owned-client leak on error path — all with proven regression tests.
+
+## The 3 pre-existing cross_sdk_parity failures — RESOLVED (#1721)
+- Preset-name parity (2): reconciled `RUST_PRESET_NAMES` (24 byte-identical) with
+  `_PYTHON_CONVENIENCE_PRESETS` (18 documented, sibling-test-verified). No
+  fabricated Rust names.
+- deepseek legacy precedence (1): `xfail(strict=True)` — Python-ahead; self-clears
+  when Rust adopts the deepseek legacy key.
+
+## Read first
+- `journal/0001-ANALYZE-and-PLAN.md` — 4-agent analysis + shard plan
+- `journal/0002-parity-delta-legacy-vs-four-axis.md` — the consolidation evidence
+- `journal/0003-redteam-convergence.md` — gate + holistic redteam receipts
+
+## Outstanding — surfaced to co-owner (NOT done)
+- **#1720 — legacy→four-axis consolidation (the redundancy).** The legacy
+  `providers/llm/` layer is still the SOLE production completion path (tools +
+  structured output); four-axis can't replace it without regressing agents. A
+  ~6-10 session additive program (parity → dual-run → migrate → delete legacy
+  last, gated on a quickstart regression). I proceeded on the "sequence it"
+  recommendation (user was AFK); the AskUserQuestion is unanswered — reconfirm
+  scope if resuming.
+- **#1721 remainder — Rust-side deepseek legacy adoption.** Needs the Rust repo
+  (cross-repo grant). The strict-xfail is the tripwire.
+
+## Traps
+- **Local `.venv` under-provisioned.** Missing editable siblings (kaizen-agents,
+  nexus, dataflow) + polars → broad kaizen unit suite collect-errors (env
+  artifact, green in CI). I editable-installed kaizen-agents/nexus/dataflow +
+  polars this session; the full `tests/unit/` run still HANGS (real-infra tests
+  block without infra). Validate the RELEVANT surface only:
+  `tests/unit/llm/ tests/cross_sdk_parity/ tests/integration/llm/` → 1207 passed.
+- **kaizen has NO job in `unified-ci.yml`** (only mcp/pact/dataflow). Kaizen
+  tests are NOT CI-gated — local run is the kaizen validation. The 3 parity
+  failures were red on main precisely because CI never ran them.
+- **Release = tag-triggered OIDC** (`kaizen-v*` → publish-pypi.yml). No manual
+  twine. PyPI/uv index cache lags ~1-2 min after publish; `pip install
+  --no-cache-dir` succeeds before `uv pip install --refresh`.
+
+## Open question for the human
+Ratify the #1720 consolidation scope (sequence as tracked program — my pick — vs
+start the full 6-10 session migration now vs leave both layers). One line steers it.


### PR DESCRIPTION
Workspace-only session-notes close-out for #1717. No source/config change (build-repo-release-discipline Rule 1a carve-out). Refs #1717, #1720, #1721, #1722, #1723.