### PR TITLE
fix(kaizen): stop Tier-1 test hangs + fix RAG parser envelope bug they exposed (#1736)

### DIFF
--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -93,9 +93,9 @@ name: Test kailash-kaizen
 #          OllamaModelManager` raises ImportError whenever the optional
 #          client library is absent — this is the declared install matrix,
 #          not a regression.
-#        - [PARTIALLY RESOLVED, issue #1736] tests/unit/rag/test_advanced_
-#          nodes.py — was HANGING (same class as tests/unit/strategies/):
-#          HyDENode / SelfCorrectingRAGNode / StepBackRAGNode construct real
+#        - [RESOLVED, issue #1736] tests/unit/rag/test_advanced_nodes.py —
+#          was HANGING (same class as tests/unit/strategies/): HyDENode /
+#          SelfCorrectingRAGNode / StepBackRAGNode construct real
 #          LLMAgentNode(provider="openai", ...) instances for their four
 #          LLM-backed steps; the SAME registry seam attempted a genuine
 #          network call whenever a real API key was configured. Fixed by a
@@ -103,18 +103,27 @@ name: Test kailash-kaizen
 #          in this test file — NOT a directory-wide conftest, so the other 14
 #          files in tests/unit/rag/ are byte-for-byte unaffected) stubbing
 #          kaizen.providers.registry.get_provider() with a deterministic
-#          completion. 48 of 50 tests now pass in ~4s (was 300s+ hangs); this
-#          file is re-included in the tier above and no longer --ignore'd.
-#          Two tests are excluded via --deselect below (NOT --ignore — the
-#          rest of the file still runs) because they hit a DISTINCT,
-#          genuinely pre-existing src/ bug this test-hygiene-only PR does not
-#          touch (see the --deselect comment for the exact root cause).
-#          Confined to these two node classes — the other rag/ files are
-#          clean once the rag extra (numpy/Pillow/networkx) is installed (see
-#          below).
+#          completion. Mocking then EXPOSED a genuinely pre-existing src/ bug
+#          (out of the original test-hygiene scope but fixed here per
+#          zero-tolerance Rule 1 — found it, own it): every `_parse_*` helper
+#          in kaizen/nodes/rag/advanced.py (_parse_abstract_query,
+#          _parse_hypotheses, _parse_query_variations,
+#          _parse_verification_response) read `response.get("content", "")` on
+#          the FULL envelope LLMAgentNode.execute() returns
+#          (`{"success": ..., "response": {"content": ...}, ...}`) — the real
+#          content is NESTED under "response", so "content" was NEVER a
+#          top-level key and all four parsers always returned empty/[],
+#          silently forcing HyDE/StepBack/SelfCorrecting RAG to their
+#          rule-based fallback on EVERY call. Fixed to unwrap the envelope
+#          (`response.get("response", response).get("content", "")`, flat-dict
+#          tolerant). All 50 tests now pass in ~4s (was 300s+ hangs); the file
+#          is re-included in the tier above and fully gated — NO --deselect.
+#          The one HyDE no-LLM test explicitly stubs an *unavailable* provider
+#          so it genuinely exercises the documented rule-based fallback rather
+#          than the mocked-completion path.
 #
-#      Four flaky/broken tests are excluded via --deselect (NOT --ignore —
-#      the rest of their file still runs):
+#      Two flaky tests are excluded via --deselect (NOT --ignore — the rest
+#      of their file still runs):
 #        - tests/unit/memory/test_semantic_memory.py::
 #          TestSemanticMemorySimilaritySearch::{test_find_similar_basic,
 #          test_find_similar_limit} — the mock simple_embedding_function is
@@ -123,26 +132,6 @@ name: Test kailash-kaizen
 #          on some seeds/versions (passed on 3.14, failed on 3.12 in a local
 #          CI repro). Pre-existing, in code this PR does NOT touch — test-
 #          hygiene follow-up.
-#        - tests/unit/rag/test_advanced_nodes.py::TestStepBackRAGNode::
-#          test_run_generates_abstract_query and ::TestHyDENode::
-#          test_run_generates_fallback_hypothesis_when_no_llm — a genuinely
-#          pre-existing src/ bug in kaizen/nodes/rag/advanced.py: every
-#          `_parse_*` helper (_parse_abstract_query, _parse_hypotheses,
-#          _parse_query_variations, _parse_verification_response) reads
-#          `response.get("content", "")` on the FULL dict LLMAgentNode.
-#          execute() returns (`{"success": ..., "response": {...}, ...}`) —
-#          the real content lives at `response["response"]["content"]`, so
-#          "content" is NEVER a top-level key and these two tests'
-#          non-empty/non-zero-length assertions fail deterministically
-#          (confirmed reproducible on unmodified main with a real API key,
-#          independent of any mocking — issue #1736 investigation). Two of
-#          the four `_parse_*` call sites (_parse_verification_response,
-#          _parse_query_variations) share the identical bug but are not
-#          currently exercised by an assertion that requires non-fallback
-#          content, so no other test in this file is affected. Fixing this
-#          requires a src/ change out of scope for this test-hygiene-only PR
-#          (NO src/ changes, NO version bump/release) — filed as a precise
-#          follow-up; NOT weakened, NOT skipped, NOT deleted.
 #
 #      ALL optional-dep failures (numpy/Pillow/networkx/prometheus/
 #      opentelemetry[+otlp-grpc-exporter]/pynacl/pytz/psutil/qrcode/
@@ -340,6 +329,4 @@ jobs:
             -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark or requires_postgres or requires_redis or requires_ollama or requires_db or requires_llm or llm_execution or real_llm or ollama_validation or cost or landing_ai or stress or endurance or requires_infrastructure or requires_kafka or requires_mongodb or memory_intensive or requires_isolation or data_intensive or flaky or slow or load or migration or openai or anthropic or google or docker or ollama or integration_llm or tier3 or performance)' \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_basic \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_limit \
-            --deselect tests/unit/rag/test_advanced_nodes.py::TestStepBackRAGNode::test_run_generates_abstract_query \
-            --deselect tests/unit/rag/test_advanced_nodes.py::TestHyDENode::test_run_generates_fallback_hypothesis_when_no_llm \
             --timeout=30 --maxfail=50 -q

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -20,16 +20,12 @@ name: Test kailash-kaizen
 #      applied ONLY to this invocation — it is NOT applied to invocation 1 so
 #      as to never narrow the original gate's selection.
 #
