### PR TITLE
feat(pact): SOC 2 evidence-collection primitives at the governance layer (#1711)

### DIFF
--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -168,6 +168,16 @@ from pact.ml import (
 )
 from pact.work import WorkResult, WorkSubmission
 
+# --- SOC 2 compliance-evidence tooling (issue #1711) ---
+from pact.compliance import (
+    ControlEvidence,
+    CriterionEvidence,
+    EvidenceCollectionError,
+    EvidenceCollector,
+    EvidenceItem,
+    EvidencePackage,
+)
+
 __all__ = [
     # Error hierarchy
     "PactError",
@@ -318,5 +328,12 @@ __all__ = [
     "MLGovernanceContext",
     "check_cross_tenant_op",
     "check_engine_method_clearance",
+    # SOC 2 compliance-evidence tooling (issue #1711)
+    "EvidenceCollector",
+    "EvidencePackage",
+    "ControlEvidence",
+    "CriterionEvidence",
+    "EvidenceItem",
+    "EvidenceCollectionError",
     "check_trial_admission",
 ]

--- a/packages/kailash-pact/src/pact/compliance/__init__.py
+++ b/packages/kailash-pact/src/pact/compliance/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""SOC 2 compliance-evidence tooling for the PACT governance layer.
+
+Derives SOC 2-aligned evidence packages from the primitives the SDK already
+emits (RBAC/ABAC grants, the hash-chained immutable audit log, tenant
+isolation, trust/delegation records, governance-config changes). This is
+evidence *tooling*, not an attestation — the deploying organization remains the
+attesting party.
+
+Public API::
+
+    from pact.compliance import EvidenceCollector
+
+    collector = EvidenceCollector(audit_store)
+    package = await collector.collect(
+        tenant_id="acme",
+        period_start=start,
+        period_end=end,
+    )
+    package.to_dict()  # structured, exportable
+"""
+
+from __future__ import annotations
+
+from pact.compliance.evidence import (
+    ControlEvidence,
+    CriterionEvidence,
+    EvidenceCollectionError,
+    EvidenceCollector,
+    EvidenceItem,
+    EvidencePackage,
+)
+from pact.compliance.vocabulary import (
+    CONTROL_SPECS,
+    EMITTED_ACTION_VOCABULARY,
+    IMPLEMENTED_CONTROLS,
+    ControlSpec,
+    CriterionSpec,
+)
+
+__all__ = [
+    "EvidenceCollector",
+    "EvidencePackage",
+    "ControlEvidence",
+    "CriterionEvidence",
+    "EvidenceItem",
+    "EvidenceCollectionError",
+    "CONTROL_SPECS",
+    "IMPLEMENTED_CONTROLS",
+    "EMITTED_ACTION_VOCABULARY",
+    "ControlSpec",
+    "CriterionSpec",
+]

--- a/packages/kailash-pact/src/pact/compliance/evidence.py
+++ b/packages/kailash-pact/src/pact/compliance/evidence.py
@@ -260,7 +260,8 @@ class EvidenceCollector:
         for control_id in selected:
             spec = CONTROL_SPECS[control_id]
             criteria = tuple(
-                self._build_criterion(cspec, events) for cspec in spec.criteria
+                self._build_criterion(cspec, events, chain_verified)
+                for cspec in spec.criteria
             )
             built.append(
                 ControlEvidence(
@@ -321,9 +322,57 @@ class EvidenceCollector:
             )
             return False
 
-    def _build_criterion(
-        self, spec: CriterionSpec, events: Iterable[AuditEvent]
+    def _build_chain_integrity(
+        self, spec: CriterionSpec, chain_verified: Optional[bool]
     ) -> CriterionEvidence:
+        # The audit store does not expose chain verification -> unmeasurable.
+        if chain_verified is None:
+            return CriterionEvidence(
+                criterion=spec.key,
+                description=spec.description,
+                verified=False,
+                evidence_count=0,
+                source_actions=spec.source_actions,
+                items=(),
+                unverified_reason=(
+                    "the configured audit store does not expose hash-chain "
+                    "verification"
+                ),
+            )
+        # Verification ran -> the criterion is measured. The pass/fail result is
+        # carried on the evidence item's outcome (a failed chain is a real,
+        # measured adverse finding, not an unmeasured control).
+        item = EvidenceItem(
+            event_id="audit-chain-integrity",
+            timestamp=_now_iso(),
+            action="audit_chain_verification",
+            actor="system",
+            outcome="success" if chain_verified else "failure",
+            resource="audit_chain",
+        )
+        return CriterionEvidence(
+            criterion=spec.key,
+            description=spec.description,
+            verified=True,
+            evidence_count=1,
+            source_actions=spec.source_actions,
+            items=(item,),
+            unverified_reason=(
+                None
+                if chain_verified
+                else "audit chain integrity verification FAILED -- tamper detected"
+            ),
+        )
+
+    def _build_criterion(
+        self,
+        spec: CriterionSpec,
+        events: Iterable[AuditEvent],
+        chain_verified: Optional[bool],
+    ) -> CriterionEvidence:
+        if spec.kind == "chain_integrity":
+            return self._build_chain_integrity(spec, chain_verified)
+
         # No emitting producer for this criterion -> honest verified=False.
         if spec.unverifiable_reason is not None:
             return CriterionEvidence(

--- a/packages/kailash-pact/src/pact/compliance/evidence.py
+++ b/packages/kailash-pact/src/pact/compliance/evidence.py
@@ -1,0 +1,352 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""SOC 2 evidence-package collector.
+
+Derives SOC 2-aligned compliance evidence from the primitives the SDK already
+emits — the hash-chained ``AuditStore`` and the PACT governance audit
+vocabulary — for a single tenant over a time window. This is evidence
+*tooling*, not an attestation: the deploying organization remains the attesting
+party. "Governance by construction" becomes "compliance evidence by
+construction."
+
+Load-bearing invariants (each covered by a test):
+
+1. **No fabrication** — evidence is derived ONLY from real emitted records.
+   A control with no emitting source primitive reports ``verified=False`` with
+   a reason, never a fabricated pass.
+2. **Tenant isolation** — every collector is scoped to one ``tenant_id``;
+   records belonging to other tenants (or unattributed records) are excluded.
+3. **Producer↔consumer contract** — every collector filter is built from the
+   real emitted action vocabulary (:mod:`pact.compliance.vocabulary`).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional, Sequence
+
+from kailash.trust.audit_store import AuditEvent, AuditFilter
+from kailash.trust.pact.exceptions import PactError
+
+from pact.compliance.vocabulary import CONTROL_SPECS, CriterionSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EvidenceCollectionError",
+    "EvidenceItem",
+    "CriterionEvidence",
+    "ControlEvidence",
+    "EvidencePackage",
+    "EvidenceCollector",
+]
+
+# A generous default scan bound. ``AuditFilter`` has no tenant filter and stops
+# at ``limit`` matches, so the collector scans the window broadly and applies
+# tenant + action selection in-process.
+_DEFAULT_SCAN_LIMIT = 1_000_000
+_DEFAULT_MAX_ITEMS = 100
+
+
+class EvidenceCollectionError(PactError):
+    """Raised when evidence collection cannot proceed (fail-closed)."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _to_iso(value: datetime) -> str:
+    if not isinstance(value, datetime):
+        raise EvidenceCollectionError(
+            "period bounds must be datetime instances",
+            details={"received_type": type(value).__name__},
+        )
+    return value.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Immutable, exportable evidence records
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """A single audit record admitted as evidence for a criterion."""
+
+    event_id: str
+    timestamp: str
+    action: str
+    actor: str
+    outcome: str
+    resource: str
+
+    @classmethod
+    def from_event(cls, event: AuditEvent) -> "EvidenceItem":
+        return cls(
+            event_id=event.event_id,
+            timestamp=event.timestamp,
+            action=event.action,
+            actor=event.actor,
+            outcome=event.outcome,
+            resource=event.resource,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "timestamp": self.timestamp,
+            "action": self.action,
+            "actor": self.actor,
+            "outcome": self.outcome,
+            "resource": self.resource,
+        }
+
+
+@dataclass(frozen=True)
+class CriterionEvidence:
+    """Evidence for one sub-criterion of a control.
+
+    ``verified`` is ``True`` when the SDK has a measurement mechanism for this
+    criterion (its ``source_actions`` are real emitted vocabulary) — even when
+    ``evidence_count`` is 0 (an honest "no such events in this window"). It is
+    ``False`` only when NO producer emits the criterion's source, in which case
+    ``unverified_reason`` explains why.
+    """
+
+    criterion: str
+    description: str
+    verified: bool
+    evidence_count: int
+    source_actions: tuple[str, ...]
+    items: tuple[EvidenceItem, ...]
+    unverified_reason: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "criterion": self.criterion,
+            "description": self.description,
+            "verified": self.verified,
+            "evidence_count": self.evidence_count,
+            "source_actions": list(self.source_actions),
+            "items": [item.to_dict() for item in self.items],
+            "unverified_reason": self.unverified_reason,
+        }
+
+
+@dataclass(frozen=True)
+class ControlEvidence:
+    """Evidence for one SOC 2 Common Criteria control."""
+
+    control: str
+    title: str
+    criteria: tuple[CriterionEvidence, ...]
+
+    @property
+    def verified_criteria(self) -> int:
+        return sum(1 for c in self.criteria if c.verified)
+
+    @property
+    def total_criteria(self) -> int:
+        return len(self.criteria)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "control": self.control,
+            "title": self.title,
+            "verified_criteria": self.verified_criteria,
+            "total_criteria": self.total_criteria,
+            "criteria": [c.to_dict() for c in self.criteria],
+        }
+
+
+@dataclass(frozen=True)
+class EvidencePackage:
+    """A tenant- and period-scoped, exportable SOC 2 evidence package."""
+
+    tenant_id: str
+    period_start: str
+    period_end: str
+    generated_at: str
+    controls: tuple[ControlEvidence, ...]
+    chain_verified: Optional[bool] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tenant_id": self.tenant_id,
+            "period_start": self.period_start,
+            "period_end": self.period_end,
+            "generated_at": self.generated_at,
+            "chain_verified": self.chain_verified,
+            "controls": [c.to_dict() for c in self.controls],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+
+class EvidenceCollector:
+    """Derives SOC 2 evidence packages from an emitted ``AuditStore``.
+
+    Args:
+        audit_store: Any object satisfying ``AuditStoreProtocol`` — an
+            append-only, hash-chained store of emitted audit events.
+        max_items_per_criterion: Cap on the number of raw evidence items
+            embedded per criterion (the ``evidence_count`` is always the full
+            match count).
+        scan_limit: Upper bound on records scanned per window query.
+    """
+
+    def __init__(
+        self,
+        audit_store: Any,
+        *,
+        max_items_per_criterion: int = _DEFAULT_MAX_ITEMS,
+        scan_limit: int = _DEFAULT_SCAN_LIMIT,
+    ) -> None:
+        if audit_store is None:
+            raise EvidenceCollectionError("audit_store is required")
+        self._store = audit_store
+        self._max_items = max(0, int(max_items_per_criterion))
+        self._scan_limit = max(1, int(scan_limit))
+
+    async def collect(
+        self,
+        *,
+        tenant_id: str,
+        period_start: datetime,
+        period_end: datetime,
+        controls: Optional[Sequence[str]] = None,
+    ) -> EvidencePackage:
+        """Collect a SOC 2 evidence package for one tenant over a window.
+
+        Args:
+            tenant_id: The tenant to scope evidence to. Records for other
+                tenants (and unattributed records) are excluded (fail-closed).
+            period_start: Inclusive lower time bound.
+            period_end: Inclusive upper time bound.
+            controls: Optional subset of control ids (e.g. ``["CC6"]``); default
+                is every implemented control.
+
+        Returns:
+            An immutable, exportable :class:`EvidencePackage`.
+
+        Raises:
+            EvidenceCollectionError: On invalid tenant / period / unknown
+                control (fail-closed).
+        """
+        if not isinstance(tenant_id, str) or not tenant_id.strip():
+            raise EvidenceCollectionError(
+                "tenant_id must be a non-empty string",
+                details={"tenant_id": repr(tenant_id)},
+            )
+        start_iso = _to_iso(period_start)
+        end_iso = _to_iso(period_end)
+        if period_end < period_start:
+            raise EvidenceCollectionError(
+                "period_end must not precede period_start",
+                details={"period_start": start_iso, "period_end": end_iso},
+            )
+
+        selected = self._resolve_controls(controls)
+        events = await self._scan_window(tenant_id, period_start, period_end)
+        chain_verified = await self._verify_chain()
+
+        built: list[ControlEvidence] = []
+        for control_id in selected:
+            spec = CONTROL_SPECS[control_id]
+            criteria = tuple(
+                self._build_criterion(cspec, events) for cspec in spec.criteria
+            )
+            built.append(
+                ControlEvidence(
+                    control=spec.control, title=spec.title, criteria=criteria
+                )
+            )
+
+        return EvidencePackage(
+            tenant_id=tenant_id,
+            period_start=start_iso,
+            period_end=end_iso,
+            generated_at=_now_iso(),
+            controls=tuple(built),
+            chain_verified=chain_verified,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _resolve_controls(self, controls: Optional[Sequence[str]]) -> list[str]:
+        if controls is None:
+            return list(CONTROL_SPECS)
+        resolved: list[str] = []
+        for control_id in controls:
+            if control_id not in CONTROL_SPECS:
+                raise EvidenceCollectionError(
+                    "unknown control id",
+                    details={
+                        "control": control_id,
+                        "implemented": list(CONTROL_SPECS),
+                    },
+                )
+            resolved.append(control_id)
+        return resolved
+
+    async def _scan_window(
+        self, tenant_id: str, period_start: datetime, period_end: datetime
+    ) -> list[AuditEvent]:
+        flt = AuditFilter(since=period_start, until=period_end, limit=self._scan_limit)
+        events = await self._store.query(flt)
+        # Tenant isolation (fail-closed): only records explicitly attributed to
+        # this tenant are admitted. Unattributed (tenant_id=None) and other
+        # tenants' records are excluded — cross-tenant leakage is BLOCKED.
+        return [
+            event for event in events if getattr(event, "tenant_id", None) == tenant_id
+        ]
+
+    async def _verify_chain(self) -> Optional[bool]:
+        verify = getattr(self._store, "verify_chain", None)
+        if verify is None:
+            return None
+        try:
+            return bool(await verify())
+        except Exception:  # pragma: no cover - defensive; fail-closed to False
+            logger.warning(
+                "EvidenceCollector: audit chain verification raised -- "
+                "reporting chain_verified=False (fail-closed)",
+                exc_info=True,
+            )
+            return False
+
+    def _build_criterion(
+        self, spec: CriterionSpec, events: Iterable[AuditEvent]
+    ) -> CriterionEvidence:
+        # No emitting producer for this criterion -> honest verified=False.
+        if spec.unverifiable_reason is not None:
+            return CriterionEvidence(
+                criterion=spec.key,
+                description=spec.description,
+                verified=False,
+                evidence_count=0,
+                source_actions=spec.source_actions,
+                items=(),
+                unverified_reason=spec.unverifiable_reason,
+            )
+
+        source = set(spec.source_actions)
+        matched = [event for event in events if event.action in source]
+        items = tuple(
+            EvidenceItem.from_event(event) for event in matched[: self._max_items]
+        )
+        return CriterionEvidence(
+            criterion=spec.key,
+            description=spec.description,
+            verified=True,
+            evidence_count=len(matched),
+            source_actions=spec.source_actions,
+            items=items,
+            unverified_reason=None,
+        )

--- a/packages/kailash-pact/src/pact/compliance/vocabulary.py
+++ b/packages/kailash-pact/src/pact/compliance/vocabulary.py
@@ -76,6 +76,11 @@ class CriterionSpec:
     description: str
     source_actions: tuple[str, ...]
     unverifiable_reason: str | None = None
+    kind: str = "records"
+    """How the criterion is measured. ``"records"`` (default) filters emitted
+    audit records by ``source_actions``; ``"chain_integrity"`` derives its
+    evidence from the audit store's hash-chain verification result instead of
+    an action filter (and so carries no ``source_actions``)."""
 
 
 @dataclass(frozen=True)
@@ -210,11 +215,76 @@ _CC8 = ControlSpec(
 
 
 # ---------------------------------------------------------------------------
+# CC7 — System Operations
+#   Hash-chain integrity of the immutable audit log + emitted security /
+#   operational-suspension events. External monitoring/alerting/incident
+#   systems are the deploying org's and are honestly reported verified=False.
+# ---------------------------------------------------------------------------
+
+_CC7 = ControlSpec(
+    control="CC7",
+    title="System Operations",
+    criteria=(
+        CriterionSpec(
+            key="audit_chain_integrity",
+            description=(
+                "Tamper-evidence: the immutable audit log's hash chain verified "
+                "intact over the period (Merkle/hash-chain verification)."
+            ),
+            source_actions=(),
+            kind="chain_integrity",
+        ),
+        CriterionSpec(
+            key="security_events",
+            description=(
+                "Security-relevant operational events: constraint violations, "
+                "denied actions/trust, barrier enforcement, and workflow/node "
+                "errors."
+            ),
+            source_actions=(
+                _AET.CONSTRAINT_VIOLATED.value,
+                _AET.ACTION_DENIED.value,
+                _AET.TRUST_DENIED.value,
+                _AET.WORKFLOW_ERROR.value,
+                _AET.NODE_ERROR.value,
+                _AET.SYSTEM_EVENT.value,
+                _PAA.BARRIER_ENFORCED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="operational_suspensions",
+            description=(
+                "Operational suspensions and resumptions: governance plan "
+                "suspend/resume and resume-condition updates."
+            ),
+            source_actions=(
+                _PAA.PLAN_SUSPENDED.value,
+                _PAA.PLAN_RESUMED.value,
+                _PAA.RESUME_CONDITION_UPDATED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="monitoring_alerts",
+            description="External monitoring, alerting, and incident/escalation records.",
+            source_actions=(),
+            unverifiable_reason=(
+                "The SDK emits no monitoring/alert/incident/escalation record "
+                "primitive; operational monitoring and incident response run in "
+                "the deploying organization's observability and on-call systems, "
+                "outside the SDK's emission surface."
+            ),
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
 # Registry of implemented controls
 # ---------------------------------------------------------------------------
 
 CONTROL_SPECS: dict[str, ControlSpec] = {
     _CC6.control: _CC6,
+    _CC7.control: _CC7,
     _CC8.control: _CC8,
 }
 """Implemented SOC 2 controls, keyed by control id."""

--- a/packages/kailash-pact/src/pact/compliance/vocabulary.py
+++ b/packages/kailash-pact/src/pact/compliance/vocabulary.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""SOC 2 evidence vocabulary — the producer↔consumer contract.
+
+Every SOC 2 evidence collector derives its findings ONLY from action names the
+SDK *actually emits*. The two authoritative producer vocabularies are:
+
+* :class:`kailash.trust.pact.audit.PactAuditAction` — the PACT governance
+  action types recorded on the tamper-evident audit chain (thesis §5.7).
+* :class:`kailash.trust.audit_store.AuditEventType` — the well-known
+  trust-plane audit event types written to the ``AuditStore``.
+
+``EMITTED_ACTION_VOCABULARY`` is the union of both enums' ``.value`` strings.
+Every ``CriterionSpec.source_actions`` entry is built by referencing an enum
+member's ``.value`` directly, so a collector filter can NEVER name an action no
+producer emits. The "dead collector" guard (an evidence filter matching a name
+no producer emits) is closed *by construction* here, and asserted by the
+producer↔consumer contract test.
+
+A criterion with a non-empty ``unverifiable_reason`` has NO emitting producer in
+the SDK (e.g. MFA enrollment state, an external monitoring/alerting system).
+Such criteria report ``verified=False`` in the evidence package — an honest
+"the SDK cannot measure this control", never a fabricated pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from kailash.trust.audit_store import AuditEventType as _AET
+from kailash.trust.pact.audit import PactAuditAction as _PAA
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EMITTED_ACTION_VOCABULARY",
+    "CriterionSpec",
+    "ControlSpec",
+    "CONTROL_SPECS",
+    "IMPLEMENTED_CONTROLS",
+]
+
+
+# ---------------------------------------------------------------------------
+# The authoritative emitted action vocabulary (union of both producer enums)
+# ---------------------------------------------------------------------------
+
+EMITTED_ACTION_VOCABULARY: frozenset[str] = frozenset(
+    [member.value for member in _PAA] + [member.value for member in _AET]
+)
+"""Every action string the SDK's governance/trust producers actually emit."""
+
+
+# ---------------------------------------------------------------------------
+# Spec dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CriterionSpec:
+    """One measurable (or honestly-unmeasurable) SOC 2 sub-criterion.
+
+    Args:
+        key: Stable machine-readable identifier for the criterion.
+        description: Human-readable description of what the criterion evidences.
+        source_actions: The emitted action names this criterion derives from.
+            EVERY entry MUST be a member of ``EMITTED_ACTION_VOCABULARY`` — the
+            producer↔consumer contract. Empty for an unmeasurable criterion.
+        unverifiable_reason: When non-None, the SDK has NO producer for this
+            criterion; the collector reports ``verified=False`` and surfaces
+            this reason instead of fabricating a pass.
+    """
+
+    key: str
+    description: str
+    source_actions: tuple[str, ...]
+    unverifiable_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ControlSpec:
+    """A SOC 2 Common Criteria control and its sub-criteria."""
+
+    control: str
+    title: str
+    criteria: tuple[CriterionSpec, ...]
+
+
+# ---------------------------------------------------------------------------
+# CC6 — Logical and Physical Access Controls
+#   Derived from real emitted access/clearance/bridge/delegation records.
+# ---------------------------------------------------------------------------
+
+_CC6 = ControlSpec(
+    control="CC6",
+    title="Logical and Physical Access Controls",
+    criteria=(
+        CriterionSpec(
+            key="logical_access_grants",
+            description=(
+                "Access permissions granted: role clearances, access grants, "
+                "knowledge-sharing partnerships, approved cross-unit bridges, "
+                "and delegations."
+            ),
+            source_actions=(
+                _PAA.CLEARANCE_GRANTED.value,
+                _PAA.KSP_CREATED.value,
+                _PAA.BRIDGE_APPROVED.value,
+                _PAA.BRIDGE_ESTABLISHED.value,
+                _PAA.BRIDGE_CONSENT.value,
+                _AET.ACCESS_GRANTED.value,
+                _AET.DELEGATION_CREATED.value,
+                _AET.TRUST_ESTABLISHED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="access_revocations",
+            description=(
+                "Access permissions withdrawn: clearance revocations and "
+                "transitions, partnership/bridge/delegation revocations, and "
+                "suspended vacancies."
+            ),
+            source_actions=(
+                _PAA.CLEARANCE_REVOKED.value,
+                _PAA.CLEARANCE_TRANSITIONED.value,
+                _PAA.KSP_REVOKED.value,
+                _PAA.BRIDGE_REVOKED.value,
+                _PAA.BRIDGE_REJECTED.value,
+                _PAA.VACANCY_SUSPENDED.value,
+                _AET.DELEGATION_REVOKED.value,
+                _AET.TRUST_REVOKED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="access_enforcement",
+            description=(
+                "Access-control enforcement decisions: containment/isolation "
+                "barrier enforcement and denied access attempts (the 5-step "
+                "access-enforcement fail-closed path)."
+            ),
+            source_actions=(
+                _PAA.BARRIER_ENFORCED.value,
+                _AET.ACCESS_DENIED.value,
+                _AET.ACTION_DENIED.value,
+                _AET.TRUST_DENIED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="mfa_state",
+            description="Multi-factor-authentication enrollment and enforcement state.",
+            source_actions=(),
+            unverifiable_reason=(
+                "No MFA-state producer emits to the trust-plane audit store; MFA "
+                "enrollment and enforcement live in the deploying organization's "
+                "identity provider, outside the SDK's emission surface."
+            ),
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# CC8 — Change Management
+#   Derived from real emitted governance-config / authorization-structure
+#   change records. Deployment/version/promotion CI records are NOT emitted by
+#   the SDK, so that criterion is honestly reported verified=False.
+# ---------------------------------------------------------------------------
+
+_CC8 = ControlSpec(
+    control="CC8",
+    title="Change Management",
+    criteria=(
+        CriterionSpec(
+            key="governance_config_changes",
+            description=(
+                "Changes to governance configuration: constraint-envelope "
+                "creation and modification, and policy changes."
+            ),
+            source_actions=(
+                _PAA.ENVELOPE_CREATED.value,
+                _PAA.ENVELOPE_MODIFIED.value,
+                _AET.POLICY_CHANGED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="authorization_structure_changes",
+            description=(
+                "Changes to the authorization structure: vacancy designations "
+                "and address (D/T/R) computations."
+            ),
+            source_actions=(
+                _PAA.VACANCY_DESIGNATED.value,
+                _PAA.ADDRESS_COMPUTED.value,
+            ),
+        ),
+        CriterionSpec(
+            key="deployment_records",
+            description="Application deployment, version, and promotion records.",
+            source_actions=(),
+            unverifiable_reason=(
+                "The SDK emits no deployment/version/promotion record primitive; "
+                "CI/CD deployment evidence is the deploying organization's "
+                "pipeline responsibility. The governance-configuration change "
+                "records above are the SDK's change-management evidence."
+            ),
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry of implemented controls
+# ---------------------------------------------------------------------------
+
+CONTROL_SPECS: dict[str, ControlSpec] = {
+    _CC6.control: _CC6,
+    _CC8.control: _CC8,
+}
+"""Implemented SOC 2 controls, keyed by control id."""
+
+IMPLEMENTED_CONTROLS: tuple[str, ...] = tuple(CONTROL_SPECS)

--- a/packages/kailash-pact/tests/unit/compliance/test_evidence_collection.py
+++ b/packages/kailash-pact/tests/unit/compliance/test_evidence_collection.py
@@ -1,0 +1,348 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""SOC 2 evidence-collection tests (issue #1711).
+
+Behavioral tests against a REAL ``InMemoryAuditStore`` populated with REAL
+``AuditEvent`` records (no mocking). Covers the three load-bearing invariants:
+
+1. No fabrication  -> unmeasured controls report ``verified=False``.
+2. Tenant isolation -> cross-tenant leakage is blocked.
+3. Producer<->consumer contract -> every filter matches a real emitted action.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kailash.trust.audit_store import AuditEventType, InMemoryAuditStore
+from kailash.trust.pact.audit import PactAuditAction
+
+from pact.compliance import (
+    CONTROL_SPECS,
+    EMITTED_ACTION_VOCABULARY,
+    EvidenceCollectionError,
+    EvidenceCollector,
+    EvidencePackage,
+)
+
+# Window used by every scenario.
+_T0 = datetime(2026, 7, 1, tzinfo=timezone.utc)
+_WINDOW_START = _T0 - timedelta(days=1)
+_WINDOW_END = _T0 + timedelta(days=1)
+
+
+async def _append(
+    store, *, tenant_id, action, actor="agent-1", outcome="success", when=None
+):
+    """Append one tenant-scoped, correctly hash-chained event.
+
+    ``tenant_id`` is not part of the audit-event hash pre-image, so we build a
+    correctly-linked event via ``create_event`` and stamp the tenant via a
+    frozen-dataclass replace without breaking chain integrity.
+    """
+    ts = (when or _T0).isoformat()
+    event = store.create_event(
+        actor=actor, action=action, resource="res", outcome=outcome, timestamp=ts
+    )
+    event = dataclasses.replace(event, tenant_id=tenant_id)
+    await store.append(event)
+    return event
+
+
+def _find_criterion(package: EvidencePackage, control: str, criterion: str):
+    ctrl = next(c for c in package.controls if c.control == control)
+    return next(c for c in ctrl.criteria if c.criterion == criterion)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — producer<->consumer contract (dead-collector guard)
+# ---------------------------------------------------------------------------
+
+
+def test_emitted_vocabulary_is_union_of_both_producer_enums():
+    expected = frozenset(
+        [m.value for m in PactAuditAction] + [m.value for m in AuditEventType]
+    )
+    assert EMITTED_ACTION_VOCABULARY == expected
+
+
+def test_every_collector_filter_matches_a_real_emitted_action():
+    """No collector filter may name an action no producer emits."""
+    for control_id, spec in CONTROL_SPECS.items():
+        for criterion in spec.criteria:
+            for action in criterion.source_actions:
+                assert action in EMITTED_ACTION_VOCABULARY, (
+                    f"{control_id}.{criterion.key} filters on '{action}' which no "
+                    f"producer emits (dead collector)"
+                )
+
+
+def test_measurable_criteria_have_sources_unmeasurable_have_reason():
+    """A criterion either has real sources OR a stated unverifiable reason."""
+    for spec in CONTROL_SPECS.values():
+        for criterion in spec.criteria:
+            if criterion.unverifiable_reason is None:
+                assert criterion.source_actions, criterion.key
+            else:
+                assert not criterion.source_actions, criterion.key
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — no fabrication (unmeasured -> verified=False, never a fake pass)
+# ---------------------------------------------------------------------------
+
+
+def test_unmeasured_controls_report_verified_false_with_reason():
+    async def scenario():
+        store = InMemoryAuditStore()
+        # Populate real access + change records so measurable criteria pass.
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.CLEARANCE_GRANTED.value
+        )
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.ENVELOPE_MODIFIED.value
+        )
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+
+    package = asyncio.run(scenario())
+
+    mfa = _find_criterion(package, "CC6", "mfa_state")
+    assert mfa.verified is False
+    assert mfa.evidence_count == 0
+    assert mfa.items == ()
+    assert mfa.unverified_reason and "MFA" in mfa.unverified_reason
+
+    deploy = _find_criterion(package, "CC8", "deployment_records")
+    assert deploy.verified is False
+    assert deploy.evidence_count == 0
+    assert deploy.unverified_reason and "deployment" in deploy.unverified_reason.lower()
+
+
+def test_measurable_criterion_with_zero_events_is_verified_true_not_false():
+    """A measurable control with no events is honest 'measured, count 0',
+    distinct from an unmeasurable 'verified=False'."""
+
+    async def scenario():
+        store = InMemoryAuditStore()  # empty store
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+
+    package = asyncio.run(scenario())
+    grants = _find_criterion(package, "CC6", "logical_access_grants")
+    assert grants.verified is True  # mechanism exists
+    assert grants.evidence_count == 0  # but no events this period
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — tenant isolation (no cross-tenant leakage)
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_isolation_no_cross_tenant_leakage():
+    async def scenario():
+        store = InMemoryAuditStore()
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            actor="acme-user",
+        )
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            actor="acme-user-2",
+        )
+        await _append(
+            store,
+            tenant_id="globex",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            actor="globex-user",
+        )
+        # An unattributed record (no tenant) must never appear in any package.
+        unattributed = store.create_event(
+            actor="ghost",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            timestamp=_T0.isoformat(),
+        )
+        await store.append(unattributed)
+        collector = EvidenceCollector(store)
+        acme = await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+        globex = await collector.collect(
+            tenant_id="globex", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+        return acme, globex
+
+    acme, globex = asyncio.run(scenario())
+
+    acme_grants = _find_criterion(acme, "CC6", "logical_access_grants")
+    assert acme_grants.evidence_count == 2
+    actors = {item.actor for item in acme_grants.items}
+    assert actors == {"acme-user", "acme-user-2"}
+    assert "globex-user" not in actors
+    assert "ghost" not in actors  # unattributed excluded (fail-closed)
+
+    globex_grants = _find_criterion(globex, "CC6", "logical_access_grants")
+    assert globex_grants.evidence_count == 1
+    assert {item.actor for item in globex_grants.items} == {"globex-user"}
+
+
+# ---------------------------------------------------------------------------
+# Functional coverage
+# ---------------------------------------------------------------------------
+
+
+def test_cc6_and_cc8_evidence_collected_and_exportable():
+    async def scenario():
+        store = InMemoryAuditStore()
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.CLEARANCE_GRANTED.value
+        )
+        await _append(
+            store, tenant_id="acme", action=AuditEventType.ACCESS_GRANTED.value
+        )
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.CLEARANCE_REVOKED.value
+        )
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.BARRIER_ENFORCED.value,
+            outcome="denied",
+        )
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.ENVELOPE_CREATED.value
+        )
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.VACANCY_DESIGNATED.value
+        )
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+
+    package = asyncio.run(scenario())
+
+    assert {c.control for c in package.controls} == {"CC6", "CC8"}
+    assert package.chain_verified is True
+
+    assert _find_criterion(package, "CC6", "logical_access_grants").evidence_count == 2
+    assert _find_criterion(package, "CC6", "access_revocations").evidence_count == 1
+    assert _find_criterion(package, "CC6", "access_enforcement").evidence_count == 1
+    assert (
+        _find_criterion(package, "CC8", "governance_config_changes").evidence_count == 1
+    )
+    assert (
+        _find_criterion(
+            package, "CC8", "authorization_structure_changes"
+        ).evidence_count
+        == 1
+    )
+
+    # Exportable to a plain dict.
+    exported = package.to_dict()
+    assert exported["tenant_id"] == "acme"
+    assert exported["chain_verified"] is True
+    assert isinstance(exported["controls"], list)
+    cc6 = next(c for c in exported["controls"] if c["control"] == "CC6")
+    assert any(
+        cr["criterion"] == "mfa_state" and cr["verified"] is False
+        for cr in cc6["criteria"]
+    )
+
+
+def test_control_subset_selection():
+    async def scenario():
+        store = InMemoryAuditStore()
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme",
+            period_start=_WINDOW_START,
+            period_end=_WINDOW_END,
+            controls=["CC6"],
+        )
+
+    package = asyncio.run(scenario())
+    assert {c.control for c in package.controls} == {"CC6"}
+
+
+def test_period_window_excludes_out_of_range_events():
+    async def scenario():
+        store = InMemoryAuditStore()
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            when=_T0,
+        )
+        # Outside the window (2 days after T0 > window_end at T0+1d).
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.CLEARANCE_GRANTED.value,
+            when=_T0 + timedelta(days=2),
+        )
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+
+    package = asyncio.run(scenario())
+    assert _find_criterion(package, "CC6", "logical_access_grants").evidence_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_tenant_id_fails_closed():
+    async def scenario():
+        collector = EvidenceCollector(InMemoryAuditStore())
+        await collector.collect(
+            tenant_id="  ", period_start=_WINDOW_START, period_end=_WINDOW_END
+        )
+
+    with pytest.raises(EvidenceCollectionError):
+        asyncio.run(scenario())
+
+
+def test_inverted_period_fails_closed():
+    async def scenario():
+        collector = EvidenceCollector(InMemoryAuditStore())
+        await collector.collect(
+            tenant_id="acme", period_start=_WINDOW_END, period_end=_WINDOW_START
+        )
+
+    with pytest.raises(EvidenceCollectionError):
+        asyncio.run(scenario())
+
+
+def test_unknown_control_fails_closed():
+    async def scenario():
+        collector = EvidenceCollector(InMemoryAuditStore())
+        await collector.collect(
+            tenant_id="acme",
+            period_start=_WINDOW_START,
+            period_end=_WINDOW_END,
+            controls=["CC99"],
+        )
+
+    with pytest.raises(EvidenceCollectionError):
+        asyncio.run(scenario())
+
+
+def test_none_store_fails_closed():
+    with pytest.raises(EvidenceCollectionError):
+        EvidenceCollector(None)

--- a/packages/kailash-pact/tests/unit/compliance/test_evidence_collection.py
+++ b/packages/kailash-pact/tests/unit/compliance/test_evidence_collection.py
@@ -85,6 +85,10 @@ def test_measurable_criteria_have_sources_unmeasurable_have_reason():
     """A criterion either has real sources OR a stated unverifiable reason."""
     for spec in CONTROL_SPECS.values():
         for criterion in spec.criteria:
+            if criterion.kind != "records":
+                # chain_integrity is measured from the hash chain, not an
+                # action filter, so it legitimately carries no source_actions.
+                continue
             if criterion.unverifiable_reason is None:
                 assert criterion.source_actions, criterion.key
             else:
@@ -234,7 +238,7 @@ def test_cc6_and_cc8_evidence_collected_and_exportable():
 
     package = asyncio.run(scenario())
 
-    assert {c.control for c in package.controls} == {"CC6", "CC8"}
+    assert {c.control for c in package.controls} == {"CC6", "CC7", "CC8"}
     assert package.chain_verified is True
 
     assert _find_criterion(package, "CC6", "logical_access_grants").evidence_count == 2
@@ -346,3 +350,91 @@ def test_unknown_control_fails_closed():
 def test_none_store_fails_closed():
     with pytest.raises(EvidenceCollectionError):
         EvidenceCollector(None)
+
+
+# ---------------------------------------------------------------------------
+# CC7 — system operations (chain integrity + security/operational events)
+# ---------------------------------------------------------------------------
+
+
+def test_cc7_chain_integrity_and_operational_events():
+    async def scenario():
+        store = InMemoryAuditStore()
+        await _append(
+            store,
+            tenant_id="acme",
+            action=AuditEventType.CONSTRAINT_VIOLATED.value,
+            outcome="denied",
+        )
+        await _append(
+            store,
+            tenant_id="acme",
+            action=PactAuditAction.BARRIER_ENFORCED.value,
+            outcome="denied",
+        )
+        await _append(
+            store, tenant_id="acme", action=PactAuditAction.PLAN_SUSPENDED.value
+        )
+        collector = EvidenceCollector(store)
+        return await collector.collect(
+            tenant_id="acme",
+            period_start=_WINDOW_START,
+            period_end=_WINDOW_END,
+            controls=["CC7"],
+        )
+
+    package = asyncio.run(scenario())
+
+    chain = _find_criterion(package, "CC7", "audit_chain_integrity")
+    assert chain.verified is True
+    assert chain.evidence_count == 1
+    assert chain.items[0].outcome == "success"  # intact chain
+
+    security = _find_criterion(package, "CC7", "security_events")
+    assert security.evidence_count == 2  # constraint_violated + barrier_enforced
+
+    suspensions = _find_criterion(package, "CC7", "operational_suspensions")
+    assert suspensions.evidence_count == 1
+
+    # External monitoring/alerting is honestly unmeasured.
+    monitoring = _find_criterion(package, "CC7", "monitoring_alerts")
+    assert monitoring.verified is False
+    assert monitoring.unverified_reason
+
+
+def test_cc7_chain_integrity_unmeasurable_without_verify_chain():
+    """A store that does not expose chain verification -> verified=False, not a
+    fabricated pass."""
+
+    class _QueryOnlyStore:
+        """A real audit store variant exposing only query (no verify_chain)."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        async def query(self, flt):
+            return await self._inner.query(flt)
+
+    async def scenario():
+        inner = InMemoryAuditStore()
+        await _append(
+            inner, tenant_id="acme", action=PactAuditAction.PLAN_SUSPENDED.value
+        )
+        collector = EvidenceCollector(_QueryOnlyStore(inner))
+        return await collector.collect(
+            tenant_id="acme",
+            period_start=_WINDOW_START,
+            period_end=_WINDOW_END,
+            controls=["CC7"],
+        )
+
+    package = asyncio.run(scenario())
+    assert package.chain_verified is None
+    chain = _find_criterion(package, "CC7", "audit_chain_integrity")
+    assert chain.verified is False
+    assert chain.evidence_count == 0
+    assert chain.unverified_reason
+    # Record-based criteria still work without chain verification.
+    assert (
+        _find_criterion(package, "CC7", "operational_suspensions").evidence_count == 1
+    )


### PR DESCRIPTION
## Summary
Governance-layer **EvidencePackage collector** in kailash-pact that derives SOC 2-aligned compliance evidence from primitives the SDK already emits (hash-chained audit log, RBAC/ABAC grants, tenant isolation, governance/deployment records). "Governance by construction" → "compliance evidence by construction." Evidence TOOLING, not an attestation.

Cross-SDK parity with the Rust SDK proposal (semantic parity, idiomatic Python).

## What's shipped (CC6 + CC7 + CC8, all landed)
- **CC6 (access control):** logical-access grants, revocations, enforcement (measured); `mfa_state` → `verified=false` (no SDK MFA producer — IdP's responsibility).
- **CC7 (system operations):** audit hash-chain integrity via `verify_chain()` (tampered chain → measured `outcome="failure"`, not a fake pass), security events, operational suspensions; `monitoring_alerts` → `verified=false`.
- **CC8 (change management):** governance-config + authorization-structure changes (measured); `deployment_records` → `verified=false` (no SDK deployment primitive — the dead-collector trap avoided).

## Load-bearing invariants (each tested)
1. **No-fabrication** — evidence only from real emitted records; unmeasured controls report `verified=false` with a reason, never a fake pass.
2. **Tenant isolation** — every collector tenant-scoped; cross-tenant + unattributed records excluded fail-closed.
3. **Producer↔consumer contract** — every collector filter maps to a REAL emitted action-vocabulary name (`PactAuditAction` + `AuditEventType`), so a dead collector is impossible by construction.

## Testing
15 behavioral tests (`packages/kailash-pact/tests/unit/compliance/test_evidence_collection.py`), all passing; `--collect-only` clean; public-facade walk (`from pact import EvidenceCollector`) + tampered-chain adverse-finding walk verified; no DeprecationWarnings.

## Related issues
Closes #1711.