### PR TITLE
feat(mcp): OAuth 2.1 client discovery chain + SSRF-hardened PRM (#1712)

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
@@ -1609,6 +1609,24 @@ class OAuth2Client:
         return f"{origin}/.well-known/oauth-protected-resource{path}"
 
     @staticmethod
+    def _same_origin(url_a: str, url_b: str) -> bool:
+        """Return True iff two URLs share scheme + host + port (RFC 6454 origin).
+
+        Used to fail-closed the RFC 9728 mechanism-1 PRM fetch: the
+        ``resource_metadata`` URL in a 401 ``WWW-Authenticate`` header is
+        attacker-influenced, so it MUST be same-origin as the connected server
+        before we fetch it (otherwise a hostile server steers the client into
+        an SSRF / rogue-AS discovery).
+        """
+        a = urlparse(url_a)
+        b = urlparse(url_b)
+        return (
+            (a.scheme or "").lower() == (b.scheme or "").lower()
+            and (a.hostname or "").lower() == (b.hostname or "").lower()
+            and a.port == b.port
+        )
+
+    @staticmethod
     def _as_metadata_urls(as_url: str) -> List[str]:
         """Candidate AS-metadata URLs: RFC 8414 first, then OIDC fallback.
 
@@ -1634,8 +1652,14 @@ class OAuth2Client:
         timeout = aiohttp.ClientTimeout(total=self.http_timeout)
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
+                # allow_redirects=False: a discovery endpoint MUST NOT redirect
+                # the client to a foreign origin. Following a redirect would let
+                # a same-origin PRM/AS URL 30x-bounce the fetch to an internal
+                # address (SSRF), defeating the same-origin pre-check below.
                 async with session.get(
-                    url, headers={"Accept": "application/json"}
+                    url,
+                    headers={"Accept": "application/json"},
+                    allow_redirects=False,
                 ) as response:
                     if response.status != 200:
                         body = (await response.text())[:200]
@@ -1698,6 +1722,19 @@ class OAuth2Client:
             prm_url = parse_www_authenticate(www_authenticate).get("resource_metadata")
         if not prm_url:
             prm_url = self._wellknown_prm_url(server_url)
+
+        # SSRF fail-closed (RFC 9728 §7.6): the resource_metadata URL is
+        # attacker-influenced (it rides an untrusted 401 WWW-Authenticate
+        # header). Per RFC 9728 the PRM is published at the resource server's
+        # OWN well-known location, so a PRM URL on a foreign origin is either a
+        # misconfiguration or an attempt to steer the client into a blind SSRF
+        # / rogue-AS discovery. Reject BEFORE the fetch — the resource-field
+        # check below runs only AFTER the request has already fired.
+        if not self._same_origin(prm_url, server_url):
+            raise OAuthDiscoveryError(
+                f"Protected Resource Metadata URL origin does not match the "
+                f"connected server (refusing cross-origin discovery fetch)"
+            )
 
         prm = await self._fetch_json(prm_url, description="Protected Resource Metadata")
 

--- a/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
@@ -71,6 +71,7 @@ import base64
 import hashlib
 import json
 import logging
+import re
 import secrets
 import time
 import uuid
@@ -125,6 +126,62 @@ def _require_oauth_extras() -> None:
 
 
 logger = logging.getLogger(__name__)
+
+
+class OAuthDiscoveryError(AuthenticationError):
+    """Raised when OAuth 2.1 authorization-server discovery fails.
+
+    Covers RFC 9728 (Protected Resource Metadata) and RFC 8414 / OIDC
+    (Authorization Server Metadata) discovery failures: network errors,
+    malformed documents, resource/issuer mismatches, and missing required
+    fields. A typed error (never a bare exception or silent fallback) so the
+    calling client can distinguish a discovery failure from an auth failure.
+    """
+
+    def __init__(self, message: str, **kwargs):
+        kwargs.setdefault("auth_type", "oauth2_discovery")
+        super().__init__(message, **kwargs)
+
+
+class OAuthPKCEUnsupportedError(OAuthDiscoveryError):
+    """Raised (fail-closed) when the authorization server does not advertise
+    PKCE ``S256`` support.
+
+    MCP (revision 2025-11-25) requires PKCE with the ``S256`` code-challenge
+    method; the ``plain`` method is discouraged. When AS metadata does not
+    confirm ``S256`` support the flow MUST be refused rather than downgraded.
+    """
+
+
+# RFC 9110 §11.6.1 auth-param: key="quoted-value". RFC 9728 emits the
+# ``resource_metadata`` (and optional ``scope``) challenge parameters this way.
+_WWW_AUTH_PARAM_RE = re.compile(r'([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"')
+
+
+def parse_www_authenticate(header: str) -> Dict[str, str]:
+    """Parse a ``WWW-Authenticate`` header's quoted auth parameters.
+
+    Extracts the ``key="value"`` challenge parameters (e.g.
+    ``resource_metadata`` and ``scope`` per RFC 9728) from a header such as::
+
+        Bearer resource_metadata="https://srv/.well-known/oauth-protected-resource", scope="mcp"
+
+    The leading auth-scheme token (``Bearer``) carries no ``=`` and is ignored.
+    Returned keys are lower-cased. An empty/absent header yields ``{}`` (no
+    challenge params) rather than raising — the caller decides the fallback.
+
+    Args:
+        header: Raw ``WWW-Authenticate`` header value.
+
+    Returns:
+        Mapping of lower-cased challenge parameter name to its value.
+    """
+    if not header:
+        return {}
+    return {
+        match.group(1).lower(): match.group(2)
+        for match in _WWW_AUTH_PARAM_RE.finditer(header)
+    }
 
 
 class GrantType(Enum):
@@ -1477,15 +1534,24 @@ class OAuth2Client:
         token_endpoint: Optional[str] = None,
         authorization_endpoint: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        resource: Optional[str] = None,
+        http_timeout: float = 30.0,
     ):
         """Initialize OAuth 2.1 client.
 
         Args:
             client_id: OAuth client ID
             client_secret: OAuth client secret
-            token_endpoint: Token endpoint URL
-            authorization_endpoint: Authorization endpoint URL
+            token_endpoint: Token endpoint URL (may be resolved via discovery)
+            authorization_endpoint: Authorization endpoint URL (may be resolved
+                via discovery)
             redirect_uri: Redirect URI
+            resource: Canonical resource-server URI sent as the RFC 8707
+                ``resource`` indicator on every grant so the issued token's
+                audience is bound to the intended MCP server. When discovery
+                runs it is derived from the Protected Resource Metadata's
+                ``resource`` field if not supplied.
+            http_timeout: Per-request timeout (seconds) for discovery fetches.
         """
         _require_oauth_extras()
         self.client_id = client_id
@@ -1493,11 +1559,298 @@ class OAuth2Client:
         self.token_endpoint = token_endpoint
         self.authorization_endpoint = authorization_endpoint
         self.redirect_uri = redirect_uri
+        # RFC 8707 canonical resource indicator (token audience binding).
+        self.resource = self._canonical_uri(resource) if resource else None
+        self.http_timeout = http_timeout
 
         # Token storage
         self._access_token: Optional[str] = None
         self._refresh_token: Optional[str] = None
         self._token_expires_at: Optional[float] = None
+
+        # Discovery results (RFC 9728 / RFC 8414 / OIDC).
+        self._authorization_servers: Optional[List[str]] = None
+        self._code_challenge_methods_supported: Optional[List[str]] = None
+        self._protected_resource_metadata: Optional[Dict[str, Any]] = None
+        self._authorization_server_metadata: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # OAuth 2.1 discovery chain (RFC 9728 → RFC 8414/OIDC → PKCE guard)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _canonical_uri(uri: str) -> str:
+        """Return the canonical form of a resource/issuer URI for comparison.
+
+        Lower-cases scheme + host and strips a trailing slash so that
+        ``https://Srv.example.com/mcp/`` and ``https://srv.example.com/mcp``
+        compare equal (the RFC 8707 canonical-URI comparison the resource
+        indicator relies on).
+        """
+        parsed = urlparse(uri)
+        scheme = (parsed.scheme or "").lower()
+        netloc = (parsed.netloc or "").lower()
+        path = parsed.path.rstrip("/")
+        canonical = f"{scheme}://{netloc}{path}"
+        if parsed.query:
+            canonical = f"{canonical}?{parsed.query}"
+        return canonical
+
+    @staticmethod
+    def _wellknown_prm_url(server_url: str) -> str:
+        """Derive the RFC 9728 Protected Resource Metadata well-known URL.
+
+        Per RFC 9728 §3 the ``/.well-known/oauth-protected-resource`` segment
+        is inserted between the origin and the resource's path.
+        """
+        parsed = urlparse(server_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        path = parsed.path.rstrip("/")
+        return f"{origin}/.well-known/oauth-protected-resource{path}"
+
+    @staticmethod
+    def _as_metadata_urls(as_url: str) -> List[str]:
+        """Candidate AS-metadata URLs: RFC 8414 first, then OIDC fallback.
+
+        RFC 8414 §3 inserts ``/.well-known/oauth-authorization-server`` between
+        origin and path (path-insertion); OpenID Connect Discovery appends
+        ``/.well-known/openid-configuration`` to the issuer (path-append).
+        """
+        parsed = urlparse(as_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        path = parsed.path.rstrip("/")
+        rfc8414 = f"{origin}/.well-known/oauth-authorization-server{path}"
+        oidc = f"{as_url.rstrip('/')}/.well-known/openid-configuration"
+        return [rfc8414, oidc]
+
+    async def _fetch_json(self, url: str, *, description: str) -> Dict[str, Any]:
+        """GET ``url`` and parse JSON with a timeout and typed failures.
+
+        Raises:
+            OAuthDiscoveryError: on non-200 status, transport error, timeout,
+                or a body that is not a JSON object.
+        """
+        _require_oauth_extras()
+        timeout = aiohttp.ClientTimeout(total=self.http_timeout)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    url, headers={"Accept": "application/json"}
+                ) as response:
+                    if response.status != 200:
+                        body = (await response.text())[:200]
+                        raise OAuthDiscoveryError(
+                            f"{description} fetch from {url} failed: "
+                            f"HTTP {response.status} {body}"
+                        )
+                    try:
+                        # content_type=None: some AS emit a non-JSON MIME type.
+                        payload = await response.json(content_type=None)
+                    except Exception as exc:  # JSON decode error
+                        raise OAuthDiscoveryError(
+                            f"{description} at {url} returned invalid JSON: {exc}"
+                        ) from exc
+        except OAuthDiscoveryError:
+            raise
+        except asyncio.TimeoutError as exc:
+            raise OAuthDiscoveryError(
+                f"{description} fetch from {url} timed out after "
+                f"{self.http_timeout}s"
+            ) from exc
+        except aiohttp.ClientError as exc:
+            raise OAuthDiscoveryError(
+                f"{description} fetch from {url} failed: {exc}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise OAuthDiscoveryError(f"{description} at {url} is not a JSON object")
+        return payload
+
+    async def discover_protected_resource_metadata(
+        self, server_url: str, www_authenticate: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Discover the Protected Resource Metadata document (RFC 9728).
+
+        Two discovery mechanisms, in order:
+
+        1. **WWW-Authenticate header** — parse a 401's
+           ``resource_metadata="<url>"`` challenge parameter and fetch it.
+        2. **Well-known fallback** — when the header is absent, probe
+           ``<server>/.well-known/oauth-protected-resource``.
+
+        The PRM's ``resource`` MUST be the canonical URI of the connected
+        server; a mismatch is rejected (a malicious/misconfigured PRM could
+        otherwise redirect the client to an attacker-controlled AS).
+
+        Args:
+            server_url: The MCP server base URL the client connected to.
+            www_authenticate: The ``WWW-Authenticate`` header from the 401, if
+                any.
+
+        Returns:
+            The parsed PRM document.
+
+        Raises:
+            OAuthDiscoveryError: on fetch failure, missing ``resource``,
+                resource mismatch, or missing ``authorization_servers``.
+        """
+        prm_url: Optional[str] = None
+        if www_authenticate:
+            prm_url = parse_www_authenticate(www_authenticate).get("resource_metadata")
+        if not prm_url:
+            prm_url = self._wellknown_prm_url(server_url)
+
+        prm = await self._fetch_json(prm_url, description="Protected Resource Metadata")
+
+        resource = prm.get("resource")
+        if not resource:
+            raise OAuthDiscoveryError(
+                f"Protected Resource Metadata at {prm_url} is missing the "
+                "required 'resource' field"
+            )
+        expected = self.resource or self._canonical_uri(server_url)
+        if self._canonical_uri(resource) != expected:
+            raise OAuthDiscoveryError(
+                f"Protected Resource Metadata 'resource' ({resource!r}) does "
+                f"not match the connected server ({expected!r})"
+            )
+
+        authorization_servers = prm.get("authorization_servers")
+        if not authorization_servers:
+            raise OAuthDiscoveryError(
+                f"Protected Resource Metadata at {prm_url} lists no "
+                "'authorization_servers'"
+            )
+
+        # Bind the canonical resource indicator (RFC 8707) from the PRM.
+        self.resource = self._canonical_uri(resource)
+        self._authorization_servers = list(authorization_servers)
+        self._protected_resource_metadata = prm
+        return prm
+
+    async def discover_authorization_server_metadata(
+        self, as_url: str
+    ) -> Dict[str, Any]:
+        """Discover Authorization Server Metadata (RFC 8414, OIDC fallback).
+
+        Tries the RFC 8414 ``oauth-authorization-server`` URL first, then the
+        OIDC ``openid-configuration`` URL. Asserts the metadata ``issuer``
+        equals the authorization-server URL (RFC 8414 §3.3 / OIDC issuer
+        validation) and resolves ``authorization_endpoint``, ``token_endpoint``,
+        and ``code_challenge_methods_supported`` onto this client.
+
+        Args:
+            as_url: Authorization-server URL (an entry from the PRM's
+                ``authorization_servers``).
+
+        Returns:
+            The parsed AS-metadata document.
+
+        Raises:
+            OAuthDiscoveryError: when neither URL yields metadata, the issuer
+                mismatches, or ``token_endpoint`` is absent.
+        """
+        errors: List[str] = []
+        metadata: Optional[Dict[str, Any]] = None
+        for candidate in self._as_metadata_urls(as_url):
+            try:
+                metadata = await self._fetch_json(
+                    candidate, description="Authorization Server Metadata"
+                )
+                break
+            except OAuthDiscoveryError as exc:
+                errors.append(str(exc))
+        if metadata is None:
+            raise OAuthDiscoveryError(
+                f"Authorization Server Metadata discovery failed for {as_url}: "
+                + "; ".join(errors)
+            )
+
+        issuer = metadata.get("issuer")
+        if not issuer:
+            raise OAuthDiscoveryError(
+                f"Authorization Server Metadata for {as_url} is missing " "'issuer'"
+            )
+        if self._canonical_uri(issuer) != self._canonical_uri(as_url):
+            raise OAuthDiscoveryError(
+                f"Authorization Server Metadata issuer ({issuer!r}) does not "
+                f"match the authorization server ({as_url!r})"
+            )
+
+        token_endpoint = metadata.get("token_endpoint")
+        if not token_endpoint:
+            raise OAuthDiscoveryError(
+                f"Authorization Server Metadata for {as_url} is missing "
+                "'token_endpoint'"
+            )
+
+        self.authorization_endpoint = metadata.get("authorization_endpoint")
+        self.token_endpoint = token_endpoint
+        self._code_challenge_methods_supported = metadata.get(
+            "code_challenge_methods_supported"
+        )
+        self._authorization_server_metadata = metadata
+        return metadata
+
+    def _assert_pkce_s256_supported(self) -> None:
+        """Fail closed unless the AS advertises PKCE ``S256`` support.
+
+        MCP (2025-11-25) requires PKCE with ``S256``. When discovery ran and
+        the ``code_challenge_methods_supported`` array does not contain
+        ``S256`` — or is absent entirely — the flow is refused rather than
+        silently downgraded to ``plain``.
+
+        Raises:
+            OAuthPKCEUnsupportedError: when ``S256`` support is not confirmed.
+        """
+        methods = self._code_challenge_methods_supported
+        if methods is None:
+            raise OAuthPKCEUnsupportedError(
+                "Authorization server did not advertise "
+                "'code_challenge_methods_supported'; PKCE S256 support "
+                "(required by MCP 2025-11-25) cannot be confirmed — refusing "
+                "the flow"
+            )
+        if "S256" not in methods:
+            raise OAuthPKCEUnsupportedError(
+                f"Authorization server does not support PKCE 'S256' "
+                f"(advertised: {methods}); refusing the flow (MCP 2025-11-25 "
+                "requires S256, not 'plain')"
+            )
+
+    async def discover(
+        self, server_url: str, www_authenticate: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Run the full OAuth 2.1 discovery chain for an MCP server.
+
+        RFC 9728 Protected Resource Metadata → pick the first authorization
+        server → RFC 8414/OIDC Authorization Server Metadata → fail-closed
+        PKCE ``S256`` guard. On success the client's ``token_endpoint``,
+        ``authorization_endpoint``, ``resource`` (RFC 8707 indicator) and
+        ``code_challenge_methods_supported`` are populated.
+
+        Args:
+            server_url: The MCP server base URL the client connected to.
+            www_authenticate: The ``WWW-Authenticate`` header from a 401, if
+                any (RFC 9728 mechanism 1); omit to force the well-known probe.
+
+        Returns:
+            ``{"protected_resource_metadata": ..., "authorization_server_metadata": ...}``.
+
+        Raises:
+            OAuthDiscoveryError / OAuthPKCEUnsupportedError: on any failure in
+                the chain (fail closed, never a silent fallback).
+        """
+        prm = await self.discover_protected_resource_metadata(
+            server_url, www_authenticate
+        )
+        as_url = self._authorization_servers[0]  # type: ignore[index]
+        as_metadata = await self.discover_authorization_server_metadata(as_url)
+        # Fail-closed: refuse the flow unless S256 is confirmed.
+        self._assert_pkce_s256_supported()
+        return {
+            "protected_resource_metadata": prm,
+            "authorization_server_metadata": as_metadata,
+        }
 
     async def get_client_credentials_token(
         self, scopes: Optional[List[str]] = None
@@ -1525,6 +1878,10 @@ class OAuth2Client:
 
         if scopes:
             data["scope"] = " ".join(scopes)
+
+        # RFC 8707: bind the issued token's audience to the canonical server.
+        if self.resource:
+            data["resource"] = self.resource
 
         # Make token request
         async with aiohttp.ClientSession() as session:
@@ -1582,8 +1939,17 @@ class OAuth2Client:
         if state:
             params["state"] = state
 
+        # RFC 8707: bind the issued token's audience to the canonical server.
+        if self.resource:
+            params["resource"] = self.resource
+
         code_verifier = None
         if use_pkce:
+            # Fail closed if discovery ran and the AS did not confirm S256.
+            # MCP 2025-11-25 requires S256; 'plain' is never emitted.
+            if self._code_challenge_methods_supported is not None:
+                self._assert_pkce_s256_supported()
+
             # Generate PKCE parameters
             code_verifier = (
                 base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip("=")
@@ -1635,6 +2001,10 @@ class OAuth2Client:
 
         if code_verifier:
             data["code_verifier"] = code_verifier
+
+        # RFC 8707: same canonical resource indicator as the authorize request.
+        if self.resource:
+            data["resource"] = self.resource
 
         # Make token request
         async with aiohttp.ClientSession() as session:
@@ -1697,6 +2067,10 @@ class OAuth2Client:
         if self.client_secret:
             data["client_secret"] = self.client_secret
 
+        # RFC 8707: keep the audience bound across refreshes.
+        if self.resource:
+            data["resource"] = self.resource
+
         # Make refresh request
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -1743,6 +2117,10 @@ class OAuth2Client:
 
         if self.client_secret:
             data["client_secret"] = self.client_secret
+
+        # RFC 8707: keep the audience bound across refreshes.
+        if self.resource:
+            data["resource"] = self.resource
 
         # Make token request
         async with aiohttp.ClientSession() as session:

--- a/packages/kailash-mcp/src/kailash_mcp/client.py
+++ b/packages/kailash-mcp/src/kailash_mcp/client.py
@@ -163,6 +163,99 @@ class MCPClient:
         else:
             self.metrics = None
 
+        # OAuth 2.1 bearer-token binding (#1712). A token provider is an async
+        # callable ``() -> str`` (or an ``OAuth2Client`` whose acquired/refreshed
+        # token is attached expiry-aware) so every outbound request carries the
+        # current ``Authorization: Bearer <token>``. Per-server config may also
+        # supply its own provider; the client-level hook is the default.
+        self._oauth_token_provider = None  # type: Optional[Any]
+        self._oauth_client = None  # type: Optional[Any]
+
+    def set_token_provider(self, provider: Any) -> None:
+        """Register a client-level OAuth bearer-token provider.
+
+        Args:
+            provider: An async callable ``() -> str`` returning the current
+                access token. Called (and awaited) before every outbound
+                request so an expiring token is refreshed then attached.
+        """
+        self._oauth_token_provider = provider
+
+    def set_oauth_client(self, oauth_client: Any) -> None:
+        """Register a client-level ``OAuth2Client`` for bearer-token binding.
+
+        The client's ``get_valid_token()`` (expiry-aware, refresh-then-return)
+        supplies the token attached to every outbound request.
+
+        Args:
+            oauth_client: An ``OAuth2Client`` (or any object exposing an async
+                ``get_valid_token()``).
+        """
+        self._oauth_client = oauth_client
+
+    async def _resolve_bearer_token(
+        self, server_config: Union[str, Dict[str, Any]]
+    ) -> Optional[str]:
+        """Resolve the current OAuth bearer token, refreshing on expiry.
+
+        Resolution order (first hit wins): the server config's own
+        ``oauth_client`` / ``token_provider``, then the client-level
+        ``_oauth_token_provider`` / ``_oauth_client``. Returns ``None`` when no
+        provider is configured (the caller then relies on static credentials).
+
+        Raises:
+            AuthenticationError: when a provider is configured but yields no
+                token (e.g. an ``OAuth2Client`` that never acquired one).
+        """
+        oauth_client = None
+        token_provider = None
+        if isinstance(server_config, dict):
+            auth_config = server_config.get("auth", {}) or {}
+            if auth_config.get("type", "").lower() == "oauth2":
+                oauth_client = auth_config.get("oauth_client")
+                token_provider = auth_config.get("token_provider")
+        oauth_client = oauth_client or self._oauth_client
+        token_provider = token_provider or self._oauth_token_provider
+
+        if token_provider is not None:
+            token = await token_provider()
+            if not token:
+                raise AuthenticationError(
+                    "OAuth token provider returned no token", auth_type="oauth2"
+                )
+            return token
+        if oauth_client is not None:
+            # Expiry-aware: get_valid_token() refreshes a near-expiry token.
+            token = await oauth_client.get_valid_token()
+            if not token:
+                raise AuthenticationError(
+                    "OAuth2 client has no valid token; acquire one first "
+                    "(client-credentials or authorization-code flow)",
+                    auth_type="oauth2",
+                )
+            return token
+        return None
+
+    async def _get_auth_headers_async(
+        self, server_config: Union[str, Dict[str, Any]]
+    ) -> Dict[str, str]:
+        """Build outbound auth headers, binding a fresh OAuth bearer token.
+
+        Wraps the synchronous static-credential header builder and, when an
+        OAuth provider is configured, attaches the current (refreshed-if-expiring)
+        ``Authorization: Bearer <token>`` so every request carries a live token
+        (#1712 fix 5).
+        """
+        headers = (
+            self._get_auth_headers(server_config)
+            if isinstance(server_config, dict)
+            else {}
+        )
+        token = await self._resolve_bearer_token(server_config)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
     def _guard_spawn_command(self, command: Any) -> None:
         """Fail-closed guard for a local-server stdio spawn command.
 
@@ -322,7 +415,7 @@ class MCPClient:
         from mcp.client.sse import sse_client
 
         url = server_config["url"]
-        headers = self._get_auth_headers(server_config)
+        headers = await self._get_auth_headers_async(server_config)
         request_timeout = timeout or self.connection_timeout
 
         tools: List[Dict[str, Any]] = []
@@ -364,7 +457,7 @@ class MCPClient:
         from mcp.client.streamable_http import streamable_http_client
 
         url = server_config["url"]
-        headers = self._get_auth_headers(server_config)
+        headers = await self._get_auth_headers_async(server_config)
         request_timeout = timeout or self.connection_timeout
 
         http_client = httpx.AsyncClient(headers=headers, timeout=request_timeout)
@@ -609,7 +702,7 @@ class MCPClient:
         from mcp.client.sse import sse_client
 
         url = server_config["url"]
-        headers = self._get_auth_headers(server_config)
+        headers = await self._get_auth_headers_async(server_config)
         request_timeout = timeout or self.connection_timeout
 
         tool_result: Dict[str, Any] = {}
@@ -660,7 +753,7 @@ class MCPClient:
         from mcp.client.streamable_http import streamable_http_client
 
         url = server_config["url"]
-        headers = self._get_auth_headers(server_config)
+        headers = await self._get_auth_headers_async(server_config)
         request_timeout = timeout or self.connection_timeout
 
         http_client = httpx.AsyncClient(headers=headers, timeout=request_timeout)

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
@@ -200,6 +200,44 @@ async def test_prm_missing_authorization_servers_rejected():
         await server.close()
 
 
+@pytest.mark.regression
+async def test_prm_cross_origin_resource_metadata_rejected_before_fetch_ssrf():
+    """A foreign-origin resource_metadata URL (from an untrusted 401 header)
+    MUST be rejected BEFORE the fetch — no SSRF request may fire."""
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        # Attacker-controlled 401 challenge steering discovery at a foreign
+        # (would-be internal) origin.
+        header = 'Bearer resource_metadata="http://169.254.169.254/latest/prm"'
+        with pytest.raises(OAuthDiscoveryError, match="origin does not match"):
+            await client.discover_protected_resource_metadata(base, header)
+        # Fail-closed BEFORE the fetch: the local server saw no discovery hit,
+        # and (crucially) the client never issued the SSRF GET at all.
+        assert record["hits"] == []
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_prm_same_host_different_port_rejected():
+    """Origin includes the port — a same-host, different-port PRM URL is a
+    distinct origin and MUST be rejected."""
+    app, _ = _build_app()
+    server, base = await _start(app)
+    try:
+        parsed = urlparse(base)
+        foreign_port = (parsed.port or 80) + 1
+        foreign = f"{parsed.scheme}://{parsed.hostname}:{foreign_port}/prm"
+        client = OAuth2Client("cid")
+        header = f'Bearer resource_metadata="{foreign}"'
+        with pytest.raises(OAuthDiscoveryError, match="origin does not match"):
+            await client.discover_protected_resource_metadata(base, header)
+    finally:
+        await server.close()
+
+
 # ---------------------------------------------------------------------------
 # 3. AS metadata discovery (RFC 8414 + OIDC fallback)
 # ---------------------------------------------------------------------------

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
@@ -1,0 +1,477 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 - client-side OAuth 2.1 discovery chain.
+
+Behavioral pins (call the function, assert raise/return - never source-grep,
+per ``rules/testing.md``) for the CLIENT-side OAuth 2.1 discovery shard of the
+MCP 2025-11-25 spec-parity work:
+
+1. **WWW-Authenticate parse (RFC 9728)** - ``parse_www_authenticate`` extracts
+   the quoted challenge parameters (``resource_metadata``, ``scope``).
+2. **PRM discovery (RFC 9728)** - both mechanisms: the ``resource_metadata``
+   header param AND the ``/.well-known/oauth-protected-resource`` fallback;
+   ``resource`` mismatch is rejected.
+3. **AS metadata discovery (RFC 8414 + OIDC)** - RFC 8414 path-insertion first,
+   OIDC ``openid-configuration`` fallback; issuer mismatch is rejected.
+4. **PKCE S256 fail-closed guard** - discovery refuses the flow (typed error)
+   unless the AS advertises ``S256``; ``plain`` is never accepted.
+5. **RFC 8707 resource indicator** - present on all four grant builders
+   (authorize URL, code exchange, client-credentials, refresh).
+6. **Bearer binding** - ``MCPClient`` attaches the OAuth2Client token to
+   outbound headers, refreshing a near-expiry token before it is attached.
+
+The network double is a REAL local ``aiohttp`` server (no mocking) exercising
+the actual ``aiohttp`` fetch path in ``OAuth2Client``.
+"""
+
+import time
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from kailash_mcp.auth.oauth import (
+    OAuth2Client,
+    OAuthDiscoveryError,
+    OAuthPKCEUnsupportedError,
+    parse_www_authenticate,
+)
+from kailash_mcp.client import MCPClient
+from kailash_mcp.errors import AuthenticationError
+
+_OMIT = object()
+
+
+def _build_app(
+    *,
+    resource=None,
+    authorization_servers=None,
+    issuer=None,
+    code_challenge_methods=("S256",),
+    serve_rfc8414=True,
+    serve_oidc=True,
+    token_response=None,
+):
+    """Build a local OAuth test double. Values referencing the server derive
+    from the incoming request host so the random test port is honoured."""
+    app = web.Application()
+    record = {"token_forms": [], "hits": []}
+
+    def _base(request):
+        return f"{request.scheme}://{request.host}"
+
+    async def prm(request):
+        record["hits"].append(request.path)
+        base = _base(request)
+        return web.json_response(
+            {
+                "resource": base if resource is None else resource,
+                "authorization_servers": (
+                    [base] if authorization_servers is None else authorization_servers
+                ),
+            }
+        )
+
+    async def as_metadata(request):
+        record["hits"].append(request.path)
+        base = _base(request)
+        md = {
+            "issuer": base if issuer is None else issuer,
+            "authorization_endpoint": f"{base}/authorize",
+            "token_endpoint": f"{base}/token",
+        }
+        if code_challenge_methods is not None:
+            md["code_challenge_methods_supported"] = list(code_challenge_methods)
+        return web.json_response(md)
+
+    async def token(request):
+        form = dict(await request.post())
+        record["token_forms"].append(form)
+        resp = token_response or {
+            "access_token": "access-token-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "refresh-token-1",
+        }
+        return web.json_response(resp)
+
+    app.router.add_get("/.well-known/oauth-protected-resource", prm)
+    app.router.add_get("/custom-prm", prm)
+    if serve_rfc8414:
+        app.router.add_get("/.well-known/oauth-authorization-server", as_metadata)
+    if serve_oidc:
+        app.router.add_get("/.well-known/openid-configuration", as_metadata)
+    app.router.add_post("/token", token)
+    return app, record
+
+
+async def _start(app):
+    server = TestServer(app)
+    await server.start_server()
+    base = str(server.make_url("")).rstrip("/")
+    return server, base
+
+
+# ---------------------------------------------------------------------------
+# 1. WWW-Authenticate parse (RFC 9728)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_parse_www_authenticate_extracts_resource_metadata_and_scope():
+    header = (
+        'Bearer resource_metadata="https://srv/.well-known/oauth-protected-resource", '
+        'scope="mcp read", error="invalid_token"'
+    )
+    params = parse_www_authenticate(header)
+    assert (
+        params["resource_metadata"]
+        == "https://srv/.well-known/oauth-protected-resource"
+    )
+    assert params["scope"] == "mcp read"
+    assert params["error"] == "invalid_token"
+
+
+@pytest.mark.regression
+def test_parse_www_authenticate_empty_header_returns_empty():
+    assert parse_www_authenticate("") == {}
+    assert parse_www_authenticate(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. PRM discovery (RFC 9728) - both mechanisms + resource validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_prm_discovery_via_www_authenticate_header():
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        header = f'Bearer resource_metadata="{base}/custom-prm"'
+        prm = await client.discover_protected_resource_metadata(base, header)
+        assert prm["resource"] == base
+        assert client._authorization_servers == [base]
+        # The header mechanism fetched the CUSTOM url, not the well-known.
+        assert "/custom-prm" in record["hits"]
+        assert "/.well-known/oauth-protected-resource" not in record["hits"]
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_prm_discovery_via_wellknown_fallback():
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        # No WWW-Authenticate header -> well-known probe.
+        prm = await client.discover_protected_resource_metadata(base)
+        assert prm["resource"] == base
+        assert "/.well-known/oauth-protected-resource" in record["hits"]
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_prm_resource_mismatch_rejected():
+    app, _ = _build_app(resource="https://evil.example.com/mcp")
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthDiscoveryError, match="does not match"):
+            await client.discover_protected_resource_metadata(base)
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_prm_missing_authorization_servers_rejected():
+    app, _ = _build_app(authorization_servers=[])
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthDiscoveryError, match="authorization_servers"):
+            await client.discover_protected_resource_metadata(base)
+    finally:
+        await server.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. AS metadata discovery (RFC 8414 + OIDC fallback)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_as_metadata_rfc8414_preferred():
+    app, record = _build_app(serve_rfc8414=True, serve_oidc=True)
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        md = await client.discover_authorization_server_metadata(base)
+        assert md["issuer"] == base
+        assert client.token_endpoint == f"{base}/token"
+        assert client.authorization_endpoint == f"{base}/authorize"
+        assert client._code_challenge_methods_supported == ["S256"]
+        # RFC 8414 URL was used; OIDC was never needed.
+        assert "/.well-known/oauth-authorization-server" in record["hits"]
+        assert "/.well-known/openid-configuration" not in record["hits"]
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_as_metadata_oidc_fallback_when_rfc8414_absent():
+    app, record = _build_app(serve_rfc8414=False, serve_oidc=True)
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        md = await client.discover_authorization_server_metadata(base)
+        assert md["token_endpoint"] == f"{base}/token"
+        # RFC 8414 404'd, OIDC fallback served the metadata.
+        assert "/.well-known/openid-configuration" in record["hits"]
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_as_metadata_issuer_mismatch_rejected():
+    app, _ = _build_app(issuer="https://evil.example.com")
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthDiscoveryError, match="issuer"):
+            await client.discover_authorization_server_metadata(base)
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_as_metadata_both_urls_fail_raises():
+    app, _ = _build_app(serve_rfc8414=False, serve_oidc=False)
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthDiscoveryError, match="discovery failed"):
+            await client.discover_authorization_server_metadata(base)
+    finally:
+        await server.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. PKCE S256 fail-closed guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_discover_full_chain_succeeds_with_s256():
+    app, _ = _build_app(code_challenge_methods=("S256",))
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        result = await client.discover(base)
+        assert "protected_resource_metadata" in result
+        assert "authorization_server_metadata" in result
+        assert client.token_endpoint == f"{base}/token"
+        assert client.resource == base  # RFC 8707 indicator bound from PRM
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_pkce_guard_fails_closed_when_methods_absent():
+    # AS metadata omits code_challenge_methods_supported entirely.
+    app, _ = _build_app(code_challenge_methods=None)
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthPKCEUnsupportedError, match="cannot be confirmed"):
+            await client.discover(base)
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_pkce_guard_rejects_plain_only():
+    app, _ = _build_app(code_challenge_methods=("plain",))
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid")
+        with pytest.raises(OAuthPKCEUnsupportedError, match="S256"):
+            await client.discover(base)
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_pkce_guard_in_authorization_url_after_discovery():
+    # Directly seed discovered methods lacking S256, then build the URL.
+    client = OAuth2Client(
+        "cid",
+        authorization_endpoint="https://as/authorize",
+        redirect_uri="https://app/callback",
+    )
+    client._code_challenge_methods_supported = ["plain"]
+    with pytest.raises(OAuthPKCEUnsupportedError):
+        client.get_authorization_url(use_pkce=True)
+
+
+# ---------------------------------------------------------------------------
+# 5. RFC 8707 resource indicator on all four grant builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_authorization_url_carries_resource_and_s256():
+    client = OAuth2Client(
+        "cid",
+        authorization_endpoint="https://as.example.com/authorize",
+        redirect_uri="https://app.example.com/callback",
+        resource="https://srv.example.com/mcp",
+    )
+    url, verifier = client.get_authorization_url(scopes=["mcp"], use_pkce=True)
+    query = parse_qs(urlparse(url).query)
+    assert query["resource"] == ["https://srv.example.com/mcp"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert "code_challenge" in query
+    assert verifier  # PKCE verifier returned
+
+
+@pytest.mark.regression
+async def test_client_credentials_sends_resource():
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client(
+            "cid",
+            client_secret="secret",
+            token_endpoint=f"{base}/token",
+            resource="https://srv.example.com/mcp",
+        )
+        await client.get_client_credentials_token(scopes=["mcp"])
+        assert record["token_forms"][-1]["resource"] == "https://srv.example.com/mcp"
+        assert record["token_forms"][-1]["grant_type"] == "client_credentials"
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_code_exchange_sends_resource():
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client(
+            "cid",
+            client_secret="secret",
+            token_endpoint=f"{base}/token",
+            redirect_uri="https://app.example.com/callback",
+            resource="https://srv.example.com/mcp",
+        )
+        await client.exchange_authorization_code("the-code", code_verifier="v")
+        form = record["token_forms"][-1]
+        assert form["resource"] == "https://srv.example.com/mcp"
+        assert form["grant_type"] == "authorization_code"
+        assert form["code_verifier"] == "v"
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_refresh_sends_resource():
+    app, record = _build_app()
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client(
+            "cid",
+            client_secret="secret",
+            token_endpoint=f"{base}/token",
+            resource="https://srv.example.com/mcp",
+        )
+        client._refresh_token = "rt-existing"
+        await client._refresh_access_token()
+        form = record["token_forms"][-1]
+        assert form["resource"] == "https://srv.example.com/mcp"
+        assert form["grant_type"] == "refresh_token"
+    finally:
+        await server.close()
+
+
+# ---------------------------------------------------------------------------
+# 6. Bearer binding on outbound requests (attach + refresh-before-attach)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_bearer_attached_from_oauth_client():
+    client = OAuth2Client("cid", token_endpoint="https://as/token")
+    client._access_token = "live-token"
+    client._token_expires_at = time.time() + 3600  # valid
+
+    mcp = MCPClient()
+    mcp.set_oauth_client(client)
+    headers = await mcp._get_auth_headers_async({"url": "https://srv/mcp"})
+    assert headers["Authorization"] == "Bearer live-token"
+
+
+@pytest.mark.regression
+async def test_bearer_refreshed_before_attach_on_expiry():
+    app, record = _build_app(
+        token_response={
+            "access_token": "refreshed-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+    )
+    server, base = await _start(app)
+    try:
+        client = OAuth2Client("cid", token_endpoint=f"{base}/token")
+        client._access_token = "stale-token"
+        client._token_expires_at = time.time() - 10  # expired
+        client._refresh_token = "rt-1"
+
+        mcp = MCPClient()
+        mcp.set_oauth_client(client)
+        headers = await mcp._get_auth_headers_async({"url": f"{base}/mcp"})
+        # Refresh happened (token endpoint hit) and the NEW token is attached.
+        assert headers["Authorization"] == "Bearer refreshed-token"
+        assert record["token_forms"][-1]["grant_type"] == "refresh_token"
+    finally:
+        await server.close()
+
+
+@pytest.mark.regression
+async def test_bearer_via_per_server_oauth_client_config():
+    client = OAuth2Client("cid", token_endpoint="https://as/token")
+    client._access_token = "cfg-token"
+    client._token_expires_at = time.time() + 3600
+
+    mcp = MCPClient()
+    server_config = {
+        "url": "https://srv/mcp",
+        "auth": {"type": "oauth2", "oauth_client": client},
+    }
+    headers = await mcp._get_auth_headers_async(server_config)
+    assert headers["Authorization"] == "Bearer cfg-token"
+
+
+@pytest.mark.regression
+async def test_configured_provider_without_token_raises():
+    client = OAuth2Client("cid")  # never acquired a token, no refresh token
+    mcp = MCPClient()
+    mcp.set_oauth_client(client)
+    with pytest.raises(AuthenticationError, match="no valid token"):
+        await mcp._get_auth_headers_async({"url": "https://srv/mcp"})
+
+
+@pytest.mark.regression
+async def test_no_provider_falls_back_to_static_headers():
+    mcp = MCPClient()
+    server_config = {
+        "url": "https://srv/mcp",
+        "auth": {"type": "bearer", "token": "static-tok"},
+    }
+    headers = await mcp._get_auth_headers_async(server_config)
+    assert headers["Authorization"] == "Bearer static-tok"


### PR DESCRIPTION
## Summary
Implements the MCP 2025-11-25 client-side OAuth 2.1 discovery chain in `auth/oauth.py` + `client.py`:
- WWW-Authenticate parse + PRM discovery (RFC 9728, both mechanisms + well-known fallback), with PRM.`resource` canonical-URI validation.
- AS metadata discovery (RFC 8414 + OIDC fallback), issuer self-consistency.
- PKCE S256 verify-before-proceeding (fail-closed when absent; never emits `plain`).
- RFC 8707 `resource` indicator on all four grant builders (authorize / code-exchange / client-credentials / refresh).
- Bearer token binding on every outbound request (expiry-aware refresh-then-attach).

**SSRF hardening** (from adversarial review): the attacker-influenced `resource_metadata` URL is now rejected unless same-origin as the connected server (RFC 9728 §7.6) — fail-closed **before** the fetch — and discovery GETs use `allow_redirects=False`. The same-origin PRM constraint transitively closes the rogue-AS redirect path.

## Verification
- 25 regression tests via a **real local aiohttp server** (no mocking), incl. 2 SSRF fail-closed-before-fetch tests; 189 tests green under the canonical `.venv`.

## Related issues
Part of #1712 (client OAuth discovery items). Server-side PRM/WWW-Authenticate emission is a later wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)