### PR TITLE
release: kailash 2.53.0 + kailash-mcp 0.3.1 + kailash-kaizen 2.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unmodified — this is a deprecation of the tier, not a reconciliation of
   the key lists.
 
+## [2.53.0] - 2026-07-15
+
+### Security
+
+- **Fail-closed MCP local-server spawn allowlist in the core transports**
+  (#1712). The `channels/mcp` `StdioTransport` and the `middleware/mcp` client
+  now reject an unlisted spawn command by default (previously fail-open), per
+  the MCP 2025-11-25 local-server spawn-safety requirement, with an
+  `allow_arbitrary_commands` opt-out.
+
+### Fixed
+
+- **Trust-plane MCP server (`EATPMCPServer`) negotiates `protocolVersion`**
+  instead of returning a hardcoded `2024-11-05` (#1712) — echoes a supported
+  requested version, else the newest supported.
+
 ## [2.52.0] - 2026-07-15
 
 ### Security

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
+
+### Fixed
+
+- **`SelfCorrectingRAGNode` crashed or looped on ill-formed LLM confidence
+  (#1755).** Post-2.33.0 the RAG advanced-node parsers consume real LLM output,
+  so `_parse_verification_response` sits on a live path. It validated field
+  *presence* only: a `confidence` returned as a string raised an uncaught
+  `TypeError` at the numeric gate in `run()`, and a `NaN` confidence
+  (`json.loads` accepts the bare `NaN` literal) never met the gate — forcing the
+  self-correction loop to run to `max_corrections` every time. Every score field
+  is now coerced to a finite float at the single parse chokepoint (`_coerce_score`);
+  an ill-formed (non-numeric / non-finite) score routes to the existing heuristic
+  fallback.
+
 ## [2.33.0] — 2026-07-15 — RAG advanced-node parser fix + Tier-1 test-hang resolution
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.33.0"
+version = "2.33.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.33.0"
+__version__ = "2.33.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.3.1] — 2026-07-15 — fail-closed MCP local-server spawn allowlist + spec-parity fixes (#1712)
+
+### Security
+
+- **Fail-closed local-server spawn allowlist** (`kailash_mcp.security.validate_spawn_command`,
+  `SpawnSecurityError`). An unlisted spawn command is now REJECTED by default
+  (never warn-and-allowed), per the MCP 2025-11-25 local-server spawn-safety
+  requirement. Wired at every process-spawn surface: the three `MCPClient` stdio
+  sites, `EnhancedStdioTransport.connect`, and the discovery health-probe.
+
+### Fixed
+
+- **Explicit `null` JSON-RPC request id** is rejected at the parse boundary
+  (`JsonRpcRequest.from_dict`), distinct from an absent id (= notification).
+- **`protocolVersion` negotiation** — the server echoes a supported requested
+  version, else returns the newest supported, instead of a hardcoded string.
+
 ## [0.3.0] — 2026-07-13 — real `mcp_tool_duration_seconds` histogram reaches unified `/metrics` (#1708)
 
 Part of the coordinated 5-package #1708 observability release. Requires

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.52.0"
+version = "2.53.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.52.0"
+__version__ = "2.53.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary
Release-prep for the two fixes merged this session:

| Package | Bump | Issue |
|---------|------|-------|
| kailash-kaizen | 2.33.0 → **2.33.1** (patch) | #1755 RAG verification-parse hardening |
| kailash-mcp | 0.3.0 → **0.3.1** (patch) | #1712 fail-closed spawn allowlist + null-id + protocolVersion |
| kailash (core) | 2.52.0 → **2.53.0** (minor) | #1712 core channels/middleware/trust MCP fail-closed + negotiate |

Version anchors (pyproject.toml + `__init__.py`) + CHANGELOG entries bumped atomically per `zero-tolerance.md` Rule 5.

**2.53.0 is a minor** — the fail-closed spawn default + new `allowed_commands`/`allow_arbitrary_commands` params on `EnhancedStdioTransport` are a behavior + public-API change → TestPyPI validation before the prod tag.

## Related issues
Releases #1755; ships the first shard of #1712 (issue stays open for the checklist follow-ups).