### PR TITLE
feat(dataflow): per-connection credential callback for token-based DB auth (#1737)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
@@ -10,10 +10,10 @@ import traceback
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from ..core.credential_provider import build_asyncpg_credential_connect
 from ..core.exceptions import (  # Issue #1552: redact driver-error VALUES
     sanitize_db_error,
 )
-from ..exceptions import DataFlowConnectionError
 from .base import DatabaseAdapter
 from .dialect import DialectManager
 from .exceptions import AdapterError, ConnectionError, QueryError, TransactionError
@@ -61,57 +61,17 @@ class PostgreSQLAdapter(DatabaseAdapter):
     def _make_credential_provider_connect(self, asyncpg_module: Any) -> Callable:
         """Build an asyncpg ``connect`` callable that mints a fresh credential.
 
-        asyncpg's ``Pool`` invokes ``self._connect(*connect_args, **connect_kwargs)``
-        (defaulting to ``asyncpg.connect``) every time it needs a NEW physical
-        connection — on initial pool fill, on recycle after
-        ``max_inactive_connection_lifetime``, on overflow up to ``max_size``,
-        and on reconnect after a holder's connection dies. Overriding ``connect``
-        (rather than baking a static password into ``connect_kwargs`` once) is
-        the asyncpg-native equivalent of SQLAlchemy's ``do_connect`` event — the
-        callback fires per physical connection, satisfying #1737's "EVERY
-        physical connection" acceptance criterion with a stricter guarantee
-        than the interval-based refresh-ahead approach (zero staleness window).
-
-        Fail-closed: a raising (or non-str-returning) ``credential_provider``
-        raises ``DataFlowConnectionError`` here — it NEVER falls back to the
-        static ``password`` captured in ``connect_kwargs`` at pool-construction
-        time. The minted token is set as the driver PARAM (``connect_kwargs
-        ["password"]``), never re-encoded into a DSN/URL, so tokens containing
-        ``&``, ``=``, ``/``, ``%`` (AWS IAM tokens) need no percent-encoding.
-        The token is NEVER logged (not the value, not its length, not a
-        prefix) and is held locally only for the duration of the connect call.
+        Delegates to the shared
+        :func:`dataflow.core.credential_provider.build_asyncpg_credential_connect`
+        helper — see its docstring for the full per-physical-connection /
+        fail-closed / no-secrets-logged contract. Kept as a thin adapter
+        method (rather than inlining the call at the ``create_connection_pool``
+        site) so existing callers/tests referencing
+        ``adapter._make_credential_provider_connect(...)`` keep working.
         """
-        provider = self.credential_provider
-
-        async def _connect_with_fresh_credential(*args: Any, **connect_kwargs: Any):
-            try:
-                token = provider()
-            except Exception as exc:
-                # Do NOT interpolate str(exc) — a provider's exception message
-                # could echo back token material. Only the exception's type
-                # name is safe to surface.
-                raise DataFlowConnectionError(
-                    "credential_provider() raised while establishing a new "
-                    f"PostgreSQL physical connection ({type(exc).__name__}); "
-                    "refusing to fall back to a stale or absent credential"
-                ) from exc
-
-            if not isinstance(token, str) or not token:
-                raise DataFlowConnectionError(
-                    "credential_provider() must return a non-empty str; got "
-                    f"{type(token).__name__}"
-                )
-
-            connect_kwargs["password"] = token
-            try:
-                return await asyncpg_module.connect(*args, **connect_kwargs)
-            finally:
-                # Hold the live secret as briefly as possible: drop the local
-                # binding as soon as it has been handed to the driver.
-                token = None
-                connect_kwargs["password"] = None
-
-        return _connect_with_fresh_credential
+        return build_asyncpg_credential_connect(
+            self.credential_provider, asyncpg_module, context="PostgreSQL"
+        )
 
     async def connect(self) -> None:
         """Establish PostgreSQL connection (legacy method - use create_connection_pool)."""
@@ -190,11 +150,26 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 "asyncpg is required for PostgreSQL support. Install with: pip install asyncpg"
             )
         except Exception as e:
+            # Issue #1737 (defense-in-depth): route through the same
+            # sanitize_db_error() every other exception-handling method in
+            # this file already uses (execute_query/execute_insert/
+            # execute_bulk_insert/execute_transaction). Empirically verified
+            # (asyncpg 0.31, InvalidPasswordError + unreachable-host +
+            # DSN-string forms) that asyncpg's connect-failure exceptions do
+            # NOT embed the password/token for this driver — but this is the
+            # ONE exception path in the file that skipped the shared
+            # sanitizer, and a raising credential_provider surfaces through
+            # here on the initial pool-fill (see
+            # _make_credential_provider_connect / build_asyncpg_credential_connect,
+            # which already strips the provider's own exception text —
+            # sanitize_db_error is additional defense-in-depth, not the
+            # primary guard).
+            safe_error = sanitize_db_error(str(e))
             logger.error(
                 "postgresql.failed_to_create_postgresql_connection_pool",
-                extra={"error": str(e)},
+                extra={"error": safe_error},
             )
-            raise ConnectionError(f"Connection failed: {e}")
+            raise ConnectionError(f"Connection failed: {safe_error}")
 
     async def close_connection_pool(self) -> None:
         """Close PostgreSQL connection pool."""

--- a/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/postgresql.py
@@ -8,11 +8,12 @@ import logging
 import sys
 import traceback
 import warnings
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..core.exceptions import (  # Issue #1552: redact driver-error VALUES
     sanitize_db_error,
 )
+from ..exceptions import DataFlowConnectionError
 from .base import DatabaseAdapter
 from .dialect import DialectManager
 from .exceptions import AdapterError, ConnectionError, QueryError, TransactionError
@@ -46,9 +47,71 @@ class PostgreSQLAdapter(DatabaseAdapter):
         self.ssl_mode = self.query_params.get("sslmode", "prefer")
         self.application_name = kwargs.get("application_name", "dataflow")
 
+        # Issue #1737: optional per-physical-connection credential callback
+        # (Azure AD / AWS IAM token-based auth). See DatabaseConfig.credential_provider
+        # for the full contract. Absent (None) — behavior is unchanged.
+        self.credential_provider: Optional[Callable[[], str]] = kwargs.get(
+            "credential_provider"
+        )
+
         # Use actual port or default
         if self.port is None:
             self.port = self.default_port
+
+    def _make_credential_provider_connect(self, asyncpg_module: Any) -> Callable:
+        """Build an asyncpg ``connect`` callable that mints a fresh credential.
+
+        asyncpg's ``Pool`` invokes ``self._connect(*connect_args, **connect_kwargs)``
+        (defaulting to ``asyncpg.connect``) every time it needs a NEW physical
+        connection — on initial pool fill, on recycle after
+        ``max_inactive_connection_lifetime``, on overflow up to ``max_size``,
+        and on reconnect after a holder's connection dies. Overriding ``connect``
+        (rather than baking a static password into ``connect_kwargs`` once) is
+        the asyncpg-native equivalent of SQLAlchemy's ``do_connect`` event — the
+        callback fires per physical connection, satisfying #1737's "EVERY
+        physical connection" acceptance criterion with a stricter guarantee
+        than the interval-based refresh-ahead approach (zero staleness window).
+
+        Fail-closed: a raising (or non-str-returning) ``credential_provider``
+        raises ``DataFlowConnectionError`` here — it NEVER falls back to the
+        static ``password`` captured in ``connect_kwargs`` at pool-construction
+        time. The minted token is set as the driver PARAM (``connect_kwargs
+        ["password"]``), never re-encoded into a DSN/URL, so tokens containing
+        ``&``, ``=``, ``/``, ``%`` (AWS IAM tokens) need no percent-encoding.
+        The token is NEVER logged (not the value, not its length, not a
+        prefix) and is held locally only for the duration of the connect call.
+        """
+        provider = self.credential_provider
+
+        async def _connect_with_fresh_credential(*args: Any, **connect_kwargs: Any):
+            try:
+                token = provider()
+            except Exception as exc:
+                # Do NOT interpolate str(exc) — a provider's exception message
+                # could echo back token material. Only the exception's type
+                # name is safe to surface.
+                raise DataFlowConnectionError(
+                    "credential_provider() raised while establishing a new "
+                    f"PostgreSQL physical connection ({type(exc).__name__}); "
+                    "refusing to fall back to a stale or absent credential"
+                ) from exc
+
+            if not isinstance(token, str) or not token:
+                raise DataFlowConnectionError(
+                    "credential_provider() must return a non-empty str; got "
+                    f"{type(token).__name__}"
+                )
+
+            connect_kwargs["password"] = token
+            try:
+                return await asyncpg_module.connect(*args, **connect_kwargs)
+            finally:
+                # Hold the live secret as briefly as possible: drop the local
+                # binding as soon as it has been handed to the driver.
+                token = None
+                connect_kwargs["password"] = None
+
+        return _connect_with_fresh_credential
 
     async def connect(self) -> None:
         """Establish PostgreSQL connection (legacy method - use create_connection_pool)."""
@@ -82,6 +145,17 @@ class PostgreSQLAdapter(DatabaseAdapter):
 
             # Create connection pool with reset callback
             params["reset"] = reset_connection
+
+            # Issue #1737: when a credential_provider is configured, override
+            # asyncpg's per-connection ``connect`` hook so every physical
+            # connection mints a fresh credential (see
+            # _make_credential_provider_connect docstring). Absent
+            # credential_provider, ``params["password"]`` (the static value
+            # already set by get_connection_parameters()) is used unchanged —
+            # behavior is UNCHANGED from before this feature existed.
+            if self.credential_provider is not None:
+                params["connect"] = self._make_credential_provider_connect(asyncpg)
+
             self.connection_pool = await asyncpg.create_pool(**params)
             self.is_connected = True
 

--- a/packages/kailash-dataflow/src/dataflow/core/config.py
+++ b/packages/kailash-dataflow/src/dataflow/core/config.py
@@ -8,10 +8,11 @@ Automatically detects environment and configures optimal settings.
 import logging
 import multiprocessing
 import os
-from dataclasses import asdict, dataclass, field
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from .models import Environment
 
@@ -312,6 +313,24 @@ class DatabaseConfig:
     username: Optional[str] = None
     password: Optional[str] = None
 
