### PR TITLE
test(kaizen): isolate CARE-004 depth tests from the #1710 chain-integrity gate

### DIFF
--- a/packages/kailash-kaizen/tests/unit/trust/adversarial/test_delegation_manipulation.py
+++ b/packages/kailash-kaizen/tests/unit/trust/adversarial/test_delegation_manipulation.py
@@ -515,6 +515,10 @@ class TestDeepChainBeyondMaxDepth:
             max_delegation_depth=3,  # Only allow 3 levels of delegation
         )
 
+        # Isolate CARE-004 depth enforcement from the #1710 chain-integrity gate
+        # (integrity is covered by tests/trust/regression/test_issue_1710_mint_fail_closed.py).
+        trust_ops._verify_source_chain_before_mint = AsyncMock(return_value=None)
+
         import asyncio
 
         loop = asyncio.new_event_loop()

--- a/packages/kailash-kaizen/tests/unit/trust/test_delegation_depth.py
+++ b/packages/kailash-kaizen/tests/unit/trust/test_delegation_depth.py
@@ -259,6 +259,10 @@ class TestDelegationDepthEnforcement:
             authority_registry, key_manager, trust_store, max_delegation_depth=2
         )
 
+        # Isolate CARE-004 depth enforcement from the #1710 chain-integrity gate
+        # (integrity is covered by tests/trust/regression/test_issue_1710_mint_fail_closed.py).
+        trust_ops._verify_source_chain_before_mint = AsyncMock(return_value=None)
+
         # Create delegator chain with depth already at 2 (at the limit)
         genesis = GenesisRecord(
             id="gen-001",
@@ -369,6 +373,10 @@ class TestDelegationDepthEnforcement:
         trust_ops = TrustOperations(
             authority_registry, key_manager, trust_store, max_delegation_depth=2
         )
+
+        # Isolate CARE-004 depth enforcement from the #1710 chain-integrity gate
+        # (integrity is covered by tests/trust/regression/test_issue_1710_mint_fail_closed.py).
+        trust_ops._verify_source_chain_before_mint = AsyncMock(return_value=None)
 
         # Create delegator chain with depth 1 (one below limit)
         genesis = GenesisRecord(


### PR DESCRIPTION
## What

Test-only follow-up to #1710 (PR #1750). #1710's new `TrustOperations._verify_source_chain_before_mint()` pre-sign integrity gate runs at the top of `delegate()`/`audit()` and verifies chain signatures **before** the depth logic. Three CARE-004 depth-enforcement unit tests build fake-signature (`signature="sig"`) chains with a plain `MagicMock` authority registry, so the gate now rejects them (`TypeError: MagicMock can't be used in 'await'` / `InvalidTrustChainError`) before the depth logic under test runs.

These are depth-enforcement unit tests — their subject is CARE-004 depth logic, not chain integrity (covered separately by `tests/trust/regression/test_issue_1710_mint_fail_closed.py`). Each now patches the gate to a no-op `AsyncMock(return_value=None)` after constructing `trust_ops`, isolating the unit under test.

## Why (regression trace)

The 3 tests **passed at pre-#1710 main (`456ee1e99`)** and **failed on current main** — a regression from #1710's correct production behavior (verify chain authenticity before acting on it; behaviour-invariant on *valid* chains, but these tests use fake chains). Main's kaizen CI gate (which runs `tests/unit/trust/`) was red until this fix.

## Tests fixed

- `test_delegation_depth.py::TestDelegationDepthEnforcement::{test_delegate_exceeds_max_depth_raises_delegation_error, test_delegate_at_max_depth_succeeds}`
- `adversarial/test_delegation_manipulation.py::TestDeepChainBeyondMaxDepth::test_deep_chain_beyond_max_depth`

## Blast radius (repo-wide grep of `.delegate(`/`.audit(` callers)

Only these 3 unit tests affected. `tests/security/test_delegation_manipulation.py` builds real Ed25519-signed chains → 23 passed, unaffected. Agent-pattern `supervisor.delegate()` / `pattern.delegate()` are a different API. Core `tests/trust/` unaffected.

## Verification

- Full kaizen trust unit suite: **1648 passed, 1 skipped** (was 3 failed / 1645 passed).
- Core `tests/trust/`: **6387 passed, 28 skipped** — unaffected.

## Related issues

Refs #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)