### PR TITLE
fix(kaizen-llm): openai_chat emits max_completion_tokens for GPT-5/o-series (found via live API test)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -19,7 +19,10 @@ Request schema (OpenAI documented contract):
   through verbatim so multimodal / tool blocks survive.
 * ``temperature`` / ``top_p`` / ``max_tokens`` / ``stop`` / ``stream`` /
   ``user`` — only emitted when the caller set them, so the produced payload
-  is stable across Python dict-ordering changes.
+  is stable across Python dict-ordering changes. The token-limit field name is
+  model-aware: OpenAI GPT-5 / o-series require ``max_completion_tokens`` (they
+  400 on ``max_tokens``), while OpenAI-compatible providers keep ``max_tokens``
+  (see ``_token_limit_field``).
 
 Response schema:
 
@@ -38,6 +41,22 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from kaizen.llm.deployment import CompletionRequest
+
+# OpenAI's GPT-5 family and the o-series reasoning models REJECT `max_tokens`
+# with a hard HTTP 400 ("'max_tokens' is not supported with this model; use
+# 'max_completion_tokens'") — verified live 2026-07-14 against `gpt-5.6-sol`.
+# OpenAI-compatible third-party providers that share this wire (DeepSeek, Groq,
+# Together, Fireworks, OpenRouter, Perplexity, LM Studio, llama.cpp, Ollama,
+# Docker Model Runner) still use `max_tokens`. Pick the field by model family so
+# both work. Match is on the resolved model id; unknown ids keep `max_tokens`.
+_MAX_COMPLETION_TOKENS_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _token_limit_field(model: str) -> str:
+    m = (model or "").lower()
+    if any(m.startswith(p) for p in _MAX_COMPLETION_TOKENS_MODEL_PREFIXES):
+        return "max_completion_tokens"
+    return "max_tokens"
 
 
 def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
@@ -59,7 +78,7 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     if request.top_p is not None:
         payload["top_p"] = request.top_p
     if request.max_tokens is not None:
-        payload["max_tokens"] = request.max_tokens
+        payload[_token_limit_field(request.model)] = request.max_tokens
     if request.stop:
         payload["stop"] = list(request.stop)
     if request.stream:

--- a/packages/kailash-kaizen/tests/unit/llm/test_openai_max_completion_tokens.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_openai_max_completion_tokens.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: OpenAI GPT-5 / o-series require `max_completion_tokens`, not
+`max_tokens` (verified live 2026-07-14 — `gpt-5.6-sol` returns HTTP 400 on
+`max_tokens`). OpenAI-compatible providers (DeepSeek, Groq, ...) keep
+`max_tokens`. The openai_chat shaper picks the field by model family.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import openai_chat
+
+
+def _req(model: str) -> CompletionRequest:
+    return CompletionRequest(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=16,
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5.6-sol",
+        "o1",
+        "o1-mini",
+        "o3",
+        "o3-mini",
+        "o4-mini",
+    ],
+)
+def test_gpt5_and_o_series_emit_max_completion_tokens(model: str) -> None:
+    payload = openai_chat.build_request_payload(_req(model))
+    assert payload["max_completion_tokens"] == 16
+    assert "max_tokens" not in payload
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4-turbo",
+        "deepseek-chat",  # OpenAI-compatible provider — verified live with max_tokens
+        "llama-3.1-70b",
+        "mixtral-8x7b",
+    ],
+)
+def test_gpt4_and_compatible_providers_keep_max_tokens(model: str) -> None:
+    payload = openai_chat.build_request_payload(_req(model))
+    assert payload["max_tokens"] == 16
+    assert "max_completion_tokens" not in payload
+
+
+def test_token_limit_field_selector() -> None:
+    assert openai_chat._token_limit_field("gpt-5.6-sol") == "max_completion_tokens"
+    assert openai_chat._token_limit_field("o1-preview") == "max_completion_tokens"
+    assert openai_chat._token_limit_field("gpt-4o") == "max_tokens"
+    assert openai_chat._token_limit_field("deepseek-chat") == "max_tokens"
+    assert openai_chat._token_limit_field("") == "max_tokens"
+
+
+def test_no_token_field_when_max_tokens_unset() -> None:
+    req = CompletionRequest(model="gpt-5", messages=[{"role": "user", "content": "hi"}])
+    payload = openai_chat.build_request_payload(req)
+    assert "max_tokens" not in payload
+    assert "max_completion_tokens" not in payload


### PR DESCRIPTION
## Real-API bug, found by testing against live providers

Exercising `LlmClient.complete()` against the **live** provider APIs (keys in `.env`) surfaced a defect the respx-mocked wire tests can't catch: OpenAI's `gpt-5.6-sol` returns **HTTP 400** — `'max_tokens' is not supported with this model; use 'max_completion_tokens'`. The #1717 `openai_chat` shaper emitted `max_tokens` unconditionally.

Notably the **legacy** provider (`providers/llm/openai.py:230`) already used `max_completion_tokens` — so the four-axis shaper had *regressed* a capability the legacy layer handled (direct evidence for the #1720 legacy-vs-four-axis question).

## Fix
Model-aware field selection (matches the existing per-model temperature-constraint pattern): GPT-5 / o1 / o3 / o4 → `max_completion_tokens`; OpenAI-compatible providers (DeepSeek, Groq, Together, …) keep `max_tokens` (DeepSeek verified live with `max_tokens`).

## Live re-verification (`LlmClient.complete()`, real APIs)
- ✅ openai `gpt-5.6-sol` (the fix)
- ✅ anthropic-direct
- ✅ deepseek (still `max_tokens`, unbroken)
- ✅ **bedrock-claude Sonnet 4.5** — the #1717 Bedrock wire transform + `AwsBearerToken`, against real Bedrock

16 new regression tests; llm + parity suite **1201 passed / 8 deselected / 1 xfailed**.

## Cross-SDK
The shaper's docstring claims byte-identical Rust parity, so the Rust openai chat builder has the same GPT-5 defect — tracked for a cross-SDK follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)