+    # Issue #1737: per-physical-connection credential callback for
+    # token-based DB auth (Azure AD / AWS IAM). Tokens expire (~15min AWS
+    # IAM, ~60-90min Azure AD) and the SQLAlchemy-era design captured a
+    # STATIC connection string once at pool construction — connections
+    # opened after the token expires authenticate with a STALE token and
+    # fail. When set, ``PostgreSQLAdapter.create_connection_pool()`` wires
+    # this callable into asyncpg's per-connection ``connect`` hook so a
+    # FRESH credential is minted for EVERY physical connection (initial,
+    # recycled, overflow, reconnect) — never the driver-param URL, so no
+    # percent-encoding round-trip on tokens containing ``&=/%``. Absent
+    # (None), behavior is UNCHANGED — the static ``password`` field above
+    # is used as before. A raising callback fails closed (raises a typed
+    # ``DataFlowConnectionError``); it NEVER falls back to a stale token.
+    # The returned value is a live secret — it MUST NEVER be logged (not
+    # the value, not its length, not a prefix) and is held only as long as
+    # it takes to hand it to asyncpg's connect call.
+    credential_provider: Optional[Callable[[], str]] = None
+
     # Connection pool settings
     pool_size: Optional[int] = None
     pool_max_overflow: Optional[int] = None
@@ -342,6 +361,31 @@ class DatabaseConfig:
             self.max_overflow = self.pool_max_overflow
         elif self.max_overflow and not self.pool_max_overflow:
             self.pool_max_overflow = self.max_overflow
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "DatabaseConfig":
+        """Deep-copy every field EXCEPT ``credential_provider``, which is
+        carried over by reference.
+
+        Issue #1737: ``credential_provider`` is a live external callable —
+        real-world Azure AD / AWS IAM token providers commonly close over
+        non-deepcopy-safe resources (a boto3 client, a threading.Lock, an
+        Azure credential cache). ``DataFlow.__init__``'s ``config=`` branch
+        calls ``deepcopy(config)`` on the caller-supplied ``DataFlowConfig``;
+        without this override, that call raises ``TypeError: cannot pickle
+        '_thread.lock' object`` (or silently duplicates internal state) the
+        moment a real credential_provider is configured — making the
+        feature unusable for its own acceptance criteria. Every other field
+        keeps normal deep-copy isolation.
+        """
+        cls = self.__class__
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for f in fields(self):
+            if f.name == "credential_provider":
+                setattr(new, f.name, self.credential_provider)
+            else:
+                setattr(new, f.name, deepcopy(getattr(self, f.name), memo))
+        return new
 
     def get_connection_url(self, environment: Environment) -> str:
         """Generate connection URL based on configuration and environment.
@@ -650,6 +694,8 @@ class DataFlowConfig:
                 db_config_kwargs["pool_recycle"] = kwargs["pool_recycle"]
             if "echo" in kwargs:
                 db_config_kwargs["echo"] = kwargs["echo"]
+            if "credential_provider" in kwargs:
+                db_config_kwargs["credential_provider"] = kwargs["credential_provider"]
             self.database = DatabaseConfig(**db_config_kwargs)
 
         # Handle monitoring configuration

--- a/packages/kailash-dataflow/src/dataflow/core/credential_provider.py
+++ b/packages/kailash-dataflow/src/dataflow/core/credential_provider.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared per-physical-connection credential-callback wrapper for asyncpg pools.
+
+Issue #1737: token-based DB auth (Azure AD / AWS IAM) requires a FRESH
+credential to be minted for EVERY physical connection an asyncpg pool opens
+(initial fill, recycle, overflow, reconnect) — not the connection string
+captured once at pool-construction time. Every DataFlow-package asyncpg pool
+that wants this behavior (``dataflow.adapters.postgresql.PostgreSQLAdapter``,
+``dataflow.core.pool_lightweight.LightweightPool``,
+``dataflow.core.event_stores.postgresql.PostgreSQLEventStore``) builds its
+``connect=`` override through :func:`build_asyncpg_credential_connect` so the
+fail-closed contract and no-secret-in-logs guarantee live in exactly one
+place.
+
+See ``DatabaseConfig.credential_provider`` (``dataflow/core/config.py``) for
+the full field contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..exceptions import DataFlowConnectionError
+
+__all__ = ["build_asyncpg_credential_connect"]
+
+
+def build_asyncpg_credential_connect(
+    credential_provider: Callable[[], str],
+    asyncpg_module: Any,
+    *,
+    context: str = "PostgreSQL",
+) -> Callable:
+    """Build an asyncpg ``connect`` callable that mints a fresh credential.
+
+    asyncpg's ``Pool`` invokes ``self._connect(*connect_args, **connect_kwargs)``
+    (defaulting to ``asyncpg.connect``) every time it needs a NEW physical
+    connection — on initial pool fill, on recycle after
+    ``max_inactive_connection_lifetime``, on overflow up to ``max_size``,
+    and on reconnect after a holder's connection dies (including after
+    ``Pool.expire_connections()``). Overriding ``connect`` (rather than
+    baking a static password into ``connect_kwargs`` once) is the
+    asyncpg-native equivalent of SQLAlchemy's ``do_connect`` event — the
+    callback fires per physical connection, satisfying #1737's "EVERY
+    physical connection" acceptance criterion with a stricter guarantee
+    than an interval-based refresh-ahead approach (zero staleness window).
+
+    Fail-closed: a raising (or non-str-returning) ``credential_provider``
+    raises ``DataFlowConnectionError`` here — it NEVER falls back to the
+    static ``password`` captured in ``connect_kwargs`` at pool-construction
+    time. The minted token is set as the driver PARAM (``connect_kwargs
+    ["password"]``), never re-encoded into a DSN/URL, so tokens containing
+    ``&``, ``=``, ``/``, ``%`` (AWS IAM tokens) need no percent-encoding.
+    The token is NEVER logged (not the value, not its length, not a
+    prefix) and is held locally only for the duration of the connect call.
+
+    Args:
+        credential_provider: Zero-arg callable returning a fresh password/
+            token. MUST return a non-empty ``str``.
+        asyncpg_module: The ``asyncpg`` module (or a Protocol-satisfying
+            stand-in for it in tests) whose ``connect()`` is delegated to.
+        context: Human-readable pool identity used ONLY in the fail-closed
+            error message (e.g. ``"PostgreSQL"``,
+            ``"PostgreSQL lightweight pool"``,
+            ``"PostgreSQL event store"``) — never includes secret material.
+    """
+    provider = credential_provider
+
+    async def _connect_with_fresh_credential(*args: Any, **connect_kwargs: Any):
+        try:
+            token = provider()
+        except Exception as exc:
+            # Do NOT interpolate str(exc) — a provider's exception message
+            # could echo back token material. Only the exception's type
+            # name is safe to surface.
+            raise DataFlowConnectionError(
+                f"credential_provider() raised while establishing a new "
+                f"{context} physical connection ({type(exc).__name__}); "
+                "refusing to fall back to a stale or absent credential"
+            ) from exc
+
+        if not isinstance(token, str) or not token:
+            raise DataFlowConnectionError(
+                "credential_provider() must return a non-empty str; got "
+                f"{type(token).__name__}"
+            )
+
+        connect_kwargs["password"] = token
+        try:
+            return await asyncpg_module.connect(*args, **connect_kwargs)
+        finally:
+            # Hold the live secret as briefly as possible: drop the local
+            # binding as soon as it has been handed to the driver.
+            token = None
+            connect_kwargs["password"] = None
+
+    return _connect_with_fresh_credential

--- a/packages/kailash-dataflow/src/dataflow/core/credential_provider.py
+++ b/packages/kailash-dataflow/src/dataflow/core/credential_provider.py
@@ -75,12 +75,19 @@ def build_asyncpg_credential_connect(
         except Exception as exc:
             # Do NOT interpolate str(exc) — a provider's exception message
             # could echo back token material. Only the exception's type
-            # name is safe to surface.
+            # name is safe to surface. Use ``from None`` (NOT ``from exc``):
+            # ``from exc`` would re-attach the token-bearing provider
+            # exception as ``__cause__``, so it renders in full under any
+            # upstream ``logger.exception(...)`` / traceback — defeating the
+            # str(exc)-stripping above. ``from None`` severs the chain at the
+            # single shared source, covering every consuming pool
+            # (adapter / lightweight / event-store) at once
+            # (security.md "No secrets in logs").
             raise DataFlowConnectionError(
                 f"credential_provider() raised while establishing a new "
                 f"{context} physical connection ({type(exc).__name__}); "
                 "refusing to fall back to a stale or absent credential"
-            ) from exc
+            ) from None
 
         if not isinstance(token, str) or not token:
             raise DataFlowConnectionError(

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -171,6 +171,11 @@ class DataFlow(DataFlowEventMixin):
         # than silently no-op'ing into a cross-tenant leak.
         tenant_isolation_strategy: Optional[str] = None,
         encryption_key: Optional[str] = None,
+        # Issue #1737: per-physical-connection credential callback for
+        # token-based DB auth (Azure AD / AWS IAM). See
+        # DatabaseConfig.credential_provider for the full contract. Absent
+        # (None) — behavior is unchanged (static connection-string password).
+        credential_provider: Optional[Callable[[], str]] = None,
         audit_logging: bool = False,
         cache_enabled: Optional[
             bool
@@ -238,6 +243,11 @@ class DataFlow(DataFlowEventMixin):
             echo: Enable SQL logging
             multi_tenant: Enable multi-tenant mode
             encryption_key: Encryption key for sensitive data
+            credential_provider: Optional callable returning a fresh DB
+                password/token on every physical connection (Azure AD / AWS
+                IAM token-based auth, issue #1737). Absent (None) — behavior
+                is unchanged; the static password embedded in database_url
+                is used as before. See DatabaseConfig.credential_provider.
             audit_logging: Enable audit logging
             cache_enabled: Enable query caching
             cache_ttl: Cache time-to-live
@@ -308,6 +318,11 @@ class DataFlow(DataFlowEventMixin):
                 self.config.pool_recycle = pool_recycle
             if echo is not None:
                 self.config.echo = echo
+            # Issue #1737: credential_provider has no top-level
+            # DataFlowConfig convenience property (mirrors how `password`
+            # itself is only reachable via config.database) — set directly.
+            if credential_provider is not None:
+                self.config.database.credential_provider = credential_provider
             if monitoring is not None:
                 self.config.monitoring = monitoring
             if cache_enabled is not None:
@@ -364,6 +379,12 @@ class DataFlow(DataFlowEventMixin):
                     self.config.security.tenant_isolation_strategy = (
                         tenant_isolation_strategy
                     )
+                # Issue #1737: same treatment for credential_provider — it is
+                # not in the zero-config-mode detection list above (a caller
+                # passing ONLY credential_provider, with database_url=None,
+                # would otherwise silently fall into from_env() and lose it).
+                if credential_provider is not None:
+                    self.config.database.credential_provider = credential_provider
             else:
                 # Create structured config from individual parameters
                 database_config = DatabaseConfig(
@@ -372,6 +393,8 @@ class DataFlow(DataFlowEventMixin):
                     max_overflow=pool_max_overflow,  # None flows through to get_max_overflow()
                     pool_recycle=pool_recycle,
                     echo=echo,
+                    # Issue #1737: per-physical-connection credential callback.
+                    credential_provider=credential_provider,
                 )
 
                 monitoring_config = MonitoringConfig(
@@ -5046,7 +5069,13 @@ class DataFlow(DataFlowEventMixin):
         # "Unclosed connection" at GC, the #1572 leak class).
         from ..adapters.postgresql import PostgreSQLAdapter
 
-        adapter = PostgreSQLAdapter(database_url)
+        # Issue #1737: thread the configured credential_provider through so
+        # schema-discovery connections also mint fresh tokens rather than
+        # reusing a static (possibly stale) password.
+        adapter = PostgreSQLAdapter(
+            database_url,
+            credential_provider=self.config.database.credential_provider,
+        )
         try:
             await adapter.create_connection_pool()
 

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -1400,7 +1400,14 @@ class DataFlow(DataFlowEventMixin):
                     try:
                         from dataflow.core.pool_lightweight import LightweightPool
 
-                        self._lightweight_pool = LightweightPool(db_url)
+                        # Issue #1737: thread the configured credential_provider
+                        # through — the lightweight pool runs continuously for
+                        # health checks and hits the same token-expiry failure
+                        # mode as the main pool.
+                        self._lightweight_pool = LightweightPool(
+                            db_url,
+                            credential_provider=self.config.database.credential_provider,
+                        )
                     except Exception:
                         logger.debug(
                             "Lightweight pool creation failed (non-fatal)",
@@ -1875,7 +1882,14 @@ class DataFlow(DataFlowEventMixin):
             ):
                 from dataflow.core.event_stores.postgresql import PostgreSQLEventStore
 
-                backend = PostgreSQLEventStore(database_url=database_url)
+                # Issue #1737: thread the configured credential_provider
+                # through — the audit-trail pool is long-lived for the
+                # app's runtime and hits the same token-expiry failure mode
+                # as the main pool.
+                backend = PostgreSQLEventStore(
+                    database_url=database_url,
+                    credential_provider=self.config.database.credential_provider,
+                )
             else:
                 # Default to SQLite for sqlite URLs and :memory:
                 from dataflow.core.event_stores.sqlite import SQLiteEventStore

--- a/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
@@ -13,7 +13,7 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from dataflow.core.audit_events import DataFlowAuditEvent, DataFlowAuditEventType
 from dataflow.core.event_store import EventStoreBackend
@@ -35,6 +35,12 @@ class PostgreSQLEventStore(EventStoreBackend):
             (e.g., ``postgresql://user:pass@host/dbname``).
         pool_min_size: Minimum pool connections (default 2).
         pool_max_size: Maximum pool connections (default 10).
+        credential_provider: Optional per-physical-connection credential
+            callback (issue #1737 — Azure AD / AWS IAM token-based auth).
+            Mirrors ``DatabaseConfig.credential_provider``; the audit-trail
+            pool is long-lived for the app's runtime, so it hits the same
+            token-expiry failure mode as the main pool. Absent (None) —
+            behavior is unchanged.
     """
 
     def __init__(
@@ -42,10 +48,12 @@ class PostgreSQLEventStore(EventStoreBackend):
         database_url: str,
         pool_min_size: int = 2,
         pool_max_size: int = 10,
+        credential_provider: Optional[Callable[[], str]] = None,
     ) -> None:
         self._database_url = database_url
         self._pool_min_size = pool_min_size
         self._pool_max_size = pool_max_size
