### PR TITLE
release: kailash-kaizen 2.31.1 (OpenAI GPT-5/o-series fix)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.31.1] — 2026-07-14 — fix: OpenAI GPT-5 / o-series completions (`max_completion_tokens`)
+
+### Fixed
+
+- **`LlmClient.complete()` against OpenAI GPT-5 / o-series models.** The
+  `openai_chat` wire shaper emitted `max_tokens` unconditionally; GPT-5 and the
+  o-series reasoning models reject it with HTTP 400 (`use 'max_completion_tokens'
+instead`) — found by exercising `complete()` against the live OpenAI API. The
+  shaper now selects the token-limit field by model family: GPT-5 / o1 / o3 / o4
+  use `max_completion_tokens`; OpenAI-compatible providers (DeepSeek, Groq,
+  Together, …) keep `max_tokens`. Verified live: OpenAI gpt-5, Anthropic-direct,
+  DeepSeek, and Bedrock-Claude completions all succeed through the four-axis
+  client. Cross-SDK: the Rust SDK's shaper carries the same defect (#1727).
+
 ## [2.31.0] — 2026-07-14 — four-axis `LlmClient` completion send path + Vertex-Claude/Bedrock wire + GCP WIF (#1717)
 
 The four-axis LLM deployment layer previously wire-sent only embeddings; this

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.31.0"
+version = "2.31.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.31.0"
+__version__ = "2.31.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
Patch release for the OpenAI GPT-5 / o-series `max_completion_tokens` fix (found via live-API testing, merged to main). Metadata-only diff (version anchors + CHANGELOG); tag `kaizen-v2.31.1` triggers the OIDC publish. Refs #1717, #1727.