### PR TITLE
deprecate(kaizen): legacy from_env() per-provider-key auto-detect tier (#1721 root-cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **kailash-kaizen: legacy `from_env()` per-provider-key auto-detect tier
+  (#1721/#1720).** `LlmClient.from_env()` resolves through three tiers —
+  `KAILASH_LLM_DEPLOYMENT` URI > `KAILASH_LLM_PROVIDER` preset selector >
+  legacy per-provider `*_API_KEY` auto-detect (`OPENAI_API_KEY`,
+  `AZURE_OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`,
+  `DEEPSEEK_API_KEY`). The legacy tier is a backward-compat layer preserving
+  the old `autoselect_provider()` behavior, and is where the #1721 cross-SDK
+  key-list divergence lives (this SDK's 5 legacy keys including Azure vs.
+  the Rust SDK's 10, without Azure) — the canonical URI/selector surface is
+  already cross-SDK-aligned, so the root-cause fix retires the legacy tier
+  rather than reconciling the two key-lists. Resolving via the legacy tier
+  ALONE (no URI, no selector configured) now emits a `DeprecationWarning`
+  plus a structured `llm_client.migration.legacy_key_autodetect_deprecated`
+  `WARNING` log line naming the detected env var and the canonical migration
+  path (`KAILASH_LLM_PROVIDER=<preset>`, e.g. `openai` / `anthropic` /
+  `google` / `deepseek` / `azure_openai`, or a `KAILASH_LLM_DEPLOYMENT` URI).
+  This is the start of the deprecation cycle only (zero-tolerance.md Rule
+  6a) — resolution behavior is unchanged this release; the legacy tier still
+  resolves and will be removed in a future release. The pre-existing
+  `llm_client.migration.legacy_and_deployment_both_configured` coexistence
+  warning (a legacy key set alongside a URI/selector) is unchanged.
+  `kaizen.llm.from_env.LEGACY_KEY_ORDER` (the 5-entry key list) is
+  unmodified — this is a deprecation of the tier, not a reconciliation of
+  the key lists.
+
 ## [2.50.0] - 2026-07-13
 
 Observability program (#1708) — a coordinated 5-package release. Configures

--- a/packages/kailash-kaizen/src/kaizen/llm/from_env.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/from_env.py
@@ -23,6 +23,20 @@ for `LlmClient.from_env()`:
 If BOTH the deployment tier (URI or selector) AND legacy per-provider
 keys are set, emits a `WARNING llm_client.migration.legacy_and_deployment_both_configured`
 and the deployment path wins.
+
+**Deprecation (#1721/#1720):** the legacy tier itself -- resolving with NO
+`KAILASH_LLM_DEPLOYMENT` URI and NO `KAILASH_LLM_PROVIDER` selector present,
+purely from a per-provider `*_API_KEY` -- is a backward-compat migration
+layer preserving the old `autoselect_provider()` behavior. This is where the
+cross-SDK key-list divergence lives (Python's 5 legacy keys incl. Azure vs.
+the Rust SDK's 10, no Azure): the canonical URI/selector surface is already
+cross-SDK-aligned, so the fix is to retire the legacy tier, not reconcile the
+key lists. Resolving via the legacy tier ALONE now emits a `DeprecationWarning`
+plus a `WARNING llm_client.migration.legacy_key_autodetect_deprecated` log
+line naming the detected key and the canonical migration path
+(`KAILASH_LLM_PROVIDER=<preset>` or a `KAILASH_LLM_DEPLOYMENT` URI). This is
+the START of the deprecation cycle -- the legacy tier still resolves this
+release; only removal is deferred (zero-tolerance.md Rule 6a).
 """
 
 from __future__ import annotations
@@ -30,6 +44,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import warnings
 from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
@@ -102,6 +117,21 @@ def resolve_env_deployment() -> LlmDeployment:
     if selector:
         return _build_from_selector(selector)
     if legacy_key is not None:
+        # Legacy tier resolving ALONE (no URI, no selector) -- this is the
+        # deprecated backward-compat auto-detect path (#1721/#1720). Does
+        # NOT change resolution behavior: the legacy tier still resolves
+        # this release. See module docstring "Deprecation" section.
+        message = _legacy_alone_deprecation_message(legacy_key)
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
+        logger.warning(
+            "llm_client.migration.legacy_key_autodetect_deprecated",
+            extra={
+                "legacy_env_var": legacy_key,
+                "suggested_selector": _legacy_preset_name(legacy_key),
+                "canonical_selector_var": ENV_SELECTOR,
+                "canonical_uri_var": ENV_DEPLOYMENT_URI,
+            },
+        )
         return _build_from_legacy(legacy_key)
 
     raise NoKeysConfigured(
@@ -118,6 +148,38 @@ def _detect_legacy_key() -> Optional[str]:
         if os.environ.get(env_var, "").strip():
             return env_var
     return None
+
+
+def _legacy_preset_name(legacy_key: str) -> Optional[str]:
+    """Return the preset/selector name paired with a legacy env var."""
+    for env_var, preset in LEGACY_KEY_ORDER:
+        if env_var == legacy_key:
+            return preset
+    return None
+
+
+def _legacy_alone_deprecation_message(legacy_key: str) -> str:
+    """Build the deprecation message for legacy-tier-ALONE resolution.
+
+    Fires only when `resolve_env_deployment()` resolves via the legacy tier
+    with NO `KAILASH_LLM_DEPLOYMENT` URI and NO `KAILASH_LLM_PROVIDER`
+    selector present (#1721/#1720). Names the detected legacy env var and
+    points at the canonical migration path -- a preset selector when this
+    key maps to one, else the general selector/URI guidance.
+    """
+    preset = _legacy_preset_name(legacy_key)
+    migration_path = (
+        f"set {ENV_SELECTOR}={preset!r}"
+        if preset is not None
+        else f"set {ENV_SELECTOR} to a registered preset name"
+    )
+    return (
+        f"LlmClient.from_env(): resolved via the legacy per-provider-key "
+        f"auto-detect tier ({legacy_key} is set; no {ENV_DEPLOYMENT_URI} or "
+        f"{ENV_SELECTOR} configured). This legacy auto-detect path is "
+        f"deprecated and will be removed in a future release -- "
+        f"{migration_path} (or a {ENV_DEPLOYMENT_URI} URI) instead."
+    )
 
 
 def _build_from_uri(uri: str) -> LlmDeployment:

--- a/packages/kailash-kaizen/src/kaizen/llm/from_env.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/from_env.py
@@ -134,11 +134,11 @@ def resolve_env_deployment() -> LlmDeployment:
         )
         return _build_from_legacy(legacy_key)
 
+    _legacy_keys = ", ".join(env_var for env_var, _preset in LEGACY_KEY_ORDER)
     raise NoKeysConfigured(
         "No LLM deployment configured. Set one of: "
         f"{ENV_DEPLOYMENT_URI} (URI), {ENV_SELECTOR} (preset name), "
-        "or a legacy per-provider API key (OPENAI_API_KEY, "
-        "ANTHROPIC_API_KEY, GOOGLE_API_KEY, AZURE_OPENAI_API_KEY)."
+        f"or a legacy per-provider API key ({_legacy_keys})."
     )
 
 
@@ -379,7 +379,7 @@ def _call_preset_from_env(selector: str, factory: Any) -> LlmDeployment:
 
 
 def _build_from_legacy(legacy_key: str) -> LlmDeployment:
-    """Legacy tier: detect one of the 4 canonical keys and build."""
+    """Legacy tier: build from the detected legacy per-provider key (one of LEGACY_KEY_ORDER)."""
     from kaizen.llm.presets import (
         anthropic_preset,
         azure_openai_preset,

--- a/packages/kailash-kaizen/tests/regression/test_issue_1721_legacy_tier_deprecation_warning.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1721_legacy_tier_deprecation_warning.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1721/#1720 -- legacy from_env() key-autodetect tier deprecation.
+
+Root cause (cross-SDK, verified against both the Python and Rust SDKs):
+`LlmClient.from_env()` is a three-tier resolver -- URI (`KAILASH_LLM_DEPLOYMENT`)
+> preset selector (`KAILASH_LLM_PROVIDER`) > legacy per-provider-key auto-detect.
+The legacy tier is a backward-compat migration layer preserving the old
+`autoselect_provider()` behavior. The #1721 cross-SDK divergence (Python: 5
+legacy keys incl. Azure; Rust: 10 keys, no Azure) lives ENTIRELY inside this
+deprecated tier -- the canonical URI/selector surface is already cross-SDK
+aligned. The fix is to DEPRECATE + retire the legacy tier, not reconcile the
+two key-lists.
+
+This is the START of the deprecation cycle (zero-tolerance.md Rule 6a):
+resolving via the legacy tier ALONE (no URI, no selector) now emits a
+`DeprecationWarning` + a structured `llm_client.migration.legacy_key_autodetect_
+deprecated` log line naming the detected key and the canonical migration path.
+Resolution behavior is UNCHANGED this release -- the legacy tier still resolves.
+
+The pre-existing `legacy_and_deployment_both_configured` coexistence warning
+(URI/selector + a legacy key both set) is untouched and MUST NOT gain the new
+DeprecationWarning -- that path already resolves through the URI/selector
+branch and never reaches the legacy-alone code path.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import pytest
+
+from kaizen.llm.client import LlmClient
+from kaizen.llm.from_env import ENV_DEPLOYMENT_URI, ENV_SELECTOR, LEGACY_KEY_ORDER
+
+
+def _clear_all_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every env var from_env() reads, so each test starts clean."""
+    for var in [
+        ENV_DEPLOYMENT_URI,
+        ENV_SELECTOR,
+        "OPENAI_API_KEY",
+        "OPENAI_PROD_MODEL",
+        "OPENAI_MODEL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_MODEL",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_MODEL",
+        "GEMINI_MODEL",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_RESOURCE",
+        "AZURE_OPENAI_DEPLOYMENT",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_REGION",
+        "BEDROCK_CLAUDE_MODEL_ID",
+        "BEDROCK_MODEL",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_PROD_MODEL",
+        "DEEPSEEK_MODEL",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.regression
+class TestIssue1721LegacyTierDeprecationWarning:
+    """Regression tests for #1721/#1720: legacy from_env() tier deprecation."""
+
+    # -- Legacy-alone resolution emits DeprecationWarning + behavior unchanged --
+
+    def test_legacy_alone_emits_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy tier resolving ALONE (no URI/selector) emits DeprecationWarning."""
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o-mini")
+
+        with pytest.warns(DeprecationWarning, match="OPENAI_API_KEY"):
+            client = LlmClient.from_env()
+
+        # Behavior UNCHANGED this release: the legacy tier still resolves.
+        assert client.deployment.wire.name == "OpenAiChat"
+        assert client.deployment.default_model == "gpt-4o-mini"
+
+    def test_legacy_alone_deprecation_message_names_canonical_migration_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Message points at KAILASH_LLM_PROVIDER=<preset> as the migration path."""
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("ANTHROPIC_MODEL", "claude-3-opus")
+
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"ANTHROPIC_API_KEY.*KAILASH_LLM_PROVIDER='anthropic'",
+        ):
+            LlmClient.from_env()
+
+    def test_legacy_alone_emits_structured_log_line(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A structured WARNING log line names the detected key + migration path."""
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "gk-test")
+        monkeypatch.setenv("GOOGLE_MODEL", "gemini-1.5-pro")
+
+        with caplog.at_level(logging.WARNING):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                LlmClient.from_env()
+
+        matching = [
+            rec
+            for rec in caplog.records
+            if "legacy_key_autodetect_deprecated" in rec.message
+        ]
+        assert (
+            matching
+        ), "expected llm_client.migration.legacy_key_autodetect_deprecated"
+        assert matching[0].legacy_env_var == "GOOGLE_API_KEY"
+        assert matching[0].suggested_selector == "google"
+        assert matching[0].canonical_selector_var == ENV_SELECTOR
+        assert matching[0].canonical_uri_var == ENV_DEPLOYMENT_URI
+
+    @pytest.mark.parametrize("legacy_var,preset", LEGACY_KEY_ORDER)
+    def test_every_legacy_key_emits_warning_naming_its_preset(
+        self, monkeypatch: pytest.MonkeyPatch, legacy_var: str, preset: str
+    ) -> None:
+        """Every one of the 5 legacy keys emits a warning naming ITS preset name."""
+        _clear_all_env(monkeypatch)
+        # Set the minimum env vars each legacy key's build path requires.
+        if legacy_var == "OPENAI_API_KEY":
+            monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+            monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o-mini")
+        elif legacy_var == "AZURE_OPENAI_API_KEY":
+            monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-test")
+            monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "myresource")
+            monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "mydeployment")
+        elif legacy_var == "ANTHROPIC_API_KEY":
+            monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+            monkeypatch.setenv("ANTHROPIC_MODEL", "claude-3-opus")
+        elif legacy_var == "GOOGLE_API_KEY":
+            monkeypatch.setenv("GOOGLE_API_KEY", "gk-test")
+            monkeypatch.setenv("GOOGLE_MODEL", "gemini-1.5-pro")
+        elif legacy_var == "DEEPSEEK_API_KEY":
+            monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test")
+            monkeypatch.setenv("DEEPSEEK_PROD_MODEL", "deepseek-chat")
+
+        with pytest.warns(
+            DeprecationWarning, match=rf"{legacy_var}.*KAILASH_LLM_PROVIDER='{preset}'"
+        ):
+            client = LlmClient.from_env()
+
+        # Behavior unchanged: a valid deployment is still returned.
+        assert client.deployment is not None
+
+    # -- URI / selector tiers do NOT emit the legacy-alone warning --
+
+    def test_uri_tier_does_not_emit_legacy_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv(ENV_DEPLOYMENT_URI, "bedrock://us-east-1/claude-3-opus")
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = LlmClient.from_env()
+
+        dep_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "legacy per-provider-key auto-detect" in str(w.message)
+        ]
+        assert dep_warnings == []
+        assert client.deployment.wire.name == "AnthropicMessages"
+
+    def test_selector_tier_does_not_emit_legacy_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv(ENV_SELECTOR, "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o-mini")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = LlmClient.from_env()
+
+        dep_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "legacy per-provider-key auto-detect" in str(w.message)
+        ]
+        assert dep_warnings == []
+        assert client.deployment.wire.name == "OpenAiChat"
+
+    def test_coexistence_path_unchanged_no_new_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """URI + legacy key both set: existing coexistence warning fires,
+        the NEW legacy-alone DeprecationWarning does NOT (per spec: 'Keep the
+        existing legacy_and_deployment_both_configured warning unchanged')."""
+        _clear_all_env(monkeypatch)
+        monkeypatch.setenv(ENV_DEPLOYMENT_URI, "bedrock://us-east-1/claude-3-opus")
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-legacy")
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o-mini")
+
+        with caplog.at_level(logging.WARNING):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                client = LlmClient.from_env()
+
+        # Deployment (URI) tier wins -- behavior unchanged.
+        assert client.deployment.wire.name == "AnthropicMessages"
+
+        # Existing coexistence WARNING log line still fires.
+        assert any(
+            "legacy_and_deployment_both_configured" in rec.message
+            for rec in caplog.records
+        )
+        # The NEW legacy-alone structured log line does NOT fire on this path.
+        assert not any(
+            "legacy_key_autodetect_deprecated" in rec.message for rec in caplog.records
+        )
+        # The NEW legacy-alone DeprecationWarning does NOT fire on this path.
+        dep_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "legacy per-provider-key auto-detect" in str(w.message)
+        ]
+        assert dep_warnings == []


### PR DESCRIPTION
## What
Root-cause fix for #1721. `LlmClient.from_env()` resolves in 3 tiers — URI > preset-selector > **legacy per-provider-key auto-detect**. The #1721 cross-SDK divergence (Python 5 legacy keys w/ Azure vs Rust 10 keys w/o) lives **entirely inside the legacy tier**, which BOTH SDKs treat as a backward-compat migration layer. Verified cross-SDK under an authorized read (both SDKs: identical URI>selector>legacy shape + the same `legacy_and_deployment_both_configured` warning). So the fix is to **retire the legacy tier, not reconcile the two key-lists**.

This lands the **deprecation-cycle START** (warning-only, NO behavior change, per zero-tolerance Rule 6a):
- Legacy-tier-**alone** resolution now emits a `DeprecationWarning` + a structured `llm_client.migration.legacy_key_autodetect_deprecated` log, pointing users to the canonical `KAILASH_LLM_PROVIDER=<preset>` / `KAILASH_LLM_DEPLOYMENT` URI path. Resolution behavior is unchanged.
- `LEGACY_KEY_ORDER` is **untouched** (retire, don't reconcile).
- Also fixed 2 pre-existing same-file staleness spots (the `NoKeysConfigured` message + a docstring omitted DeepSeek) — root-caused by deriving from `LEGACY_KEY_ORDER`.

## Tests
11 behavioral regression tests (`pytest.warns`) + the 2 pre-existing fixes verified: 28 passed. Full `tests/unit/llm/` (1181) green. secret-safe (log carries env-var NAMES only, never values).

## Redteam
reviewer + security-reviewer: CLEAN. Behavior-unchanged, secret-safe, Rule-6a shape, stacklevel empirically confirmed.

## Related issues
Refs #1721, #1720. Retire step + the lockstep Rust deprecation follow after this cycle. (Rust SDK referenced by role only per disclosure discipline.)