### PR TITLE
fix(eatp): fail-closed resource bounds on BH3 origin-digest ingress (DoS) (#1713)

### DIFF
--- a/src/kailash/trust/_jcs.py
+++ b/src/kailash/trust/_jcs.py
@@ -40,11 +40,140 @@ from __future__ import annotations
 import hashlib
 import math
 import re
+from dataclasses import fields, is_dataclass
 from typing import Any
 
 from kailash.trust._canonical import canonical_scalars
 
-__all__ = ["jcs_encode", "jcs_subject_hash"]
+__all__ = [
+    "MAX_DIGEST_CHILDREN",
+    "MAX_DIGEST_DEPTH",
+    "MAX_DIGEST_NODES",
+    "MAX_DIGEST_STRING_TOTAL_BYTES",
+    "jcs_encode",
+    "jcs_subject_hash",
+]
+
+# ---------------------------------------------------------------------------
+# Fail-closed resource bounds on the digest ingress (issue #1713).
+#
+# `jcs_encode` is the SHARED ingress for every attacker-influenceable subject
+# that reaches this canonical encoder: the BH3 origin digest
+# (`reasoning.origin.compute_origin_digest`, #1510) AND the EATP Audit-Anchor
+# external-`subject_hash` path (`pact.audit`, #1590), plus the weft / bilateral
+# / attestation content-hash paths. Every one of those runs an attacker-shaped
+# `Any` through TWO unbounded recursive passes (`canonical_scalars` then
+# `_encode`) and a SHA-256 BEFORE any auth check — an unauthenticated CPU /
+# memory denial-of-service. A crafted wide/large payload burns unbounded
+# CPU+memory; a deeply-nested payload drives the recursion toward RecursionError
+# (swallowed to False on verify, but propagated UNCAUGHT on the sign path).
+#
+# The guard below traverses the RAW input ONCE, iteratively (its own traversal
+# CANNOT RecursionError), and fails closed with a typed ValueError naming the
+# exceeded limit + the observed value BEFORE canonicalization/hashing runs. The
+# magnitudes mirror the PACT org-compilation limits (`pact.compilation`,
+# `pact-governance.md` §7) — they are DoS backstops, NOT business limits, and
+# are generous enough that every legitimate subject passes unchanged. A
+# reject-only bound changes ZERO bytes for in-bounds input, so the pinned
+# cross-SDK conformance vectors stay byte-identical (no cross-SDK lockstep).
+# ---------------------------------------------------------------------------
+
+MAX_DIGEST_DEPTH: int = 50
+"""Maximum container-nesting depth of a subject passed to :func:`jcs_encode`."""
+
+MAX_DIGEST_NODES: int = 100_000
+"""Maximum total nodes (scalars + containers + dict keys) traversed."""
+
+MAX_DIGEST_CHILDREN: int = 500
+"""Maximum direct children (entries / elements) of any single container."""
+
+MAX_DIGEST_STRING_TOTAL_BYTES: int = 10_000_000
+"""Maximum cumulative UTF-8 byte length of all strings/bytes in the subject
+(10 MB) — rejects a single multi-GB string or the sum of many large ones."""
+
+
+def _check_digest_bounds(root: Any) -> None:
+    """Fail-closed resource-bound check over the RAW digest input (issue #1713).
+
+    Traverses ``root`` ONCE with an explicit stack (never Python recursion — so
+    a deeply-nested adversarial payload cannot RecursionError the guard itself),
+    enforcing :data:`MAX_DIGEST_DEPTH`, :data:`MAX_DIGEST_NODES`,
+    :data:`MAX_DIGEST_CHILDREN`, and :data:`MAX_DIGEST_STRING_TOTAL_BYTES`. Runs
+    BEFORE :func:`canonical_scalars` / :func:`_encode` / the SHA-256 so an
+    oversize subject is rejected before any unbounded work.
+
+    Raises:
+        ValueError: ``origin-oversize-rejected``-class error naming the exceeded
+            limit AND the observed value. Fail-closed: unknown/error → reject
+            (never sign/verify).
+    """
+    total_nodes = 0
+    total_str_bytes = 0
+    # Stack of (node, depth); iterative to bound the guard's own memory/stack.
+    stack: list[tuple[Any, int]] = [(root, 1)]
+    while stack:
+        node, depth = stack.pop()
+        total_nodes += 1
+        if total_nodes > MAX_DIGEST_NODES:
+            raise ValueError(
+                "origin-oversize-rejected: subject exceeds max total nodes "
+                f"(limit={MAX_DIGEST_NODES}, observed>{MAX_DIGEST_NODES})"
+            )
+        if depth > MAX_DIGEST_DEPTH:
+            raise ValueError(
+                "origin-oversize-rejected: subject exceeds max nesting depth "
+                f"(limit={MAX_DIGEST_DEPTH}, observed={depth})"
+            )
+
+        # Leaf scalars carrying byte weight — accumulate and stop descending.
+        if isinstance(node, str):
+            total_str_bytes += len(node.encode("utf-8"))
+            if total_str_bytes > MAX_DIGEST_STRING_TOTAL_BYTES:
+                raise ValueError(
+                    "origin-oversize-rejected: subject exceeds max cumulative "
+                    f"string length (limit={MAX_DIGEST_STRING_TOTAL_BYTES} bytes, "
+                    f"observed>{MAX_DIGEST_STRING_TOTAL_BYTES})"
+                )
+            continue
+        if isinstance(node, (bytes, bytearray)):
+            total_str_bytes += len(node)
+            if total_str_bytes > MAX_DIGEST_STRING_TOTAL_BYTES:
+                raise ValueError(
+                    "origin-oversize-rejected: subject exceeds max cumulative "
+                    f"string length (limit={MAX_DIGEST_STRING_TOTAL_BYTES} bytes, "
+                    f"observed>{MAX_DIGEST_STRING_TOTAL_BYTES})"
+                )
+            continue
+
+        # Containers — count direct children, then descend. Mirrors the type
+        # whitelist canonical_scalars recurses into (dict / set / list / tuple /
+        # dataclass) so the guard sees exactly what the encoder will.
+        children: list[Any] | None = None
+        if not isinstance(node, type) and is_dataclass(node):
+            children = [getattr(node, f.name) for f in fields(node)]
+        elif isinstance(node, dict):
+            # Both keys and values are traversed by the encoder; count entries.
+            if len(node) > MAX_DIGEST_CHILDREN:
+                raise ValueError(
+                    "origin-oversize-rejected: container exceeds max children "
+                    f"(limit={MAX_DIGEST_CHILDREN}, observed={len(node)})"
+                )
+            for key, value in node.items():
+                stack.append((key, depth + 1))
+                stack.append((value, depth + 1))
+            continue
+        elif isinstance(node, (list, tuple, set, frozenset)):
+            children = list(node)
+
+        if children is not None:
+            if len(children) > MAX_DIGEST_CHILDREN:
+                raise ValueError(
+                    "origin-oversize-rejected: container exceeds max children "
+                    f"(limit={MAX_DIGEST_CHILDREN}, observed={len(children)})"
+                )
+            for child in children:
+                stack.append((child, depth + 1))
+
 
 # repr(float) either has an exponent ("1e+21", "1.5e-08") or does not
 # ("123.45", "1.0"). Split on the exponent marker to recover mantissa + exponent.
@@ -237,10 +366,15 @@ def jcs_encode(value: Any) -> str:
     sorted by UTF-16 code unit, no inter-token whitespace.
 
     Raises:
-        ValueError: if ``value`` contains a non-finite float.
+        ValueError: if ``value`` exceeds a digest resource bound (issue #1713 —
+            depth / node-count / per-container children / cumulative string
+            length), or if ``value`` contains a non-finite float.
         TypeError: if ``value`` contains a value with no RFC-8785 encoding
             after normalization, or a non-string object key.
     """
+    # Fail-closed resource-bound check on the RAW input BEFORE the two unbounded
+    # recursive passes (canonical_scalars → _encode) + hash run (issue #1713).
+    _check_digest_bounds(value)
     normalized = canonical_scalars(value)
     return _encode(normalized)
 

--- a/tests/regression/test_issue_1713_bh3_dos_bounds.py
+++ b/tests/regression/test_issue_1713_bh3_dos_bounds.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: fail-closed resource bounds on the BH3 origin-digest ingress.
+
+Issue #1713 — the BH3 origin digest (and the shared #1590 Audit-Anchor
+`subject_hash`) ran an attacker-shaped ``Any`` through TWO unbounded recursive
+passes (``canonical_scalars`` → ``_encode``) and a SHA-256 BEFORE any auth
+check, an unauthenticated CPU/memory DoS. A crafted wide/large payload burns
+unbounded CPU+memory; a deeply-nested payload drives the recursion toward
+RecursionError (swallowed → False on the verify path, but propagated UNCAUGHT
+on the sign path).
+
+The fix adds a fail-closed bounded-traversal guard at the SHARED ingress
+(``jcs_encode``) that rejects an oversize subject with a typed ``ValueError``
+naming the exceeded limit BEFORE canonicalization/hashing runs.
+
+These tests are BEHAVIORAL (call the function; assert raise/return) — never a
+source-grep (per testing.md § "Behavioral Regression Tests Over Source-Grep").
+Byte-neutrality (a valid in-bounds subject digests identically to pre-guard) is
+asserted here and doubly pinned by the BH3 conformance vectors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from kailash.trust._jcs import (
+    MAX_DIGEST_CHILDREN,
+    MAX_DIGEST_DEPTH,
+    MAX_DIGEST_NODES,
+    MAX_DIGEST_STRING_TOTAL_BYTES,
+    jcs_encode,
+    jcs_subject_hash,
+)
+from kailash.trust.reasoning.origin import (
+    compute_origin_digest,
+    sign_origin_bound_trace,
+    verify_origin_bound_trace,
+)
+from kailash.trust.reasoning.traces import ReasoningTrace
+
+pytestmark = pytest.mark.regression
+
+
+# A valid, in-bounds originating instruction (the shape a real BH3 caller uses;
+# mirrors tests/trust/pact/conformance/vectors/bh3_origin_bound.json).
+VALID_INSTRUCTION = {
+    "instruction": "deploy service X to staging",
+    "issued_by": "D1-R1",
+    "nonce": "abc123",
+}
+
+# A valid in-bounds trace (mirrors the bh3_origin_bound.json vector's trace).
+VALID_TRACE_DICT = {
+    "decision": "approve deploy",
+    "rationale": "cost within envelope",
+    "confidentiality": "restricted",
+    "timestamp": "2026-01-15T10:30:00+00:00",
+    "alternatives_considered": ["defer"],
+    "evidence": [{"cost": 500}],
+    "methodology": "cost_benefit",
+    "confidence": 0.9,
+}
+
+
+def _deeply_nested(depth: int):
+    """A list nested ``depth`` levels deep: [[[ ... ]]]."""
+    node: object = "leaf"
+    for _ in range(depth):
+        node = [node]
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Over-limit DEEP nesting → typed error naming the depth limit.
+# ---------------------------------------------------------------------------
+
+
+def test_over_limit_deep_nesting_rejected_via_compute_origin_digest() -> None:
+    payload = _deeply_nested(MAX_DIGEST_DEPTH + 5)
+    with pytest.raises(ValueError, match="max nesting depth"):
+        compute_origin_digest(payload)
+
+
+def test_over_limit_deep_nesting_rejected_via_jcs_encode() -> None:
+    payload = _deeply_nested(MAX_DIGEST_DEPTH + 5)
+    with pytest.raises(ValueError) as exc:
+        jcs_encode(payload)
+    msg = str(exc.value)
+    assert "origin-oversize-rejected" in msg
+    assert "max nesting depth" in msg
+    assert str(MAX_DIGEST_DEPTH) in msg  # names the limit
+
+
+def test_deep_nesting_does_not_recursionerror_the_guard() -> None:
+    # A payload deep enough to blow Python's default recursion limit MUST be
+    # rejected as a clean ValueError, NOT a RecursionError — the guard traverses
+    # iteratively so the sign path surfaces a typed error, not a stack blow-up.
+    payload = _deeply_nested(10_000)
+    with pytest.raises(ValueError, match="max nesting depth"):
+        compute_origin_digest(payload)
+
+
+# ---------------------------------------------------------------------------
+# Over-limit WIDE (huge element count) → typed error naming the node limit.
+# ---------------------------------------------------------------------------
+
+
+def test_over_limit_node_count_rejected() -> None:
+    # A single container with > MAX_DIGEST_CHILDREN elements is rejected by the
+    # per-container children bound; grow past MAX_DIGEST_NODES by nesting so the
+    # NODE bound is what trips.
+    outer = [[i for i in range(MAX_DIGEST_CHILDREN)] for _ in range(500)]
+    with pytest.raises(ValueError) as exc:
+        jcs_encode(outer)
+    msg = str(exc.value)
+    assert "origin-oversize-rejected" in msg
+    # Either the node bound or the (inner) children bound may trip first; both
+    # are the wide-payload DoS defense. Assert a resource limit is named.
+    assert (
+        f"max total nodes (limit={MAX_DIGEST_NODES}" in msg
+        or f"max children (limit={MAX_DIGEST_CHILDREN}" in msg
+    )
+
+
+def test_over_limit_children_names_the_children_limit() -> None:
+    wide = list(range(MAX_DIGEST_CHILDREN + 1))
+    with pytest.raises(ValueError, match="max children") as exc:
+        compute_origin_digest(wide)
+    assert str(MAX_DIGEST_CHILDREN) in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Over-limit LONG string → typed error naming the string/bytes limit.
+# ---------------------------------------------------------------------------
+
+
+def test_over_limit_long_string_rejected() -> None:
+    payload = {"instruction": "A" * (MAX_DIGEST_STRING_TOTAL_BYTES + 1)}
+    with pytest.raises(ValueError) as exc:
+        compute_origin_digest(payload)
+    msg = str(exc.value)
+    assert "origin-oversize-rejected" in msg
+    assert "max cumulative string length" in msg
+    assert str(MAX_DIGEST_STRING_TOTAL_BYTES) in msg
+
+
+# ---------------------------------------------------------------------------
+# A valid, in-bounds subject → digests successfully AND byte-identically
+# (behavior-invariance). Covers BOTH the sign and verify paths.
+# ---------------------------------------------------------------------------
+
+# Pinned pre-guard digest of VALID_INSTRUCTION (from the committed BH3 bound
+# conformance vector). The guard MUST NOT alter this byte-for-byte.
+EXPECTED_DIGEST = (
+    "sha256:be309592b937446a1e63c99921f72d200a44096a5e8cd73a4e450271371276fc"
+)
+
+
+def test_in_bounds_subject_digests_byte_identically() -> None:
+    digest = compute_origin_digest(VALID_INSTRUCTION)
+    assert digest == EXPECTED_DIGEST  # byte-identical to pre-guard
+
+    # jcs_encode output recomputes the same SHA-256.
+    encoded = jcs_encode(VALID_INSTRUCTION)
+    assert "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest() == digest
+    assert jcs_subject_hash(VALID_INSTRUCTION) == digest
+
+
+def test_in_bounds_sign_and_verify_roundtrip_unchanged() -> None:
+    # Ed25519 keypair for the sign→verify round-trip (both paths run the guard).
+    nacl = pytest.importorskip("nacl.signing")
+    import base64
+
+    signing_key = nacl.SigningKey.generate()
+    private_key = base64.b64encode(bytes(signing_key)).decode("ascii")
+    public_key = base64.b64encode(bytes(signing_key.verify_key)).decode("ascii")
+
+    trace = ReasoningTrace.from_dict(VALID_TRACE_DICT)
+
+    # SIGN path — computes the origin digest through the guarded ingress.
+    record = sign_origin_bound_trace(
+        trace,
+        private_key,
+        signed_by="D1-R1",
+        originating_instruction=VALID_INSTRUCTION,
+    )
+    assert record.origin_bound is True
+    assert record.origin_digest == EXPECTED_DIGEST  # byte-identical
+
+    # VERIFY path — recomputes the origin digest through the guarded ingress.
+    assert (
+        verify_origin_bound_trace(
+            record, public_key, originating_instruction=VALID_INSTRUCTION
+        )
+        is True
+    )
+
+
+def test_sign_path_surfaces_typed_error_not_recursionerror() -> None:
+    # The sign path (origin.py:241) previously propagated an UNCAUGHT
+    # RecursionError on a deeply-nested instruction; it now surfaces a clean
+    # typed ValueError from the guard.
+    nacl = pytest.importorskip("nacl.signing")
+    import base64
+
+    signing_key = nacl.SigningKey.generate()
+    private_key = base64.b64encode(bytes(signing_key)).decode("ascii")
+
+    trace = ReasoningTrace.from_dict(VALID_TRACE_DICT)
+    with pytest.raises(ValueError, match="max nesting depth"):
+        sign_origin_bound_trace(
+            trace,
+            private_key,
+            signed_by="D1-R1",
+            originating_instruction=_deeply_nested(10_000),
+        )
+
+
+def test_verify_path_fails_closed_on_oversize_instruction() -> None:
+    # A bound record whose AUTHORITATIVE instruction (held by the verifier) is
+    # oversize: the verify path catches the guard's ValueError and fails closed
+    # to False (never raises out, never passes).
+    nacl = pytest.importorskip("nacl.signing")
+    import base64
+
+    signing_key = nacl.SigningKey.generate()
+    private_key = base64.b64encode(bytes(signing_key)).decode("ascii")
+    public_key = base64.b64encode(bytes(signing_key.verify_key)).decode("ascii")
+
+    trace = ReasoningTrace.from_dict(VALID_TRACE_DICT)
+    record = sign_origin_bound_trace(
+        trace,
+        private_key,
+        signed_by="D1-R1",
+        originating_instruction=VALID_INSTRUCTION,
+    )
+    # Verifier presents an oversize authoritative instruction → fail-closed.
+    assert (
+        verify_origin_bound_trace(
+            record, public_key, originating_instruction=_deeply_nested(10_000)
+        )
+        is False
+    )


### PR DESCRIPTION
## What

Adds a fail-closed bounded-traversal guard `_check_digest_bounds()` at the shared `jcs_encode` ingress (`src/kailash/trust/_jcs.py`), closing an **unauthenticated DoS**: attacker-shaped `Any` input previously ran through two unbounded recursive passes (`canonical_scalars` → `_encode`) + SHA-256 **before any auth check**.

Bounds (module constants, mirror PACT org-compilation limits per `pact-governance.md` §7):
- `MAX_DIGEST_DEPTH = 50`, `MAX_DIGEST_NODES = 100_000`, `MAX_DIGEST_CHILDREN = 500`, `MAX_DIGEST_STRING_TOTAL_BYTES = 10_000_000`

The guard traverses the RAW input **once, iteratively (explicit stack)** — so it cannot itself `RecursionError` — and raises a typed `ValueError` (`origin-oversize-rejected:` prefix) naming the exceeded limit + observed value, before any unbounded work.

## Why

Two attacker vectors reached real callers pre-auth: deep nesting → `RecursionError` (propagated uncaught on the sign path `origin.py:241`), and wide/large payloads (huge lists / multi-GB strings) → unbounded CPU+memory.

## Enforcement-Surface Parity

Placement at `jcs_encode` (the shared ingress `jcs_subject_hash` delegates to) covers **every** attacker-influenceable caller in one guard: BH3 origin-digest (`reasoning/origin.py:87`), #1590 Audit-Anchor `subject_hash` (`pact/audit.py:269`), plus weft/bilateral/attestation content-hash paths. No un-guarded sibling ingress.

## Byte-neutrality (no cross-SDK lockstep)

A reject-only bound changes **zero** bytes for in-bounds input. BH3 conformance vectors (`tests/trust/pact/conformance/`) stay GREEN — pure fail-closed addition per `cross-sdk-inspection.md`, no byte-changing cross-SDK lockstep.

## Tests

`tests/regression/test_issue_1713_bh3_dos_bounds.py` (`@pytest.mark.regression`, behavioral): over-limit deep / wide / long-string → typed `ValueError` naming the limit; valid in-bounds input digests byte-identically (both sign + verify paths). **166 passed**, conformance GREEN.

## Gate review

- **Code review (reviewer): CLEAN** — ran a guard-neutralization probe confirming 7/10 tests are load-bearing; verified per-branch depth tracking, Enforcement-Surface Parity, module hygiene.
- **Security review (security-reviewer): CLEAN** on all logic checks (iterative/self-DoS-safe, type completeness vs `canonical_scalars` recurse-set, cumulative-byte counter, error hygiene, byte-neutrality). One initial "guard un-wired" CRITICAL was refuted as a stale-worktree read artifact — the committed blob has `_check_digest_bounds(value)` wired at `_jcs.py:377` (verified via `git show`) and the reviewer's own 166-passed run corroborates.

## Cross-SDK

BH3 has a Rust SDK sibling (module references the `rs#1707` handoff); a `cross-sdk`-labelled mirror issue for the DoS bound is a pending authorized-cross-repo action (not filed in this PR).

## Related issues

Fixes #1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)