### PR TITLE
release: kailash-dataflow 2.17.0 + kailash-kaizen 2.32.0

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,7 +2,37 @@
 
 ## [Unreleased]
 
-## [2.16.0] — 2026-07-13 — Query-duration RED histogram reaches unified `/metrics` (#1708)
+## [2.17.0] — 2026-07-14 — Per-connection credential callback for token-based DB auth (#1737)
+
+### Added
+
+- **Per-physical-connection credential callback (#1737).** `DatabaseConfig`
+  now accepts `credential_provider: Optional[Callable[[], str]]` — a zero-arg
+  callable returning a fresh password/token minted on **every** new physical
+  connection (initial fill, recycle, overflow, reconnect). This is the
+  asyncpg-native equivalent of SQLAlchemy's `do_connect` event (overriding the
+  pool's per-connection `connect` hook), giving token-based DB auth (Azure AD /
+  AWS IAM tokens used as the password) a zero-staleness refresh with no
+  background refresh-ahead task. The token is set as the driver `password`
+  param — never re-encoded into a DSN/URL — so tokens containing `&=/%` need no
+  percent-encoding. Wired identically on all three long-lived asyncpg pools:
+  the main `PostgreSQLAdapter`, the `LightweightPool` (health checks), and the
+  `PostgreSQLEventStore` (audit trail). The CRUD hot path + remaining pools are
+  a tracked follow-up (#1741). Shared contract lives in one place
+  (`dataflow.core.credential_provider.build_asyncpg_credential_connect`).
+
+### Security
+
+- **Fail-closed credential resolution.** A `credential_provider` that raises,
+  returns a non-`str`, or returns empty raises a typed `DataFlowConnectionError`
+  — it never falls back to a stale or absent credential.
+- **No-secret-in-logs hardening (#1737 /redteam).** The token value/length/
+  prefix is never logged, repr'd, or interpolated. The fail-closed error
+  surfaces only the provider exception's _type name_ and severs it from the
+  `__cause__`/traceback chain so it cannot render under an upstream exception
+  logger. `create_pool`/connect failures are wrapped so a driver error cannot
+  propagate the credentialed DSN, and the shared `sanitize_db_error()` now
+  redacts `scheme://user:PASSWORD@host` connection-string credentials.
 
 Part of the coordinated 5-package #1708 observability release. Requires
 `kailash>=2.50.0` (the unified `/metrics` exposition this histogram now

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.16.0"
+version = "2.17.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.16.0"
+__version__ = "2.17.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.32.0] — 2026-07-14 — Manifest module + from_env() legacy-tier deprecation
+
+### Added
+
+- **`kaizen.manifest` module (#1735).** Declarative agent / app / governance
+  manifests (TOML) — parse, validate, and introspect Kaizen agent and
+  application definitions, with typed errors (`ManifestError`,
+  `ManifestParseError`, `ManifestValidationError`) and a governance budget
+  model. Includes hardened parsing: full C0 control-character escaping in TOML
+  string emission, `[[agent]]` array-of-tables validation, non-finite / overflow
+  budget rejection (`math.isfinite` guard), type-guarded list coercion on every
+  `from_dict` / TOML-parse / introspection path, and bounded (`max_len`) error
+  messages so a malformed manifest cannot flood logs.
+
+### Deprecated
+
+- **`LlmClient.from_env()` legacy per-provider-key auto-detect tier
+  (#1721/#1720).** Resolving a client purely from a per-provider API key
+  (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / …) with no `KAILASH_LLM_DEPLOYMENT`
+  (URI) or `KAILASH_LLM_PROVIDER` (selector) set now emits a
+  `DeprecationWarning`. This backward-compat migration tier will be removed in a
+  future major; migrate to the URI or selector tier. The `NoKeysConfigured`
+  message + docstring are now derived from the canonical `LEGACY_KEY_ORDER` so
+  they cannot drift from the resolver.
+
+### Changed
+
+- **Expanded Kaizen CI unit suite (#1734).** Broader FAST unit-tier coverage
+  (LLM + cross-SDK parity) and repaired pre-existing test staleness surfaced by
+  the CI-gate audit. No user-facing behavior change.
+
 ## [2.31.2] — 2026-07-14 — docs: honest `supports()` contract (provider capability vs client emission)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.31.2"
+version = "2.32.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.31.2"
+__version__ = "2.32.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
Two independent minor releases. Metadata-only diff (version anchors + CHANGELOG).

## kailash-dataflow 2.16.0 → 2.17.0
- feat: per-connection credential callback for token-based DB auth (#1737), wired on the main adapter + health-check pool + audit event store
- security: no-secret-in-logs hardening (fail-closed, exc-chain sever, DSN-credential redaction) — from the #1737 /redteam
- CRUD-path extension tracked in #1741

## kailash-kaizen 2.31.2 → 2.32.0
- feat: rescued `kaizen.manifest` module + 6 hardenings (#1735)
- deprecate: `LlmClient.from_env()` legacy per-provider-key tier now emits `DeprecationWarning` (#1721/#1720)
- chore: expanded CI unit suite (#1734)

## Release discipline
- Version anchors bumped consistently (pyproject + `__init__`) — zero-tolerance Rule 5.
- §3 sibling-drift enumeration: clean — every other package main==PyPI; scope is exactly these two.
- Code already CI-green + security-reviewed on the source PRs (#1740, #1739); this bump adds no code.
- Post-merge: TestPyPI validate (mandatory for minor) → tag `dataflow-v2.17.0` + `kaizen-v2.32.0` → OIDC PyPI publish → clean-venv install verify.

## Related issues
Releases #1737, #1735, #1721, #1734.