-#      Three subdirectories are deliberately EXCLUDED by directory:
+#      Two subdirectories are deliberately EXCLUDED by directory (a third —
+#      tests/unit/strategies/ — was RESOLVED and is no longer excluded; see
+#      note below):
 #        - tests/unit/package/  — SLOW: test_installation.py performs real
 #          `pip install`/build-wheel/build-sdist subprocess calls (~85-170s
 #          total for 5 tests) — infra-shaped, not a per-PR-gate fit.
-#        - tests/unit/strategies/ — HANGS: multiple files (test_multi_cycle_
-#          strategy.py, test_single_shot_strategy.py, ...) construct a real
-#          BaseAgent + strategy and call .execute() with zero LLM/MCP
-#          mocking, attempting real network calls with no distinguishing
-#          pytest marker; pytest-timeout's signal-based --timeout does not
-#          reliably abort the resulting hang.
 #        - tests/unit/examples/ — HANGS: confirmed via a full 300s bounded
 #          run whose traceback shows an in-flight `ssl.SSLSocket.recv()`
 #          blocked inside `httpcore` — a genuine outbound network call, not
@@ -37,6 +33,25 @@ name: Test kailash-kaizen
 #          workflow's header comment already excluded "the slow
 #          example-script suite"); this audit independently reproduced the
 #          hang with byte-level evidence and confirms the exclusion.
+#        - [RESOLVED, issue #1736] tests/unit/strategies/ — was HANGING:
+#          multiple files (test_multi_cycle_strategy.py, test_single_shot_
+#          strategy.py, ...) construct a real BaseAgent + strategy and call
+#          .execute() with zero LLM/MCP mocking; WorkflowGenerator.
+#          generate_signature_workflow() defaults the LLMAgentNode `provider`
+#          to `"openai"` whenever BaseAgentConfig.llm_provider is unset (the
+#          common case in these tests), so any environment with a real
+#          OPENAI_API_KEY configured attempted a genuine outbound network
+#          call — pytest-timeout's signal-based --timeout did not reliably
+#          abort the resulting 300s+ hang. Fixed by an autouse conftest.py
+#          fixture (tests/unit/strategies/conftest.py) stubbing both the
+#          kaizen.providers.registry.get_provider() registry seam and the
+#          legacy direct-instantiation seam (kaizen.providers.llm.openai.
+#          OpenAIProvider, used by BaseAgent._simple_execute_async) with a
+#          deterministic, well-formed completion — no behavioral assertion
+#          was weakened; every strategy still executes real code against a
+#          real (mocked) completion. All 240 tests now pass in ~30s (was
+#          300s+ hangs). It is now gated on every CI run like every other
+#          test in this tier.
 #        tests/unit/performance/ is EXCLUDED because its 18 tests assert
 #        ABSOLUTE wall-clock p95-latency thresholds (`assert perf["p95"] <
 #        10/50/100` ms) — deterministic locally (~0.11s) but flake-prone on
@@ -46,9 +61,10 @@ name: Test kailash-kaizen
 #        would ratchet the thresholds under CI load; excluded until the tests
 #        are rewritten to self-normalizing ratios.
 #
