### PR TITLE
fix(kaizen): rescue uncommitted kaizen.manifest module + harden 6 findings (#1735)

### DIFF
--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -263,6 +263,8 @@ jobs:
             tests/unit/kaizen/ \
             tests/unit/l3/ \
             tests/unit/mcp/ \
+            tests/unit/test_manifest.py \
+            tests/unit/test_manifest_fixes.py \
             tests/unit/memory/ \
             tests/unit/mixins/ \
             tests/unit/ml/ \

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -46,21 +46,27 @@ name: Test kailash-kaizen
 #        would ratchet the thresholds under CI load; excluded until the tests
 #        are rewritten to self-normalizing ratios.
 #
-#      Three files are excluded via --ignore within an otherwise-clean tier:
-#        - tests/unit/mcp/test_catalog_server.py — RED on CI: 35 failures,
-#          all `ModuleNotFoundError: No module named 'kaizen.manifest'`.
-#          src/kaizen/mcp/catalog_server/tools/{deployment,application,
-#          governance}.py import a `kaizen.manifest` package (AgentManifest/
-#          AppManifest/GovernanceManifest + TOML loader/validation errors).
-#          The module IS implemented (~26KB at src/kaizen/manifest/, ~4
-#          months old) but is UNCOMMITTED: the repo-root .gitignore
-#          `MANIFEST` pattern (intended for the sdist MANIFEST file) also
-#          matches the `kaizen/manifest/` directory on case-insensitive
-#          filesystems (macOS APFS), so `git add` silently skips it and it
-#          never reached CI. On Linux CI (case-sensitive) the module is
-#          genuinely absent, so this exclusion holds TODAY; the real fix is a
-#          .gitignore anchor + committing the existing code (tracked as an
-#          urgent follow-up), NOT a ~500-LOC feature build.
+#      Two files are excluded via --ignore within an otherwise-clean tier
+#      (a third — tests/unit/mcp/test_catalog_server.py — was RESOLVED and
+#      is no longer excluded; see note below):
+#        - [RESOLVED, issue #1735] tests/unit/mcp/test_catalog_server.py —
+#          was RED on CI (35 failures, all `ModuleNotFoundError: No module
+#          named 'kaizen.manifest'`) because src/kaizen/mcp/catalog_server/
+#          tools/{deployment,application,governance}.py import a
+#          `kaizen.manifest` package (AgentManifest/AppManifest/
+#          GovernanceManifest + TOML loader/validation errors) that was
+#          fully implemented on disk (~26KB at src/kaizen/manifest/) but
+#          UNCOMMITTED: the repo-root .gitignore `MANIFEST` pattern
+#          (intended for the sdist MANIFEST file) also matched the
+#          `kaizen/manifest/` directory on case-insensitive filesystems
+#          (macOS APFS), so `git add` silently skipped it and it never
+#          reached CI (Linux CI is case-sensitive, so the module was
+#          genuinely absent there). Fixed by anchoring the .gitignore
+#          pattern to `/MANIFEST` (repo-root sdist file only), committing
+#          the module (with 5 review-driven hardening fixes — see
+#          packages/kailash-kaizen/tests/unit/test_manifest_fixes.py), and
+#          re-including this file in the tier above. It is now gated on
+#          every CI run like every other test in this tier.
 #        - tests/unit/providers/test_ollama_model_manager.py —
 #          INFRA-DEPENDENT: `ollama` (the pip client library, distinct from
 #          the vendored `ollama_provider.py`/`ollama_model_manager.py`
@@ -256,7 +262,7 @@ jobs:
             tests/unit/judges/ \
             tests/unit/kaizen/ \
             tests/unit/l3/ \
-            tests/unit/mcp/ --ignore=tests/unit/mcp/test_catalog_server.py \
+            tests/unit/mcp/ \
             tests/unit/memory/ \
             tests/unit/mixins/ \
             tests/unit/ml/ \

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
+/MANIFEST
 
 # Virtual environments
 .env

--- a/packages/kailash-kaizen/src/kaizen/manifest/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/__init__.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kaizen Manifest Models — declarative agent and application manifests.
+
+Provides :class:`AgentManifest`, :class:`AppManifest`, and
+:class:`GovernanceManifest` as ``@dataclass`` models with TOML parsing,
+dict round-trip serialization, and A2A Agent Card conversion.
+"""
+
+from kaizen.manifest.agent import AgentManifest
+from kaizen.manifest.app import AppManifest
+from kaizen.manifest.errors import (
+    ManifestError,
+    ManifestParseError,
+    ManifestValidationError,
+)
+from kaizen.manifest.governance import GovernanceManifest
+
+__all__ = [
+    "AgentManifest",
+    "AppManifest",
+    "GovernanceManifest",
+    "ManifestError",
+    "ManifestParseError",
+    "ManifestValidationError",
+]

--- a/packages/kailash-kaizen/src/kaizen/manifest/_coerce.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/_coerce.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared type-guarded coercion helpers for manifest ``from_dict`` methods.
+
+``list(value)`` silently char-splits a ``str`` (``list("pii")`` ->
+``['p', 'i', 'i']``) instead of raising — a type-confusion bug per
+``security.md``'s "Type-Confusion MUST Raise, Not Silently Coerce"
+discipline.  :func:`coerce_list_field` is the single shared guard used by
+every ``from_dict`` classmethod in this package so a should-be-list field
+(``capabilities``, ``tools``, ``supported_models``, ``agents_requested``,
+``data_access_needed``) raises a clear, field-named
+:class:`~kaizen.manifest.errors.ManifestValidationError` instead of
+silently producing a per-character list.
+"""
+
+from typing import Any, List
+
+from kaizen.manifest.errors import ManifestValidationError
+
+__all__ = ["coerce_list_field"]
+
+
+def coerce_list_field(value: Any, field_name: str) -> List[Any]:
+    """Coerce *value* to a ``list``, raising on type-confused input.
+
+    Args:
+        value: The raw value pulled from a ``dict`` (typically via
+            ``data.get(field_name, [])``).
+        field_name: The manifest field name, used in the error message.
+
+    Returns:
+        A new ``list`` containing *value*'s items.
+
+    Raises:
+        ManifestValidationError: If *value* is a ``str``/``bytes`` (which
+            would silently char-split) or any other non-list/tuple type.
+    """
+    if isinstance(value, (str, bytes)):
+        raise ManifestValidationError(
+            f"Field {field_name!r} must be a list, got a "
+            f"{type(value).__name__} ({value!r}); a string would silently "
+            f"split into individual characters",
+            details={"field": field_name, "received_type": type(value).__name__},
+        )
+    if not isinstance(value, (list, tuple)):
+        raise ManifestValidationError(
+            f"Field {field_name!r} must be a list, got {type(value).__name__} "
+            f"({value!r})",
+            details={"field": field_name, "received_type": type(value).__name__},
+        )
+    return list(value)

--- a/packages/kailash-kaizen/src/kaizen/manifest/_coerce.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/_coerce.py
@@ -20,7 +20,31 @@ from typing import Any, List
 
 from kaizen.manifest.errors import ManifestValidationError
 
-__all__ = ["coerce_list_field"]
+__all__ = ["coerce_list_field", "safe_repr"]
+
+_DEFAULT_REPR_CAP = 200
+_TRUNCATION_SUFFIX = "…(truncated)"
+
+
+def safe_repr(value: Any, max_len: int = _DEFAULT_REPR_CAP) -> str:
+    """Return a length-bounded ``repr`` of *value* for error messages.
+
+    Manifest validation errors are forwarded verbatim to the MCP client
+    (the catalog server relays ``ManifestValidationError`` messages —
+    ``ManifestError`` is a ``ValueError`` subclass). Echoing an
+    attacker-controlled field value with an unbounded ``{value!r}`` lets a
+    caller amplify a tiny request into a huge error payload
+    (DoS / input-validation, per ``security.md`` length-limits). Every
+    attacker-influenced ``{X!r}`` in a manifest error message MUST route
+    through this helper, which truncates the ``repr`` to *max_len*
+    characters (truncation suffix included within the budget) so the
+    emitted message stays bounded regardless of input size.
+    """
+    rendered = repr(value)
+    if len(rendered) <= max_len:
+        return rendered
+    keep = max(0, max_len - len(_TRUNCATION_SUFFIX))
+    return rendered[:keep] + _TRUNCATION_SUFFIX
 
 
 def coerce_list_field(value: Any, field_name: str) -> List[Any]:
@@ -41,14 +65,14 @@ def coerce_list_field(value: Any, field_name: str) -> List[Any]:
     if isinstance(value, (str, bytes)):
         raise ManifestValidationError(
             f"Field {field_name!r} must be a list, got a "
-            f"{type(value).__name__} ({value!r}); a string would silently "
-            f"split into individual characters",
+            f"{type(value).__name__} ({safe_repr(value)}); a string would "
+            f"silently split into individual characters",
             details={"field": field_name, "received_type": type(value).__name__},
         )
     if not isinstance(value, (list, tuple)):
         raise ManifestValidationError(
             f"Field {field_name!r} must be a list, got {type(value).__name__} "
-            f"({value!r})",
+            f"({safe_repr(value)})",
             details={"field": field_name, "received_type": type(value).__name__},
         )
     return list(value)

--- a/packages/kailash-kaizen/src/kaizen/manifest/agent.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/agent.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from kaizen.manifest._coerce import coerce_list_field
+from kaizen.manifest._coerce import coerce_list_field, safe_repr
 from kaizen.manifest.errors import ManifestParseError, ManifestValidationError
 from kaizen.manifest.governance import GovernanceManifest
 
@@ -113,7 +113,7 @@ class AgentManifest:
         if self.manifest_version not in _SUPPORTED_VERSIONS:
             errors["manifest_version"] = (
                 f"manifest_version must be one of {sorted(_SUPPORTED_VERSIONS)}, "
-                f"got {self.manifest_version!r}"
+                f"got {safe_repr(self.manifest_version)}"
             )
         if errors:
             # Use the first error key for the message so pytest.raises(match=...)

--- a/packages/kailash-kaizen/src/kaizen/manifest/agent.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/agent.py
@@ -291,9 +291,13 @@ class AgentManifest:
             module=agent_section.get("module", ""),
             class_name=agent_section.get("class_name", agent_section.get("class", "")),
             description=agent_section.get("description", ""),
-            capabilities=list(agent_section.get("capabilities", [])),
-            tools=list(agent_section.get("tools", [])),
-            supported_models=list(agent_section.get("supported_models", [])),
+            capabilities=coerce_list_field(
+                agent_section.get("capabilities", []), "capabilities"
+            ),
+            tools=coerce_list_field(agent_section.get("tools", []), "tools"),
+            supported_models=coerce_list_field(
+                agent_section.get("supported_models", []), "supported_models"
+            ),
             governance=governance,
         )
 
