### PR TITLE
fix(eatp): fail-closed chain-integrity + expiry + genesis gate before capability/lineage mint (#1710)

### DIFF
--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -1223,6 +1223,121 @@ class TrustOperations:
             level=VerificationLevel.FULL,
         )
 
+    async def _verify_source_chain_before_mint(
+        self,
+        chain: TrustLineageChain,
+        subject_id: str,
+    ) -> None:
+        """Fail-closed pre-sign gate for any mint that derives a *signed,
+        portable* artifact from a stored trust chain (#1710).
+
+        EATP-07 capability attestations and trust-lineage aggregates are signed,
+        portable artifacts: a relying party verifies the signature WITHOUT ever
+        seeing the underlying chain. If a mint reads the source chain via an
+        un-verified, expiry-blind path, a signed artifact can be produced from a
+        *tampered* chain or an *expired* grant and then trusted off-chain. This
+        gate closes that hole by refusing -- BEFORE any signature is produced --
+        when the source chain:
+
+        1. lacks a verifiable genesis issuer (no genesis / no issuing authority),
+        2. is expired (the grant's validity window has closed), or
+        3. fails cryptographic integrity verification (tampered signatures).
+
+        This is the single shared pre-sign verification used by EVERY mint
+        surface that reads a chain and signs a portable record (``delegate`` and
+        ``audit``), so the surfaces cannot drift (``rules/security.md`` §
+        Enforcement-Surface Parity).
+
+        Fail-closed (``rules/eatp.md``): unknown / error states DENY. Every
+        refusal raises a typed :class:`TrustError` subclass carrying ``.details``
+        and NO signature is produced on any refusal path. On a valid, unexpired,
+        genesis-anchored chain this is behaviour-invariant -- it only ever adds
+        refusals, never a new success shape.
+
+        Args:
+            chain: The source trust chain the mint reads.
+            subject_id: The agent the mint is acting for (used in error details).
+
+        Raises:
+            InvalidTrustChainError: If the chain lacks a genesis issuer, is
+                expired, or fails integrity verification.
+        """
+        # (a) Require a genesis issuer. Checked first so ``is_expired()`` and
+        # ``_verify_signatures`` never dereference a missing genesis. A chain
+        # with no verifiable genesis has no anchor of trust to mint from.
+        genesis = getattr(chain, "genesis", None)
+        if genesis is None or not getattr(genesis, "authority_id", None):
+            logger.warning(
+                "mint refused: source chain has no verifiable genesis issuer "
+                "(fail-closed)",
+                extra={"subject_id": subject_id},
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                "source chain has no verifiable genesis issuer",
+                violations=["missing_genesis_issuer"],
+            )
+
+        # (b) Reject an expired grant. Minting a fresh signed artifact from an
+        # expired chain would let the artifact outlive the grant it derives from.
+        if chain.is_expired():
+            logger.warning(
+                "mint refused: source chain grant is expired (fail-closed)",
+                extra={"subject_id": subject_id},
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                "source chain grant is expired",
+                violations=["expired_grant"],
+            )
+
+        # (c) Verify cryptographic chain integrity. Reuses the existing
+        # full-chain signature verifier (genesis + capability + delegation
+        # signatures) -- no new crypto is hand-rolled. A tampered chain fails
+        # here and no signature is produced.
+        try:
+            integrity = await self._verify_signatures(chain)
+        except (AuthorityNotFoundError, AuthorityInactiveError) as exc:
+            # An unresolvable / unusable genesis authority means the chain has
+            # no verifiable issuer -- fail closed as a missing-issuer refusal.
+            logger.warning(
+                "mint refused: source chain genesis issuer unresolved " "(fail-closed)",
+                extra={"subject_id": subject_id, "error": str(exc)},
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                "source chain genesis issuer could not be resolved",
+                violations=["missing_genesis_issuer"],
+            ) from exc
+        except InvalidSignatureError as exc:
+            # A malformed / wrong-length / unverifiable genesis signature raises
+            # (rather than returning False) from _verify_signatures' genesis
+            # check. That is a chain-integrity failure -- fail closed with the
+            # same typed refusal the returned-False integrity path uses, so a
+            # tampered genesis cannot mint a signed artifact.
+            logger.warning(
+                "mint refused: source chain has a malformed / unverifiable "
+                "signature (fail-closed)",
+                extra={"subject_id": subject_id, "error": str(exc)},
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                "source chain failed integrity verification: malformed signature",
+                violations=["chain_integrity_failed"],
+            ) from exc
+
+        if not integrity.valid:
+            logger.warning(
+                "mint refused: source chain failed integrity verification "
+                "(fail-closed)",
+                extra={"subject_id": subject_id, "reason": integrity.reason},
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                f"source chain failed integrity verification: {integrity.reason}",
+                violations=["chain_integrity_failed"],
+            )
+
     async def _verify_delegation_signature(
         self,
         delegation: DelegationRecord,
@@ -1486,6 +1601,15 @@ class TrustOperations:
         except TrustChainNotFoundError:
             raise TrustChainNotFoundError(delegator_id)
 
+        # 1b. Fail-closed pre-sign gate (#1710): verify the delegator chain's
+        # genesis issuer + validity window + cryptographic integrity BEFORE any
+        # signed, portable artifact (delegation record / derived genesis /
+        # derived capability attestations) is minted from it. Refuses a
+        # tampered / expired / genesis-less source chain (subsumes the former
+        # standalone is_expired() check via the shared helper -- one gate across
+        # every mint surface, per rules/security.md Enforcement-Surface Parity).
+        await self._verify_source_chain_before_mint(delegator_chain, delegator_id)
+
         # 2. Verify delegator has all requested capabilities
         delegator_caps = {cap.capability for cap in delegator_chain.capabilities}
         for requested_cap in capabilities:
@@ -1498,14 +1622,6 @@ class TrustOperations:
                     requested_cap,
                     f"Delegator {delegator_id} does not have capability '{requested_cap}'",
                 )