-#      Two files are excluded via --ignore within an otherwise-clean tier
-#      (a third — tests/unit/mcp/test_catalog_server.py — was RESOLVED and
-#      is no longer excluded; see note below):
+#      One file is excluded via --ignore within an otherwise-clean tier (two
+#      others — tests/unit/mcp/test_catalog_server.py and tests/unit/rag/
+#      test_advanced_nodes.py — were RESOLVED and are no longer --ignore'd;
+#      see notes below):
 #        - [RESOLVED, issue #1735] tests/unit/mcp/test_catalog_server.py —
 #          was RED on CI (35 failures, all `ModuleNotFoundError: No module
 #          named 'kaizen.manifest'`) because src/kaizen/mcp/catalog_server/
@@ -77,16 +93,28 @@ name: Test kailash-kaizen
 #          OllamaModelManager` raises ImportError whenever the optional
 #          client library is absent — this is the declared install matrix,
 #          not a regression.
-#        - tests/unit/rag/test_advanced_nodes.py — HANGS (same class as
-#          tests/unit/strategies/): HyDENode / SelfCorrectingRAGNode /
-#          StepBackRAGNode tests construct real node instances with zero
-#          LLM mocking; 4 of 5 failures are pytest-timeout(30s) hits, the
-#          5th an empty-string assertion from an un-mocked completion path.
-#          Confined to this one file — the other rag/ files are clean once
-#          the rag extra (numpy/Pillow/networkx) is installed (see below).
+#        - [PARTIALLY RESOLVED, issue #1736] tests/unit/rag/test_advanced_
+#          nodes.py — was HANGING (same class as tests/unit/strategies/):
+#          HyDENode / SelfCorrectingRAGNode / StepBackRAGNode construct real
+#          LLMAgentNode(provider="openai", ...) instances for their four
+#          LLM-backed steps; the SAME registry seam attempted a genuine
+#          network call whenever a real API key was configured. Fixed by a
+#          module-scoped autouse fixture (_stub_llm_provider, added directly
+#          in this test file — NOT a directory-wide conftest, so the other 14
+#          files in tests/unit/rag/ are byte-for-byte unaffected) stubbing
+#          kaizen.providers.registry.get_provider() with a deterministic
+#          completion. 48 of 50 tests now pass in ~4s (was 300s+ hangs); this
+#          file is re-included in the tier above and no longer --ignore'd.
+#          Two tests are excluded via --deselect below (NOT --ignore — the
+#          rest of the file still runs) because they hit a DISTINCT,
+#          genuinely pre-existing src/ bug this test-hygiene-only PR does not
+#          touch (see the --deselect comment for the exact root cause).
+#          Confined to these two node classes — the other rag/ files are
+#          clean once the rag extra (numpy/Pillow/networkx) is installed (see
+#          below).
 #
-#      Two flaky tests are excluded via --deselect (NOT --ignore — the rest of
-#      their file still runs):
+#      Four flaky/broken tests are excluded via --deselect (NOT --ignore —
+#      the rest of their file still runs):
 #        - tests/unit/memory/test_semantic_memory.py::
 #          TestSemanticMemorySimilaritySearch::{test_find_similar_basic,
 #          test_find_similar_limit} — the mock simple_embedding_function is
@@ -95,6 +123,26 @@ name: Test kailash-kaizen
 #          on some seeds/versions (passed on 3.14, failed on 3.12 in a local
 #          CI repro). Pre-existing, in code this PR does NOT touch — test-
 #          hygiene follow-up.
+#        - tests/unit/rag/test_advanced_nodes.py::TestStepBackRAGNode::
+#          test_run_generates_abstract_query and ::TestHyDENode::
+#          test_run_generates_fallback_hypothesis_when_no_llm — a genuinely
+#          pre-existing src/ bug in kaizen/nodes/rag/advanced.py: every
+#          `_parse_*` helper (_parse_abstract_query, _parse_hypotheses,
+#          _parse_query_variations, _parse_verification_response) reads
+#          `response.get("content", "")` on the FULL dict LLMAgentNode.
+#          execute() returns (`{"success": ..., "response": {...}, ...}`) —
+#          the real content lives at `response["response"]["content"]`, so
+#          "content" is NEVER a top-level key and these two tests'
+#          non-empty/non-zero-length assertions fail deterministically
+#          (confirmed reproducible on unmodified main with a real API key,
+#          independent of any mocking — issue #1736 investigation). Two of
+#          the four `_parse_*` call sites (_parse_verification_response,
+#          _parse_query_variations) share the identical bug but are not
+#          currently exercised by an assertion that requires non-fallback
+#          content, so no other test in this file is affected. Fixing this
+#          requires a src/ change out of scope for this test-hygiene-only PR
+#          (NO src/ changes, NO version bump/release) — filed as a precise
+#          follow-up; NOT weakened, NOT skipped, NOT deleted.
 #
 #      ALL optional-dep failures (numpy/Pillow/networkx/prometheus/
 #      opentelemetry[+otlp-grpc-exporter]/pynacl/pytz/psutil/qrcode/