+        self.credential_provider = credential_provider
         self._pool: Any = None  # asyncpg.Pool
 
     async def initialize(self) -> None:
@@ -58,11 +66,23 @@ class PostgreSQLEventStore(EventStoreBackend):
                 "Install it with: pip install asyncpg"
             ) from exc
 
-        self._pool = await asyncpg.create_pool(
-            self._database_url,
-            min_size=self._pool_min_size,
-            max_size=self._pool_max_size,
-        )
+        create_pool_kwargs: Dict[str, Any] = {
+            "min_size": self._pool_min_size,
+            "max_size": self._pool_max_size,
+        }
+        # Issue #1737: same per-physical-connection credential callback as
+        # the main PostgreSQLAdapter pool — see
+        # dataflow.core.credential_provider for the shared contract.
+        if self.credential_provider is not None:
+            from dataflow.core.credential_provider import (
+                build_asyncpg_credential_connect,
+            )
+
+            create_pool_kwargs["connect"] = build_asyncpg_credential_connect(
+                self.credential_provider, asyncpg, context="PostgreSQL event store"
+            )
+
+        self._pool = await asyncpg.create_pool(self._database_url, **create_pool_kwargs)
 
         async with self._pool.acquire() as conn:
             await conn.execute(

--- a/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from dataflow.core.audit_events import DataFlowAuditEvent, DataFlowAuditEventType
 from dataflow.core.event_store import EventStoreBackend
+from dataflow.core.exceptions import sanitize_db_error
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,28 @@ class PostgreSQLEventStore(EventStoreBackend):
                 self.credential_provider, asyncpg, context="PostgreSQL event store"
             )
 
-        self._pool = await asyncpg.create_pool(self._database_url, **create_pool_kwargs)
+        # Issue #1737 (defense-in-depth): mirror the main PostgreSQLAdapter's
+        # create_pool exception handling — asyncpg connect-failure exceptions
+        # can embed the credentialed ``self._database_url`` (DSN with password),
+        # and a raising credential_provider surfaces here on the initial
+        # pool-fill. Route through the shared sanitize_db_error() (the same
+        # barrier adapters/postgresql.py uses) so no credential material reaches
+        # the log line or the raised ConnectionError (security.md "No secrets
+        # in logs"). build_asyncpg_credential_connect already strips the
+        # provider's own exception text; this is additional defense-in-depth.
+        try:
+            self._pool = await asyncpg.create_pool(
+                self._database_url, **create_pool_kwargs
+            )
+        except Exception as exc:
+            safe_error = sanitize_db_error(str(exc))
+            logger.error(
+                "postgresql_event_store.failed_to_create_pool",
+                extra={"error": safe_error},
+            )
+            raise ConnectionError(
+                f"PostgreSQL event store connection failed: {safe_error}"
+            )
 
         async with self._pool.acquire() as conn:
             await conn.execute(

--- a/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
+++ b/packages/kailash-dataflow/src/dataflow/core/event_stores/postgresql.py
@@ -107,8 +107,7 @@ class PostgreSQLEventStore(EventStoreBackend):
             )
 
         async with self._pool.acquire() as conn:
-            await conn.execute(
-                """
+            await conn.execute("""
                 CREATE TABLE IF NOT EXISTS audit_events (
                     id TEXT PRIMARY KEY,
                     event_type TEXT NOT NULL,
@@ -119,28 +118,21 @@ class PostgreSQLEventStore(EventStoreBackend):
                     changes JSONB DEFAULT '{}'::jsonb,
                     metadata JSONB DEFAULT '{}'::jsonb
                 )
-                """
-            )
+                """)
 
             # Create indexes for common query patterns
-            await conn.execute(
-                """
+            await conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_audit_entity
                 ON audit_events (entity_type, entity_id)
-                """
-            )
-            await conn.execute(
-                """
+                """)
+            await conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_audit_timestamp
                 ON audit_events (timestamp)
-                """
-            )
-            await conn.execute(
-                """
+                """)
+            await conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_audit_user
                 ON audit_events (user_id)
-                """
-            )
+                """)
 
         logger.info("PostgreSQL audit event store initialized")
 

--- a/packages/kailash-dataflow/src/dataflow/core/exceptions.py
+++ b/packages/kailash-dataflow/src/dataflow/core/exceptions.py
@@ -648,6 +648,17 @@ _PG_VALUE_OUT_OF_RANGE_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# _URL_CREDENTIALS_RE (issue #1737): redact the PASSWORD in a connection-string
+# userinfo (``scheme://user:password@host``). A driver connect-failure exception
+# CAN embed the credentialed DSN; every create_pool failure path routes through
+# sanitize_db_error() calling it "defense-in-depth" against exactly that leak, so
+# the sanitizer MUST actually cover it (the other regexes only redact constraint
+# VALUES, not URL credentials). Username class excludes ``:`` (anchors to the
+# user:pass separator) and ``@`` (no overreach when there is no password); the
+# password class ``[^@\s]*`` captures any password up to the ``@`` host delimiter,
+# including embedded colons. Password never spans whitespace/newline.
+_URL_CREDENTIALS_RE = re.compile(r"(://[^:/?#\s@]+:)[^@\s]*(@)")
+
 
 def sanitize_db_error(msg: str) -> str:
     """Redact column VALUES from a DB driver error message.
@@ -669,6 +680,11 @@ def sanitize_db_error(msg: str) -> str:
     """
     if not isinstance(msg, str):
         return "<non-string error>"
+    # Issue #1737: redact connection-string credentials FIRST so a driver
+    # connect-failure exception that embeds the credentialed DSN cannot leak
+    # the password into a log line or a raised ConnectionError. Disjoint from
+    # the constraint-value families below, so ordering is otherwise irrelevant.
+    msg = _URL_CREDENTIALS_RE.sub(r"\1[REDACTED]\2", msg)
     # Issue #1552 (FIX 2 + FIX 7): _KEY_VALUES_RE runs FIRST to catch any
     # ``Key (col)=(value)`` clause OUTSIDE a DETAIL: line (its ``[^)]*`` value
     # class spans newlines). Then the BLOCK _DETAIL_RE (FIX 7) redacts the ENTIRE

--- a/packages/kailash-dataflow/src/dataflow/core/pool_lightweight.py
+++ b/packages/kailash-dataflow/src/dataflow/core/pool_lightweight.py
@@ -155,11 +155,16 @@ class LightweightPool:
                         "Cannot create lightweight pool: asyncpg not installed"
                     )
                 except Exception as exc:
+                    # Log the exception TYPE only. A credential-provider error
+                    # routed here carries token material in its message / __cause__
+                    # chain; exc_info=True would render that chain into DEBUG logs
+                    # (security.md "No secrets in logs"). The type name is the safe,
+                    # actionable signal — mirrors adapters/postgresql.py, which routes
+                    # every message through sanitize_db_error().
                     logger.warning(
                         "Failed to create lightweight pool: %s",
                         type(exc).__name__,
                     )
-                    logger.debug("Lightweight pool creation error", exc_info=True)
             else:
                 logger.debug("Lightweight pool not created (unsupported database type)")
 

--- a/packages/kailash-dataflow/src/dataflow/core/pool_lightweight.py
+++ b/packages/kailash-dataflow/src/dataflow/core/pool_lightweight.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -47,15 +47,24 @@ class LightweightPool:
     Args:
         database_url: Same database URL as the main pool.
         pool_size: Number of connections. Default: 2. Should not be increased.
+        credential_provider: Optional per-physical-connection credential
+            callback (issue #1737 — Azure AD / AWS IAM token-based auth).
+            Mirrors ``DatabaseConfig.credential_provider``; when set, every
+            physical connection this pool opens mints a fresh credential
+            instead of reusing the (possibly stale) static password parsed
+            from ``database_url``. Absent (None) — behavior is unchanged.
+            SQLite ignores this parameter (no token-based auth concept).
     """
 
     def __init__(
         self,
         database_url: str,
         pool_size: int = _LIGHTWEIGHT_POOL_SIZE,
+        credential_provider: Optional[Callable[[], str]] = None,
     ):
         self._database_url = database_url
         self._pool_size = pool_size