@@ -343,8 +347,12 @@ class AgentManifest:
             module=info.get("module", ""),
             class_name=info.get("class_name", ""),
             description=info.get("description", ""),
-            capabilities=list(info.get("capabilities", [])),
-            tools=list(info.get("tools", [])),
-            supported_models=list(info.get("supported_models", [])),
+            capabilities=coerce_list_field(
+                info.get("capabilities", []), "capabilities"
+            ),
+            tools=coerce_list_field(info.get("tools", []), "tools"),
+            supported_models=coerce_list_field(
+                info.get("supported_models", []), "supported_models"
+            ),
             governance=governance,
         )

--- a/packages/kailash-kaizen/src/kaizen/manifest/agent.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/agent.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentManifest — declarative agent identity and capabilities.
+
+Parsed from ``[agent]`` + ``[governance]`` sections of a TOML manifest
+file.  Supports round-trip serialization (``to_toml`` / ``from_toml_str``)
+and conversion to the A2A Agent Card format (``to_agent_card``).
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from kaizen.manifest._coerce import coerce_list_field
+from kaizen.manifest.errors import ManifestParseError, ManifestValidationError
+from kaizen.manifest.governance import GovernanceManifest
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AgentManifest"]
+
+_SUPPORTED_VERSIONS = frozenset({"1.0"})
+
+
+def _escape_toml_string(s: str) -> str:
+    """Escape special characters for TOML basic string values.
+
+    Escapes the standard TOML basic-string escapes (backslash, double
+    quote, newline, carriage return, tab) plus every remaining C0 control
+    byte (``\\x00``-``\\x1f``) not already covered by one of those, using
+    TOML's ``\\uXXXX`` escape form.  Without this, a control byte embedded
+    in a name/description/list item (e.g. from untrusted introspection
+    data) would be written into the TOML output unescaped, producing a
+    file that either fails to round-trip through ``from_toml_str`` or —
+    worse — is misparsed by a downstream TOML consumer.
+    """
+    result = (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    escaped_chars = []
+    for ch in result:
+        codepoint = ord(ch)
+        if codepoint < 0x20 and ch not in ("\n", "\r", "\t"):
+            escaped_chars.append(f"\\u{codepoint:04x}")
+        else:
+            escaped_chars.append(ch)
+    return "".join(escaped_chars)
+
+
+def _load_tomllib():
+    """Return the tomllib module (stdlib 3.11+ or tomli fallback)."""
+    try:
+        import tomllib
+
+        return tomllib
+    except ModuleNotFoundError:
+        pass
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+        return tomllib
+    except ModuleNotFoundError:
+        raise ImportError(
+            "TOML parsing requires Python 3.11+ (tomllib) or the 'tomli' "
+            "package.  Install with: pip install tomli"
+        )
+
+
+@dataclass
+class AgentManifest:
+    """Declarative manifest for a Kaizen agent.
+
+    Attributes:
+        manifest_version: Schema version — must be ``"1.0"`` (RT-12).
+        name: Unique agent identifier (required, non-empty).
+        module: Python module path (required, non-empty).
+        class_name: Agent class name inside *module* (required, non-empty).
+        description: Human-readable summary.
+        capabilities: List of capability tags (e.g. ``["pii-detection"]``).
+        tools: Tool identifiers the agent may invoke.
+        supported_models: LLM model identifiers the agent can work with.
+        governance: Optional governance constraints.
+    """
+
+    name: str = ""
+    module: str = ""
+    class_name: str = ""
+    manifest_version: str = "1.0"
+    description: str = ""
+    capabilities: List[str] = field(default_factory=list)
+    tools: List[str] = field(default_factory=list)
+    supported_models: List[str] = field(default_factory=list)
+    governance: Optional[GovernanceManifest] = None
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+    def __post_init__(self) -> None:
+        errors: Dict[str, str] = {}
+        if not self.name or not self.name.strip():
+            errors["name"] = "name must be a non-empty string"
+        if not self.module or not self.module.strip():
+            errors["module"] = "module must be a non-empty string"
+        if not self.class_name or not self.class_name.strip():
+            errors["class_name"] = "class_name must be a non-empty string"
+        if self.manifest_version not in _SUPPORTED_VERSIONS:
+            errors["manifest_version"] = (
+                f"manifest_version must be one of {sorted(_SUPPORTED_VERSIONS)}, "
+                f"got {self.manifest_version!r}"
+            )
+        if errors:
+            # Use the first error key for the message so pytest.raises(match=...)
+            # can locate the relevant field name.
+            first_key = next(iter(errors))
+            raise ManifestValidationError(
+                f"AgentManifest validation failed: {errors[first_key]}",
+                details=errors,
+            )
+
+    # ------------------------------------------------------------------
+    # Dict serialization
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict."""
+        result: Dict[str, Any] = {
+            "manifest_version": self.manifest_version,
+            "name": self.name,
+            "module": self.module,
+            "class_name": self.class_name,
+            "description": self.description,
+            "capabilities": list(self.capabilities),
+            "tools": list(self.tools),
+            "supported_models": list(self.supported_models),
+        }
+        if self.governance is not None:
+            result["governance"] = self.governance.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AgentManifest:
+        """Deserialize from a plain dict (inverse of ``to_dict``)."""
+        governance = None
+        if "governance" in data and data["governance"] is not None:
+            governance = GovernanceManifest.from_dict(data["governance"])
+        return cls(
+            manifest_version=data.get("manifest_version", "1.0"),
+            name=data.get("name", ""),
+            module=data.get("module", ""),
+            class_name=data.get("class_name", ""),
+            description=data.get("description", ""),
+            capabilities=coerce_list_field(
+                data.get("capabilities", []), "capabilities"
+            ),
+            tools=coerce_list_field(data.get("tools", []), "tools"),
+            supported_models=coerce_list_field(
+                data.get("supported_models", []), "supported_models"
+            ),
+            governance=governance,
+        )
+
+    # ------------------------------------------------------------------
+    # TOML serialization
+    # ------------------------------------------------------------------
+    def to_toml(self) -> str:
+        """Serialize to a TOML string (hand-formatted, no toml library needed)."""
+        lines: List[str] = ["[agent]"]
+        lines.append(
+            f'manifest_version = "{_escape_toml_string(self.manifest_version)}"'
+        )
+        lines.append(f'name = "{_escape_toml_string(self.name)}"')
+        lines.append(f'module = "{_escape_toml_string(self.module)}"')
+        lines.append(f'class_name = "{_escape_toml_string(self.class_name)}"')
+        if self.description:
+            lines.append(f'description = "{_escape_toml_string(self.description)}"')
+        if self.capabilities:
+            cap_items = ", ".join(
+                f'"{_escape_toml_string(c)}"' for c in self.capabilities
+            )
+            lines.append(f"capabilities = [{cap_items}]")
+        if self.tools:
+            tool_items = ", ".join(f'"{_escape_toml_string(t)}"' for t in self.tools)
+            lines.append(f"tools = [{tool_items}]")
+        if self.supported_models:
+            model_items = ", ".join(
+                f'"{_escape_toml_string(m)}"' for m in self.supported_models
+            )
+            lines.append(f"supported_models = [{model_items}]")
+
+        if self.governance is not None:
+            lines.append("")
+            lines.append("[governance]")
+            g = self.governance
+            lines.append(f'purpose = "{_escape_toml_string(g.purpose)}"')
+            lines.append(f'risk_level = "{_escape_toml_string(g.risk_level)}"')
+            if g.data_access_needed:
+                da_items = ", ".join(
+                    f'"{_escape_toml_string(d)}"' for d in g.data_access_needed
+                )
+                lines.append(f"data_access_needed = [{da_items}]")
+            else:
+                lines.append("data_access_needed = []")
+            lines.append(
+                f'suggested_posture = "{_escape_toml_string(g.suggested_posture)}"'
+            )
+            if g.max_budget_microdollars is not None:
+                lines.append(f"max_budget_microdollars = {g.max_budget_microdollars}")
+
+        lines.append("")  # trailing newline
+        return "\n".join(lines)
+
+    @classmethod
+    def from_toml(cls, path: str) -> AgentManifest:
+        """Parse an AgentManifest from a TOML file on disk.
+
+        Raises:
+            ManifestParseError: If the file cannot be read or parsed.
+        """
+        try:
+            with open(path, "rb") as fh:
+                raw = fh.read()
+        except FileNotFoundError as exc:
+            raise ManifestParseError(
+                f"Manifest file not found: {path}",
+                details={"path": path},
+            ) from exc
+        except OSError as exc:
+            raise ManifestParseError(
+                f"Cannot read manifest file: {path}: {exc}",
+                details={"path": path},
+            ) from exc
+
+        return cls._parse_toml_bytes(raw, source=path)
+
+    @classmethod
+    def from_toml_str(cls, content: str) -> AgentManifest:
+        """Parse an AgentManifest from an in-memory TOML string.
+
+        Raises:
+            ManifestParseError: If the string is not valid TOML.
+            ManifestValidationError: If required fields are missing.
+        """
+        return cls._parse_toml_bytes(content.encode("utf-8"), source="<string>")
+
+    @classmethod
+    def _parse_toml_bytes(cls, raw: bytes, *, source: str = "<bytes>") -> AgentManifest:
+        """Internal: parse raw TOML bytes into an AgentManifest."""
+        tomllib = _load_tomllib()
+        try:
+            data = tomllib.loads(raw.decode("utf-8"))
+        except Exception as exc:
+            raise ManifestParseError(
+                f"Invalid TOML in {source}: {exc}",
+                details={"source": source},
+            ) from exc
+
+        agent_section = data.get("agent", {})
+        if not agent_section:
+            # No [agent] section — try top-level for very minimal files,
+            # but normally we require it.  Raise clear error.
+            raise ManifestValidationError(
+                f"Missing [agent] section in manifest ({source})",
+                details={"source": source, "name": ""},
+            )
+        if not isinstance(agent_section, dict):
+            # A legal-but-wrong array-of-tables declaration (``[[agent]]``)
+            # parses [agent] to a list, not a dict.  Without this guard,
+            # ``agent_section.get(...)`` below raises a raw AttributeError
+            # instead of the documented ManifestParseError.
+            raise ManifestParseError(
+                f"Invalid [agent] section in manifest ({source}): expected a "
+                f"table (did you use [[agent]] — array of tables — instead of "
+                f"[agent]?), got {type(agent_section).__name__}",
+                details={"source": source},
+            )
+
+        governance = None
+        gov_data = data.get("governance", agent_section.get("governance"))
+        if gov_data and isinstance(gov_data, dict):
+            governance = GovernanceManifest.from_dict(gov_data)
+
+        return cls(
+            manifest_version=str(agent_section.get("manifest_version", "1.0")),
+            name=agent_section.get("name", ""),
+            module=agent_section.get("module", ""),
+            class_name=agent_section.get("class_name", agent_section.get("class", "")),
+            description=agent_section.get("description", ""),
+            capabilities=list(agent_section.get("capabilities", [])),
+            tools=list(agent_section.get("tools", [])),
+            supported_models=list(agent_section.get("supported_models", [])),
+            governance=governance,
+        )
+
+    # ------------------------------------------------------------------
+    # A2A Agent Card
+    # ------------------------------------------------------------------
+    def to_agent_card(self) -> Dict[str, Any]:
+        """Convert this manifest to an A2A-compatible Agent Card dict.
+
+        The returned dict follows the A2A Agent Card structure with
+        optional governance extensions.
+        """
+        card: Dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "version": self.manifest_version,
+            "capabilities": list(self.capabilities),
+            "tools": list(self.tools),
+            "supported_models": list(self.supported_models),
+            "protocols": ["a2a/1.0", "kaizen-manifest/1.0"],
+            "module": self.module,
+            "class_name": self.class_name,
+        }
+        if self.governance is not None:
+            card["governance"] = self.governance.to_dict()
+        return card
+
+    # ------------------------------------------------------------------
+    # Introspection factory
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_introspection(cls, info: Dict[str, Any]) -> AgentManifest:
+        """Create an AgentManifest from a runtime introspection dict.
+
+        The *info* dict is expected to contain at minimum ``name``,
+        ``module``, and ``class_name``.
+
+        Raises:
+            ManifestValidationError: If required keys are missing.
+        """
+        governance = None
+        if "governance" in info and isinstance(info["governance"], dict):
+            governance = GovernanceManifest.from_dict(info["governance"])
+
+        return cls(
+            name=info.get("name", ""),
+            module=info.get("module", ""),
+            class_name=info.get("class_name", ""),
+            description=info.get("description", ""),
+            capabilities=list(info.get("capabilities", [])),
+            tools=list(info.get("tools", [])),
+            supported_models=list(info.get("supported_models", [])),
+            governance=governance,
+        )

--- a/packages/kailash-kaizen/src/kaizen/manifest/app.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/app.py
@@ -182,7 +182,9 @@ class AppManifest:
         agents_req_section = app_section.get("agents_requested", {})
         agents_requested: List[str] = []
         if isinstance(agents_req_section, dict):
-            agents_requested = list(agents_req_section.get("agents", []))
+            agents_requested = coerce_list_field(
+                agents_req_section.get("agents", []), "agents_requested"
+            )
         elif isinstance(agents_req_section, list):
             agents_requested = list(agents_req_section)
 

--- a/packages/kailash-kaizen/src/kaizen/manifest/app.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/app.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional
 
-from kaizen.manifest._coerce import coerce_list_field
+from kaizen.manifest._coerce import coerce_list_field, safe_repr
 from kaizen.manifest.errors import ManifestParseError, ManifestValidationError
 
 logger = logging.getLogger(__name__)
@@ -205,11 +205,17 @@ class AppManifest:
             monthly_raw = budget_section["monthly"]
             try:
                 budget_monthly_microdollars = int(Decimal(str(monthly_raw)) * 1_000_000)
-            except (InvalidOperation, ValueError) as exc:
+            except (InvalidOperation, ValueError, OverflowError) as exc:
+                # OverflowError: int(Decimal('Infinity')) — a TOML `inf`
+                # literal reaches Decimal('inf') cleanly, then int() of it
+                # overflows. Same non-finite input class as the governance
+                # budget guard; caught here so the tool surfaces a clean
+                # ManifestValidationError, not a raw OverflowError.
                 raise ManifestValidationError(
                     f"Invalid [application.budget].monthly value in manifest "
-                    f"({source}): expected a number, got {monthly_raw!r}",
-                    details={"source": source, "monthly": repr(monthly_raw)},
+                    f"({source}): expected a finite number, got "
+                    f"{safe_repr(monthly_raw)}",
+                    details={"source": source, "monthly": safe_repr(monthly_raw)},
                 ) from exc
 
         return cls(

--- a/packages/kailash-kaizen/src/kaizen/manifest/app.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/app.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""AppManifest — application-level manifest for multi-agent deployments.
+
+Parsed from ``[application]`` sections of a TOML manifest file.
+Budget values in TOML are expressed as floats (dollars) and converted
+to integer microdollars (1 dollar = 1,000,000 microdollars) using
+``Decimal`` for precision.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional
+
+from kaizen.manifest._coerce import coerce_list_field
+from kaizen.manifest.errors import ManifestParseError, ManifestValidationError
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AppManifest"]
+
+
+def _load_tomllib():
+    """Return the tomllib module (stdlib 3.11+ or tomli fallback)."""
+    try:
+        import tomllib
+
+        return tomllib
+    except ModuleNotFoundError:
+        pass
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+        return tomllib
+    except ModuleNotFoundError:
+        raise ImportError(
+            "TOML parsing requires Python 3.11+ (tomllib) or the 'tomli' "
+            "package.  Install with: pip install tomli"
+        )
+
+
+@dataclass
+class AppManifest:
+    """Application manifest declaring agents requested and budget.
+
+    Attributes:
+        name: Application identifier (required, non-empty).
+        description: Human-readable summary.
+        owner: Contact email or identifier for the application owner.
+        org_unit: Organizational unit (optional).
+        duration: Requested deployment duration (optional, e.g. "6 months").
+        agents_requested: Agent identifiers this application needs.
+        budget_monthly_microdollars: Monthly budget in microdollars (optional).
+        justification: Why these agents are needed.
+    """
+
+    name: str = ""
+    description: str = ""
+    owner: str = ""
+    org_unit: Optional[str] = None
+    duration: Optional[str] = None
+    agents_requested: List[str] = field(default_factory=list)
+    budget_monthly_microdollars: Optional[int] = None
+    justification: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ManifestValidationError(
+                "AppManifest validation failed: name must be a non-empty string",
+                details={"name": "name must be a non-empty string"},
+            )
+
+    # ------------------------------------------------------------------
+    # Dict serialization
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict."""
+        result: Dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "owner": self.owner,
+            "agents_requested": list(self.agents_requested),
+            "justification": self.justification,
+        }
+        if self.org_unit is not None:
+            result["org_unit"] = self.org_unit
+        if self.duration is not None:
+            result["duration"] = self.duration
+        if self.budget_monthly_microdollars is not None:
+            result["budget_monthly_microdollars"] = self.budget_monthly_microdollars
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AppManifest:
+        """Deserialize from a plain dict (inverse of ``to_dict``)."""
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            owner=data.get("owner", ""),
+            org_unit=data.get("org_unit"),
+            duration=data.get("duration"),
+            agents_requested=coerce_list_field(
+                data.get("agents_requested", []), "agents_requested"
+            ),
+            budget_monthly_microdollars=data.get("budget_monthly_microdollars"),
+            justification=data.get("justification", ""),
+        )
+
+    # ------------------------------------------------------------------
+    # TOML parsing
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_toml(cls, path: str) -> AppManifest:
+        """Parse an AppManifest from a TOML file on disk.
+
+        Raises:
+            ManifestParseError: If the file cannot be read or parsed.
+        """
+        try:
+            with open(path, "rb") as fh:
+                raw = fh.read()
+        except FileNotFoundError as exc:
+            raise ManifestParseError(
+                f"Manifest file not found: {path}",
+                details={"path": path},
+            ) from exc
+        except OSError as exc:
+            raise ManifestParseError(
+                f"Cannot read manifest file: {path}: {exc}",
+                details={"path": path},
+            ) from exc
+
+        return cls._parse_toml_bytes(raw, source=path)
+
+    @classmethod
+    def from_toml_str(cls, content: str) -> AppManifest:
+        """Parse an AppManifest from an in-memory TOML string.
+
+        Raises:
+            ManifestParseError: If the string is not valid TOML.
+            ManifestValidationError: If required fields are missing.
+        """
+        return cls._parse_toml_bytes(content.encode("utf-8"), source="<string>")
+
+    @classmethod
+    def _parse_toml_bytes(cls, raw: bytes, *, source: str = "<bytes>") -> AppManifest:
+        """Internal: parse raw TOML bytes into an AppManifest."""
+        tomllib = _load_tomllib()
+        try:
+            data = tomllib.loads(raw.decode("utf-8"))
+        except Exception as exc:
+            raise ManifestParseError(
+                f"Invalid TOML in {source}: {exc}",
+                details={"source": source},
+            ) from exc
+
+        app_section = data.get("application", {})
+        if not app_section:
+            raise ManifestValidationError(
+                f"Missing [application] section in manifest ({source})",
+                details={"source": source, "name": ""},
+            )
+        if not isinstance(app_section, dict):
+            # A legal-but-wrong array-of-tables declaration
+            # (``[[application]]``) parses [application] to a list, not a
+            # dict.  Without this guard, ``app_section.get(...)`` below
+            # raises a raw AttributeError instead of the documented
+            # ManifestParseError.
+            raise ManifestParseError(
+                f"Invalid [application] section in manifest ({source}): "
+                f"expected a table (did you use [[application]] — array of "
+                f"tables — instead of [application]?), got "
+                f"{type(app_section).__name__}",
+                details={"source": source},
+            )
+
+        # Extract agents_requested from nested section
+        agents_req_section = app_section.get("agents_requested", {})
+        agents_requested: List[str] = []
+        if isinstance(agents_req_section, dict):
+            agents_requested = list(agents_req_section.get("agents", []))
+        elif isinstance(agents_req_section, list):
+            agents_requested = list(agents_req_section)
+
+        # Extract justification — may live in agents_requested subsection or top-level
+        justification = ""
+        if (
+            isinstance(agents_req_section, dict)
+            and "justification" in agents_req_section
+        ):
+            justification = str(agents_req_section["justification"])
+        elif "justification" in app_section:
+            justification = str(app_section["justification"])
+
+        # Budget: convert float dollars -> integer microdollars
+        budget_monthly_microdollars: Optional[int] = None
+        budget_section = app_section.get("budget", {})
+        if isinstance(budget_section, dict) and "monthly" in budget_section:
+            monthly_raw = budget_section["monthly"]
+            try:
+                budget_monthly_microdollars = int(Decimal(str(monthly_raw)) * 1_000_000)
+            except (InvalidOperation, ValueError) as exc:
+                raise ManifestValidationError(
+                    f"Invalid [application.budget].monthly value in manifest "
+                    f"({source}): expected a number, got {monthly_raw!r}",
+                    details={"source": source, "monthly": repr(monthly_raw)},
+                ) from exc
+
+        return cls(
+            name=app_section.get("name", ""),
+            description=app_section.get("description", ""),
+            owner=app_section.get("owner", ""),
+            org_unit=app_section.get("org_unit"),
+            duration=app_section.get("duration"),
+            agents_requested=agents_requested,
+            budget_monthly_microdollars=budget_monthly_microdollars,
+            justification=justification,
+        )