@@ -102,17 +150,24 @@ name: Test kailash-kaizen
 #      extras + the OTLP gRPC exporter + the loose deps above — NOT by
 #      exclusion. The auth/SSO + autonomy tests that appeared undeclared-dep
 #      now run (qrcode/psutil are installed as loose deps). Verified against a
-#      local fresh-venv Python-3.12 CI repro: 6480 passed, 0 dep errors.
+#      local fresh-venv Python-3.12 CI repro post-#1736 (strategies/ +
+#      test_advanced_nodes.py re-included): 6773 passed, 73 skipped, 1820
+#      deselected, 0 dep errors, in 171.97s.
 #
 # A per-test --timeout on both invocations makes any hang fail loudly
-# instead of hanging the job.
+# instead of hanging the job. timeout_method=thread is set in pytest.ini
+# (issue #1736) for stronger hang enforcement — the default "signal" method
+# does not reliably interrupt a hang blocked inside a C extension's blocking
+# syscall (e.g. a real outbound network read when a Tier-1 test is missing
+# LLM mocking); the same local repro above (0 failures across 6773 tests)
+# confirms the switch does not regress any other kaizen tier.
 #
 # COST: single Python (3.12), triggered only on kaizen path changes — mirrors
 # the test-pact single-version precedent. Pre-expansion ~3-5 min/run. Post-
 # expansion the install grows (observability/rag extras + otlp-grpc exporter +
 # loose deps numpy/Pillow/networkx/otel/prometheus/pynacl/pytz/psutil/qrcode/
-# beautifulsoup4) and the expanded invocation runs ~6480 tests in ~175s (local
-# 3.12 repro) — total est. ~9-13 min/run post-expansion.
+# beautifulsoup4) and the expanded invocation runs ~6773 tests in ~172s (local
+# 3.12 repro, post-#1736) — total est. ~9-13 min/run post-expansion.
 
 on:
   push:
@@ -273,15 +328,18 @@ jobs:
             tests/unit/observability/ \
             tests/unit/orchestration/ \
             tests/unit/providers/ --ignore=tests/unit/providers/test_ollama_model_manager.py \
-            tests/unit/rag/ --ignore=tests/unit/rag/test_advanced_nodes.py \
+            tests/unit/rag/ \
             tests/unit/research/ \
             tests/unit/runtime/ \
             tests/unit/security/ \
             tests/unit/session/ \
             tests/unit/signatures/ \
+            tests/unit/strategies/ \
             tests/unit/tools/ \
             tests/unit/trust/ \
             -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark or requires_postgres or requires_redis or requires_ollama or requires_db or requires_llm or llm_execution or real_llm or ollama_validation or cost or landing_ai or stress or endurance or requires_infrastructure or requires_kafka or requires_mongodb or memory_intensive or requires_isolation or data_intensive or flaky or slow or load or migration or openai or anthropic or google or docker or ollama or integration_llm or tier3 or performance)' \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_basic \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_limit \
+            --deselect tests/unit/rag/test_advanced_nodes.py::TestStepBackRAGNode::test_run_generates_abstract_query \
+            --deselect tests/unit/rag/test_advanced_nodes.py::TestHyDENode::test_run_generates_fallback_hypothesis_when_no_llm \
             --timeout=30 --maxfail=50 -q

--- a/packages/kailash-kaizen/pytest.ini
+++ b/packages/kailash-kaizen/pytest.ini
@@ -95,6 +95,15 @@ markers =
 
 # Timeout configurations by tier
 timeout = 120
+# timeout_method = thread (issue #1736): the default "signal" method relies on
+# a SIGALRM being delivered and handled cooperatively between Python bytecode
+# instructions -- it does NOT reliably interrupt a hang blocked inside a C
+# extension's blocking syscall (e.g. a real outbound HTTP socket read via
+# httpcore/openai when a Tier-1 test is missing LLM mocking). The "thread"
+# method runs a watchdog thread that force-terminates the process on timeout
+# regardless of what the main thread is blocked in, giving genuinely
+# unmockable hangs a hard stop instead of a 300s+ CI hang.
+timeout_method = thread
 # Individual test timeouts managed by @pytest.mark.timeout decorators:
 # - Unit tests: @pytest.mark.timeout(1) - 1 second max
 # - Integration tests: @pytest.mark.timeout(5) - 5 seconds max

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -638,7 +638,11 @@ Assess the quality and provide improvement suggestions:
     def _parse_verification_response(self, response: Dict) -> Dict[str, Any]:
         """Parse verification response from LLM"""
         try:
-            content = response.get("content", "")
+            # LLMAgentNode.execute() returns an envelope {"success", "response":
+            # {"content": ...}, ...} — the content is NESTED, not top-level. Unwrap
+            # the envelope while tolerating a flat {"content": ...} shape (issue #1736).
+            inner = response.get("response", response)
+            content = inner.get("content", "") if isinstance(inner, dict) else ""
             if isinstance(content, list):
                 content = content[0] if content else "{}"
 
