### PR TITLE
release: kailash-pact 0.15.0 — SOC 2 evidence-collection (#1711)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,19 @@
 # PACT Changelog
 
+## [0.15.0] — 2026-07-15 — SOC 2 evidence-collection primitives at the governance layer (#1711)
+
+### Added
+
+- **`EvidenceCollector` / `EvidencePackage`** — a governance-layer SOC 2 evidence
+  collector deriving CC6 (access control), CC7 (system operations), and CC8
+  (change management) evidence from primitives the SDK already emits (hash-chained
+  audit log, RBAC/ABAC grants, tenant isolation, governance records). Every
+  collector is tenant-scoped and fail-closed (cross-tenant + unattributed records
+  excluded); unmeasured controls report `verified=false` with a reason (no
+  fabricated passes); a producer↔consumer contract test binds every collector
+  filter to a real emitted action-vocabulary name (`PactAuditAction` /
+  `AuditEventType`). Exposed via `from pact import EvidenceCollector, EvidencePackage`.
+
 ## [0.14.3] — 2026-06-25 — fix: enforce MCP tool clearance fail-closed before the cost flag and at re-registration (#1456)
 
 ### Security

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.14.3"
+version = "0.15.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.14.3"
+__version__ = "0.15.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (


### PR DESCRIPTION
Release-prep for the SOC 2 EvidenceCollector merged in #1761. Bumps kailash-pact 0.14.3 → **0.15.0** (minor — new `pact.compliance` public API) + CHANGELOG. TestPyPI-validated before the prod `pact-v0.15.0` tag. Ships #1711.