### PR TITLE
feat(mcp): #1712 Wave 2 — server-side capability parity (2025-11-25) + OAuth resource-server + hardening

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 import weakref
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Protocol, Set, Union
@@ -474,10 +475,26 @@ class ResourceSubscription:
 class CursorManager:
     """Manages cursor generation and validation for pagination."""
 
+    # Cap on the number of outstanding cursors held in memory. Bounds memory
+    # so a client minting cursors — now across tools / prompts / resource-
+    # templates / resources list pagination — cannot grow the store without
+    # limit (a remote DoS). On overflow the OLDEST cursor is evicted (FIFO),
+    # mirroring ``MCPServer._MAX_SEEN_REQUEST_IDS``. Time-based expiry
+    # (``cleanup_expired`` / ``is_valid``) still applies on top of this bound.
+    _MAX_CURSORS = 4096
+
     def __init__(self, ttl_seconds: int = 3600):
         self.ttl_seconds = ttl_seconds
-        self._cursors: Dict[str, Dict[str, Any]] = {}
+        # Insertion-ordered so the oldest cursor is evictable in O(1) on
+        # overflow via ``popitem(last=False)``.
+        self._cursors: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
         self._lock = asyncio.Lock()
+
+    def _evict_overflow(self) -> None:
+        """Evict oldest cursors until the store is within ``_MAX_CURSORS``."""
+        while len(self._cursors) > self._MAX_CURSORS:
+            # popitem(last=False) removes the oldest (FIFO) entry.
+            self._cursors.popitem(last=False)
 
     def generate_cursor(self) -> str:
         """Generate a unique cursor."""
@@ -488,6 +505,9 @@ class CursorManager:
         cursor = hashlib.sha256(cursor_data.encode()).hexdigest()[:16]
 
         self._cursors[cursor] = {"created_at": timestamp, "data": {}}
+        # Bound the store: a client cannot mint unbounded cursors across the
+        # newly-routed list types; the oldest is evicted on overflow.
+        self._evict_overflow()
 
         return cursor
 

--- a/packages/kailash-mcp/src/kailash_mcp/auth/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/__init__.py
@@ -16,6 +16,18 @@ from kailash_mcp.auth.providers import (
     RateLimiter,
 )
 
+# RFC 9728 server-publish surface (PRM builder + WWW-Authenticate challenge +
+# live-transport routes). Pure stdlib — no [auth-oauth] extra required, so these
+# import unconditionally (Starlette in build_well_known_routes is lazy).
+from kailash_mcp.auth.well_known import (
+    WELL_KNOWN_PROTECTED_RESOURCE_SUFFIX,
+    build_well_known_routes,
+    build_www_authenticate_challenge,
+    create_protected_resource_metadata_app,
+    protected_resource_metadata_path,
+    protected_resource_metadata_url,
+)
+
 # OAuth 2.1 — requires the [auth-oauth] extra (aiohttp + PyJWT + cryptography).
 # Gate the import so a base kailash-mcp install still imports `kailash_mcp.auth`
 # cleanly, and raise a descriptive ImportError if a consumer tries to use an
@@ -87,6 +99,13 @@ __all__ = [
     "AuthManager",
     "PermissionManager",
     "RateLimiter",
+    # RFC 9728 server-publish surface (pure stdlib, no extra required)
+    "WELL_KNOWN_PROTECTED_RESOURCE_SUFFIX",
+    "protected_resource_metadata_path",
+    "protected_resource_metadata_url",
+    "build_www_authenticate_challenge",
+    "create_protected_resource_metadata_app",
+    "build_well_known_routes",
     # OAuth 2.1 (requires [auth-oauth])
     *_OAUTH_EXPORTS,
 ]

--- a/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py
@@ -105,6 +105,10 @@ except ImportError:  # pragma: no cover
     rsa = None  # type: ignore[assignment]
 
 from kailash_mcp.auth.providers import AuthProvider
+from kailash_mcp.auth.well_known import (
+    build_www_authenticate_challenge,
+    protected_resource_metadata_url,
+)
 from kailash_mcp.errors import AuthenticationError, AuthorizationError, MCPError
 
 
@@ -387,11 +391,13 @@ class AuthorizationCode:
                 base64.urlsafe_b64encode(verifier_hash).decode().rstrip("=")
             )
             return verifier_challenge == self.code_challenge
-        elif self.code_challenge_method == "plain":
-            # Plain challenge method
-            return code_verifier == self.code_challenge
-        else:
-            return False
+        # Fail-closed: PKCE "plain" (and any non-S256 method) can NEVER validate.
+        # The AS advertises ``code_challenge_methods_supported == ["S256"]`` and
+        # rejects a non-S256 method at issuance (create_authorization_url /
+        # generate_authorization_code); dropping the "plain" branch here closes
+        # the enforcement-surface gap so a stored "plain" challenge cannot pass
+        # verification even if one were ever persisted (PKCE downgrade defense).
+        return False
 
 
 class ClientStore(ABC):
@@ -722,12 +728,24 @@ class JWTManager:
         Returns:
             Token payload or None if invalid
         """
+        # Audience enforcement belongs to the RESOURCE SERVER, not this shared
+        # token layer: the JWTManager mints tokens for many resources and does
+        # not know which single audience a given verify call expects.
+        # ``ResourceServer.authenticate`` performs the fail-closed audience check
+        # (reject audience-absent AND foreign-audience) against its configured
+        # ``audience``. PyJWT's default, however, REJECTS any ``aud``-bearing
+        # token when no ``audience`` kwarg is supplied — which would reject every
+        # correctly-scoped RFC 8707 token here and leave the resource server's
+        # own audience check unreachable. Disable PyJWT aud-verification so the
+        # resource-server boundary is the sole (and live) audience authority.
+        options: Dict[str, Any] = {"verify_aud": False}
         decode_kwargs: Dict[str, Any] = {
             "algorithms": [self.algorithm],
+            "options": options,
         }
         if self.issuer is not None:
             decode_kwargs["issuer"] = self.issuer
-            decode_kwargs["options"] = {"require": ["exp", "iss"]}
+            options["require"] = ["exp", "iss"]
 
         try:
             payload = jwt.decode(token, self.public_key, **decode_kwargs)  # type: ignore[arg-type]
@@ -1012,6 +1030,15 @@ class AuthorizationServer:
             params["scope"] = scope
         if state:
             params["state"] = state
+        # Fail-closed S256-only enforcement (parity with the S256-only posture
+        # advertised at get_well_known_metadata). Reject any explicitly-supplied
+        # non-S256 method — "plain" is a PKCE downgrade the metadata claims is
+        # unsupported — so the enforcement surface matches the advertisement.
+        if code_challenge_method is not None and code_challenge_method != "S256":
+            raise AuthorizationError(
+                f"unsupported code_challenge_method {code_challenge_method!r}; "
+                f"only 'S256' is supported (PKCE 'plain' is rejected)"
+            )
         if code_challenge:
             params["code_challenge"] = code_challenge
             params["code_challenge_method"] = code_challenge_method or "S256"
@@ -1053,6 +1080,16 @@ class AuthorizationServer:
 
         # Convert scopes list to string
         scope = " ".join(scopes) if scopes else None
+
+        # Fail-closed S256-only enforcement (parity with the S256-only posture
+        # advertised at get_well_known_metadata). A non-S256 method — "plain" is
+        # a PKCE downgrade — is refused at issuance so a "plain" challenge is
+        # never persisted; validate_pkce additionally fails-closed on it.
+        if code_challenge_method is not None and code_challenge_method != "S256":
+            raise AuthorizationError(
+                f"unsupported code_challenge_method {code_challenge_method!r}; "
+                f"only 'S256' is supported (PKCE 'plain' is rejected)"
+            )
 
         # Create authorization code
         auth_code = AuthorizationCode(
@@ -1416,7 +1453,12 @@ class AuthorizationServer:
                 "client_secret_basic",
                 "client_secret_post",
             ],
-            "code_challenge_methods_supported": ["S256", "plain"],
+            # S256-only per the MCP 2025-11-25 posture the client enforces
+            # (OAuth2Client._assert_pkce_s256_supported rejects a flow unless the
+            # AS advertises S256; "plain" is never accepted). Advertising "plain"
+            # here would let a downstream reader believe the downgrade-prone
+            # method is supported — it is not.
+            "code_challenge_methods_supported": ["S256"],
         }
 
 
@@ -1429,6 +1471,10 @@ class ResourceServer:
         audience: str,
         jwt_manager: Optional[JWTManager] = None,
         required_scopes: Optional[List[str]] = None,
+        resource: Optional[str] = None,
+        authorization_servers: Optional[List[str]] = None,
+        bearer_methods_supported: Optional[List[str]] = None,
+        resource_metadata_url: Optional[str] = None,
     ):
         """Initialize resource server.
 
@@ -1437,12 +1483,55 @@ class ResourceServer:
             audience: Expected token audience
             jwt_manager: JWT manager for token verification
             required_scopes: Required scopes for access
+            resource: Canonical RFC 8707 resource identifier this server
+                represents (the ``resource`` field of the RFC 9728 Protected
+                Resource Metadata document). Defaults to ``audience`` — for an
+                OAuth resource server the token audience IS the resource URI.
+            authorization_servers: Authorization-server issuer URLs advertised in
+                the PRM ``authorization_servers`` array. Defaults to
+                ``[issuer]``.
+            bearer_methods_supported: RFC 6750 bearer-token presentation methods
+                the server accepts, advertised in PRM
+                ``bearer_methods_supported``. Defaults to ``["header"]`` (the
+                ``Authorization: Bearer`` header form).
+            resource_metadata_url: Absolute RFC 9728 PRM URL emitted in the
+                ``WWW-Authenticate`` challenge. Defaults to the value derived
+                from ``resource`` per RFC 9728 §3.1.
         """
         _require_oauth_extras()
         self.issuer = issuer
         self.audience = audience
         self.jwt_manager = jwt_manager or JWTManager(issuer=issuer)
         self.required_scopes = required_scopes or []
+        # RFC 8707 resource identifier == token audience for a resource server.
+        # ``resource`` and ``audience`` stay INDEPENDENT: the AS mints ``aud``
+        # from the audience and ``authenticate`` compares the token's ``aud``
+        # against ``self.audience``; only the RFC 9728 PRM URL is derived from
+        # ``self.resource``. That derivation REQUIRES an absolute http(s) URL —
+        # a bare-string audience used as the effective resource (the documented
+        # ``ResourceServer(issuer=..., audience="mcp-api")`` default) would emit
+        # a corrupt PRM doc / route path / challenge (``:///.well-known/...``)
+        # that no RFC 9728 client can bootstrap. Fail loud (mirroring the
+        # double-quote guard in ``build_www_authenticate_challenge``) rather
+        # than serve a silently-broken URL.
+        self.resource = resource or audience
+        _parsed_resource = urlparse(self.resource)
+        if (
+            _parsed_resource.scheme not in ("http", "https")
+            or not _parsed_resource.netloc
+        ):
+            raise ValueError(
+                f"ResourceServer resource identifier must be an absolute "
+                f"http(s) URL for RFC 9728 PRM derivation (scheme http/https + "
+                f"non-empty host); got {self.resource!r}. When 'audience' is a "
+                f'bare token, pass resource="https://<host>/<path>" explicitly '
+                f"(audience and resource remain independent)."
+            )
+        self.authorization_servers = authorization_servers or [issuer]
+        self.bearer_methods_supported = bearer_methods_supported or ["header"]
+        self.resource_metadata_url = resource_metadata_url or (
+            protected_resource_metadata_url(self.resource)
+        )
 
     async def authenticate(
         self, credentials: Union[str, Dict[str, Any]]
@@ -1461,7 +1550,7 @@ class ResourceServer:
         else:
             token = credentials.get("token")
             if not token:
-                raise AuthenticationError("No token provided")
+                raise self._unauthorized("No token provided", error="invalid_request")
 
         # Remove 'Bearer ' prefix if present
         if token.startswith("Bearer "):
@@ -1470,15 +1559,23 @@ class ResourceServer:
         # Verify JWT token
         payload = self.jwt_manager.verify_access_token(token)
         if not payload:
-            raise AuthenticationError("Invalid token")
+            raise self._unauthorized("Invalid token", error="invalid_token")
 
-        # Check audience
+        # Check audience — fail-closed: reject BOTH an audience-absent token
+        # (empty ``aud`` never contains self.audience) AND a foreign-audience
+        # token, so a token minted for a different resource cannot be replayed
+        # here (RFC 8707 / rules/security.md audience fail-closed).
         token_audience = payload.get("aud", [])
         if isinstance(token_audience, str):
             token_audience = [token_audience]
 
         if self.audience not in token_audience:
-            raise AuthorizationError("Invalid token audience")
+            raise self._unauthorized(
+                "Invalid token audience",
+                error="invalid_token",
+                error_description="token audience does not match this resource",
+                exc_type=AuthorizationError,
+            )
 
         # Check required scopes
         token_scope = payload.get("scope", "")
@@ -1486,7 +1583,11 @@ class ResourceServer:
 
         for required_scope in self.required_scopes:
             if required_scope not in token_scopes:
-                raise AuthenticationError(f"Missing required scope: {required_scope}")
+                raise self._unauthorized(
+                    f"Missing required scope: {required_scope}",
+                    error="insufficient_scope",
+                    scope=required_scope,
+                )
 
         return {
             "id": payload.get("sub") or payload.get("client_id"),
@@ -1522,6 +1623,112 @@ class ResourceServer:
             Empty dict as resource server doesn't add headers
         """
         return {}