@@ -1062,7 +1066,10 @@ Generate {self.num_query_variations} high-quality variations that will improve r
     def _parse_query_variations(self, response: Dict) -> List[str]:
         """Parse query variations from LLM response"""
         try:
-            content = response.get("content", "")
+            # LLMAgentNode.execute() nests content under "response"; unwrap the
+            # envelope while tolerating a flat {"content": ...} shape (issue #1736).
+            inner = response.get("response", response)
+            content = inner.get("content", "") if isinstance(inner, dict) else ""
             if isinstance(content, list):
                 content = content[0] if content else "{}"
 
@@ -1558,7 +1565,10 @@ Generate {self.num_hypotheses if self.use_multiple_hypotheses else 1} detailed h
     def _parse_hypotheses(self, response: Dict) -> List[str]:
         """Parse hypotheses from LLM response"""
         try:
-            content = response.get("content", "")
+            # LLMAgentNode.execute() nests content under "response"; unwrap the
+            # envelope while tolerating a flat {"content": ...} shape (issue #1736).
+            inner = response.get("response", response)
+            content = inner.get("content", "") if isinstance(inner, dict) else ""
             if isinstance(content, list):
                 content = content[0] if content else "{}"
 
@@ -1901,7 +1911,10 @@ Generate a broader, more abstract version that would help retrieve relevant back
         # cannot reference an unbound name if response.get(...) itself raises.
         content: Any = ""
         try:
-            content = response.get("content", "")
+            # LLMAgentNode.execute() nests content under "response"; unwrap the
+            # envelope while tolerating a flat {"content": ...} shape (issue #1736).
+            inner = response.get("response", response)
+            content = inner.get("content", "") if isinstance(inner, dict) else ""
             if isinstance(content, list):
                 content = content[0] if content else "{}"
 

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -8,11 +8,24 @@ import.
 
 ``SelfCorrectingRAGNode`` / ``RAGFusionNode`` / ``HyDENode`` /
 ``StepBackRAGNode`` are ``kailash.nodes.base.Node`` subclasses with a direct
-``run()``. With NO LLM key configured (the realistic deployment of the
-resurrected ``[rag]`` toolkit, which declares no LLM dependency), each node's
-LLM-backed step degrades to a real rule-based fallback inside a
-``try/except`` block — the fallback IS a deterministic implementation, so the
-golden path here is the no-key path and there is nothing to mock.
+``run()``. Each constructs a real ``LLMAgentNode(provider="openai", ...)`` for
+its LLM-backed step (verifier / query-generator / hypothesis-generator /
+abstraction-generator).
+
+Historical note (issue #1736): this docstring previously assumed "no LLM key
+configured is the realistic deployment ... there is nothing to mock." That
+assumption does not hold whenever a real ``OPENAI_API_KEY`` is configured
+(``rules/env-models.md``) — ``LLMAgentNode._provider_llm_response()``
+resolves a real provider via ``kaizen.providers.registry.get_provider()`` and
+attempts a genuine outbound network call, hanging Tier-1 (pytest-timeout's
+signal-based ``--timeout`` did not reliably abort it; 4 of the 5 affected
+tests were 30s-timeout hits). Per ``rules/testing.md`` "3-Tier Testing"
+(Tier 1: mocking allowed, MUST be offline + deterministic), the
+``_stub_llm_provider`` fixture below stubs the provider seam so every test in
+this file runs offline and fast regardless of which real API keys are
+configured in the environment — the LLM-backed steps still execute real
+node/parsing code against a deterministic, well-formed completion; only the
+network boundary is faked.
 
 The shared base workflow every node retrieves through is the
 ``create_hybrid_rag_workflow`` ``WorkflowNode`` (A-S2 of this shard): dense +
@@ -25,6 +38,10 @@ list lengths, score ordering, types, typed raises).
 """
 
 from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from kailash.nodes.logic.workflow import WorkflowNode
@@ -39,6 +56,80 @@ from kaizen.nodes.rag.advanced import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+# A single JSON payload that is a superset of every shape the four LLM-backed
+# steps in this module parse (hypotheses / variations / abstract_query /
+# retrieval+generation quality fields). Each ``_parse_*`` helper extracts only
+# the keys it needs via ``.get(...)``, so one deterministic payload satisfies
+# every call site without per-test/per-node customization.
+_MOCK_CONTENT = json.dumps(
+    {
+        "hypotheses": [
+            "Mocked hypothesis one for deterministic Tier-1 testing (issue #1736).",
+            "Mocked hypothesis two for deterministic Tier-1 testing (issue #1736).",
+        ],
+        "reasoning": "Mocked reasoning for deterministic Tier-1 testing.",
+        "variations": [
+            "Mocked query variation one.",
+            "Mocked query variation two.",
+            "Mocked query variation three.",
+        ],
+        "abstract_query": "What are the general principles related to this topic?",
+        "concepts_identified": ["mocked-concept-a", "mocked-concept-b"],
+        "retrieval_quality": 0.8,
+        "generation_quality": 0.8,
+        "confidence": 0.8,
+        "issues": [],
+        "suggestions": [],
+        "needs_refinement": False,
+    }
+)
+
+
+def _fake_chat_response(**_: Any) -> dict:
+    """A deterministic, well-formed provider ``chat()`` response."""
+    return {
+        "id": "test-1736-mock",
+        "content": _MOCK_CONTENT,
+        "role": "assistant",
+        "model": "mock-model",
+        "created": 0,
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _make_fake_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """Build a fresh fake provider satisfying the ``BaseProvider`` surface."""
+    provider = MagicMock()
+    provider.is_available.return_value = True
+    provider.chat.side_effect = _fake_chat_response
+
+    async def _chat_async(**kwargs: Any) -> dict:
+        return _fake_chat_response(**kwargs)
+
+    provider.chat_async.side_effect = _chat_async
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def _stub_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the kaizen provider registry seam for this module only (issue #1736).
+
+    ``kaizen.nodes.rag.advanced`` constructs ``LLMAgentNode(provider="openai",
+    ...)`` directly for its four LLM-backed steps. ``LLMAgentNode.
+    _provider_llm_response()`` resolves the provider via
+    ``kaizen.providers.registry.get_provider(name)`` and calls
+    ``provider.chat(...)`` — the real network seam. Stubbing it here (module-
+    scoped, NOT a directory-wide conftest) keeps every other file in
+    ``tests/unit/rag/`` byte-for-byte unaffected, per issue #1736 scope.
+    """
+    monkeypatch.setattr(
+        "kaizen.providers.registry.get_provider",
+        _make_fake_provider,
+    )
 
 
 # A small deterministic corpus reused across the node tests. d1/d3 overlap the

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from kailash.nodes.logic.workflow import WorkflowNode
@@ -111,6 +111,20 @@ def _make_fake_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
         return _fake_chat_response(**kwargs)
 
     provider.chat_async.side_effect = _chat_async
