### PR TITLE
chore(workspace): /sweep + /wrapup (post-release 2026-07-14)

### DIFF
--- a/workspaces/issue-1717-vertex-claude/.session-notes
+++ b/workspaces/issue-1717-vertex-claude/.session-notes
@@ -2,71 +2,46 @@
 
 ## Where we are
 
-All in-flight work is SHIPPED and RELEASED. This session drove three workstreams
-merged AND published to PyPI, plus a cross-SDK handoff. Repo clean; the only
-remaining items are explicit follow-ups (tracked) and co-owner-gated design
-questions. Nothing local in flight.
+Clean post-release state. Three workstreams (#1721 deprecation, #1735 manifest,
+#1737 credential callback) shipped, merged, and RELEASED to PyPI; repo swept +
+consolidated (orphan worktree removed). Nothing in flight; main clean.
 
-## Executed this session (chronological)
+## Read first
 
-1. **#1721 from_env legacy-tier deprecation** → PR #1738 merged. Legacy
-   per-provider-key auto-detect tier now emits `DeprecationWarning`;
-   `NoKeysConfigured` msg derived from `LEGACY_KEY_ORDER`. Root cause: the
-   legacy tier is a deprecated backward-compat layer in BOTH SDKs (grant
-   journal/0006, discovery journal/0007) — retire-not-reconcile.
-2. **#1735 kaizen.manifest rescue** → PR #1739 merged. Rescued the uncommitted
-   `kaizen.manifest` module + hardened 10 review findings (C0 escaping, budget
-   isFinite guard, str-char-split on the production TOML path, safe_repr bounding).
-3. **#1737 dataflow per-connection credential callback** → PR #1740 merged.
-   Token-based DB auth (Azure AD / AWS IAM) via asyncpg's native per-connection
-   `connect=` hook; wired on main adapter + health-check pool + audit event
-   store. Security /redteam surfaced HIGH (exc_info leak) + Important
-   (event-store wrap) + MERGE-WITH-FIXES M1/M2 (from-exc token chain; DSN
-   redaction in sanitize_db_error) — ALL fixed in-PR. Grant journal/0008,
-   discovery journal/0009.
-4. **rs#1810 cross-SDK lockstep** → comment posted (authorized cross-repo write,
-   grant journal/0010). Records the semantics for the Rust side to mirror.
-5. **RELEASE (2 packages, published + verified):**
-   - kailash-dataflow **2.16.0 → 2.17.0** (tag `dataflow-v2.17.0`) — #1737
-   - kailash-kaizen **2.31.2 → 2.32.0** (tag `kaizen-v2.32.0`) — #1735/#1721/#1734
-   - §3 sibling-drift enumeration clean (every other package main==PyPI).
-   - TestPyPI validated → PyPI OIDC publish (both runs SUCCESS) → clean-venv
-     import verified (dataflow DSN-redaction + kaizen.manifest exports) →
-     pip resolved+downloaded both real PyPI wheels.
+1. `workspaces/issue-1717-vertex-claude/04-validate/sweep-2026-07-14b.md` — the post-release sweep (all clean; ranked next items)
+2. `workspaces/issue-1717-vertex-claude/journal/0010-*` — the rs#1810 cross-repo grant receipt
+3. GH #1720 — legacy→four-axis consolidation (biggest lever; co-owner-gated)
+4. GH #1741 — CRUD-path credential-callback extension (this session's follow-up)
 
-## Follow-ups (tracked, not in-flight)
+## In-flight state
 
-- **#1741** — extend the #1737 credential callback to the core-SDK CRUD hot path
-  (`async_sql.py::create_pool`) + 3 remaining asyncpg pools (DatabaseRegistry /
-  staging / SyncTransactionManager). Value-anchor: the CRUD path is where most
-  token-auth users actually hit the DB (only health-check/audit/main-adapter
-  wired today). Higher blast radius → own review cycle.
-- **#1727** — Rust openai_chat `max_completion_tokens` sibling (Rust side).
+- None — tree clean, main == origin/main, no open PRs, no active todos.
 