--- a/packages/kailash-kaizen/src/kaizen/manifest/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/errors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manifest error hierarchy.
+
+All manifest errors inherit from ManifestError, which carries a
+``details`` dict for structured error context.
+"""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ManifestError", "ManifestParseError", "ManifestValidationError"]
+
+
+class ManifestError(ValueError):
+    """Base error for all manifest operations.
+
+    Inherits from ``ValueError`` (not ``Exception``) so that callers which
+    forward validation-style errors to untrusted clients — e.g. the MCP
+    catalog server's ``_dispatch_tool`` (see
+    ``kaizen/mcp/catalog_server/server.py``), which only relays real error
+    messages for ``(ValueError, KeyError, TypeError)`` — surface the
+    module's real validation message instead of an opaque "Internal tool
+    error".
+    """
+
+    def __init__(self, message: str, details: Dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details: Dict[str, Any] = details or {}
+
+
+class ManifestValidationError(ManifestError):
+    """Raised when manifest data fails validation.
+
+    Examples include missing required fields (name, module, class_name)
+    or unsupported manifest_version values.
+    """
+
+
+class ManifestParseError(ManifestError):
+    """Raised when TOML parsing fails.
+
+    This covers both syntactically invalid TOML and structurally
+    invalid manifest files (e.g., missing ``[agent]`` section).
+    """

--- a/packages/kailash-kaizen/src/kaizen/manifest/governance.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/governance.py
@@ -13,6 +13,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from kaizen.manifest._coerce import coerce_list_field
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["GovernanceManifest"]
@@ -79,7 +81,9 @@ class GovernanceManifest:
         return cls(
             purpose=data.get("purpose", ""),
             risk_level=data.get("risk_level", "medium"),
-            data_access_needed=list(data.get("data_access_needed", [])),
+            data_access_needed=coerce_list_field(
+                data.get("data_access_needed", []), "data_access_needed"
+            ),
             suggested_posture=data.get("suggested_posture", "supervised"),
             max_budget_microdollars=data.get("max_budget_microdollars"),
         )

--- a/packages/kailash-kaizen/src/kaizen/manifest/governance.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/governance.py
@@ -10,10 +10,12 @@ with the EATP trust posture model.
 """
 
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from kaizen.manifest._coerce import coerce_list_field
+from kaizen.manifest._coerce import coerce_list_field, safe_repr
+from kaizen.manifest.errors import ManifestValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -45,23 +47,32 @@ class GovernanceManifest:
 
     def __post_init__(self) -> None:
         if self.risk_level not in _VALID_RISK_LEVELS:
-            raise ValueError(
+            raise ManifestValidationError(
                 f"risk_level must be one of {sorted(_VALID_RISK_LEVELS)}, "
-                f"got {self.risk_level!r}"
+                f"got {safe_repr(self.risk_level)}"
             )
         if self.suggested_posture not in _VALID_POSTURES:
-            raise ValueError(
+            raise ManifestValidationError(
                 f"suggested_posture must be one of {sorted(_VALID_POSTURES)}, "
-                f"got {self.suggested_posture!r}"
+                f"got {safe_repr(self.suggested_posture)}"
             )
-        if (
-            self.max_budget_microdollars is not None
-            and self.max_budget_microdollars < 0
-        ):
-            raise ValueError(
-                f"max_budget_microdollars must be non-negative, "
-                f"got {self.max_budget_microdollars}"
-            )
+        if self.max_budget_microdollars is not None:
+            budget = self.max_budget_microdollars
+            # A budget ceiling MUST be a finite, non-negative number. TOML
+            # accepts ``inf``/``nan`` literals and ``float('inf') < 0`` /
+            # ``float('nan') < 0`` are BOTH False, so a bare ``< 0`` guard
+            # lets a non-finite value through — declaring a spend cap of "no
+            # cap" that reaches the live deploy_agent MCP tool. Mirror the
+            # ``math.isfinite`` guard in mcp/catalog_server/tools/governance.py.
+            # The message MUST NOT echo the unbounded value back.
+            if (
+                not isinstance(budget, (int, float))
+                or not math.isfinite(budget)
+                or budget < 0
+            ):
+                raise ManifestValidationError(
+                    "max_budget_microdollars must be a finite, " "non-negative number"
+                )
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a plain dict."""

--- a/packages/kailash-kaizen/src/kaizen/manifest/governance.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/governance.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""GovernanceManifest — declares an agent's governance posture and constraints.
+
+Maps to the ``[governance]`` section in agent TOML manifests and aligns
+with the EATP trust posture model.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GovernanceManifest"]
+
+_VALID_RISK_LEVELS = frozenset({"low", "medium", "high", "critical"})
+_VALID_POSTURES = frozenset(
+    {"pseudo_agent", "supervised", "shared_planning", "continuous_insight", "delegated"}
+)
+
+
+@dataclass
+class GovernanceManifest:
+    """Governance metadata for an agent or application manifest.
+
+    Attributes:
+        purpose: Human-readable description of why this agent exists.
+        risk_level: One of low, medium, high, critical.
+        data_access_needed: List of data categories the agent requires.
+        suggested_posture: EATP trust posture (pseudo_agent through delegated).
+        max_budget_microdollars: Optional spending cap in microdollars.
+    """
+
+    purpose: str = ""
+    risk_level: str = "medium"
+    data_access_needed: List[str] = field(default_factory=list)
+    suggested_posture: str = "supervised"
+    max_budget_microdollars: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.risk_level not in _VALID_RISK_LEVELS:
+            raise ValueError(
+                f"risk_level must be one of {sorted(_VALID_RISK_LEVELS)}, "
+                f"got {self.risk_level!r}"
+            )
+        if self.suggested_posture not in _VALID_POSTURES:
+            raise ValueError(
+                f"suggested_posture must be one of {sorted(_VALID_POSTURES)}, "
+                f"got {self.suggested_posture!r}"
+            )
+        if (
+            self.max_budget_microdollars is not None
+            and self.max_budget_microdollars < 0
+        ):
+            raise ValueError(
+                f"max_budget_microdollars must be non-negative, "
+                f"got {self.max_budget_microdollars}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict."""
+        result: Dict[str, Any] = {
+            "purpose": self.purpose,
+            "risk_level": self.risk_level,
+            "data_access_needed": list(self.data_access_needed),
+            "suggested_posture": self.suggested_posture,
+        }
+        if self.max_budget_microdollars is not None:
+            result["max_budget_microdollars"] = self.max_budget_microdollars
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> GovernanceManifest:
+        """Deserialize from a plain dict."""
+        return cls(
+            purpose=data.get("purpose", ""),
+            risk_level=data.get("risk_level", "medium"),
+            data_access_needed=list(data.get("data_access_needed", [])),
+            suggested_posture=data.get("suggested_posture", "supervised"),
+            max_budget_microdollars=data.get("max_budget_microdollars"),
+        )

--- a/packages/kailash-kaizen/src/kaizen/manifest/loader.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convenience loaders for manifest files.
+
+Validates the file extension before delegating to the appropriate
+manifest class.
+"""
+
+import logging
+
+from kaizen.manifest.agent import AgentManifest
+from kaizen.manifest.app import AppManifest
+from kaizen.manifest.errors import ManifestParseError
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["load_manifest", "load_app_manifest"]
+
+
+def load_manifest(path: str) -> AgentManifest:
+    """Load an AgentManifest from a TOML file.
+
+    Args:
+        path: Filesystem path to the ``.toml`` manifest.
+
+    Returns:
+        Parsed :class:`AgentManifest`.
+
+    Raises:
+        ManifestParseError: If *path* does not end with ``.toml`` or
+            the file cannot be read/parsed.
+    """
+    if not path.endswith(".toml"):
+        raise ManifestParseError(
+            f"Expected .toml file, got: {path}",
+            details={"path": path},
+        )
+    return AgentManifest.from_toml(path)
+
+
+def load_app_manifest(path: str) -> AppManifest:
+    """Load an AppManifest from a TOML file.
+
+    Args:
+        path: Filesystem path to the ``.toml`` manifest.
+
+    Returns:
+        Parsed :class:`AppManifest`.
+
+    Raises:
+        ManifestParseError: If *path* does not end with ``.toml`` or
+            the file cannot be read/parsed.
+    """
+    if not path.endswith(".toml"):
+        raise ManifestParseError(
+            f"Expected .toml file, got: {path}",
+            details={"path": path},
+        )
+    return AppManifest.from_toml(path)

--- a/packages/kailash-kaizen/src/kaizen/manifest/loader.py
+++ b/packages/kailash-kaizen/src/kaizen/manifest/loader.py
@@ -1,13 +1,28 @@
-from __future__ import annotations
-
-# Copyright 2026 Terrene Foundation
-# SPDX-License-Identifier: Apache-2.0
-
 """Convenience loaders for manifest files.
 
 Validates the file extension before delegating to the appropriate
 manifest class.
+
+SECURITY — path handling
+-------------------------
+``load_manifest`` / ``load_app_manifest`` open the ``path`` they are
+handed after only a ``.toml`` suffix check; they apply NO path-traversal,
+symlink, or allowlist containment guard. This is safe today because NO
+caller passes an externally-influenced path: the MCP catalog server's
+``deploy_agent`` tool takes inline TOML content (and explicitly rejects
+anything that looks like a file path, RT-06), and never imports this
+module. Any FUTURE caller that passes a ``path`` derived from untrusted
+input (an HTTP request, an MCP argument, a manifest field) MUST FIRST
+resolve the path and confirm it stays within an approved base directory
+(e.g. ``Path(base).resolve() in Path(path).resolve().parents``) or match
+it against an allowlist — otherwise ``../../etc/secrets.toml`` and symlink
+escapes become readable. Do not add such a caller without that guard.
 """
+
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
 
 import logging
 
@@ -32,6 +47,12 @@ def load_manifest(path: str) -> AgentManifest:
     Raises:
         ManifestParseError: If *path* does not end with ``.toml`` or
             the file cannot be read/parsed.
+
+    Security:
+        *path* is opened after only a suffix check — no traversal /
+        allowlist containment guard is applied. A caller passing an
+        externally-influenced *path* MUST apply a containment or allowlist
+        check first (see the module docstring).
     """
     if not path.endswith(".toml"):
         raise ManifestParseError(
@@ -53,6 +74,12 @@ def load_app_manifest(path: str) -> AppManifest:
     Raises:
         ManifestParseError: If *path* does not end with ``.toml`` or
             the file cannot be read/parsed.
+
+    Security:
+        *path* is opened after only a suffix check — no traversal /
+        allowlist containment guard is applied. A caller passing an
+        externally-influenced *path* MUST apply a containment or allowlist
+        check first (see the module docstring).
     """
     if not path.endswith(".toml"):
         raise ManifestParseError(

--- a/packages/kailash-kaizen/src/kaizen/mcp/catalog_server/registry.py
+++ b/packages/kailash-kaizen/src/kaizen/mcp/catalog_server/registry.py
@@ -16,6 +16,8 @@ import re
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
+from kaizen.manifest._coerce import safe_repr
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MemoryRegistry", "LocalRegistry"]
@@ -35,8 +37,13 @@ def _validate_name(name: str) -> None:
         ValueError: If the name does not match the allowed pattern.
     """
     if not _VALID_NAME_RE.match(name):
+        # ``name`` is attacker-controlled (arrives via the deploy_agent /
+        # app_register MCP tools) and this message is forwarded to the
+        # client; bound the echoed value to prevent error-payload
+        # amplification (security.md length-limits).
         raise ValueError(
-            f"Invalid name {name!r}: must match ^[a-zA-Z][a-zA-Z0-9_-]{{0,127}}$"
+            f"Invalid name {safe_repr(name)}: "
+            f"must match ^[a-zA-Z][a-zA-Z0-9_-]{{0,127}}$"
         )
 
 

--- a/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
+++ b/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
@@ -411,3 +411,201 @@ class TestListFieldTypeConfusionRaises:
                 '[application]\nname="x"\n'
                 '[application.agents_requested]\nagents="single"\n'
             )
+
+
+# ===========================================================================
+# Security review findings (4) + governance-error consistency
+# ===========================================================================
+
+
+def _agent_toml_with_budget(budget_literal: str) -> str:
+    """Build an agent manifest whose [governance] declares a raw budget
+    literal (unquoted → parsed as a TOML number)."""
+    return (
+        '[agent]\nname="x"\nmodule="m"\nclass_name="C"\n'
+        "[governance]\n"
+        'purpose="p"\n'
+        'risk_level="low"\n'
+        'suggested_posture="supervised"\n'
+        f"max_budget_microdollars = {budget_literal}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 (HIGH) — non-finite governance budget (inf/nan) is rejected
+# ---------------------------------------------------------------------------
+class TestGovernanceBudgetRejectsNonFinite:
+    def test_inf_budget_raises_validation_error(self):
+        with pytest.raises(ManifestValidationError):
+            AgentManifest.from_toml_str(_agent_toml_with_budget("inf"))
+
+    def test_nan_budget_raises_validation_error(self):
+        with pytest.raises(ManifestValidationError):
+            AgentManifest.from_toml_str(_agent_toml_with_budget("nan"))
+
+    def test_negative_inf_budget_raises_validation_error(self):
+        with pytest.raises(ManifestValidationError):
+            AgentManifest.from_toml_str(_agent_toml_with_budget("-inf"))
+
+    def test_direct_construction_inf_raises(self):
+        with pytest.raises(ManifestValidationError):
+            GovernanceManifest(max_budget_microdollars=float("inf"))
+
+    def test_direct_construction_nan_raises(self):
+        with pytest.raises(ManifestValidationError):
+            GovernanceManifest(max_budget_microdollars=float("nan"))
+
+    def test_error_message_does_not_echo_unbounded_value(self):
+        """The message MUST NOT echo 'inf'/'nan' back (an attacker-supplied
+        non-finite value should not appear in the forwarded error)."""
+        with pytest.raises(ManifestValidationError) as exc_info:
+            GovernanceManifest(max_budget_microdollars=float("inf"))
+        msg = str(exc_info.value).lower()
+        assert "inf" not in msg
+        assert "nan" not in msg
+
+    def test_finite_budget_still_accepted(self):
+        manifest = AgentManifest.from_toml_str(_agent_toml_with_budget("5000000"))
+        assert manifest.governance is not None
+        assert manifest.governance.max_budget_microdollars == 5_000_000
+
+    def test_negative_finite_budget_still_rejected(self):
+        with pytest.raises(ManifestValidationError):
+            GovernanceManifest(max_budget_microdollars=-100)
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 (MEDIUM) — attacker-controlled field values are length-bounded
+# in forwarded error messages (no error-payload amplification)
+# ---------------------------------------------------------------------------
+class TestErrorMessagesAreLengthBounded:
+    def test_coerce_list_field_huge_value_message_is_bounded(self):
+        huge = "p" * 100_000
+        with pytest.raises(ManifestValidationError) as exc_info:
+            AgentManifest.from_dict(
+                {
+                    "name": "b",
+                    "module": "m",
+                    "class_name": "C",
+                    "capabilities": huge,
+                }
+            )
+        msg = str(exc_info.value)
+        # Bounded: the 100KB payload MUST NOT be echoed verbatim.
+        assert len(msg) < 400
+        assert len(msg) < len(huge)
+        assert huge not in msg
+
+    def test_manifest_version_huge_value_message_is_bounded(self):
+        huge = "9" * 100_000
+        with pytest.raises(ManifestValidationError) as exc_info:
+            AgentManifest(manifest_version=huge, name="b", module="m", class_name="C")
+        msg = str(exc_info.value)
+        assert len(msg) < 400
+        assert huge not in msg
+
+    def test_governance_risk_level_huge_value_message_is_bounded(self):
+        huge = "z" * 100_000
+        with pytest.raises(ManifestValidationError) as exc_info:
+            GovernanceManifest(risk_level=huge)
+        msg = str(exc_info.value)
+        assert len(msg) < 400
+        assert huge not in msg
+
+    def test_registry_invalid_name_message_is_bounded(self):
+        from kaizen.mcp.catalog_server.registry import _validate_name
+
+        huge = "!" * 100_000  # fails the name regex
+        with pytest.raises(ValueError) as exc_info:
+            _validate_name(huge)
+        msg = str(exc_info.value)
+        assert len(msg) < 400
+        assert huge not in msg
+
+    def test_safe_repr_truncates_and_marks(self):
+        from kaizen.manifest._coerce import safe_repr
+
+        out = safe_repr("a" * 5000, max_len=200)
+        assert len(out) <= 200
+        assert out.endswith("…(truncated)")
+
+    def test_safe_repr_short_value_unchanged(self):
+        from kaizen.manifest._coerce import safe_repr
+
+        assert safe_repr("small") == "'small'"
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 (LOW) — non-finite app budget raises ManifestValidationError,
+# not a raw OverflowError
+# ---------------------------------------------------------------------------
+class TestAppBudgetOverflow:
+    def _app_toml(self, budget_literal: str) -> str:
+        return (
+            '[application]\nname="a"\nowner="o@example.com"\n'
+            f"[application.budget]\nmonthly = {budget_literal}\n"
+        )
+
+    def test_inf_app_budget_raises_validation_error(self):
+        with pytest.raises(ManifestValidationError, match="monthly"):
+            AppManifest.from_toml_str(self._app_toml("inf"))
+
+    def test_inf_app_budget_does_not_raise_raw_overflow_error(self):
+        try:
+            AppManifest.from_toml_str(self._app_toml("inf"))
+        except OverflowError:
+            pytest.fail(
+                "from_toml_str raised a raw OverflowError instead of "
+                "ManifestValidationError for an inf budget"
+            )
+        except ManifestValidationError:
+            pass  # expected
+
+    def test_nan_app_budget_raises_validation_error(self):
+        with pytest.raises(ManifestValidationError, match="monthly"):
+            AppManifest.from_toml_str(self._app_toml("nan"))
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 (LOW, documentation) — loader path-handling security warning
+# ---------------------------------------------------------------------------
+class TestLoaderDocumentsPathTraversalRisk:
+    def test_module_docstring_warns_about_path_containment(self):
+        import kaizen.manifest.loader as loader_mod
+
+        doc = (loader_mod.__doc__ or "").lower()
+        assert "traversal" in doc or "containment" in doc or "allowlist" in doc
+
+    def test_load_manifest_docstring_warns(self):
+        from kaizen.manifest.loader import load_manifest
+
+        doc = (load_manifest.__doc__ or "").lower()
+        assert "containment" in doc or "allowlist" in doc
+
+    def test_load_app_manifest_docstring_warns(self):
+        from kaizen.manifest.loader import load_app_manifest
+
+        doc = (load_app_manifest.__doc__ or "").lower()
+        assert "containment" in doc or "allowlist" in doc
+
+
+# ---------------------------------------------------------------------------
+# Consistency — governance risk_level/suggested_posture raise
+# ManifestValidationError (aligned with the rest of the module), which is a
+# ValueError subclass so existing pytest.raises(ValueError) still passes.
+# ---------------------------------------------------------------------------
+class TestGovernanceErrorConsistency:
+    def test_invalid_risk_level_raises_manifest_validation_error(self):
+        with pytest.raises(ManifestValidationError, match="risk_level"):
+            GovernanceManifest(risk_level="extreme")
+
+    def test_invalid_posture_raises_manifest_validation_error(self):
+        with pytest.raises(ManifestValidationError, match="suggested_posture"):
+            GovernanceManifest(suggested_posture="autonomous")
+
+    def test_governance_errors_are_still_value_errors(self):
+        # Backward-compat: existing callers catching ValueError still work.
+        with pytest.raises(ValueError):
+            GovernanceManifest(risk_level="extreme")
+        with pytest.raises(ValueError):
+            GovernanceManifest(suggested_posture="autonomous")

--- a/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
+++ b/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
@@ -41,6 +41,7 @@ if "kaizen" not in sys.modules:
 
 from kaizen.manifest.agent import AgentManifest  # noqa: E402
 from kaizen.manifest.app import AppManifest  # noqa: E402
+from kaizen.manifest.governance import GovernanceManifest  # noqa: E402
 from kaizen.manifest.errors import (  # noqa: E402
     ManifestError,
     ManifestParseError,
@@ -379,3 +380,12 @@ class TestListFieldTypeConfusionRaises:
             }
         )
         assert manifest.capabilities == ["pii-detection", "classification"]
+
+    def test_governance_data_access_needed_string_raises(self):
+        # Fix #5 extended to GovernanceManifest.from_dict (same char-split class)
+        with pytest.raises(ManifestValidationError, match="data_access_needed"):
+            GovernanceManifest.from_dict({"data_access_needed": "pii"})
+
+    def test_governance_data_access_needed_list_still_works(self):
+        g = GovernanceManifest.from_dict({"data_access_needed": ["pii", "logs"]})
+        assert g.data_access_needed == ["pii", "logs"]

--- a/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
+++ b/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
@@ -389,3 +389,25 @@ class TestListFieldTypeConfusionRaises:
     def test_governance_data_access_needed_list_still_works(self):
         g = GovernanceManifest.from_dict({"data_access_needed": ["pii", "logs"]})
         assert g.data_access_needed == ["pii", "logs"]
+
+    # Fix #5 extended to the TOML-parse + introspection paths — the PRODUCTION
+    # path (deployment.py -> from_toml_str) goes through these, NOT from_dict.
+    def test_from_toml_str_capabilities_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="capabilities"):
+            AgentManifest.from_toml_str(
+                '[agent]\nname="a"\nmodule="m"\nclass_name="C"\n'
+                'capabilities="pii-detection"\n'
+            )
+
+    def test_from_introspection_capabilities_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="capabilities"):
+            AgentManifest.from_introspection(
+                {"name": "a", "module": "m", "class_name": "C", "capabilities": "pii"}
+            )
+
+    def test_app_from_toml_str_agents_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="agents_requested"):
+            AppManifest.from_toml_str(
+                '[application]\nname="x"\n'
+                '[application.agents_requested]\nagents="single"\n'
+            )