+    return provider
+
+
+def _make_unavailable_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """A provider that reports itself unavailable — the genuine no-LLM deployment.
+
+    ``LLMAgentNode._provider_llm_response`` raises ``RuntimeError`` (before any
+    network call) when ``is_available()`` is False and no per-request api_key is
+    supplied, which drives each advanced-RAG node's ``try/except`` rule-based
+    fallback. Used by the one test whose whole point is the no-LLM path (issue
+    #1736), overriding the module autouse content-stub.
+    """
+    provider = MagicMock()
+    provider.is_available.return_value = False
     return provider
 
 
@@ -450,8 +464,22 @@ class TestHyDENode:
         assert set(result.keys()) == _HYDE_KEYS
 
     def test_run_generates_fallback_hypothesis_when_no_llm(self):
-        """With no LLM key the rule-based fallback yields >=1 hypothesis."""
-        result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
+        """With no LLM available the rule-based fallback yields >=1 hypothesis.
+
+        This test's whole point is the genuine NO-LLM path, so it explicitly
+        overrides the module autouse content-stub with an *unavailable* provider
+        (``is_available()`` -> False). That drives ``_generate_hypotheses``'s
+        ``try/except`` rule-based fallback (the documented behavior) rather than
+        the mocked-completion path the other tests exercise — offline either way,
+        no network (issue #1736).
+        """
+        with patch(
+            "kaizen.providers.registry.get_provider",
+            side_effect=_make_unavailable_provider,
+        ):
+            result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
+        # The rule-based fallback ("A comprehensive answer to '<query>'…") — NOT a
+        # mocked completion — is what produces these hypotheses.
         assert len(result["hypotheses_generated"]) >= 1
         assert result["hyde_metadata"]["method"] == "HyDE"
 

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -605,3 +605,58 @@ class TestStepBackRAGNode:
         node = StepBackRAGNode()
         out = node._parse_abstract_query("not-a-dict")  # type: ignore[arg-type]
         assert isinstance(out, str)
