### PR TITLE
fix(mcp): fail-closed spawn allowlist + null-id + protocolVersion negotiation (#1712)

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/client.py
+++ b/packages/kailash-mcp/src/kailash_mcp/client.py
@@ -27,6 +27,7 @@ from kailash_mcp.errors import (
     RetryStrategy,
     TransportError,
 )
+from kailash_mcp.security import validate_spawn_command
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,27 @@ class MCPClient:
         else:
             self.metrics = None
 
+    def _guard_spawn_command(self, command: Any) -> None:
+        """Fail-closed guard for a local-server stdio spawn command.
+
+        Per the MCP spec (2025-11-25) local-server spawn safety requirement,
+        an unlisted spawn command is REJECTED (never warn-and-allowed). The
+        allowlist is read from the client ``config``:
+
+        - ``allowed_commands``: optional explicit allowlist (defaults to the
+          curated standard MCP launcher set when absent).
+        - ``allow_arbitrary_commands``: explicit opt-out (never the default).
+
+        Raises:
+            SpawnSecurityError: if ``command`` is not in the effective
+                allowlist (and the opt-out is not set).
+        """
+        validate_spawn_command(
+            command,
+            allowed_commands=self.config.get("allowed_commands"),
+            allow_arbitrary=bool(self.config.get("allow_arbitrary_commands", False)),
+        )
+
     async def discover_tools(
         self,
         server_config: Union[str, Dict[str, Any]],
@@ -249,6 +271,9 @@ class MCPClient:
         command = server_config.get("command", "python")
         args = server_config.get("args", [])
         env = server_config.get("env", {})
+
+        # Fail-closed spawn safety (MCP 2025-11-25 local-server spawn safety).
+        self._guard_spawn_command(command)
 
         # Merge environment
         server_env = os.environ.copy()
@@ -526,6 +551,9 @@ class MCPClient:
         command = server_config.get("command", "python")
         args = server_config.get("args", [])
         env = server_config.get("env", {})
+
+        # Fail-closed spawn safety (MCP 2025-11-25 local-server spawn safety).
+        self._guard_spawn_command(command)
 
         server_env = os.environ.copy()
         server_env.update(env)
@@ -907,6 +935,8 @@ class MCPClient:
         command = server_config.get("command", "python")
         args = server_config.get("args", [])
         env = server_config.get("env", {})
+        # Fail-closed spawn safety (MCP 2025-11-25 local-server spawn safety).
+        self._guard_spawn_command(command)
         server_env = os.environ.copy()
         server_env.update(env)
         server_params = StdioServerParameters(

--- a/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
+++ b/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
@@ -50,6 +50,7 @@ from urllib.parse import urlparse
 
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, ServiceDiscoveryError
+from kailash_mcp.security import SpawnSecurityError, validate_spawn_command
 
 logger = logging.getLogger(__name__)
 
@@ -1151,6 +1152,22 @@ class HealthChecker:
             elif server.transport == "stdio":
                 # For stdio, check if command exists and is executable
                 if server.command:
+                    # Fail-closed spawn allowlist (MCP 2025-11-25 local-server
+                    # spawn safety): a health probe MUST NOT spawn an unlisted
+                    # command. server.command is untrusted (registry / discovery
+                    # response). Reject before spawn; report blocked, don't run.
+                    try:
+                        validate_spawn_command(server.command)
+                    except SpawnSecurityError as e:
+                        logger.warning(
+                            "health_check.spawn_blocked",
+                            extra={"error": str(e)},
+                        )
+                        return {
+                            "status": "blocked",
+                            "response_time": None,
+                            "error": str(e),
+                        }
                     try:
                         # Test if we can run the command
                         import asyncio

--- a/packages/kailash-mcp/src/kailash_mcp/protocol/messages.py
+++ b/packages/kailash-mcp/src/kailash_mcp/protocol/messages.py
@@ -267,6 +267,16 @@ class JsonRpcRequest:
             )
         if "method" not in data:
             raise JsonRpcValidationError("JsonRpcRequest requires 'method' field")
+        # JSON-RPC 2.0 / MCP 2025-11-25: an EXPLICIT null ``id`` is invalid and
+        # is distinct from an ABSENT ``id`` (which denotes a notification).
+        # ``data.get("id")`` alone would silently collapse ``{"id": null}`` into
+        # a notification; reject the explicit-null form here at the parse
+        # boundary (the only place the key's presence is observable).
+        if "id" in data and data["id"] is None:
+            raise JsonRpcValidationError(
+                "JsonRpcRequest: explicit null 'id' is invalid; omit the 'id' "
+                "field entirely for a notification"
+            )
         return cls(
             method=data["method"],
             params=data.get("params"),

--- a/packages/kailash-mcp/src/kailash_mcp/security.py
+++ b/packages/kailash-mcp/src/kailash_mcp/security.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Terrene Foundation
+"""Local-server spawn safety — fail-closed command allowlist.
+
+Per the MCP specification (revision 2025-11-25) local-server spawn safety
+requirement: the command allowlist for spawning local MCP servers MUST fail
+closed by default — an unlisted command is REJECTED, never warn-and-allowed.
+
+A caller that spawns a local MCP server passes an untrusted ``command`` string
+(often sourced from agent output, a config file, or a discovery response).
+Spawning an arbitrary command is remote-code-execution by construction; the
+fail-closed allowlist is the structural defense.
+
+Design
+------
+* A curated :data:`DEFAULT_ALLOWED_MCP_COMMANDS` set of the standard MCP
+  launcher executables ships as the default. An attacker-injected ``sh`` /
+  ``bash`` / ``rm`` / ``curl`` / absolute-path binary is NOT in the set and is
+  rejected fail-closed, while the ordinary launchers work out of the box.
+* A caller MAY narrow or extend the set with ``allowed_commands``.
+* A caller MAY opt OUT of the allowlist entirely with
+  ``allow_arbitrary=True`` — an explicit, auditable escape hatch (never the
+  default, never a silent warn-and-allow).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Sequence
+
+from kailash_mcp.errors import MCPError, MCPErrorCode
+
+# Standard MCP launcher executables considered safe to spawn without an
+# explicit per-caller allowlist. Deliberately EXCLUDES shells (``sh``,
+# ``bash``, ``zsh``, ``cmd``, ``powershell``) and generic download/exec tools
+# (``curl``, ``wget``) — those are the arbitrary-command-injection vectors the
+# fail-closed default exists to reject.
+DEFAULT_ALLOWED_MCP_COMMANDS = frozenset(
+    {
+        "python",
+        "python3",
+        "uv",
+        "uvx",
+        "node",
+        "npx",
+        "deno",
+        "bunx",
+        "bun",
+        "docker",
+    }
+)
+
+
+class SpawnSecurityError(MCPError):
+    """Raised when a local-server spawn command fails the fail-closed allowlist.
+
+    Carries :data:`MCPErrorCode.AUTHORIZATION_FAILED` (``-32003``) — a spawn
+    rejection is an authorization decision, not a transport or validation
+    failure.
+    """
+
+    def __init__(self, message: str, command: Optional[str] = None) -> None:
+        super().__init__(
+            message,
+            error_code=MCPErrorCode.AUTHORIZATION_FAILED,
+            data={"command": command} if command is not None else None,
+        )
+
+
+def validate_spawn_command(
+    command: object,
+    *,
+    allowed_commands: Optional[Sequence[str]] = None,
+    allow_arbitrary: bool = False,
+) -> None:
+    """Validate a local-server spawn command against the fail-closed allowlist.
+
+    Args:
+        command: The executable to spawn. MUST be a non-empty string.
+        allowed_commands: Optional explicit allowlist (basenames or full
+            command strings). When ``None`` the curated
+            :data:`DEFAULT_ALLOWED_MCP_COMMANDS` set is used — the fail-closed
+            default. Passing an empty sequence rejects EVERY command (the
+            maximally-closed posture).
+        allow_arbitrary: Explicit opt-out of the allowlist. When ``True`` any
+            non-empty, non-traversing command is permitted. This is the ONLY
+            way to spawn an unlisted command; it is never the default and is
+            intended to be set knowingly by a trusted caller.
+
+    Raises:
+        SpawnSecurityError: If ``command`` is empty / not a string, contains a
+            path-traversal segment, or (unless ``allow_arbitrary``) is not in
+            the effective allowlist.
+    """
+    if not isinstance(command, str) or not command:
+        raise SpawnSecurityError(
+            "spawn command must be a non-empty string",
+            command=command if isinstance(command, str) else None,
+        )
+
+    # Reject path traversal regardless of the allowlist / opt-out — a ``..``
+    # segment is never a legitimate launcher and is a directory-escape vector.
+    segments = command.replace("\\", "/").split("/")
+    if ".." in segments:
+        raise SpawnSecurityError(
+            f"spawn command rejected (path traversal): {command!r}",
+            command=command,
+        )
+
+    if allow_arbitrary:
+        return
+
+    allowed = (
+        frozenset(allowed_commands)
+        if allowed_commands is not None
+        else DEFAULT_ALLOWED_MCP_COMMANDS
+    )
+    basename = os.path.basename(command)
+    if basename in allowed or command in allowed:
+        return
+
+    raise SpawnSecurityError(
+        f"spawn command {command!r} is not in the allowlist "
+        f"(allowed: {sorted(allowed)}). Add it to `allowed_commands`, or set "
+        f"`allow_arbitrary_commands=True` to permit arbitrary commands.",
+        command=command,
+    )

--- a/packages/kailash-mcp/src/kailash_mcp/security.py
+++ b/packages/kailash-mcp/src/kailash_mcp/security.py
@@ -120,7 +120,8 @@ def validate_spawn_command(
 
     raise SpawnSecurityError(
         f"spawn command {command!r} is not in the allowlist "
-        f"(allowed: {sorted(allowed)}). Add it to `allowed_commands`, or set "
-        f"`allow_arbitrary_commands=True` to permit arbitrary commands.",
+        f"(allowed: {sorted(allowed)}). Add it to `allowed_commands`, pass "
+        f"`allow_arbitrary=True` (or set `allow_arbitrary_commands=True` in the "
+        f"client/transport config) to permit arbitrary commands.",
         command=command,
     )

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -94,6 +94,33 @@ from kailash_mcp.utils import (
 
 logger = logging.getLogger(__name__)
 
+
+# Supported MCP protocol-handshake revisions, newest first. The server
+# negotiates genuinely (MCP base-protocol lifecycle): on ``initialize`` it
+# echoes the client's requested version when supported, else returns the
+# newest supported version. A hardcoded/echoed fixed version string is
+# non-compliant.
+SUPPORTED_PROTOCOL_VERSIONS = (
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
+)
+LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+
+def negotiate_protocol_version(requested: Any) -> str:
+    """Negotiate the response ``protocolVersion`` for an ``initialize`` request.
+
+    Echoes the client's requested version when the server supports it;
+    otherwise returns the newest supported version (never a hardcoded fixed
+    string). ``requested`` is the client-sent ``params["protocolVersion"]``
+    (or ``None`` when absent).
+    """
+    if isinstance(requested, str) and requested in SUPPORTED_PROTOCOL_VERSIONS:
+        return requested
+    return LATEST_PROTOCOL_VERSION
+
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -1915,7 +1942,9 @@ class MCPServer:
         return {
             "jsonrpc": "2.0",
             "result": {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": negotiate_protocol_version(
+                    params.get("protocolVersion")
+                ),
                 "capabilities": {
                     "tools": {"listSupported": True, "callSupported": True},
                     "resources": {

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -68,6 +68,7 @@ import websockets
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, TransportError
 from kailash_mcp.protocol.protocol import MetaData, ProtocolManager
+from kailash_mcp.security import validate_spawn_command
 
 logger = logging.getLogger(__name__)
 
@@ -251,6 +252,8 @@ class EnhancedStdioTransport(BaseTransport):
         env: Optional[Dict[str, str]] = None,
         working_directory: Optional[str] = None,
         environment_filter: Optional[List[str]] = None,
+        allowed_commands: Optional[List[str]] = None,
+        allow_arbitrary_commands: bool = False,
         **kwargs,
     ):
         """Initialize enhanced STDIO transport.
@@ -261,6 +264,11 @@ class EnhancedStdioTransport(BaseTransport):
             env: Environment variables
             working_directory: Working directory
             environment_filter: Allowed environment variables
+            allowed_commands: Optional explicit spawn allowlist (basenames or
+                full command strings). ``None`` uses the fail-closed default
+                (``DEFAULT_ALLOWED_MCP_COMMANDS``).
+            allow_arbitrary_commands: Explicit opt-out of the spawn allowlist.
+                Never the default — set knowingly by a trusted caller.
             **kwargs: Base transport arguments
         """
         super().__init__("stdio", **kwargs)
@@ -270,6 +278,8 @@ class EnhancedStdioTransport(BaseTransport):
         self.env = env or {}
         self.working_directory = working_directory
         self.environment_filter = environment_filter
+        self.allowed_commands = allowed_commands
+        self.allow_arbitrary_commands = allow_arbitrary_commands
 
         # Process management
         self.process: Optional[asyncio.subprocess.Process] = None
@@ -281,6 +291,17 @@ class EnhancedStdioTransport(BaseTransport):
         """Start the subprocess and connect."""
         if self._connected:
             return
+
+        # Fail-closed spawn allowlist (MCP 2025-11-25 local-server spawn
+        # safety). self.command is untrusted (config / agent output /
+        # discovery response); reject an unlisted command before spawn.
+        # Placed OUTSIDE the try so SpawnSecurityError (AUTHORIZATION_FAILED)
+        # propagates typed, not wrapped into a generic TransportError.
+        validate_spawn_command(
+            self.command,
+            allowed_commands=self.allowed_commands,
+            allow_arbitrary=self.allow_arbitrary_commands,
+        )
 
         try:
             # Prepare environment

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
@@ -188,3 +188,101 @@ def test_negotiate_returns_latest_for_unsupported_or_absent(requested):
 @pytest.mark.regression
 def test_latest_is_newest_of_supported_set():
     assert LATEST_PROTOCOL_VERSION == SUPPORTED_PROTOCOL_VERSIONS[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Sibling spawn-site parity — the fail-closed guard is wired at EVERY
+#    process-spawn surface, not only the MCPClient sites. Surfaced by an
+#    adversarial security review of the first shard (enforcement-surface
+#    parity, ``rules/security.md`` § Multi-Site Kwarg Plumbing).
+# ---------------------------------------------------------------------------
+import asyncio
+
+from kailash_mcp.discovery.discovery import HealthChecker, ServerInfo
+from kailash_mcp.transports.transports import EnhancedStdioTransport
+
+
+@pytest.mark.asyncio
+async def test_enhanced_stdio_transport_connect_fails_closed(monkeypatch):
+    """EnhancedStdioTransport.connect rejects an unlisted command BEFORE spawn.
+
+    The typed SpawnSecurityError must propagate (not be wrapped into a generic
+    TransportError), and the subprocess must never be spawned.
+    """
+    spawned = {"called": False}
+
+    async def _no_spawn(*args, **kwargs):
+        spawned["called"] = True
+        raise AssertionError("spawn must not be reached for an unlisted command")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _no_spawn)
+    transport = EnhancedStdioTransport(command="sh")  # shell — not in the allowlist
+    with pytest.raises(SpawnSecurityError) as exc_info:
+        await transport.connect()
+    assert exc_info.value.error_code == MCPErrorCode.AUTHORIZATION_FAILED
+    assert spawned["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_enhanced_stdio_transport_default_launcher_reaches_spawn(monkeypatch):
+    """A listed launcher (python) passes the guard and reaches the spawn call."""
+    reached = {"cmd": None}
+
+    async def _fake_spawn(cmd, *args, **kwargs):
+        reached["cmd"] = cmd
+        raise RuntimeError("stub-spawn-stop")  # halt before real I/O tasks
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    transport = EnhancedStdioTransport(command="python")
+    with pytest.raises(Exception):  # TransportError from the stubbed spawn
+        await transport.connect()
+    assert reached["cmd"] == "python"  # guard passed, spawn reached
+
+
+@pytest.mark.asyncio
+async def test_enhanced_stdio_transport_allow_arbitrary_bypasses_guard(monkeypatch):
+    """allow_arbitrary_commands=True bypasses the allowlist and reaches spawn."""
+    reached = {"cmd": None}
+
+    async def _fake_spawn(cmd, *args, **kwargs):
+        reached["cmd"] = cmd
+        raise RuntimeError("stub-spawn-stop")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    transport = EnhancedStdioTransport(
+        command="my-unlisted-server", allow_arbitrary_commands=True
+    )
+    with pytest.raises(Exception):
+        await transport.connect()
+    assert reached["cmd"] == "my-unlisted-server"  # opt-out honored, spawn reached
+
+
+@pytest.mark.asyncio
+async def test_discovery_health_check_blocks_unlisted_command():
+    """HealthChecker.check_server_health reports 'blocked' for an unlisted stdio
+    command instead of spawning it to probe liveness."""
+    checker = HealthChecker(None)
+    server = ServerInfo(
+        name="evil", transport="stdio", command="sh", args=["-c", "echo pwned"]
+    )
+    result = await checker.check_server_health(server)
+    assert result["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_discovery_health_check_allows_listed_launcher(monkeypatch):
+    """A listed launcher passes the discovery guard and reaches the probe spawn."""
+    reached = {"cmd": None}
+
+    async def _fake_spawn(cmd, *args, **kwargs):
+        reached["cmd"] = cmd
+        raise RuntimeError("stub-spawn-stop")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    checker = HealthChecker(None)
+    server = ServerInfo(name="ok", transport="stdio", command="python", args=["-V"])
+    result = await checker.check_server_health(server)
+    # spawn was reached (guard passed); the stub failure surfaces as unhealthy,
+    # NOT blocked — the key assertion is status != "blocked".
+    assert result["status"] != "blocked"
+    assert reached["cmd"] == "python"

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 - MCP spec-compliance parity (revision 2025-11-25).
+
+Behavioral pins (call the function, assert raise/return - never source-grep,
+per ``rules/testing.md``) for the three in-shard fixes:
+
+1. **Local-server spawn safety** - ``kailash_mcp.security.validate_spawn_command``
+   fails CLOSED by default: an unlisted command is REJECTED, never
+   warn-and-allowed. Wired into all three ``MCPClient`` stdio spawn sites via
+   ``MCPClient._guard_spawn_command``.
+2. **Request-id rules** - ``JsonRpcRequest.from_dict`` rejects an EXPLICIT
+   ``null`` id (distinct from an ABSENT id = notification).
+3. **protocolVersion negotiation** - ``negotiate_protocol_version`` echoes a
+   supported requested version, else returns the newest supported version
+   (never a hardcoded fixed string).
+"""
+
+import pytest
+
+from kailash_mcp.client import MCPClient
+from kailash_mcp.errors import MCPErrorCode
+from kailash_mcp.protocol.messages import JsonRpcRequest, JsonRpcValidationError
+from kailash_mcp.security import (
+    DEFAULT_ALLOWED_MCP_COMMANDS,
+    SpawnSecurityError,
+    validate_spawn_command,
+)
+from kailash_mcp.server import (
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    negotiate_protocol_version,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Local-server spawn safety - fail closed by default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("launcher", sorted(DEFAULT_ALLOWED_MCP_COMMANDS))
+def test_default_allowlist_permits_standard_launchers(launcher):
+    """Every curated launcher is permitted under the default (no raise)."""
+    validate_spawn_command(launcher)  # must not raise
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "command",
+    ["sh", "bash", "zsh", "cmd", "powershell", "curl", "wget", "rm", "make"],
+)
+def test_default_allowlist_rejects_unlisted_command(command):
+    """An unlisted command is REJECTED fail-closed - not warn-and-allowed."""
+    with pytest.raises(SpawnSecurityError):
+        validate_spawn_command(command)
+
+
+@pytest.mark.regression
+def test_absolute_path_to_unlisted_binary_rejected():
+    """A full absolute path whose basename is unlisted is rejected."""
+    with pytest.raises(SpawnSecurityError):
+        validate_spawn_command("/usr/bin/curl")
+
+
+@pytest.mark.regression
+def test_absolute_path_to_listed_basename_permitted():
+    """A full path whose basename IS a listed launcher is permitted."""
+    validate_spawn_command("/usr/local/bin/python3")  # basename python3 -> ok
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("bad", ["../evil", "/opt/../bin/sh", "a/../../sh"])
+def test_path_traversal_rejected_even_with_opt_out(bad):
+    """Path traversal is rejected regardless of the arbitrary opt-out."""
+    with pytest.raises(SpawnSecurityError):
+        validate_spawn_command(bad, allow_arbitrary=True)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("empty", ["", None, 123, ["python"]])
+def test_empty_or_non_string_command_rejected(empty):
+    with pytest.raises(SpawnSecurityError):
+        validate_spawn_command(empty)
+
+
+@pytest.mark.regression
+def test_allow_arbitrary_opt_out_permits_unlisted():
+    """The explicit opt-out permits an otherwise-unlisted command."""
+    validate_spawn_command("my-custom-mcp-server", allow_arbitrary=True)
+
+
+@pytest.mark.regression
+def test_explicit_allowlist_narrows_and_rejects_default_launchers():
+    """An explicit allowlist REPLACES the default (fail-closed narrowing)."""
+    validate_spawn_command("python", allowed_commands=["python"])  # ok
+    with pytest.raises(SpawnSecurityError):
+        # uvx is in the DEFAULT set but NOT in this explicit allowlist.
+        validate_spawn_command("uvx", allowed_commands=["python"])
+
+
+@pytest.mark.regression
+def test_empty_allowlist_rejects_everything():
+    """An explicit empty allowlist is the maximally-closed posture."""
+    with pytest.raises(SpawnSecurityError):
+        validate_spawn_command("python", allowed_commands=[])
+
+
+@pytest.mark.regression
+def test_spawn_error_carries_authorization_error_code():
+    """The typed error carries the AUTHORIZATION_FAILED JSON-RPC code."""
+    with pytest.raises(SpawnSecurityError) as exc_info:
+        validate_spawn_command("sh")
+    assert exc_info.value.error_code == MCPErrorCode.AUTHORIZATION_FAILED
+
+
+@pytest.mark.regression
+def test_mcpclient_guard_reads_config_allowlist():
+    """MCPClient._guard_spawn_command enforces the fail-closed default."""
+    client = MCPClient()
+    client._guard_spawn_command("python")  # default set -> ok
+    with pytest.raises(SpawnSecurityError):
+        client._guard_spawn_command("sh")
+
+
+@pytest.mark.regression
+def test_mcpclient_guard_honors_allow_arbitrary_config():
+    """MCPClient reads allow_arbitrary_commands from its config."""
+    client = MCPClient(config={"allow_arbitrary_commands": True})
+    client._guard_spawn_command("my-custom-server")  # opt-out -> ok
+
+
+@pytest.mark.regression
+def test_mcpclient_guard_honors_explicit_allowlist_config():
+    client = MCPClient(config={"allowed_commands": ["python"]})
+    client._guard_spawn_command("python")
+    with pytest.raises(SpawnSecurityError):
+        client._guard_spawn_command("uvx")
+
+
+# ---------------------------------------------------------------------------
+# 2. Request-id rules - explicit null id is invalid (distinct from absent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_explicit_null_id_rejected():
+    """An explicit ``{"id": null}`` is invalid - not a notification."""
+    with pytest.raises(JsonRpcValidationError):
+        JsonRpcRequest.from_dict({"jsonrpc": "2.0", "method": "x", "id": None})
+
+
+@pytest.mark.regression
+def test_absent_id_is_notification():
+    """An ABSENT id denotes a notification (id=None, is_notification True)."""
+    req = JsonRpcRequest.from_dict({"jsonrpc": "2.0", "method": "notify"})
+    assert req.id is None
+    assert req.is_notification is True
+
+
+@pytest.mark.regression
+def test_present_id_is_request():
+    req = JsonRpcRequest.from_dict({"jsonrpc": "2.0", "method": "x", "id": 7})
+    assert req.id == 7
+    assert req.is_notification is False
+
+
+# ---------------------------------------------------------------------------
+# 3. protocolVersion negotiation - genuine, not a hardcoded echo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("version", SUPPORTED_PROTOCOL_VERSIONS)
+def test_negotiate_echoes_supported_requested_version(version):
+    """A supported requested version is echoed back verbatim."""
+    assert negotiate_protocol_version(version) == version
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("requested", ["1999-01-01", "", None, 123, "2099-12-31"])
+def test_negotiate_returns_latest_for_unsupported_or_absent(requested):
+    """An unsupported / absent requested version yields the newest supported."""
+    assert negotiate_protocol_version(requested) == LATEST_PROTOCOL_VERSION
+
+
+@pytest.mark.regression
+def test_latest_is_newest_of_supported_set():
+    assert LATEST_PROTOCOL_VERSION == SUPPORTED_PROTOCOL_VERSIONS[0]

--- a/src/kailash/channels/mcp/stdio.py
+++ b/src/kailash/channels/mcp/stdio.py
@@ -16,9 +16,12 @@ parity. Both implementations are wire-level compatible — a Python
 client can speak to a Rust-spawned MCP server and vice versa.
 
 Security: subprocess spawning never invokes a shell (``shell=False``),
-so the command/args are not interpreted by ``/bin/sh``. The caller is
-responsible for the executable allowlist; supply ``allowed_commands``
-to enforce one.
+so the command/args are not interpreted by ``/bin/sh``. The executable
+allowlist fails CLOSED by default (MCP 2025-11-25 local-server spawn
+safety) — absent an explicit ``allowed_commands`` the curated
+:data:`DEFAULT_ALLOWED_COMMANDS` launcher set is enforced and an unlisted
+command is rejected. Pass ``allowed_commands=[...]`` to narrow/extend it,
+or ``allow_arbitrary_commands=True`` to opt out explicitly.
 """
 
 from __future__ import annotations
@@ -37,6 +40,27 @@ CONTENT_LENGTH_PREFIX = "Content-Length: "
 # guards against malicious / runaway peers that would otherwise drive
 # us to OOM by sending an outsized Content-Length header.
 MAX_MESSAGE_SIZE = 64 * 1024 * 1024
+
+# Fail-closed default allowlist of standard MCP launcher executables (MCP
+# 2025-11-25 local-server spawn safety). Deliberately EXCLUDES shells
+# (``sh`` / ``bash`` / ``cmd`` / ``powershell``) and generic download-exec
+# tools (``curl`` / ``wget``) — those are the arbitrary-command-injection
+# vectors the fail-closed default exists to reject. Absent an explicit
+# ``allowed_commands``, an unlisted command is REJECTED, never warn-and-allowed.
+DEFAULT_ALLOWED_COMMANDS = frozenset(
+    {
+        "python",
+        "python3",
+        "uv",
+        "uvx",
+        "node",
+        "npx",
+        "deno",
+        "bunx",
+        "bun",
+        "docker",
+    }
+)
 
 
 class StdioTransport(Transport):
@@ -76,19 +100,29 @@ class StdioTransport(Transport):
         args: Optional[Sequence[str]] = None,
         *,
         allowed_commands: Optional[Sequence[str]] = None,
+        allow_arbitrary_commands: bool = False,
         env: Optional[dict] = None,
         cwd: Optional[str] = None,
     ) -> "StdioTransport":
         """Spawn an MCP server subprocess and connect a transport.
 
+        The command allowlist fails CLOSED by default (MCP 2025-11-25
+        local-server spawn safety): an unlisted command is REJECTED, never
+        warn-and-allowed.
+
         Args:
             command: Path or basename of the executable to spawn. Path
                 traversal sequences (``..``) are rejected.
             args: Optional list of arguments to pass to the executable.
-            allowed_commands: If provided, the command's basename MUST
-                appear in this list — otherwise a :class:`TransportError`
-                is raised. Use this to enforce a strict allowlist for
-                user-supplied input.
+            allowed_commands: Explicit allowlist. When omitted, the curated
+                :data:`DEFAULT_ALLOWED_COMMANDS` set (standard MCP launchers)
+                is enforced — the fail-closed default. A command whose
+                basename (or full string) is not in the effective allowlist
+                raises :class:`TransportError`.
+            allow_arbitrary_commands: Explicit opt-out of the allowlist. When
+                ``True`` any non-empty, non-traversing command is permitted.
+                This is the only way to spawn an unlisted command; it is never
+                the default.
             env: Optional environment mapping (passed to the subprocess).
             cwd: Optional working directory for the subprocess.
 
@@ -99,7 +133,7 @@ class StdioTransport(Transport):
             TransportError: If the command fails validation or spawning
                 fails.
         """
-        cls._validate_command(command, allowed_commands)
+        cls._validate_command(command, allowed_commands, allow_arbitrary_commands)
         cmd_args: list[str] = list(args or [])
         try:
             process = await asyncio.create_subprocess_exec(
@@ -126,18 +160,27 @@ class StdioTransport(Transport):
         return cls(process)
 
     @staticmethod
-    def _validate_command(command: str, allowed: Optional[Sequence[str]]) -> None:
+    def _validate_command(
+        command: str,
+        allowed: Optional[Sequence[str]],
+        allow_arbitrary: bool = False,
+    ) -> None:
         if not isinstance(command, str) or not command:
             raise TransportError("command must be a non-empty string")
-        if ".." in command.split(os.sep):
+        if ".." in command.replace("\\", "/").split("/"):
             raise TransportError(f"command rejected (path traversal): {command!r}")
-        if allowed is not None:
-            basename = os.path.basename(command)
-            if basename not in allowed and command not in allowed:
-                allowed_str = ", ".join(repr(c) for c in allowed)
-                raise TransportError(
-                    f"command {command!r} not in the allowlist [{allowed_str}]"
-                )
+        if allow_arbitrary:
+            return
+        # Fail closed: absent an explicit allowlist, enforce the curated
+        # default launcher set rather than permitting arbitrary commands.
+        effective = allowed if allowed is not None else DEFAULT_ALLOWED_COMMANDS
+        basename = os.path.basename(command)
+        if basename not in effective and command not in effective:
+            allowed_str = ", ".join(repr(c) for c in sorted(effective))
+            raise TransportError(
+                f"command {command!r} not in the allowlist [{allowed_str}]; "
+                f"pass allowed_commands=[...] or allow_arbitrary_commands=True"
+            )
 
     # ------------------------------------------------------------------
     # Transport protocol
@@ -298,10 +341,30 @@ def _quote_for_log(command: str, args: Sequence[str]) -> str:
     return shlex.join([command, *args])
 
 
+def validate_spawn_command(
+    command: str,
+    allowed_commands: Optional[Sequence[str]] = None,
+    allow_arbitrary_commands: bool = False,
+) -> None:
+    """Fail-closed validation of an MCP local-server spawn command.
+
+    Shared entry point for every MCP stdio spawn site (this transport AND the
+    middleware MCP client). Absent ``allowed_commands`` the curated
+    :data:`DEFAULT_ALLOWED_COMMANDS` set is enforced; an unlisted command
+    raises :class:`TransportError` (never warn-and-allow). Set
+    ``allow_arbitrary_commands=True`` to opt out explicitly.
+    """
+    StdioTransport._validate_command(
+        command, allowed_commands, allow_arbitrary_commands
+    )
+
+
 __all__ = [
     "StdioTransport",
     "write_framed_message",
     "read_framed_message",
+    "validate_spawn_command",
+    "DEFAULT_ALLOWED_COMMANDS",
     "MAX_MESSAGE_SIZE",
     "CONTENT_LENGTH_PREFIX",
 ]

--- a/src/kailash/middleware/mcp/client_integration.py
+++ b/src/kailash/middleware/mcp/client_integration.py
@@ -113,6 +113,18 @@ class MCPServerConnection:
                         "stdio transport requires 'command' in connection_config"
                     )
 
+                # Fail-closed spawn safety (MCP 2025-11-25 local-server spawn
+                # safety): reject an unlisted command rather than warn-and-allow.
+                from ...channels.mcp.stdio import validate_spawn_command
+
+                validate_spawn_command(
+                    command,
+                    allowed_commands=self.connection_config.get("allowed_commands"),
+                    allow_arbitrary_commands=bool(
+                        self.connection_config.get("allow_arbitrary_commands", False)
+                    ),
+                )
+
                 params = StdioServerParameters(  # type: ignore[reportOptionalCall]
                     command=command,
                     args=args,

--- a/src/kailash/trust/mcp/server.py
+++ b/src/kailash/trust/mcp/server.py
@@ -65,7 +65,21 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _JSONRPC_VERSION = "2.0"
-_MCP_PROTOCOL_VERSION = "2024-11-05"
+
+# MCP protocol versions this trust-plane server can speak, newest first. The
+# initialize handshake NEGOTIATES rather than echoing a fixed string (a
+# hardcoded/echoed version is non-compliant with the MCP lifecycle, #1712):
+# echo the client's requested version when supported, else return the newest
+# supported version.
+_SUPPORTED_MCP_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+_LATEST_MCP_PROTOCOL_VERSION = _SUPPORTED_MCP_PROTOCOL_VERSIONS[0]
+
+
+def _negotiate_mcp_protocol_version(requested: Any) -> str:
+    """Echo the client's requested protocolVersion if supported, else newest."""
+    if isinstance(requested, str) and requested in _SUPPORTED_MCP_PROTOCOL_VERSIONS:
+        return requested
+    return _LATEST_MCP_PROTOCOL_VERSION
 
 
 def _ok_response(id: Any, result: Any) -> Dict[str, Any]:
@@ -461,8 +475,9 @@ class EATPMCPServer:
     async def _handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle the ``initialize`` handshake."""
         await self._ensure_initialized()
+        requested = params.get("protocolVersion") if isinstance(params, dict) else None
         return {
-            "protocolVersion": _MCP_PROTOCOL_VERSION,
+            "protocolVersion": _negotiate_mcp_protocol_version(requested),
             "capabilities": {
                 "tools": {"listChanged": False},
                 "resources": {"subscribe": False, "listChanged": False},

--- a/tests/trust/integration/test_mcp_integration.py
+++ b/tests/trust/integration/test_mcp_integration.py
@@ -299,6 +299,34 @@ class TestProtocol:
         assert result["serverInfo"]["name"] == "eatp-mcp-server"
         assert "version" in result["serverInfo"]
 
+    async def test_initialize_negotiates_newer_supported_version(self, server):
+        """A client requesting a newer SUPPORTED version gets it echoed, not a
+        hardcoded fixed string (#1712 protocolVersion negotiation)."""
+        request = _make_request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+            },
+        )
+        response = _parse_response(await server.handle_message(request))
+        assert response["result"]["protocolVersion"] == "2025-06-18"
+
+    async def test_initialize_unsupported_version_returns_latest(self, server):
+        """An unsupported requested version negotiates to the newest supported
+        version — the server never blindly echoes the client's string."""
+        request = _make_request(
+            "initialize",
+            {
+                "protocolVersion": "1999-01-01",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+            },
+        )
+        response = _parse_response(await server.handle_message(request))
+        assert response["result"]["protocolVersion"] == "2025-06-18"
+
     async def test_initialized_notification_returns_none(self, server):
         """notifications/initialized is a notification (no id) and returns None."""
         notification = _make_notification("notifications/initialized")

--- a/tests/unit/channels/test_mcp_transports.py
+++ b/tests/unit/channels/test_mcp_transports.py
@@ -166,6 +166,41 @@ class TestStdioTransport:
         with pytest.raises(TransportError):
             await StdioTransport.spawn(command="", args=[])
 
+    # ----- #1712: fail-closed spawn allowlist by default -------------------
+
+    def test_validate_spawn_command_default_permits_launcher(self) -> None:
+        from kailash.channels.mcp.stdio import validate_spawn_command
+
+        validate_spawn_command("python3")  # curated default set -> no raise
+
+    @pytest.mark.parametrize("cmd", ["bash", "sh", "curl", "rm", "/usr/bin/curl"])
+    def test_validate_spawn_command_default_rejects_unlisted(self, cmd) -> None:
+        from kailash.channels.mcp.stdio import validate_spawn_command
+
+        with pytest.raises(TransportError):
+            validate_spawn_command(cmd)  # fail-closed, not warn-and-allow
+
+    def test_validate_spawn_command_opt_out_permits_arbitrary(self) -> None:
+        from kailash.channels.mcp.stdio import validate_spawn_command
+
+        validate_spawn_command("my-custom-server", allow_arbitrary_commands=True)
+
+    @pytest.mark.parametrize("bad", ["../evil", "a/../../sh"])
+    def test_validate_spawn_command_rejects_traversal_even_with_opt_out(
+        self, bad
+    ) -> None:
+        from kailash.channels.mcp.stdio import validate_spawn_command
+
+        with pytest.raises(TransportError):
+            validate_spawn_command(bad, allow_arbitrary_commands=True)
+
+    @pytest.mark.asyncio
+    async def test_spawn_default_rejects_unlisted_command(self) -> None:
+        # No allowed_commands: the fail-closed default rejects an unlisted
+        # command BEFORE spawning a subprocess (MCP 2025-11-25 spawn safety).
+        with pytest.raises(TransportError):
+            await StdioTransport.spawn(command="bash", args=["-c", "echo hi"])
+
 
 # ----- exception hierarchy --------------------------------------------------
 


### PR DESCRIPTION
## Summary
First convergence shard against the MCP 2025-11-25 spec-compliance checklist (#1712). The issue is a spec checklist, not a state assertion — this PR **audits** the current implementation and lands the in-budget **security + small-conformance** items, prioritizing fail-closed security. Remaining gaps are enumerated as scoped follow-ups (see issue comment).

## Fixed this shard
1. **[SECURITY] Fail-closed local-server spawn allowlist** — new `kailash_mcp/security.py` (`validate_spawn_command` + `DEFAULT_ALLOWED_MCP_COMMANDS` + typed `SpawnSecurityError`). Wired at **every** spawn surface in one change (multi-site plumbing): the 3 `MCPClient` stdio sites, the core `StdioTransport` (default flipped fail-open→fail-closed with an `allow_arbitrary_commands` opt-out), and the middleware MCP client. Default rejects `sh`/`bash`/`curl`/`rm`/unlisted binaries; path-traversal rejected even under opt-out.
2. **Explicit `null` request-id rejection** at the parse boundary (`protocol/messages.py::from_dict`) — distinct from an absent id (= notification).
3. **Genuine server-side protocolVersion negotiation** (`server.py::negotiate_protocol_version`) — echoes a supported requested version, else returns the newest supported; removes the hardcoded `2024-11-05` echo.

## Testing
- 47 new behavioral tests (`test_issue_1712_mcp_spec_parity.py`) + fail-closed tests in `test_mcp_transports.py`.
- kailash-mcp package: 108 passed. Core channels/transports + mcp-server units: 107 passed. No existing suite regressed.

## Follow-ups (not in this shard — see issue #1712 comment for the full audit table)
Server-side RFC 8707 token-audience fail-closed validation; stdio newline-delimited wire-format (cross-SDK lockstep); Streamable HTTP single-endpoint + `MCP-Protocol-Version` header→400 + `MCP-Session-Id` lifecycle; notification-no-body/202 chokepoint; client-side protocolVersion validation; pagination; OAuth PRM discovery; sampling/roots/elicitation-url/tool-result conformance depth. Sibling: `EATPMCPServer` hardcodes protocolVersion (same negotiation fix needed).

## Related issues
Addresses #1712 (partial — first shard; issue stays open for the follow-up checklist).