### PR TITLE
ci: wire kaizen into CI (LLM + cross-SDK parity gate) + correct #1721 xfail reason

### DIFF
--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -1,0 +1,127 @@
+name: Test kailash-kaizen
+
+# Wires kailash-kaizen into CI. Previously kaizen had NO CI job (unified-ci.yml
+# runs only core + mcp + pact + dataflow), so kaizen tests — including the
+# cross_sdk_parity gate — were never exercised on PRs. This job closes that gap.
+#
+# SCOPE (initial): the LLM deployment layer (tests/unit/llm) + the cross-SDK
+# parity gate (tests/cross_sdk_parity) — the fast, deterministic, no-infra
+# surface that was previously un-gated (and where the #1721 parity drift hid
+# red on main). Infra/credential-gated tiers (integration, e2e, requires_*) and
+# the slow example-script suite are excluded here and tracked for a follow-up
+# expansion. A per-test --timeout makes any hang fail loudly instead of hanging
+# the job.
+#
+# COST: single Python (3.12), triggered only on kaizen path changes — mirrors
+# the test-pact single-version precedent. ~3-5 min/run.
+
+on:
+  push:
+    branches: [feat/*, feature/*, fix/*, docs/*, session/*, session-*, chore/*]
+    paths:
+      - "packages/kailash-kaizen/**"
+      - ".github/workflows/test-kailash-kaizen.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/kailash-kaizen/**"
+      - ".github/workflows/test-kailash-kaizen.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  version-check:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Check version consistency (pyproject.toml == __init__.py)
+        run: |
+          PYPROJECT_VER=$(python -c "
+          import tomllib
+          with open('packages/kailash-kaizen/pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          INIT_VER=$(python -c "
+          import ast, pathlib
+          src = pathlib.Path('packages/kailash-kaizen/src/kaizen/__init__.py').read_text()
+          for node in ast.walk(ast.parse(src)):
+              if isinstance(node, ast.Assign):
+                  for t in node.targets:
+                      if getattr(t, 'id', '') == '__version__':
+                          print(ast.literal_eval(node.value))
+          ")
+          echo "pyproject.toml: $PYPROJECT_VER"
+          echo "__init__.py:    $INIT_VER"
+          if [ "$PYPROJECT_VER" != "$INIT_VER" ]; then
+            echo "::error::Version mismatch: pyproject.toml=$PYPROJECT_VER vs __init__.py=$INIT_VER"
+            exit 1
+          fi
+
+  test-kaizen:
+    name: Test kailash-kaizen (LLM + cross-SDK parity)
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 — their
+    # diff is metadata-only; version-check above still runs on the release cut.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    needs: version-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Restore uv cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-kaizen-py3.12-${{ hashFiles('packages/kailash-kaizen/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-kaizen-py3.12-
+
+      - name: Install kailash-kaizen[dev] + sibling packages
+        run: |
+          uv venv .venv
+          # Root kailash editable — kaizen imports the current core surface.
+          uv pip install -e "." --python .venv/bin/python
+          # Sibling packages kaizen's import graph pulls in at collection time.
+          uv pip install -e "packages/kailash-nexus" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kaizen-agents" --python .venv/bin/python
+          uv pip install -e "packages/kailash-kaizen[dev]" --python .venv/bin/python
+          uv pip install polars --python .venv/bin/python
+
+      - name: Lint (ruff — syntax/undefined only)
+        run: |
+          .venv/bin/ruff check \
+            packages/kailash-kaizen/src/kaizen/llm/ \
+            packages/kailash-kaizen/tests/cross_sdk_parity/ \
+            --select=E9,F63,F7,F82
+
+      - name: Test (LLM unit + cross-SDK parity, infra-free)
+        timeout-minutes: 10
+        working-directory: packages/kailash-kaizen
+        run: |
+          ../../.venv/bin/python -m pytest \
+            tests/unit/llm/ \
+            tests/cross_sdk_parity/ \
+            -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark)' \
+            --timeout=60 --maxfail=15 -q

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -106,7 +106,10 @@ jobs:
           uv pip install -e "packages/kailash-nexus" --python .venv/bin/python
           uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
           uv pip install -e "packages/kaizen-agents" --python .venv/bin/python
-          uv pip install -e "packages/kailash-kaizen[dev]" --python .venv/bin/python
+          # LLM-provider extras the wire/auth tests exercise: bedrock (botocore
+          # SigV4), vertex (google-auth OAuth/WIF), providers-azure (Entra),
+          # providers-google (google-genai), providers-tokens (tiktoken).
+          uv pip install -e "packages/kailash-kaizen[dev,bedrock,vertex,providers-azure,providers-google,providers-tokens]" --python .venv/bin/python
           uv pip install polars --python .venv/bin/python
 
       - name: Lint (ruff — syntax/undefined only)

--- a/packages/kailash-kaizen/tests/cross_sdk_parity/test_from_env_precedence_matches_rust.py
+++ b/packages/kailash-kaizen/tests/cross_sdk_parity/test_from_env_precedence_matches_rust.py
@@ -102,17 +102,20 @@ def test_supported_schemes_match_rust(rust_fixture: dict) -> None:
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Python-ahead cross-SDK divergence (tracked #1721). #1609 added "
-        "DEEPSEEK_API_KEY as a 5th legacy auto-detect key (placed last, so it "
-        "never displaces an existing provider); a bare DEEPSEEK_API_KEY then "
-        "resolves to the deepseek preset. The Rust from_env precedence fixture "
-        "still pins the big-4 (OpenAI>Azure>Anthropic>Google). deepseek is "
-        "already a byte-identical cross-SDK preset AND a parity-verified "
-        "`deepseek_from_env` convenience preset, so the legacy auto-detect is a "
-        "natural parity extension Rust should ADOPT — not a Python feature to "
-        "revert, and the fixture must not claim deepseek until Rust ships it. "
-        "strict=True self-clears (XPASS) the moment the Rust fixture is "
-        "regenerated with the deepseek legacy key, forcing this marker's removal."
+        "Genuine Python<->Rust from_env legacy-precedence divergence + stale "
+        "fixture (tracked #1721). Verified against the Rust source under an "
+        "authorized read (journal/0004+0005): the Rust legacy tier "
+        "(kailash-rs client.rs:481-590) is OPENAI, ANTHROPIC, GOOGLE, MISTRAL, "
+        "COHERE, OLLAMA, HUGGINGFACE, PERPLEXITY, DEEPSEEK, DOCKER — 10 keys, NO "
+        "Azure. Python LEGACY_KEY_ORDER is OPENAI, AZURE_OPENAI, ANTHROPIC, "
+        "GOOGLE, DEEPSEEK — 5 keys, WITH Azure. So DEEPSEEK is cross-SDK-ALIGNED "
+        "(Rust has it at client.rs:580), NOT Python-ahead; the real blocker is a "
+        "genuine divergence (Python has Azure + only 5 keys; Rust has the 6 extra "
+        "providers, no Azure) AND a checked-in fixture (4 keys) that matches "
+        "NEITHER SDK. Reconciling which legacy set/order is canonical is a "
+        "cross-SDK DESIGN decision + a write (co-owner call). strict=True "
+        "self-clears (XPASS) once LEGACY_KEY_ORDER and the fixture are reconciled "
+        "to a single canonical order, forcing this marker's removal."
     ),
 )
 def test_legacy_key_order_matches_rust(rust_fixture: dict) -> None:

--- a/workspaces/issue-1717-vertex-claude/journal/0004-cross-repo-grant-1721-rust-read.md
+++ b/workspaces/issue-1717-vertex-claude/journal/0004-cross-repo-grant-1721-rust-read.md
@@ -1,0 +1,44 @@
+---
+type: DECISION
+date: 2026-07-14
+author: human
+project: issue-1717-vertex-claude
+topic: user-authorized cross-repo READ of the Rust SDK for #1721 deepseek legacy-precedence parity
+phase: redteam
+verified_id: (solo, un-enrolled public repo)
+person_id: (solo)
+display_id: (solo)
+tags: [cross-repo, grant, "1721", cross-sdk, read-only]
+relates_to: 0002-parity-delta-legacy-vs-four-axis
+---
+
+# Cross-repo READ grant — Rust SDK, #1721 deepseek legacy precedence
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+## Grant (repo-scope-discipline § User-Authorized Exception — all five conditions)
+
+- **Requester (user-initiated):** the co-owner, verbatim: _"approved read on 1721"_
+  (in direct reply to my surfacing that #1721's remaining item — whether the Rust
+  SDK's kaizen from_env legacy precedence includes `DEEPSEEK_API_KEY` — needs a
+  cross-repo read).
+- **Target repo:** the Rust SDK — resolver key `build.rs`; real path
+  `esperie-enterprise/kailash-rs` (private) per the operator memory
+  `reference_kailash_rs_repo_location`.
+- **Exact bounded action:** READ-ONLY inspection of the Rust kaizen `from_env`
+  legacy per-provider-key precedence order (the `crates/kailash-kaizen/src/llm/`
+  from_env / deployment source) to determine whether `DEEPSEEK_API_KEY` is present
+  in the legacy auto-detect tier. NO write, NO issue filing, NO other file reads.
+- **Confirmed:** the user's explicit "approved read on 1721" is the confirmation;
+  scope restated here before acting.
+- **Journaled before acting:** this entry lands BEFORE any command runs against
+  the Rust repo (the receipt that distinguishes an authorized read from an
+  unauthorized one).
+- **Scoped exactly:** only the deepseek-legacy-precedence question for #1721.
+
+## Disposition after read
+- If Rust legacy precedence INCLUDES deepseek → regenerate
+  `rust_from_env_precedence.json` with the deepseek key + remove the strict-xfail
+  (the divergence is resolved; both SDKs match).
+- If Rust legacy precedence EXCLUDES deepseek → the strict-xfail is correct as-is
+  (Python-ahead, pending Rust adoption); #1721 stays open on the Rust side.

--- a/workspaces/issue-1717-vertex-claude/journal/0005-DISCOVERY-1721-rust-legacy-precedence-read.md
+++ b/workspaces/issue-1717-vertex-claude/journal/0005-DISCOVERY-1721-rust-legacy-precedence-read.md
@@ -1,0 +1,54 @@
+---
+type: DISCOVERY
+date: 2026-07-14
+author: agent
+project: issue-1717-vertex-claude
+topic: "#1721 read receipt — Rust kaizen from_env legacy precedence (deepseek + broader divergence)"
+phase: redteam
+tags: [cross-sdk, "1721", read-receipt, from-env, parity]
+relates_to: 0004-cross-repo-grant-1721-rust-read
+---
+
+# Read receipt — Rust legacy from_env precedence (grant 0004)
+
+Cross-repo READ executed under the journaled grant (0004, `cross-repo-authorized:
+esperie-enterprise/kailash-rs`). Read-only, scoped to the from_env legacy-precedence
+question. Evidence quoted from the local Rust clone
+`/Users/esperie/repos/kailash/build/kailash-rs`.
+
+## Finding 1 — Rust HAS deepseek in its legacy tier (my xfail reason was WRONG)
+`crates/kailash-kaizen/src/llm/client.rs:580`:
+`if let Ok(key) = std::env::var("DEEPSEEK_API_KEY") { ... keys.insert(LlmProvider::DeepSeek, key); }`
+So Python's `DEEPSEEK_API_KEY` legacy entry is cross-SDK-ALIGNED, not "Python-ahead."
+The strict-xfail's original reason ("Rust should adopt") is incorrect and must be fixed.
+
+## Finding 2 — genuine, broader Python↔Rust legacy divergence
+Actual Rust legacy if-let order (client.rs:481–590):
+`OPENAI, ANTHROPIC, GOOGLE(/GEMINI), MISTRAL, COHERE, OLLAMA, HUGGINGFACE,
+PERPLEXITY, DEEPSEEK, DOCKER_MODEL_RUNNER` — **10 keys, NO Azure**
+(`AZURE_OPENAI_API_KEY` appears in Rust ONLY at client.rs:4967/5137 = test code).
+
+Python `from_env.py::LEGACY_KEY_ORDER`:
+`OPENAI, AZURE_OPENAI, ANTHROPIC, GOOGLE, DEEPSEEK` — **5 keys, WITH Azure**.
+
+They genuinely diverge:
+- Python HAS `AZURE_OPENAI_API_KEY` in legacy auto-detect; Rust does NOT.
+- Rust HAS MISTRAL/COHERE/OLLAMA/HUGGINGFACE/PERPLEXITY/DOCKER in legacy; Python does NOT.
+- Both share OPENAI, ANTHROPIC, GOOGLE, DEEPSEEK.
+
+## Finding 3 — the checked-in fixture is stale, matches NEITHER SDK
+`tests/cross_sdk_parity/fixtures/rust_from_env_precedence.json::precedence_order[2].key_order`
+= `[OPENAI, AZURE_OPENAI, ANTHROPIC, GOOGLE]` (4 keys). This matches neither the actual
+Rust source (10 keys, no Azure) nor Python (5 keys). It is stale/incorrect.
+
+## Disposition
+- The deepseek-specific question is RESOLVED: Rust has it; Python is aligned.
+- The test cannot be cleanly un-xfailed: a genuine Python↔Rust legacy-precedence
+  divergence (Azure + 6 providers + order) remains, and the fixture is stale.
+- Reconciliation (which legacy set/order is canonical? does Python keep Azure? does
+  it adopt the 6 Rust providers? does the fixture regenerate to real Rust?) is a
+  cross-SDK DESIGN decision + a WRITE — beyond this read-only grant.
+- Action taken IN-REPO (safe, no semantic change): correct the strict-xfail reason
+  to the accurate finding; surface the reconciliation to the co-owner on #1721.
+- NOT taken (needs co-owner + write authorization): editing the fixture or
+  `LEGACY_KEY_ORDER` to force a match — that decides cross-SDK semantics.


### PR DESCRIPTION
## Wire kaizen into CI

kaizen previously had **no CI job** — `unified-ci.yml` runs only core + mcp + pact + dataflow. So kaizen tests (including the `cross_sdk_parity` gate) were never exercised on PRs, which is exactly why the #1721 parity drift sat red on `main` undetected.

New `test-kailash-kaizen.yml` (mirrors the `test-kailash-ml.yml` per-package pattern):
- **Scope (initial):** the fast, deterministic, infra-free surface — `tests/unit/llm/` + `tests/cross_sdk_parity/`. This is the area that was un-gated and where the regressions hid. Verified green locally: **1185 passed / 8 deselected / 1 xfailed in ~2s**.
- Per-test `--timeout=60` so a hang fails loudly instead of hanging the job.
- `version-check` job (pyproject.toml == `__init__.py`).
- Release-prep `release/*` skip per ci-runners Rule 8.

**Cost:** single Python 3.12, triggered only on `packages/kailash-kaizen/**` changes — ~3-5 min/run, comparable to the existing `test-pact` job. Infra/e2e/`requires_*` and the slow example-script tier are **excluded** here (they need creds/infra and the example suite is slow); expanding to the full unit suite after triaging those tiers is a tracked follow-up.

## Correct the #1721 xfail reason (from an authorized Rust read)

Under the journaled read grant (`journal/0004`), I inspected the Rust kaizen from_env legacy precedence (`journal/0005`). Finding: **Rust *does* have `DEEPSEEK_API_KEY` in its legacy tier** (`kailash-rs client.rs:580`), so Python's deepseek entry is cross-SDK-*aligned*, not "Python-ahead" as the xfail originally claimed. The real blocker is a genuine Python↔Rust legacy divergence (Python has Azure + 5 keys; Rust has 10 incl. mistral/cohere/ollama/hf/perplexity/docker, no Azure) + a stale fixture matching neither. Corrected the strict-xfail reason; reconciliation is a co-owner design decision surfaced on #1721.

## Related issues
Refs #1721. Closes the CI-gap that let #1721 hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)