+
+
+# ==========================================================================
+# Regression — envelope-unwrap on all four LLM-response parsers (issue #1736)
+# ==========================================================================
+
+
+@pytest.mark.regression
+class TestParserEnvelopeUnwrapRegression:
+    """All four ``_parse_*`` helpers MUST read the NESTED content.
+
+    ``LLMAgentNode.execute()`` returns an envelope
+    ``{"success": ..., "response": {"content": ...}, ...}`` — the LLM's real
+    content is under ``response["response"]["content"]``, NOT the top level.
+    The pre-#1736 parsers read ``response.get("content", "")`` on the OUTER
+    dict, so they always saw ``""`` and every LLM-backed step silently fell
+    back to its rule-based path. These behavioral tests feed the real envelope
+    shape and assert the parser extracts the nested payload — they fail if a
+    future refactor reverts to the top-level read. A flat ``{"content": ...}``
+    (direct provider) shape MUST still parse (backward tolerance).
+    """
+
+    def _envelope(self, content: str) -> dict:
+        return {"success": True, "response": {"content": content}}
+
+    def test_parse_hypotheses_reads_nested_content(self):
+        node = HyDENode()
+        env = self._envelope('{"hypotheses": ["h-one", "h-two"]}')
+        assert node._parse_hypotheses(env) == ["h-one", "h-two"]  # type: ignore[attr-defined]
+        # flat shape (direct provider) still parses
+        flat = {"content": '{"hypotheses": ["h-flat"]}'}
+        assert node._parse_hypotheses(flat) == ["h-flat"]  # type: ignore[attr-defined]
+
+    def test_parse_query_variations_reads_nested_content(self):
+        node = RAGFusionNode(num_query_variations=3)
+        env = self._envelope('{"variations": ["v-one", "v-two"]}')
+        assert node._parse_query_variations(env) == ["v-one", "v-two"]  # type: ignore[attr-defined]
+
+    def test_parse_abstract_query_reads_nested_content(self):
+        node = StepBackRAGNode()
+        env = self._envelope('{"abstract_query": "broad question?"}')
+        assert node._parse_abstract_query(env) == "broad question?"  # type: ignore[attr-defined]
+
+    def test_parse_verification_response_reads_nested_content(self):
+        node = SelfCorrectingRAGNode()
+        env = self._envelope(
+            '{"confidence": 0.9, "retrieval_quality": 0.8, '
+            '"generation_quality": 0.7, "needs_refinement": false}'
+        )
+        out = node._parse_verification_response(env)  # type: ignore[attr-defined]
+        # The nested JSON is parsed through (not the fallback heuristic, which
+        # would emit confidence 0.4/0.6 from a keyword scan of empty content).
+        assert out["confidence"] == 0.9
+        assert out["retrieval_quality"] == 0.8
+        assert out["generation_quality"] == 0.7

--- a/packages/kailash-kaizen/tests/unit/strategies/conftest.py
+++ b/packages/kailash-kaizen/tests/unit/strategies/conftest.py
@@ -1,0 +1,111 @@
+"""Tier-1 offline LLM-provider stub for ``tests/unit/strategies/`` (issue #1736).
+
+Several tests in this directory construct a real ``BaseAgent`` + strategy
+(e.g. ``MultiCycleStrategy``, ``SingleShotStrategy``) and call
+``strategy.execute(agent, inputs)`` with zero LLM mocking. That call reaches
+``LocalRuntime().execute(workflow.build(), ...)``, which runs a real
+``LLMAgentNode``. ``LLMAgentNode._provider_llm_response()`` resolves the
+provider via ``kaizen.providers.registry.get_provider(name)`` and calls
+``provider.chat(...)`` -- a genuine outbound network call whenever a real
+API key is configured (as this environment's ``.env`` does, per
+``rules/env-models.md``), because ``WorkflowGenerator.generate_signature_
+workflow()`` defaults ``provider`` to ``"openai"`` whenever
+``BaseAgentConfig.llm_provider`` is unset (the common case in these tests).
+pytest-timeout's signal-based ``--timeout`` does not reliably abort the
+resulting hang inside the C-level socket read (300s+ hangs pre-fix).
+
+Per ``rules/testing.md`` "3-Tier Testing" (Tier 1: mocking allowed, MUST be
+offline + deterministic) and the "Tier-1 Conftest Stub for Newly-Side-
+Effecting Internal Methods" pattern (canonical for ~10+ shared call sites),
+this autouse, directory-scoped fixture stubs the provider seam so every test
+under ``tests/unit/strategies/`` resolves fast and offline -- without
+weakening any behavioral assertion (cycle counts, dict shape, tool-call
+handling, termination logic all still exercise real strategy code against a
+real, deterministic completion).
+
+Two independent call paths reach a live provider from this test directory
+and are both stubbed:
+
+1. **Registry path** -- ``LLMAgentNode._provider_llm_response()`` ->
+   ``kaizen.providers.registry.get_provider(name)`` -> ``provider.chat(...)``.
+   Used by every strategy that runs through ``LocalRuntime`` + ``LLMAgentNode``
+   (``MultiCycleStrategy``, ``SingleShotStrategy``'s workflow path, etc).
+2. **Legacy direct-instantiation path** -- ``BaseAgent._simple_execute_async``
+   imports ``kaizen.providers.llm.openai.OpenAIProvider`` directly and calls
+   ``.chat_async()``, bypassing the registry entirely.
+
+Tests that already mock their own network boundary (e.g.
+``test_single_shot_mcp.py`` patches ``kaizen.strategies.single_shot.
+LocalRuntime`` per-test) never reach this seam, so this fixture is a no-op
+for them -- it changes NOTHING about their behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# A single JSON payload that is a superset of every shape the strategies
+# under test parse (ReAct thought/action/observation, "response"/"answer"
+# keys, RAG-style fields). Each parser extracts only the keys it needs via
+# `.get(...)`, so one deterministic payload satisfies every call site
+# without per-test/per-node customization.
+_MOCK_CONTENT = json.dumps(
+    {
+        "thought": "Mocked reasoning step for deterministic Tier-1 testing (issue #1736).",
+        "action": "FINAL ANSWER: mocked result",
+        "observation": "Mocked observation.",
+        "response": "Mocked final response.",
+        "answer": "Mocked answer.",
+    }
+)
+
+
+def _fake_chat_response(**_: Any) -> dict:
+    """A deterministic, well-formed provider ``chat()`` response."""
+    return {
+        "id": "test-1736-mock",
+        "content": _MOCK_CONTENT,
+        "role": "assistant",
+        "model": "mock-model",
+        "created": 0,
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _make_fake_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """Build a fresh fake provider satisfying the ``BaseProvider`` surface."""
+    provider = MagicMock()
+    provider.is_available.return_value = True
+    provider.chat.side_effect = _fake_chat_response
+
+    async def _chat_async(**kwargs: Any) -> dict:
+        return _fake_chat_response(**kwargs)
+
+    provider.chat_async.side_effect = _chat_async
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def _stub_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub both the registry seam and the legacy direct-instantiation seam."""
+    monkeypatch.setattr(
+        "kaizen.providers.registry.get_provider",
+        _make_fake_provider,
+    )
+
+    from kaizen.providers.llm.openai import OpenAIProvider
+
+    async def _openai_chat_async(self: Any, **kwargs: Any) -> dict:
+        return _fake_chat_response(**kwargs)
+
+    monkeypatch.setattr(OpenAIProvider, "is_available", lambda self: True)
+    monkeypatch.setattr(
+        OpenAIProvider, "chat", lambda self, **kwargs: _fake_chat_response(**kwargs)
+    )
+    monkeypatch.setattr(OpenAIProvider, "chat_async", _openai_chat_async)


