### PR TITLE
release: kailash 2.51.0 + kailash-dataflow 2.18.0 (#1741 token-auth completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unmodified — this is a deprecation of the tier, not a reconciliation of
   the key lists.
 
-## [2.50.0] - 2026-07-13
+## [2.51.0] - 2026-07-14
+
+### Added
+
+- **Core-SDK per-connection credential callback for token-based DB auth
+  (#1741).** `kailash.nodes.data.async_sql.DatabaseConfig` now accepts an
+  optional `credential_provider: Optional[Callable[[], str]]` — a zero-arg
+  callable that mints a fresh password/token on **every** physical connection
+  the core `AsyncSQLDatabaseNode` / `PostgreSQLAdapter` pool opens (initial
+  fill, recycle, overflow, reconnect). This is the pool the `db.express` /
+  `db.transactions` CRUD hot path actually opens — DataFlow rides the callback
+  in through `_get_or_create_async_sql_node`. New shared helper
+  `kailash.nodes.data.credential_provider.build_asyncpg_credential_connect`
+  installs asyncpg's per-connection `connect` hook; it is fail-closed (a
+  raising / non-str provider raises `NodeExecutionError` and NEVER falls back
+  to a stale token), never logs the token, sets it as the driver `password`
+  param (never re-encoded into a DSN — tokens containing `&=/%` need no
+  percent-encoding), and severs the provider-exception cause chain. Absent the
+  callback, behavior is unchanged. Companion to kailash-dataflow 2.18.0, which
+  extends the same callback across every DataFlow connection path.
 
 Observability program (#1708) — a coordinated 5-package release. Configures
 the previously-inert OpenTelemetry provider layer, unifies every server's

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## [Unreleased]
 
+## [2.18.0] — 2026-07-14 — Complete token-based DB auth across every connection path (#1741)
+
+### Added
+
+- **Per-connection credential callback extended to EVERY DataFlow connection
+  path (#1741, follow-up to #1737).** #1737 wired the callback into three side
+  pools (adapter probe, health-check `LightweightPool`, audit-trail
+  `PostgreSQLEventStore`) but missed the pool the token-auth user's actual
+  `db.express` / `db.transactions` / bulk CRUD queries open — the core-SDK
+  `AsyncSQLDatabaseNode` pool — so token auth still failed intermittently on
+  real CRUD traffic after the first token expiry. 2.18.0 closes every path:
+  - **CRUD hot path:** DataFlow rides `config.database.credential_provider`
+    into the core pool via `_get_or_create_async_sql_node` (+ the no-scope CRUD
+    retry fallback). Requires **kailash >= 2.51.0** (new core
+    `DatabaseConfig.credential_provider` field + connect hook).
+  - **The remaining pools:** `DatabaseRegistry`, `StagingEnvironmentManager`
+    (pool + reachability probe + maintenance-DB admin connects), and the
+    `SyncTransactionManager` single-connection path.
+  - **DDL / migration paths:** the engine DDL / verify / `get_connection`
+    connects, the DDL-executor + migration-executor wrappers, the
+    migration-lock tx connection, and the sync `psycopg2` migration connect
+    (via a sync `resolve_fresh_credential` mint).
+  - **Standalone `WorkflowBuilder` bulk nodes** (`BulkCreatePoolNode` /
+    `DataFlowBulkUpsertNode`, which hold no DataFlow instance): a new
+    context-scoped side-channel — `dataflow.core.credential_provider.
+credential_provider_scope(cp)` (public) binds the provider; the nodes read
+    `get_active_credential_provider()`. The Kailash runtime's `copy_context()`
+    snapshot carries it across the node-dispatch boundary. The
+    `db.express` / `db.bulk_*` path needs no scope (already threaded).
+- **Single shared entry point** `open_credentialed_connection` — every non-pool
+  single connection routes through it, so the fail-closed + no-secret-in-logs
+  contract lives in exactly one place.
+
+### Security
+
+- `sanitize_db_error` now also redacts the `password=<value>` keyword form (the
+  discrete-kwargs pools' connect-failure errors), not only the `://u:pw@` URL
+  form. A fail-closed credential error in the psycopg2 migration path is no
+  longer swallowed into the `:memory:` SQLite fallback.
+
+### Out of scope (distinct surfaces)
+
+- The migration-staging validation connects (ephemeral staging DB, not the
+  user's prod), the Docker test-container managers, and the fabric read-only
+  source adapter (its config carries no `credential_provider`).
+
 ## [2.17.0] — 2026-07-14 — Per-connection credential callback for token-based DB auth (#1737)
 
 ### Added

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.17.0"
+version = "2.18.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.50.0",
+    "kailash>=2.51.0",  # #1741: core DatabaseConfig.credential_provider + connect hook
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.50.0"
+version = "2.51.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.50.0"
+__version__ = "2.51.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Coordinated release closing #1741 (per-connection credential callback / token-based DB auth across **every** DataFlow connection path). Metadata-only (version bumps + CHANGELOGs + dependency floor).

- **kailash 2.50.0 → 2.51.0** — new core `DatabaseConfig.credential_provider` field + `build_asyncpg_credential_connect` connect hook (the CRUD hot-path pool `db.express`/`db.transactions` open).
- **kailash-dataflow 2.17.0 → 2.18.0** — extends the callback to every remaining path (DDL/migration, the 3 named pools, standalone bulk nodes via the context-scoped `credential_provider_scope`); floors `kailash>=2.51.0` (it needs the new core field).

Version consistency verified (`pyproject.toml` + `__init__.py` for both packages). No sibling drift — all other packages at PyPI parity.

## Related issues

Closes #1741. Code landed in #1745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)