-
-        # 3. Verify delegator's trust is not expired
-        if delegator_chain.is_expired():
-            raise DelegationError(
-                "Delegator's trust chain is expired",
-                delegator_id=delegator_id,
-                delegatee_id=delegatee_id,
-            )
 
         # 4. Verify delegator can delegate (not explicitly restricted)
         delegator_constraints = [
@@ -1800,6 +1916,16 @@ class TrustOperations:
             chain = await self.trust_store.get_chain(agent_id)
         except TrustChainNotFoundError:
             raise TrustChainNotFoundError(agent_id)
+
+        # 1b. Fail-closed pre-sign gate (#1710): an AuditAnchor is a signed,
+        # portable artifact bound to this chain's ``trust_chain_hash`` -- a
+        # relying party verifies it off-chain. Verify the source chain's genesis
+        # issuer + validity window + cryptographic integrity BEFORE signing, so
+        # a tampered / expired / genesis-less chain cannot produce a signed
+        # anchor asserting a provenance the chain no longer supports (the same
+        # shared gate ``delegate`` uses -- rules/security.md Enforcement-Surface
+        # Parity).
+        await self._verify_source_chain_before_mint(chain, agent_id)
 
         # 2. Compute current trust chain hash
         trust_chain_hash = hash_chain(chain.to_dict())

--- a/tests/trust/regression/test_issue_1710_mint_fail_closed.py
+++ b/tests/trust/regression/test_issue_1710_mint_fail_closed.py
@@ -1,0 +1,381 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #1710 — fail-closed pre-sign mint gate.
+
+EATP-07 capability attestations and trust-lineage aggregates are signed,
+portable artifacts: a relying party verifies the signature WITHOUT ever seeing
+the underlying chain. If a mint reads the agent's chain via an un-verified,
+expiry-blind path, a signed artifact can be produced from a *tampered* chain or
+an *expired* grant and then trusted off-chain.
+
+The fix couples every mint surface that reads a stored chain and signs a
+portable record (``TrustOperations.delegate`` and ``TrustOperations.audit``) to
+a single shared fail-closed gate (``_verify_source_chain_before_mint``) that,
+BEFORE producing any signature:
+
+  (a) requires a verifiable genesis issuer,
+  (b) rejects an expired grant, and
+  (c) verifies the chain's cryptographic integrity.
+
+These tests cover each failure-mode class (a tampered / expired / genesis-less
+chain → mint REFUSED, no artifact produced) plus the behaviour-invariance case
+(a valid, unexpired, genesis-anchored chain still mints AND the artifact
+verifies) — proving the change ONLY adds refusals.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import (
+    ActionResult,
+    AuthorityType,
+    CapabilityType,
+    GenesisRecord,
+)
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.exceptions import (
+    InvalidTrustChainError,
+    TrustChainNotFoundError,
+    TrustError,
+)
+from kailash.trust.execution_context import ExecutionContext, HumanOrigin
+from kailash.trust.operations import (
+    CapabilityRequest,
+    TrustKeyManager,
+    TrustOperations,
+)
+from kailash.trust.signing.crypto import generate_keypair
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a real authority, key manager, in-memory store, and operations
+# instance (NO mocking — Tier 2 style, mirrors tests/trust/integration).
+# ---------------------------------------------------------------------------
+
+
+class _AuthorityRegistry:
+    """Minimal real authority registry (not a mock — stores/retrieves)."""
+
+    def __init__(self) -> None:
+        self._authorities: dict = {}
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def initialize(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        from kailash.trust.exceptions import AuthorityNotFoundError
+
+        if authority_id not in self._authorities:
+            raise AuthorityNotFoundError(authority_id)
+        return self._authorities[authority_id]
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def authority(keypair):
+    _, public_key = keypair
+    return OrganizationalAuthority(
+        id="org-acme",
+        name="ACME Corporation",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="acme-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.DELEGATE_TRUST,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+
+
+@pytest.fixture
+def registry(authority):
+    reg = _AuthorityRegistry()
+    reg.register(authority)
+    return reg
+
+
+@pytest.fixture
+def key_manager(keypair):
+    private_key, _ = keypair
+    km = TrustKeyManager()
+    km.register_key("acme-key-001", private_key)
+    return km
+
+
+@pytest.fixture
+async def store():
+    s = InMemoryTrustStore()
+    await s.initialize()
+    return s
+
+
+@pytest.fixture
+async def ops(registry, key_manager, store):
+    operations = TrustOperations(
+        authority_registry=registry,
+        key_manager=key_manager,
+        trust_store=store,
+    )
+    await operations.initialize()
+    return operations
+
+
+@pytest.fixture
+def execution_ctx():
+    return ExecutionContext(
+        human_origin=HumanOrigin(
+            human_id="alice@acme.com",
+            display_name="Alice Chen",
+            auth_provider="okta",
+            session_id="sess-1710",
+            authenticated_at=datetime.now(timezone.utc),
+        ),
+        delegation_chain=["pseudo:alice@acme.com"],
+        delegation_depth=0,
+    )
+
+
+async def _establish(ops, agent_id="agent-001", expires_at=None):
+    return await ops.establish(
+        agent_id=agent_id,
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="analyze_data",
+                capability_type=CapabilityType.ACTION,
+            )
+        ],
+        expires_at=expires_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) Behaviour-invariance: a valid, unexpired, genesis-anchored chain still
+# mints AND the produced signature verifies. Proves the change ONLY adds
+# refusals for bad chains — good chains are byte-identical.
+# ---------------------------------------------------------------------------
+
+
+class TestBehaviourInvariantOnValidChain:
+    async def test_delegate_valid_chain_still_mints_and_verifies(
+        self, ops, execution_ctx
+    ):
+        await _establish(ops)
+        delegation = await ops.delegate(
+            delegator_id="agent-001",
+            delegatee_id="agent-002",
+            task_id="task-1",
+            capabilities=["analyze_data"],
+            context=execution_ctx,
+        )
+        # Minted successfully with a real signature.
+        assert delegation.signature != ""
+        # The derived delegatee chain verifies end-to-end (integrity preserved).
+        result = await ops.verify(agent_id="agent-002", action="analyze_data")
+        assert result.valid is True
+
+    async def test_audit_valid_chain_still_mints_and_signs(self, ops, execution_ctx):
+        await _establish(ops)
+        anchor = await ops.audit(
+            agent_id="agent-001",
+            action="analyze_data",
+            resource="finance_db",
+            result=ActionResult.SUCCESS,
+            context=execution_ctx,
+        )
+        assert anchor.signature != ""
+        assert anchor.trust_chain_hash != ""
+
+    async def test_delegate_signature_is_deterministic_pre_and_post_gate(
+        self, ops, execution_ctx
+    ):
+        """The gate is a pure pre-check: a valid chain produces the exact same
+        signing payload it did before the gate existed (no new fields, no
+        mutation of the source chain)."""
+        chain = await _establish(ops)
+        genesis_sig_before = chain.genesis.signature
+        cap_sig_before = chain.capabilities[0].signature
+        await ops.delegate(
+            delegator_id="agent-001",
+            delegatee_id="agent-002",
+            task_id="task-1",
+            capabilities=["analyze_data"],
+            context=execution_ctx,
+        )
+        # The gate MUST NOT have mutated the source chain's signatures.
+        reloaded = await ops.trust_store.get_chain("agent-001")
+        assert reloaded.genesis.signature == genesis_sig_before
+        assert reloaded.capabilities[0].signature == cap_sig_before
+
+
+# ---------------------------------------------------------------------------
+# (a) Tampered chain (signature-invalid) → mint REFUSED, no artifact produced.
+# ---------------------------------------------------------------------------
+
+
+class TestTamperedChainRefused:
+    async def test_delegate_refused_on_tampered_genesis_signature(
+        self, ops, execution_ctx
+    ):
+        await _establish(ops)
+        # Tamper: corrupt the stored genesis signature.
+        chain = await ops.trust_store.get_chain("agent-001")
+        chain.genesis.signature = "deadbeef" * 8  # invalid signature bytes
+        await ops.trust_store.update_chain("agent-001", chain)
+
+        with pytest.raises(InvalidTrustChainError) as exc:
+            await ops.delegate(
+                delegator_id="agent-001",
+                delegatee_id="agent-002",
+                task_id="task-1",
+                capabilities=["analyze_data"],
+                context=execution_ctx,
+            )
+        assert "integrity" in str(exc.value).lower()
+        assert isinstance(exc.value, TrustError)
+        # Fail-closed BEFORE signing: no delegatee chain was ever created.
+        with pytest.raises(TrustChainNotFoundError):
+            await ops.trust_store.get_chain("agent-002")
+
+    async def test_audit_refused_on_tampered_capability_signature(
+        self, ops, execution_ctx
+    ):
+        await _establish(ops)
+        chain = await ops.trust_store.get_chain("agent-001")
+        chain.capabilities[0].signature = "00" * 64  # invalid signature bytes
+        await ops.trust_store.update_chain("agent-001", chain)
+
+        chain_after = await ops.trust_store.get_chain("agent-001")
+        anchors_before = len(chain_after.audit_anchors)
+
+        with pytest.raises(InvalidTrustChainError):
+            await ops.audit(
+                agent_id="agent-001",
+                action="analyze_data",
+                result=ActionResult.SUCCESS,
+                context=execution_ctx,
+            )
+        # Fail-closed BEFORE signing: no audit anchor was appended.
+        reloaded = await ops.trust_store.get_chain("agent-001")
+        assert len(reloaded.audit_anchors) == anchors_before
+
+
+# ---------------------------------------------------------------------------
+# (b) Expired grant → mint REFUSED.
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredChainRefused:
+    async def test_delegate_refused_on_expired_grant(self, ops, execution_ctx):
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        await _establish(ops, expires_at=past)
+
+        with pytest.raises(InvalidTrustChainError) as exc:
+            await ops.delegate(
+                delegator_id="agent-001",
+                delegatee_id="agent-002",
+                task_id="task-1",
+                capabilities=["analyze_data"],
+                context=execution_ctx,
+            )
+        assert "expired" in str(exc.value).lower()
+        with pytest.raises(TrustChainNotFoundError):
+            await ops.trust_store.get_chain("agent-002")
+
+    async def test_audit_refused_on_expired_grant(self, ops, execution_ctx):
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        chain = await _establish(ops, expires_at=past)
+        anchors_before = len(chain.audit_anchors)
+
+        with pytest.raises(InvalidTrustChainError) as exc:
+            await ops.audit(
+                agent_id="agent-001",
+                action="analyze_data",
+                result=ActionResult.SUCCESS,
+                context=execution_ctx,
+            )
+        assert "expired" in str(exc.value).lower()
+        reloaded = await ops.trust_store.get_chain("agent-001")
+        assert len(reloaded.audit_anchors) == anchors_before
+
+
+# ---------------------------------------------------------------------------
+# (c) Genesis-less / no-issuer chain → mint REFUSED.
+# ---------------------------------------------------------------------------
+
+
+class TestGenesisLessChainRefused:
+    async def test_delegate_refused_on_missing_genesis_issuer(self, ops, execution_ctx):
+        await _establish(ops)
+        chain = await ops.trust_store.get_chain("agent-001")
+        # Strip the genesis issuer (authority_id) — no verifiable issuer.
+        chain.genesis.authority_id = ""
+        await ops.trust_store.update_chain("agent-001", chain)
+
+        with pytest.raises(InvalidTrustChainError) as exc:
+            await ops.delegate(
+                delegator_id="agent-001",
+                delegatee_id="agent-002",
+                task_id="task-1",
+                capabilities=["analyze_data"],
+                context=execution_ctx,
+            )
+        assert "genesis" in str(exc.value).lower()
+        with pytest.raises(TrustChainNotFoundError):
+            await ops.trust_store.get_chain("agent-002")
+
+    async def test_audit_refused_when_genesis_authority_unresolvable(
+        self, ops, execution_ctx
+    ):
+        """A genesis naming an authority that does not exist in the registry has
+        no verifiable issuer — the integrity verifier's authority resolution
+        fails closed as a missing-issuer refusal, not an opaque crash."""
+        await _establish(ops)
+        chain = await ops.trust_store.get_chain("agent-001")
+        chain.genesis.authority_id = "org-does-not-exist"
+        await ops.trust_store.update_chain("agent-001", chain)
+
+        with pytest.raises(InvalidTrustChainError) as exc:
+            await ops.audit(
+                agent_id="agent-001",
+                action="analyze_data",
+                result=ActionResult.SUCCESS,
+                context=execution_ctx,
+            )
+        assert "genesis" in str(exc.value).lower() or "issuer" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Structural: both mint surfaces route through the ONE shared helper (parity).
+# ---------------------------------------------------------------------------
+
+
+def test_mint_surfaces_share_a_single_fail_closed_helper():
+    """Enforcement-Surface Parity: delegate() and audit() MUST both call the
+    single shared pre-sign gate so the two surfaces cannot drift."""
+    import inspect
+
+    src = inspect.getsource(TrustOperations)
+    assert src.count("_verify_source_chain_before_mint(") >= 3  # def + 2 calls
+
+    delegate_src = inspect.getsource(TrustOperations.delegate)
+    audit_src = inspect.getsource(TrustOperations.audit)
+    assert "_verify_source_chain_before_mint" in delegate_src
+    assert "_verify_source_chain_before_mint" in audit_src


### PR DESCRIPTION
## What

Adds a shared fail-closed pre-sign gate `_verify_source_chain_before_mint(chain, subject_id)` (`src/kailash/trust/operations/__init__.py`) called by **both** mint surfaces that produce a signed, portable artifact from a *stored* trust chain — `delegate()` and `audit()`. Before producing any signature it: (a) requires a verifiable **genesis issuer**, (b) rejects an **expired grant**, (c) verifies **chain integrity** by reusing the existing Ed25519 verifier `_verify_signatures()` (no new crypto).

## Why

Capability attestations and trust-lineage / audit-anchor aggregates are signed, portable artifacts a relying party trusts off-chain **without seeing the underlying chain**. Pre-fix, `delegate()` checked expiry only and `audit()` checked nothing — so a signed artifact could be minted from a **tampered chain or an expired grant** and then trusted off-chain. `establish()` / `_create_capability_attestation()` are correctly excluded (they create a new genesis from an authority, not mint from an untrusted stored chain).

## Enforcement-Surface Parity

Both mint-from-stored-chain surfaces route through the **one** shared helper (can't drift). Full sweep of all 8 `key_manager.sign` sites confirms no other surface mints a portable artifact from a stored chain.

## Behavior-invariance

The gate is a pure read-only pre-check (raises or returns `None`); it never touches `to_signing_payload` / `serialize_for_signing` / `key_manager.sign`. It resolves the genesis authority with `include_inactive=True` — *more* permissive than the signing path — so it cannot reject a chain the signer would already accept. Valid, unexpired, genesis-anchored chains mint **byte-identically**.

## Tests

`tests/trust/regression/test_issue_1710_mint_fail_closed.py` — per failure-mode class: tampered chain (real signature-byte mutation) → refused; expired grant → refused; genesis-less → refused; valid chain → mints + verifies; deterministic-signature (source chain unmutated by gate); structural single-helper parity. **10 passed**; full `tests/trust/` **6387 passed / 28 skipped** (+10, no regression).

## Gate review

- **security-reviewer: CLEAN** — no fail-open path, gate-before-sign on both surfaces, real crypto integrity (not structural), complete mint-surface sweep, behavior-invariance verified.
- **reviewer: CLEAN** — removed `is_expired()` block is byte-identically subsumed, neutralization probe confirms 7 refusal tests load-bearing, no new warnings.

## Design note (non-blocking, LOW)

Fail-closing `audit()` on an *expired-but-untampered* chain means post-expiry activity produces no signed anchor (rather than an audited-with-expiry-flag anchor). This faithfully implements #1710's mandate ("reject an expired grant before producing any signature"); accepted as intended. A future split (flag-on-expiry / hard-refuse-on-tamper) is possible if a compliance posture wants "audit even a degraded chain".

## Cross-SDK

EATP D6 sibling of an equivalent Rust SDK fix (matching semantics, independent implementation). A `cross-sdk` mirror issue is a pending authorized-cross-repo action (not filed in this PR).

## Related issues

Fixes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)