### PR TITLE
feat(mcp): #1712 Wave 4 — sampling + elicitation 2025-11-25 + redteam hardening

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -760,10 +760,231 @@ class StreamingHandler:
                 await asyncio.sleep(0)  # Allow other tasks to run
 
 
+# A CapabilityFn returns True when at least one connected client has advertised
+# the ``elicitation`` capability, so the send-half can fail closed instead of
+# dispatching an ``elicitation/create`` a client cannot handle (spec 2025-11-25
+# § Elicitation — capability-gated). See MCPServer._bind_elicitation_transport.
+CapabilityFn = Callable[[], bool]
+
+# The two elicitation modes defined by MCP 2025-11-25. ``form`` collects a set
+# of flat primitives inline via ``requestedSchema``; ``url`` hands the user off
+# to a server-issued URL so sensitive data is provided OUT-OF-BAND (never inline
+# in the JSON-RPC params). Any other requested mode is rejected with -32602.
+ELICITATION_MODE_FORM = "form"
+ELICITATION_MODE_URL = "url"
+ELICITATION_MODES = frozenset({ELICITATION_MODE_FORM, ELICITATION_MODE_URL})
+
+# Primitive JSON-Schema types permitted for a form-mode ``requestedSchema``
+# property. The 2025-11-25 form shape is a FLAT object of primitives — no
+# nested objects, no arrays — so a client can always render a simple form and
+# no structured payload smuggles through the collection surface.
+_FLAT_PRIMITIVE_TYPES = frozenset({"string", "number", "integer", "boolean"})
+
+# JSON-Schema structural keywords that reintroduce nesting or indirection and
+# therefore have NO place in a flat-primitive form schema. Present at the top
+# level OR on any property, each is a fail-closed rejection — a form schema that
+# smuggles one of these back in is not renderable as a flat form and could carry
+# a structured payload through the collection surface.
+_SCHEMA_COMBINATOR_KEYS = frozenset({"allOf", "anyOf", "oneOf", "not", "$ref", "$defs"})
+
+# JSON primitive scalar types permitted as ``enum`` members (``None`` — JSON
+# ``null`` — is handled separately since it is not a type instance). ``bool`` is
+# a subclass of ``int``; both are covered by the tuple.
+_ENUM_PRIMITIVE_TYPES = (bool, int, float, str)
+
+
+def _validate_flat_primitive_schema(schema: Dict[str, Any]) -> None:
+    """Validate a form-mode ``requestedSchema`` is a flat object of primitives.
+
+    The MCP 2025-11-25 form-elicitation shape restricts ``requestedSchema`` to
+    an object whose properties are each a primitive (``string`` / ``number`` /
+    ``integer`` / ``boolean``) or an ``enum`` of primitives — NO nested objects
+    and NO arrays. This keeps the collection surface renderable as a flat form
+    and prevents a structured payload from smuggling through it.
+
+    Args:
+        schema: The candidate ``requestedSchema`` dict.
+
+    The guard is EXHAUSTIVE and fail-closed: beyond the obvious nested-object /
+    array cases it rejects every structural JSON-Schema vector that could
+    reintroduce nesting or indirection — top-level ``additionalProperties`` (any
+    value other than ``false`` or a flat-primitive schema), ``patternProperties``,
+    the combinators / refs in :data:`_SCHEMA_COMBINATOR_KEYS` (top-level AND
+    per-property), a property whose ``type`` is not a single primitive string
+    (this closes the previously-uncaught ``TypeError`` on a LIST/union ``type``),
+    a property carrying ``$ref`` (even alongside a primitive ``type`` sibling),
+    and an ``enum`` whose members are not JSON primitive scalars.
+
+    Raises:
+        MCPError(INVALID_PARAMS, -32602): The schema is not a flat-primitive
+            object.
+    """
+    if not isinstance(schema, dict):
+        raise MCPError(
+            "form-mode requestedSchema must be a JSON Schema object, got "
+            f"{type(schema).__name__}",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+
+    declared_type = schema.get("type", "object")
+    if declared_type != "object":
+        raise MCPError(
+            "form-mode requestedSchema must declare type 'object' with flat "
+            f"primitive properties, got type '{declared_type}'",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+
+    # Top-level combinators / refs reintroduce nesting or indirection.
+    _reject_flat_schema_combinators(schema, "form-mode requestedSchema")
+
+    # ``patternProperties`` describes arbitrarily-keyed nested subschemas — a
+    # structured smuggling surface a flat form cannot render.
+    if "patternProperties" in schema:
+        raise MCPError(
+            "form-mode requestedSchema must not use 'patternProperties'; form "
+            "mode requires an explicit flat set of primitive properties "
+            "(use url mode for open-ended / structured schemas)",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+
+    # ``additionalProperties`` may only be ``false`` (a closed object) or itself
+    # a flat-primitive schema; a ``true`` / non-``false`` scalar / nested-object
+    # value reopens the smuggling surface this guard exists to close.
+    if "additionalProperties" in schema:
+        addl = schema["additionalProperties"]
+        if addl is not False:
+            if not isinstance(addl, dict):
+                raise MCPError(
+                    "form-mode requestedSchema 'additionalProperties' must be "
+                    "false or a flat-primitive schema, got "
+                    f"{type(addl).__name__}",
+                    error_code=MCPErrorCode.INVALID_PARAMS,
+                )
+            _validate_flat_primitive_property("<additionalProperties>", addl)
+
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        raise MCPError(
+            "form-mode requestedSchema 'properties' must be an object",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+
+    for field_name, prop in properties.items():
+        _validate_flat_primitive_property(field_name, prop)
+
+
+def _reject_flat_schema_combinators(schema: Dict[str, Any], context: str) -> None:
+    """Reject any :data:`_SCHEMA_COMBINATOR_KEYS` keyword on ``schema``.
+
+    Fail-closed with MCPError(INVALID_PARAMS) naming the offending keyword.
+    Applied at the top level AND per-property so a combinator / ``$ref`` cannot
+    reintroduce nesting or indirection at either level.
+    """
+    for key in _SCHEMA_COMBINATOR_KEYS:
+        if key in schema:
+            raise MCPError(
+                f"{context} must not use the '{key}' JSON-Schema keyword; form "
+                "mode requires a flat object of primitive properties "
+                "(use url mode for structured / combinator schemas)",
+                error_code=MCPErrorCode.INVALID_PARAMS,
+            )
+
+
+def _validate_enum_primitive_members(field_name: str, enum: Any) -> None:
+    """Assert every ``enum`` member is a JSON primitive scalar.
+
+    Members must be ``string`` / ``number`` / ``integer`` / ``boolean`` / ``null``
+    (Python ``str`` / ``int`` / ``float`` / ``bool`` / ``None``). An object- or
+    array-valued member reintroduces nesting through the enum and is rejected
+    with a clean -32602.
+    """
+    if not isinstance(enum, list):
+        raise MCPError(
+            f"form-mode property '{field_name}' 'enum' must be a list, got "
+            f"{type(enum).__name__}",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+    for member in enum:
+        if member is not None and not isinstance(member, _ENUM_PRIMITIVE_TYPES):
+            raise MCPError(
+                f"form-mode property '{field_name}' enum members must be JSON "
+                "primitive scalars (string/number/integer/boolean/null), got "
+                f"{type(member).__name__}",
+                error_code=MCPErrorCode.INVALID_PARAMS,
+            )
+
+
+def _validate_flat_primitive_property(field_name: str, prop: Any) -> None:
+    """Validate one form-mode property is a flat primitive. Raises MCPError.
+
+    Shared by the top-level ``properties`` loop and the ``additionalProperties``
+    (schema form) check so both surfaces enforce the identical flat-primitive
+    contract.
+    """
+    if not isinstance(prop, dict):
+        raise MCPError(
+            f"form-mode property '{field_name}' must be a schema object",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+    # A property may not reintroduce nesting via structural markers ``properties``
+    # (object) / ``items`` (array) / ``patternProperties``.
+    if "properties" in prop or "items" in prop or "patternProperties" in prop:
+        raise MCPError(
+            f"form-mode property '{field_name}' must be a flat primitive; "
+            "nested objects and arrays are not permitted in form mode "
+            "(use url mode for structured data)",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+    # A combinator or ``$ref`` on the property is rejected BEFORE the ``type``
+    # check, so a property carrying ``$ref`` alongside a primitive ``type``
+    # sibling is still rejected.
+    _reject_flat_schema_combinators(prop, f"form-mode property '{field_name}'")
+
+    prop_type = prop.get("type")
+    # An ``enum`` of primitive scalars is a valid flat primitive even without an
+    # explicit ``type``.
+    if prop_type is None and "enum" in prop:
+        _validate_enum_primitive_members(field_name, prop["enum"])
+        return
+    # ``type`` MUST be a SINGLE primitive string. A LIST type (union) or a
+    # non-primitive type reintroduces nesting / ambiguity and is rejected — this
+    # also converts the previously-uncaught ``TypeError`` on ``type: [..]`` into
+    # a clean -32602.
+    if not isinstance(prop_type, str) or prop_type not in _FLAT_PRIMITIVE_TYPES:
+        raise MCPError(
+            f"form-mode property '{field_name}' has non-primitive type "
+            f"{prop_type!r}; form mode allows only a single primitive type in "
+            f"{sorted(_FLAT_PRIMITIVE_TYPES)} or an enum of primitive scalars "
+            "(use url mode for nested objects / arrays / unions)",
+            error_code=MCPErrorCode.INVALID_PARAMS,
+        )
+    # A primitive ``type`` MAY still carry an ``enum`` constraint whose members
+    # MUST be primitive scalars.
+    if "enum" in prop:
+        _validate_enum_primitive_members(field_name, prop["enum"])
+
+
+def _form_response_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a form schema hardened with ``additionalProperties: false``.
+
+    A form-mode response MUST NOT carry undeclared (nested) keys past
+    validation. Injecting ``additionalProperties: false`` at the top level when
+    absent rejects any key the form schema did not declare. If the author
+    already set ``additionalProperties`` (constrained by
+    :func:`_validate_flat_primitive_schema` to ``false`` or a flat-primitive
+    schema), their value is respected. url-mode schemas never reach this path.
+    """
+    if not isinstance(schema, dict) or "additionalProperties" in schema:
+        return schema
+    hardened = dict(schema)
+    hardened["additionalProperties"] = False
+    return hardened
+
+
 class ElicitationSystem:
     """Interactive user input collection system (MCP elicitation/create).
 
-    Implements the MCP 2025-06-18 `elicitation/create` server-to-client request.
+    Implements the MCP 2025-11-25 `elicitation/create` server-to-client request.
     The system is split into two halves, both wired into the framework's hot
     path per rules/orphan-detection.md §1:
 
@@ -791,7 +1012,13 @@ class ElicitationSystem:
     See specs/mcp-server.md §4.9 for the full contract.
     """
 
-    def __init__(self, send: Optional[SendFn] = None):
+    def __init__(
+        self,
+        send: Optional[SendFn] = None,
+        *,
+        server_identity: Optional[Dict[str, Any]] = None,
+        capability_provider: Optional[CapabilityFn] = None,
+    ):
         """Initialize elicitation system.
 
         Args:
@@ -799,11 +1026,48 @@ class ElicitationSystem:
                 can issue `elicitation/create` requests. When None, the system
                 is receive-only — `request_input()` raises MCPError until
                 `bind_transport()` is called.
+            server_identity: Optional server-identity descriptor bound into
+                every ``url``-mode elicitation so the client can verify which
+                server issued the hand-off (spec 2025-11-25). ``url`` mode
+                requires this — see `request_input`.
+            capability_provider: Optional zero-arg callable returning True when
+                a connected client has advertised the ``elicitation``
+                capability. When bound, `request_input` fails closed if it
+                returns False (a client that cannot handle elicitation is never
+                sent one blindly). When None, the capability gate is skipped
+                (in-process / receive-only construction).
         """
         self._send: Optional[SendFn] = send
+        self._server_identity: Optional[Dict[str, Any]] = server_identity
+        self._capability_provider: Optional[CapabilityFn] = capability_provider
         self._pending_requests: Dict[str, Dict[str, Any]] = {}
         self._response_callbacks: Dict[str, Callable] = {}
         self._cancel_callbacks: Dict[str, Callable] = {}
+
+    def bind_capability_provider(self, provider: CapabilityFn) -> None:
+        """Bind the client-elicitation-capability provider.
+
+        Idempotent: a later call replaces the prior provider. When bound,
+        `request_input` consults it BEFORE dispatching and fails closed if the
+        provider reports no client advertises the ``elicitation`` capability.
+
+        Args:
+            provider: Zero-arg callable returning True when ≥1 connected client
+                advertises the ``elicitation`` capability.
+        """
+        self._capability_provider = provider
+
+    def bind_server_identity(self, server_identity: Dict[str, Any]) -> None:
+        """Bind the server-identity descriptor used for ``url``-mode elicitation.
+
+        Idempotent: a later call replaces the prior identity.
+
+        Args:
+            server_identity: Descriptor (e.g. ``{"name": server.name}``) bound
+                into every ``url``-mode outbound request so the client can
+                verify the issuing server.
+        """
+        self._server_identity = server_identity
 
     def bind_transport(self, send: SendFn) -> None:
         """Bind a transport send-callable after construction.
@@ -830,32 +1094,67 @@ class ElicitationSystem:
         prompt: str,
         input_schema: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = 300.0,
+        *,
+        mode: str = ELICITATION_MODE_FORM,
+        url: Optional[str] = None,
     ) -> Any:
         """Request input from the connected client.
 
-        Emits an MCP `elicitation/create` JSON-RPC request, awaits the
-        matching `elicitation/response`, validates against `input_schema`,
-        and returns the validated payload.
+        Emits an MCP 2025-11-25 `elicitation/create` JSON-RPC request with the
+        ``{mode, message, requestedSchema}`` shape, awaits the matching
+        `elicitation/response`, validates against `input_schema`, and returns
+        the validated payload.
+
+        Two modes (spec 2025-11-25):
+
+        - **form** (default): collect a set of FLAT PRIMITIVES inline via
+          `input_schema` (→ ``requestedSchema``). The schema MUST be a flat
+          object of primitives (string / number / integer / boolean / enum) —
+          nested objects and arrays are rejected at request time.
+        - **url**: hand the user off to a server-issued `url`. Sensitive data is
+          provided OUT-OF-BAND at that URL — it is NEVER inlined in the JSON-RPC
+          params. The outbound request carries an ``elicitationId`` and the
+          bound server-identity descriptor so the client can verify the issuing
+          server. An `input_schema` is REJECTED in url mode (it would inline the
+          collection surface url mode exists to keep out-of-band).
 
         Args:
             prompt: Prompt shown to the user by the client.
-            input_schema: Optional JSON Schema (Draft 7) for response
-                validation. When None, defaults to `{"type": "string"}` on the
-                wire (per MCP spec: `requestedSchema` is required in the
-                outbound message).
+            input_schema: Optional JSON Schema for response validation. In form
+                mode, MUST be a flat-primitive object; when None, defaults to
+                `{"type": "string"}` on the wire. MUST be None in url mode.
             timeout: Seconds to wait for the response. When None, waits
                 indefinitely.
+            mode: ``"form"`` (default) or ``"url"``. Any other value is rejected
+                with ``INVALID_PARAMS`` (-32602).
+            url: Required in url mode — the server-issued URL the client opens to
+                collect input out-of-band. Ignored in form mode.
 
         Returns:
             The validated response payload from the client.
 
         Raises:
-            MCPError(INVALID_REQUEST): No send-transport is bound.
+            MCPError(INVALID_PARAMS, code=-32602): `mode` is not in
+                {form, url}, a form-mode schema is not flat-primitive, or a
+                url-mode call is missing `url` / passes an inline schema.
+            MCPError(INVALID_REQUEST): No send-transport is bound, the client
+                has not advertised the ``elicitation`` capability, or url mode
+                is requested with no server identity bound.
             MCPError(MCP_ELICITATION_TIMEOUT, code=-32001): Client did not respond within `timeout`.
             MCPError(MCP_REQUEST_CANCELLED, code=-32800): Client returned a `decline` or
                 `cancel` action.
             ValidationError: Response failed `input_schema` validation.
         """
+        # (1) Mode validation FIRST — an undeclared/unknown mode is a client
+        # contract error rejected with INVALID_PARAMS (-32602) before any
+        # transport work (security.md § Input Validation).
+        if mode not in ELICITATION_MODES:
+            raise MCPError(
+                f"Unknown elicitation mode {mode!r}; supported modes are "
+                f"{sorted(ELICITATION_MODES)}",
+                error_code=MCPErrorCode.INVALID_PARAMS,
+            )
+
         if self._send is None:
             raise MCPError(
                 "ElicitationSystem has no send transport bound. Construct via "
@@ -864,6 +1163,50 @@ class ElicitationSystem:
                 "request_input(). See specs/mcp-server.md §4.9.",
                 error_code=MCPErrorCode.INVALID_REQUEST,
             )
+
+        # (2) Capability gate — never dispatch an elicitation/create to a
+        # client that has not advertised the ``elicitation`` capability. When a
+        # provider is bound and reports no capable client, fail closed instead
+        # of sending blindly (spec 2025-11-25 § capability-gated).
+        if self._capability_provider is not None and not self._capability_provider():
+            raise MCPError(
+                "No connected client has advertised the 'elicitation' "
+                "capability; refusing to send elicitation/create. The client "
+                "MUST declare `capabilities.elicitation` in initialize.",
+                error_code=MCPErrorCode.INVALID_REQUEST,
+            )
+
+        # (3) Per-mode request-shape validation.
+        if mode == ELICITATION_MODE_FORM:
+            # A form schema, when supplied, MUST be a flat object of primitives.
+            if input_schema is not None:
+                _validate_flat_primitive_schema(input_schema)
+        else:  # ELICITATION_MODE_URL
+            if not url:
+                raise MCPError(
+                    "url-mode elicitation requires a non-empty 'url' the client "
+                    "opens to collect input out-of-band.",
+                    error_code=MCPErrorCode.INVALID_PARAMS,
+                )
+            if input_schema is not None:
+                # An inline schema in url mode would inline the collection
+                # surface url mode exists to keep OUT-OF-BAND — reject it so no
+                # sensitive field is described (or later carried) inline.
+                raise MCPError(
+                    "url-mode elicitation MUST NOT carry an inline "
+                    "requestedSchema; sensitive data is collected out-of-band "
+                    "at the url. Use form mode for inline collection.",
+                    error_code=MCPErrorCode.INVALID_PARAMS,
+                )
+            if not self._server_identity:
+                # url mode binds a server identity so the client can verify the
+                # issuer; without it the hand-off is unverifiable.
+                raise MCPError(
+                    "url-mode elicitation requires a bound server identity. "
+                    "Construct ElicitationSystem(server_identity=...) or call "
+                    "bind_server_identity(...) before request_input(mode='url').",
+                    error_code=MCPErrorCode.INVALID_REQUEST,
+                )
 
         request_id = str(uuid.uuid4())
         start_ts = time.monotonic()
@@ -880,6 +1223,8 @@ class ElicitationSystem:
         self._pending_requests[request_id] = {
             "prompt": prompt,
             "schema": input_schema,
+            "mode": mode,
+            "url": url,
             "timestamp": time.time(),
         }
 
@@ -901,7 +1246,9 @@ class ElicitationSystem:
 
         try:
             # Dispatch the elicitation/create request through the bound transport
-            await self._send_elicitation_request(request_id, prompt, input_schema)
+            await self._send_elicitation_request(
+                request_id, prompt, input_schema, mode=mode, url=url
+            )
 
             # Wait for the matching response (or cancel / timeout)
             if timeout:
@@ -913,7 +1260,11 @@ class ElicitationSystem:
             # BEFORE returning to the calling tool — skipping validation lets
             # client-supplied payloads reach downstream tools as trusted input.
             if input_schema:
-                validator = SchemaValidator(input_schema)
+                # Harden the form schema with ``additionalProperties: false`` so
+                # a response carrying undeclared (nested) keys is rejected rather
+                # than passing validation. url-mode never reaches here (its
+                # input_schema is rejected earlier), so this is form-only.
+                validator = SchemaValidator(_form_response_schema(input_schema))
                 validator.validate(response)
 
             elapsed_ms = (time.monotonic() - start_ts) * 1000
@@ -1033,21 +1384,34 @@ class ElicitationSystem:
         request_id: str,
         prompt: str,
         schema: Optional[Dict[str, Any]],
+        *,
+        mode: str = ELICITATION_MODE_FORM,
+        url: Optional[str] = None,
     ) -> None:
         """Serialize and dispatch an MCP elicitation/create request.
 
-        Builds a JSON-RPC 2.0 message per MCP 2025-06-18 and pushes it
-        through the bound send-callable. The client responds asynchronously
-        via the MCP transport's normal receive loop; the server's dispatch
-        layer routes the inbound `elicitation/response` back into
-        `provide_input()` or `cancel_request()`.
+        Builds a JSON-RPC 2.0 message per MCP 2025-11-25 (the
+        ``{mode, message, requestedSchema}`` shape) and pushes it through the
+        bound send-callable. The client responds asynchronously via the MCP
+        transport's normal receive loop; the server's dispatch layer routes the
+        inbound `elicitation/response` back into `provide_input()` or
+        `cancel_request()`.
+
+        In **form** mode the outbound params carry ``requestedSchema`` (the
+        flat-primitive collection schema). In **url** mode the params carry an
+        ``elicitationId`` + ``url`` + the bound ``server`` identity and carry NO
+        ``requestedSchema`` and NO inline field values — sensitive data is
+        collected OUT-OF-BAND at the url, so nothing sensitive is ever placed in
+        the JSON-RPC params (security invariant).
 
         Args:
             request_id: Unique request ID (also used as the JSON-RPC `id`).
             prompt: Prompt string shown to the user.
-            schema: Optional JSON Schema for the response. When None, the
-                outbound `requestedSchema` defaults to
-                `{"type": "string"}` per MCP spec requirement.
+            schema: Optional form-mode JSON Schema for the response. When None
+                in form mode, the outbound `requestedSchema` defaults to
+                `{"type": "string"}`. Unused in url mode.
+            mode: ``"form"`` or ``"url"`` (already validated by `request_input`).
+            url: The out-of-band collection URL (url mode only).
 
         Raises:
             MCPError(INVALID_REQUEST): No send-callable is bound. Callers
@@ -1065,22 +1429,40 @@ class ElicitationSystem:
                 error_code=MCPErrorCode.INVALID_REQUEST,
             )
 
-        requested_schema = schema if schema is not None else {"type": "string"}
+        if mode == ELICITATION_MODE_URL:
+            # url mode: OUT-OF-BAND collection. The params reference the data
+            # via ``url`` + ``elicitationId`` and bind the server identity so
+            # the client can verify the issuer; NO requestedSchema and NO inline
+            # field values are carried (sensitive data never touches the wire).
+            params: Dict[str, Any] = {
+                "requestId": request_id,
+                "mode": ELICITATION_MODE_URL,
+                "message": prompt,
+                "elicitationId": request_id,
+                "url": url,
+                "server": self._server_identity,
+            }
+        else:
+            requested_schema = schema if schema is not None else {"type": "string"}
+            params = {
+                "requestId": request_id,
+                "mode": ELICITATION_MODE_FORM,
+                "message": prompt,
+                "requestedSchema": requested_schema,
+            }
+
         message: Dict[str, Any] = {
             "jsonrpc": "2.0",
             "id": request_id,
             "method": "elicitation/create",
-            "params": {
-                "requestId": request_id,
-                "message": prompt,
-                "requestedSchema": requested_schema,
-            },
+            "params": params,
         }
 
         logger.info(
             "elicitation.send",
             extra={
                 "elicitation_request_id": request_id,
+                "elicitation_mode": mode,
                 "has_schema": schema is not None,
                 "mode": "real",
             },

--- a/packages/kailash-mcp/src/kailash_mcp/errors.py
+++ b/packages/kailash-mcp/src/kailash_mcp/errors.py
@@ -88,6 +88,20 @@ class MCPErrorCode(Enum):
     MCP_TRANSPORT_REBOUND = -32002  # alias of AUTHENTICATION_FAILED
     MCP_SCHEMA_VALIDATION = -32602  # alias of INVALID_PARAMS
 
+    # MCP 2025-11-25 sampling/createMessage wire codes — the JSON-RPC error
+    # payloads for the human-in-the-loop (HITL) approval outcomes on a
+    # server-initiated sampling request. Mirrors the elicitation block above.
+    # Distinct application-range values (< -32768, outside the JSON-RPC
+    # reserved band) keep sampling rejection/timeout/decline greppable and
+    # distinct from the elicitation cancellation code (-32800). The server
+    # does NOT auto-approve model-generated content: an unbound approver
+    # fails closed with MCP_SAMPLING_REJECTED (security.md HITL fail-closed).
+    MCP_SAMPLING_REJECTED = (
+        -32810
+    )  # HITL fail-closed: no approver bound / approval rejected
+    MCP_SAMPLING_TIMEOUT = -32811  # HITL approval timed out
+    MCP_SAMPLING_DECLINED = -32812  # human reviewer explicitly declined
+
 
 class MCPError(Exception):
     """Enhanced MCP error with structured information.

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -58,6 +58,7 @@ import asyncio
 import base64
 import functools
 import gzip
+import inspect
 import json
 import logging
 import re
@@ -121,6 +122,173 @@ SUPPORTED_PROTOCOL_VERSIONS = (
     "2024-11-05",
 )
 LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+
+# Content-block types permitted inside a sampling message (MCP 2025-11-25).
+# ``text`` / ``image`` / ``audio`` are the base SamplingMessage ContentBlock
+# types; ``tool_use`` / ``tool_result`` are the tool-enabled-sampling
+# additions. This is a SERVER-SIDE allowlist (rules/ui-backend-defense.md) —
+# the client-supplied content ``type`` is validated against it, never trusted.
+SAMPLING_CONTENT_TYPES = frozenset(
+    {"text", "image", "audio", "tool_use", "tool_result"}
+)
+
+
+def _sampling_content_error(content: Any, where: str) -> Optional[str]:
+    """Validate one message ``content`` value's content-type(s).
+
+    Returns an error string when the content carries an unknown content type,
+    or ``None`` when every block is a permitted type. Plain-string content is
+    accepted (treated as ``text`` on the wire, the common shorthand shape).
+
+    A single content block is a dict carrying a ``type`` key; content MAY also
+    be a list of such blocks (multi-part messages). Anything whose declared
+    ``type`` is not in :data:`SAMPLING_CONTENT_TYPES` is rejected — the
+    input-validation gate for sampling (security.md § Input Validation).
+    """
+
+    def _check_block(block: Any) -> Optional[str]:
+        # Plain string is text shorthand — always permitted.
+        if isinstance(block, str):
+            return None
+        if not isinstance(block, dict):
+            return (
+                f"sampling message content {where} must be a string or an object "
+                f"with a 'type'; got {type(block).__name__}"
+            )
+        block_type = block.get("type")
+        if block_type is None:
+            return f"sampling message content {where} object missing required 'type'"
+        if block_type not in SAMPLING_CONTENT_TYPES:
+            return (
+                f"sampling message content {where} has unsupported type "
+                f"{block_type!r}; expected one of {sorted(SAMPLING_CONTENT_TYPES)}"
+            )
+        return None
+
+    if isinstance(content, list):
+        for block in content:
+            err = _check_block(block)
+            if err is not None:
+                return err
+        return None
+    return _check_block(content)
+
+
+def _iter_content_blocks(content: Any):
+    """Yield the individual content blocks of a message ``content`` value.
+
+    Normalizes the three legal shapes (plain string, single dict block, list of
+    blocks) into an iterable of blocks so tool_use / tool_result balance can be
+    computed uniformly.
+    """
+    if isinstance(content, list):
+        yield from content
+    else:
+        yield content
+
+
+def validate_sampling_messages(messages: Any) -> Optional[str]:
+    """Validate a sampling ``messages`` sequence (MCP 2025-11-25).
+
+    Enforces two contracts required by tool-enabled sampling:
+
+    1. **Content-type validation** — every content block declares a type in
+       :data:`SAMPLING_CONTENT_TYPES` (text / image / audio / tool_use /
+       tool_result). Unknown types are rejected.
+    2. **tool_use ↔ tool_result balance (ORDER-aware)** — every ``tool_use``
+       block carries a UNIQUE, hashable ``id``; every ``tool_result`` block's
+       ``tool_use_id`` MUST reference an ``id`` introduced by an EARLIER-position
+       ``tool_use`` (a forward or self reference is rejected), and every
+       ``tool_use`` MUST have at least one matching ``tool_result``. A duplicate
+       ``tool_use`` id, a forward/unknown ``tool_result`` reference, or an orphan
+       ``tool_use`` is rejected. Id values are hashability-guarded (mirroring
+       ``_mark_request_id_seen``) so an unhashable id yields a clean -32602
+       error string rather than an uncaught ``TypeError`` (-32603).
+
+    Returns an error string on the first violation, or ``None`` when the whole
+    sequence is valid. A non-list ``messages`` (or a non-object message) is
+    itself a violation — the shape is validated explicitly (ui-backend-defense).
+    """
+    if not isinstance(messages, list):
+        return f"sampling 'messages' must be a list; got {type(messages).__name__}"
+
+    # ``seen_use_ids`` holds tool_use ids introduced SO FAR (iteration order),
+    # so a tool_result can be checked against only EARLIER-position tool_use
+    # blocks. ``matched_use_ids`` records which of those a later tool_result
+    # referenced, for the trailing orphan-tool_use check.
+    seen_use_ids: set = set()
+    matched_use_ids: set = set()
+
+    for idx, message in enumerate(messages):
+        if not isinstance(message, dict):
+            return (
+                f"sampling message[{idx}] must be an object; "
+                f"got {type(message).__name__}"
+            )
+        content = message.get("content")
+        if content is None:
+            return f"sampling message[{idx}] missing required 'content'"
+
+        # (1) content-type validation
+        err = _sampling_content_error(content, f"in message[{idx}]")
+        if err is not None:
+            return err
+
+        # (2) order-aware tool_use / tool_result balance
+        for block in _iter_content_blocks(content):
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "tool_use":
+                use_id = block.get("id")
+                if use_id is None:
+                    return (
+                        f"sampling message[{idx}] tool_use block missing required 'id'"
+                    )
+                try:
+                    hash(use_id)
+                except TypeError:
+                    return (
+                        f"sampling message[{idx}] tool_use 'id' must be a hashable "
+                        f"scalar; got {type(use_id).__name__}"
+                    )
+                if use_id in seen_use_ids:
+                    return (
+                        f"duplicate tool_use id {use_id!r} at message[{idx}]; each "
+                        "tool_use id must be unique"
+                    )
+                seen_use_ids.add(use_id)
+            elif btype == "tool_result":
+                ref_id = block.get("tool_use_id")
+                if ref_id is None:
+                    return (
+                        f"sampling message[{idx}] tool_result block missing required "
+                        f"'tool_use_id'"
+                    )
+                try:
+                    hash(ref_id)
+                except TypeError:
+                    return (
+                        f"sampling message[{idx}] tool_result 'tool_use_id' must be "
+                        f"a hashable scalar; got {type(ref_id).__name__}"
+                    )
+                if ref_id not in seen_use_ids:
+                    return (
+                        "unbalanced tool_use/tool_result: tool_result at "
+                        f"message[{idx}] references tool_use id {ref_id!r} not "
+                        "introduced by an earlier tool_use"
+                    )
+                matched_use_ids.add(ref_id)
+
+    # Trailing balance: every introduced tool_use MUST have been referenced.
+    orphan_uses = seen_use_ids - matched_use_ids
+    if orphan_uses:
+        return (
+            "unbalanced tool_use/tool_result: tool_use id(s) "
+            f"{sorted(orphan_uses, key=str)} have no matching tool_result"
+        )
+    return None
 
 
 def negotiate_protocol_version(requested: Any) -> str:
@@ -826,13 +994,95 @@ class MCPServer:
         self._transport = None
 
         # ElicitationSystem — server-to-client interactive-input subsystem
-        # (MCP 2025-06-18 elicitation/create). Constructed without a bound
+        # (MCP 2025-11-25 elicitation/create). Constructed without a bound
         # send-callable; the send-half is bound via `_bind_elicitation_transport`
         # when the transport is established. Exposed as a public attribute
         # so tools can call `server.elicitation_system.request_input(...)`.
         # This is the production call site required by
         # rules/orphan-detection.md §1 for the ElicitationSystem manager.
-        self.elicitation_system: ElicitationSystem = ElicitationSystem()
+        #
+        # ``server_identity`` binds this server's identity into every url-mode
+        # elicitation so the client can verify the issuer (spec 2025-11-25).
+        # ``capability_provider`` is a zero-arg predicate that reports whether
+        # any connected client advertised the ``elicitation`` capability, so the
+        # send-half fails closed instead of dispatching to a client that cannot
+        # handle it.
+        self.elicitation_system: ElicitationSystem = ElicitationSystem(
+            server_identity={"name": self.name},
+            capability_provider=self._any_client_advertises_elicitation,
+        )
+
+        # Human-in-the-loop (HITL) approval callback for sampling/createMessage
+        # (MCP 2025-11-25). The server does NOT auto-approve model-generated
+        # content: a sampling request is fulfilled only after this callback
+        # approves it. When None (the default), sampling FAILS CLOSED — every
+        # request is rejected with MCP_SAMPLING_REJECTED, never silently
+        # auto-approved (security.md § HITL fail-closed). Bind an approver via
+        # ``set_sampling_approver`` — the transport-bound-callback idiom used by
+        # ElicitationSystem in advanced/features.py.
+        #
+        # Signature: ``approver(request: dict) -> bool | Awaitable[bool]`` where
+        # ``request`` carries ``messages`` / ``model_preferences`` /
+        # ``target_client`` / ``tool_choice``. Return truthy to approve; return
+        # falsy to decline (→ MCP_SAMPLING_DECLINED); raise ``asyncio.
+        # TimeoutError`` for a review timeout (→ MCP_SAMPLING_TIMEOUT); raise
+        # ``MCPError`` to surface a specific rejection code.
+        self._sampling_approver: Optional[Callable[[Dict[str, Any]], Any]] = None
+
+    def set_sampling_approver(
+        self, approver: Optional[Callable[[Dict[str, Any]], Any]]
+    ) -> None:
+        """Bind (or clear) the human-in-the-loop sampling approval callback.
+
+        Args:
+            approver: Callable invoked with the sampling-request context before
+                any ``sampling/createMessage`` is fulfilled. Returns (or awaits
+                to) a truthy value to approve, a falsy value to decline. May
+                raise ``asyncio.TimeoutError`` (review timeout) or ``MCPError``
+                (specific rejection). Pass ``None`` to clear the binding and
+                restore the fail-closed default (all sampling rejected).
+
+        Idempotent — a later call replaces the prior approver.
+        """
+        self._sampling_approver = approver
+        logger.info(
+            "sampling.approver.bound",
+            extra={"has_approver": approver is not None},
+        )
+
+    @staticmethod
+    def _client_advertises_elicitation(info: Dict[str, Any]) -> bool:
+        """Return True when a client's ``initialize`` info advertised elicitation.
+
+        A client declares support via the spec-2025-11-25 top-level
+        ``capabilities.elicitation`` key, whose value is a capability OBJECT
+        (often empty ``{}``). So the test is "is it a dict" — an empty ``{}``
+        still counts as advertised, but an explicit ``false`` / ``0`` / ``""``
+        does NOT (those are fail-OPEN under a bare ``is not None`` check). The
+        retained ``experimental.elicitation`` alias is a truthiness flag.
+        """
+        caps = info.get("capabilities", {})
+        if not isinstance(caps, dict):
+            return False
+        if isinstance(caps.get("elicitation"), dict):
+            return True
+        experimental = caps.get("experimental", {})
+        return bool(
+            isinstance(experimental, dict) and experimental.get("elicitation", False)
+        )
+
+    def _any_client_advertises_elicitation(self) -> bool:
+        """Capability provider for the ElicitationSystem gate.
+
+        Returns True when at least one connected client advertised the
+        ``elicitation`` capability. Bound into ``self.elicitation_system`` so
+        ``request_input`` fails closed rather than dispatching an
+        ``elicitation/create`` a client cannot handle (spec 2025-11-25).
+        """
+        return any(
+            self._client_advertises_elicitation(info)
+            for info in self.client_info.values()
+        )
 
     def _bind_elicitation_transport(self) -> None:
         """Bind the active transport's send-callable to the elicitation system.
@@ -902,7 +1152,13 @@ class MCPServer:
                 await self.elicitation_system.cancel_request(rid, reason=reason)
                 return True
             result = message.get("result", {})
-            # MCP 2025-06-18 ElicitResult: { action: "accept"|"decline"|"cancel", content?: {...} }
+            # MCP 2025-11-25 ElicitResult three-action model:
+            # { action: "accept"|"decline"|"cancel", content?: {...} }
+            #   accept  → provide_input(content)     (the collected payload)
+            #   decline → cancel_request("declined") (user declined to provide)
+            #   cancel  → cancel_request("cancelled")(user dismissed the prompt)
+            # decline and cancel are BOTH terminal-without-data but carry
+            # distinct reasons so a caller / audit trail can tell them apart.
             if isinstance(result, dict):
                 action = result.get("action", "accept")
                 if action == "accept":
@@ -912,7 +1168,18 @@ class MCPServer:
                     payload = content if content is not None else result
                     await self.elicitation_system.provide_input(rid, payload)
                     return True
-                # decline / cancel
+                if action == "decline":
+                    await self.elicitation_system.cancel_request(
+                        rid, reason="client declined (action=decline)"
+                    )
+                    return True
+                if action == "cancel":
+                    await self.elicitation_system.cancel_request(
+                        rid, reason="client cancelled (action=cancel)"
+                    )
+                    return True
+                # Any other/unknown action is treated as a terminal cancel so the
+                # awaiting request never hangs on an unrecognized action.
                 await self.elicitation_system.cancel_request(
                     rid, reason=f"client action={action}"
                 )
@@ -2391,11 +2658,24 @@ class MCPServer:
                     # experimental.completion alias below is retained for
                     # backward compatibility with older clients.
                     "completions": {},
+                    # Spec-2025-11-25 top-level ``sampling`` capability key. The
+                    # experimental.sampling alias below is retained for
+                    # backward compatibility with older clients / code that
+                    # still reads the experimental namespace.
+                    "sampling": {},
+                    # Spec-2025-11-25 top-level ``elicitation`` capability. The
+                    # server advertises BOTH elicitation modes it serves —
+                    # ``form`` (flat-primitive inline collection) and ``url``
+                    # (out-of-band collection with server-identity binding). The
+                    # experimental.elicitation alias below is retained for
+                    # backward compatibility with older clients.
+                    "elicitation": {"modes": ["form", "url"]},
                     "experimental": {
                         "progressNotifications": True,
                         "cancellation": True,
                         "completion": True,
                         "sampling": True,
+                        "elicitation": True,
                         "websocketCompression": self.enable_websocket_compression,
                     },
                 },
@@ -3769,19 +4049,75 @@ class MCPServer:
     async def _handle_sampling_create_message(
         self, params: Dict[str, Any], request_id: Any
     ) -> Dict[str, Any]:
-        """Handle sampling/createMessage - this is typically server-to-client."""
-        # This is usually initiated by the server to request LLM sampling from the client
-        # For server-side handling, we can validate and forward to connected clients
+        """Handle sampling/createMessage (MCP 2025-11-25 sampling).
 
-        protocol_mgr = get_protocol_manager()
+        Full 2025-11-25 sampling flow, in order:
 
-        # Check if any client supports sampling
+        1. **Content-type + tool-balance validation** (``validate_sampling_
+           messages``): every message content block is a permitted type
+           (text / image / audio / tool_use / tool_result) and every
+           ``tool_use`` has a matching ``tool_result`` (and vice versa). An
+           invalid sequence is rejected with ``INVALID_PARAMS`` (-32602)
+           before any model-generated content is requested.
+        2. **Capability check**: at least one connected client must advertise
+           ``sampling`` (top-level or the ``experimental.sampling`` alias).
+        3. **Human-in-the-loop (HITL) approval**: the request is routed
+           through ``self._sampling_approver`` BEFORE it is fulfilled. When no
+           approver is bound the request FAILS CLOSED
+           (``MCP_SAMPLING_REJECTED``) — the server never silently
+           auto-approves model-generated content (security.md § HITL
+           fail-closed). A bound approver may approve, decline
+           (``MCP_SAMPLING_DECLINED``), time out (``MCP_SAMPLING_TIMEOUT``),
+           or raise a specific ``MCPError``.
+        4. **Dispatch**: the approved request is forwarded to the selected
+           sampling client's transport and tracked in
+           ``_pending_sampling_requests``.
+        """
+        # (1) Content-type + tool_use/tool_result balance validation. Input
+        # validation runs FIRST so a malformed request never reaches the HITL
+        # gate or the transport (security.md § Input Validation).
+        messages = params.get("messages", [])
+        validation_error = validate_sampling_messages(messages)
+        if validation_error is not None:
+            logger.warning(
+                "sampling.validation.rejected",
+                extra={"reason": validation_error},
+            )
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": MCPErrorCode.INVALID_PARAMS.value,
+                    "message": f"Invalid sampling request: {validation_error}",
+                },
+                "id": request_id,
+            }
+
+        # ``toolChoice`` — tool-enabled sampling: forward the client's choice.
+        tool_choice = params.get("toolChoice")
+
+        # (2) Capability check — a client must advertise ``sampling`` either as
+        # the spec-2025-11-25 TOP-LEVEL capability key or via the retained
+        # ``experimental.sampling`` alias.
+        def _advertises_sampling(info: Dict[str, Any]) -> bool:
+            caps = info.get("capabilities", {})
+            if not isinstance(caps, dict):
+                return False
+            # Top-level ``sampling`` capability (spec 2025-11-25): the value is
+            # a capability OBJECT (often empty ``{}``), so "is it a dict" is the
+            # correct test. An empty ``{}`` counts as advertised; an explicit
+            # ``false`` / ``0`` / ``""`` does NOT (those fail OPEN under a bare
+            # ``is not None`` check).
+            if isinstance(caps.get("sampling"), dict):
+                return True
+            experimental = caps.get("experimental", {})
+            return bool(
+                isinstance(experimental, dict) and experimental.get("sampling", False)
+            )
+
         sampling_clients = [
             client_id
             for client_id, info in self.client_info.items()
-            if info.get("capabilities", {})
-            .get("experimental", {})
-            .get("sampling", False)
+            if _advertises_sampling(info)
         ]
 
         if not sampling_clients:
@@ -3794,9 +4130,36 @@ class MCPServer:
                 "id": request_id,
             }
 
-        # Create sampling request
-        messages = params.get("messages", [])
-        sampling_params = {
+        # Select the target client (first advertised; selection logic may grow).
+        target_client = sampling_clients[0]
+
+        # (3) Human-in-the-loop approval — the server MUST NOT fulfil a sampling
+        # request (model-generated content) without a human-review/approval
+        # decision. Fails CLOSED: no approver bound → reject, never
+        # auto-approve (security.md § HITL fail-closed).
+        approval_context: Dict[str, Any] = {
+            "messages": messages,
+            "model_preferences": params.get("modelPreferences"),
+            "system_prompt": params.get("systemPrompt"),
+            "tool_choice": tool_choice,
+            "target_client": target_client,
+            "request_id": request_id,
+        }
+        approval_error = await self._evaluate_sampling_approval(approval_context)
+        if approval_error is not None:
+            code, message = approval_error
+            logger.warning(
+                "sampling.approval.rejected",
+                extra={"code": code, "reason": message},
+            )
+            return {
+                "jsonrpc": "2.0",
+                "error": {"code": code, "message": message},
+                "id": request_id,
+            }
+
+        # (4) Dispatch the approved sampling request to the target client.
+        sampling_params: Dict[str, Any] = {
             "messages": messages,
             "model_preferences": params.get("modelPreferences"),
             "system_prompt": params.get("systemPrompt"),
@@ -3804,11 +4167,10 @@ class MCPServer:
             "max_tokens": params.get("maxTokens"),
             "metadata": params.get("metadata"),
         }
+        # Only forward toolChoice when the client set it (tool-enabled sampling).
+        if tool_choice is not None:
+            sampling_params["tool_choice"] = tool_choice
 
-        # Send to first available sampling client (or implement selection logic)
-        target_client = sampling_clients[0]
-
-        # Create server-to-client request
         sampling_request = {
             "jsonrpc": "2.0",
             "method": "sampling/createMessage",
@@ -3816,7 +4178,6 @@ class MCPServer:
             "id": f"sampling_{uuid.uuid4().hex[:8]}",
         }
 
-        # Send via WebSocket to client
         if self._transport and hasattr(self._transport, "send_message"):
             await self._transport.send_message(
                 sampling_request, client_id=target_client
@@ -3850,6 +4211,65 @@ class MCPServer:
                 },
                 "id": request_id,
             }
+
+    async def _evaluate_sampling_approval(
+        self, context: Dict[str, Any]
+    ) -> Optional["tuple[int, str]"]:
+        """Run the HITL approval gate for a sampling request.
+
+        Returns ``None`` when the request is APPROVED (dispatch may proceed),
+        or a ``(json_rpc_error_code, message)`` tuple when it is NOT approved.
+        Fails CLOSED: when no approver is bound the request is rejected with
+        ``MCP_SAMPLING_REJECTED`` — the server never auto-approves
+        model-generated content (security.md § HITL fail-closed).
+
+        The bound approver may:
+        * return (or await to) a truthy value → APPROVED;
+        * return (or await to) a falsy value → DECLINED
+          (``MCP_SAMPLING_DECLINED``);
+        * raise ``asyncio.TimeoutError`` → review timeout
+          (``MCP_SAMPLING_TIMEOUT``);
+        * raise ``MCPError`` → that error's code + message;
+        * raise any other exception → treated as a rejection
+          (``MCP_SAMPLING_REJECTED``), logged, never swallowed silently.
+        """
+        approver = self._sampling_approver
+        if approver is None:
+            # Fail closed — the default posture is deny, not auto-approve.
+            return (
+                MCPErrorCode.MCP_SAMPLING_REJECTED.value,
+                "sampling requires human-in-the-loop approval but no approver is "
+                "bound; the server fails closed and will not auto-approve "
+                "model-generated content (bind one via set_sampling_approver)",
+            )
+
+        try:
+            decision = approver(context)
+            if inspect.isawaitable(decision):
+                decision = await decision
+        except asyncio.TimeoutError:
+            return (
+                MCPErrorCode.MCP_SAMPLING_TIMEOUT.value,
+                "sampling approval timed out awaiting human review",
+            )
+        except MCPError as exc:
+            return (exc.error_code.value, exc.message)
+        except Exception as exc:  # noqa: BLE001 - surfaced as a rejection, logged
+            logger.warning(
+                "sampling.approval.error",
+                extra={"error": str(exc)},
+            )
+            return (
+                MCPErrorCode.MCP_SAMPLING_REJECTED.value,
+                f"sampling approval failed: {exc}",
+            )
+
+        if not decision:
+            return (
+                MCPErrorCode.MCP_SAMPLING_DECLINED.value,
+                "sampling request declined by human reviewer",
+            )
+        return None
 
     async def run_stdio(self):
         """Run the server using stdio transport for testing."""

--- a/packages/kailash-mcp/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/packages/kailash-mcp/tests/integration/mcp_server/test_elicitation_integration.py
@@ -64,10 +64,9 @@ per spec § 4.9 Cross-SDK Parity table (kailash-rs#471, kailash-py#572).
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Coroutine, Callable, Dict, List
+from typing import Any, Callable, Coroutine, Dict, List
 
 import pytest
-
 from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.server import MCPServer
 
@@ -134,6 +133,12 @@ def server() -> MCPServer:
         enable_metrics=False,
         enable_subscriptions=False,
     )
+    # Register a client that advertised the ``elicitation`` capability during
+    # initialize (spec 2025-11-25). The server's ElicitationSystem is
+    # capability-gated — it fails closed unless a connected client supports
+    # elicitation — so this mirrors the realistic production precondition for
+    # sending elicitation/create.
+    srv.client_info["test-client"] = {"capabilities": {"elicitation": {}}}
     return srv
 
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_elicitation_2025_11_25.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_elicitation_2025_11_25.py
@@ -1,0 +1,513 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 4 - elicitation/create
+(MCP revision 2025-11-25, gap E3).
+
+Behavioral pins (call the REAL ``ElicitationSystem`` / real ``MCPServer``
+handler & dispatch path — never source-grep, per ``rules/testing.md``) for the
+five sub-points of the E3 gap:
+
+1. **{mode, message, requestedSchema} request shape** — the outbound
+   ``elicitation/create`` params carry a ``mode`` field. ``form`` mode restricts
+   ``requestedSchema`` to a FLAT object of primitives (nested objects / arrays
+   rejected at request time). ``url`` mode carries an ``elicitationId`` + a
+   server-identity binding and forces sensitive data OUT-OF-BAND (no inline
+   requestedSchema / field values in the JSON-RPC params).
+2. **-32602 on undeclared/unknown mode** — a mode not in {form, url} is
+   rejected with ``INVALID_PARAMS`` (-32602).
+3. **Capability-gated** — before sending, the send-half checks a client
+   advertised the ``elicitation`` capability; if none has, it FAILS CLOSED
+   (never dispatches blindly).
+4. **Three-action accept/decline/cancel response model** — the server dispatch
+   path maps accept → provide_input, decline → declined cancel, cancel →
+   cancelled cancel, each distinguishable.
+5. **Advertise ``elicitation`` capability in initialize** — the server's
+   ``_handle_initialize`` advertises ``elicitation`` (form + url modes) at the
+   top level, with the experimental alias retained.
+
+All tests use REAL objects (no SDK mocking of the class under test); the
+in-process ``async def`` send-callable is a Protocol-Satisfying Deterministic
+Adapter (rules/testing.md § Tier 2 Exception) conforming to the ``SendFn``
+protocol — it captures outbound JSON-RPC ``elicitation/create`` requests so the
+test can inspect them, and delivers responses through the SAME production
+dispatch path (``MCPServer._route_server_initiated_response``) the server uses
+for real client transports.
+"""
+
+import asyncio
+
+import pytest
+from kailash_mcp.advanced.features import ElicitationSystem
+from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
+from kailash_mcp.server import MCPServer
+
+
+class _CapturingTransport:
+    """Real (non-mock) deterministic adapter capturing outbound requests."""
+
+    def __init__(self):
+        self.sent: list = []
+
+    async def send_message(self, message, client_id=None):
+        self.sent.append(message)
+
+
+def _make_system(*, capability: bool = True, server_identity=None):
+    """A real ElicitationSystem wired to a capturing transport.
+
+    ``capability`` drives the bound capability provider so the capability gate
+    can be exercised without a full server.
+    """
+    transport = _CapturingTransport()
+    system = ElicitationSystem(
+        send=transport.send_message,
+        server_identity=server_identity or {"name": "test-server"},
+        capability_provider=lambda: capability,
+    )
+    return system, transport
+
+
+# ---------------------------------------------------------------------------
+# (1) form mode — flat-primitive schema accepted, nested rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_form_mode_flat_primitive_schema_accepted():
+    """A flat object of primitives (string/number/boolean/enum) is accepted and
+    dispatched with the {mode, message, requestedSchema} shape."""
+    system, transport = _make_system()
+    flat_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "score": {"type": "number"},
+            "active": {"type": "boolean"},
+            "tier": {"enum": ["free", "pro"]},
+        },
+    }
+    fut = asyncio.ensure_future(
+        system.request_input("Fill the form", input_schema=flat_schema, timeout=1.0)
+    )
+    await asyncio.sleep(0.02)
+    assert len(transport.sent) == 1
+    params = transport.sent[0]["params"]
+    assert params["mode"] == "form"
+    assert params["message"] == "Fill the form"
+    assert params["requestedSchema"] == flat_schema
+    fut.cancel()
+    with pytest.raises((asyncio.CancelledError, MCPError)):
+        await fut
+
+
+@pytest.mark.asyncio
+async def test_form_mode_nested_object_schema_rejected():
+    """A property with a nested object is rejected with INVALID_PARAMS."""
+    system, transport = _make_system()
+    nested_schema = {
+        "type": "object",
+        "properties": {
+            "addr": {"type": "object", "properties": {"city": {"type": "string"}}}
+        },
+    }
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", input_schema=nested_schema, mode="form")
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+    assert exc.value.error_code.value == -32602
+    # Nothing was dispatched — rejection is at request time, before transport.
+    assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_form_mode_array_property_schema_rejected():
+    """A property with an array type is rejected with INVALID_PARAMS."""
+    system, _ = _make_system()
+    array_schema = {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+    }
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", input_schema=array_schema, mode="form")
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# (1) url mode — elicitationId + server-identity + no inline sensitive data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_url_mode_out_of_band_shape():
+    """url mode carries elicitationId + server identity and inlines NO
+    sensitive collection surface (no requestedSchema / field values)."""
+    system, transport = _make_system(server_identity={"name": "issuer-1"})
+    fut = asyncio.ensure_future(
+        system.request_input(
+            "Confirm at the link", mode="url", url="https://srv/e/abc", timeout=1.0
+        )
+    )
+    await asyncio.sleep(0.02)
+    assert len(transport.sent) == 1
+    params = transport.sent[0]["params"]
+    assert params["mode"] == "url"
+    assert params["url"] == "https://srv/e/abc"
+    # elicitationId present so the client can correlate the out-of-band flow.
+    assert params["elicitationId"]
+    # server-identity binding present so the client can verify the issuer.
+    assert params["server"] == {"name": "issuer-1"}
+    # SECURITY INVARIANT: no inline collection surface / field values.
+    assert "requestedSchema" not in params
+    assert "content" not in params
+    fut.cancel()
+    with pytest.raises((asyncio.CancelledError, MCPError)):
+        await fut
+
+
+@pytest.mark.asyncio
+async def test_url_mode_rejects_inline_schema():
+    """Passing an inline schema in url mode is rejected — it would inline the
+    collection surface url mode exists to keep out-of-band."""
+    system, transport = _make_system()
+    with pytest.raises(MCPError) as exc:
+        await system.request_input(
+            "x",
+            input_schema={"type": "object", "properties": {"pin": {"type": "string"}}},
+            mode="url",
+            url="https://srv/e/1",
+        )
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+    assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_url_mode_requires_url():
+    """url mode with no url is rejected with INVALID_PARAMS."""
+    system, _ = _make_system()
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", mode="url")
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+
+
+@pytest.mark.asyncio
+async def test_url_mode_requires_server_identity():
+    """url mode with no bound server identity is refused (unverifiable issuer)."""
+    system = ElicitationSystem(
+        send=_CapturingTransport().send_message,
+        server_identity=None,
+        capability_provider=lambda: True,
+    )
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", mode="url", url="https://srv/e/1")
+    assert exc.value.error_code == MCPErrorCode.INVALID_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# (2) -32602 on undeclared / unknown mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_mode_rejected_with_invalid_params():
+    """A mode not in {form, url} → INVALID_PARAMS (-32602), before transport."""
+    system, transport = _make_system()
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", mode="webhook")
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+    assert exc.value.error_code.value == -32602
+    assert transport.sent == []
+
+
+# ---------------------------------------------------------------------------
+# (3) capability-gated — no client elicitation capability → refused
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capability_gate_refuses_when_no_client_advertises():
+    """When the capability provider reports no client supports elicitation, the
+    send-half FAILS CLOSED and dispatches nothing."""
+    system, transport = _make_system(capability=False)
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", mode="form")
+    assert exc.value.error_code == MCPErrorCode.INVALID_REQUEST
+    assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_capability_gate_allows_when_client_advertises():
+    """When a client advertises elicitation, the request dispatches."""
+    system, transport = _make_system(capability=True)
+    fut = asyncio.ensure_future(system.request_input("x", mode="form", timeout=1.0))
+    await asyncio.sleep(0.02)
+    assert len(transport.sent) == 1
+    fut.cancel()
+    with pytest.raises((asyncio.CancelledError, MCPError)):
+        await fut
+
+
+# ---------------------------------------------------------------------------
+# (3) capability detection at the MCPServer level (real handler)
+# ---------------------------------------------------------------------------
+
+
+def test_server_detects_elicitation_capability_top_level():
+    """A client advertising the top-level ``elicitation`` capability is seen."""
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"elicitation": {}}}
+    assert server._any_client_advertises_elicitation() is True
+
+
+def test_server_detects_elicitation_capability_experimental_alias():
+    """The experimental.elicitation alias is honored."""
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"experimental": {"elicitation": True}}}
+    assert server._any_client_advertises_elicitation() is True
+
+
+def test_server_no_elicitation_capability_when_absent():
+    """A client that does not advertise elicitation is not counted."""
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"sampling": {}}}
+    assert server._any_client_advertises_elicitation() is False
+
+
+# ---------------------------------------------------------------------------
+# (4) three-action accept / decline / cancel routing (real dispatch path)
+# ---------------------------------------------------------------------------
+
+
+async def _run_action(server, transport, action, content=None):
+    """Drive one elicitation round through the real server dispatch path."""
+    fut = asyncio.ensure_future(
+        server.elicitation_system.request_input("prompt", mode="form", timeout=1.0)
+    )
+    await asyncio.sleep(0.02)
+    rid = transport.sent[-1]["id"]
+    result = {"action": action}
+    if content is not None:
+        result["content"] = content
+    routed = await server._route_server_initiated_response(rid, {"result": result})
+    return fut, routed
+
+
+def _server_with_elicitation():
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"elicitation": {}}}
+    transport = _CapturingTransport()
+    server.elicitation_system.bind_transport(transport.send_message)
+    return server, transport
+
+
+@pytest.mark.asyncio
+async def test_route_accept_returns_content():
+    server, transport = _server_with_elicitation()
+    fut, routed = await _run_action(server, transport, "accept", {"answer": 42})
+    assert routed is True
+    assert await fut == {"answer": 42}
+
+
+@pytest.mark.asyncio
+async def test_route_decline_cancels_with_declined_reason():
+    server, transport = _server_with_elicitation()
+    fut, routed = await _run_action(server, transport, "decline")
+    assert routed is True
+    with pytest.raises(MCPError) as exc:
+        await fut
+    assert exc.value.error_code == MCPErrorCode.MCP_REQUEST_CANCELLED
+    assert "decline" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_route_cancel_cancels_with_cancelled_reason():
+    server, transport = _server_with_elicitation()
+    fut, routed = await _run_action(server, transport, "cancel")
+    assert routed is True
+    with pytest.raises(MCPError) as exc:
+        await fut
+    assert exc.value.error_code == MCPErrorCode.MCP_REQUEST_CANCELLED
+    assert "cancel" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# (5) initialize advertises the elicitation capability (form + url modes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initialize_advertises_elicitation_capability():
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    resp = await server._handle_initialize(
+        {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "c"},
+        },
+        1,
+        "c1",
+    )
+    caps = resp["result"]["capabilities"]
+    # Top-level elicitation capability advertises BOTH modes.
+    assert "elicitation" in caps
+    assert set(caps["elicitation"]["modes"]) == {"form", "url"}
+    # Experimental alias retained for backward compatibility.
+    assert caps["experimental"]["elicitation"] is True
+
+
+# ---------------------------------------------------------------------------
+# G1-redteam Finding 1 — the flat-primitive form guard is EXHAUSTIVE:
+# every structural JSON-Schema vector that reintroduces nesting/indirection is
+# rejected with -32602 at request time (nothing dispatched). Each vector was a
+# CONFIRMED bypass of the properties-only guard.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "bad_schema",
+    [
+        # top-level additionalProperties whose value is a (nested-object) schema
+        {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "additionalProperties": {"type": "object"},
+        },
+        # top-level additionalProperties: true (open object)
+        {"type": "object", "additionalProperties": True},
+        # top-level patternProperties (arbitrarily-keyed subschemas)
+        {"type": "object", "patternProperties": {"^x": {"type": "string"}}},
+        # top-level combinators
+        {"type": "object", "allOf": [{"type": "object"}]},
+        {"type": "object", "anyOf": [{"type": "string"}]},
+        {"type": "object", "oneOf": [{"type": "string"}]},
+        {"type": "object", "not": {"type": "string"}},
+        {"type": "object", "$ref": "#/$defs/x"},
+        {"type": "object", "$defs": {"x": {"type": "string"}}},
+        # a property carrying $ref alongside a primitive type sibling
+        {"type": "object", "properties": {"a": {"$ref": "#/d", "type": "string"}}},
+        # an enum whose members are objects / arrays
+        {"type": "object", "properties": {"a": {"enum": [{"o": 1}]}}},
+        {"type": "object", "properties": {"a": {"enum": [["x"]]}}},
+        # a property whose type is a LIST/union (previously an uncaught TypeError)
+        {"type": "object", "properties": {"a": {"type": ["string", "object"]}}},
+    ],
+    ids=[
+        "additionalProperties-as-schema",
+        "additionalProperties-true",
+        "patternProperties",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "not",
+        "ref",
+        "defs",
+        "prop-ref-plus-type",
+        "enum-of-objects",
+        "enum-of-arrays",
+        "type-list-union",
+    ],
+)
+@pytest.mark.asyncio
+async def test_form_mode_rejects_structural_bypass_vectors(bad_schema):
+    """Each structural bypass vector is rejected with a clean -32602 at request
+    time; the type-list vector in particular no longer raises an uncaught
+    TypeError. Nothing reaches the transport."""
+    system, transport = _make_system()
+    with pytest.raises(MCPError) as exc:
+        await system.request_input("x", input_schema=bad_schema, mode="form")
+    assert exc.value.error_code == MCPErrorCode.INVALID_PARAMS
+    assert exc.value.error_code.value == -32602
+    assert transport.sent == []
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_form_mode_accepts_additional_properties_false_and_enum_scalars():
+    """A closed object (additionalProperties:false) with primitive + enum-scalar
+    properties is still accepted and dispatched (no over-rejection)."""
+    system, transport = _make_system()
+    good = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "name": {"type": "string"},
+            "tier": {"enum": ["free", "pro", 1, True, None]},
+            "level": {"type": "integer", "enum": [1, 2, 3]},
+        },
+    }
+    fut = asyncio.ensure_future(
+        system.request_input("Fill", input_schema=good, mode="form", timeout=1.0)
+    )
+    await asyncio.sleep(0.02)
+    assert len(transport.sent) == 1
+    fut.cancel()
+    with pytest.raises((asyncio.CancelledError, MCPError)):
+        await fut
+
+
+# ---------------------------------------------------------------------------
+# G1-redteam Finding 2 — form-mode response validation enforces
+# additionalProperties:false, so a response carrying undeclared (nested) keys
+# is rejected instead of passing validation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_form_response_rejects_undeclared_nested_key():
+    """A response carrying a key the form schema did not declare is rejected."""
+    system, transport = _make_system()
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fut = asyncio.ensure_future(
+        system.request_input("Fill", input_schema=schema, mode="form", timeout=1.0)
+    )
+    await asyncio.sleep(0.02)
+    rid = transport.sent[-1]["id"]
+    # Undeclared nested key alongside the declared field.
+    await system.provide_input(rid, {"name": "alice", "evil": {"nested": 1}})
+    with pytest.raises((ValidationError, MCPError)):
+        await fut
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_form_response_accepts_declared_keys_only():
+    """A response with only declared keys still validates and returns."""
+    system, transport = _make_system()
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    fut = asyncio.ensure_future(
+        system.request_input("Fill", input_schema=schema, mode="form", timeout=1.0)
+    )
+    await asyncio.sleep(0.02)
+    rid = transport.sent[-1]["id"]
+    await system.provide_input(rid, {"name": "alice"})
+    assert await fut == {"name": "alice"}
+
+
+# ---------------------------------------------------------------------------
+# G1-redteam Finding 4 — the elicitation capability check treats ONLY a dict as
+# advertised; an explicit false/0/"" is NOT advertised (was fail-open), while an
+# empty {} still counts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_value", [False, 0, ""])
+def test_elicitation_explicit_falsey_capability_not_advertised(bad_value):
+    """An explicit non-dict elicitation value fails CLOSED (not advertised)."""
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"elicitation": bad_value}}
+    assert server._any_client_advertises_elicitation() is False
+    assert (
+        MCPServer._client_advertises_elicitation(
+            {"capabilities": {"elicitation": bad_value}}
+        )
+        is False
+    )
+
+
+def test_elicitation_empty_dict_capability_is_advertised():
+    """An empty {} elicitation object DOES count as advertised."""
+    server = MCPServer("s", enable_cache=False, enable_metrics=False)
+    server.client_info["c1"] = {"capabilities": {"elicitation": {}}}
+    assert server._any_client_advertises_elicitation() is True

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
@@ -1,0 +1,484 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 4 - sampling/createMessage
+(MCP revision 2025-11-25, gap E1).
+
+Behavioral pins (call the real ``MCPServer`` handler / real
+``validate_sampling_messages`` — never source-grep, per ``rules/testing.md``)
+for the five sub-points of the E1 gap:
+
+1. **Tool-enabled sampling** — ``toolChoice`` is forwarded, and tool_use /
+   tool_result BALANCE in the message sequence is enforced (orphan tool_use or
+   orphan tool_result rejected).
+2. **Content-type validation** — message content must be text / image / audio /
+   tool_use / tool_result; an unknown content type is rejected.
+3. **Human-in-the-loop (HITL)** — sampling routes through an injectable
+   approval callback BEFORE fulfilment. No approver bound → FAILS CLOSED
+   (rejected, never auto-approved). An approving approver reaches dispatch; a
+   declining approver is rejected.
+4. **Dedicated sampling error codes** — rejection / timeout / user-decline use
+   the sampling-specific JSON-RPC error codes from ``errors.py``.
+5. **Capability** — ``sampling`` is advertised as a TOP-LEVEL client-capability
+   key in ``initialize`` (experimental alias retained).
+
+All tests use REAL ``MCPServer`` objects and REAL handlers (no SDK mocking of
+the class under test); a minimal capturing transport double satisfies the
+``send_message`` structural contract only.
+"""
+
+import asyncio
+
+import pytest
+from kailash_mcp.errors import MCPError, MCPErrorCode
+from kailash_mcp.server import MCPServer, validate_sampling_messages
+
+
+class _CapturingTransport:
+    """Real (non-mock) transport double capturing outbound sampling requests."""
+
+    def __init__(self):
+        self.sent: list = []
+
+    async def send_message(self, message, client_id=None):
+        self.sent.append((message, client_id))
+
+
+def _make_server() -> MCPServer:
+    server = MCPServer("w4-sampling-test", enable_cache=False, enable_metrics=False)
+    server.client_info = {}
+    server._pending_sampling_requests = {}
+    server._transport = _CapturingTransport()
+    # A client that advertises sampling (top-level key, spec 2025-11-25).
+    server.client_info["client-1"] = {"capabilities": {"sampling": {}}}
+    return server
+
+
+# ---------------------------------------------------------------------------
+# (2) Content-type validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_spec_content_types():
+    """text / image / audio / tool_use+tool_result blocks all validate."""
+    messages = [
+        {"role": "user", "content": "plain string is text shorthand"},
+        {"role": "user", "content": {"type": "text", "text": "hi"}},
+        {"role": "user", "content": {"type": "image", "data": "..."}},
+        {"role": "user", "content": {"type": "audio", "data": "..."}},
+    ]
+    assert validate_sampling_messages(messages) is None
+
+
+def test_validate_rejects_unknown_content_type():
+    """An unknown content type is rejected with a descriptive message."""
+    err = validate_sampling_messages(
+        [{"role": "user", "content": {"type": "video", "data": "x"}}]
+    )
+    assert err is not None
+    assert "video" in err
+    assert "unsupported type" in err
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_rejects_unknown_content_type_with_invalid_params():
+    """Handler rejects an unknown content type with INVALID_PARAMS (-32602)."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": {"type": "video"}}]},
+        "req-1",
+    )
+    assert "error" in result
+    assert result["error"]["code"] == MCPErrorCode.INVALID_PARAMS.value
+    # Rejected BEFORE any content is requested from the client.
+    assert server._transport.sent == []
+
+
+# ---------------------------------------------------------------------------
+# (1) Tool-enabled sampling — toolChoice + tool_use/tool_result balance
+# ---------------------------------------------------------------------------
+
+
+def test_validate_balanced_tool_use_result():
+    messages = [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1"}]},
+    ]
+    assert validate_sampling_messages(messages) is None
+
+
+def test_validate_rejects_orphan_tool_use():
+    """A tool_use with no matching tool_result is unbalanced → rejected."""
+    err = validate_sampling_messages(
+        [{"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]}]
+    )
+    assert err is not None
+    assert "unbalanced" in err
+    assert "t1" in err
+
+
+def test_validate_rejects_orphan_tool_result():
+    """A tool_result referencing an unknown tool_use is unbalanced → rejected."""
+    err = validate_sampling_messages(
+        [{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "ghost"}]}]
+    )
+    assert err is not None
+    assert "unbalanced" in err
+    assert "ghost" in err
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_rejects_imbalanced_tool_sequence():
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {
+            "messages": [
+                {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]}
+            ]
+        },
+        "req-2",
+    )
+    assert "error" in result
+    assert result["error"]["code"] == MCPErrorCode.INVALID_PARAMS.value
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_forwards_tool_choice():
+    """toolChoice is forwarded on the outbound sampling request."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "toolChoice": {"type": "auto"},
+        },
+        "req-3",
+    )
+    assert "result" in result
+    assert result["result"]["status"] == "sampling_requested"
+    sent_msg, _client = server._transport.sent[0]
+    assert sent_msg["params"]["tool_choice"] == {"type": "auto"}
+
+
+# ---------------------------------------------------------------------------
+# (3) HITL approval — fail closed / approve / decline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_fails_closed_without_approver():
+    """No approver bound → sampling is REJECTED, never auto-approved."""
+    server = _make_server()
+    # Deliberately do NOT bind an approver.
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-4",
+    )
+    assert "error" in result
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_REJECTED.value
+    # Nothing dispatched — no model-generated content was requested.
+    assert server._transport.sent == []
+    assert server._pending_sampling_requests == {}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_approver_approves_reaches_dispatch():
+    server = _make_server()
+    approved_contexts: list = []
+
+    def approver(ctx):
+        approved_contexts.append(ctx)
+        return True
+
+    server.set_sampling_approver(approver)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-5",
+    )
+    assert "result" in result
+    assert result["result"]["status"] == "sampling_requested"
+    # The approver saw the request context BEFORE dispatch.
+    assert len(approved_contexts) == 1
+    assert approved_contexts[0]["target_client"] == "client-1"
+    assert len(server._transport.sent) == 1
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_async_approver_supported():
+    """The approval callback may be an async coroutine (awaited)."""
+    server = _make_server()
+
+    async def approver(ctx):
+        await asyncio.sleep(0)
+        return True
+
+    server.set_sampling_approver(approver)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-6",
+    )
+    assert result["result"]["status"] == "sampling_requested"
+
+
+# ---------------------------------------------------------------------------
+# (4) Dedicated sampling error codes — decline / timeout / error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_decline_uses_declined_code():
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: False)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-7",
+    )
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_DECLINED.value
+    assert server._transport.sent == []
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_timeout_uses_timeout_code():
+    server = _make_server()
+
+    def approver(ctx):
+        raise asyncio.TimeoutError()
+
+    server.set_sampling_approver(approver)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-8",
+    )
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_TIMEOUT.value
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_approver_mcperror_propagates_code():
+    """An approver raising MCPError surfaces that specific code + message."""
+    server = _make_server()
+
+    def approver(ctx):
+        raise MCPError(
+            "policy blocked this sample",
+            error_code=MCPErrorCode.MCP_SAMPLING_DECLINED,
+        )
+
+    server.set_sampling_approver(approver)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-9",
+    )
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_DECLINED.value
+    assert "policy blocked" in result["error"]["message"]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_approver_unexpected_error_fails_closed():
+    """An approver raising an unexpected error fails CLOSED (rejected)."""
+    server = _make_server()
+
+    def approver(ctx):
+        raise RuntimeError("approver crashed")
+
+    server.set_sampling_approver(approver)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-10",
+    )
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_REJECTED.value
+    assert server._transport.sent == []
+
+
+def test_sampling_error_codes_are_distinct():
+    """The three sampling codes are distinct and distinct from elicitation."""
+    codes = {
+        MCPErrorCode.MCP_SAMPLING_REJECTED.value,
+        MCPErrorCode.MCP_SAMPLING_TIMEOUT.value,
+        MCPErrorCode.MCP_SAMPLING_DECLINED.value,
+    }
+    assert len(codes) == 3
+    assert MCPErrorCode.MCP_REQUEST_CANCELLED.value not in codes
+
+
+# ---------------------------------------------------------------------------
+# (5) Capability advertisement — top-level ``sampling`` key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_initialize_advertises_sampling_top_level():
+    server = MCPServer("w4-cap-test", enable_cache=False, enable_metrics=False)
+    result = await server._handle_initialize(
+        {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "c", "version": "1"},
+        },
+        "init-1",
+        "client-1",
+    )
+    caps = result["result"]["capabilities"]
+    # Top-level key is the spec requirement.
+    assert "sampling" in caps
+    # Experimental alias retained for backward compatibility.
+    assert caps["experimental"]["sampling"] is True
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_capability_check_accepts_experimental_alias():
+    """A client advertising only experimental.sampling is still recognized."""
+    server = _make_server()
+    server.client_info = {
+        "old-client": {"capabilities": {"experimental": {"sampling": True}}}
+    }
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-11",
+    )
+    assert result["result"]["status"] == "sampling_requested"
+    assert result["result"]["target_client"] == "old-client"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_no_capable_client_rejected_before_hitl():
+    """No sampling-capable client → capability error (fires before HITL)."""
+    server = _make_server()
+    server.client_info = {"plain": {"capabilities": {}}}
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-12",
+    )
+    assert result["error"]["code"] == -32601
+    assert "No connected clients support sampling" in result["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# G1-redteam Finding 3 — tool_use/tool_result balance is ORDER-aware,
+# duplicate-detecting, and hashability-guarded (was id-SETS only: blind to
+# order + duplicates, and an unhashable id raised an uncaught TypeError).
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_out_of_order_tool_result():
+    """A tool_result whose tool_use is introduced at a LATER index is a forward
+    reference — rejected (the set-based balance accepted it)."""
+    messages = [
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1"}]},
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]},
+    ]
+    err = validate_sampling_messages(messages)
+    assert err is not None
+    assert "not introduced by an earlier tool_use" in err
+
+
+def test_validate_rejects_duplicate_tool_use_id():
+    """Two tool_use blocks sharing one id are rejected (the set-based balance
+    silently deduped and never saw the collision)."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "t1"},
+                {"type": "tool_use", "id": "t1"},
+            ],
+        }
+    ]
+    err = validate_sampling_messages(messages)
+    assert err is not None
+    assert "duplicate tool_use id" in err
+
+
+def test_validate_unhashable_tool_use_id_returns_clean_error_string():
+    """An unhashable tool_use id yields an error STRING (mapped to -32602 by the
+    handler), NOT an uncaught TypeError (which surfaced as -32603)."""
+    messages = [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": ["a", "b"]}]}
+    ]
+    err = validate_sampling_messages(messages)
+    assert err is not None
+    assert "hashable" in err
+
+
+def test_validate_unhashable_tool_result_ref_returns_clean_error_string():
+    messages = [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": {"k": 1}}]},
+    ]
+    err = validate_sampling_messages(messages)
+    assert err is not None
+    assert "hashable" in err
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_unhashable_id_is_invalid_params_not_internal_error():
+    """Through the REAL handler, an unhashable tool_use id maps to -32602
+    (INVALID_PARAMS), never -32603 (INTERNAL_ERROR)."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {
+            "messages": [
+                {"role": "assistant", "content": [{"type": "tool_use", "id": ["x"]}]}
+            ]
+        },
+        "req-unhashable",
+    )
+    assert "error" in result
+    assert result["error"]["code"] == MCPErrorCode.INVALID_PARAMS.value
+    assert result["error"]["code"] != -32603
+
+
+# ---------------------------------------------------------------------------
+# G1-redteam Finding 4 — sampling capability check treats ONLY a dict as
+# advertised; an explicit false/0/"" is NOT advertised (was fail-open under a
+# bare ``is not None`` check), while an empty {} still counts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", [False, 0, ""])
+async def test_sampling_explicit_falsey_capability_not_advertised(bad_value):
+    """A non-dict ``sampling`` value fails CLOSED → no-capable-client error."""
+    server = _make_server()
+    server.client_info = {"c": {"capabilities": {"sampling": bad_value}}}
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-falsey",
+    )
+    assert result["error"]["code"] == -32601
+    assert "No connected clients support sampling" in result["error"]["message"]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_empty_dict_capability_is_advertised():
+    """An empty ``sampling: {}`` object DOES count as advertised (reaches
+    dispatch)."""
+    server = _make_server()
+    server.client_info = {"c": {"capabilities": {"sampling": {}}}}
+    server.set_sampling_approver(lambda ctx: True)
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "req-empty",
+    )
+    assert result["result"]["status"] == "sampling_requested"

--- a/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
+++ b/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
@@ -120,12 +120,33 @@ class TestElicitationSystemCallSites:
     def test_elicitation_system_constructor_signature_invariant(self) -> None:
         """Locks the ElicitationSystem init signature so a future refactor
         toward a different shape fails loudly.