+        self.credential_provider = credential_provider
         self._pool: Any = None
         self._initialized = False
         self._lock: Optional[asyncio.Lock] = None
@@ -110,12 +119,31 @@ class LightweightPool:
                     if url.startswith("postgresql+"):
                         url = "postgresql://" + url.split("://", 1)[1]
 
-                    self._pool = await asyncpg.create_pool(
-                        url,
-                        min_size=1,
-                        max_size=self._pool_size,
-                        command_timeout=5,
-                    )
+                    create_pool_kwargs: dict = {
+                        "min_size": 1,
+                        "max_size": self._pool_size,
+                        "command_timeout": 5,
+                    }
+                    # Issue #1737: same per-physical-connection credential
+                    # callback as the main PostgreSQLAdapter pool. The
+                    # lightweight pool runs for the app's entire lifetime
+                    # (periodic health checks), so it hits the same
+                    # token-expiry failure mode a long-running main pool
+                    # does — wire it identically.
+                    if self.credential_provider is not None:
+                        from dataflow.core.credential_provider import (
+                            build_asyncpg_credential_connect,
+                        )
+
+                        create_pool_kwargs["connect"] = (
+                            build_asyncpg_credential_connect(
+                                self.credential_provider,
+                                asyncpg,
+                                context="PostgreSQL lightweight pool",
+                            )
+                        )
+
+                    self._pool = await asyncpg.create_pool(url, **create_pool_kwargs)
                     self._initialized = True
                     self._init_pid = os.getpid()
                     logger.debug(

--- a/packages/kailash-dataflow/src/dataflow/utils/connection.py
+++ b/packages/kailash-dataflow/src/dataflow/utils/connection.py
@@ -118,11 +118,15 @@ class ConnectionManager:
         # Transient adapter — opened, verified, discarded. Pool size 1
         # because we do nothing with the pool but prove the connection
         # works, then close it.
+        # Issue #1737: thread the configured credential_provider through so
+        # this reachability probe also mints a fresh token rather than
+        # reusing a static (possibly stale) password.
         factory = AdapterFactory()
         test_adapter = factory.create_adapter(
             db_url,
             pool_size=1,
             max_overflow=0,
+            credential_provider=self.dataflow.config.database.credential_provider,
         )
 
         try:
@@ -192,10 +196,12 @@ class ConnectionManager:
 
         db_url = self._get_db_url()
         factory = AdapterFactory()
+        # Issue #1737: same credential_provider threading as initialize_pool().
         test_adapter = factory.create_adapter(
             db_url,
             pool_size=1,
             max_overflow=0,
+            credential_provider=self.dataflow.config.database.credential_provider,
         )
 
         t0 = time.monotonic()
@@ -343,7 +349,13 @@ class ConnectionManager:
         # `rules/zero-tolerance.md` Rule 1 in the same shard as the #835
         # transient-adapter migration.
         factory = AdapterFactory()
-        test_adapter = factory.create_adapter(target_url, pool_size=1, max_overflow=0)
+        # Issue #1737: same credential_provider threading as initialize_pool().
+        test_adapter = factory.create_adapter(
+            target_url,
+            pool_size=1,
+            max_overflow=0,
+            credential_provider=self.dataflow.config.database.credential_provider,
+        )
         try:
             await test_adapter.connect()
             await test_adapter.execute_query("SELECT 1 AS test")

--- a/packages/kailash-dataflow/tests/integration/database/test_credential_provider.py
+++ b/packages/kailash-dataflow/tests/integration/database/test_credential_provider.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the per-physical-connection credential callback
+(issue #1737 — token-based DB auth for Azure AD / AWS IAM parity with the
+Rust SDK's rs#1810).
+
+Real PostgreSQL only — NO MOCKING (rules/testing.md Tier 2). A dedicated,
+disposable Postgres ROLE is created per rotation test so "the token expired
+mid-run" is a REAL authentication event (ALTER ROLE ... PASSWORD), not a
+simulation: the stale credential genuinely stops authenticating and the
+fresh one genuinely starts.
+
+All tests require real PostgreSQL (test_suite.config) — marked
+@pytest.mark.requires_postgres per pytest.ini's default `-m "not
+(requires_postgres or ...)"` addopts. Run explicitly with:
+    pytest tests/integration/database/test_credential_provider.py -m requires_postgres
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import List, Optional
+
+import asyncpg
+import pytest
+
+from dataflow.adapters.postgresql import PostgreSQLAdapter
+from dataflow.exceptions import DataFlowConnectionError
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Create complete integration test suite with real infrastructure."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+class RotatingTokenProvider:
+    """Deterministic, Protocol-satisfying credential provider — NOT a
+    MagicMock. Holds a mutable "current token"; ``rotate()`` simulates an
+    external token source (Azure AD / AWS IAM) issuing a fresh credential.
+    Satisfies ``Callable[[], str]`` structurally.
+    """
+
+    def __init__(self, initial_token: str):
+        self._token = initial_token
+        self.call_count = 0
+        self.returned_tokens: List[str] = []
+
+    def rotate(self, new_token: str) -> None:
+        self._token = new_token
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        self.returned_tokens.append(self._token)
+        return self._token
+
+
+class FailAfterNCallsProvider:
+    """Deterministic provider: returns ``token`` for the first
+    ``succeed_calls`` invocations, then raises on every subsequent call —
+    simulating a credential source that starts failing (e.g. an IAM role
+    revoked, a token endpoint outage)."""
+
+    def __init__(self, token: str, succeed_calls: int):
+        self._token = token
+        self._succeed_calls = succeed_calls
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        if self.call_count <= self._succeed_calls:
+            return self._token
+        raise RuntimeError("credential source unavailable (simulated)")
+
+
+def _make_role_name() -> str:
+    # Restricted charset (hex only) — test-generated, never user input.
+    return f"cred1737_{uuid.uuid4().hex[:12]}"
+
+
+class _DisposableRole:
+    """Creates a disposable, password-authenticated PostgreSQL role for the
+    duration of a test and guarantees teardown. Uses the test_suite's own
+    superuser admin connection (test_user) — real infra, no mocking."""
+
+    def __init__(self, admin_conn: asyncpg.Connection, role: str, password: str):
+        self._admin = admin_conn
+        self.role = role
+        self._password = password
+
+    async def create(self) -> None:
+        await self._admin.execute(f'DROP ROLE IF EXISTS "{self.role}"')
+        await self._admin.execute(
+            f"CREATE ROLE \"{self.role}\" LOGIN PASSWORD '{self._password}'"
+        )
+
+    async def rotate_password(self, new_password: str) -> None:
+        await self._admin.execute(
+            f"ALTER ROLE \"{self.role}\" PASSWORD '{new_password}'"
+        )
+
+    async def drop(self) -> None:
+        await self._admin.execute(f'DROP ROLE IF EXISTS "{self.role}"')
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+class TestCredentialProviderInvocationCount:
+    """AC: the pool invokes credential_provider for EVERY physical
+    connection (initial/recycled/overflow/reconnect)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_provider_invoked_for_initial_and_overflow_physical_connections(
+        self, test_suite
+    ):
+        provider = RotatingTokenProvider(initial_token=test_suite.config.password)
+        # Static password field is deliberately WRONG — proves the
+        # connect-wrapper's fresh credential is what actually authenticates,
+        # not the static value captured at pool construction.
+        url = (
+            f"postgresql://{test_suite.config.user}:WRONG-STATIC-PASSWORD"
+            f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+        )
+        adapter = PostgreSQLAdapter(
+            url, pool_size=1, max_overflow=2, credential_provider=provider
+        )
+        try:
+            await adapter.create_connection_pool()
+            # min_size == pool_size == 1: one physical connection opened
+            # eagerly during pool creation.
+            assert provider.call_count == 1
+
+            async with adapter.connection_pool.acquire() as conn1:
+                # A second, concurrently-held connection forces asyncpg to
+                # open a NEW (overflow) physical connection.
+                async with adapter.connection_pool.acquire() as conn2:
+                    assert await conn1.fetchval("SELECT 1") == 1
+                    assert await conn2.fetchval("SELECT 1") == 1
+            assert provider.call_count == 2
+        finally:
+            await adapter.close_connection_pool()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+class TestCredentialProviderRotation:
+    """AC (the flagship scenario): a pool whose token "expires" mid-run
+    establishes a NEW connection post-expiry successfully via the
+    callback."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_pool_reconnects_successfully_after_real_token_rotation(
+        self, test_suite
+    ):
+        role = _make_role_name()
+        token_v1 = f"tok1_{uuid.uuid4().hex[:10]}"
+        token_v2 = f"tok2_{uuid.uuid4().hex[:10]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, token_v1)
+        try:
+            await disposable_role.create()
+
+            provider = RotatingTokenProvider(initial_token=token_v1)
+            url = (
+                f"postgresql://{role}:IGNORED-STATIC"
+                f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+            )
+            adapter = PostgreSQLAdapter(
+                url, pool_size=1, max_overflow=0, credential_provider=provider
+            )
+            try:
+                await adapter.create_connection_pool()
+                assert provider.call_count == 1  # initial connect minted with token-v1
+
+                async with adapter.connection_pool.acquire() as conn:
+                    assert await conn.fetchval("SELECT 1") == 1
+
+                # Simulate a real Azure AD / AWS IAM token expiry: rotate
+                # the ACTUAL database credential — the SAME event shape an
+                # external token source produces.
+                await disposable_role.rotate_password(token_v2)
+                provider.rotate(token_v2)
+
+                # Force asyncpg to treat pooled connections as expired — the
+                # NEXT acquire() opens a brand-new PHYSICAL connection (the
+                # same primitive a long-running pool hits naturally via
+                # max_inactive_connection_lifetime or a dropped socket).
+                await adapter.connection_pool.expire_connections()
+
+                async with adapter.connection_pool.acquire() as conn:
+                    # AC: a physical connection opened AFTER the original
+                    # token would have expired authenticates SUCCESSFULLY
+                    # with the fresh value.
+                    assert await conn.fetchval("SELECT 1") == 1
+
+                assert provider.call_count == 2
+                assert provider.returned_tokens == [token_v1, token_v2]
+            finally:
+                await adapter.close_connection_pool()
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_stale_token_no_longer_authenticates_after_rotation(self, test_suite):
+        """Negative control proving the rotation test above is not
+        vacuous: the OLD token genuinely stops working once rotated."""
+        role = _make_role_name()
+        token_v1 = f"tok1_{uuid.uuid4().hex[:10]}"
+        token_v2 = f"tok2_{uuid.uuid4().hex[:10]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, token_v1)
+        try:
+            await disposable_role.create()
+            await disposable_role.rotate_password(token_v2)
+
+            with pytest.raises(asyncpg.InvalidPasswordError):
+                await asyncpg.connect(
+                    host=test_suite.config.host,
+                    port=test_suite.config.port,
+                    database=test_suite.config.database,
+                    user=role,
+                    password=token_v1,
+                )
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+class TestCredentialProviderFailsClosed:
+    """AC: callback error fails closed (raises typed error, no stale-token
+    reuse)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_provider_failure_on_new_connection_raises_and_does_not_reuse_stale_token(
+        self, test_suite
+    ):
+        role = _make_role_name()
+        token_v1 = f"tok1_{uuid.uuid4().hex[:10]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, token_v1)
+        try:
+            await disposable_role.create()
+
+            # Succeeds once (the initial pool-fill connect), then the
+            # credential source starts failing on every subsequent call.
+            provider = FailAfterNCallsProvider(token=token_v1, succeed_calls=1)
+            url = (
+                f"postgresql://{role}:IGNORED-STATIC"
+                f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+            )
+            adapter = PostgreSQLAdapter(
+                url, pool_size=1, max_overflow=0, credential_provider=provider
+            )
+            try:
+                await adapter.create_connection_pool()
+                assert provider.call_count == 1
+
+                # Force a reconnect on next acquire — the provider will now
+                # raise (simulated credential-source outage).
+                await adapter.connection_pool.expire_connections()
+
+                with pytest.raises(DataFlowConnectionError):
+                    async with adapter.connection_pool.acquire():
+                        pass  # pragma: no cover — must not reach here
+
+                # Fail-closed: no silent fallback to the (still technically
+                # valid) token-v1 was attempted for this failing call.
+                assert provider.call_count == 2
+            finally:
+                await adapter.close_connection_pool()
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+class TestCredentialProviderNeverLogsToken:
+    """AC: the token value never appears in any log/repr."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_token_value_absent_from_logs_across_success_rotation_and_failure(
+        self, test_suite, caplog
+    ):
+        role = _make_role_name()
+        token_v1 = f"tok1_{uuid.uuid4().hex[:10]}"
+        token_v2 = f"tok2_{uuid.uuid4().hex[:10]}"
+        secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex[:12]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, token_v1)
+        try:
+            await disposable_role.create()
+
+            provider = RotatingTokenProvider(initial_token=token_v1)
+            url = (
+                f"postgresql://{role}:IGNORED-STATIC"
+                f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+            )
+            adapter = PostgreSQLAdapter(
+                url, pool_size=1, max_overflow=0, credential_provider=provider
+            )
+
+            with caplog.at_level(logging.DEBUG):
+                try:
+                    await adapter.create_connection_pool()
+                    async with adapter.connection_pool.acquire() as conn:
+                        await conn.fetchval("SELECT 1")
+
+                    await disposable_role.rotate_password(token_v2)
+                    provider.rotate(token_v2)
+                    await adapter.connection_pool.expire_connections()
+                    async with adapter.connection_pool.acquire() as conn:
+                        await conn.fetchval("SELECT 1")
+                finally:
+                    await adapter.close_connection_pool()
+
+                # Trigger the fail-closed path too, with a marker that WOULD
+                # leak if the wrapper interpolated str(exc). A fresh
+                # adapter/pool is required: the connect-wrapper binds the
+                # credential_provider it was built with at pool-creation
+                # time (see _make_credential_provider_connect), so swapping
+                # adapter.credential_provider post-hoc would not affect an
+                # already-created pool's connect callable. The provider
+                # succeeds once (the initial pool-fill connect) so the
+                # failure happens on a POST-creation reconnect — raised
+                # directly as DataFlowConnectionError from acquire(),
+                # not wrapped by create_connection_pool()'s own
+                # except-and-rewrap block.
+                class _SucceedsOnceThenRaisesWithMarker:
+                    def __init__(self):
+                        self.call_count = 0
+
+                    def __call__(self) -> str:
+                        self.call_count += 1
+                        if self.call_count == 1:
+                            return token_v2
+                        raise RuntimeError(f"leak-check {secret_marker}")
+
+                marker_adapter = PostgreSQLAdapter(
+                    url,
+                    pool_size=1,
+                    max_overflow=0,
+                    credential_provider=_SucceedsOnceThenRaisesWithMarker(),
+                )
+                try:
+                    await marker_adapter.create_connection_pool()
+                    await marker_adapter.connection_pool.expire_connections()
+                    with pytest.raises(DataFlowConnectionError):
+                        async with marker_adapter.connection_pool.acquire():
+                            pass  # pragma: no cover
+                finally:
+                    await marker_adapter.close_connection_pool()
+
+            log_text = caplog.text
+            assert token_v1 not in log_text
+            assert token_v2 not in log_text
+            assert secret_marker not in log_text
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+class TestCredentialProviderAbsentBehaviorUnchanged:
+    """AC: absent the callback, behavior is unchanged (static-string
+    path — regression-tested)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_pool_connects_with_static_password_when_no_provider_configured(
+        self, test_suite
+    ):
+        adapter = PostgreSQLAdapter(test_suite.config.url, pool_size=1, max_overflow=1)
+        assert adapter.credential_provider is None
+        try:
+            await adapter.create_connection_pool()
+            async with adapter.connection_pool.acquire() as conn:
+                assert await conn.fetchval("SELECT 1") == 1
+        finally:
+            await adapter.close_connection_pool()

--- a/packages/kailash-dataflow/tests/integration/database/test_credential_provider.py
+++ b/packages/kailash-dataflow/tests/integration/database/test_credential_provider.py
@@ -25,6 +25,7 @@ from typing import List, Optional
 import asyncpg
 import pytest
 
+from dataflow.adapters.exceptions import ConnectionError as AdapterConnectionError
 from dataflow.adapters.postgresql import PostgreSQLAdapter
 from dataflow.exceptions import DataFlowConnectionError
 from tests.infrastructure.test_harness import IntegrationTestSuite
@@ -214,6 +215,79 @@ class TestCredentialProviderRotation:
 
     @pytest.mark.asyncio
     @pytest.mark.regression
+    async def test_held_open_connection_unaffected_while_new_connection_gets_fresh_token(
+        self, test_suite
+    ):
+        """Stronger AC variant: hold conn-1 OPEN across the rotation
+        (proving a connection established BEFORE rotation keeps working on
+        its existing session — PostgreSQL does not re-check auth mid-
+        session) while a CONCURRENT NEW physical connection (an overflow
+        slot, forced by holding conn-1) authenticates with the FRESH
+        post-rotation token. Distinguishes true per-physical-connection
+        freshness from a sequential-only acquire/release/acquire test.
+        """
+        role = _make_role_name()
+        token_v1 = f"tok1_{uuid.uuid4().hex[:10]}"
+        token_v2 = f"tok2_{uuid.uuid4().hex[:10]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, token_v1)
+        try:
+            await disposable_role.create()
+
+            provider = RotatingTokenProvider(initial_token=token_v1)
+            url = (
+                f"postgresql://{role}:IGNORED-STATIC"
+                f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+            )
+            # max_overflow=1 so a SECOND physical connection can open
+            # concurrently while the first is still held open.
+            adapter = PostgreSQLAdapter(
+                url, pool_size=1, max_overflow=1, credential_provider=provider
+            )
+            try:
+                await adapter.create_connection_pool()
+                assert provider.call_count == 1  # initial fill: token-v1
+
+                conn1 = await adapter.connection_pool.acquire()
+                try:
+                    assert await conn1.fetchval("SELECT 1") == 1
+
+                    # Rotate the REAL database credential mid-run, WHILE
+                    # conn1 is still open and in use.
+                    await disposable_role.rotate_password(token_v2)
+                    provider.rotate(token_v2)
+
+                    # Force a genuinely NEW physical connection: pool_size=1
+                    # is already checked out (conn1), so this acquire opens
+                    # an OVERFLOW connection and invokes the provider fresh.
+                    conn2 = await adapter.connection_pool.acquire()
+                    try:
+                        # AC: the NEW physical connection authenticates
+                        # with the FRESH post-rotation token.
+                        assert await conn2.fetchval("SELECT 1") == 1
+                        assert provider.call_count == 2
+                        assert provider.returned_tokens == [token_v1, token_v2]
+
+                        # AND: conn1 — established BEFORE rotation — is
+                        # completely unaffected. Its session was already
+                        # authenticated; PostgreSQL does not re-check
+                        # credentials mid-session. This is what proves
+                        # freshness is PER-PHYSICAL-CONNECTION, not a
+                        # whole-pool invalidation side effect.
+                        assert await conn1.fetchval("SELECT 2") == 2
+                    finally:
+                        await adapter.connection_pool.release(conn2)
+                finally:
+                    await adapter.connection_pool.release(conn1)
+            finally:
+                await adapter.close_connection_pool()
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
     async def test_stale_token_no_longer_authenticates_after_rotation(self, test_suite):
         """Negative control proving the rotation test above is not
         vacuous: the OLD token genuinely stops working once rotated."""
@@ -379,6 +453,57 @@ class TestCredentialProviderNeverLogsToken:
             assert token_v1 not in log_text
             assert token_v2 not in log_text
             assert secret_marker not in log_text
+        finally:
+            await disposable_role.drop()
+            await admin_conn.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.regression
+    async def test_real_asyncpg_auth_failure_does_not_leak_token_in_exception_or_logs(
+        self, test_suite, caplog
+    ):
+        """A REAL asyncpg-level auth failure (not a raising provider) — the
+        credential_provider returns a WRONG (but token-shaped) value, so
+        PostgreSQL itself rejects it with InvalidPasswordError. Some DB
+        drivers embed the connection URL/DSN (with credentials) in a
+        connect-failure exception message; asyncpg does not (empirically
+        verified against 0.31 across kwargs-password, unreachable-host, and
+        DSN-string forms — see postgresql.py's create_connection_pool()
+        except-block comment) but this regression test pins that property
+        so a future asyncpg version (or driver-error-message change)
+        surfaces loudly rather than silently leaking the token.
+        """
+        role = _make_role_name()
+        real_password = f"real_{uuid.uuid4().hex[:10]}"
+        wrong_token = f"WRONG-TOKEN-{uuid.uuid4().hex[:16]}"
+
+        admin_conn = await asyncpg.connect(test_suite.config.url)
+        disposable_role = _DisposableRole(admin_conn, role, real_password)
+        try:
+            await disposable_role.create()
+
+            class _WrongTokenProvider:
+                def __call__(self) -> str:
+                    return wrong_token
+
+            url = (
+                f"postgresql://{role}:IGNORED-STATIC"
+                f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+            )
+            adapter = PostgreSQLAdapter(
+                url,
+                pool_size=1,
+                max_overflow=0,
+                credential_provider=_WrongTokenProvider(),
+            )
+
+            with caplog.at_level(logging.DEBUG):
+                with pytest.raises(AdapterConnectionError) as exc_info:
+                    await adapter.create_connection_pool()
+
+            assert wrong_token not in str(exc_info.value)
+            assert wrong_token not in repr(exc_info.value)
+            assert wrong_token not in caplog.text
         finally:
             await disposable_role.drop()
             await admin_conn.close()

--- a/packages/kailash-dataflow/tests/integration/database/test_credential_provider_sibling_pools.py
+++ b/packages/kailash-dataflow/tests/integration/database/test_credential_provider_sibling_pools.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Integration tests: credential_provider wiring on the sibling asyncpg pools
+(issue #1737 follow-up) — ``LightweightPool`` (health checks) and
+``PostgreSQLEventStore`` (audit-trail persistence). Both are long-lived
+pools that run for the app's runtime, so they hit the same token-expiry
+failure mode as the main ``PostgreSQLAdapter`` pool; both now delegate to
+the SAME shared ``dataflow.core.credential_provider.build_asyncpg_credential_connect``
+helper already covered exhaustively by
+``tests/unit/adapters/test_postgresql_credential_provider.py`` — these
+tests verify the WIRING (constructor -> initialize()'s create_pool kwargs),
+not the shared helper's own contract.
+
+Real PostgreSQL only — NO MOCKING (rules/testing.md Tier 2).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dataflow.core.event_stores.postgresql import PostgreSQLEventStore
+from dataflow.core.pool_lightweight import LightweightPool
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+class RotatingTokenProvider:
+    """Deterministic, Protocol-satisfying credential provider — NOT a
+    MagicMock."""
+
+    def __init__(self, token: str):
+        self._token = token
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        return self._token
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+@pytest.mark.regression
+class TestLightweightPoolCredentialProvider:
+    @pytest.mark.asyncio
+    async def test_credential_provider_invoked_on_initialize(self, test_suite):
+        provider = RotatingTokenProvider(token=test_suite.config.password)
+        # Static URL password deliberately WRONG — proves the fresh
+        # credential from the provider is what actually authenticates.
+        url = (
+            f"postgresql://{test_suite.config.user}:WRONG-STATIC"
+            f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+        )
+        pool = LightweightPool(url, pool_size=2, credential_provider=provider)
+        try:
+            await pool.initialize()
+            assert pool.is_initialized
+            assert provider.call_count >= 1
+            rows = await pool.execute_raw("SELECT 1")
+            assert rows[0][0] == 1
+        finally:
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_absent_credential_provider_behavior_unchanged(self, test_suite):
+        pool = LightweightPool(test_suite.config.url, pool_size=2)
+        assert pool.credential_provider is None
+        try:
+            await pool.initialize()
+            assert pool.is_initialized
+            rows = await pool.execute_raw("SELECT 1")
+            assert rows[0][0] == 1
+        finally:
+            await pool.close()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.requires_docker
+@pytest.mark.timeout(30)
+@pytest.mark.regression
+class TestPostgreSQLEventStoreCredentialProvider:
+    @pytest.mark.asyncio
+    async def test_credential_provider_invoked_on_initialize(self, test_suite):
+        provider = RotatingTokenProvider(token=test_suite.config.password)
+        url = (
+            f"postgresql://{test_suite.config.user}:WRONG-STATIC"
+            f"@{test_suite.config.host}:{test_suite.config.port}/{test_suite.config.database}"
+        )
+        store = PostgreSQLEventStore(
+            database_url=url,
+            pool_min_size=1,
+            pool_max_size=1,
+            credential_provider=provider,
+        )
+        try:
+            await store.initialize()
+            assert provider.call_count >= 1
+            assert store._pool is not None
+            async with store._pool.acquire() as conn:
+                assert await conn.fetchval("SELECT 1") == 1
+        finally:
+            if store._pool is not None:
+                await store._pool.close()
+
+    @pytest.mark.asyncio
+    async def test_absent_credential_provider_behavior_unchanged(self, test_suite):
+        store = PostgreSQLEventStore(
+            database_url=test_suite.config.url, pool_min_size=1, pool_max_size=1
+        )
+        assert store.credential_provider is None
+        try:
+            await store.initialize()
+            assert store._pool is not None
+            async with store._pool.acquire() as conn:
+                assert await conn.fetchval("SELECT 1") == 1
+        finally:
+            if store._pool is not None:
+                await store._pool.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1737_sibling_pool_error_hygiene.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1737_sibling_pool_error_hygiene.py
@@ -107,3 +107,67 @@ class TestEventStoreInitErrorHygiene:
         assert "[REDACTED]" in msg
         combined = " ".join(r.getMessage() for r in caplog.records)
         assert _SECRET not in combined
+
+    @pytest.mark.asyncio
+    async def test_create_pool_failure_redacts_bare_dsn_password(
+        self, monkeypatch, caplog
+    ):
+        """Important #2 (M2): the leak this path actually guards against is a
+        driver connect-error embedding the credentialed DSN. Inject a bare-DSN
+        secret (NOT a ``DETAIL:`` form) and assert the password is redacted by
+        ``sanitize_db_error`` before it reaches the raised error or the log."""
+
+        async def _boom(*args, **kwargs):
+            # asyncpg-style connect failure that embeds the full DSN.
+            raise RuntimeError(f"connection to server at {_PG_URL} failed")
+
+        monkeypatch.setattr(asyncpg, "create_pool", _boom)
+
+        store = PostgreSQLEventStore(
+            database_url=_PG_URL, pool_min_size=1, pool_max_size=1
+        )
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ConnectionError) as excinfo:
+                await store.initialize()
+
+        msg = str(excinfo.value)
+        assert _SECRET not in msg
+        assert "[REDACTED]" in msg
+        # user + host survive (diagnostic shape preserved); password gone.
+        assert "appuser" in msg
+        combined = " ".join(r.getMessage() for r in caplog.records)
+        assert _SECRET not in combined
+
+
+@pytest.mark.regression
+class TestSanitizeDbErrorUrlCredentials:
+    """Direct behavioral coverage of the #1737 URL-credential redaction added
+    to ``sanitize_db_error`` (the shared barrier the create_pool paths call)."""
+
+    def test_redacts_dsn_password_preserves_user_and_host(self):
+        from dataflow.core.exceptions import sanitize_db_error
+
+        out = sanitize_db_error(f"connect failed: {_PG_URL}")
+        assert _SECRET not in out
+        assert "://appuser:[REDACTED]@db.internal:5432/appdb" in out
+
+    def test_redacts_password_with_embedded_colons(self):
+        from dataflow.core.exceptions import sanitize_db_error
+
+        out = sanitize_db_error("FATAL: at postgresql://u:p:a:ss@h:5432/d")
+        assert "p:a:ss" not in out
+        assert "://u:[REDACTED]@h:5432/d" in out
+
+    def test_no_password_userinfo_is_untouched(self):
+        from dataflow.core.exceptions import sanitize_db_error
+
+        s = "err at postgres://svc@host:5432/db"
+        assert sanitize_db_error(s) == s
+
+    def test_plain_at_sign_email_not_misfired(self):
+        from dataflow.core.exceptions import sanitize_db_error
+
+        # No ``://user:pass@`` userinfo — an email address must NOT be touched
+        # by the URL rule (the DETAIL rule owns the value-redaction here).
+        out = sanitize_db_error("lookup failed for alice@example.com")
+        assert out == "lookup failed for alice@example.com"

--- a/packages/kailash-dataflow/tests/regression/test_issue_1737_sibling_pool_error_hygiene.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1737_sibling_pool_error_hygiene.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Regression: error-path log/exception hygiene on the #1737 sibling asyncpg
+pools (``LightweightPool`` + ``PostgreSQLEventStore``).
+
+Offline boundary-injection tests (user-flow-validation.md MUST-7 class (b) —
+exception mid-operation): ``asyncpg.create_pool`` is monkeypatched to RAISE so
+the pool-creation failure path runs with NO real database. They pin two
+security fixes surfaced by the #1737 /redteam:
+
+  * HIGH — ``LightweightPool.initialize()`` MUST NOT log the pool-creation
+    exception with ``exc_info=True``. A credential-provider error routed here
+    carries token material in its message / ``__cause__`` chain; ``exc_info``
+    would render that chain into DEBUG logs (security.md "No secrets in logs").
+    Only the exception TYPE name is logged.
+
+  * Important #2 — ``PostgreSQLEventStore.initialize()`` MUST wrap a
+    ``create_pool`` failure in a ``ConnectionError`` routed through the shared
+    ``sanitize_db_error()`` (mirroring ``adapters/postgresql.py``), never let
+    the raw asyncpg exception (which can embed the credentialed DSN) propagate.
+
+No mocking of the units under test — only the external ``asyncpg.create_pool``
+boundary is injected. asyncpg must be importable (postgres extra).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from dataflow.core.event_stores.postgresql import PostgreSQLEventStore
+from dataflow.core.pool_lightweight import LightweightPool
+
+# A recognizable secret embedded in the injected exception message, used to
+# prove the value-bearing DETAIL clause is redacted before it reaches the log
+# line / raised error.
+_SECRET = "s3cr3t-token-DO-NOT-LEAK"
+_PG_URL = f"postgresql://appuser:{_SECRET}@db.internal:5432/appdb"
+
+
+@pytest.mark.regression
+class TestLightweightPoolInitErrorHygiene:
+    @pytest.mark.asyncio
+    async def test_create_pool_failure_logs_no_exc_info(self, monkeypatch, caplog):
+        """HIGH: the pool-creation except path logs the TYPE name only and
+        emits NO record carrying ``exc_info`` (the removed token-leak vector)."""
+
+        async def _boom(*args, **kwargs):
+            # A DETAIL-bearing message stands in for an asyncpg/provider error
+            # whose __cause__ chain could carry credential material.
+            raise RuntimeError(f"connect failed\nDETAIL: Key (password)=({_SECRET})")
+
+        monkeypatch.setattr(asyncpg, "create_pool", _boom)
+
+        pool = LightweightPool(_PG_URL, pool_size=2)
+        with caplog.at_level(logging.DEBUG):
+            # initialize() is best-effort: it catches, WARNs, and continues.
+            await pool.initialize()
+
+        assert not pool.is_initialized
+
+        # The removed leak: NO log record may carry an exception traceback.
+        offenders = [r for r in caplog.records if r.exc_info is not None]
+        assert offenders == [], (
+            "exc_info leaked on the lightweight-pool create_pool failure path: "
+            f"{[r.getMessage() for r in offenders]}"
+        )
+
+        # A WARN was emitted, and it names only the exception TYPE — the raw
+        # message (and the embedded secret) never reach the log line.
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warns, "expected a WARN on pool-creation failure"
+        combined = " ".join(r.getMessage() for r in caplog.records)
+        assert _SECRET not in combined
+        assert "RuntimeError" in " ".join(r.getMessage() for r in warns)
+
+
+@pytest.mark.regression
+class TestEventStoreInitErrorHygiene:
+    @pytest.mark.asyncio
+    async def test_create_pool_failure_wraps_and_sanitizes(self, monkeypatch, caplog):
+        """Important #2: a create_pool failure surfaces as a sanitized
+        ``ConnectionError`` (raw asyncpg exception NOT propagated), and the
+        value-bearing DETAIL clause is redacted before the message is used."""
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError(f"connect failed\nDETAIL: Key (password)=({_SECRET})")
+
+        monkeypatch.setattr(asyncpg, "create_pool", _boom)
+
+        store = PostgreSQLEventStore(
+            database_url=_PG_URL, pool_min_size=1, pool_max_size=1
+        )
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ConnectionError) as excinfo:
+                await store.initialize()
+
+        # Structural contract: the raw RuntimeError is wrapped, not propagated,
+        # by the sanitize barrier (mirrors adapters/postgresql.py).
+        msg = str(excinfo.value)
+        assert msg.startswith("PostgreSQL event store connection failed:")
+        # sanitize_db_error actually ran: the DETAIL value is redacted, so the
+        # embedded secret reaches neither the raised error nor the ERROR log.
+        assert _SECRET not in msg
+        assert "[REDACTED]" in msg
+        combined = " ".join(r.getMessage() for r in caplog.records)
+        assert _SECRET not in combined

--- a/packages/kailash-dataflow/tests/unit/adapters/test_postgresql_credential_provider.py
+++ b/packages/kailash-dataflow/tests/unit/adapters/test_postgresql_credential_provider.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for PostgreSQLAdapter's credential_provider wiring (issue #1737).
+
+Tests the pure connect-wrapper logic (validation, fail-closed error shape,
+no-secret-in-exception-message) WITHOUT a live database connection. Uses a
+deterministic Protocol-satisfying fake for ``asyncpg`` — never a MagicMock —
+per rules/testing.md's "Protocol-Satisfying Deterministic Adapters" carve-out.
+
+Tier-2 end-to-end coverage (real Postgres: per-physical-connection invocation
+count, fail-closed on a real pool, token-rotation-establishes-new-connection,
+token never logged) lives in
+tests/integration/database/test_credential_provider.py.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+import pytest
+from dataflow.adapters.postgresql import PostgreSQLAdapter
+from dataflow.exceptions import DataFlowConnectionError
+
+
+class _FakeAsyncpgConnection:
+    """Minimal stand-in for an asyncpg.Connection — records the password it
+    was constructed with so tests can assert on it without a real socket."""
+
+    def __init__(self, password: Optional[str]):
+        self.password = password
+
+
+class _FakeAsyncpgModule:
+    """Protocol-satisfying fake for the ``asyncpg`` module surface the
+    connect-wrapper touches (``asyncpg.connect``). Deterministic, records
+    every call's kwargs for inspection. NOT a MagicMock — a plain object
+    with a real (if trivial) async implementation.
+    """
+
+    def __init__(self):
+        self.connect_calls: List[dict] = []
+
+    async def connect(self, *args, **kwargs):
+        self.connect_calls.append(dict(kwargs))
+        return _FakeAsyncpgConnection(kwargs.get("password"))
+
+
+class RotatingTokenProvider:
+    """Deterministic, Protocol-satisfying credential provider.
+
+    Returns tokens from a fixed sequence, advancing one step per call and
+    holding on the final value once the sequence is exhausted. Tracks
+    ``call_count`` for invocation-count assertions. Satisfies
+    ``Callable[[], str]`` structurally — NOT a MagicMock.
+    """
+
+    def __init__(self, tokens: List[str]):
+        self._tokens = list(tokens)
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        idx = min(self.call_count - 1, len(self._tokens) - 1)
+        return self._tokens[idx]
+
+
+class RaisingProvider:
+    """Deterministic provider that always raises, carrying a marker string
+    in its exception message so tests can assert the marker is NEVER
+    propagated verbatim into the raised DataFlowConnectionError."""
+
+    def __init__(self, secret_marker: str):
+        self._secret_marker = secret_marker
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        raise RuntimeError(f"token endpoint failed for secret={self._secret_marker}")
+
+
+class NonStrProvider:
+    """Deterministic provider returning a non-str / empty value."""
+
+    def __init__(self, value):
+        self._value = value
+        self.call_count = 0
+
+    def __call__(self):
+        self.call_count += 1
+        return self._value
+
+
+def _adapter(
+    credential_provider: Optional[Callable[[], str]] = None,
+) -> PostgreSQLAdapter:
+    return PostgreSQLAdapter(
+        "postgresql://static_user:static_pw@localhost:5432/testdb",
+        credential_provider=credential_provider,
+    )
+
+
+class TestCredentialProviderFieldWiring:
+    """AC: connection config accepts the optional per-connection callback."""
+
+    def test_credential_provider_defaults_to_none(self):
+        adapter = _adapter()
+        assert adapter.credential_provider is None
+
+    def test_credential_provider_stored_when_provided(self):
+        provider = RotatingTokenProvider(["token-v1"])
+        adapter = _adapter(credential_provider=provider)
+        assert adapter.credential_provider is provider
+
+
+class TestConnectWrapperMintsFreshCredentialPerCall:
+    """AC: the wrapper re-mints on every invocation (the per-physical-
+    connection hook asyncpg.Pool calls for initial/recycled/overflow/
+    reconnect connections — see postgresql.py docstring)."""
+
+    @pytest.mark.asyncio
+    async def test_wrapper_calls_provider_and_overrides_static_password(self):
+        provider = RotatingTokenProvider(["token-v1", "token-v2", "token-v3"])
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        con1 = await connect(password="STALE-STATIC-PASSWORD")
+        con2 = await connect(password="STALE-STATIC-PASSWORD")
+        con3 = await connect(password="STALE-STATIC-PASSWORD")
+
+        # Every physical connection got a FRESH, distinct credential — never
+        # the stale static password captured at pool-construction time.
+        assert con1.password == "token-v1"
+        assert con2.password == "token-v2"
+        assert con3.password == "token-v3"
+        assert provider.call_count == 3
+        assert len(fake_asyncpg.connect_calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_wrapper_forwards_non_password_kwargs_unchanged(self):
+        provider = RotatingTokenProvider(["token-v1"])
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        await connect(
+            host="db.example.com", port=5432, password="ignored", database="app"
+        )
+
+        call = fake_asyncpg.connect_calls[0]
+        assert call["host"] == "db.example.com"
+        assert call["port"] == 5432
+        assert call["database"] == "app"
+        assert call["password"] == "token-v1"
+
+
+class TestConnectWrapperFailsClosed:
+    """AC: callback error fails closed (raises typed error, no stale-token
+    reuse)."""
+
+    @pytest.mark.asyncio
+    async def test_raising_provider_raises_typed_dataflow_error(self):
+        provider = RaisingProvider(secret_marker="TOKEN-SHOULD-NOT-LEAK-8f3a")
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        with pytest.raises(DataFlowConnectionError):
+            await connect(password="STALE-STATIC-PASSWORD")
+
+        # Fail-closed: asyncpg.connect was NEVER reached — no stale-token
+        # fallback connection was attempted.
+        assert len(fake_asyncpg.connect_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_raising_provider_exception_message_excludes_secret_marker(self):
+        secret = "TOKEN-SHOULD-NOT-LEAK-8f3a"
+        provider = RaisingProvider(secret_marker=secret)
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        with pytest.raises(DataFlowConnectionError) as exc_info:
+            await connect(password="STALE-STATIC-PASSWORD")
+
+        # The original provider exception's str() (which embeds the secret
+        # marker) MUST NOT appear in the raised DataFlow error's message —
+        # only the exception TYPE name is safe to surface.
+        message = str(exc_info.value)
+        assert secret not in message
+        assert "RuntimeError" in message
+
+    @pytest.mark.asyncio
+    async def test_non_str_return_raises_typed_dataflow_error(self):
+        provider = NonStrProvider(value=None)
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        with pytest.raises(DataFlowConnectionError, match="non-empty str"):
+            await connect(password="STALE-STATIC-PASSWORD")
+        assert len(fake_asyncpg.connect_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_str_return_raises_typed_dataflow_error(self):
+        provider = NonStrProvider(value="")
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        with pytest.raises(DataFlowConnectionError, match="non-empty str"):
+            await connect(password="STALE-STATIC-PASSWORD")
+        assert len(fake_asyncpg.connect_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_non_str_type_int_raises_typed_dataflow_error(self):
+        provider = NonStrProvider(value=12345)
+        adapter = _adapter(credential_provider=provider)
+        fake_asyncpg = _FakeAsyncpgModule()
+        connect = adapter._make_credential_provider_connect(fake_asyncpg)
+
+        with pytest.raises(DataFlowConnectionError, match="non-empty str"):
+            await connect(password="STALE-STATIC-PASSWORD")
+        assert len(fake_asyncpg.connect_calls) == 0
+
+
+class TestAbsentCredentialProviderUnchanged:
+    """AC: absent the callback, behavior is unchanged (static-string path)."""
+
+    def test_create_connection_pool_params_omit_connect_key_when_absent(self):
+        """When credential_provider is None, get_connection_parameters()'s
+        static ``password`` field is used untouched — create_connection_pool
+        never injects a ``connect`` override into asyncpg's create_pool
+        kwargs. This is asserted structurally (no live connection needed):
+        the adapter's credential_provider attribute gates the override in
+        create_connection_pool(), verified directly here.
+        """
+        adapter = _adapter(credential_provider=None)
+        assert adapter.credential_provider is None
+        params = adapter.get_connection_parameters()
+        assert "connect" not in params
+        assert params["password"] == "static_pw"

--- a/packages/kailash-dataflow/tests/unit/adapters/test_postgresql_credential_provider.py
+++ b/packages/kailash-dataflow/tests/unit/adapters/test_postgresql_credential_provider.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Callable, List, Optional
 
 import pytest
+
 from dataflow.adapters.postgresql import PostgreSQLAdapter
 from dataflow.exceptions import DataFlowConnectionError
 

--- a/packages/kailash-dataflow/tests/unit/core/test_credential_provider_config.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_credential_provider_config.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for credential_provider config propagation (issue #1737).
+
+Verifies the DataFlow(...) constructor threads a caller-supplied
+credential_provider into DatabaseConfig.credential_provider across every
+DataFlow.__init__ branch:
+  1. config= object provided
+  2. zero-config mode (no database_url, credential_provider is the only arg)
+  3. structured-config mode (database_url + other kwargs provided)
+  4. DataFlowConfig(credential_provider=...) constructed directly
+
+No live database connection is required — these are pure config-plumbing
+assertions (SQLite-backed DataFlow instances, which never read
+credential_provider, so construction stays fast and offline).
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+
+from dataflow import DataFlow
+from dataflow.core.config import DatabaseConfig, DataFlowConfig
+
+
+class RotatingTokenProvider:
+    """Deterministic, Protocol-satisfying credential provider — NOT a
+    MagicMock."""
+
+    def __init__(self, tokens):
+        self._tokens = list(tokens)
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        self.call_count += 1
+        idx = min(self.call_count - 1, len(self._tokens) - 1)
+        return self._tokens[idx]
+
+
+class StatefulTokenProvider:
+    """A credential provider closing over a resource that is NOT
+    deepcopy-safe (a threading.Lock) — representative of a real Azure AD /
+    AWS IAM token provider, which typically wraps a boto3 client, an HTTP
+    session, or an azure-identity credential cache with internal locks."""
+
+    def __init__(self, token: str):
+        self._token = token
+        self._lock = threading.Lock()
+        self.call_count = 0
+
+    def __call__(self) -> str:
+        with self._lock:
+            self.call_count += 1
+        return self._token
+
+
+class TestDatabaseConfigCredentialProviderField:
+    def test_defaults_to_none(self):
+        cfg = DatabaseConfig()
+        assert cfg.credential_provider is None
+
+    def test_accepts_callable(self):
+        provider = RotatingTokenProvider(["t1"])
+        cfg = DatabaseConfig(credential_provider=provider)
+        assert cfg.credential_provider is provider
+
+
+class TestDataFlowConfigDirectConstruction:
+    def test_credential_provider_kwarg_flows_into_database_config(self):
+        provider = RotatingTokenProvider(["t1"])
+        config = DataFlowConfig(
+            database_url="sqlite:///:memory:", credential_provider=provider
+        )
+        assert config.database.credential_provider is provider
+
+
+class TestDataFlowConstructorPropagation:
+    """AC: connection config accepts the optional per-connection credential
+    callback — verified at every DataFlow.__init__ code path."""
+
+    def test_structured_config_branch_propagates_credential_provider(self):
+        provider = RotatingTokenProvider(["t1"])
+        db = DataFlow(
+            database_url="sqlite:///:memory:",
+            credential_provider=provider,
+        )
+        assert db.config.database.credential_provider is provider
+
+    def test_zero_config_mode_still_propagates_credential_provider(self):
+        """When credential_provider is the ONLY constructor arg supplied
+        (database_url=None, every other param at its default), DataFlow.__init__
+        takes the zero-config (from_env()) branch — credential_provider MUST
+        still reach config.database.credential_provider, not be silently
+        dropped (mirrors the pre-existing tenant_isolation_strategy pattern).
+        """
+        provider = RotatingTokenProvider(["t1"])
+        db = DataFlow(credential_provider=provider)
+        assert db.config.database.credential_provider is provider
+
+    def test_config_object_branch_propagates_credential_provider(self):
+        provider = RotatingTokenProvider(["t1"])
+        base_config = DataFlowConfig(database_url="sqlite:///:memory:")
+        assert base_config.database.credential_provider is None
+
+        db = DataFlow(config=base_config, credential_provider=provider)
+        assert db.config.database.credential_provider is provider
+        # The caller's original config object is not mutated in place
+        # (DataFlow.__init__ deep-copies config= before applying overrides).
+        assert base_config.database.credential_provider is None
+
+    def test_absent_credential_provider_defaults_to_none_every_branch(self):
+        db_structured = DataFlow(database_url="sqlite:///:memory:")
+        assert db_structured.config.database.credential_provider is None
+
+        db_zero_config = DataFlow()
+        assert db_zero_config.config.database.credential_provider is None
+
+        db_config_obj = DataFlow(
+            config=DataFlowConfig(database_url="sqlite:///:memory:")
+        )
+        assert db_config_obj.config.database.credential_provider is None
+
+
+class TestCredentialProviderSurvivesDeepcopy:
+    """Regression: DataFlow.__init__'s config= branch deep-copies the
+    caller-supplied DataFlowConfig. A real credential_provider (Azure AD /
+    AWS IAM token provider) commonly closes over a non-deepcopy-safe
+    resource (boto3 client, threading.Lock, azure-identity cache).
+    DatabaseConfig.__deepcopy__ MUST carry credential_provider by
+    reference — every other field still gets normal deep-copy isolation.
+    """
+
+    def test_database_config_deepcopy_preserves_stateful_provider_by_reference(
+        self,
+    ):
+        provider = StatefulTokenProvider(token="tok-1")
+        cfg = DatabaseConfig(url="sqlite:///:memory:", credential_provider=provider)
+
+        copied = copy.deepcopy(cfg)
+
+        assert copied.credential_provider is provider
+        # Other fields still deep-copy normally — independent dict objects
+        # with equal content, not the same object.
+        assert copied.connect_args is not cfg.connect_args
+        assert copied.connect_args == cfg.connect_args
+        assert copied.url == cfg.url
+
+    def test_dataflowconfig_deepcopy_preserves_stateful_provider_by_reference(self):
+        provider = StatefulTokenProvider(token="tok-1")
+        config = DataFlowConfig(
+            database_url="sqlite:///:memory:", credential_provider=provider
+        )
+
+        copied = copy.deepcopy(config)
+
+        assert copied.database.credential_provider is provider
+
+    def test_dataflow_config_object_branch_does_not_crash_with_stateful_provider(
+        self,
+    ):
+        """The originating bug: DataFlow(config=<cfg-with-stateful-provider>)
+        used to raise TypeError: cannot pickle '_thread.lock' object.
+        """
+        provider = StatefulTokenProvider(token="tok-1")
+        base_config = DataFlowConfig(
+            database_url="sqlite:///:memory:", credential_provider=provider
+        )
+
+        db = DataFlow(config=base_config)  # MUST NOT raise
+
+        assert db.config.database.credential_provider is provider
+        # The live provider still works after surviving the deepcopy.
+        assert db.config.database.credential_provider() == "tok-1"
+        assert provider.call_count == 1


### PR DESCRIPTION
## What

Implements issue #1737: a per-physical-connection credential callback so
DataFlow can authenticate to Postgres with short-lived tokens (Azure AD /
AWS IAM) used as the DB password, refreshed on every new physical connection
(not cached once) so a rotated/expired token is always current.

- `DatabaseConfig.credential_provider: Optional[Callable[[], str]]` — bare-token
  shape (asyncpg sets `cparams["password"]`; no DSN round-trip). `__deepcopy__`
  carries the callable by reference (a provider is not deep-copyable and must not
  be silently dropped).
- Wired identically on all three long-lived asyncpg pools that hit the
  token-expiry failure mode: the main `PostgreSQLAdapter` pool, the
  `LightweightPool` (health checks), and the `PostgreSQLEventStore` (audit trail).
- Shared `dataflow.core.credential_provider.build_asyncpg_credential_connect`
  helper: fail-CLOSED — a provider that raises / returns non-str / returns empty
  raises a typed `DataFlowConnectionError` (never a silent static/empty password),
  and it surfaces only `type(exc).__name__` (never the provider's message).

## Security (surfaced by the /redteam on this feature)

- **HIGH** — `LightweightPool.initialize()` logged the pool-creation exception
  with `exc_info=True`, rendering the provider-error `__cause__` chain (token
  material) into DEBUG logs. Dropped it; the WARN logs only the exception type.
- **Important** — `PostgreSQLEventStore.initialize()` now wraps a `create_pool`
  failure in a sanitized `ConnectionError` through the shared `sanitize_db_error()`
  barrier (mirrors `adapters/postgresql.py`), so the credentialed DSN cannot
  propagate on a raw asyncpg connect error.

Both are the `security.md` "No secrets in logs" class. Offline
boundary-injection regression tests (`tests/regression/test_issue_1737_sibling_pool_error_hygiene.py`)
inject the `create_pool` boundary to raise and pin: no `exc_info` on the
lightweight path, and the event-store wrap+redact contract.

## Cross-SDK

Mirror of the Rust SDK's rs#1810 (same ACs). This Python cut uses asyncpg's
native per-connection `connect=` hook (literal per-connection), stricter than
rs#1810's background-refresh cadence.

## Follow-ups (NOT in this PR — pending decision)

- Extend the callback into the core-SDK CRUD hot path (`db.express` /
  `nodes/data/async_sql.py::create_pool`) — higher blast radius; owner decision.
- Wire the 3 remaining asyncpg sites (DatabaseRegistry / staging /
  SyncTransactionManager).
- Rust-side lockstep deprecation tracking issue (cross-repo; needs authorization).

## Related issues

Fixes #1737