### PR TITLE
release: kailash-kaizen 2.33.0 (#1736 RAG parser fix + test-hang resolution)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,7 +2,42 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
-## [2.32.0] — 2026-07-14 — Manifest module + from_env() legacy-tier deprecation
+## [2.33.0] — 2026-07-15 — RAG advanced-node parser fix + Tier-1 test-hang resolution
+
+### Fixed
+
+- **RAG advanced nodes silently ignored LLM output and always used the
+  rule-based fallback (#1736).** The four LLM-response parsers backing
+  the HyDE, StepBack, SelfCorrecting, and RAGFusion nodes
+  (`_parse_verification_response`, `_parse_query_variations`,
+  `_parse_hypotheses`, `_parse_abstract_query` in
+  `kaizen/nodes/rag/advanced.py`) read `response.get("content", "")` off
+  the **outer** `LLMAgentNode.execute()` envelope, but the LLM's actual
+  content is nested one level deeper at
+  `response["response"]["content"]`. Every one of these nodes therefore
+  called the LLM, discarded its output, and silently fell back to the
+  rule-based path — invisible in practice because the fallback produced
+  plausible-looking output, and the only tests that exercised these code
+  paths were hanging on real network calls (see below) rather than
+  failing. Each parser now unwraps the nested envelope
+  (`inner = response.get("response", response)`, flat-dict tolerant),
+  so these four nodes actually consume LLM output for the first time.
+
+- **Kaizen Tier-1 unit tests hung for 300s+ on unmocked LLM/network
+  calls (#1736).** `tests/unit/strategies/` and
+  `tests/unit/rag/test_advanced_nodes.py` constructed real `BaseAgent` /
+  RAG nodes and invoked `.execute()` / `.run()` with no LLM mocking,
+  triggering real outbound network calls that `pytest-timeout`'s signal
+  method could not reliably abort. Added an autouse conftest stub
+  (`tests/unit/strategies/conftest.py`) and a module-scoped fixture in
+  `test_advanced_nodes.py` stubbing the provider seam (`get_provider` +
+  `OpenAIProvider.{chat,chat_async,is_available}`) so these suites run
+  offline and deterministically; `pytest.ini` now sets
+  `timeout_method = thread` for stronger hang enforcement; both suites
+  are re-included in the kaizen CI gate
+  (`.github/workflows/test-kailash-kaizen.yml`) with zero per-test
+  deselects. Fixing the test hang is what exposed the parser bug above —
+  both are fixed in this release, not just the hang.
 
 ### Added
 

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.32.0"
+version = "2.33.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Metadata-only release-prep PR — version bump + CHANGELOG only, no code changes.

- Bumps `kailash-kaizen` 2.32.0 → 2.33.0 (`packages/kailash-kaizen/pyproject.toml`, `packages/kailash-kaizen/src/kaizen/__init__.py`)
- Adds `## [2.33.0] — 2026-07-15` CHANGELOG section covering **#1736** (merged via #1751):
  - Fixes the kaizen Tier-1 unit-test hangs (`tests/unit/strategies/`, `tests/unit/rag/test_advanced_nodes.py`) caused by unmocked LLM/network calls, re-including both suites in the CI gate with zero deselects
  - Fixes the real `src/kaizen/nodes/rag/advanced.py` bug the mocking exposed: the HyDE / StepBack / SelfCorrecting / RAGFusion parsers read the wrong envelope level and silently always used the rule-based fallback instead of actual LLM output

The parser fix is a behavioral change (these four RAG nodes now genuinely use LLM output), so a minor version bump is correct per semver.

## Related issues

Part of the release cycle for #1736 (merged to main this session via #1751).

🤖 Generated with [Claude Code](https://claude.com/claude-code)