+
+        MCP 2025-11-25 (gap E3) grew the constructor with two BACKWARD-COMPATIBLE
+        keyword-only params — ``server_identity`` (url-mode issuer binding) and
+        ``capability_provider`` (the client-elicitation-capability gate). Cross-SDK
+        parity relies on ``send`` remaining the FIRST POSITIONAL callable
+        (unchanged); the additions are keyword-only so every existing positional
+        caller ``ElicitationSystem(send)`` still binds identically.
         """
         from kailash_mcp.advanced.features import ElicitationSystem
 
         sig = inspect.signature(ElicitationSystem.__init__)
         params = [p for p in sig.parameters.values() if p.name != "self"]
-        assert [p.name for p in params] == ["send"], (
+        assert [p.name for p in params] == [
+            "send",
+            "server_identity",
+            "capability_provider",
+        ], (
             f"ElicitationSystem.__init__ signature drifted: {sig}. "
-            f"Cross-SDK parity relies on a fixed send-callable shape."
+            f"Cross-SDK parity relies on `send` staying the first positional "
+            f"callable with the 2025-11-25 additions keyword-only."
         )
+        # ``send`` MUST remain a positional-or-keyword first param; the 2025-11-25
+        # additions MUST be keyword-only (so ElicitationSystem(send) is unchanged).
+        send_param = sig.parameters["send"]
+        assert send_param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.POSITIONAL_ONLY,
+        )
+        for name in ("server_identity", "capability_provider"):
+            assert sig.parameters[name].kind == inspect.Parameter.KEYWORD_ONLY

--- a/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/tests/integration/mcp_server/test_elicitation_integration.py
@@ -89,15 +89,19 @@ async def test_elicitation_json_rpc_wire_shape() -> None:
     async def capturing_send(message: Dict[str, Any]) -> None:
         captured.append(message)
 
-        # Feed a response so request_input returns instead of timing out.
+        # Feed a valid form-mode response so request_input returns instead of
+        # timing out. The response MUST satisfy the flat-object schema (hardened
+        # with additionalProperties: false), so it is an object, not a bare str.
         async def later() -> None:
             await asyncio.sleep(0)
-            await system.provide_input(message["id"], "done")
+            await system.provide_input(message["id"], {"name": "Ada"})
 
         asyncio.create_task(later())
 
     system.bind_transport(capturing_send)
-    schema = {"type": "string", "minLength": 1}
+    # MCP 2025-11-25 form mode requires a flat OBJECT-of-primitives schema; a
+    # bare `{"type": "string"}` is rejected by _validate_flat_primitive_schema.
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
     await system.request_input("Enter name:", input_schema=schema, timeout=1.0)
 
     assert len(captured) == 1
@@ -107,6 +111,8 @@ async def test_elicitation_json_rpc_wire_shape() -> None:
     assert isinstance(msg["id"], str) and len(msg["id"]) > 0
     params = msg["params"]
     assert params["requestId"] == msg["id"]
+    # 2025-11-25 params carry the elicitation `mode` alongside message + schema.
+    assert params["mode"] == "form"
     assert params["message"] == "Enter name:"
     assert params["requestedSchema"] == schema
 
@@ -272,6 +278,10 @@ async def test_mcpserver_route_server_initiated_response_accept_action() -> None
     """MCPServer._route_server_initiated_response delivers accept-action results."""
     captured: List[Dict[str, Any]] = []
     server = MCPServer("test-server")
+    # 2025-11-25 capability gate: request_input fails closed unless a connected
+    # client has advertised the `elicitation` capability. Register one so the
+    # accept-action routing (not the gate) is what this test exercises.
+    server.client_info["c1"] = {"capabilities": {"elicitation": {}}}
 
     async def capturing_send(message: Dict[str, Any]) -> None:
         captured.append(message)
@@ -300,6 +310,9 @@ async def test_mcpserver_route_server_initiated_response_accept_action() -> None
 async def test_mcpserver_route_server_initiated_response_decline_action() -> None:
     """Decline/cancel action surfaces as MCPError(REQUEST_CANCELLED)."""
     server = MCPServer("test-server")
+    # 2025-11-25 capability gate: register a capable client so the decline-action
+    # routing (not the fail-closed gate) is what this test exercises.
+    server.client_info["c1"] = {"capabilities": {"elicitation": {}}}
 
     async def declining_send(message: Dict[str, Any]) -> None:
         async def later() -> None:

--- a/tests/integration/mcp_server/test_missing_handlers_integration.py
+++ b/tests/integration/mcp_server/test_missing_handlers_integration.py
@@ -350,6 +350,14 @@ class TestSamplingCreateMessageIntegration(DockerIntegrationTestBase):
 
         server._transport = MockWebSocketTransport()
 
+        # Bind an approving HITL approver so the FORWARD-path tests in this
+        # class exercise dispatch. Sampling fails CLOSED when no approver is
+        # bound (MCP 2025-11-25 HITL, #1712 W4) — a server that accepts
+        # sampling has an approver, the realistic production precondition.
+        # Mirrors the unit-test fixture fix in
+        # tests/unit/mcp_server/test_missing_handlers.py.
+        server.set_sampling_approver(lambda ctx: True)
+
         return server
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp_server/test_missing_handlers.py
+++ b/tests/unit/mcp_server/test_missing_handlers.py
@@ -379,6 +379,13 @@ class TestSamplingCreateMessage:
         mock_transport.send_message = AsyncMock()
         server._transport = mock_transport
 
+        # Bind an approving HITL approver so the FORWARD-path tests in this
+        # class exercise dispatch. Sampling fails CLOSED when no approver is
+        # bound (MCP 2025-11-25 HITL, #1712 W4 E1) — the fail-closed default
+        # and the decline/timeout/error outcomes are pinned in
+        # packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py.
+        server.set_sampling_approver(lambda ctx: True)
+
         return server
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Wave 4 (final implementation wave) of the MCP 2025-11-25 spec-parity effort (#1712) — server-side **sampling** and **elicitation** client-features, gated by an adversarial G1 redteam whose crown-jewel security checks **held** (HITL fail-closed ✅, url-mode out-of-band ✅). **384 package + 645 core mcp tests green.**

### Sampling (`server.py` + `errors.py`)
- Full `sampling/createMessage`: tool-enabled sampling (`toolChoice` + **order-aware** `tool_use`/`tool_result` balance with hashability guard → clean `-32602`), content-type allowlist validation, and a **human-in-the-loop approval gate that fails closed** — no approver bound ⇒ rejected, never silent auto-approve of model-generated content. Dedicated sampling error codes; `sampling` advertised top-level.

### Elicitation (`advanced/features.py` + `server.py`)
- 2025-11-25 `{mode, message, requestedSchema}`. **form mode** restricts the schema to flat primitives via an exhaustive guard (rejects `additionalProperties`-as-schema, `patternProperties`, `allOf`/`anyOf`/`oneOf`/`not`/`$ref`/`$defs`, enum-of-non-primitives, union/list types → `-32602`) and enforces `additionalProperties:false` on response validation. **url mode** carries `elicitationId` + server-identity binding and forces sensitive data out-of-band (no inline schema/content). Undeclared mode → `-32602`; fail-closed client-capability gate; three-action accept/decline/cancel routing.

### Redteam findings (all MED/LOW, fixed + verified)
The adversarial pass downgraded both initial HIGH findings to MED (no remote attack surface: `request_input` is a server-author API, responses still schema-validated) and confirmed the HITL + url-mode invariants held. Fixed: exhaustive flat-primitive guard, response `additionalProperties:false`, order-aware sampling balance, dict-based capability check.

## Related issues
Refs #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)