+
+    def get_protected_resource_metadata(self) -> Dict[str, Any]:
+        """Return this server's RFC 9728 Protected Resource Metadata document.
+
+        Served at ``GET /.well-known/oauth-protected-resource`` (see
+        ``kailash_mcp.auth.well_known``) and referenced by the
+        ``resource_metadata`` param of the 401 ``WWW-Authenticate`` challenge, so
+        a client can discover which authorization server(s) issue tokens for this
+        resource and what scopes it accepts.
+
+        Returns:
+            The RFC 9728 §2 metadata document: ``resource``,
+            ``authorization_servers``, ``scopes_supported``,
+            ``bearer_methods_supported``.
+        """
+        return {
+            "resource": self.resource,
+            "authorization_servers": list(self.authorization_servers),
+            "scopes_supported": list(self.required_scopes),
+            "bearer_methods_supported": list(self.bearer_methods_supported),
+        }
+
+    def www_authenticate_challenge(
+        self,
+        *,
+        scope: Optional[str] = None,
+        error: Optional[str] = None,
+        error_description: Optional[str] = None,
+    ) -> str:
+        """Build this server's ``WWW-Authenticate: Bearer`` challenge value.
+
+        Points a challenged client at this resource's PRM document
+        (``resource_metadata``) per RFC 9728 §5.1, advertising the required
+        scope and (optionally) an RFC 6750 error classification. All values are
+        drawn from this server's configuration — never hard-coded literals.
+
+        Args:
+            scope: Space-delimited scope to advertise; defaults to the server's
+                configured ``required_scopes`` joined by spaces.
+            error: RFC 6750 error code.
+            error_description: RFC 6750 human-readable description.
+
+        Returns:
+            The ``WWW-Authenticate`` header VALUE.
+        """
+        if scope is None and self.required_scopes:
+            scope = " ".join(self.required_scopes)
+        return build_www_authenticate_challenge(
+            resource_metadata_url=self.resource_metadata_url,
+            scope=scope,
+            error=error,
+            error_description=error_description,
+        )
+
+    def _unauthorized(
+        self,
+        message: str,
+        *,
+        error: str,
+        error_description: Optional[str] = None,
+        scope: Optional[str] = None,
+        exc_type: type = AuthenticationError,
+    ) -> AuthenticationError:
+        """Build a typed auth-failure carrying the ``WWW-Authenticate`` header.
+
+        The challenge is attached as the ``www_authenticate`` attribute (and in
+        ``data['www_authenticate']``) so the HTTP/SSE transport can surface it on
+        the 401 response without re-deriving it. The exception is returned (not
+        raised) so the caller keeps a single ``raise`` site.
+        """
+        challenge = self.www_authenticate_challenge(
+            scope=scope, error=error, error_description=error_description
+        )
+        exc = exc_type(message)
+        exc.www_authenticate = challenge
+        exc.data["www_authenticate"] = challenge
+        return exc
+
+    def unauthorized_response(
+        self,
+        *,
+        error: str = "invalid_token",
+        error_description: Optional[str] = None,
+        scope: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build a ready-to-emit HTTP 401 challenging with RFC 9728 PRM.
+
+        A transport serving the resource emits this verbatim when a request
+        arrives without a valid token, so an MCP client learns where to obtain
+        one (the RFC 9728 §5 discovery bootstrap).
+
+        Returns:
+            ``{"status": 401, "headers": {"WWW-Authenticate": <challenge>},
+            "body": {"error": <error>, ...}}``.
+        """
+        challenge = self.www_authenticate_challenge(
+            scope=scope, error=error, error_description=error_description
+        )
+        body: Dict[str, Any] = {"error": error}
+        if error_description is not None:
+            body["error_description"] = error_description
+        return {
+            "status": 401,
+            "headers": {"WWW-Authenticate": challenge},
+            "body": body,
+        }
 
 
 class OAuth2Client:
@@ -1732,8 +1939,8 @@ class OAuth2Client:
         # check below runs only AFTER the request has already fired.
         if not self._same_origin(prm_url, server_url):
             raise OAuthDiscoveryError(
-                f"Protected Resource Metadata URL origin does not match the "
-                f"connected server (refusing cross-origin discovery fetch)"
+                "Protected Resource Metadata URL origin does not match the "
+                "connected server (refusing cross-origin discovery fetch)"
             )
 
         prm = await self._fetch_json(prm_url, description="Protected Resource Metadata")

--- a/packages/kailash-mcp/src/kailash_mcp/auth/providers.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/providers.py
@@ -21,13 +21,18 @@ Examples:
 
     JWT authentication:
 
-    >>> auth = JWTAuth(secret="my-secret", algorithm="HS256")
+    >>> auth = JWTAuth(
+    ...     secret="my-secret",
+    ...     algorithm="HS256",
+    ...     audience="https://mcp.example.com",
+    ... )
     >>> token = auth.create_token({"user": "alice", "permissions": ["read", "write"]})
 """
 
 import base64
 import binascii
 import hmac
+import inspect
 import json
 import logging
 import os
@@ -232,15 +237,15 @@ class BearerTokenAuth(AuthProvider):
             to be present AND equal to this value. When ``None`` (default),
             absent-iss tokens are accepted (existing behaviour preserved).
         expected_audience: The canonical resource URI this MCP server
-            identifies as (a.k.a. the token audience). When set, JWT
-            validation FAILS CLOSED on the audience dimension — it rejects
-            BOTH audience-absent tokens (missing required ``aud``) AND
-            foreign-audience tokens (``aud`` mismatch), per the MCP
-            2025-11-25 spec. When ``None`` (default), audience is NOT
-            validated (existing behaviour preserved) and a one-time WARNING
-            is logged: MCP servers accepting JWTs MUST set
-            ``expected_audience`` for spec compliance — an unconfigured
-            audience cannot be validated against anything.
+            identifies as (a.k.a. the token audience). REQUIRED whenever
+            ``validate_jwt=True`` — construction raises ``ValueError`` if it is
+            absent (fail-closed, enforcement-surface parity with
+            ``ResourceServer``). JWT validation then FAILS CLOSED on the
+            audience dimension — it rejects BOTH audience-absent tokens
+            (missing required ``aud``) AND foreign-audience tokens (``aud``
+            mismatch), per the MCP 2025-11-25 spec. There is no fail-open
+            default: the only way to skip audience validation is to not
+            validate JWTs (``validate_jwt=False``).
 
     Examples:
         Simple bearer token:
@@ -284,19 +289,23 @@ class BearerTokenAuth(AuthProvider):
         if validate_jwt and not jwt_secret:
             raise ValueError("JWT secret required when validate_jwt=True")
 
-        # Spec-compliance guard (MCP 2025-11-25): a JWT-validating server that
-        # does NOT pin an expected audience cannot reject foreign-audience
-        # tokens minted for a different resource. Surface this ONCE, loudly,
-        # at construction — the audience check is fail-closed WHENEVER
-        # expected_audience is set (see _validate_jwt_token) and disabled when
-        # it is not.
+        # Fail-closed audience guard (MCP 2025-11-25) — enforcement-surface
+        # parity with ``ResourceServer`` (rules/security.md § Enforcement-Surface
+        # Parity). A JWT-validating provider that does NOT pin an expected
+        # audience cannot reject a foreign-audience token minted for a different
+        # resource, so audience enforcement would silently be fail-OPEN. Rather
+        # than warn-and-continue (the pre-fix behaviour that shipped the open
+        # default), REFUSE construction — mirroring the ``jwt_secret`` guard
+        # above. Every JWT-validating provider is now audience fail-closed by
+        # construction; the only way to disable audience validation is to not
+        # validate JWTs at all.
         if validate_jwt and not expected_audience:
-            logger.warning(
-                "JWT auth enabled without expected_audience: token audience "
-                "validation is DISABLED. The MCP 2025-11-25 spec REQUIRES "
-                "servers to validate the token audience fail-closed; set "
-                "expected_audience=<canonical resource URI> to reject "
-                "audience-absent and foreign-audience tokens."
+            raise ValueError(
+                "expected_audience is required when validate_jwt=True: the MCP "
+                "2025-11-25 spec REQUIRES servers to validate the token audience "
+                "fail-closed (reject audience-absent AND foreign-audience "
+                "tokens). Pass expected_audience=<canonical resource URI> so a "
+                "token minted for a different resource cannot be replayed here."
             )
 
         logger.info(f"Initialized Bearer Token auth (JWT: {validate_jwt})")
@@ -377,7 +386,9 @@ class BearerTokenAuth(AuthProvider):
 
         try:
             payload = jwt.decode(  # type: ignore[union-attr]
-                token, self.jwt_secret, **decode_kwargs  # type: ignore[arg-type]
+                token,
+                self.jwt_secret,
+                **decode_kwargs,  # type: ignore[arg-type]
             )
 
             return {
@@ -462,14 +473,14 @@ class JWTAuth(BearerTokenAuth):
             issued by :py:meth:`create_token` AND as the ``expected_issuer``
             allowlist on validation. When set, validation REQUIRES ``iss``
             to be present (cross-SDK port of esperie/kailash-rs#599).
-        audience: The canonical resource URI this server identifies as. Used
-            both as the ``aud`` claim on tokens issued by
-            :py:meth:`create_token` AND as the ``expected_audience`` allowlist
-            on validation. When set, validation is FAIL-CLOSED on audience —
-            it REQUIRES ``aud`` to be present AND equal to this value, per the
-            MCP 2025-11-25 spec. When ``None`` (default), audience is not
-            validated and a one-time WARNING is logged; MCP servers SHOULD set
-            it for spec compliance.
+        audience: The canonical resource URI this server identifies as.
+            REQUIRED — ``JWTAuth`` always validates JWTs, so an absent
+            ``audience`` raises ``ValueError`` at construction (fail-closed,
+            enforcement-surface parity with ``ResourceServer``). Used both as
+            the ``aud`` claim on tokens issued by :py:meth:`create_token` AND
+            as the ``expected_audience`` allowlist on validation, which is
+            FAIL-CLOSED on audience — it REQUIRES ``aud`` to be present AND
+            equal to this value, per the MCP 2025-11-25 spec.
 
     Examples:
         Create JWT auth provider (spec-compliant, audience fail-closed):
@@ -882,7 +893,53 @@ class AuthManager:
     def authenticate_and_authorize(
         self, credentials: Dict[str, Any], required_permission: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Authenticate credentials and check authorization.
+        """Authenticate credentials and check authorization (SYNC path).
+
+        Use this from a synchronous dispatch context. For an ASYNC provider
+        (one whose ``authenticate`` is a coroutine function, e.g.
+        ``ResourceServer``) call :py:meth:`authenticate_and_authorize_async`
+        from an async context instead — a coroutine cannot be awaited here.
+
+        Args:
+            credentials: Authentication credentials
+            required_permission: Required permission for the operation
+
+        Returns:
+            User information dict
+
+        Raises:
+            AuthenticationError: If authentication fails, OR if the configured
+                provider is async and therefore cannot run on the sync path.
+            PermissionError: If user lacks required permission
+            RateLimitError: If rate limit exceeded
+        """
+        result = self.provider.authenticate(credentials)
+        if inspect.isawaitable(result):
+            # An async provider reached the SYNC auth path. Fail CLOSED with a
+            # typed AuthenticationError rather than letting the un-awaited
+            # coroutine leak downstream into an opaque AttributeError -> 500.
+            # Close the coroutine so no "was never awaited" RuntimeWarning
+            # fires at GC.
+            result.close()  # type: ignore[union-attr]
+            raise AuthenticationError(
+                "authentication provider is async; call "
+                "authenticate_and_authorize_async from an async dispatch "
+                "context (async tool handler / WebSocket dispatch)"
+            )
+        return self._authorize(result, required_permission)
+
+    async def authenticate_and_authorize_async(
+        self, credentials: Dict[str, Any], required_permission: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Authenticate credentials and check authorization (ASYNC-aware path).
+
+        Awaits the provider's ``authenticate`` when it is async (e.g.
+        ``ResourceServer.authenticate``), and calls it directly when it is a
+        plain sync provider — so a sync ``AuthProvider`` subclass works
+        unchanged through this path too. This is the path the server's async
+        tool dispatch (WebSocket) uses so an async ``auth_provider`` is
+        actually reachable through the documented server wiring rather than
+        crashing on an un-awaited coroutine.
 
         Args:
             credentials: Authentication credentials
@@ -896,9 +953,21 @@ class AuthManager:
             PermissionError: If user lacks required permission
             RateLimitError: If rate limit exceeded
         """
-        # Authenticate
-        user_info = self.provider.authenticate(credentials)
+        result = self.provider.authenticate(credentials)
+        if inspect.isawaitable(result):
+            user_info = await result
+        else:
+            user_info = result
+        return self._authorize(user_info, required_permission)
 
+    def _authorize(
+        self, user_info: Dict[str, Any], required_permission: Optional[str]
+    ) -> Dict[str, Any]:
+        """Post-authentication rate-limit + permission + audit gate.
+
+        Shared by both the sync and async authenticate paths so the
+        authorization semantics are identical regardless of dispatch context.
+        """
         # Check rate limits
         if self.rate_limiter:
             self.rate_limiter.check_rate_limit(user_info)

--- a/packages/kailash-mcp/src/kailash_mcp/auth/well_known.py
+++ b/packages/kailash-mcp/src/kailash_mcp/auth/well_known.py
@@ -1,0 +1,263 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-publish half of the OAuth 2.1 protected-resource surface (#1712).
+
+The ``kailash-mcp`` server acts as an OAuth 2.1 **resource server**. Per the MCP
+2025-11-25 authorization spec it MUST publish RFC 9728 *Protected Resource
+Metadata* (PRM) and MUST challenge unauthenticated requests with an RFC 9110
+§11.6.1 ``WWW-Authenticate: Bearer`` header pointing at that metadata. The
+CLIENT half (RFC 9728 PRM fetch, RFC 8414/OIDC AS-metadata discovery, PKCE-S256
+pre-check) already lives in ``kailash_mcp.auth.oauth.OAuth2Client``; this module
+is the SERVER half those clients discover.
+
+This module carries the pure, dependency-free builders (the PRM well-known URL
+derivation and the ``WWW-Authenticate`` challenge string) so ``oauth.py`` can
+import them without a cycle, plus two mountable route surfaces for the live
+HTTP/SSE transport:
+
+* :func:`create_protected_resource_metadata_app` — a pure ASGI 3.0 application
+  serving ``GET /.well-known/oauth-protected-resource`` (no framework dep), and
+* :func:`build_well_known_routes` — a Starlette ``Route`` list for mounting on
+  the FastMCP / SSE Starlette surface (Starlette imported lazily).
+
+The well-known metadata endpoint is intentionally **unauthenticated** — RFC 9728
+§3 requires it be publicly fetchable so a client can discover where to obtain a
+token before it has one.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from urllib.parse import ParseResult, urlparse
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids Starlette runtime dep
+    from starlette.routing import Route
+
+logger = logging.getLogger(__name__)
+
+# RFC 9728 §3.1 — the registered well-known URI suffix for Protected Resource
+# Metadata. The served path is this suffix followed by the resource's path
+# component (empty for an origin-root resource → the bare well-known path).
+WELL_KNOWN_PROTECTED_RESOURCE_SUFFIX = "/.well-known/oauth-protected-resource"
+
+
+def _require_absolute_resource_url(resource_uri: str) -> ParseResult:
+    """Parse + validate ``resource_uri`` as an absolute http(s) URL.
+
+    RFC 9728 §3.1 derives the PRM well-known URL from the resource identifier,
+    whose path component is spliced after the well-known suffix. A NON-URL
+    identifier (a bare token such as ``"mcp-api"``) has no scheme/host and its
+    ``urlparse().path`` carries no leading ``/`` — deriving a PRM URL from it
+    yields a corrupt string (``":///.well-known/oauth-protected-resourcemcp-api"``)
+    that no RFC 9728 client can fetch. Reject it fail-loud (defense in depth for
+    ``ResourceServer.__init__``'s own guard) rather than emit a broken doc.
+    """
+    parsed = urlparse(resource_uri)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(
+            f"RFC 9728 protected-resource identifier must be an absolute "
+            f"http(s) URL (scheme http/https + non-empty host); got "
+            f'{resource_uri!r}. Pass resource="https://<host>/<path>".'
+        )
+    return parsed
+
+
+def protected_resource_metadata_path(resource_uri: str) -> str:
+    """Return the request path a client fetches PRM from for ``resource_uri``.
+
+    Per RFC 9728 §3.1 the ``/.well-known/oauth-protected-resource`` segment is
+    inserted between the origin and the resource's path. For an origin-root
+    resource (``https://srv.example.com``) this is exactly the well-known
+    suffix; for a path-bearing resource (``https://srv.example.com/mcp``) the
+    resource path is appended (``/.well-known/oauth-protected-resource/mcp``).
+
+    A validated URL's ``path`` is empty (origin-root) or begins with ``/``, so
+    the composition below always carries the correct ``/`` separator; a non-URL
+    ``resource_uri`` is rejected fail-loud by :func:`_require_absolute_resource_url`.
+
+    This mirrors ``OAuth2Client._wellknown_prm_url`` on the client side so the
+    path the server serves is byte-identical to the one the client derives.
+    """
+    path = _require_absolute_resource_url(resource_uri).path.rstrip("/")
+    return f"{WELL_KNOWN_PROTECTED_RESOURCE_SUFFIX}{path}"
+
+
+def protected_resource_metadata_url(resource_uri: str) -> str:
+    """Return the absolute RFC 9728 PRM URL for ``resource_uri``.
+
+    ``https://srv.example.com/mcp`` →
+    ``https://srv.example.com/.well-known/oauth-protected-resource/mcp``.
+
+    Raises ``ValueError`` (via :func:`_require_absolute_resource_url`) when
+    ``resource_uri`` is not an absolute http(s) URL.
+    """
+    parsed = _require_absolute_resource_url(resource_uri)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{origin}{protected_resource_metadata_path(resource_uri)}"
+
+
+def build_www_authenticate_challenge(
+    *,
+    resource_metadata_url: str,
+    scope: Optional[str] = None,
+    error: Optional[str] = None,
+    error_description: Optional[str] = None,
+) -> str:
+    """Build an RFC 9110 §11.6.1 ``WWW-Authenticate: Bearer`` challenge value.
+
+    Emits the quoted ``key="value"`` auth-param form that
+    ``kailash_mcp.auth.oauth.parse_www_authenticate`` parses — the two are
+    inverse operations sharing one param shape. ``resource_metadata`` (RFC 9728
+    §5.1) points a challenged client at this resource server's PRM document;
+    ``scope`` (RFC 6750 §3) advertises the scope the caller lacked; ``error`` /
+    ``error_description`` (RFC 6750 §3) classify the failure.
+
+    Args:
+        resource_metadata_url: Absolute RFC 9728 PRM URL for this resource.
+        scope: Space-delimited required scope(s), if any.
+        error: RFC 6750 error code (``invalid_token`` / ``invalid_request`` /
+            ``insufficient_scope``), if the challenge follows a failed auth.
+        error_description: Human-readable RFC 6750 error description.
+
+    Returns:
+        The ``WWW-Authenticate`` header VALUE, e.g.
+        ``Bearer resource_metadata="https://…", scope="mcp"``.
+    """
+    # A double quote would break the RFC 9110 quoted-string parse (the
+    # parse_www_authenticate regex stops at the first '"'); reject it fail-loud
+    # rather than emit a corrupt, silently-truncating header.
+    params = [("resource_metadata", resource_metadata_url)]
+    if error is not None:
+        params.append(("error", error))
+    if error_description is not None:
+        params.append(("error_description", error_description))
+    if scope:
+        params.append(("scope", scope))
+
+    rendered = []
+    for key, value in params:
+        if '"' in value:
+            raise ValueError(
+                f"WWW-Authenticate param {key!r} contains a double quote, which "
+                f"would corrupt the RFC 9110 §11.6.1 quoted-string form: {value!r}"
+            )
+        rendered.append(f'{key}="{value}"')
+    return "Bearer " + ", ".join(rendered)
+
+
+# ---------------------------------------------------------------------------
+# Live-transport route surfaces
+# ---------------------------------------------------------------------------
+
+# Duck-typed protocol for the object the route surfaces consume: any object
+# exposing ``get_protected_resource_metadata() -> dict`` (ResourceServer does).
+_MetadataProvider = Any
+
+
+def create_protected_resource_metadata_app(
+    resource_server: _MetadataProvider,
+) -> Callable:
+    """Build a pure ASGI 3.0 app serving the RFC 9728 PRM document.
+
+    Returns an ``async def app(scope, receive, send)`` callable that answers
+    ``GET`` at the resource's PRM path (:func:`protected_resource_metadata_path`)
+    with a ``200 application/json`` body of
+    ``resource_server.get_protected_resource_metadata()``, and ``404`` for any
+    other path/method. No web framework is required — the app mounts on any ASGI
+    server (uvicorn, hypercorn, the FastMCP Starlette surface).
+
+    The endpoint is unauthenticated by design (RFC 9728 §3): a client must be
+    able to fetch it before it holds a token.
+    """
+    metadata = resource_server.get_protected_resource_metadata()
+    metadata_path = protected_resource_metadata_path(metadata["resource"])
+    body = json.dumps(metadata).encode("utf-8")
+
+    async def app(scope: Dict[str, Any], receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":  # pragma: no cover - defensive
+            raise ValueError(
+                f"protected-resource-metadata app supports only the 'http' ASGI "
+                f"scope, got {scope['type']!r}"
+            )
+        if scope["method"] == "GET" and scope["path"] == metadata_path:
+            logger.info(
+                "oauth.protected_resource_metadata.serve path=%s resource=%s",
+                metadata_path,
+                metadata["resource"],
+            )
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"cache-control", b"public, max-age=3600"),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        logger.debug(
+            "oauth.protected_resource_metadata.miss method=%s path=%s",
+            scope.get("method"),
+            scope.get("path"),
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 404,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"error":"not_found"}'})
+
+    return app
+
+
+def build_well_known_routes(resource_server: _MetadataProvider) -> "List[Route]":
+    """Build Starlette ``Route``\\ s serving the RFC 9728 PRM document.
+
+    For mounting on the FastMCP / SSE Starlette surface. Starlette is imported
+    lazily so ``import kailash_mcp.auth.well_known`` works without it; the import
+    raises a descriptive error only if this function is actually called without
+    Starlette installed.
+
+    Returns a single-element list: a ``GET`` route at the resource's PRM path
+    returning the metadata JSON.
+    """
+    try:
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+    except ImportError as exc:  # pragma: no cover - exercised only sans starlette
+        raise ImportError(
+            "build_well_known_routes requires Starlette (installed with the "
+            "FastMCP HTTP/SSE server surface); install kailash-mcp[server]."
+        ) from exc
+
+    metadata = resource_server.get_protected_resource_metadata()
+    metadata_path = protected_resource_metadata_path(metadata["resource"])
+
+    async def _metadata_endpoint(request: "Request") -> "JSONResponse":
+        doc = resource_server.get_protected_resource_metadata()
+        logger.info(
+            "oauth.protected_resource_metadata.serve path=%s resource=%s",
+            metadata_path,
+            doc["resource"],
+        )
+        return JSONResponse(
+            doc,
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    return [
+        Route(
+            metadata_path,
+            _metadata_endpoint,
+            methods=["GET"],
+            name="oauth_protected_resource_metadata",
+        )
+    ]

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -60,6 +60,7 @@ import functools
 import gzip
 import json
 import logging
+import re
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -109,6 +110,7 @@ logger = logging.getLogger(__name__)
 # newest supported version. A hardcoded/echoed fixed version string is
 # non-compliant.
 SUPPORTED_PROTOCOL_VERSIONS = (
+    "2025-11-25",
     "2025-06-18",
     "2025-03-26",
     "2024-11-05",
@@ -127,6 +129,106 @@ def negotiate_protocol_version(requested: Any) -> str:
     if isinstance(requested, str) and requested in SUPPORTED_PROTOCOL_VERSIONS:
         return requested
     return LATEST_PROTOCOL_VERSION
+
+
+# Server-chosen page size for opaque-cursor list pagination (spec 2025-11-25).
+# The server picks the page size itself: a client does NOT need to send a
+# ``limit`` to receive a ``nextCursor``. Cursors are opaque to clients; an
+# invalid/expired cursor is answered with a ``-32602`` error.
+_DEFAULT_PAGE_SIZE = 100
+
+# MCP logging severity ladder (logging/setLevel + notifications/message,
+# spec 2025-11-25), ordered least→most severe. The rank gates emission: a
+# message below a client's set minimum level is suppressed.
+_MCP_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+_MCP_LOG_LEVEL_RANK = {lvl: idx for idx, lvl in enumerate(_MCP_LOG_LEVELS)}
+
+# Content-redaction patterns for notifications/message ``data`` (security.md —
+# no secrets/PII on an observable surface). A sensitive object KEY has its whole
+# value replaced; every string is scanned for secret/PII token shapes.
+_SECRET_KEY_PATTERN = re.compile(
+    r"(pass(word|wd)?|secret|token|api[_-]?key|apikey|authorization|"
+    r"access[_-]?token|refresh[_-]?token|client[_-]?secret|private[_-]?key|"
+    r"credential|ssn|session[_-]?id)",
+    re.IGNORECASE,
+)
+# scheme://user:PASS@host — replace the userinfo (user:pass) span, KEEP the
+# scheme and host so the log line stays legible. Handled first (before the
+# token-shape patterns below) so the retained host does not re-trigger a match.
+_URL_USERINFO_PATTERN = re.compile(r"([A-Za-z][A-Za-z0-9+.\-]*://)[^\s:/@]+:[^\s/@]+@")
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),  # email
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),  # US SSN
+    re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9_\-]{12,}\b"),  # provider API keys
+    re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{8,}\b", re.IGNORECASE),  # bearer
+    re.compile(r"\beyJ[A-Za-z0-9._\-]{10,}\b"),  # JWT (eyJ… header)
+    re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),  # AWS access key id
+    # AWS secret access key: 40-char base64 that INCLUDES a `/` or `+` (which
+    # excludes hex digests like a 40-char SHA-1, so a git SHA is not redacted).
+    re.compile(r"\b(?=[A-Za-z0-9/+]{40}\b)[A-Za-z0-9]*[/+][A-Za-z0-9/+]*\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"),  # GitHub token
+    re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b"),  # Google API key
+    re.compile(r"\bxox[baprs]-[0-9A-Za-z\-]{10,}\b"),  # Slack token
+)
+
+_REDACTED = "[REDACTED]"
+
+
+def _completion_rank(candidate: str, partial: str) -> int:
+    """Relevance rank for a completion candidate (lower = more relevant).
+
+    ``0`` exact match, ``1`` prefix match (``startswith``), ``2`` substring
+    match. Case-insensitive. Used to order completion/complete candidates so the
+    100-item cap keeps the most relevant matches (spec 2025-11-25).
+    """
+    cand = candidate.lower()
+    part = partial.lower()
+    if cand == part:
+        return 0
+    if cand.startswith(part):
+        return 1
+    return 2
+
+
+def _redact_log_string(text: str) -> str:
+    """Scrub secret/PII token shapes from a single string."""
+    # Userinfo first: keep scheme + host, redact the user:pass span so a
+    # credential embedded in a connection string does not leak, and the
+    # retained host does not re-trigger a token-shape match below.
+    text = _URL_USERINFO_PATTERN.sub(r"\1" + _REDACTED + "@", text)
+    for pattern in _SECRET_VALUE_PATTERNS:
+        text = pattern.sub(_REDACTED, text)
+    return text
+
+
+def _redact_log_data(value: Any) -> Any:
+    """Recursively scrub secrets/PII from a ``notifications/message`` payload.
+
+    A sensitive object KEY (``password`` / ``api_key`` / ``token`` / …) has its
+    whole value replaced with ``[REDACTED]``; every string value AND every
+    string KEY is additionally scanned for secret/PII token shapes (AWS/GitHub/
+    Google/Slack keys, provider API keys, bearer tokens, JWTs, URL-userinfo
+    credentials, emails, SSNs). Scanning KEYS too closes the gap where a secret
+    lives in the key position (e.g. ``{"AKIA…": "…"}``) — a value-only scrubber
+    would ship it to the notifications wire. Non-container scalars pass through
+    unchanged. Applied to the emitted ``data`` before it leaves the server
+    (security.md § Redactor Contract — no secrets/PII on an observable surface).
+    """
+    if isinstance(value, dict):
+        redacted: Dict[Any, Any] = {}
+        for key, val in value.items():
+            # Scrub secret/PII token shapes embedded in the KEY string itself.
+            out_key = _redact_log_string(key) if isinstance(key, str) else key
+            if isinstance(key, str) and _SECRET_KEY_PATTERN.search(key):
+                redacted[out_key] = _REDACTED
+            else:
+                redacted[out_key] = _redact_log_data(val)
+        return redacted
+    if isinstance(value, (list, tuple)):
+        return [_redact_log_data(item) for item in value]
+    if isinstance(value, str):
+        return _redact_log_string(value)
+    return value
 
 
 # MCP content-block discriminators a tool may return directly (tools/call
@@ -674,6 +776,25 @@ class MCPServer:
                 rate_limiter=getattr(self, "rate_limiter", None),
             )
 
+        # Opaque-cursor pagination store (spec 2025-11-25). Server-owned so
+        # tools/list, prompts/list, resources/list AND resources/templates/list
+        # all page through ONE cursor scheme. Reuse the subscription manager's
+        # instance when subscriptions are enabled so a cursor issued by one
+        # list method validates through the same store.
+        if self.subscription_manager is not None:
+            self._cursor_manager = self.subscription_manager.cursor_manager
+        else:
+            from kailash_mcp.advanced.subscriptions import CursorManager
+
+            self._cursor_manager = CursorManager()
+
+        # MCP logging levels (logging/setLevel + notifications/message,
+        # spec 2025-11-25). Per-client minimum level gates notifications/message
+        # emission — a message below a client's set level is suppressed. Clients
+        # that never call setLevel fall back to ``_log_level_default``.
+        self._client_log_levels: Dict[str, str] = {}
+        self._log_level_default = "INFO"
+
         # Transport instance (for WebSocket and other transports)
         self._transport = None
 
@@ -1042,7 +1163,9 @@ class MCPServer:
                     )
                     try:
                         self.auth_manager.rate_limiter.check_rate_limit(  # type: ignore[reportOptionalMemberAccess]
-                            user_id, tool_name, **rate_limit  # type: ignore[reportCallIssue]
+                            user_id,
+                            tool_name,
+                            **rate_limit,  # type: ignore[reportCallIssue]
                         )
                     except RateLimitError as e:
                         if self.error_aggregator:
@@ -1222,7 +1345,15 @@ class MCPServer:
                         user_info = None
                     else:
                         try:
-                            user_info = self.auth_manager.authenticate_and_authorize(
+                            # Async dispatch context (WebSocket): use the
+                            # async-aware path so an async auth_provider (e.g.
+                            # ResourceServer, whose authenticate() is a
+                            # coroutine) is actually awaited. The sync path
+                            # would leave the coroutine un-awaited and crash
+                            # with an AttributeError -> 500 instead of a clean
+                            # fail-closed AuthorizationError. Sync providers
+                            # work unchanged through this path.
+                            user_info = await self.auth_manager.authenticate_and_authorize_async(
                                 credentials, required_permission
                             )
                             # Add user info to session
@@ -1249,7 +1380,9 @@ class MCPServer:
                     )
                     try:
                         self.auth_manager.rate_limiter.check_rate_limit(  # type: ignore[reportOptionalMemberAccess]
-                            user_id, tool_name, **rate_limit  # type: ignore[reportCallIssue]
+                            user_id,
+                            tool_name,
+                            **rate_limit,  # type: ignore[reportCallIssue]
                         )
                     except RateLimitError as e:
                         if self.error_aggregator:
@@ -2054,8 +2187,7 @@ class MCPServer:
                     "error": {
                         "code": -32600,
                         "message": (
-                            f"Request id already used in this session: "
-                            f"{request_id!r}"
+                            f"Request id already used in this session: {request_id!r}"
                         ),
                     },
                     "id": request_id,
@@ -2091,6 +2223,8 @@ class MCPServer:
             return await self._handle_call_tool(params, request_id)
         elif method == "resources/list":
             return await self._handle_list_resources(params, request_id)
+        elif method == "resources/templates/list":
+            return await self._handle_list_resource_templates(params, request_id)
         elif method == "resources/read":
             return await self._handle_read_resource(params, request_id, client_id)
         elif method == "resources/subscribe":
@@ -2106,7 +2240,10 @@ class MCPServer:
         elif method == "prompts/get":
             return await self._handle_get_prompt(params, request_id)
         elif method == "logging/setLevel":
-            return await self._handle_logging_set_level(params, request_id)
+            # Merge client_id so the level is tracked per-session for
+            # notifications/message gating (spec 2025-11-25).
+            params_with_client = {**params, "client_id": client_id}
+            return await self._handle_logging_set_level(params_with_client, request_id)
         elif method == "roots/list":
             # Add client_id to params for roots/list handler
             params_with_client = {**params, "client_id": client_id}
@@ -2127,7 +2264,10 @@ class MCPServer:
             }
 
     async def _handle_initialize(
-        self, params: Dict[str, Any], request_id: Any, client_id: str = None  # type: ignore[reportArgumentType]
+        self,
+        params: Dict[str, Any],
+        request_id: Any,
+        client_id: str = None,  # type: ignore[reportArgumentType]
     ) -> Dict[str, Any]:
         """Handle initialize request."""
         # Store client information for capability checks
@@ -2154,10 +2294,16 @@ class MCPServer:
                         "listChanged": self.enable_subscriptions,
                         "batch_subscribe": self.enable_subscriptions,
                         "batch_unsubscribe": self.enable_subscriptions,
+                        # resources/templates/list is served (spec 2025-11-25).
+                        "resourceTemplates": {"listSupported": True},
                     },
                     "prompts": {"listSupported": True, "getSupported": True},
                     "logging": {"setLevel": True},
                     "roots": {"list": True},
+                    # Spec-2025-11-25 top-level completions capability. The
+                    # experimental.completion alias below is retained for
+                    # backward compatibility with older clients.
+                    "completions": {},
                     "experimental": {
                         "progressNotifications": True,
                         "cancellation": True,
@@ -2202,7 +2348,70 @@ class MCPServer:
                     tool_desc["annotations"] = mcp_annotations
                 tools.append(tool_desc)
 
-        return {"jsonrpc": "2.0", "result": {"tools": tools}, "id": request_id}
+        page, next_cursor, error = self._paginate(
+            tools, params.get("cursor"), request_id
+        )
+        if error is not None:
+            return error
+        result: Dict[str, Any] = {"tools": page}
+        if next_cursor:
+            result["nextCursor"] = next_cursor
+        return {"jsonrpc": "2.0", "result": result, "id": request_id}
+
+    def _paginate(
+        self, all_items: List[Any], cursor: Any, request_id: Any
+    ) -> "tuple[Optional[List[Any]], Optional[str], Optional[Dict[str, Any]]]":
+        """Server-chosen opaque-cursor pagination (spec 2025-11-25).
+
+        Returns ``(page, next_cursor, error)``. ``error`` is a ``-32602``
+        JSON-RPC envelope when ``cursor`` is present but invalid/expired (clients
+        treat cursors as opaque); otherwise ``None`` and ``page`` carries this
+        page's items. The server picks the page size (``_DEFAULT_PAGE_SIZE``) —
+        a client does NOT need to send a ``limit`` to receive a ``nextCursor``.
+        """
+        start = 0
+        if cursor is not None:
+            # A cursor is an OPAQUE STRING (spec 2025-11-25). A non-string
+            # cursor (int, list, dict, ...) is a malformed param — return the
+            # -32602 envelope rather than letting an unhashable/typed value
+            # raise an unhandled TypeError deep in the cursor manager. Mirrors
+            # the invalid-string-cursor branch below.
+            if not isinstance(cursor, str):
+                return (
+                    None,
+                    None,
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32602,
+                            "message": "Invalid or expired cursor",
+                        },
+                        "id": request_id,
+                    },
+                )
+            if not self._cursor_manager.is_valid(cursor):
+                return (
+                    None,
+                    None,
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32602,
+                            "message": "Invalid or expired cursor",
+                        },
+                        "id": request_id,
+                    },
+                )
+            start = self._cursor_manager.get_cursor_position(cursor) or 0
+
+        end = start + _DEFAULT_PAGE_SIZE
+        page = all_items[start:end]
+        next_cursor = None
+        if end < len(all_items):
+            next_cursor = self._cursor_manager.create_cursor_for_position(
+                all_items, end
+            )
+        return page, next_cursor, None
 
     async def _handle_call_tool(
         self, params: Dict[str, Any], request_id: Any
@@ -2402,7 +2611,10 @@ class MCPServer:
         return {"jsonrpc": "2.0", "result": {"resources": resources}, "id": request_id}
 
     async def _handle_read_resource(
-        self, params: Dict[str, Any], request_id: Any, client_id: str = None  # type: ignore[reportArgumentType]
+        self,
+        params: Dict[str, Any],
+        request_id: Any,
+        client_id: str = None,  # type: ignore[reportArgumentType]
     ) -> Dict[str, Any]:
         """Handle resources/read request with change detection.
 
@@ -2469,8 +2681,11 @@ class MCPServer:
                 }
 
                 # Check for changes and notify subscribers
-                change = await self.subscription_manager.resource_monitor.check_for_changes(
-                    uri, resource_data  # type: ignore[reportArgumentType]
+                change = (
+                    await self.subscription_manager.resource_monitor.check_for_changes(
+                        uri,
+                        resource_data,  # type: ignore[reportArgumentType]
+                    )
                 )
 
                 if change:
@@ -2550,7 +2765,7 @@ class MCPServer:
     async def _handle_list_prompts(
         self, params: Dict[str, Any], request_id: Any
     ) -> Dict[str, Any]:
-        """Handle prompts/list request."""
+        """Handle prompts/list request with cursor-based pagination."""
         prompts = []
         for name, info in self._prompt_registry.items():
             prompts.append(
@@ -2561,7 +2776,48 @@ class MCPServer:
                 }
             )
 
-        return {"jsonrpc": "2.0", "result": {"prompts": prompts}, "id": request_id}
+        page, next_cursor, error = self._paginate(
+            prompts, params.get("cursor"), request_id
+        )
+        if error is not None:
+            return error
+        result: Dict[str, Any] = {"prompts": page}
+        if next_cursor:
+            result["nextCursor"] = next_cursor
+        return {"jsonrpc": "2.0", "result": result, "id": request_id}
+
+    async def _handle_list_resource_templates(
+        self, params: Dict[str, Any], request_id: Any
+    ) -> Dict[str, Any]:
+        """Handle resources/templates/list with cursor-based pagination.
+
+        A registered resource whose URI carries a ``{placeholder}`` is a
+        template (the shape ``_match_resource_template`` expands); it is
+        advertised here via its ``uriTemplate`` (spec 2025-11-25). Concrete
+        (placeholder-free) resources stay in resources/list. Pagination reuses
+        the shared opaque-cursor scheme — an invalid cursor -> ``-32602``.
+        """
+        templates = []
+        for uri, info in self._resource_registry.items():
+            if "{" in uri and "}" in uri:
+                templates.append(
+                    {
+                        "uriTemplate": uri,
+                        "name": info.get("name", uri),
+                        "description": info.get("description", ""),
+                        "mimeType": info.get("mime_type", "text/plain"),
+                    }
+                )
+
+        page, next_cursor, error = self._paginate(
+            templates, params.get("cursor"), request_id
+        )
+        if error is not None:
+            return error
+        result: Dict[str, Any] = {"resourceTemplates": page}
+        if next_cursor:
+            result["nextCursor"] = next_cursor
+        return {"jsonrpc": "2.0", "result": result, "id": request_id}
 
     async def _handle_get_prompt(
         self, params: Dict[str, Any], request_id: Any
@@ -2904,7 +3160,7 @@ class MCPServer:
         level = params.get("level", "INFO").upper()
 
         # Validate log level
-        valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        valid_levels = list(_MCP_LOG_LEVELS)
         if level not in valid_levels:
             return {
                 "jsonrpc": "2.0",
@@ -2915,7 +3171,17 @@ class MCPServer:
                 "id": request_id,
             }
 
-        # Set the log level
+        # Record the per-session minimum level so notifications/message emission
+        # is gated per client (spec 2025-11-25); a message below this level is
+        # suppressed for this client. Absent a real client_id, update the
+        # server-wide default.
+        client_id = params.get("client_id")
+        if client_id and client_id != "unknown":
+            self._client_log_levels[client_id] = level
+        else:
+            self._log_level_default = level
+
+        # Set the process log level too (existing behaviour).
         logging.getLogger().setLevel(getattr(logging, level))
         logger.info(f"Log level changed to {level}")
 
@@ -2939,6 +3205,65 @@ class MCPServer:
             "result": {"level": level, "levels": valid_levels},
             "id": request_id,
         }
+
+    async def send_log_message(
+        self,
+        level: str,
+        data: Any,
+        *,
+        logger_name: Optional[str] = None,
+        client_id: Optional[str] = None,
+    ) -> int:
+        """Emit an MCP ``notifications/message`` to connected clients.
+
+        The server-to-client logging path required by spec 2025-11-25:
+        ``logging/setLevel`` only sets a level; THIS is how the server actually
+        pushes a log record. Emission is GATED by the per-client minimum level
+        set via ``logging/setLevel`` (falling back to ``_log_level_default``) —
+        a message BELOW a client's level is suppressed for that client. The
+        ``data`` payload is scrubbed of secrets/PII (``_redact_log_data``,
+        security.md) before send.
+
+        Args:
+            level: severity (one of ``_MCP_LOG_LEVELS``); case-insensitive.
+            data: the log payload (dict/str/scalar); redacted before send.
+            logger_name: optional ``logger`` field on the notification.
+            client_id: when given, target ONLY that client (still level-gated);
+                otherwise every initialized client.
+
+        Returns:
+            The number of clients the notification was actually sent to.
+        """
+        norm = str(level).upper()
+        msg_rank = _MCP_LOG_LEVEL_RANK.get(norm)
+        if msg_rank is None:
+            raise ValueError(
+                f"Invalid log level: {level}. Must be one of {list(_MCP_LOG_LEVELS)}"
+            )
+
+        params: Dict[str, Any] = {"level": norm, "data": _redact_log_data(data)}
+        if logger_name is not None:
+            params["logger"] = logger_name
+        notification = {
+            "jsonrpc": "2.0",
+            "method": "notifications/message",
+            "params": params,
+        }
+
+        if client_id is not None:
+            targets = [client_id]
+        else:
+            targets = list(self.client_info.keys())
+
+        sent = 0
+        for target in targets:
+            effective = self._client_log_levels.get(target, self._log_level_default)
+            # Suppress messages below this client's configured minimum level.
+            if msg_rank < _MCP_LOG_LEVEL_RANK.get(effective, 0):
+                continue
+            await self._send_websocket_notification(target, notification)
+            sent += 1
+        return sent
 
     async def _handle_roots_list(
         self, params: Dict[str, Any], request_id: Any
@@ -2991,49 +3316,65 @@ class MCPServer:
         partial_value = argument.get("value", "")
 
         try:
-            values = []
+            # Collect (match_key, value) so candidates can be relevance-ranked
+            # BEFORE the 100-item cap, so the cap keeps the TOP matches rather
+            # than an arbitrary registry-order slice (spec 2025-11-25).
+            collected: List["tuple[str, Dict[str, Any]]"] = []
 
             if ref_type == "resource":
                 # Search through registered resources
                 for uri, resource_info in self._resource_registry.items():
-                    if partial_value in uri:  # Simple prefix/substring matching
-                        values.append(
-                            {
-                                "uri": uri,
-                                "name": resource_info.get("name", uri),
-                                "description": resource_info.get("description", ""),
-                            }
+                    if partial_value in uri:  # substring candidate
+                        collected.append(
+                            (
+                                uri,
+                                {
+                                    "uri": uri,
+                                    "name": resource_info.get("name", uri),
+                                    "description": resource_info.get("description", ""),
+                                },
+                            )
                         )
 
             elif ref_type == "prompt":
                 # Search through registered prompts
                 for name, prompt_info in self._prompt_registry.items():
-                    if partial_value in name:  # Simple prefix/substring matching
-                        values.append(
-                            {
-                                "name": name,
-                                "description": prompt_info.get("description", ""),
-                                "arguments": prompt_info.get("arguments", []),
-                            }
+                    if partial_value in name:  # substring candidate
+                        collected.append(
+                            (
+                                name,
+                                {
+                                    "name": name,
+                                    "description": prompt_info.get("description", ""),
+                                    "arguments": prompt_info.get("arguments", []),
+                                },
+                            )
                         )
 
             elif ref_type == "tool":
                 # Search through registered tools
                 for name, tool_info in self._tool_registry.items():
                     if partial_value in name:
-                        values.append(
-                            {
-                                "name": name,
-                                "description": tool_info.get("description", ""),
-                                "inputSchema": tool_info.get("inputSchema", {}),
-                            }
+                        collected.append(
+                            (
+                                name,
+                                {
+                                    "name": name,
+                                    "description": tool_info.get("description", ""),
+                                    "inputSchema": tool_info.get("inputSchema", {}),
+                                },
+                            )
                         )
 
+            # Relevance-rank: exact match first, then prefix, then substring
+            # (stable within a rank). Ranking precedes the cap so the top-100
+            # are the most relevant candidates, not a registry-order prefix.
+            collected.sort(key=lambda pair: _completion_rank(pair[0], partial_value))
+
             # Limit to 100 items and add hasMore flag if needed
-            total_matches = len(values)
+            total_matches = len(collected)
             has_more = total_matches > 100
-            if has_more:
-                values = values[:100]
+            values = [value for _, value in collected[:100]]
 
             result = {
                 "completion": {

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -15,6 +15,13 @@ Features:
 - Connection pooling and management
 - Health checking and monitoring
 
+.. note::
+    ``StreamableHTTPTransport`` in this module is a NON-SPEC legacy transport
+    (custom ``POST /session`` + ``X-Session-ID`` + ``GET /receive`` scheme) and
+    is deprecated. Spec-compliant MCP HTTP goes through the upstream-delegated
+    ``streamable_http_client`` used by ``kailash_mcp.client.MCPClient``
+    (``client.py``); see that class's ``__init__`` for details.
+
 Examples:
     Enhanced STDIO transport:
 
@@ -56,6 +63,7 @@ import socket
 import subprocess
 import time
 import uuid
+import warnings
 import weakref
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
@@ -683,7 +691,26 @@ class SSETransport(BaseTransport):
 
 
 class StreamableHTTPTransport(BaseTransport):
-    """StreamableHTTP transport with session management."""
+    """NON-SPEC legacy StreamableHTTP transport with a custom session scheme.
+
+    .. deprecated::
+        This transport does NOT implement the MCP 2025-11-25 Streamable HTTP
+        specification. It uses a custom, non-standard session scheme: a
+        separate ``POST /session`` handshake, the non-spec header name
+        ``X-Session-ID`` (the spec mandates ``MCP-Session-Id``), and a
+        ``GET /receive`` long-poll. No MCP-spec server implements this scheme,
+        so this transport interoperates only with a matching non-spec server.
+
+        The spec-compliant MCP HTTP client path is the upstream-delegated
+        ``streamable_http_client`` used by ``kailash_mcp.client.MCPClient``
+        (see ``MCPClient._discover_tools_http`` / ``MCPClient._call_tool_http``
+        in ``kailash_mcp/client.py``), which speaks the single-endpoint
+        Streamable HTTP transport with correct ``MCP-Session-Id`` and
+        ``MCP-Protocol-Version`` handling. Use that for any real MCP server.
+
+        This class is retained for backward compatibility with existing
+        non-spec consumers and emits a ``DeprecationWarning`` on instantiation.
+    """
 
     def __init__(
         self,
@@ -706,6 +733,16 @@ class StreamableHTTPTransport(BaseTransport):
             skip_security_validation: Skip all security validation (for testing)
             **kwargs: Base transport arguments
         """
+        warnings.warn(
+            "StreamableHTTPTransport is a NON-SPEC legacy transport using a "
+            "custom session scheme (POST /session, X-Session-ID header, "
+            "GET /receive) that no MCP 2025-11-25 server implements. For "
+            "spec-compliant MCP HTTP, use the upstream-delegated "
+            "streamable_http_client via kailash_mcp.client.MCPClient "
+            "(MCP-Session-Id + MCP-Protocol-Version handling).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__("streamable_http", **kwargs)
 
         self.base_url = base_url.rstrip("/")

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_audience_validation.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_audience_validation.py
@@ -128,56 +128,52 @@ def test_foreign_audience_token_rejected():
 
 
 # ---------------------------------------------------------------------------
-# (d) expected_audience unset: behaviour unchanged + warning emitted
+# (d) expected_audience unset: FAIL-CLOSED — construction refuses (F4)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.regression
-def test_audience_unset_preserves_existing_behaviour(caplog):
-    """With no expected_audience, an audience-ABSENT token is still accepted
-    (audience not validated — the pre-fix, non-fail-closed behaviour) and a
-    spec-compliance WARNING is emitted once at construction.
+def test_validate_jwt_without_audience_raises():
+    """A JWT-validating provider with NO expected_audience REFUSES construction.
 
-    An aud-absent token sailing through is exactly the gap the fix closes: the
-    MCP 2025-11-25 spec requires rejecting audience-absent tokens, which the
-    unconfigured path does not do. (PyJWT already rejects a present-but-
-    unexpected `aud` by default, so the residual gap is the absent-aud case.)
+    Enforcement-surface parity (rules/security.md § Enforcement-Surface Parity):
+    ``ResourceServer`` is audience fail-closed, so the ``BearerTokenAuth`` /
+    ``JWTAuth`` JWT path MUST be too. The pre-fix behaviour merely WARNED and
+    continued with audience validation DISABLED (fail-OPEN) — a token minted
+    for a different resource was accepted. The fix raises ``ValueError`` at
+    construction, mirroring the ``jwt_secret``-required guard, so there is no
+    fail-open default.
     """
-    with caplog.at_level(logging.WARNING, logger="kailash_mcp.auth.providers"):
-        auth = BearerTokenAuth(
+    with pytest.raises(ValueError) as excinfo:
+        BearerTokenAuth(
             validate_jwt=True,
             jwt_secret=SECRET,
             jwt_algorithm=ALGO,
-            # expected_audience deliberately omitted
+            # expected_audience deliberately omitted -> fail-closed refusal
         )
+    assert "expected_audience" in str(excinfo.value)
 
-    # The warning fired exactly once, at construction.
-    warnings = [
-        r
-        for r in caplog.records
-        if r.levelno == logging.WARNING and "expected_audience" in r.getMessage()
-    ]
-    assert len(warnings) == 1
 
-    # Behaviour is unchanged: an audience-absent token still authenticates
-    # because audience is not validated when unconfigured (the residual gap
-    # the warning flags and expected_audience closes).
-    token = _encode({"sub": "alice"})  # no aud claim
-    result = auth.authenticate(token)
-    assert result["user_id"] == "alice"
+@pytest.mark.regression
+def test_jwtauth_without_audience_raises():
+    """JWTAuth always validates JWTs, so an absent audience also refuses."""
+    with pytest.raises(ValueError) as excinfo:
+        JWTAuth(secret=SECRET)  # no audience
+    assert "expected_audience" in str(excinfo.value)
 
 
 @pytest.mark.regression
 def test_no_warning_when_audience_configured(caplog):
-    """No spec-compliance warning when expected_audience IS set."""
+    """With expected_audience set, construction SUCCEEDS and emits no warning."""
     with caplog.at_level(logging.WARNING, logger="kailash_mcp.auth.providers"):
-        BearerTokenAuth(
+        auth = BearerTokenAuth(
             validate_jwt=True,
             jwt_secret=SECRET,
             jwt_algorithm=ALGO,
             expected_audience=CANONICAL_AUDIENCE,
         )
 
+    assert auth.expected_audience == CANONICAL_AUDIENCE
     warnings = [
         r
         for r in caplog.records

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_cursor_bound.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_cursor_bound.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for #1712 - ``CursorManager`` unbounded-store DoS (L4).
+
+Wave 2 routed tools / prompts / resource-templates list pagination through the
+shared ``CursorManager._cursors`` store, widening a client's ability to mint
+cursors. The store was an unbounded ``dict`` with no size cap, so a client
+minting cursors across those list types could grow server memory without
+limit (a remote DoS).
+
+The fix bounds the store with FIFO eviction (``_MAX_CURSORS``), mirroring
+``MCPServer._MAX_SEEN_REQUEST_IDS``. These behavioral pins construct a real
+``CursorManager`` (no mocking, per ``rules/testing.md`` Tier 2), mint real
+cursors, and assert the store stays bounded AND that recent cursors still
+round-trip.
+"""
+
+import pytest
+
+from kailash_mcp.advanced.subscriptions import CursorManager
+
+
+@pytest.mark.regression
+def test_cursor_store_stays_bounded_on_overflow():
+    """Minting far more than the cap keeps the store at exactly the cap."""
+    cm = CursorManager()
+    cm._MAX_CURSORS = 5  # small cap so the test is fast and explicit
+
+    minted = [cm.generate_cursor() for _ in range(50)]
+
+    # The store never exceeds the cap despite 50 mints.
+    assert len(cm._cursors) == 5
+    # The 5 MOST-RECENT cursors survive; the rest were FIFO-evicted.
+    for cursor in minted[-5:]:
+        assert cm.is_valid(cursor) is True
+    for cursor in minted[:-5]:
+        assert cm.is_valid(cursor) is False
+
+
+@pytest.mark.regression
+def test_cursor_fifo_evicts_oldest_first():
+    """The OLDEST cursor is evicted first when the cap is exceeded."""
+    cm = CursorManager()
+    cm._MAX_CURSORS = 3
+
+    first = cm.generate_cursor()
+    second = cm.generate_cursor()
+    third = cm.generate_cursor()
+
+    # At the cap — all three still valid.
+    assert cm.is_valid(first) is True
+
+    # One more mint overflows: the oldest (`first`) is evicted, the rest stay.
+    fourth = cm.generate_cursor()
+    assert cm.is_valid(first) is False
+    assert cm.is_valid(second) is True
+    assert cm.is_valid(third) is True
+    assert cm.is_valid(fourth) is True
+    assert len(cm._cursors) == 3
+
+
+@pytest.mark.regression
+def test_recent_cursor_round_trips_under_bound():
+    """A valid recent position cursor still resolves after the store bounds.
+
+    Bounding the store MUST NOT break the common case: a cursor minted for a
+    list position still resolves to that position while it is recent.
+    """
+    cm = CursorManager()
+    cm._MAX_CURSORS = 4
+
+    items = ["a", "b", "c", "d", "e"]
+    cursor = cm.create_cursor_for_position(items, position=2)
+
+    # Mint more cursors (but stay at/under the cap window around this one).
+    for _ in range(2):
+        cm.generate_cursor()
+
+    # The position cursor is still recent, so it round-trips correctly.
+    assert cm.is_valid(cursor) is True
+    assert cm.get_cursor_position(cursor) == 2
+
+
+@pytest.mark.regression
+def test_default_cap_bounds_store():
+    """The default ``_MAX_CURSORS`` bounds the store without an override."""
+    cm = CursorManager()
+    cap = cm._MAX_CURSORS
+
+    for _ in range(cap + 100):
+        cm.generate_cursor()
+
+    assert len(cm._cursors) == cap

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_lifecycle_lists.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_lifecycle_lists.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 2 - server lifecycle & list capabilities
+(MCP revision 2025-11-25).
+
+Behavioral pins (call the real handler on a real ``MCPServer``, assert the
+returned envelope - never source-grep, per ``rules/testing.md``) for the four
+server-side gaps:
+
+* **B1** protocolVersion negotiation reaches ``2025-11-25`` (newest supported).
+* **D1** opaque-cursor pagination (nextCursor round-trip + ``-32602`` on a bad
+  cursor) on tools/list AND prompts/list AND the new resources/templates/list;
+  the server chooses the page size (no client ``limit`` needed to page).
+* **D2** completion/complete ranks candidates (exact > prefix > substring)
+  BEFORE the 100-item cap; the ``completions`` capability is advertised
+  top-level.
+* **D3** notifications/message is EMITTED, gated by the per-client level set via
+  logging/setLevel (below-level suppressed), with secrets/PII redacted.
+"""
+
+import pytest
+
+from kailash_mcp.server import (
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    MCPServer,
+    negotiate_protocol_version,
+)
+
+_PAGE = 100  # server-chosen page size (_DEFAULT_PAGE_SIZE)
+
+
+def _make_server() -> MCPServer:
+    """A minimal MCPServer with no cache/metrics/auth for handler pins."""
+    return MCPServer(
+        "lifecycle-lists-test",
+        enable_cache=False,
+        enable_metrics=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# B1 - protocolVersion reaches 2025-11-25
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_2025_11_25_is_newest_supported():
+    """2025-11-25 is in the supported set AND is the newest (latest)."""
+    assert "2025-11-25" in SUPPORTED_PROTOCOL_VERSIONS
+    assert LATEST_PROTOCOL_VERSION == "2025-11-25"
+    assert SUPPORTED_PROTOCOL_VERSIONS[0] == "2025-11-25"
+
+
+@pytest.mark.regression
+def test_negotiate_echoes_2025_11_25():
+    """A client requesting 2025-11-25 gets it echoed back verbatim."""
+    assert negotiate_protocol_version("2025-11-25") == "2025-11-25"
+
+
+@pytest.mark.regression
+def test_negotiate_unknown_yields_2025_11_25():
+    """An unsupported/absent version negotiates DOWN to the newest (2025-11-25)."""
+    assert negotiate_protocol_version("1999-01-01") == "2025-11-25"
+    assert negotiate_protocol_version(None) == "2025-11-25"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_initialize_advertises_2025_11_25_and_new_capabilities():
+    """initialize echoes 2025-11-25 + advertises completions + resourceTemplates."""
+    server = _make_server()
+    resp = await server._handle_initialize(
+        {"protocolVersion": "2025-11-25"}, request_id=1, client_id="c1"
+    )
+    result = resp["result"]
+    assert result["protocolVersion"] == "2025-11-25"
+    caps = result["capabilities"]
+    # D2 - top-level completions capability (spec 2025-11-25).
+    assert "completions" in caps
+    # experimental.completion alias retained for backward-compat.
+    assert caps["experimental"]["completion"] is True
+    # D1 - resource templates advertised under resources.
+    assert caps["resources"]["resourceTemplates"] == {"listSupported": True}
+
+
+# ---------------------------------------------------------------------------
+# D1 - opaque-cursor pagination across the list surfaces
+# ---------------------------------------------------------------------------
+
+
+async def _first_and_second_page(server, method, list_key):
+    """Drive one list handler through page 1 + page 2 via its nextCursor."""
+    handler = getattr(server, method)
+    page1 = (await handler({}, request_id=1))["result"]
+    assert len(page1[list_key]) == _PAGE
+    assert "nextCursor" in page1, "server must emit a cursor without a client limit"
+
+    page2 = (await handler({"cursor": page1["nextCursor"]}, request_id=2))["result"]
+    return page1, page2
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_tools_list_cursor_round_trips_and_rejects_bad_cursor():
+    """tools/list pages via nextCursor; a bad cursor -> -32602."""
+    server = _make_server()
+    for i in range(150):
+        server._tool_registry[f"tool{i:03d}"] = {
+            "description": "",
+            "input_schema": {},
+        }
+
+    page1, page2 = await _first_and_second_page(server, "_handle_list_tools", "tools")
+    assert len(page2["tools"]) == 50
+    assert "nextCursor" not in page2  # 150 total, second page exhausts it
+
+    # No duplicates across pages (real position advance, not a repeat).
+    names = {t["name"] for t in page1["tools"]} | {t["name"] for t in page2["tools"]}
+    assert len(names) == 150
+
+    bad = await server._handle_list_tools({"cursor": "not-a-real-cursor"}, request_id=3)
+    assert "result" not in bad
+    assert bad["error"]["code"] == -32602
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_prompts_list_cursor_round_trips_and_rejects_bad_cursor():
+    """prompts/list pages via nextCursor; a bad cursor -> -32602."""
+    server = _make_server()
+    for i in range(150):
+        server._prompt_registry[f"prompt{i:03d}"] = {
+            "description": "",
+            "arguments": [],
+        }
+
+    _, page2 = await _first_and_second_page(server, "_handle_list_prompts", "prompts")
+    assert len(page2["prompts"]) == 50
+
+    bad = await server._handle_list_prompts({"cursor": "bogus"}, request_id=3)
+    assert "result" not in bad
+    assert bad["error"]["code"] == -32602
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_resource_templates_list_cursor_round_trips_and_rejects_bad_cursor():
+    """resources/templates/list lists template-URIs, pages, and rejects a bad cursor."""
+    server = _make_server()
+    # 150 templates (URI carries a {placeholder}) + one concrete resource.
+    for i in range(150):
+        server._resource_registry[f"res://item/{{id{i:03d}}}"] = {
+            "name": f"item{i:03d}",
+            "description": "",
+            "mime_type": "application/json",
+        }
+    server._resource_registry["res://static/readme"] = {
+        "name": "readme",
+        "description": "",
+        "mime_type": "text/plain",
+    }
+
+    page1 = (await server._handle_list_resource_templates({}, request_id=1))["result"]
+    assert len(page1["resourceTemplates"]) == _PAGE
+    # concrete (placeholder-free) resource is NOT a template.
+    assert all("{" in tpl["uriTemplate"] for tpl in page1["resourceTemplates"])
+    assert page1["resourceTemplates"][0]["uriTemplate"].startswith("res://item/")
+    assert "nextCursor" in page1
+
+    page2 = (
+        await server._handle_list_resource_templates(
+            {"cursor": page1["nextCursor"]}, request_id=2
+        )
+    )["result"]
+    assert len(page2["resourceTemplates"]) == 50  # 150 templates, static excluded
+    assert "nextCursor" not in page2
+
+    bad = await server._handle_list_resource_templates({"cursor": "nope"}, request_id=3)
+    assert "result" not in bad
+    assert bad["error"]["code"] == -32602
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_resource_templates_dispatch_branch_wired():
+    """resources/templates/list is routed by the live WS dispatcher."""
+    server = _make_server()
+    server._resource_registry["res://doc/{name}"] = {
+        "name": "doc",
+        "description": "",
+        "mime_type": "text/plain",
+    }
+    resp = await server._dispatch_ws_method(
+        "resources/templates/list", {}, request_id=1, client_id="c1"
+    )
+    assert resp["result"]["resourceTemplates"][0]["uriTemplate"] == "res://doc/{name}"
+
+
+# ---------------------------------------------------------------------------
+# D2 - completion ranking (exact > prefix > substring) before the cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_completion_ranks_exact_prefix_substring():
+    """completion/complete orders exact, then prefix, then substring matches."""
+    server = _make_server()
+    # Insert in a deliberately NON-ranked order to prove sorting happens.
+    for name in ("barfoo", "foobar", "foo"):
+        server._tool_registry[name] = {"description": "", "inputSchema": {}}
+
+    resp = await server._handle_completion_complete(
+        {"ref": {"type": "tool"}, "argument": {"value": "foo"}}, request_id=1
+    )
+    values = resp["result"]["completion"]["values"]
+    names = [v["name"] for v in values]
+    assert names == ["foo", "foobar", "barfoo"], names
+    assert resp["result"]["completion"]["total"] == 3
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_completion_cap_keeps_top_ranked():
+    """The 100-item cap keeps the TOP-ranked candidates, not a registry slice."""
+    server = _make_server()
+    # 120 substring-only matches + 1 exact. The exact MUST survive the cap.
+    for i in range(120):
+        server._tool_registry[f"zzz-match{i:03d}"] = {
+            "description": "",
+            "inputSchema": {},
+        }
+    server._tool_registry["match"] = {"description": "", "inputSchema": {}}
+
+    resp = await server._handle_completion_complete(
+        {"ref": {"type": "tool"}, "argument": {"value": "match"}}, request_id=1
+    )
+    completion = resp["result"]["completion"]
+    assert completion["total"] == 121
+    assert completion["hasMore"] is True
+    assert len(completion["values"]) == 100
+    # The exact match ranked first -> it is in the retained top-100.
+    assert completion["values"][0]["name"] == "match"
+
+
+# ---------------------------------------------------------------------------
+# D3 - notifications/message emission, level-gated, redacted
+# ---------------------------------------------------------------------------
+
+
+class _CaptureTransport:
+    """Minimal WS transport double that records every notification sent."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, message, client_id=None):
+        self.sent.append((client_id, message))
+
+
+def _server_with_client(level="WARNING"):
+    """A server with one initialized client at a given minimum log level."""
+    server = _make_server()
+    server._transport = _CaptureTransport()
+    server.client_info["c1"] = {"capabilities": {}, "name": "c", "version": "1"}
+    server._client_log_levels["c1"] = level
+    return server
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_setlevel_records_per_client_level():
+    """logging/setLevel records the per-client minimum level for gating."""
+    server = _make_server()
+    resp = await server._handle_logging_set_level(
+        {"level": "error", "client_id": "c1"}, request_id=1
+    )
+    assert resp["result"]["level"] == "ERROR"
+    assert server._client_log_levels["c1"] == "ERROR"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_message_at_or_above_level_is_emitted_and_redacted():
+    """An at/above-level notifications/message is sent with data redacted."""
+    server = _server_with_client(level="WARNING")
+
+    sent = await server.send_log_message(
+        "ERROR",
+        {"api_key": "sk-secret0123456789ab", "note": "email a@b.com"},
+        logger_name="db",
+    )
+    assert sent == 1
+    client_id, message = server._transport.sent[0]
+    assert client_id == "c1"
+    assert message["method"] == "notifications/message"
+    assert message["params"]["level"] == "ERROR"
+    assert message["params"]["logger"] == "db"
+    # Secret KEY redacted; PII scrubbed from the string value.
+    assert message["params"]["data"]["api_key"] == "[REDACTED]"
+    assert "a@b.com" not in message["params"]["data"]["note"]
+    assert "[REDACTED]" in message["params"]["data"]["note"]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_message_below_level_is_suppressed():
+    """A below-level notifications/message is suppressed (not sent)."""
+    server = _server_with_client(level="WARNING")
+
+    sent = await server.send_log_message("INFO", {"note": "chatty"})
+    assert sent == 0
+    assert server._transport.sent == []
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_message_invalid_level_raises():
+    """An unknown severity is a typed error, not a silent drop."""
+    server = _server_with_client()
+    with pytest.raises(ValueError):
+        await server.send_log_message("LOUD", {"note": "x"})

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_hardening.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_hardening.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 2 security hardening (F2 + F5).
+
+Behavioral pins — construct the REAL SDK objects, call the real methods, assert
+the real fail-loud / fail-closed behavior (no mocking of the SDK under test, per
+``rules/testing.md`` Tier 2).
+
+**F2 (MED) — PRM URL malformed on the module's documented default config.**
+``ResourceServer(issuer=..., audience="mcp-api")`` (the documented example, no
+``resource``) set ``self.resource == "mcp-api"`` — a bare token. RFC 9728 §3.1
+PRM URL derivation from a non-URL identifier produced a corrupt
+``:///.well-known/oauth-protected-resource...`` string (served PRM doc, mountable
+route path, AND the ``WWW-Authenticate`` ``resource_metadata`` param all broken),
+so a spec RFC 9728 client could not bootstrap. Fix: ``ResourceServer.__init__``
+now REQUIRES the effective ``resource`` to be an absolute http(s) URL and raises
+``ValueError`` otherwise; ``well_known`` PRM helpers reject a non-URL resource
+too (defense in depth). ``resource`` and ``audience`` remain INDEPENDENT — a
+URL ``resource`` with a bare-token ``audience`` stays valid.
+
+**F5 (MED) — S256-only advertised but not enforced at the Authorization Server.**
+``get_well_known_metadata`` advertised only ``["S256"]`` while
+``create_authorization_url`` / ``generate_authorization_code`` still accepted
+``code_challenge_method == "plain"`` and ``AuthorizationCode.validate_pkce``
+still validated a ``plain`` challenge — a PKCE downgrade the metadata claims is
+unsupported (enforcement-surface parity failure). Fix: the AS enforcement
+surfaces reject any non-S256 method fail-closed; the ``plain`` validation branch
+is dropped so a ``plain`` challenge can never validate. S256 stays fully working.
+"""
+
+import asyncio
+import base64
+import hashlib
+import secrets
+
+import pytest
+
+from kailash_mcp.auth.oauth import (
+    AuthorizationCode,
+    AuthorizationServer,
+    JWTManager,
+    ResourceServer,
+    parse_www_authenticate,
+)
+from kailash_mcp.auth.well_known import (
+    protected_resource_metadata_path,
+    protected_resource_metadata_url,
+)
+from kailash_mcp.errors import AuthorizationError
+
+_ISSUER = "https://as.example.com"
+_WELL_KNOWN_SUFFIX = "/.well-known/oauth-protected-resource"
+
+
+# ---------------------------------------------------------------------------
+# F2 — resource identifier must be an absolute http(s) URL for PRM derivation
+# ---------------------------------------------------------------------------
+
+
+def test_resource_server_bare_audience_no_resource_raises():
+    """The documented default ``ResourceServer(audience="mcp-api")`` (no URL
+    resource) must fail loud rather than emit a corrupt PRM URL."""
+    with pytest.raises(ValueError) as exc_info:
+        ResourceServer(
+            issuer=_ISSUER,
+            audience="mcp-api",
+            jwt_manager=JWTManager(issuer=_ISSUER),
+        )
+    msg = str(exc_info.value)
+    assert "mcp-api" in msg
+    assert "absolute" in msg and "http(s)" in msg
+    assert 'resource="https://' in msg  # actionable instruction to the caller
+
+
+@pytest.mark.parametrize("bad_resource", ["mcp-api", "not a url", "ftp://x/y", ""])
+def test_resource_server_non_url_resource_raises(bad_resource):
+    """Any non-absolute-http(s) ``resource`` is rejected regardless of ``audience``."""
+    with pytest.raises(ValueError):
+        ResourceServer(
+            issuer=_ISSUER,
+            audience="mcp-api",
+            resource=bad_resource,
+            jwt_manager=JWTManager(issuer=_ISSUER),
+        )
+
+
+def test_resource_server_url_resource_bare_audience_is_valid():
+    """A URL-shaped ``resource`` with a bare-token ``audience`` stays valid:
+    the PRM URL derives from ``resource``; the audience check uses ``audience``.
+    ``resource`` and ``audience`` remain independent params."""
+    rs = ResourceServer(
+        issuer=_ISSUER,
+        audience="mcp-api",  # bare token — used for the RFC 8707 aud check
+        resource="https://mcp.example.com/mcp",  # URL — used for PRM derivation
+        jwt_manager=JWTManager(issuer=_ISSUER),
+        required_scopes=["mcp:read"],
+    )
+    # audience and resource stay independent
+    assert rs.audience == "mcp-api"
+    assert rs.resource == "https://mcp.example.com/mcp"
+
+    # PRM URL is well-formed
+    url = rs.resource_metadata_url
+    assert url.startswith("https://")
+    assert _WELL_KNOWN_SUFFIX in url
+    assert url == "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+
+    # PRM document carries the URL resource identifier
+    doc = rs.get_protected_resource_metadata()
+    assert doc["resource"] == "https://mcp.example.com/mcp"
+
+    # the 401 challenge resource_metadata is a valid https URL
+    challenge = rs.www_authenticate_challenge(error="invalid_token")
+    params = parse_www_authenticate(challenge)
+    assert params["resource_metadata"].startswith("https://")
+    assert _WELL_KNOWN_SUFFIX in params["resource_metadata"]
+    assert params["resource_metadata"] == url
+
+
+def test_well_known_helpers_reject_non_url_resource():
+    """Defense in depth: the pure PRM builders reject a non-URL resource too,
+    with the correct ``/`` separator preserved for a valid URL."""
+    with pytest.raises(ValueError):
+        protected_resource_metadata_url("mcp-api")
+    with pytest.raises(ValueError):
+        protected_resource_metadata_path("mcp-api")
+
+    # valid URL → correct separator, no missing '/'
+    assert (
+        protected_resource_metadata_path("https://mcp.example.com/mcp")
+        == "/.well-known/oauth-protected-resource/mcp"
+    )
+    # origin-root → bare well-known path
+    assert (
+        protected_resource_metadata_path("https://mcp.example.com")
+        == "/.well-known/oauth-protected-resource"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F5 — S256-only enforced at every Authorization Server surface (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def _registered_client(server: AuthorizationServer, redirect_uri: str):
+    """Register a public client (no secret) able to run the auth-code flow."""
+    return asyncio.run(
+        server.register_client(
+            client_name="test-client",
+            redirect_uris=[redirect_uri],
+            grant_types=["authorization_code"],
+            scopes=["mcp.tools"],
+            client_type="public",
+        )
+    )
+
+
+def _s256_pair():
+    verifier = secrets.token_urlsafe(64)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+def test_create_authorization_url_rejects_plain():
+    server = AuthorizationServer(issuer=_ISSUER)
+    redirect_uri = "https://client.example.com/cb"
+    client = _registered_client(server, redirect_uri)
+    with pytest.raises(AuthorizationError) as exc_info:
+        asyncio.run(
+            server.create_authorization_url(
+                client_id=client.client_id,
+                redirect_uri=redirect_uri,
+                code_challenge="whatever",
+                code_challenge_method="plain",
+            )
+        )
+    assert "S256" in str(exc_info.value)
+    assert "plain" in str(exc_info.value)
+
+
+def test_generate_authorization_code_rejects_plain():
+    server = AuthorizationServer(issuer=_ISSUER)
+    redirect_uri = "https://client.example.com/cb"
+    client = _registered_client(server, redirect_uri)
+    with pytest.raises(AuthorizationError) as exc_info:
+        asyncio.run(
+            server.generate_authorization_code(
+                client_id=client.client_id,
+                user_id="user-1",
+                redirect_uri=redirect_uri,
+                code_challenge="whatever",
+                code_challenge_method="plain",
+            )
+        )
+    assert "S256" in str(exc_info.value)
+
+
+def test_validate_pkce_plain_challenge_never_validates():
+    """A stored ``plain`` challenge can never validate (fail-closed), even when
+    the verifier equals the challenge (the old ``plain`` semantics)."""
+    code = AuthorizationCode(
+        code="c",
+        client_id="client",
+        redirect_uri="https://client.example.com/cb",
+        code_challenge="literal-secret",
+        code_challenge_method="plain",
+    )
+    assert code.validate_pkce("literal-secret") is False
+    assert code.validate_pkce("anything") is False
+
+
+def test_s256_flow_succeeds_end_to_end():
+    """S256 stays fully working: issue an S256 code, exchange it with the
+    matching verifier, receive a token."""
+    server = AuthorizationServer(issuer=_ISSUER)
+    redirect_uri = "https://client.example.com/cb"
+    client = _registered_client(server, redirect_uri)
+    verifier, challenge = _s256_pair()
+
+    code = asyncio.run(
+        server.generate_authorization_code(
+            client_id=client.client_id,
+            user_id="user-1",
+            redirect_uri=redirect_uri,
+            scopes=["mcp.tools"],
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
+    )
+    assert isinstance(code, str) and code
+
+    tokens = asyncio.run(
+        server.exchange_authorization_code(
+            client_id=client.client_id,
+            client_secret=None,  # public client
+            code=code,
+            redirect_uri=redirect_uri,
+            code_verifier=verifier,
+        )
+    )
+    assert tokens["access_token"]
+    assert tokens["token_type"] == "Bearer"
+
+
+def test_s256_flow_rejects_wrong_verifier():
+    """S256 still rejects a mismatched verifier (fail-closed unchanged)."""
+    server = AuthorizationServer(issuer=_ISSUER)
+    redirect_uri = "https://client.example.com/cb"
+    client = _registered_client(server, redirect_uri)
+    _, challenge = _s256_pair()
+
+    code = asyncio.run(
+        server.generate_authorization_code(
+            client_id=client.client_id,
+            user_id="user-1",
+            redirect_uri=redirect_uri,
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
+    )
+    with pytest.raises(AuthorizationError):
+        asyncio.run(
+            server.exchange_authorization_code(
+                client_id=client.client_id,
+                client_secret=None,
+                code=code,
+                redirect_uri=redirect_uri,
+                code_verifier="the-wrong-verifier",
+            )
+        )

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_server_prm.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_server_prm.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 - server-publish half of the OAuth 2.1 surface.
+
+Behavioral pins (construct the REAL objects, call the method, drive the REAL
+ASGI route - never source-grep, never mock the SDK under test, per
+``rules/testing.md`` Tier 2) for the SERVER-PUBLISH shard of the MCP 2025-11-25
+spec-parity work. The CLIENT-side discovery chain is pinned separately in
+``test_issue_1712_oauth_discovery.py``; this file pins the server half those
+clients discover:
+
+1. **PRM document (RFC 9728 §2)** - ``ResourceServer.get_protected_resource_metadata``
+   returns ``{resource, authorization_servers, scopes_supported,
+   bearer_methods_supported}`` drawn from config.
+2. **Live-transport route (RFC 9728 §3)** - the metadata is served at
+   ``GET /.well-known/oauth-protected-resource`` on BOTH the Starlette route
+   surface (real ``TestClient``) AND the pure-ASGI app (real scope/receive/send
+   harness).
+3. **401 challenge (RFC 9110 §11.6.1 / RFC 9728 §5.1)** - the auth-failure path
+   emits ``WWW-Authenticate: Bearer resource_metadata="<prm-url>", scope="..."``,
+   and the header round-trips through ``parse_www_authenticate``.
+4. **Audience fail-closed (RFC 8707 / rules/security.md)** - an audience-absent
+   token AND a foreign-audience token are both rejected, each carrying the 401
+   challenge.
+5. **PKCE S256-only posture** - ``AuthorizationServer.get_well_known_metadata``
+   advertises ``code_challenge_methods_supported == ["S256"]`` with ``"plain"``
+   absent.
+
+No SDK object is mocked. The route double is a REAL Starlette app driven by the
+real ``starlette.testclient.TestClient`` and, separately, the pure-ASGI app
+driven directly through the ASGI protocol.
+"""
+
+import asyncio
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from kailash_mcp.auth.oauth import (
+    AuthorizationServer,
+    JWTManager,
+    ResourceServer,
+    parse_www_authenticate,
+)
+from kailash_mcp.auth.well_known import (
+    build_well_known_routes,
+    build_www_authenticate_challenge,
+    create_protected_resource_metadata_app,
+    protected_resource_metadata_url,
+)
+from kailash_mcp.errors import AuthenticationError, AuthorizationError
+
+_ISSUER = "https://as.example.com"
+_RESOURCE = "https://mcp.example.com"  # origin-root → bare well-known path
+_SCOPES = ["mcp:read", "mcp:write"]
+
+
+def _resource_server(**overrides) -> ResourceServer:
+    """Construct a real ResourceServer with a real RS256 JWTManager."""
+    kwargs = dict(
+        issuer=_ISSUER,
+        audience=_RESOURCE,
+        jwt_manager=JWTManager(issuer=_ISSUER),
+        required_scopes=list(_SCOPES),
+    )
+    kwargs.update(overrides)
+    return ResourceServer(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. PRM document shape
+# ---------------------------------------------------------------------------
+
+
+def test_protected_resource_metadata_document_shape():
+    rs = _resource_server()
+    doc = rs.get_protected_resource_metadata()
+
+    assert doc == {
+        "resource": _RESOURCE,
+        "authorization_servers": [_ISSUER],
+        "scopes_supported": _SCOPES,
+        "bearer_methods_supported": ["header"],
+    }
+    # Every RFC 9728 §2 required field present.
+    assert set(doc) == {
+        "resource",
+        "authorization_servers",
+        "scopes_supported",
+        "bearer_methods_supported",
+    }
+
+
+def test_prm_document_honours_explicit_config():
+    rs = _resource_server(
+        resource="https://api.example.com/mcp",
+        authorization_servers=["https://as1.example.com", "https://as2.example.com"],
+        bearer_methods_supported=["header", "body"],
+    )
+    doc = rs.get_protected_resource_metadata()
+    assert doc["resource"] == "https://api.example.com/mcp"
+    assert doc["authorization_servers"] == [
+        "https://as1.example.com",
+        "https://as2.example.com",
+    ]
+    assert doc["bearer_methods_supported"] == ["header", "body"]
+
+
+def test_prm_returns_fresh_lists_not_shared_mutable_state():
+    rs = _resource_server()
+    doc = rs.get_protected_resource_metadata()
+    doc["scopes_supported"].append("mcp:admin")
+    # Mutating the returned doc MUST NOT corrupt server config.
+    assert rs.required_scopes == _SCOPES
+
+
+# ---------------------------------------------------------------------------
+# 2. Live-transport route registration
+# ---------------------------------------------------------------------------
+
+
+def test_starlette_route_serves_prm_at_wellknown_path():
+    rs = _resource_server()
+    app = Starlette(routes=build_well_known_routes(rs))
+    client = TestClient(app)
+
+    resp = client.get("/.well-known/oauth-protected-resource")
+    assert resp.status_code == 200
+    assert resp.json() == rs.get_protected_resource_metadata()
+    assert resp.headers["content-type"].startswith("application/json")
+
+
+def test_starlette_route_path_tracks_resource_path_component():
+    # A path-bearing resource serves PRM at the path-suffixed well-known URL,
+    # byte-identical to the client's derivation.
+    rs = _resource_server(resource="https://mcp.example.com/mcp")
+    app = Starlette(routes=build_well_known_routes(rs))
+    client = TestClient(app)
+
+    resp = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert resp.status_code == 200
+    assert resp.json()["resource"] == "https://mcp.example.com/mcp"
+    # And the client-side URL helper agrees on the served path.
+    assert protected_resource_metadata_url("https://mcp.example.com/mcp") == (
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+    )
+
+
+def test_pure_asgi_app_serves_prm_document():
+    rs = _resource_server()
+    app = create_protected_resource_metadata_app(rs)
+
+    status, headers, body = _drive_asgi(
+        app, method="GET", path="/.well-known/oauth-protected-resource"
+    )
+    assert status == 200
+    assert dict(headers)[b"content-type"] == b"application/json"
+    import json
+
+    assert json.loads(body) == rs.get_protected_resource_metadata()
+
+
+def test_pure_asgi_app_404_for_other_paths():
+    rs = _resource_server()
+    app = create_protected_resource_metadata_app(rs)
+    status, _headers, _body = _drive_asgi(app, method="GET", path="/somewhere-else")
+    assert status == 404
+
+
+# ---------------------------------------------------------------------------
+# 3. WWW-Authenticate 401 challenge
+# ---------------------------------------------------------------------------
+
+
+def test_unauthorized_response_header_string():
+    rs = _resource_server()
+    resp = rs.unauthorized_response()
+
+    prm_url = protected_resource_metadata_url(_RESOURCE)
+    expected = (
+        f'Bearer resource_metadata="{prm_url}", '
+        f'error="invalid_token", scope="mcp:read mcp:write"'
+    )
+    assert resp["status"] == 401
+    assert resp["headers"]["WWW-Authenticate"] == expected
+    assert resp["body"]["error"] == "invalid_token"
+
+
+def test_challenge_roundtrips_through_parser():
+    # The server-built challenge MUST be parseable by the client-side parser -
+    # the two are inverse operations sharing one param shape.
+    rs = _resource_server()
+    header = rs.www_authenticate_challenge(error="invalid_token")
+    params = parse_www_authenticate(header)
+
+    assert params["resource_metadata"] == protected_resource_metadata_url(_RESOURCE)
+    assert params["scope"] == "mcp:read mcp:write"
+    assert params["error"] == "invalid_token"
+
+
+def test_challenge_builder_rejects_quote_injection():
+    with pytest.raises(ValueError, match="double quote"):
+        build_www_authenticate_challenge(
+            resource_metadata_url='https://x/"><script>', scope="s"
+        )
+
+
+def test_missing_token_raises_with_challenge():
+    rs = _resource_server()
+    with pytest.raises(AuthenticationError) as exc_info:
+        asyncio.run(rs.authenticate({"other": "no-token-key"}))
+    challenge = getattr(exc_info.value, "www_authenticate", None)
+    assert challenge is not None
+    assert parse_www_authenticate(challenge)["error"] == "invalid_request"
+
+
+# ---------------------------------------------------------------------------
+# 4. Audience fail-closed - both audience-absent AND foreign-audience rejected
+# ---------------------------------------------------------------------------
+
+
+def test_audience_absent_token_rejected_fail_closed():
+    jwt_manager = JWTManager(issuer=_ISSUER)
+    rs = _resource_server(jwt_manager=jwt_manager)
+    # Token minted with NO audience claim.
+    token = jwt_manager.create_access_token(
+        subject="user-1", scope="mcp:read mcp:write"
+    ).token
+
+    with pytest.raises(AuthorizationError) as exc_info:
+        asyncio.run(rs.authenticate(token))
+    challenge = getattr(exc_info.value, "www_authenticate", None)
+    assert challenge is not None
+    assert parse_www_authenticate(challenge)["error"] == "invalid_token"
+
+
+def test_foreign_audience_token_rejected_fail_closed():
+    jwt_manager = JWTManager(issuer=_ISSUER)
+    rs = _resource_server(jwt_manager=jwt_manager)
+    # Token minted for a DIFFERENT resource server.
+    token = jwt_manager.create_access_token(
+        subject="user-1",
+        scope="mcp:read mcp:write",
+        audience=["https://other-resource.example.com"],
+    ).token
+
+    with pytest.raises(AuthorizationError):
+        asyncio.run(rs.authenticate(token))
+
+
+def test_valid_audience_and_scope_authenticates():
+    jwt_manager = JWTManager(issuer=_ISSUER)
+    rs = _resource_server(jwt_manager=jwt_manager)
+    token = jwt_manager.create_access_token(
+        subject="user-1",
+        client_id="client-1",
+        scope="mcp:read mcp:write",
+        audience=[_RESOURCE],
+    ).token
+
+    result = asyncio.run(rs.authenticate(token))
+    assert result["subject"] == "user-1"
+    assert result["scopes"] == ["mcp:read", "mcp:write"]
+
+
+def test_insufficient_scope_carries_scope_param():
+    jwt_manager = JWTManager(issuer=_ISSUER)
+    rs = _resource_server(jwt_manager=jwt_manager)
+    # Valid audience, but missing mcp:write.
+    token = jwt_manager.create_access_token(
+        subject="user-1", scope="mcp:read", audience=[_RESOURCE]
+    ).token
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        asyncio.run(rs.authenticate(token))
+    params = parse_www_authenticate(exc_info.value.www_authenticate)
+    assert params["error"] == "insufficient_scope"
+    assert params["scope"] == "mcp:write"
+
+
+# ---------------------------------------------------------------------------
+# 5. PKCE S256-only posture
+# ---------------------------------------------------------------------------
+
+
+def test_authorization_server_metadata_advertises_s256_only():
+    server = AuthorizationServer(issuer=_ISSUER)
+    metadata = server.get_well_known_metadata()
+
+    assert metadata["code_challenge_methods_supported"] == ["S256"]
+    assert "plain" not in metadata["code_challenge_methods_supported"]
+
+
+# ---------------------------------------------------------------------------
+# ASGI test harness (real ASGI protocol, no mocking)
+# ---------------------------------------------------------------------------
+
+
+def _drive_asgi(app, *, method: str, path: str):
+    """Drive a pure-ASGI app through one request; return (status, headers, body)."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+    }
+    messages = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    body = b"".join(
+        m.get("body", b"") for m in messages if m["type"] == "http.response.body"
+    )
+    return start["status"], start["headers"], body

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sse_retry.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sse_retry.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for #1712 - SSE ``retry:`` reconnection field.
+
+The native ``SseTransport`` (``kailash.channels.mcp.sse``) previously
+discarded the SSE ``retry:`` field ("Any other field (event:, id:, retry:)
+is ignored"). MCP requires clients to respect the SSE ``retry:``
+reconnection time. These behavioral pins (call the parser / feed the stream,
+assert the captured value - never source-grep, per ``rules/testing.md``)
+verify the field is now parsed and captured.
+
+Real parsing only - no mocking. The transport's event reader is driven with
+a real async iterator of real ``bytes`` SSE lines (real input to real
+parsing code), and the pure field parser is called directly.
+"""
+
+import pytest
+
+from kailash.channels.mcp.sse import (
+    MAX_RECONNECT_MS,
+    SseTransport,
+    _parse_sse_retry_field,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure field parser - captures ASCII-digit milliseconds, rejects the rest
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_field_captures_millisecond_value():
+    """A well-formed ``retry:`` value is parsed to an int (milliseconds)."""
+    # The value passed to the parser is the text AFTER "retry:", exactly as
+    # the transport slices it. A single leading space is stripped.
+    assert _parse_sse_retry_field(" 5000") == 5000
+    assert _parse_sse_retry_field("2500") == 2500
+    assert _parse_sse_retry_field("0") == 0
+
+
+def test_parse_retry_field_rejects_non_digit_values():
+    """Per the SSE spec, non-ASCII-digit values cause the field to be ignored."""
+    assert _parse_sse_retry_field("") is None
+    assert _parse_sse_retry_field("   ") is None
+    assert _parse_sse_retry_field("5000ms") is None
+    assert _parse_sse_retry_field("abc") is None
+    assert _parse_sse_retry_field("-1") is None
+    assert _parse_sse_retry_field("1.5") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Transport captures the retry field off a real SSE line stream
+# ---------------------------------------------------------------------------
+
+
+async def _byte_lines(*lines: str):
+    """A real async iterator yielding real ``bytes`` SSE lines.
+
+    This is a genuine async generator over real input data fed to the real
+    parser in :meth:`SseTransport._read_event` - not a mock of any behavior.
+    """
+    for line in lines:
+        yield (line + "\r\n").encode("utf-8")
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_captures_retry_field():
+    """``_read_event`` records the server's ``retry:`` into ``reconnect_delay_ms``."""
+    transport = SseTransport("https://mcp.example.com", allow_private=False)
+
+    # Before any event, no server reconnect delay has been observed.
+    assert transport.reconnect_delay_ms is None
+
+    event = await transport._read_event(
+        _byte_lines(
+            "retry: 5000",
+            'data: {"jsonrpc": "2.0", "id": 1, "result": {}}',
+            "",  # blank line terminates the event
+        )
+    )
+
+    # The data payload is returned to the caller...
+    assert event == '{"jsonrpc": "2.0", "id": 1, "result": {}}'
+    # ...and the retry reconnection delay is now captured (previously discarded).
+    assert transport.reconnect_delay_ms == 5000
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_ignores_malformed_retry_field():
+    """A non-digit ``retry:`` value leaves ``reconnect_delay_ms`` unset."""
+    transport = SseTransport("https://mcp.example.com")
+
+    event = await transport._read_event(
+        _byte_lines(
+            "retry: not-a-number",
+            'data: {"jsonrpc": "2.0"}',
+            "",
+        )
+    )
+
+    assert event == '{"jsonrpc": "2.0"}'
+    assert transport.reconnect_delay_ms is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Ceiling clamp (L1) — a hostile/huge retry cannot pin the client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_clamps_retry_above_ceiling():
+    """A ``retry:`` above ``MAX_RECONNECT_MS`` is clamped to the ceiling.
+
+    Without the clamp a malicious/misconfigured server could send a huge
+    ``retry:`` (e.g. one hour) and pin the client into an arbitrarily long
+    reconnect wait — a DoS on the client's own reconnect path.
+    """
+    transport = SseTransport("https://mcp.example.com")
+
+    # 3_600_000 ms == 1 hour, far above the 5-minute ceiling.
+    huge = MAX_RECONNECT_MS * 12
+    event = await transport._read_event(
+        _byte_lines(
+            f"retry: {huge}",
+            'data: {"jsonrpc": "2.0"}',
+            "",
+        )
+    )
+
+    assert event == '{"jsonrpc": "2.0"}'
+    # Stored value is clamped to the ceiling, never the server's huge value.
+    assert transport.reconnect_delay_ms == MAX_RECONNECT_MS
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_retry_at_ceiling_passes_through():
+    """A ``retry:`` exactly at the ceiling is stored unchanged."""
+    transport = SseTransport("https://mcp.example.com")
+
+    await transport._read_event(
+        _byte_lines(f"retry: {MAX_RECONNECT_MS}", 'data: {"jsonrpc": "2.0"}', "")
+    )
+
+    assert transport.reconnect_delay_ms == MAX_RECONNECT_MS
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_normal_retry_passes_through_unclamped():
+    """A normal in-range ``retry:`` is stored verbatim (clamp only bites above)."""
+    transport = SseTransport("https://mcp.example.com")
+
+    await transport._read_event(
+        _byte_lines("retry: 5000", 'data: {"jsonrpc": "2.0"}', "")
+    )
+
+    assert transport.reconnect_delay_ms == 5000
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sse_transport_negative_retry_leaves_default():
+    """A negative ``retry:`` is rejected by the parser → the default stands.
+
+    The parser only accepts an ASCII-digit run, so ``-1`` returns ``None`` and
+    ``reconnect_delay_ms`` keeps its default (``None`` — no server-requested
+    delay), rather than storing a nonsensical negative sleep.
+    """
+    transport = SseTransport("https://mcp.example.com")
+
+    await transport._read_event(
+        _byte_lines("retry: -1", 'data: {"jsonrpc": "2.0"}', "")
+    )
+
+    assert transport.reconnect_delay_ms is None

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_wave2_hardening.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_wave2_hardening.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave-2 hardening (G1-redteam findings).
+
+Covers four confirmed findings, each pinned behaviorally against a real
+``MCPServer`` / real auth objects (no mocking of the SDK under test, per
+``rules/testing.md`` § 3-Tier Testing):
+
+* **F1 (HIGH)** — the fail-closed OAuth audience gate must be REACHABLE through
+  the documented server wiring. ``ResourceServer.authenticate`` is ``async``;
+  the async tool-dispatch path must AWAIT it (via
+  ``AuthManager.authenticate_and_authorize_async``) so a foreign-audience or
+  audience-absent token is DENIED with a clean auth error — NOT crashed into an
+  un-awaited-coroutine ``AttributeError`` → 500. Three server-wired cases:
+  correctly-scoped → ALLOWED; foreign-audience → DENIED; audience-absent →
+  DENIED.
+* **F4 (MED)** — covered in ``test_issue_1712_audience_validation.py`` (audience
+  fail-closed default: a JWT-validating provider with no ``expected_audience``
+  refuses construction).
+* **F3 (MED)** — ``MCPServer._paginate`` returns the spec ``-32602`` envelope
+  for a non-string (unhashable) cursor instead of an unhandled ``TypeError``.
+* **F6 (MED)** — ``_redact_log_data`` scrubs secret token shapes in dict KEYS
+  (not only values) and covers cloud-cred formats (AWS / GitHub / Google /
+  Slack / URL-userinfo) before the payload reaches the notifications wire.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash_mcp.errors import ToolError
+from kailash_mcp.server import MCPServer
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example"
+AUDIENCE = "mcp-api"
+RESOURCE = "https://mcp.example.com/mcp"
+
+
+def _make_server(auth_provider=None) -> MCPServer:
+    return MCPServer(
+        "wave2-hardening-test",
+        enable_cache=False,
+        enable_metrics=False,
+        auth_provider=auth_provider,
+    )
+
+
+def _async_secure_tool(server: MCPServer):
+    """Build the server's real auth-enforcing async wrapper for a tool that
+    requires the ``read`` permission. This is the exact enhanced-tool surface
+    every registered async tool goes through — the F1 bug lived in its call to
+    the auth manager."""
+
+    async def secure_tool(x: int = 0) -> int:
+        return x + 1
+
+    wrapper = server._create_enhanced_tool(
+        secure_tool,
+        "secure_tool",
+        None,  # cache_key
+        None,  # cache_ttl
+        None,  # response_format
+        "read",  # required_permission
+        None,  # rate_limit
+        False,  # enable_circuit_breaker
+        None,  # timeout
+        False,  # retryable
+        False,  # stream_response
+    )
+    # The wrapper updates per-tool stats in the registry (call_count /
+    # error_count / last_called); seed the entry the tool decorator would
+    # normally create so those bookkeeping writes resolve.
+    server._tool_registry["secure_tool"] = {
+        "description": "",
+        "inputSchema": {},
+        "call_count": 0,
+        "error_count": 0,
+        "last_called": None,
+    }
+    return wrapper
+
+
+# ===========================================================================
+# F1 — async OAuth audience gate reachable through the server auth path
+# ===========================================================================
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f1_correctly_scoped_token_allowed_through_server():
+    """A correctly-scoped, correct-audience token is ALLOWED through the
+    server's async auth dispatch (the audience gate ran and passed)."""
+    pytest.importorskip("cryptography", reason="oauth path requires [auth-oauth]")
+    from kailash_mcp.auth.oauth import ResourceServer
+
+    rs = ResourceServer(issuer=ISSUER, audience=AUDIENCE, resource=RESOURCE)
+    server = _make_server(auth_provider=rs)
+    wrapper = _async_secure_tool(server)
+
+    token = rs.jwt_manager.create_access_token(
+        subject="alice", scope="mcp.tools", audience=[AUDIENCE]
+    ).token
+
+    # Correct audience + default "read" permission -> the tool body runs.
+    result = await wrapper(x=41, mcp_auth={"token": token})
+    assert result == 42
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f1_foreign_audience_token_denied_through_server():
+    """A foreign-audience token is DENIED with a clean auth error (NOT a 500 /
+    AttributeError from an un-awaited coroutine) through the server."""
+    pytest.importorskip("cryptography", reason="oauth path requires [auth-oauth]")
+    from kailash_mcp.auth.oauth import ResourceServer
+
+    rs = ResourceServer(issuer=ISSUER, audience=AUDIENCE, resource=RESOURCE)
+    server = _make_server(auth_provider=rs)
+    wrapper = _async_secure_tool(server)
+
+    # Token minted for a DIFFERENT resource.
+    foreign = rs.jwt_manager.create_access_token(
+        subject="mallory", scope="mcp.tools", audience=["some-other-api"]
+    ).token
+
+    with pytest.raises(ToolError) as excinfo:
+        await wrapper(x=1, mcp_auth={"token": foreign})
+
+    # Clean fail-closed DENY — the audience gate ran through the server.
+    assert "Access denied" in str(excinfo.value)
+    # The bug this pins: an un-awaited coroutine crashed with AttributeError.
+    assert "AttributeError" not in str(excinfo.value)
+    assert "coroutine" not in str(excinfo.value).lower()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f1_audience_absent_token_denied_through_server():
+    """An audience-ABSENT token is DENIED (fail-closed) through the server."""
+    pytest.importorskip("cryptography", reason="oauth path requires [auth-oauth]")
+    from kailash_mcp.auth.oauth import ResourceServer
+
+    rs = ResourceServer(issuer=ISSUER, audience=AUDIENCE, resource=RESOURCE)
+    server = _make_server(auth_provider=rs)
+    wrapper = _async_secure_tool(server)
+
+    # No audience claim at all.
+    no_aud = rs.jwt_manager.create_access_token(
+        subject="nobody", scope="mcp.tools"
+    ).token
+
+    with pytest.raises(ToolError) as excinfo:
+        await wrapper(x=1, mcp_auth={"token": no_aud})
+
+    assert "Access denied" in str(excinfo.value)
+    assert "AttributeError" not in str(excinfo.value)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f1_sync_path_rejects_async_provider_cleanly():
+    """Belt-and-suspenders: if an async provider is reached on the SYNC auth
+    path, it fails CLOSED with a typed AuthenticationError — never an opaque
+    AttributeError from an un-awaited coroutine."""
+    pytest.importorskip("cryptography", reason="oauth path requires [auth-oauth]")
+    from kailash_mcp.auth.oauth import ResourceServer
+    from kailash_mcp.auth.providers import AuthenticationError, AuthManager
+
+    rs = ResourceServer(issuer=ISSUER, audience=AUDIENCE, resource=RESOURCE)
+    mgr = AuthManager(provider=rs)
+
+    with pytest.raises(AuthenticationError) as excinfo:
+        mgr.authenticate_and_authorize({"token": "irrelevant"}, "read")
+
+    assert "async" in str(excinfo.value).lower()
+
+
+# ===========================================================================
+# F3 — non-string cursor -> -32602 (not an unhandled TypeError)
+# ===========================================================================
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("bad_cursor", [123, ["a"], {"k": "v"}, 4.5, object()])
+def test_f3_non_string_cursor_returns_invalid_params(bad_cursor):
+    """A non-string / unhashable cursor yields the -32602 envelope."""
+    server = _make_server()
+    page, next_cursor, error = server._paginate(
+        ["item-a", "item-b"], bad_cursor, request_id=7
+    )
+    assert page is None
+    assert next_cursor is None
+    assert error is not None
+    assert error["error"]["code"] == -32602
+    assert error["id"] == 7
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f3_non_string_cursor_through_list_handler():
+    """The -32602 guard holds through the real tools/list handler surface."""
+    server = _make_server()
+    server._tool_registry["t1"] = {"description": "", "inputSchema": {}}
+
+    resp = await server._handle_list_tools({"cursor": 999}, request_id=3)
+    assert resp["error"]["code"] == -32602
+    assert resp["id"] == 3
+
+
+@pytest.mark.regression
+def test_f3_none_and_valid_string_cursor_still_work():
+    """A None cursor (first page) and a valid string cursor are unaffected."""
+    server = _make_server()
+    items = [f"i{n}" for n in range(5)]
+    page, _next, error = server._paginate(items, None, request_id=1)
+    assert error is None
+    assert page == items  # first page, under default page size
+
+
+# ===========================================================================
+# F6 — dict-KEY secret scrub + broadened cloud-cred value patterns
+# ===========================================================================
+
+# These fixture tokens are real-SHAPED (they must match the redaction regexes in
+# server.py::_SECRET_VALUE_PATTERNS) but are assembled from fragments so the
+# contiguous secret pattern never appears in the source bytes — GitHub push
+# protection would otherwise block the commit. Do NOT re-join into a single literal.
+AWS_ACCESS_KEY_ID = "AKIA" + "IOSFODNN7EXAMPLE"
+GITHUB_TOKEN = "ghp" + "_0123456789abcdefghij0123456789ABCD"
+
+
+def _redact(data):
+    from kailash_mcp.server import _redact_log_data
+
+    return _redact_log_data(data)
+
+
+@pytest.mark.regression
+def test_f6_secret_in_dict_key_is_scrubbed():
+    """A secret token in the KEY position is scrubbed (was value-only before)."""
+    out = _redact({AWS_ACCESS_KEY_ID: "harmless-value"})
+    assert AWS_ACCESS_KEY_ID not in out
+    assert "[REDACTED]" in out  # the key was replaced by the scrubbed form
+
+
+@pytest.mark.regression
+def test_f6_aws_access_key_in_value_redacted():
+    out = _redact({"note": f"leaked {AWS_ACCESS_KEY_ID} in prose"})
+    assert AWS_ACCESS_KEY_ID not in out["note"]
+    assert "[REDACTED]" in out["note"]
+
+
+@pytest.mark.regression
+def test_f6_github_token_in_value_redacted():
+    # key "gh" is not a secret-name, so the VALUE pattern must catch it.
+    out = _redact({"gh": GITHUB_TOKEN})
+    assert GITHUB_TOKEN not in out["gh"]
+    assert out["gh"] == "[REDACTED]"
+
+
+@pytest.mark.regression
+def test_f6_url_userinfo_password_redacted_host_kept():
+    dsn = "postgres://admin:s3cr3tpass@dbhost:5432/app"
+    out = _redact({"dsn": dsn})
+    assert "s3cr3tpass" not in out["dsn"]
+    assert "[REDACTED]" in out["dsn"]
+    # Scheme + host stay legible; only the userinfo is scrubbed.
+    assert out["dsn"].startswith("postgres://")
+    assert "dbhost" in out["dsn"]
+
+
+@pytest.mark.regression
+def test_f6_google_and_slack_values_redacted():
+    # Fragment-assembled (see AWS/GitHub note above): real-shaped for the redaction
+    # regex, but no contiguous secret literal for GitHub push protection to flag.
+    google = "AIza" + "SyA0123456789abcdefghijklmnopqrstuv"
+    slack = "xox" + "b-0123456789-abcdefABCDEF01"
+    out = _redact({"g": google, "s": slack})
+    assert out["g"] == "[REDACTED]"
+    assert out["s"] == "[REDACTED]"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_f6_redaction_holds_through_send_log_message():
+    """The broadened redaction reaches the real notifications/message wire."""
+
+    class _CaptureTransport:
+        def __init__(self):
+            self.sent = []
+
+        async def send_message(self, message, client_id=None):
+            self.sent.append((client_id, message))
+
+    server = _make_server()
+    server._transport = _CaptureTransport()
+    server.client_info["c1"] = {"capabilities": {}, "name": "c", "version": "1"}
+    server._client_log_levels["c1"] = "WARNING"
+
+    sent = await server.send_log_message(
+        "ERROR",
+        {
+            AWS_ACCESS_KEY_ID: "x",  # secret in KEY
+            "gh": GITHUB_TOKEN,  # GitHub in value
+            "dsn": "redis://user:hunter2@cache:6379/0",  # URL-userinfo
+        },
+        logger_name="db",
+    )
+    assert sent == 1
+    _client_id, message = server._transport.sent[0]
+    data = message["params"]["data"]
+    assert AWS_ACCESS_KEY_ID not in data  # key scrubbed
+    assert GITHUB_TOKEN not in str(data)
+    assert "hunter2" not in str(data)

--- a/packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py
@@ -54,6 +54,12 @@ AuthenticationError = (ProvidersAuthenticationError, OAuthAuthenticationError)
 JWT_TEST_SECRET = "test-secret-key-minimum-32-bytes!"
 JWT_TEST_ISSUER = "https://issuer.test.example"
 JWT_TEST_ALGO = "HS256"
+# Audience is fail-closed-REQUIRED whenever validate_jwt=True (F4 /
+# enforcement-surface parity). These #625 tests exercise the `iss` dimension,
+# so they pin a matching `aud` on every token and pass expected_audience to
+# every JWT-validating provider — otherwise construction refuses and the token
+# is rejected for the wrong reason (missing aud), masking the iss assertion.
+JWT_TEST_AUDIENCE = "https://mcp.test.example/resource"
 
 
 def _encode(claims: dict, *, secret: str = JWT_TEST_SECRET) -> str:
@@ -62,12 +68,14 @@ def _encode(claims: dict, *, secret: str = JWT_TEST_SECRET) -> str:
 
 
 def _make_claims(*, include_iss: bool, issuer_value: str = JWT_TEST_ISSUER) -> dict:
-    """Build canonical claims with `exp` always set (required by PyJWT)."""
+    """Build canonical claims with `exp` and `aud` always set (required by
+    PyJWT under the fail-closed audience guard)."""
     now = datetime.now(timezone.utc)
     claims: dict = {
         "sub": "user-625",
         "exp": int((now + timedelta(seconds=3600)).timestamp()),
         "iat": int(now.timestamp()),
+        "aud": JWT_TEST_AUDIENCE,
         "permissions": ["read"],
     }
     if include_iss:
@@ -93,6 +101,7 @@ def test_missing_iss_rejected_when_issuer_configured():
         jwt_secret=JWT_TEST_SECRET,
         jwt_algorithm=JWT_TEST_ALGO,
         expected_issuer=JWT_TEST_ISSUER,
+        expected_audience=JWT_TEST_AUDIENCE,
     )
 
     # Token deliberately OMITS the `iss` claim.
@@ -120,6 +129,7 @@ def test_missing_iss_allowed_when_issuer_not_configured():
         validate_jwt=True,
         jwt_secret=JWT_TEST_SECRET,
         jwt_algorithm=JWT_TEST_ALGO,
+        expected_audience=JWT_TEST_AUDIENCE,
         # expected_issuer NOT set — opt-out path
     )
 
@@ -138,6 +148,7 @@ def test_present_iss_validated_against_allowlist():
         jwt_secret=JWT_TEST_SECRET,
         jwt_algorithm=JWT_TEST_ALGO,
         expected_issuer=JWT_TEST_ISSUER,
+        expected_audience=JWT_TEST_AUDIENCE,
     )
 
     # iss is present but does NOT match the configured allowlist.
@@ -157,6 +168,7 @@ def test_matching_iss_accepted_when_issuer_configured():
         jwt_secret=JWT_TEST_SECRET,
         jwt_algorithm=JWT_TEST_ALGO,
         expected_issuer=JWT_TEST_ISSUER,
+        expected_audience=JWT_TEST_AUDIENCE,
     )
 
     token = _encode(_make_claims(include_iss=True))
@@ -180,7 +192,9 @@ def test_jwtauth_inherits_iss_required_from_issuer_kwarg():
     so every JWTAuth instance is an issuer-allowlist caller — the
     iss-required behaviour MUST flow through the super().__init__ call.
     """
-    auth = JWTAuth(secret=JWT_TEST_SECRET, issuer=JWT_TEST_ISSUER)
+    auth = JWTAuth(
+        secret=JWT_TEST_SECRET, issuer=JWT_TEST_ISSUER, audience=JWT_TEST_AUDIENCE
+    )
 
     # Forged absent-iss token signed with the right secret.
     token = _encode(_make_claims(include_iss=False))
@@ -196,7 +210,9 @@ def test_jwtauth_round_trip_token_validates():
     Belt-and-suspenders: the iss-required tightening must NOT regress the
     canonical create→verify flow on tokens this very provider issues.
     """
-    auth = JWTAuth(secret=JWT_TEST_SECRET, issuer=JWT_TEST_ISSUER)
+    auth = JWTAuth(
+        secret=JWT_TEST_SECRET, issuer=JWT_TEST_ISSUER, audience=JWT_TEST_AUDIENCE
+    )
 
     token = auth.create_token({"user": "alice", "permissions": ["read"]})
     user_info = auth.authenticate(token)

--- a/src/kailash/channels/mcp/http.py
+++ b/src/kailash/channels/mcp/http.py
@@ -19,6 +19,16 @@ is passed (intended for trusted internal endpoints).
 HTTP is a request/response transport — :meth:`receive` raises
 :class:`NotImplementedError` because the protocol does not support
 unsolicited server-push.
+
+Transport status (native vs spec-delegated): this ``HttpTransport`` is a
+native internal/legacy client transport (plain JSON-RPC over ``POST``). The
+MCP 2025-11-25 spec-compliant HTTP client path is the upstream-delegated
+``streamable_http_client`` (single-endpoint Streamable HTTP with
+``MCP-Session-Id`` + ``MCP-Protocol-Version`` handling), used by
+``kailash_mcp.client.MCPClient._discover_tools_http`` /
+``_call_tool_http``; and the spec stdio *server* is FastMCP, run via
+``kailash_mcp.server.MCPServerBase.start`` (``self._mcp.run()``). Prefer
+those for interoperability with spec MCP peers.
 """
 
 from __future__ import annotations
@@ -141,6 +151,8 @@ class HttpTransport(Transport):
             try:
                 await self._session.close()
             except Exception:
+                # Expected-failure cleanup (zero-tolerance Rule 3 carve-out):
+                # a session that errors on close is already unusable.
                 pass
             self._session = None
 

--- a/src/kailash/channels/mcp/sse.py
+++ b/src/kailash/channels/mcp/sse.py
@@ -40,6 +40,13 @@ except ImportError as exc:  # pragma: no cover — covered by structural invaria
 
 from .base import ProtocolError, Transport, TransportError, validate_url
 
+# Upper bound on the server-supplied SSE ``retry:`` reconnection delay
+# (milliseconds). The server sends this value verbatim; without a ceiling a
+# malicious or misconfigured server could pin the client into an arbitrarily
+# long reconnect wait (a denial-of-service on the client's own reconnect
+# path). Any parsed value above this ceiling is clamped to it (5 minutes).
+MAX_RECONNECT_MS = 300_000
+
 
 class SseTransport(Transport):
     """MCP client transport over Server-Sent Events.
@@ -97,6 +104,15 @@ class SseTransport(Transport):
         self._closed = False
         self._sse_response: Optional[aiohttp.ClientResponse] = None
         self._sse_lock = asyncio.Lock()
+        # Server-requested reconnection delay from the SSE ``retry:`` field
+        # (milliseconds). ``None`` until the server sends a ``retry:`` line.
+        # MCP requires clients to respect this reconnection time; the value
+        # is honored as a delay before re-opening a closed SSE stream.
+        self._reconnect_delay_ms: Optional[int] = None
+        # Whether the SSE stream has been opened at least once, so the
+        # reconnection delay is applied only on an actual re-open, never on
+        # the first connection.
+        self._sse_opened_once = False
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -115,6 +131,16 @@ class SseTransport(Transport):
     @property
     def sse_url(self) -> str:
         return f"{self.base_url}{self.sse_path}"
+
+    @property
+    def reconnect_delay_ms(self) -> Optional[int]:
+        """Server-requested SSE reconnection delay in milliseconds.
+
+        Populated from the SSE ``retry:`` field the server sends on the
+        event stream; ``None`` until the server sends one. The transport
+        waits this long before re-opening a closed SSE stream.
+        """
+        return self._reconnect_delay_ms
 
     # ------------------------------------------------------------------
     # Transport protocol
@@ -166,6 +192,11 @@ class SseTransport(Transport):
         async with self._sse_lock:
             session = await self._ensure_session()
             if self._sse_response is None or self._sse_response.closed:
+                # Honor the server-requested reconnection delay (the SSE
+                # ``retry:`` field) before RE-opening a closed stream. The
+                # first open is never delayed.
+                if self._sse_opened_once and self._reconnect_delay_ms is not None:
+                    await asyncio.sleep(self._reconnect_delay_ms / 1000.0)
                 try:
                     self._sse_response = await session.get(
                         self.sse_url,
@@ -175,6 +206,7 @@ class SseTransport(Transport):
                     raise TransportError(
                         f"failed to open SSE stream at {self.sse_url}: {exc}"
                     ) from exc
+                self._sse_opened_once = True
                 if self._sse_response.status >= 400:
                     text = await self._sse_response.text()
                     self._sse_response.release()
@@ -183,22 +215,51 @@ class SseTransport(Transport):
                         f"SSE GET returned HTTP {self._sse_response.status if self._sse_response else '???'}: {text}"
                     )
 
-            data_lines: list[str] = []
-            async for raw_line in self._sse_response.content:
-                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
-                if line == "":
-                    if data_lines:
-                        return "\n".join(data_lines)
-                    continue
-                if line.startswith(":"):
-                    # SSE comment line — ignore.
-                    continue
-                if line.startswith("data:"):
-                    data_lines.append(line[len("data:") :].lstrip())
-                # Any other field (event:, id:, retry:) is ignored for
-                # the JSON-RPC payload purposes.
+            event = await self._read_event(self._sse_response.content)
+            if event is None:
+                raise TransportError("SSE stream closed before delivering an event")
+            return event
 
-            raise TransportError("SSE stream closed before delivering an event")
+    async def _read_event(self, line_source) -> Optional[str]:
+        """Read one SSE event from an async line source.
+
+        Consumes decoded ``bytes`` lines from ``line_source`` (an async
+        iterator such as :attr:`aiohttp.ClientResponse.content`) until an
+        event boundary (a blank line following ``data:`` lines). When the
+        stream sends a ``retry:`` field, :attr:`reconnect_delay_ms` is
+        updated so a subsequent reconnect honors the server's requested
+        reconnection time (per the SSE specification and the MCP transport
+        requirement that clients respect ``retry:``).
+
+        Returns the joined ``data:`` payload for the event, or ``None`` if
+        the stream ended before a complete event was delivered.
+        """
+        data_lines: list[str] = []
+        async for raw_line in line_source:
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if line == "":
+                if data_lines:
+                    return "\n".join(data_lines)
+                continue
+            if line.startswith(":"):
+                # SSE comment line — ignore.
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[len("data:") :].lstrip())
+                continue
+            if line.startswith("retry:"):
+                delay = _parse_sse_retry_field(line[len("retry:") :])
+                if delay is not None:
+                    # Clamp the server-supplied reconnection delay to a sane
+                    # ceiling so a malicious/misconfigured server cannot pin
+                    # the client into an arbitrarily long reconnect wait (DoS).
+                    # Negative / non-digit values are already rejected by the
+                    # parser (return None), leaving the prior default in place.
+                    self._reconnect_delay_ms = min(delay, MAX_RECONNECT_MS)
+                continue
+            # Any other field (event:, id:) is ignored for the JSON-RPC
+            # payload purposes.
+        return None
 
     async def close(self) -> None:
         """Close the SSE stream and (if owned) the HTTP session."""
@@ -210,6 +271,8 @@ class SseTransport(Transport):
             try:
                 self._sse_response.release()
             except Exception:
+                # Expected-failure cleanup (zero-tolerance Rule 3 carve-out):
+                # releasing an already-broken response must not mask close().
                 pass
             self._sse_response = None
 
@@ -217,8 +280,26 @@ class SseTransport(Transport):
             try:
                 await self._session.close()
             except Exception:
+                # Expected-failure cleanup (zero-tolerance Rule 3 carve-out):
+                # a session that errors on close is already unusable.
                 pass
             self._session = None
+
+
+def _parse_sse_retry_field(value: str) -> Optional[int]:
+    """Parse the value of an SSE ``retry:`` field into milliseconds.
+
+    Per the SSE specification the reconnection-time value MUST consist only
+    of ASCII digits; any other content causes the field to be ignored. A
+    single leading space after the colon is stripped before parsing.
+
+    Returns the integer number of milliseconds, or ``None`` when the value
+    is empty or not a base-10 ASCII-digit run.
+    """
+    stripped = value.lstrip()
+    if stripped and all(ch in "0123456789" for ch in stripped):
+        return int(stripped)
+    return None
 
 
 def _strip_sse_data_prefix(text: str) -> str:

--- a/src/kailash/channels/mcp/stdio.py
+++ b/src/kailash/channels/mcp/stdio.py
@@ -22,6 +22,16 @@ safety) — absent an explicit ``allowed_commands`` the curated
 :data:`DEFAULT_ALLOWED_COMMANDS` launcher set is enforced and an unlisted
 command is rejected. Pass ``allowed_commands=[...]`` to narrow/extend it,
 or ``allow_arbitrary_commands=True`` to opt out explicitly.
+
+Transport status (native vs spec-delegated): this ``StdioTransport`` is a
+native internal/legacy client transport using LSP-style ``Content-Length``
+framing. The MCP-spec-compliant surfaces are the upstream-delegated ones:
+the client HTTP path routes through the upstream ``streamable_http_client``
+(see ``kailash_mcp.client.MCPClient._discover_tools_http`` /
+``_call_tool_http``), and the spec stdio *server* is FastMCP, run via
+``kailash_mcp.server.MCPServerBase.start`` which delegates to
+``self._mcp.run()`` (newline-delimited spec stdio). Prefer those for
+interoperability with spec MCP peers.
 """
 
 from __future__ import annotations
@@ -220,6 +230,8 @@ class StdioTransport(Transport):
             if self._stdin and not self._stdin.is_closing():
                 self._stdin.close()
         except Exception:
+            # Expected-failure cleanup (zero-tolerance Rule 3 carve-out):
+            # closing an already-broken stdin must not mask shutdown.
             pass
 
         if self.process.returncode is None:
@@ -240,6 +252,8 @@ class StdioTransport(Transport):
                     try:
                         await self.process.wait()
                     except Exception:
+                        # Expected-failure cleanup (zero-tolerance Rule 3
+                        # carve-out): reaping an already-dead process.
                         pass
 
 

--- a/tests/unit/mcp_server/test_auth.py
+++ b/tests/unit/mcp_server/test_auth.py
@@ -330,13 +330,21 @@ class TestJWTAuth:
 
     def test_init(self):
         """Test JWT auth initialization."""
-        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        auth = JWTAuth(
+            self.JWT_TEST_SECRET,
+            algorithm="HS256",
+            audience="https://mcp.example.com",
+        )
         assert auth.jwt_secret == self.JWT_TEST_SECRET
         assert auth.jwt_algorithm == "HS256"
 
     def test_create_token(self):
         """Test JWT token creation."""
-        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        auth = JWTAuth(
+            self.JWT_TEST_SECRET,
+            algorithm="HS256",
+            audience="https://mcp.example.com",
+        )
 
         payload = {"user": "testuser", "permissions": ["read", "write"]}
         token = auth.create_token(payload, expiration=3600)
@@ -346,7 +354,11 @@ class TestJWTAuth:
 
     def test_authenticate_valid_jwt(self):
         """Test authentication with valid JWT token."""
-        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        auth = JWTAuth(
+            self.JWT_TEST_SECRET,
+            algorithm="HS256",
+            audience="https://mcp.example.com",
+        )
 
         payload = {"user": "testuser", "permissions": ["read"]}
         token = auth.create_token(payload, expiration=3600)
@@ -358,14 +370,22 @@ class TestJWTAuth:
 
     def test_authenticate_invalid_jwt(self):
         """Test authentication with invalid JWT token."""
-        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        auth = JWTAuth(
+            self.JWT_TEST_SECRET,
+            algorithm="HS256",
+            audience="https://mcp.example.com",
+        )
 
         with pytest.raises(AuthenticationError):
             auth.authenticate("invalid.jwt.token")
 
     def test_authenticate_expired_jwt(self):
         """Test authentication with expired JWT token."""
-        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        auth = JWTAuth(
+            self.JWT_TEST_SECRET,
+            algorithm="HS256",
+            audience="https://mcp.example.com",
+        )
 
         # Create token that expires in the past
         payload = {"user": "testuser", "exp": int(time.time()) - 3600}  # 1 hour ago

--- a/tests/unit/mcp_server/test_missing_handlers.py
+++ b/tests/unit/mcp_server/test_missing_handlers.py
@@ -8,7 +8,6 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-
 from kailash_mcp.errors import MCPError
 from kailash_mcp.protocol.protocol import get_protocol_manager
 from kailash_mcp.server import MCPServer
@@ -646,8 +645,10 @@ class TestMessageRouting:
 
         result = await server._handle_websocket_message(message, "client_123")
 
+        # Wave 2 (#1712): dispatch merges client_id into params so the level is
+        # tracked per-session for notifications/message gating (spec 2025-11-25).
         server._handle_logging_set_level.assert_called_once_with(
-            {"level": "DEBUG"}, "test_123"
+            {"level": "DEBUG", "client_id": "client_123"}, "test_123"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Wave 2 of the MCP 2025-11-25 spec-parity effort (#1712) — the **server-side capability** half plus OAuth resource-server publishing. Built as 3 file-disjoint parallel shards, gated by an adversarial G1 redteam (3 reviewers + verification of every HIGH/CRIT finding), then 3 fix shards, then integrated. Full kailash-mcp suite green (**305 passed**) + core channels (**45 passed**).

### Capability parity (`server.py`)
- **protocolVersion** reaches `2025-11-25` (was capped at `2025-06-18`).
- **Pagination** (opaque `cursor`/`nextCursor` + `-32602`) extended from `resources/list` to `tools/list`, `prompts/list`, and a new `resources/templates/list`.
- **completion/complete** ranks (exact→prefix→substring) before the 100-item cap; `completions` promoted to a top-level server capability.
- **logging** now **emits** `notifications/message` (was `setLevel`-only), level-gated, with secret/PII redaction (key + value scrubbing).

### OAuth resource-server (`auth/**`)
- Publishes **RFC 9728** Protected Resource Metadata (mountable surfaces) + **401 `WWW-Authenticate`** challenge on auth failure.
- **S256-only PKCE** enforced fail-closed at the AS (not just advertised).
- Fixed a latent security bug: `verify_access_token` rejected *every* `aud`-bearing token (audience check was dead code); audience now enforced fail-closed at the resource-server boundary.

### Transport disposition (`channels/mcp/**`)
- Verified production MCP HTTP + stdio delegate to the spec-compliant upstream SDK; non-spec native transport `DeprecationWarning`-shimmed; SSE `retry` field honored (clamped).

### G1-redteam fixes
async-aware `AuthManager` (audience gate now fires through the documented server wiring — was an un-awaited coroutine → 500) · fail-loud non-URL PRM `resource` · audience fail-closed default for JWT providers · non-string cursor → `-32602` · bounded `CursorManager`.

## ⚠️ Breaking change (0.x minor → 0.4.0)
`BearerTokenAuth`/`JWTAuth` now **require** `expected_audience` when `validate_jwt=True` (was warn-and-continue, fail-open). This is a fail-open→fail-closed security tightening; a deprecation cycle would leave the audience hole open. All in-repo call sites updated. Will be prominently noted in the 0.4.0 CHANGELOG at release.

## Scope note
Transport-layer native reimplementation was deliberately **not** done — production delegates to the upstream `mcp` SDK, so a parallel native spec-transport stack would duplicate it (framework-first / zero-tolerance Rule 4). Remaining #1712 waves (progress/cancellation + roots; sampling + elicitation) follow.

## Related issues
Refs #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)