### PR DESCRIPTION
## What

Closes the kaizen Tier-1 unit-test hangs (#1736) **and** fixes a genuine `src/` bug the hangs were masking.

### 1. Test-hang fix (the reported issue)
`tests/unit/strategies/` and `tests/unit/rag/test_advanced_nodes.py` constructed real `BaseAgent`/RAG nodes and called `.execute()`/`.run()` with zero LLM mocking → real outbound network → 300s+ hangs (`pytest-timeout`'s signal method couldn't abort them).
- Added an autouse conftest stub (`tests/unit/strategies/conftest.py`) and a module-scoped fixture in `test_advanced_nodes.py` stubbing the kaizen provider seam (`get_provider` + `OpenAIProvider.{chat,chat_async,is_available}`) — offline, deterministic. The other 14 `rag/` files are untouched.
- `pytest.ini`: `timeout_method = thread` (stronger hang enforcement than the signal method).
- Re-included `tests/unit/strategies/` + `tests/unit/rag/test_advanced_nodes.py` in the kaizen CI gate (`.github/workflows/test-kailash-kaizen.yml`), **zero per-test deselects**.

### 2. Real `src/` bug the mocking exposed (fixed, not deferred)
`kaizen/nodes/rag/advanced.py` — all four LLM-response parsers (`_parse_verification_response`, `_parse_query_variations`, `_parse_hypotheses`, `_parse_abstract_query`) read `response.get("content","")` on the **outer** `LLMAgentNode.execute()` envelope, but content is nested at `response["response"]["content"]`. So **HyDE / StepBack / SelfCorrecting / RAGFusion nodes called the LLM, discarded its output, and always used the rule-based fallback** — invisible because the fallback produced plausible output and the only tests hitting these paths were hanging on the network. Fixed each to `inner = response.get("response", response); content = inner.get("content","") if isinstance(inner, dict) else ""` (envelope-unwrap, flat-dict tolerant). Added a `@pytest.mark.regression` guard feeding the real `execute()` envelope to all four parsers.

## Why

Per zero-tolerance Rule 1, the exposed parser bug is fixed in this run, not deselected — deselecting would have shipped the gate with the same 2 tests still excluded, defeating the issue's goal.

## Tests

- `test_advanced_nodes.py`: **54 passed** (50 originals green + 4 new regression), zero exclusions.
- Full CI-gate invocation (strategies/ + advanced_nodes re-included, no deselects): **6810 passed, 73 skipped, 0 failures** — no regression to any other kaizen tier.

## Release

Touches `src/kaizen` → warrants a kailash-kaizen release after merge.

## Related issues

Fixes #1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)