-## Outstanding ledger (forest) — co-owner-gated
+## Executed this session (external / not in this repo's git log)
 
-| ID     | Item                                           | Status                              |
-| ------ | ---------------------------------------------- | ----------------------------------- |
-| F1720  | Retire legacy→four-axis LLM redundancy         | BLOCKED on co-owner scope (#1720)   |
-| FVERT  | Vertex-Claude/Gemini LIVE validation           | BLOCKED on GCP creds (not in .env)  |
+- Released **kailash-dataflow 2.17.0** (tag `dataflow-v2.17.0`) + **kailash-kaizen
+  2.32.0** (tag `kaizen-v2.32.0`) to PyPI — OIDC publish, TestPyPI-validated,
+  clean-venv import verified, GH releases created.
+- Posted a cross-SDK lockstep comment on the Rust SDK's rs#1810 (authorized
+  cross-repo write; grant journal/0010).
 
-Closed this session: #1721 (deprecation shipped), #1735 (manifest shipped),
-#1737 (credential callback shipped) — all via kaizen 2.32.0 / dataflow 2.17.0.
+## Outstanding ledger (forest)
+
+| ID    | Item                                          | Value-anchor                                                        | Status                          |
+| ----- | --------------------------------------------- | ------------------------------------------------------------------ | ------------------------------- |
+| F1720 | Retire legacy→four-axis LLM redundancy        | User's #1717 follow-on ("resolve the redundancy") — #1720          | BLOCKED on co-owner scope       |
+| F1741 | Extend credential callback to CRUD hot path   | The path most token-auth users hit (#1737 wired only 3 pools) — #1741 | queued (own review cycle)     |
+| FVERT | Vertex-Claude/Gemini LIVE validation          | The #1717 headline path; only wire-proven, never live               | BLOCKED on GCP creds (not .env) |
+
+Closed this session: `#1721` → kaizen 2.32.0 deprecation; `#1735` → kaizen 2.32.0 manifest; `#1737` → dataflow 2.17.0 (PR #1740, tags above).
 
 ## Traps
 
-- Running python from `/tmp` → `enum.py` shadow crash; use a clean cwd / `mktemp -d`.
-- Fresh cold venv under machine load can make `import dataflow` hang >5min — it's
-  environmental (same code imports fast in a warm venv; CI green). Verify install
-  via `pip show` + import in a warm venv, not a cold `/tmp` venv under load.
-- PyPI/pip simple-index lag post-publish: `/pypi/<pkg>/<ver>/json` updates before
-  the simple index pip resolves against; retry `pip download --no-cache-dir` a few
-  times (build-repo-release §2). The publish DID happen if the workflow is green +
-  the JSON endpoint serves the version.
-- The `gh --repo terrene-foundation/kailash-py` flag trips the repo-scope lexical
-  hook even though it's the CWD repo (false positive); omit `--repo` on same-repo gh.
+- Cold `/tmp` venv under machine load makes `import dataflow`/`kaizen` hang >5min — environmental (same code imports fast in a warm venv + CI green). Verify via `pip show` + warm-venv import, not a cold `/tmp` venv.
+- PyPI simple-index lags the `/json` endpoint post-publish; retry `pip download --no-cache-dir` a few times (build-repo-release §2).
+- `gh --repo terrene-foundation/kailash-py` trips the repo-scope lexical hook though it's the CWD repo (false positive); omit `--repo` on same-repo gh.
 
 ## Open questions for the human
 
-- #1720 consolidation scope (biggest lever). One line unblocks it.
-- Whether to prioritize #1741 (CRUD-path credential extension) next session.
+- #1720 consolidation scope (biggest lever) — one line unblocks it.
+- Prioritize #1741 (CRUD-path credential extension) next session?

--- a/workspaces/issue-1717-vertex-claude/04-validate/sweep-2026-07-14b.md
+++ b/workspaces/issue-1717-vertex-claude/04-validate/sweep-2026-07-14b.md
@@ -1,0 +1,38 @@
+# /sweep — 2026-07-14 (post-release consolidation)
+
+Repo-wide sweep after the #1721/#1735/#1737 ship + dataflow 2.17.0 / kaizen 2.32.0 release.
+Repo: `terrene-foundation/kailash-py` (BUILD). main @ `3d9940ba2`.
+
+## Findings
+
+| Sev | Sweep | Finding                                                                                           | Disposition                                                                                                                                  | Pointer                            |
+| --- | ----- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| LOW | 6     | Orphan worktree `feat/1737-dataflow-credential-provider` (merged into main via #1740, clean tree) | **FIXED** — `git worktree remove` + `git branch -d` (was 127c07bfe)                                                                          | —                                  |
+| —   | 1     | Active todos across workspaces                                                                    | CLEAN — none                                                                                                                                 | `workspaces/*/todos/active/` empty |
+| —   | 2     | Pending journals (`.pending/`)                                                                    | CLEAN — none                                                                                                                                 | —                                  |
+| —   | 3     | Open GH issues (10) — pre-existing backlog                                                        | DEFER — none session-created except #1741; none closeable-as-delivered; none stale-abandonable                                               | see below                          |
+| —   | 4     | Open PRs / orphan branches                                                                        | CLEAN — none                                                                                                                                 | —                                  |
+| —   | 5     | Redteam gaps (spec compliance)                                                                    | N/A — `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->` (this workspace has no `specs/` dir)             | —                                  |
+| —   | 7     | Process hygiene (uncommitted / divergence / stubs)                                                | CLEAN — tree clean, main==origin (0/0)                                                                                                       | —                                  |
+| —   | 8     | Release readiness                                                                                 | CLEAN — no unreleased CORE (`src/kailash` empty since v2.50.0); dataflow 2.17.0 + kaizen 2.32.0 released under per-package tags this session | —                                  |
+| —   | 9     | Cross-ecosystem roll-up                                                                           | N/A — BUILD repo, not orchestration root                                                                                                     | —                                  |
+
+## Sweep 3 — open-issue backlog (all pre-existing; none this-session's mess)
+
+Three dispositions per `value-prioritization.md` MUST-3/4 — none auto-closed:
+
+- **Co-owner-gated (design decision required):** #1720 (consolidate legacy→four-axis LLM — biggest lever), #1721 (Python preset-registry drift vs Rust fixture). This session shipped the #1721 _deprecation_ (kaizen 2.32.0); the _reconcile/consolidate_ scope stays with the co-owner.
+- **Queued-actionable (future sessions):** #1741 (CRUD-path credential extension — this session's tracked follow-up, value-anchor: the path most token-auth users hit), #1736 (kaizen unit tests hang on unmocked LLM/network), #1727 (Rust openai_chat max_completion_tokens sibling), #1713 (EATP BH3 origin-digest DoS bounds), #1712 (MCP spec-compliance parity gaps), #1711 (SOC2 evidence primitives), #1710 (EATP capability-attestation trust-posture, cross-sdk/security), #1694 (Gate-1 onboarding-suite stranded fixes).
+- **Abandon-with-user-gate:** none — no stale issue warrants closure.
+
+## Cross-cutting
+
+- Repo is in a clean post-release state: nothing in flight, tree clean, all this-session work merged + released + verified.
+- The open backlog is genuine future work + two co-owner design questions — NOT deferral-as-forgetting; each carries an issue with context.
+
+## Ranked next-session candidates (human call — sweep does not decide)
+
+1. **#1720** legacy→four-axis consolidation — highest lever; one co-owner line unblocks scope. (co-owner-gated)
+2. **#1741** CRUD-path credential extension — this session's direct follow-up; the path most token-auth users hit. (actionable, own review cycle)
+3. **#1736** kaizen test-hang fix — unblocks reliable full kaizen CI. (actionable, test hygiene)
+4. **#1710** EATP capability-attestation trust-posture — security + cross-SDK. (actionable)


### PR DESCRIPTION
Workspace-only (sweep report + .session-notes). build-repo-release §1a carve-out — no release. Post-release sweep clean; orphan worktree removed.