### PR TITLE
fix(kaizen-llm): supports() contract honesty — provider capability vs client emission (#1720)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
@@ -30,6 +30,19 @@ in ``crates/kailash-kaizen/src/llm/deployment/capabilities.rs``. Per
 ``rules/cross-sdk-inspection.md`` § 3a, divergence between the two SDKs
 breaks downstream callers who port code between languages — the rows MUST
 stay in lockstep across releases.
+
+Provider capability vs client emission (IMPORTANT): these rows report what
+the **provider / wire protocol** supports — they do NOT assert that this
+SDK's four-axis ``LlmClient.complete()`` / ``stream()`` currently EMITS the
+feature. The four-axis completion client sends only the shared
+``CompletionRequest`` fields today; it does not yet emit ``tools`` /
+structured-output / batch / caching / audio request features (tracked in the
+legacy→four-axis consolidation, issue #1720). So ``tools=True`` here means
+"the provider supports tool-calling", NOT "``complete()`` will send tools".
+Callers needing those features today use the ``kaizen.providers`` layer. The
+rows stay provider-scoped (not client-scoped) BECAUSE they are the cross-SDK
+negotiation contract above — narrowing them to client-emission status would
+break the Rust byte-parity lock.
 """
 
 from __future__ import annotations

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -419,6 +419,22 @@ class LlmDeployment(BaseModel):
         vision but ``gpt-3.5-turbo`` does not is the caller's
         responsibility, typically wired through model registry metadata).
 
+        .. warning::
+
+           This matrix reports the **provider / wire-protocol** capability
+           (for cross-SDK negotiation) — NOT what this SDK's four-axis
+           ``LlmClient.complete()`` / ``stream()`` currently EMITS. As of this
+           release the four-axis completion client sends only the shared
+           ``CompletionRequest`` fields (model, messages, temperature, top_p,
+           max_tokens, stop, stream, user); it does NOT yet emit ``tools`` /
+           function-calling, structured output (``response_format``), batch,
+           prompt-caching, or audio request features. So ``supports()["tools"]
+           is True`` means "the provider supports tool-calling", NOT
+           "``complete()`` will send my tools". Wiring these request features
+           into the four-axis client is tracked in the legacy→four-axis
+           consolidation (issue #1720); until then, tool / structured-output /
+           multimodal agent work goes through the ``kaizen.providers`` layer.
+
         Fail-closed default (``rules/security.md`` § Fail-Closed Security
         Defaults): manual constructions whose ``preset_name`` is ``None``
         AND any unknown / future preset name return all-False. Adding a

--- a/packages/kailash-kaizen/tests/unit/llm/test_supports_provider_vs_client_capability.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_supports_provider_vs_client_capability.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract: `deployment.supports()` reports PROVIDER/wire capability (cross-SDK
+negotiation, byte-parity with Rust) — NOT what the four-axis `LlmClient` currently
+EMITS. This pins the honest reconciliation the docstrings now state and acts as a
+tripwire: when #1720 wires tool/structured-output emission into the client, the
+`extra="forbid"` assertions below flip and force the docstring caveat to be updated.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.presets import openai_preset
+
+
+def test_supports_reports_provider_capability_for_tools() -> None:
+    """The matrix advertises the PROVIDER's tool capability (unchanged — this is
+    the cross-SDK contract; it must NOT be narrowed to client-emission status)."""
+    dep = openai_preset(api_key="sk-test", model="gpt-4o")
+    assert dep.supports()["tools"] is True
+    assert dep.supports()["vision"] is True
+
+
+@pytest.mark.parametrize("feature_kwarg", ["tools", "response_format", "functions"])
+def test_completion_request_does_not_yet_accept_client_emission_features(
+    feature_kwarg: str,
+) -> None:
+    """The four-axis client CANNOT emit tools/structured-output today —
+    `CompletionRequest` (`extra="forbid"`) rejects the kwargs entirely. This is
+    the client-emission gap the supports() docstring warns about. If a future
+    #1720 change adds one of these fields, this test flips and the docstring
+    caveat MUST be updated in the same change."""
+    with pytest.raises(ValidationError):
+        CompletionRequest(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            **{feature_kwarg: []},
+        )
+
+
+def test_completion_request_shared_fields_are_accepted() -> None:
+    """The fields the four-axis client DOES emit are accepted — the honest
+    surface `supports()` must not be read as exceeding."""
+    req = CompletionRequest(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=32,
+        stop=["\n"],
+        stream=False,
+        user="u1",
+    )
+    assert req.model == "gpt-4o"


### PR DESCRIPTION
The #1720 head-to-head flagged `supports()["tools"] == True` as a **false green** — the four-axis `LlmClient.complete()`/`stream()` can't actually emit tools (`CompletionRequest` has `extra="forbid"`; no `tools` param), yet `supports()` advertises `tools=True`.

## Why not just flip the matrix to `tools=False`?

Because the capability matrix is — by design and by the `cross-sdk-inspection.md §3a` contract — a **provider/wire-capability negotiation matrix**, **byte-parity-locked with the Rust SDK** (with cross_sdk_parity tests). Flipping the rows to client-emission status would break that documented, tested parity and change the contract for every caller. The defect is an **expectation gap**, not a data error.

## Fix (contract honesty, matrix unchanged)
- `supports()` (deployment.py) + the `capabilities.py` module docstring now state explicitly: the rows report **provider** capability, **not** what the four-axis client emits today (no tools / structured-output / batch / caching / audio); those are tracked in the #1720 consolidation; agent work needing them uses `kaizen.providers` meanwhile.
- New contract test pins the reconciliation (provider `tools=True` **and** `CompletionRequest` rejects `tools`/`response_format`/`functions`) — a **tripwire**: when #1720 wires client emission, the `extra="forbid"` assertions flip and force the docstring update in the same change.

Matrix rows unchanged (cross-SDK parity preserved). Suite: **1206 passed / 8 deselected / 1 xfailed**.

## Related issues
Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)