--- a/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
+++ b/packages/kailash-kaizen/tests/unit/test_manifest_fixes.py
@@ -1,0 +1,381 @@
+"""
+Regression tests for the 5 review fixes applied when rescuing the
+uncommitted ``kaizen.manifest`` module (issue #1735).
+
+SELF-CONTAINED: mirrors ``tests/unit/test_manifest.py`` — pre-seeds
+``sys.modules["kaizen"]`` with a placeholder so that ``kaizen.manifest.*``
+resolves without triggering the full ``kaizen/__init__.py`` import chain
+(which pulls in ``kailash.nodes.base`` and fails on a pre-existing import
+error unrelated to this module).
+
+Each test class below maps 1:1 to one of the 5 fixes:
+
+    1. ManifestError(Exception) -> ManifestError(ValueError)
+    2. agent.py::_escape_toml_string control-byte escaping
+    3. agent.py/app.py::_parse_toml_bytes array-of-tables guard
+    4. app.py budget parsing non-numeric guard
+    5. agent.py/app.py::from_dict list-field type-confusion guard
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bypass kaizen/__init__.py — seed a minimal placeholder in sys.modules
+# so that ``kaizen.manifest`` can be imported without triggering the full
+# kaizen init chain.
+# ---------------------------------------------------------------------------
+if "kaizen" not in sys.modules:
+    _placeholder = types.ModuleType("kaizen")
+    _placeholder.__path__ = [  # type: ignore[attr-defined]
+        str(
+            __import__("pathlib").Path(__file__).resolve().parents[2] / "src" / "kaizen"
+        )
+    ]
+    _placeholder.__package__ = "kaizen"
+    sys.modules["kaizen"] = _placeholder
+
+from kaizen.manifest.agent import AgentManifest  # noqa: E402
+from kaizen.manifest.app import AppManifest  # noqa: E402
+from kaizen.manifest.errors import (  # noqa: E402
+    ManifestError,
+    ManifestParseError,
+    ManifestValidationError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — ManifestError(Exception) -> ManifestError(ValueError)
+# ---------------------------------------------------------------------------
+class TestManifestErrorIsValueError:
+    """The MCP catalog server's ``_dispatch_tool`` only forwards real error
+    messages to the client for ``(ValueError, KeyError, TypeError)``; every
+    ManifestError subclass MUST be a ValueError so malformed-manifest
+    submissions surface the real validation message instead of an opaque
+    "Internal tool error".
+    """
+
+    def test_manifest_error_is_value_error_subclass(self):
+        assert issubclass(ManifestError, ValueError)
+
+    def test_manifest_parse_error_is_value_error_subclass(self):
+        assert issubclass(ManifestParseError, ValueError)
+
+    def test_manifest_validation_error_is_value_error_subclass(self):
+        assert issubclass(ManifestValidationError, ValueError)
+
+    def test_malformed_manifest_raises_value_error_with_real_message(self):
+        """A malformed manifest through the public parsing API raises a
+        ValueError-subclass exception carrying the module's real
+        validation message (not swallowed/generic)."""
+        bad_toml = "this is [not valid toml"
+        with pytest.raises(ValueError) as exc_info:
+            AgentManifest.from_toml_str(bad_toml)
+        assert isinstance(exc_info.value, ManifestParseError)
+        assert "Invalid TOML" in str(exc_info.value)
+
+    def test_missing_required_field_raises_value_error_with_real_message(self):
+        toml_str = """\
+[agent]
+module = "kaizen.agents.x"
+class_name = "X"
+"""
+        with pytest.raises(ValueError) as exc_info:
+            AgentManifest.from_toml_str(toml_str)
+        assert isinstance(exc_info.value, ManifestValidationError)
+        assert "name" in str(exc_info.value)
+
+    def test_mcp_catalog_server_relays_real_message_not_internal_error(self):
+        """End-to-end through the MCP catalog server's deploy_agent tool:
+        a malformed manifest_toml MUST surface the real ManifestError
+        message via ``_dispatch_tool``'s ``(ValueError, KeyError,
+        TypeError)`` relay path, NOT the sanitized "Internal tool error"
+        fallback reserved for unexpected exceptions.
+        """
+        import json
+        import os
+
+        # Bypass the same broken kailash.nodes.base import chain the MCP
+        # catalog server tests work around.
+        _src_dir = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), os.pardir, "..", "src")
+        )
+        if _src_dir not in sys.path:
+            sys.path.insert(0, _src_dir)
+
+        from kaizen.mcp.catalog_server.server import CatalogMCPServer
+
+        server = CatalogMCPServer()
+        server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {},
+            }
+        )
+        resp = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "deploy_agent",
+                    "arguments": {"manifest_toml": "[agent]\nname = "},
+                },
+            }
+        )
+        result = json.loads(resp["result"]["content"][0]["text"])
+        assert resp["result"]["isError"] is True
+        assert result["error"] != "Internal tool error"
+        assert "Invalid TOML" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — _escape_toml_string control-byte escaping
+# ---------------------------------------------------------------------------
+class TestControlByteRoundTrip:
+    def test_control_byte_in_name_round_trips(self):
+        raw_name = "name\x00with\x01control\x1fbytes"
+        manifest = AgentManifest(
+            name=raw_name, module="kaizen.agents.x", class_name="X"
+        )
+        toml_output = manifest.to_toml()
+        restored = AgentManifest.from_toml_str(toml_output)
+        assert restored.name == raw_name
+
+    def test_control_byte_in_description_round_trips(self):
+        raw_description = "line1\x02line2\x1fline3"
+        manifest = AgentManifest(
+            name="bot",
+            module="kaizen.agents.bot",
+            class_name="Bot",
+            description=raw_description,
+        )
+        toml_output = manifest.to_toml()
+        restored = AgentManifest.from_toml_str(toml_output)
+        assert restored.description == raw_description
+
+    def test_control_byte_in_capability_list_item_round_trips(self):
+        raw_cap = "cap\x07withbell"
+        manifest = AgentManifest(
+            name="bot",
+            module="kaizen.agents.bot",
+            class_name="Bot",
+            capabilities=[raw_cap, "normal-cap"],
+        )
+        toml_output = manifest.to_toml()
+        restored = AgentManifest.from_toml_str(toml_output)
+        assert restored.capabilities == [raw_cap, "normal-cap"]
+
+    def test_escaped_output_contains_no_raw_control_bytes(self):
+        """The serialized TOML string itself MUST NOT contain the raw
+        control byte (only the escaped \\uXXXX form) — otherwise the
+        output is not valid TOML in the first place."""
+        manifest = AgentManifest(name="name\x00null", module="m", class_name="C")
+        toml_output = manifest.to_toml()
+        assert "\x00" not in toml_output
+        assert "\\u0000" in toml_output
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — array-of-tables ([[agent]] / [[application]]) guard
+# ---------------------------------------------------------------------------
+class TestArrayOfTablesRaisesParseError:
+    def test_agent_array_of_tables_raises_manifest_parse_error(self):
+        toml_str = """\
+[[agent]]
+name = "bot-a"
+module = "kaizen.agents.a"
+class_name = "A"
+
+[[agent]]
+name = "bot-b"
+module = "kaizen.agents.b"
+class_name = "B"
+"""
+        with pytest.raises(ManifestParseError):
+            AgentManifest.from_toml_str(toml_str)
+
+    def test_agent_array_of_tables_does_not_raise_attribute_error(self):
+        toml_str = """\
+[[agent]]
+name = "bot-a"
+module = "kaizen.agents.a"
+class_name = "A"
+"""
+        try:
+            AgentManifest.from_toml_str(toml_str)
+        except AttributeError:
+            pytest.fail(
+                "from_toml_str raised a raw AttributeError instead of "
+                "ManifestParseError for [[agent]] array-of-tables input"
+            )
+        except ManifestParseError:
+            pass  # expected
+
+    def test_application_array_of_tables_raises_manifest_parse_error(self):
+        toml_str = """\
+[[application]]
+name = "app-a"
+owner = "alex@example.com"
+"""
+        with pytest.raises(ManifestParseError):
+            AppManifest.from_toml_str(toml_str)
+
+    def test_application_array_of_tables_does_not_raise_attribute_error(self):
+        toml_str = """\
+[[application]]
+name = "app-a"
+owner = "alex@example.com"
+"""
+        try:
+            AppManifest.from_toml_str(toml_str)
+        except AttributeError:
+            pytest.fail(
+                "from_toml_str raised a raw AttributeError instead of "
+                "ManifestParseError for [[application]] array-of-tables input"
+            )
+        except ManifestParseError:
+            pass  # expected
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — non-numeric budget raises ManifestValidationError
+# ---------------------------------------------------------------------------
+class TestNonNumericBudgetRaises:
+    def test_non_numeric_budget_raises_manifest_validation_error(self):
+        toml_str = """\
+[application]
+name = "budget-test"
+owner = "bob@example.com"
+
+[application.budget]
+monthly = "free"
+"""
+        with pytest.raises(ManifestValidationError, match="monthly"):
+            AppManifest.from_toml_str(toml_str)
+
+    def test_non_numeric_budget_does_not_raise_raw_invalid_operation(self):
+        toml_str = """\
+[application]
+name = "budget-test"
+owner = "bob@example.com"
+
+[application.budget]
+monthly = "free"
+"""
+        import decimal
+
+        try:
+            AppManifest.from_toml_str(toml_str)
+        except decimal.InvalidOperation:
+            pytest.fail(
+                "from_toml_str raised a raw decimal.InvalidOperation "
+                "instead of ManifestValidationError for non-numeric budget"
+            )
+        except ManifestValidationError:
+            pass  # expected
+
+    def test_numeric_budget_still_works(self):
+        """Regression guard: the fix must not break the happy path."""
+        toml_str = """\
+[application]
+name = "budget-test"
+owner = "bob@example.com"
+
+[application.budget]
+monthly = 250
+"""
+        manifest = AppManifest.from_toml_str(toml_str)
+        assert manifest.budget_monthly_microdollars == 250_000_000
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — should-be-list fields raise on str (type-confusion), not
+# silently char-split
+# ---------------------------------------------------------------------------
+class TestListFieldTypeConfusionRaises:
+    def test_capabilities_string_raises_not_char_split(self):
+        with pytest.raises(ManifestValidationError, match="capabilities"):
+            AgentManifest.from_dict(
+                {
+                    "name": "bot",
+                    "module": "kaizen.agents.bot",
+                    "class_name": "Bot",
+                    "capabilities": "pii",
+                }
+            )
+
+    def test_tools_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="tools"):
+            AgentManifest.from_dict(
+                {
+                    "name": "bot",
+                    "module": "kaizen.agents.bot",
+                    "class_name": "Bot",
+                    "tools": "scanner",
+                }
+            )
+
+    def test_supported_models_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="supported_models"):
+            AgentManifest.from_dict(
+                {
+                    "name": "bot",
+                    "module": "kaizen.agents.bot",
+                    "class_name": "Bot",
+                    "supported_models": "gpt-4",
+                }
+            )
+
+    def test_agents_requested_string_raises(self):
+        with pytest.raises(ManifestValidationError, match="agents_requested"):
+            AppManifest.from_dict(
+                {
+                    "name": "app",
+                    "owner": "bob@example.com",
+                    "agents_requested": "doc-classifier",
+                }
+            )
+
+    def test_capabilities_dict_raises(self):
+        """Non-list, non-string types are also rejected (not just str)."""
+        with pytest.raises(ManifestValidationError, match="capabilities"):
+            AgentManifest.from_dict(
+                {
+                    "name": "bot",
+                    "module": "kaizen.agents.bot",
+                    "class_name": "Bot",
+                    "capabilities": {"pii": True},
+                }
+            )
+
+    def test_capabilities_list_still_works(self):
+        """Regression guard: the fix must not break the happy path."""
+        manifest = AgentManifest.from_dict(
+            {
+                "name": "bot",
+                "module": "kaizen.agents.bot",
+                "class_name": "Bot",
+                "capabilities": ["pii-detection", "classification"],
+            }
+        )
+        assert manifest.capabilities == ["pii-detection", "classification"]
+
+    def test_capabilities_tuple_coerced_to_list(self):
+        """A tuple is a legitimate list-like input and MUST still coerce
+        (not raise) — only str/bytes/non-sequence types are rejected."""
+        manifest = AgentManifest.from_dict(
+            {
+                "name": "bot",
+                "module": "kaizen.agents.bot",
+                "class_name": "Bot",
+                "capabilities": ("pii-detection", "classification"),
+            }
+        )
+        assert manifest.capabilities == ["pii-detection", "classification"]


### PR DESCRIPTION
## What
Rescues the `kaizen.manifest` module (`AgentManifest`/`AppManifest`/`GovernanceManifest` + TOML loader/errors, 732 LOC) that existed on disk for ~4 months but was **never committed** — hidden because the repo-root `.gitignore` `MANIFEST` pattern matches the `kaizen/manifest/` dir on case-insensitive filesystems (macOS APFS). It is the sole dependency of the MCP `deploy_agent` catalog tool; its absence is the tracked `test_catalog_server.py` collection failure + CI exclusion this issue reports.

## Why now
Leaving it uncommitted is actively worse (data-loss risk + a tracked red test). Reviewed → COMMIT-WITH-FIXES.

## Fixes hardened before commit (6)
1. **HIGH:** `ManifestError(Exception)` → `ManifestError(ValueError)` — the MCP server only forwards real messages for `(ValueError,KeyError,TypeError)`, so malformed manifests returned opaque "Internal tool error"; now they relay the real validation message.
2. TOML control-byte escaping (`_escape_toml_string`) — full C0 coverage → `to_toml()` round-trips.
3. `[[agent]]`/`[[application]]` array-of-tables → `ManifestParseError` not raw `AttributeError`.
4. Non-numeric budget → `ManifestValidationError` not raw `decimal.InvalidOperation`.
5. `from_dict` silent str→char-split → raises `ManifestValidationError` (via shared `_coerce.coerce_list_field`), across agent/app **and** governance from_dict.
6. `.gitignore` `MANIFEST` → `/MANIFEST` (root sdist file only; module un-ignored, root MANIFEST still ignored).

## Tests / CI
112 passed (42 existing + 24 fix-tests + 2 governance + 44 catalog-server). Re-gated `test_catalog_server.py` (dropped the `--ignore`) AND added the top-level `test_manifest{,_fixes}.py` to the CI invocation (they were subdir-gated only).

## Related issues
Fixes #1735.