### PR TITLE
release: kailash-kaizen 2.31.2 (supports() contract honesty)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.31.2] — 2026-07-14 — docs: honest `supports()` contract (provider capability vs client emission)
+
+### Fixed
+
+- **`LlmDeployment.supports()` contract honesty.** The per-preset capability
+  matrix advertised `tools=True` / `vision=True` etc., which a caller could
+  misread as "the four-axis `LlmClient.complete()` will send my tools" — but the
+  four-axis client emits only the shared `CompletionRequest` fields today (no
+  tools / structured-output / batch / caching / audio). The matrix is a
+  **provider/wire-capability** negotiation surface, byte-parity-locked with the
+  Rust SDK, so the rows are unchanged (flipping them would break cross-SDK
+  parity); instead the `supports()` + `capabilities` docstrings now state
+  explicitly that the rows report provider capability, not client emission
+  (client-side wiring tracked in #1720). A contract test pins the reconciliation
+  and trips when client emission is added. Docstring/test only — no behavior
+  change.
+
 ## [2.31.1] — 2026-07-14 — fix: OpenAI GPT-5 / o-series completions (`max_completion_tokens`)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.31.1"
+version = "2.31.2"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.31.1"
+__version__ = "2.31.2"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
Patch release for the `supports()` provider-vs-client capability docstring honesty fix (#1720). Metadata-only diff; tag `kaizen-v2.31.2` triggers publish. Refs #1720.