### PR TITLE
release: kailash-mcp 0.4.0 — server-initiated request/response lifecycle hardening (#1712)

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.4.0] — 2026-07-16 — Server-initiated request/response lifecycle hardening (#1712)
+
+Completes the #1712 MCP 2025-11-25 work. The 2025-11-25 wire surface
+(`sampling/createMessage`, `elicitation/create`, `roots/list`, progress,
+cancellation, completion, logging) shipped in the 0.3.x line; this release makes
+the **server-initiated** request/response lifecycle correct and concurrency-safe.
+No new wire methods — the changes harden the existing surface.
+
+### Fixed
+
+- **Single-client server-initiated round-trips no longer deadlock.** The native
+  WebSocket server transport now dispatches each inbound message in its own task,
+  so the read loop keeps draining the socket while a tool handler awaits a
+  server-initiated reply (sampling / elicitation / roots) that arrives on the SAME
+  connection. Previously the handler blocked until its timeout.
+- **A server-initiated reply reaches the original requester.** The model
+  completion / elicitation result / roots list is routed back to the client that
+  owns the pending request (previously the sampling reply could be dropped with a
+  spurious `-32601`).
+- **Replies are client-scoped fail-closed.** A server-initiated result is accepted
+  only from the client that owns the pending request; a mismatched responder is
+  rejected, never silently routed. Tool→client scope is carried via contextvars so
+  it stays correct under concurrent dispatch.
+
+### Security / hardening
+
+Newly reachable once handlers run concurrently:
+
+- Per-client progress tokens are namespaced by request id, so two concurrent calls
+  reusing one `progressToken` value cannot cross-deliver or evict each other's
+  progress.
+- A server-initiated dispatch-send failure drops the pending request from every
+  tracking map and cancels its future — no leaked future or FIFO entry.
+- Every outbound WebSocket send for a client serializes through one per-client
+  lock, so a server-initiated send and a response send cannot interleave frames.
+- The pending-sampling map stays FIFO-bounded and is cleared on client disconnect.
+
 ## [0.3.2] — 2026-07-15 — JWT audience fail-closed + OAuth 2.1 client discovery + server conformance (#1712)
 
 Second MCP 2025-11-25 spec-parity wave. Part of #1712 — the checklist remains open for later waves.

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.3.2"
+version = "0.4.0"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -1325,7 +1325,11 @@ class ElicitationSystem:
             # callbacks — the awaiter is never left hanging until timeout.
             try:
                 await self._send_elicitation_request(
-                    request_id, prompt, input_schema, mode=mode, url=url,
+                    request_id,
+                    prompt,
+                    input_schema,
+                    mode=mode,
+                    url=url,
                     client_id=client_id,
                 )
             except MCPError:

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -65,6 +65,7 @@ Examples:
 
 import asyncio
 import base64
+import inspect
 import json
 import logging
 import mimetypes
@@ -766,6 +767,34 @@ class StreamingHandler:
 # § Elicitation — capability-gated). See MCPServer._bind_elicitation_transport.
 CapabilityFn = Callable[[], bool]
 
+# Resolves the client_id an elicitation targets when ``request_input`` is called
+# without an explicit ``client_id`` — bound by MCPServer to read the client of
+# the ``tools/call`` currently executing (FINDING 3 — elicitation client-scoping).
+# Returns None when no client context is active (unscoped, backward compatible).
+ClientIdFn = Callable[[], Optional[str]]
+
+
+def _send_accepts_client_id(send: "SendFn") -> bool:
+    """Report whether the bound transport send-callable accepts a ``client_id``.
+
+    A multi-client transport (``WebSocketServerTransport.send_message``) accepts
+    ``client_id`` so an ``elicitation/create`` can be dispatched to ONE specific
+    client instead of broadcast to every connection (cross-client isolation —
+    FINDING 3). A single-client transport (e.g. stdio) does not, so the caller
+    falls back to the unscoped send.
+    """
+    try:
+        sig = inspect.signature(send)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == "client_id":
+            return True
+    return False
+
+
 # The two elicitation modes defined by MCP 2025-11-25. ``form`` collects a set
 # of flat primitives inline via ``requestedSchema``; ``url`` hands the user off
 # to a server-issued URL so sensitive data is provided OUT-OF-BAND (never inline
@@ -1018,6 +1047,7 @@ class ElicitationSystem:
         *,
         server_identity: Optional[Dict[str, Any]] = None,
         capability_provider: Optional[CapabilityFn] = None,
+        client_id_provider: Optional[ClientIdFn] = None,
     ):
         """Initialize elicitation system.
 
@@ -1040,6 +1070,7 @@ class ElicitationSystem:
         self._send: Optional[SendFn] = send
         self._server_identity: Optional[Dict[str, Any]] = server_identity
         self._capability_provider: Optional[CapabilityFn] = capability_provider
+        self._client_id_provider: Optional[ClientIdFn] = client_id_provider
         self._pending_requests: Dict[str, Dict[str, Any]] = {}
         self._response_callbacks: Dict[str, Callable] = {}
         self._cancel_callbacks: Dict[str, Callable] = {}
@@ -1056,6 +1087,31 @@ class ElicitationSystem:
                 advertises the ``elicitation`` capability.
         """
         self._capability_provider = provider
+
+    def bind_client_id_provider(self, provider: ClientIdFn) -> None:
+        """Bind the resolver for the client a client-less ``request_input`` targets.
+
+        Idempotent. When bound, ``request_input`` called without an explicit
+        ``client_id`` consults it so an elicitation raised from inside a
+        ``tools/call`` inherits the invoking client — the elicitation is then
+        dispatched to, and resolvable ONLY by, that client (FINDING 3). A
+        provider returning None leaves the request unscoped (backward compatible).
+
+        Args:
+            provider: Zero-arg callable returning the current client_id or None.
+        """
+        self._client_id_provider = provider
+
+    def pending_client_id(self, request_id: str) -> Optional[str]:
+        """Return the client_id bound to a pending elicitation, or None.
+
+        The MCPServer response router reads this to enforce that only the client
+        an elicitation was issued to may resolve it (FINDING 3 — cross-client
+        isolation). Returns None for an unknown request_id or an unscoped
+        pending entry (no bound client).
+        """
+        entry = self._pending_requests.get(request_id)
+        return entry.get("client_id") if entry else None
 
     def bind_server_identity(self, server_identity: Dict[str, Any]) -> None:
         """Bind the server-identity descriptor used for ``url``-mode elicitation.
@@ -1217,6 +1273,12 @@ class ElicitationSystem:
                     error_code=MCPErrorCode.INVALID_REQUEST,
                 )
 
+        # Resolve the target client. An explicit ``client_id`` wins; otherwise
+        # inherit the client of the currently-executing ``tools/call`` via the
+        # bound provider (FINDING 3). None → unscoped (backward compatible).
+        if client_id is None and self._client_id_provider is not None:
+            client_id = self._client_id_provider()
+
         request_id = str(uuid.uuid4())
         start_ts = time.monotonic()
         logger.info(
@@ -1256,10 +1318,24 @@ class ElicitationSystem:
         )
 
         try:
-            # Dispatch the elicitation/create request through the bound transport
-            await self._send_elicitation_request(
-                request_id, prompt, input_schema, mode=mode, url=url
-            )
+            # Dispatch the elicitation/create request through the bound
+            # transport, TARGETING ``client_id`` (FINDING 3). Wrap the send so a
+            # transport failure (the client vanished mid-dispatch) surfaces as a
+            # typed MCPError and the ``finally`` below cleans the pending Future /
+            # callbacks — the awaiter is never left hanging until timeout.
+            try:
+                await self._send_elicitation_request(
+                    request_id, prompt, input_schema, mode=mode, url=url,
+                    client_id=client_id,
+                )
+            except MCPError:
+                raise
+            except Exception as exc:
+                raise MCPError(
+                    f"Failed to dispatch elicitation/create request "
+                    f"{request_id}: {exc}",
+                    error_code=MCPErrorCode.INVALID_REQUEST,
+                ) from exc
 
             # Wait for the matching response (or cancel / timeout)
             if timeout:
@@ -1445,6 +1521,7 @@ class ElicitationSystem:
         *,
         mode: str = ELICITATION_MODE_FORM,
         url: Optional[str] = None,
+        client_id: Optional[str] = None,
     ) -> None:
         """Serialize and dispatch an MCP elicitation/create request.
 
@@ -1525,7 +1602,15 @@ class ElicitationSystem:
                 "mode": "real",
             },
         )
-        await self._send(message)
+        # Dispatch to the SPECIFIC target client when one is bound AND the
+        # transport's send-callable accepts ``client_id`` — so elicitation/create
+        # is never broadcast to every connected client (cross-client isolation —
+        # FINDING 3). A single-client transport (no ``client_id`` kwarg) or an
+        # unscoped request falls back to the unscoped send.
+        if client_id is not None and _send_accepts_client_id(self._send):
+            await self._send(message, client_id=client_id)
+        else:
+            await self._send(message)
 
 
 class ProgressReporter:

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -1097,6 +1097,7 @@ class ElicitationSystem:
         *,
         mode: str = ELICITATION_MODE_FORM,
         url: Optional[str] = None,
+        client_id: Optional[str] = None,
     ) -> Any:
         """Request input from the connected client.
 
@@ -1129,6 +1130,14 @@ class ElicitationSystem:
                 with ``INVALID_PARAMS`` (-32602).
             url: Required in url mode — the server-issued URL the client opens to
                 collect input out-of-band. Ignored in form mode.
+            client_id: Optional id of the client this elicitation targets. When
+                provided it is recorded on the pending request so (a) only that
+                client may resolve it — a response from another client is
+                rejected by the server's response router (cross-client
+                isolation) — and (b) that client's disconnect cancels+evicts the
+                pending request (``cancel_requests_for_client``). When None the
+                request is UNSCOPED: any responder may resolve it and a
+                disconnect does not evict it (backward-compatible default).
 
         Returns:
             The validated response payload from the client.
@@ -1219,12 +1228,14 @@ class ElicitationSystem:
             },
         )
 
-        # Store request metadata
+        # Store request metadata. ``client_id`` (may be None) scopes the request
+        # to a single client for response-routing + disconnect eviction.
         self._pending_requests[request_id] = {
             "prompt": prompt,
             "schema": input_schema,
             "mode": mode,
             "url": url,
+            "client_id": client_id,
             "timestamp": time.time(),
         }
 
@@ -1378,6 +1389,53 @@ class ElicitationSystem:
             return True
 
         return False
+
+    def cancel_requests_for_client(
+        self, client_id: Optional[str], reason: str = "client disconnected"
+    ) -> int:
+        """Cancel + evict every pending request SCOPED to ``client_id``.
+
+        Called from the MCPServer transport-disconnect handler (a SYNC context)
+        so a disconnecting client's awaiting ``request_input()`` callers get a
+        clean ``MCP_REQUEST_CANCELLED`` immediately instead of hanging until
+        their timeout. Synchronous by design — it only invokes the already-
+        registered cancel callbacks (each sets an exception on the awaiting
+        Future) and evicts the pending entry; it never awaits.
+
+        Requests with no bound ``client_id`` (UNSCOPED) are left intact — a
+        disconnect cannot know they targeted the departing client, so evicting
+        them would wrongly cancel unrelated in-flight elicitations. A ``None``
+        ``client_id`` argument therefore matches nothing.
+
+        Args:
+            client_id: The disconnecting client. ``None`` matches no request.
+            reason: Reason string propagated into the raised MCPError.
+
+        Returns:
+            The number of pending requests cancelled + evicted.
+        """
+        if client_id is None:
+            return 0
+        stale = [
+            rid
+            for rid, meta in self._pending_requests.items()
+            if meta.get("client_id") == client_id
+        ]
+        for rid in stale:
+            callback = self._cancel_callbacks.get(rid)
+            if callback is not None:
+                # Sets MCP_REQUEST_CANCELLED on the awaiting Future; the
+                # request_input() finally-block pops the callbacks as it unwinds.
+                callback(reason)
+            # Evict the metadata now so a duplicate disconnect is idempotent and
+            # a receive-only pending request (no awaiter) does not leak.
+            self._pending_requests.pop(rid, None)
+        if stale:
+            logger.info(
+                "elicitation.client_disconnect.cancelled",
+                extra={"client_id": client_id, "count": len(stale)},
+            )
+        return len(stale)
 
     async def _send_elicitation_request(
         self,

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -56,6 +56,7 @@ Enhanced Production Usage:
 
 import asyncio
 import base64
+import contextvars
 import functools
 import gzip
 import inspect
@@ -108,6 +109,19 @@ from kailash_mcp.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Client_id of the ``tools/call`` currently executing on this event loop. A tool
+# that raises an elicitation via ``server.elicitation_system.request_input(...)``
+# without an explicit ``client_id`` inherits THIS client, so the elicitation is
+# dispatched to — and resolvable ONLY by — the invoking client (FINDING 3 —
+# elicitation client-scoping). ``_handle_call_tool`` sets it for the tool body's
+# duration; default None → unscoped (backward compatible). An asyncio Task copies
+# the context at creation, so a per-request tool task sees the value set before
+# it was spawned and concurrent tool calls never see each other's client.
+_CURRENT_TOOL_CLIENT: "contextvars.ContextVar[Optional[str]]" = (
+    contextvars.ContextVar("mcp_current_tool_client", default=None)
+)
 
 
 # Supported MCP protocol-handshake revisions, newest first. The server
@@ -1030,6 +1044,10 @@ class MCPServer:
         self.elicitation_system: ElicitationSystem = ElicitationSystem(
             server_identity={"name": self.name},
             capability_provider=self._any_client_advertises_elicitation,
+            # A client-less request_input() (a tool raising an elicitation)
+            # inherits the invoking tools/call's client so the elicitation is
+            # dispatched to — and resolvable only by — that client (FINDING 3).
+            client_id_provider=lambda: _CURRENT_TOOL_CLIENT.get(),
         )
 
         # Human-in-the-loop (HITL) approval callback for sampling/createMessage
@@ -1131,19 +1149,24 @@ class MCPServer:
     ) -> bool:
         """Report whether a response's client fails the client-scope check.
 
-        A server-initiated request records the client it was issued to; only
-        that client may resolve it. Returns True (mismatch → do NOT resolve)
-        only when BOTH ids are known AND they differ. When either is unknown
-        (an internal caller that did not thread the responder, or a request
-        issued without a bound client), the check is a no-op and resolution
-        proceeds — an unscoped request keeps its prior behaviour (FINDING 4 —
-        cross-client isolation on the shared router).
+        FAIL-CLOSED for a SCOPED request (round-2 re-redteam FINDING 3): when a
+        request was issued to a specific client (``expected_client_id`` set),
+        ONLY that exact client may resolve it. A responder that is None/empty OR
+        differs is REFUSED (returns True → do NOT resolve) — a None
+        ``responding_client_id`` can no longer resolve a scoped sampling / roots
+        / elicitation request, closing the cross-client gap (FINDING 3 / F4).
+
+        An UNSCOPED request (``expected_client_id`` None/empty — no bound client)
+        keeps permissive resolution (returns False): an internal / in-process
+        caller that never bound a client is not client-scoped, so any responder
+        (including None) still resolves it (backward compatible).
         """
-        return (
-            responding_client_id is not None
-            and expected_client_id is not None
-            and responding_client_id != expected_client_id
-        )
+        if not expected_client_id:
+            # Unscoped — no bound client to enforce against.
+            return False
+        # Scoped — fail closed: only the exact bound client may resolve it, and
+        # a None/empty responder never can.
+        return responding_client_id != expected_client_id
 
     async def _route_server_initiated_response(
         self,
@@ -1222,7 +1245,7 @@ class MCPServer:
         if rid in self.elicitation_system._pending_requests:
             if self._client_scope_mismatch(
                 responding_client_id,
-                self.elicitation_system._pending_requests[rid].get("client_id"),
+                self.elicitation_system.pending_client_id(rid),
             ):
                 logger.warning(
                     "elicitation.response.cross_client_rejected",
@@ -2965,10 +2988,18 @@ class MCPServer:
         cancel_key = self._cancel_key(client_id, request_id)
 
         async def _run_tool() -> Any:
-            result = self._execute_tool(tool_name, arguments)
-            if asyncio.iscoroutine(result) or asyncio.isfuture(result):
-                result = await result
-            return result
+            # Scope any elicitation this tool raises to the invoking client
+            # (FINDING 3). Set inside the task's own context so it is visible to
+            # request_input() called from the tool body and never leaks to a
+            # concurrent tool call.
+            token = _CURRENT_TOOL_CLIENT.set(client_id)
+            try:
+                result = self._execute_tool(tool_name, arguments)
+                if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                    result = await result
+                return result
+            finally:
+                _CURRENT_TOOL_CLIENT.reset(token)
 
         task = asyncio.ensure_future(_run_tool())
         self._inflight_tasks[cancel_key] = task

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -1210,8 +1210,7 @@ class MCPServer:
                     extra={"sampling_id": rid, "responder": responding_client_id},
                 )
                 return False
-            entry = self._pending_sampling_requests.pop(rid)
-            self._pending_sampling_clients.pop(rid, None)
+            entry = self._drop_pending_sampling(rid)
             fut = entry.get("future")
             # The FULL message (result OR error) is delivered so the handler can
             # relay a client error distinctly from a model completion.
@@ -2541,8 +2540,7 @@ class MCPServer:
             if cid == client_id
         ]
         for sid in stale_sampling:
-            self._pending_sampling_clients.pop(sid, None)
-            entry = self._pending_sampling_requests.pop(sid, None)
+            entry = self._drop_pending_sampling(sid)
             if entry is not None:
                 fut = entry.get("future")
                 if fut is not None and not fut.done():
@@ -4266,8 +4264,26 @@ class MCPServer:
                 "id": request_id,
             }
 
-        # Select the target client (first advertised; selection logic may grow).
-        target_client = sampling_clients[0]
+        # (FINDING 4 — cross-client isolation) Route sampling to the REQUESTER's
+        # OWN client, never a blind ``sampling_clients[0]`` pick: that would send
+        # client A's messages to client B's LLM (cross-client content exposure).
+        # The requester's client_id is merged into params by the WS dispatch. If
+        # the requester's own client does not advertise sampling, reject (-32601)
+        # rather than silently fall back to a DIFFERENT client.
+        requester = params.get("client_id")
+        if requester is None or requester not in sampling_clients:
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32601,
+                    "message": (
+                        "requesting client does not advertise sampling; a "
+                        "sampling request is routed to the requester's own client"
+                    ),
+                },
+                "id": request_id,
+            }
+        target_client = requester
 
         # (3) Human-in-the-loop approval — the server MUST NOT fulfil a sampling
         # request (model-generated content) without a human-review/approval
@@ -4340,8 +4356,7 @@ class MCPServer:
         try:
             completion = await asyncio.wait_for(fut, self._sampling_timeout)
         except asyncio.TimeoutError:
-            self._pending_sampling_requests.pop(sampling_id, None)
-            self._pending_sampling_clients.pop(sampling_id, None)
+            self._drop_pending_sampling(sampling_id)
             logger.warning(
                 "sampling.timeout",
                 extra={"sampling_id": sampling_id, "target_client": target_client},
@@ -4364,8 +4379,7 @@ class MCPServer:
             # Only the former is a sampling failure we translate; a real task
             # cancel is re-raised so cancellation is not silently swallowed.
             if fut.cancelled():
-                self._pending_sampling_requests.pop(sampling_id, None)
-                self._pending_sampling_clients.pop(sampling_id, None)
+                self._drop_pending_sampling(sampling_id)
                 logger.warning(
                     "sampling.target_disconnected",
                     extra={"sampling_id": sampling_id, "target_client": target_client},
@@ -4398,6 +4412,23 @@ class MCPServer:
             "result": result,
             "id": request_id,
         }
+
+    def _drop_pending_sampling(self, sampling_id: str) -> Optional[Dict[str, Any]]:
+        """Remove a pending sampling entry from ALL THREE tracking structures.
+
+        Convergence round-2 (FINDING 1): the FIFO-cap deque
+        ``_pending_sampling_order`` MUST be pruned at every resolution site
+        (reply / timeout / disconnect / cancelled) so the cap counts only LIVE
+        entries. Otherwise dead (resolved) ids fill the deque and a genuinely
+        in-flight request is spuriously evicted+cancelled once
+        ``_MAX_PENDING_SAMPLING`` OTHER requests complete.
+        """
+        self._pending_sampling_clients.pop(sampling_id, None)
+        try:
+            self._pending_sampling_order.remove(sampling_id)
+        except ValueError:
+            pass
+        return self._pending_sampling_requests.pop(sampling_id, None)
 
     def _register_pending_sampling(
         self,

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -921,7 +921,27 @@ class MCPServer:
 
         # Client management for new handlers
         self.client_info: Dict[str, Dict[str, Any]] = {}
+        # Server-initiated ``sampling/createMessage`` (server->client) request
+        # tracking. Maps an outbound sampling id to an entry carrying the
+        # awaiting ``future`` + the ORIGINAL requester's ``original_request_id``
+        # + the TARGET ``client_id`` (the expected responder). The target
+        # client's reply resolves the Future via ``_route_server_initiated_
+        # response`` so the model completion reaches the original requester
+        # (FINDING 1 — the reply was previously dropped with a spurious -32601).
         self._pending_sampling_requests: Dict[str, Dict[str, Any]] = {}
+        # Maps an outbound sampling id to the TARGET client_id it was dispatched
+        # to, so (a) a disconnecting target's pending sampling Futures can be
+        # cancelled+popped (_on_ws_disconnect) and (b) the response router can
+        # enforce that the RESPONDING client matches the client the request was
+        # sent to — cross-client isolation (FINDING 2 + FINDING 4).
+        self._pending_sampling_clients: Dict[str, str] = {}
+        # FIFO order of pending sampling ids so a stream of never-answered
+        # requests cannot grow the maps without limit (mirrors the
+        # _MAX_SEEN_REQUEST_IDS reuse-set cap) — FINDING 2 (unbounded growth).
+        self._pending_sampling_order: "deque[str]" = deque()
+        # Seconds to await a sampling target's reply before returning a
+        # MCP_SAMPLING_TIMEOUT to the original requester.
+        self._sampling_timeout: float = 30.0
 
         # Server-initiated ``roots/list`` (server->client) request tracking and
         # per-client cached roots (spec 2025-11-25). ``_pending_roots_requests``
@@ -1106,24 +1126,54 @@ class MCPServer:
             extra={"transport_type": type(self._transport).__name__},
         )
 
+    def _client_scope_mismatch(
+        self, responding_client_id: Optional[str], expected_client_id: Optional[str]
+    ) -> bool:
+        """Report whether a response's client fails the client-scope check.
+
+        A server-initiated request records the client it was issued to; only
+        that client may resolve it. Returns True (mismatch → do NOT resolve)
+        only when BOTH ids are known AND they differ. When either is unknown
+        (an internal caller that did not thread the responder, or a request
+        issued without a bound client), the check is a no-op and resolution
+        proceeds — an unscoped request keeps its prior behaviour (FINDING 4 —
+        cross-client isolation on the shared router).
+        """
+        return (
+            responding_client_id is not None
+            and expected_client_id is not None
+            and responding_client_id != expected_client_id
+        )
+
     async def _route_server_initiated_response(
-        self, request_id: Any, message: Dict[str, Any]
+        self,
+        request_id: Any,
+        message: Dict[str, Any],
+        responding_client_id: Optional[str] = None,
     ) -> bool:
         """Route an inbound JSON-RPC response to its originating pending request.
 
-        Server-initiated JSON-RPC requests (elicitation/create today;
-        sampling/createMessage in the future) expect a matching response
-        from the client. This method inspects `self.elicitation_system._pending_requests`
-        and other pending-request registries, routing the response to the
-        appropriate subsystem.
+        Server-initiated JSON-RPC requests (roots/list, elicitation/create,
+        sampling/createMessage) expect a matching response from the client.
+        This method inspects the per-feature pending-request registries and
+        routes the response to the awaiting Future / callback.
+
+        Every branch is CLIENT-SCOPED: the ``responding_client_id`` (the client
+        that sent this reply) MUST match the client the request was issued to,
+        so a reply from client B can never resolve client A's pending request
+        (FINDING 4). When the responder or the stored client is unknown the
+        scope check is a no-op (back-compat for unscoped requests).
 
         Args:
             request_id: `id` field of the inbound response.
             message: Full inbound message dict (with `result` or `error`).
+            responding_client_id: client_id of the WS connection this reply
+                arrived on (threaded from ``_handle_websocket_message``).
 
         Returns:
             True when a matching pending request existed and was resolved.
-            False when no pending request matched — caller should fall
+            False when no pending request matched OR the responding client did
+            not match the client the request was issued to — caller should fall
             through to the regular request dispatch.
         """
         rid = str(request_id)
@@ -1133,14 +1183,53 @@ class MCPServer:
         # ``request_client_roots`` can distinguish a real roots list from a
         # ``-32601`` "roots unsupported" fallback.
         if rid in self._pending_roots_requests:
+            if self._client_scope_mismatch(
+                responding_client_id, self._pending_roots_clients.get(rid)
+            ):
+                logger.warning(
+                    "roots.response.cross_client_rejected",
+                    extra={"request_id": rid, "responder": responding_client_id},
+                )
+                return False
             fut = self._pending_roots_requests.pop(rid)
             self._pending_roots_clients.pop(rid, None)
             if not fut.done():
                 fut.set_result(message)
             return True
 
+        # Route a server-initiated ``sampling/createMessage`` (server->client)
+        # response back to the awaiting handler so the ORIGINAL requester
+        # receives the model completion (FINDING 1). Client-scoped: only the
+        # client the request was dispatched TO may resolve it (FINDING 4).
+        if rid in self._pending_sampling_requests:
+            if self._client_scope_mismatch(
+                responding_client_id, self._pending_sampling_clients.get(rid)
+            ):
+                logger.warning(
+                    "sampling.response.cross_client_rejected",
+                    extra={"sampling_id": rid, "responder": responding_client_id},
+                )
+                return False
+            entry = self._pending_sampling_requests.pop(rid)
+            self._pending_sampling_clients.pop(rid, None)
+            fut = entry.get("future")
+            # The FULL message (result OR error) is delivered so the handler can
+            # relay a client error distinctly from a model completion.
+            if fut is not None and not fut.done():
+                fut.set_result(message)
+            return True
+
         # Check pending elicitation requests
         if rid in self.elicitation_system._pending_requests:
+            if self._client_scope_mismatch(
+                responding_client_id,
+                self.elicitation_system._pending_requests[rid].get("client_id"),
+            ):
+                logger.warning(
+                    "elicitation.response.cross_client_rejected",
+                    extra={"request_id": rid, "responder": responding_client_id},
+                )
+                return False
             if "error" in message:
                 # Treat as cancellation with the error message as reason
                 err = message.get("error", {})
@@ -2380,6 +2469,12 @@ class MCPServer:
     # still detected within this most-recent-N window.
     _MAX_SEEN_REQUEST_IDS = 4096
 
+    # Cap on the pending server-initiated sampling map. A stream of sampling
+    # requests whose targets never reply cannot grow the map without limit —
+    # the oldest pending Future is evicted (cancelled) FIFO past this bound
+    # (FINDING 2 — remote-triggerable memory growth).
+    _MAX_PENDING_SAMPLING = 1024
+
     def _mark_request_id_seen(self, client_id: str, request_id: Any) -> bool:
         """Record ``request_id`` for ``client_id`` and report prior use.
 
@@ -2433,6 +2528,32 @@ class MCPServer:
             fut = self._pending_roots_requests.pop(rid, None)
             if fut is not None and not fut.done():
                 fut.cancel()
+
+        # Cancel + drop any pending server->client sampling Futures whose TARGET
+        # (the expected responder) is this disconnecting client. Without this
+        # the entry (and its Future) leaks forever AND the original requester
+        # blocks until the sampling timeout — FINDING 2 (per-client sampling
+        # cleanup). The cancelled Future surfaces to the handler as a
+        # MCP_SAMPLING_REJECTED, so the requester is unblocked immediately.
+        stale_sampling = [
+            sid
+            for sid, cid in self._pending_sampling_clients.items()
+            if cid == client_id
+        ]
+        for sid in stale_sampling:
+            self._pending_sampling_clients.pop(sid, None)
+            entry = self._pending_sampling_requests.pop(sid, None)
+            if entry is not None:
+                fut = entry.get("future")
+                if fut is not None and not fut.done():
+                    fut.cancel()
+
+        # Cancel + evict any pending ELICITATION requests targeting this client
+        # so a disconnecting client's awaiting request_input() caller gets a
+        # clean MCP_REQUEST_CANCELLED instead of hanging until timeout —
+        # FINDING 3 (elicitation had no disconnect-eviction path). Unscoped
+        # requests (no bound client_id) are left intact.
+        self.elicitation_system.cancel_requests_for_client(client_id)
 
         # Cancel + drop any in-flight tool tasks for this client. Keys are the
         # (client_id, request_id) composite; the NUL-separated prefix isolates
@@ -2488,7 +2609,7 @@ class MCPServer:
                 )
             ):
                 handled = await self._route_server_initiated_response(
-                    request_id, decompressed_request
+                    request_id, decompressed_request, responding_client_id=client_id
                 )
                 if handled:
                     # Response routed to originating pending request; no
@@ -3898,6 +4019,12 @@ class MCPServer:
         loop = asyncio.get_event_loop()
         fut: "asyncio.Future" = loop.create_future()
         self._pending_roots_requests[req_id] = fut
+        # Record the TARGET client so (a) the response router can enforce that
+        # only THIS client resolves the request (FINDING 4 — cross-client
+        # isolation) and (b) a disconnect of this client cancels+pops the
+        # pending Future (_on_ws_disconnect). Previously this map was declared
+        # but never populated, so both paths were dead.
+        self._pending_roots_clients[req_id] = client_id
 
         await self._transport.send_message(
             {"jsonrpc": "2.0", "id": req_id, "method": "roots/list", "params": {}},
@@ -3908,6 +4035,7 @@ class MCPServer:
             message = await asyncio.wait_for(fut, timeout)
         except asyncio.TimeoutError:
             self._pending_roots_requests.pop(req_id, None)
+            self._pending_roots_clients.pop(req_id, None)
             logger.warning(
                 "request_client_roots timed out client=%s; treating as no roots",
                 client_id,
@@ -4069,9 +4197,17 @@ class MCPServer:
            fail-closed). A bound approver may approve, decline
            (``MCP_SAMPLING_DECLINED``), time out (``MCP_SAMPLING_TIMEOUT``),
            or raise a specific ``MCPError``.
-        4. **Dispatch**: the approved request is forwarded to the selected
-           sampling client's transport and tracked in
-           ``_pending_sampling_requests``.
+        4. **Dispatch + round-trip**: the approved request is forwarded to the
+           selected sampling client's transport and tracked in
+           ``_pending_sampling_requests`` (a Future keyed by the outbound
+           sampling id + the TARGET client). The handler AWAITS the target
+           client's reply (routed back via
+           ``_route_server_initiated_response``) and returns the model
+           completion (or the client's error) to the ORIGINAL requester — the
+           reply is never dropped with a spurious ``-32601``. A target
+           disconnect (MCP_SAMPLING_REJECTED) or no reply within
+           ``_sampling_timeout`` (MCP_SAMPLING_TIMEOUT) unblocks the requester
+           with a typed error.
         """
         # (1) Content-type + tool_use/tool_result balance validation. Input
         # validation runs FIRST so a malformed request never reaches the HITL
@@ -4178,31 +4314,7 @@ class MCPServer:
             "id": f"sampling_{uuid.uuid4().hex[:8]}",
         }
 
-        if self._transport and hasattr(self._transport, "send_message"):
-            await self._transport.send_message(
-                sampling_request, client_id=target_client
-            )
-
-            # Store pending sampling request
-            if not hasattr(self, "_pending_sampling_requests"):
-                self._pending_sampling_requests = {}
-
-            self._pending_sampling_requests[sampling_request["id"]] = {
-                "original_request_id": request_id,
-                "client_id": params.get("client_id"),
-                "timestamp": time.time(),
-            }
-
-            return {
-                "jsonrpc": "2.0",
-                "result": {
-                    "status": "sampling_requested",
-                    "sampling_id": sampling_request["id"],
-                    "target_client": target_client,
-                },
-                "id": request_id,
-            }
-        else:
+        if not (self._transport and hasattr(self._transport, "send_message")):
             return {
                 "jsonrpc": "2.0",
                 "error": {
@@ -4211,6 +4323,114 @@ class MCPServer:
                 },
                 "id": request_id,
             }
+
+        # Register the pending sampling request (Future + provenance) BEFORE
+        # dispatch so a fast reply cannot race ahead of registration. The
+        # awaited completion is routed back through
+        # ``_route_server_initiated_response`` so the ORIGINAL requester
+        # receives the model result, not a spurious ack that dropped the reply
+        # with a -32601 (FINDING 1). Mirrors the roots/list Future pattern.
+        sampling_id = sampling_request["id"]
+        loop = asyncio.get_event_loop()
+        fut: "asyncio.Future" = loop.create_future()
+        self._register_pending_sampling(sampling_id, fut, request_id, target_client)
+
+        await self._transport.send_message(sampling_request, client_id=target_client)
+
+        try:
+            completion = await asyncio.wait_for(fut, self._sampling_timeout)
+        except asyncio.TimeoutError:
+            self._pending_sampling_requests.pop(sampling_id, None)
+            self._pending_sampling_clients.pop(sampling_id, None)
+            logger.warning(
+                "sampling.timeout",
+                extra={"sampling_id": sampling_id, "target_client": target_client},
+            )
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": MCPErrorCode.MCP_SAMPLING_TIMEOUT.value,
+                    "message": (
+                        f"sampling request {sampling_id} timed out after "
+                        f"{self._sampling_timeout}s awaiting client "
+                        f"{target_client}"
+                    ),
+                },
+                "id": request_id,
+            }
+        except asyncio.CancelledError:
+            # Distinguish OUR Future being cancelled (the target disconnected —
+            # `_on_ws_disconnect` cancelled it) from a genuine task cancellation.
+            # Only the former is a sampling failure we translate; a real task
+            # cancel is re-raised so cancellation is not silently swallowed.
+            if fut.cancelled():
+                self._pending_sampling_requests.pop(sampling_id, None)
+                self._pending_sampling_clients.pop(sampling_id, None)
+                logger.warning(
+                    "sampling.target_disconnected",
+                    extra={"sampling_id": sampling_id, "target_client": target_client},
+                )
+                return {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": MCPErrorCode.MCP_SAMPLING_REJECTED.value,
+                        "message": (
+                            f"sampling target client {target_client} "
+                            f"disconnected before responding"
+                        ),
+                    },
+                    "id": request_id,
+                }
+            raise
+
+        # The completion is the FULL inbound JSON-RPC message (result OR error).
+        # Relay it back to the ORIGINAL requester under the requester's id so a
+        # client-side error is distinguishable from a real model completion.
+        if isinstance(completion, dict) and "error" in completion:
+            return {
+                "jsonrpc": "2.0",
+                "error": completion["error"],
+                "id": request_id,
+            }
+        result = completion.get("result", {}) if isinstance(completion, dict) else {}
+        return {
+            "jsonrpc": "2.0",
+            "result": result,
+            "id": request_id,
+        }
+
+    def _register_pending_sampling(
+        self,
+        sampling_id: str,
+        fut: "asyncio.Future",
+        original_request_id: Any,
+        target_client: str,
+    ) -> None:
+        """Register a pending server-initiated sampling request.
+
+        Records the awaiting ``fut`` + provenance keyed by ``sampling_id``, the
+        TARGET client (the expected responder, for client-scoped routing +
+        disconnect eviction), and enforces a FIFO cap so a stream of
+        never-answered requests cannot grow the maps without limit (FINDING 2).
+        Past the cap the OLDEST pending Future is cancelled + evicted, which
+        surfaces to its awaiting handler as a MCP_SAMPLING_REJECTED.
+        """
+        self._pending_sampling_requests[sampling_id] = {
+            "future": fut,
+            "original_request_id": original_request_id,
+            "client_id": target_client,
+            "timestamp": time.time(),
+        }
+        self._pending_sampling_clients[sampling_id] = target_client
+        self._pending_sampling_order.append(sampling_id)
+        while len(self._pending_sampling_order) > self._MAX_PENDING_SAMPLING:
+            evicted = self._pending_sampling_order.popleft()
+            self._pending_sampling_clients.pop(evicted, None)
+            entry = self._pending_sampling_requests.pop(evicted, None)
+            if entry is not None:
+                ev_fut = entry.get("future")
+                if ev_fut is not None and not ev_fut.done():
+                    ev_fut.cancel()
 
     async def _evaluate_sampling_approval(
         self, context: Dict[str, Any]

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -2971,7 +2971,7 @@ class MCPServer:
 
         # Correlate any progress emitted during this call to the client's
         # ``_meta.progressToken`` (opt-in). Returns None when no token supplied.
-        progress_ctx = self._begin_progress(params, client_id, tool_name)
+        progress_ctx = self._begin_progress(params, client_id, tool_name, request_id)
 
         # FINDING 3 (server-side) — make cancellation REAL, not inert. Run the
         # tool body inside a tracked ``asyncio.Task`` keyed by the CLIENT-SCOPED
@@ -3043,7 +3043,11 @@ class MCPServer:
         return {"jsonrpc": "2.0", "result": result_obj, "id": request_id}
 
     def _begin_progress(
-        self, params: Dict[str, Any], client_id: Optional[str], operation_name: str
+        self,
+        params: Dict[str, Any],
+        client_id: Optional[str],
+        operation_name: str,
+        request_id: Any = None,
     ) -> Optional[ProgressToken]:
         """Start progress tracking correlated to the client's progressToken.
 
@@ -3074,7 +3078,11 @@ class MCPServer:
         # ``_finish_progress`` reuses THIS same namespaced token, so completion
         # targets the correct per-client key (security.md — per-client isolation).
         token_obj = ProgressToken(
-            value=f"{client_id}:{client_token}", operation_name=operation_name
+            # round-3: include request_id so two CONCURRENT same-client
+            # calls reusing one progressToken value do not collide in the
+            # process-global ProgressManager (concurrent WS dispatch).
+            value=f"{client_id}:{request_id}:{client_token}",
+            operation_name=operation_name,
         )
         protocol.progress.start_progress(operation_name, progress_token=token_obj)
 
@@ -4055,10 +4063,21 @@ class MCPServer:
         # but never populated, so both paths were dead.
         self._pending_roots_clients[req_id] = client_id
 
-        await self._transport.send_message(
-            {"jsonrpc": "2.0", "id": req_id, "method": "roots/list", "params": {}},
-            client_id=client_id,
-        )
+        try:
+            await self._transport.send_message(
+                {"jsonrpc": "2.0", "id": req_id, "method": "roots/list", "params": {}},
+                client_id=client_id,
+            )
+        except Exception as exc:
+            # round-3 F2: a send failure must not leak the pending roots entry.
+            self._pending_roots_requests.pop(req_id, None)
+            self._pending_roots_clients.pop(req_id, None)
+            if not fut.done():
+                fut.cancel()
+            logger.warning(
+                "request_client_roots dispatch failed client=%s: %s", client_id, exc
+            )
+            return []
 
         try:
             message = await asyncio.wait_for(fut, timeout)
@@ -4382,7 +4401,29 @@ class MCPServer:
         fut: "asyncio.Future" = loop.create_future()
         self._register_pending_sampling(sampling_id, fut, request_id, target_client)
 
-        await self._transport.send_message(sampling_request, client_id=target_client)
+        try:
+            await self._transport.send_message(
+                sampling_request, client_id=target_client
+            )
+        except Exception as exc:
+            # round-3 F2: the pending entry was registered BEFORE the send; a
+            # send failure MUST NOT leak the entry/Future or seed a dead id into
+            # the FIFO deque (_drop_pending_sampling prunes all three maps).
+            self._drop_pending_sampling(sampling_id)
+            if not fut.done():
+                fut.cancel()
+            logger.warning(
+                "sampling.dispatch_failed",
+                extra={"sampling_id": sampling_id, "error": str(exc)},
+            )
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32603,
+                    "message": f"failed to dispatch sampling request: {exc}",
+                },
+                "id": request_id,
+            }
 
         try:
             completion = await asyncio.wait_for(fut, self._sampling_timeout)

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -119,8 +119,8 @@ logger = logging.getLogger(__name__)
 # duration; default None → unscoped (backward compatible). An asyncio Task copies
 # the context at creation, so a per-request tool task sees the value set before
 # it was spawned and concurrent tool calls never see each other's client.
-_CURRENT_TOOL_CLIENT: "contextvars.ContextVar[Optional[str]]" = (
-    contextvars.ContextVar("mcp_current_tool_client", default=None)
+_CURRENT_TOOL_CLIENT: "contextvars.ContextVar[Optional[str]]" = contextvars.ContextVar(
+    "mcp_current_tool_client", default=None
 )
 
 

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -1290,6 +1290,7 @@ class WebSocketServerTransport(BaseTransport):
             else:
                 # Broadcast to all clients
                 if self._clients:
+
                     async def _locked_send(cid: str, client: Any) -> None:
                         async with self._get_send_lock(cid):
                             await client.send(message_data)

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -1185,6 +1185,10 @@ class WebSocketServerTransport(BaseTransport):
         # Server state
         self.server: Optional[websockets.WebSocketServer] = None
         self._clients: Dict[str, Any] = {}  # websockets.WebSocketServerProtocol
+        # round-3 F3: ONE send lock per client_id, shared by the response send
+        # path (_process_and_respond) AND every server-initiated send
+        # (send_message) so concurrent frames on one socket never interleave.
+        self._send_locks: Dict[str, "asyncio.Lock"] = {}
         self._client_sessions: Dict[str, Dict[str, Any]] = {}
         self._server_task: Optional[asyncio.Task] = None
 
@@ -1246,6 +1250,14 @@ class WebSocketServerTransport(BaseTransport):
 
         logger.info("WebSocket server stopped")
 
+    def _get_send_lock(self, client_id: str) -> "asyncio.Lock":
+        """Return the per-client send lock, creating it on first use."""
+        lock = self._send_locks.get(client_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._send_locks[client_id] = lock
+        return lock
+
     async def send_message(
         self, message: Dict[str, Any], client_id: Optional[str] = None
     ) -> None:
@@ -1266,7 +1278,8 @@ class WebSocketServerTransport(BaseTransport):
             if client_id:
                 # Send to specific client
                 if client_id in self._clients:
-                    await self._clients[client_id].send(message_data)
+                    async with self._get_send_lock(client_id):
+                        await self._clients[client_id].send(message_data)
                     self._update_metrics("messages_sent")
                     self._update_metrics("bytes_sent", len(message_data))
                 else:
@@ -1277,10 +1290,14 @@ class WebSocketServerTransport(BaseTransport):
             else:
                 # Broadcast to all clients
                 if self._clients:
+                    async def _locked_send(cid: str, client: Any) -> None:
+                        async with self._get_send_lock(cid):
+                            await client.send(message_data)
+
                     await asyncio.gather(
                         *[
-                            client.send(message_data)
-                            for client in self._clients.values()
+                            _locked_send(cid, client)
+                            for cid, client in self._clients.items()
                         ],
                         return_exceptions=True,
                     )
@@ -1325,7 +1342,9 @@ class WebSocketServerTransport(BaseTransport):
         # does not block the read loop; those concurrent handlers' response
         # sends would otherwise interleave on the wire. Serialize every send
         # through this lock so no two frames corrupt each other (FINDING 2).
-        send_lock = asyncio.Lock()
+        # round-3 F3: the SHARED per-client lock (also used by every
+        # server-initiated send in send_message) — not a fresh local lock.
+        send_lock = self._get_send_lock(client_id)
         # In-flight per-message handler tasks — tracked so a disconnect can
         # cancel + await them instead of orphaning a handler blocked mid-await.
         inflight: "set" = set()
@@ -1364,6 +1383,7 @@ class WebSocketServerTransport(BaseTransport):
                 await asyncio.gather(*inflight, return_exceptions=True)
             # Clean up the transport's own per-client maps.
             self._clients.pop(client_id, None)
+            self._send_locks.pop(client_id, None)
             self._client_sessions.pop(client_id, None)
             # Let the server release any state it keyed on this client_id
             # (request-id reuse set, client_info, ...) so a churned connection

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -1320,62 +1320,48 @@ class WebSocketServerTransport(BaseTransport):
         logger.info(f"Client {client_id} connected from {websocket.remote_address}")
         self._update_metrics("connections_total")
 
+        # Per-connection outbound send lock. Each inbound message is handled in
+        # its OWN task (below) so a handler that awaits a server-initiated reply
+        # does not block the read loop; those concurrent handlers' response
+        # sends would otherwise interleave on the wire. Serialize every send
+        # through this lock so no two frames corrupt each other (FINDING 2).
+        send_lock = asyncio.Lock()
+        # In-flight per-message handler tasks — tracked so a disconnect can
+        # cancel + await them instead of orphaning a handler blocked mid-await.
+        inflight: "set" = set()
+
         try:
             async for message in websocket:
-                try:
-                    # Parse message
-                    request = json.loads(message)
+                self._update_metrics("messages_received")
+                self._update_metrics("bytes_received", len(message))
 
-                    # Update metrics
-                    self._update_metrics("messages_received")
-                    self._update_metrics("bytes_received", len(message))
-
-                    # Handle message
-                    if self.message_handler:
-                        response = await self._handle_message_safely(request, client_id)
-                    else:
-                        response = {
-                            "jsonrpc": "2.0",
-                            "error": {
-                                "code": -32601,
-                                "message": "No message handler configured",
-                            },
-                            "id": request.get("id"),
-                        }
-
-                    # A None response is the no-send sentinel — a notification
-                    # (absent JSON-RPC id) or an already-routed inbound response
-                    # gets NO reply body (MCP lifecycle: notifications expect no
-                    # response). Only send a real response envelope.
-                    if response is not None:
-                        payload = json.dumps(response)
-                        await websocket.send(payload)
-                        self._update_metrics("messages_sent")
-                        self._update_metrics("bytes_sent", len(payload))
-
-                except json.JSONDecodeError as e:
-                    logger.error(f"Invalid JSON from client {client_id}: {e}")
-                    self._update_metrics("errors_total")
-
-                    error_response = {
-                        "jsonrpc": "2.0",
-                        "error": {
-                            "code": -32700,
-                            "message": "Parse error: Invalid JSON",
-                        },
-                        "id": None,
-                    }
-                    await websocket.send(json.dumps(error_response))
-
-                except Exception as e:
-                    logger.error(f"Error handling message from client {client_id}: {e}")
-                    self._update_metrics("errors_total")
+                # Dispatch each inbound message CONCURRENTLY. The read loop MUST
+                # keep draining the socket while a handler awaits a
+                # server-initiated reply (sampling/createMessage,
+                # elicitation/create, roots/list) that arrives as a NEW inbound
+                # frame on THIS SAME connection — the single-client
+                # (target == requester) case. A sequential read loop would never
+                # read that reply until the handler returned, deadlocking the
+                # handler until its timeout (FINDING 2). Spawning a task lets the
+                # loop advance to the reply frame immediately.
+                task = asyncio.ensure_future(
+                    self._process_and_respond(message, client_id, websocket, send_lock)
+                )
+                inflight.add(task)
+                task.add_done_callback(inflight.discard)
 
         except websockets.exceptions.ConnectionClosed:
             logger.info(f"Client {client_id} disconnected")
         except Exception as e:
             logger.error(f"Error in client handler for {client_id}: {e}")
         finally:
+            # Cancel + await any handler tasks still in flight so none leak past
+            # the connection. A handler blocked awaiting a reply that will now
+            # never arrive is unblocked by the cancel; gather() reaps them.
+            for task in list(inflight):
+                task.cancel()
+            if inflight:
+                await asyncio.gather(*inflight, return_exceptions=True)
             # Clean up the transport's own per-client maps.
             self._clients.pop(client_id, None)
             self._client_sessions.pop(client_id, None)
@@ -1391,6 +1377,66 @@ class WebSocketServerTransport(BaseTransport):
                         client_id,
                         exc,
                     )
+
+    async def _process_and_respond(
+        self, message, client_id: str, websocket, send_lock
+    ) -> None:
+        """Parse, handle, and respond to ONE inbound WS message as its own task.
+
+        Spawned per-message by ``handle_client`` so the read loop keeps draining
+        the socket while this handler awaits a server-initiated reply on the
+        SAME connection (FINDING 2 — single-client server-initiated round-trip).
+        Every outbound send serializes through ``send_lock`` so concurrent
+        handlers' responses never interleave on the wire. A handler exception
+        still yields the JSON-RPC error response / metrics update, exactly as the
+        prior sequential loop did.
+        """
+        try:
+            try:
+                request = json.loads(message)
+            except json.JSONDecodeError as e:
+                logger.error(f"Invalid JSON from client {client_id}: {e}")
+                self._update_metrics("errors_total")
+                error_response = {
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32700, "message": "Parse error: Invalid JSON"},
+                    "id": None,
+                }
+                payload = json.dumps(error_response)
+                async with send_lock:
+                    await websocket.send(payload)
+                return
+
+            if self.message_handler:
+                response = await self._handle_message_safely(request, client_id)
+            else:
+                response = {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32601,
+                        "message": "No message handler configured",
+                    },
+                    "id": request.get("id"),
+                }
+
+            # A None response is the no-send sentinel — a notification (absent
+            # JSON-RPC id) or an already-routed inbound response gets NO reply
+            # body (MCP lifecycle: notifications expect no response). Only send a
+            # real response envelope.
+            if response is not None:
+                payload = json.dumps(response)
+                async with send_lock:
+                    await websocket.send(payload)
+                self._update_metrics("messages_sent")
+                self._update_metrics("bytes_sent", len(payload))
+
+        except asyncio.CancelledError:
+            # Connection tore down while this handler was mid-await; propagate so
+            # handle_client's gather() observes the cancellation cleanly.
+            raise
+        except Exception as e:
+            logger.error(f"Error handling message from client {client_id}: {e}")
+            self._update_metrics("errors_total")
 
     async def _handle_message_safely(
         self, request: Dict[str, Any], client_id: str

--- a/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
+++ b/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-WebSocket end-to-end tests for #1712 W6 FINDING 2 — the single-client
+server-initiated round-trip must NOT deadlock.
+
+These tests stand up a REAL ``WebSocketServerTransport`` bound to REAL
+``MCPServer`` handlers on a loopback port (``websockets.serve``) and connect ONE
+REAL ``websockets`` client. The client is BOTH the requester AND the responder
+on the SAME socket — exactly the ``target == requester`` case F4 made the normal
+one. The client's inbound reply to the server-initiated request arrives as a NEW
+frame on the same connection, so ``handle_client`` MUST keep reading the socket
+while a handler awaits that reply.
+
+This DRIVES the actual ``handle_client`` loop end to end — it is NOT a
+task-injected reply on a side channel (the exact bypass FINDING 2 calls out). A
+sequential read loop would never read the reply frame while the sampling /
+elicitation handler is mid-await, so the handler would block until its timeout
+(-32811 for sampling); the concurrent-dispatch fix reads it immediately.
+"""
+
+import asyncio
+import json
+import socket
+
+import pytest
+import websockets
+
+from kailash_mcp.server import MCPServer
+from kailash_mcp.transports.transports import WebSocketServerTransport
+
+
+def _free_port() -> int:
+    """Return an unused loopback TCP port."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _serve(server: MCPServer) -> WebSocketServerTransport:
+    """Bind a real WS transport to the server's handlers on a free port."""
+    port = _free_port()
+    transport = WebSocketServerTransport(
+        host="127.0.0.1",
+        port=port,
+        message_handler=server._handle_websocket_message,
+        disconnect_handler=server._on_ws_disconnect,
+    )
+    server._transport = transport
+    await transport.connect()
+    # Bind the transport's send-callable to the elicitation system exactly as the
+    # server's own WS-startup path does, so elicitation/create dispatches over
+    # this real connection.
+    server._bind_elicitation_transport()
+    transport._test_port = port  # type: ignore[attr-defined]
+    return transport
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_single_client_sampling_roundtrip_no_deadlock():
+    """One real client sends sampling/createMessage and REPLIES to the
+    server-initiated sampling/createMessage on the SAME socket; the requester's
+    original request receives the model completion within a short timeout — NOT
+    a -32811 sampling timeout (FINDING 2 — WS single-client deadlock)."""
+    server = MCPServer("ws-roundtrip-sampling", enable_cache=False, enable_metrics=False)
+    server.set_sampling_approver(lambda ctx: True)
+    # Short timeout: a REGRESSED sequential loop would surface as a fast -32811,
+    # not a 30s hang — the test fails loud within seconds either way.
+    server._sampling_timeout = 4.0
+
+    transport = await _serve(server)
+    port = transport._test_port  # type: ignore[attr-defined]
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:
+            # (a) register + advertise sampling via initialize.
+            await ws.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "init",
+                        "method": "initialize",
+                        "params": {
+                            "capabilities": {"sampling": {}},
+                            "clientInfo": {"name": "t", "version": "1"},
+                        },
+                    }
+                )
+            )
+            init = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+            assert init["id"] == "init"
+
+            completion = {
+                "role": "assistant",
+                "content": {"type": "text", "text": "hello from the client"},
+                "model": "test-model",
+            }
+            final: dict = {}
+
+            async def client_loop():
+                # (b) send an inbound sampling/createMessage (this client is the
+                # requester).
+                await ws.send(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": "req-1",
+                            "method": "sampling/createMessage",
+                            "params": {
+                                "messages": [{"role": "user", "content": "hi"}]
+                            },
+                        }
+                    )
+                )
+                # (c) concurrently read inbound frames and REPLY to the
+                # server-initiated sampling/createMessage on the SAME socket.
+                while True:
+                    msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=6))
+                    if msg.get("method") == "sampling/createMessage":
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": msg["id"],
+                                    "result": completion,
+                                }
+                            )
+                        )
+                        continue
+                    if msg.get("id") == "req-1":
+                        final.update(msg)
+                        return
+
+            await asyncio.wait_for(client_loop(), timeout=6)
+
+            assert "error" not in final, f"expected completion, got error: {final}"
+            assert final["result"] == completion
+    finally:
+        await transport.disconnect()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_single_client_elicitation_roundtrip_no_deadlock():
+    """A tool invoked by the client awaits elicitation input; the SAME client
+    replies to the server-initiated elicitation/create on the SAME socket and the
+    tools/call completes (FINDING 2 concurrent dispatch + FINDING 3
+    client-scoped elicitation dispatched to the invoking client)."""
+    server = MCPServer(
+        "ws-roundtrip-elicitation", enable_cache=False, enable_metrics=False
+    )
+
+    @server.tool()
+    async def ask_name() -> dict:
+        answer = await server.elicitation_system.request_input(
+            "your name?",
+            input_schema={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            timeout=4.0,
+        )
+        return {"greeted": answer["name"]}
+
+    transport = await _serve(server)
+    port = transport._test_port  # type: ignore[attr-defined]
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:
+            await ws.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "init",
+                        "method": "initialize",
+                        "params": {
+                            "capabilities": {"elicitation": {"modes": ["form"]}},
+                            "clientInfo": {"name": "t", "version": "1"},
+                        },
+                    }
+                )
+            )
+            init = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+            assert init["id"] == "init"
+
+            final: dict = {}
+
+            async def client_loop():
+                await ws.send(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": "call-1",
+                            "method": "tools/call",
+                            "params": {"name": "ask_name", "arguments": {}},
+                        }
+                    )
+                )
+                while True:
+                    msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=6))
+                    if msg.get("method") == "elicitation/create":
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": msg["id"],
+                                    "result": {
+                                        "action": "accept",
+                                        "content": {"name": "Ada"},
+                                    },
+                                }
+                            )
+                        )
+                        continue
+                    if msg.get("id") == "call-1":
+                        final.update(msg)
+                        return
+
+            await asyncio.wait_for(client_loop(), timeout=6)
+
+            assert final.get("id") == "call-1"
+            assert "error" not in final, f"expected tool result, got error: {final}"
+            assert final["result"].get("isError") is not True
+            # The collected name round-tripped through the tool result.
+            assert "Ada" in json.dumps(final["result"])
+    finally:
+        await transport.disconnect()

--- a/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
+++ b/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
@@ -65,7 +65,9 @@ async def test_single_client_sampling_roundtrip_no_deadlock():
     server-initiated sampling/createMessage on the SAME socket; the requester's
     original request receives the model completion within a short timeout — NOT
     a -32811 sampling timeout (FINDING 2 — WS single-client deadlock)."""
-    server = MCPServer("ws-roundtrip-sampling", enable_cache=False, enable_metrics=False)
+    server = MCPServer(
+        "ws-roundtrip-sampling", enable_cache=False, enable_metrics=False
+    )
     server.set_sampling_approver(lambda ctx: True)
     # Short timeout: a REGRESSED sequential loop would surface as a fast -32811,
     # not a 30s hang — the test fails loud within seconds either way.
@@ -108,9 +110,7 @@ async def test_single_client_sampling_roundtrip_no_deadlock():
                             "jsonrpc": "2.0",
                             "id": "req-1",
                             "method": "sampling/createMessage",
-                            "params": {
-                                "messages": [{"role": "user", "content": "hi"}]
-                            },
+                            "params": {"messages": [{"role": "user", "content": "hi"}]},
                         }
                     )
                 )

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_progress_cancel_roots.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_progress_cancel_roots.py
@@ -72,9 +72,14 @@ class _CapturingTransport:
         ):
             reply = {"jsonrpc": "2.0", "id": message["id"], **self._roots_reply}
             # Schedule the client's response on the same loop; request_client_roots
-            # is awaiting the pending Future and will resolve when this runs.
+            # is awaiting the pending Future and will resolve when this runs. The
+            # reply carries the responding client_id (the client the roots/list was
+            # dispatched to) — the response router is fail-closed for scoped
+            # requests (W6 FINDING 3), so a None responder would be refused.
             asyncio.get_event_loop().create_task(
-                self._server._route_server_initiated_response(reply["id"], reply)
+                self._server._route_server_initiated_response(
+                    reply["id"], reply, responding_client_id=client_id
+                )
             )
 
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
@@ -75,6 +75,11 @@ async def _drive_sampling(
     ``reply`` is the JSON-RPC body sans envelope (e.g. ``{"result": {...}}`` or
     ``{"error": {...}}``). Returns ``(handler_result, sent_messages)``.
     """
+    # Finding 4: sampling routes to the REQUESTER's own client. The responder
+    # (the target that replies) IS the requester's client, so the requester's
+    # client_id must be the sampling-capable responder unless the caller set it.
+    params = {**params}
+    params.setdefault("client_id", responder)
     task = asyncio.create_task(
         server._handle_sampling_create_message(params, request_id)
     )
@@ -226,7 +231,7 @@ async def test_sampling_fails_closed_without_approver():
     server = _make_server()
     # Deliberately do NOT bind an approver.
     result = await server._handle_sampling_create_message(
-        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
         "req-4",
     )
     assert "error" in result
@@ -291,7 +296,7 @@ async def test_sampling_decline_uses_declined_code():
     server = _make_server()
     server.set_sampling_approver(lambda ctx: False)
     result = await server._handle_sampling_create_message(
-        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
         "req-7",
     )
     assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_DECLINED.value
@@ -308,7 +313,7 @@ async def test_sampling_timeout_uses_timeout_code():
 
     server.set_sampling_approver(approver)
     result = await server._handle_sampling_create_message(
-        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
         "req-8",
     )
     assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_TIMEOUT.value
@@ -328,7 +333,7 @@ async def test_sampling_approver_mcperror_propagates_code():
 
     server.set_sampling_approver(approver)
     result = await server._handle_sampling_create_message(
-        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
         "req-9",
     )
     assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_DECLINED.value
@@ -346,7 +351,7 @@ async def test_sampling_approver_unexpected_error_fails_closed():
 
     server.set_sampling_approver(approver)
     result = await server._handle_sampling_create_message(
-        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
         "req-10",
     )
     assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_REJECTED.value
@@ -561,7 +566,7 @@ async def test_sampling_full_round_trip_delivers_completion_no_32601():
 
     task = asyncio.create_task(
         server._handle_sampling_create_message(
-            {"messages": [{"role": "user", "content": "summarize"}]},
+            {"messages": [{"role": "user", "content": "summarize"}], "client_id": "client-1"},
             "orig-req",
         )
     )
@@ -635,7 +640,7 @@ async def test_disconnect_evicts_pending_sampling_and_unblocks_requester():
 
     task = asyncio.create_task(
         server._handle_sampling_create_message(
-            {"messages": [{"role": "user", "content": "hi"}]},
+            {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-1"},
             "orig-disc",
         )
     )

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
@@ -54,6 +54,50 @@ def _make_server() -> MCPServer:
     return server
 
 
+_TEXT_COMPLETION = {"role": "assistant", "content": {"type": "text", "text": "ok"}}
+
+
+async def _drive_sampling(
+    server: MCPServer,
+    params: dict,
+    request_id,
+    reply: dict,
+    *,
+    responder: str = "client-1",
+):
+    """Run the sampling handler to completion by feeding the target's reply.
+
+    The Wave-5 handler AWAITS the target client's reply (roots-Future model),
+    so the round-trip must be driven: dispatch the handler as a task, wait for
+    the outbound request to land on the transport, feed the target's reply
+    through the response router, then await the handler's completion.
+
+    ``reply`` is the JSON-RPC body sans envelope (e.g. ``{"result": {...}}`` or
+    ``{"error": {...}}``). Returns ``(handler_result, sent_messages)``.
+    """
+    task = asyncio.create_task(
+        server._handle_sampling_create_message(params, request_id)
+    )
+    # Let the handler dispatch the outbound sampling/createMessage request.
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if server._transport.sent:
+            break
+    else:  # pragma: no cover - defensive: handler never dispatched
+        task.cancel()
+        raise AssertionError("handler did not dispatch a sampling request")
+
+    sampling_msg, _target = server._transport.sent[0]
+    sampling_id = sampling_msg["id"]
+    reply_msg = {"jsonrpc": "2.0", "id": sampling_id, **reply}
+    handled = await server._route_server_initiated_response(
+        sampling_id, reply_msg, responding_client_id=responder
+    )
+    assert handled is True, "the target client's reply was NOT consumed"
+    result = await asyncio.wait_for(task, timeout=5)
+    return result, server._transport.sent
+
+
 # ---------------------------------------------------------------------------
 # (2) Content-type validation
 # ---------------------------------------------------------------------------
@@ -152,17 +196,22 @@ async def test_sampling_forwards_tool_choice():
     """toolChoice is forwarded on the outbound sampling request."""
     server = _make_server()
     server.set_sampling_approver(lambda ctx: True)
-    result = await server._handle_sampling_create_message(
+    result, sent = await _drive_sampling(
+        server,
         {
             "messages": [{"role": "user", "content": "hi"}],
             "toolChoice": {"type": "auto"},
         },
         "req-3",
+        {"result": _TEXT_COMPLETION},
     )
-    assert "result" in result
-    assert result["result"]["status"] == "sampling_requested"
-    sent_msg, _client = server._transport.sent[0]
+    # The ORIGINAL requester receives the model completion, not a bare ack.
+    assert result["result"] == _TEXT_COMPLETION
+    assert result["id"] == "req-3"
+    sent_msg, _client = sent[0]
     assert sent_msg["params"]["tool_choice"] == {"type": "auto"}
+    # Pending map drained after the round-trip.
+    assert server._pending_sampling_requests == {}
 
 
 # ---------------------------------------------------------------------------
@@ -198,16 +247,17 @@ async def test_sampling_approver_approves_reaches_dispatch():
         return True
 
     server.set_sampling_approver(approver)
-    result = await server._handle_sampling_create_message(
+    result, sent = await _drive_sampling(
+        server,
         {"messages": [{"role": "user", "content": "hi"}]},
         "req-5",
+        {"result": _TEXT_COMPLETION},
     )
-    assert "result" in result
-    assert result["result"]["status"] == "sampling_requested"
+    assert result["result"] == _TEXT_COMPLETION
     # The approver saw the request context BEFORE dispatch.
     assert len(approved_contexts) == 1
     assert approved_contexts[0]["target_client"] == "client-1"
-    assert len(server._transport.sent) == 1
+    assert len(sent) == 1
 
 
 @pytest.mark.regression
@@ -221,11 +271,13 @@ async def test_sampling_async_approver_supported():
         return True
 
     server.set_sampling_approver(approver)
-    result = await server._handle_sampling_create_message(
+    result, _sent = await _drive_sampling(
+        server,
         {"messages": [{"role": "user", "content": "hi"}]},
         "req-6",
+        {"result": _TEXT_COMPLETION},
     )
-    assert result["result"]["status"] == "sampling_requested"
+    assert result["result"] == _TEXT_COMPLETION
 
 
 # ---------------------------------------------------------------------------
@@ -346,12 +398,17 @@ async def test_sampling_capability_check_accepts_experimental_alias():
         "old-client": {"capabilities": {"experimental": {"sampling": True}}}
     }
     server.set_sampling_approver(lambda ctx: True)
-    result = await server._handle_sampling_create_message(
+    result, sent = await _drive_sampling(
+        server,
         {"messages": [{"role": "user", "content": "hi"}]},
         "req-11",
+        {"result": _TEXT_COMPLETION},
+        responder="old-client",
     )
-    assert result["result"]["status"] == "sampling_requested"
-    assert result["result"]["target_client"] == "old-client"
+    assert result["result"] == _TEXT_COMPLETION
+    # The request was dispatched to the experimental-alias client.
+    _sent_msg, target = sent[0]
+    assert target == "old-client"
 
 
 @pytest.mark.regression
@@ -477,8 +534,156 @@ async def test_sampling_empty_dict_capability_is_advertised():
     server = _make_server()
     server.client_info = {"c": {"capabilities": {"sampling": {}}}}
     server.set_sampling_approver(lambda ctx: True)
-    result = await server._handle_sampling_create_message(
+    result, _sent = await _drive_sampling(
+        server,
         {"messages": [{"role": "user", "content": "hi"}]},
         "req-empty",
+        {"result": _TEXT_COMPLETION},
+        responder="c",
     )
-    assert result["result"]["status"] == "sampling_requested"
+    assert result["result"] == _TEXT_COMPLETION
+
+
+# ---------------------------------------------------------------------------
+# W5 Finding 1 — sampling responses are ROUTED end-to-end: the target client's
+# reply is CONSUMED (no spurious -32601), the model completion reaches the
+# ORIGINAL requester, and the pending map drains.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_full_round_trip_delivers_completion_no_32601():
+    """The reply is consumed (router returns True → NO -32601), the completion
+    reaches the original requester, and the pending map is drained."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+
+    task = asyncio.create_task(
+        server._handle_sampling_create_message(
+            {"messages": [{"role": "user", "content": "summarize"}]},
+            "orig-req",
+        )
+    )
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if server._transport.sent:
+            break
+    sampling_msg, target = server._transport.sent[0]
+    sampling_id = sampling_msg["id"]
+    assert target == "client-1"
+    # The pending entry exists while the handler awaits (before the reply).
+    assert sampling_id in server._pending_sampling_requests
+
+    completion = {
+        "role": "assistant",
+        "content": {"type": "text", "text": "the summary"},
+        "model": "test-model",
+    }
+    # Feed the client's reply through the SAME path the WS server uses.
+    handled = await server._route_server_initiated_response(
+        sampling_id,
+        {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+        responding_client_id="client-1",
+    )
+    # (a) reply CONSUMED — the router owned it, so the dispatch layer emits
+    #     NO -32601 "method not found" for the response.
+    assert handled is True
+
+    result = await asyncio.wait_for(task, timeout=5)
+    # (b) the model completion reached the ORIGINAL requester under its id.
+    assert result["id"] == "orig-req"
+    assert result["result"] == completion
+    assert "error" not in result
+    # (c) the pending maps are drained.
+    assert server._pending_sampling_requests == {}
+    assert server._pending_sampling_clients == {}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_client_error_reply_relayed_to_requester():
+    """A client ERROR reply is relayed as an error to the original requester
+    (distinct from a completion) — the reply is still consumed."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+    result, _sent = await _drive_sampling(
+        server,
+        {"messages": [{"role": "user", "content": "hi"}]},
+        "orig-err",
+        {"error": {"code": -32000, "message": "client model unavailable"}},
+    )
+    assert "error" in result
+    assert result["error"]["message"] == "client model unavailable"
+    assert result["id"] == "orig-err"
+    assert server._pending_sampling_requests == {}
+
+
+# ---------------------------------------------------------------------------
+# W5 Finding 2 — the pending-sampling map is bounded: a disconnecting target
+# evicts its pending entries, and a FIFO cap bounds never-answered requests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_disconnect_evicts_pending_sampling_and_unblocks_requester():
+    """A target-client disconnect cancels+pops its pending sampling entry and
+    unblocks the original requester with a typed REJECTED error."""
+    server = _make_server()
+    server.set_sampling_approver(lambda ctx: True)
+
+    task = asyncio.create_task(
+        server._handle_sampling_create_message(
+            {"messages": [{"role": "user", "content": "hi"}]},
+            "orig-disc",
+        )
+    )
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if server._transport.sent:
+            break
+    sampling_msg, _target = server._transport.sent[0]
+    sampling_id = sampling_msg["id"]
+    assert sampling_id in server._pending_sampling_requests
+
+    # The target client disconnects before replying.
+    server._on_ws_disconnect("client-1")
+
+    # Maps evicted immediately.
+    assert sampling_id not in server._pending_sampling_requests
+    assert sampling_id not in server._pending_sampling_clients
+
+    # The requester is unblocked with a typed error, not a hang.
+    result = await asyncio.wait_for(task, timeout=5)
+    assert result["id"] == "orig-disc"
+    assert result["error"]["code"] == MCPErrorCode.MCP_SAMPLING_REJECTED.value
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_pending_sampling_fifo_cap_bounds_map():
+    """Never-answered sampling requests cannot grow the map without limit — the
+    FIFO cap evicts (cancels) the oldest pending Future past the bound."""
+    server = _make_server()
+    # Shrink the cap so the test is fast + deterministic.
+    server._MAX_PENDING_SAMPLING = 3
+
+    futures = []
+    for i in range(10):
+        fut = asyncio.get_event_loop().create_future()
+        futures.append(fut)
+        server._register_pending_sampling(f"s-{i}", fut, f"req-{i}", "client-1")
+        await asyncio.sleep(0)
+
+    # The map never exceeds the cap despite 10 registrations.
+    assert len(server._pending_sampling_requests) <= 3
+    assert len(server._pending_sampling_clients) <= 3
+    # Only the most-recent 3 remain.
+    assert set(server._pending_sampling_requests) == {"s-7", "s-8", "s-9"}
+    # The evicted oldest Futures were cancelled (not leaked).
+    assert futures[0].cancelled()
+    assert futures[6].cancelled()
+    # Cancel the survivors so the test leaves no pending Futures.
+    for fut in futures[7:]:
+        fut.cancel()

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
@@ -566,7 +566,10 @@ async def test_sampling_full_round_trip_delivers_completion_no_32601():
 
     task = asyncio.create_task(
         server._handle_sampling_create_message(
-            {"messages": [{"role": "user", "content": "summarize"}], "client_id": "client-1"},
+            {
+                "messages": [{"role": "user", "content": "summarize"}],
+                "client_id": "client-1",
+            },
             "orig-req",
         )
     )

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
@@ -196,7 +196,7 @@ async def test_sampling_response_from_wrong_client_cannot_resolve():
 
     task = asyncio.create_task(
         server._handle_sampling_create_message(
-            {"messages": [{"role": "user", "content": "hi"}]},
+            {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-A"},
             "orig-req",
         )
     )
@@ -227,3 +227,52 @@ async def test_sampling_response_from_wrong_client_cannot_resolve():
     result = await asyncio.wait_for(task, timeout=5)
     assert result["result"] == completion
     assert result["id"] == "orig-req"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_pending_sampling_order_pruned_on_resolution_no_spurious_evict():
+    """Convergence round-2 F1: the FIFO-cap deque (_pending_sampling_order) is
+    pruned at every resolution site, so the cap counts only LIVE entries — a
+    lone in-flight request survives a flood of completed unrelated requests
+    (it is NOT spuriously evicted+cancelled)."""
+    server = _server()
+    server._MAX_PENDING_SAMPLING = 4
+    live = asyncio.get_running_loop().create_future()
+    server._register_pending_sampling("LIVE", live, "orig", "cA")
+    for i in range(12):
+        f = asyncio.get_running_loop().create_future()
+        server._register_pending_sampling(f"d{i}", f, f"o{i}", "cA")
+        handled = await server._route_server_initiated_response(
+            f"d{i}", {"id": f"d{i}", "result": {"x": i}}, responding_client_id="cA"
+        )
+        assert handled is True
+        # The deque never drifts from the live requests map (dead ids pruned).
+        assert len(server._pending_sampling_order) == len(
+            server._pending_sampling_requests
+        )
+    assert "LIVE" in server._pending_sampling_requests
+    assert not live.done() and not live.cancelled()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_routes_to_requester_not_arbitrary_client():
+    """Convergence round-2 F4: sampling routes to the REQUESTER's OWN client,
+    never a blind pick — a requester whose own client does not advertise
+    sampling is rejected (-32601), NOT routed to a DIFFERENT capable client
+    (which would expose the requester's messages to that client's LLM)."""
+    server = _server()
+    server.set_sampling_approver(lambda ctx: True)
+    server.client_info = {
+        "client-A": {"capabilities": {"sampling": {}}},
+        "client-B": {"capabilities": {}},
+    }
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "secret"}], "client_id": "client-B"},
+        "req-x",
+    )
+    assert "error" in result
+    assert result["error"]["code"] == -32601
+    # NOTHING dispatched to client-A — no cross-client content exposure.
+    assert server._transport.sent == []

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 5 convergence — the four cross-shard
+findings from the holistic redteam:
+
+- **F3** — a client disconnecting with a PENDING elicitation is cancelled +
+  evicted (its awaiting ``request_input()`` caller gets a clean
+  ``MCP_REQUEST_CANCELLED``, not a hang). An UNSCOPED elicitation (no bound
+  ``client_id``) is left intact on a disconnect (backward compatible).
+- **F4** — the shared server-initiated response router is CLIENT-SCOPED for
+  ALL THREE features (roots, elicitation, sampling): a response from client B
+  cannot resolve client A's pending request.
+
+All tests use REAL ``MCPServer`` / ``ElicitationSystem`` objects and REAL
+handlers (no SDK mocking of the class under test). A minimal capturing
+transport double satisfies the ``send_message`` structural contract only.
+"""
+
+import asyncio
+
+import pytest
+from kailash_mcp.errors import MCPError, MCPErrorCode
+from kailash_mcp.server import MCPServer
+
+
+class _CapturingTransport:
+    """Real (non-mock) transport double capturing outbound requests."""
+
+    def __init__(self):
+        self.sent: list = []
+
+    async def send_message(self, message, client_id=None):
+        self.sent.append((message, client_id))
+
+
+def _server() -> MCPServer:
+    server = MCPServer("w5-convergence-test", enable_cache=False, enable_metrics=False)
+    server.client_info = {}
+    server._transport = _CapturingTransport()
+    return server
+
+
+async def _pump_until(predicate, *, tries: int = 200):
+    for _ in range(tries):
+        await asyncio.sleep(0)
+        if predicate():
+            return
+    raise AssertionError("condition never became true")
+
+
+# ---------------------------------------------------------------------------
+# F3 — elicitation disconnect eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pending_elicitation_for_client():
+    """A disconnect cancels+evicts a client's pending elicitation; the awaiting
+    caller raises MCP_REQUEST_CANCELLED instead of hanging."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(
+        server.elicitation_system.request_input(
+            "your name?", client_id="client-A", timeout=30
+        )
+    )
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+
+    server._on_ws_disconnect("client-A")
+
+    # Evicted immediately.
+    assert rid not in server.elicitation_system._pending_requests
+
+    # The awaiting caller gets a clean cancellation, not a hang.
+    with pytest.raises(MCPError) as ei:
+        await asyncio.wait_for(task, timeout=5)
+    assert ei.value.error_code == MCPErrorCode.MCP_REQUEST_CANCELLED
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_disconnect_leaves_unscoped_elicitation_intact():
+    """An UNSCOPED elicitation (no client_id) is NOT evicted on a disconnect —
+    a disconnect cannot know it targeted the departing client."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(server.elicitation_system.request_input("q?", timeout=5))
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+
+    server._on_ws_disconnect("client-A")
+
+    # Unscoped request survives the disconnect.
+    assert rid in server.elicitation_system._pending_requests
+
+    # Clean up: resolve it so the awaiting task does not leak.
+    await server.elicitation_system.cancel_request(rid, reason="test cleanup")
+    with pytest.raises(MCPError):
+        await asyncio.wait_for(task, timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# F4 — client-scoped response routing (roots / elicitation / sampling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_roots_response_from_wrong_client_cannot_resolve():
+    """A roots/list response from client B cannot resolve client A's pending
+    request; the real responder (A) still can."""
+    server = _server()
+
+    task = asyncio.create_task(server.request_client_roots("client-A", timeout=5))
+    await _pump_until(lambda: bool(server._pending_roots_requests))
+    req_id = next(iter(server._pending_roots_requests))
+
+    roots_result = {"roots": [{"uri": "file:///workspace"}]}
+
+    # Wrong client — router refuses; the pending request survives.
+    handled = await server._route_server_initiated_response(
+        req_id,
+        {"jsonrpc": "2.0", "id": req_id, "result": roots_result},
+        responding_client_id="client-B",
+    )
+    assert handled is False
+    assert not task.done()
+    assert req_id in server._pending_roots_requests
+
+    # Correct client — resolves.
+    handled = await server._route_server_initiated_response(
+        req_id,
+        {"jsonrpc": "2.0", "id": req_id, "result": roots_result},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    roots = await asyncio.wait_for(task, timeout=5)
+    assert roots == [{"uri": "file:///workspace"}]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_elicitation_response_from_wrong_client_cannot_resolve():
+    """An elicitation response from client B cannot resolve client A's pending
+    request; the real responder (A) still can."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(
+        server.elicitation_system.request_input(
+            "your name?", client_id="client-A", timeout=5
+        )
+    )
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+
+    accept = {"action": "accept", "content": {"answer": "Ada"}}
+
+    # Wrong client — router refuses; the pending request survives.
+    handled = await server._route_server_initiated_response(
+        rid,
+        {"jsonrpc": "2.0", "id": rid, "result": accept},
+        responding_client_id="client-B",
+    )
+    assert handled is False
+    assert not task.done()
+    assert rid in server.elicitation_system._pending_requests
+
+    # Correct client — resolves with the collected content.
+    handled = await server._route_server_initiated_response(
+        rid,
+        {"jsonrpc": "2.0", "id": rid, "result": accept},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    response = await asyncio.wait_for(task, timeout=5)
+    assert response == {"answer": "Ada"}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_response_from_wrong_client_cannot_resolve():
+    """A sampling response from client B cannot resolve the request dispatched
+    to client A; the real target (A) still can."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"sampling": {}}}}
+    server.set_sampling_approver(lambda ctx: True)
+
+    task = asyncio.create_task(
+        server._handle_sampling_create_message(
+            {"messages": [{"role": "user", "content": "hi"}]},
+            "orig-req",
+        )
+    )
+    await _pump_until(lambda: bool(server._transport.sent))
+    sampling_msg, target = server._transport.sent[0]
+    sampling_id = sampling_msg["id"]
+    assert target == "client-A"
+
+    completion = {"role": "assistant", "content": {"type": "text", "text": "hi!"}}
+
+    # Wrong client — router refuses; the pending request survives.
+    handled = await server._route_server_initiated_response(
+        sampling_id,
+        {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+        responding_client_id="client-B",
+    )
+    assert handled is False
+    assert not task.done()
+    assert sampling_id in server._pending_sampling_requests
+
+    # Correct target — resolves and the requester gets the completion.
+    handled = await server._route_server_initiated_response(
+        sampling_id,
+        {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    result = await asyncio.wait_for(task, timeout=5)
+    assert result["result"] == completion
+    assert result["id"] == "orig-req"

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w6_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w6_convergence.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1712 Wave 6 convergence round-2 — FINDING 3
+(elicitation client-scoping + fail-closed response routing).
+
+- Elicitation pending entries now carry a bound ``client_id`` (threaded from
+  ``request_input`` / resolved from the invoking ``tools/call`` via the bound
+  provider) and elicitation/create is dispatched to THAT specific client, not
+  broadcast.
+- The shared response router (``_route_server_initiated_response``) is
+  FAIL-CLOSED for a SCOPED request across ALL THREE features (roots / sampling /
+  elicitation): a reply from the WRONG client — OR a None/empty responder —
+  cannot resolve another client's pending request.
+
+REAL ``MCPServer`` / ``ElicitationSystem`` objects and REAL handlers; a minimal
+capturing transport double satisfies the ``send_message`` structural contract.
+"""
+
+import asyncio
+
+import pytest
+from kailash_mcp.errors import MCPError, MCPErrorCode
+from kailash_mcp.server import MCPServer
+
+
+class _CapturingTransport:
+    """Real (non-mock) transport double capturing outbound (message, client_id)."""
+
+    def __init__(self):
+        self.sent: list = []
+
+    async def send_message(self, message, client_id=None):
+        self.sent.append((message, client_id))
+
+
+def _server() -> MCPServer:
+    server = MCPServer("w6-convergence-test", enable_cache=False, enable_metrics=False)
+    server.client_info = {}
+    server._transport = _CapturingTransport()
+    return server
+
+
+async def _pump_until(predicate, *, tries: int = 200):
+    for _ in range(tries):
+        await asyncio.sleep(0)
+        if predicate():
+            return
+    raise AssertionError("condition never became true")
+
+
+# ---------------------------------------------------------------------------
+# Elicitation is dispatched to the bound client, NOT broadcast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_elicitation_dispatched_to_bound_client_not_broadcast():
+    """request_input inherits the invoking client (via the bound provider) and
+    dispatches elicitation/create to THAT client — not a broadcast (client_id
+    None). The pending entry is scoped to the same client (accessor)."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+    # Emulate the tools/call contextvar binding the server installs.
+    server.elicitation_system.bind_client_id_provider(lambda: "client-A")
+
+    task = asyncio.create_task(server.elicitation_system.request_input("q?", timeout=5))
+    await _pump_until(lambda: bool(server._transport.sent))
+
+    message, target = server._transport.sent[0]
+    assert message["method"] == "elicitation/create"
+    # Dispatched to the SPECIFIC client, never broadcast (target would be None).
+    assert target == "client-A"
+
+    rid = message["id"]
+    assert server.elicitation_system.pending_client_id(rid) == "client-A"
+
+    # Clean up the awaiting task.
+    await server.elicitation_system.cancel_request(rid, reason="test cleanup")
+    with pytest.raises(MCPError):
+        await asyncio.wait_for(task, timeout=5)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_explicit_client_id_still_scopes_elicitation():
+    """An explicit client_id on request_input still scopes the pending entry and
+    dispatch (unchanged public signature — backward compatible)."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(
+        server.elicitation_system.request_input("q?", client_id="client-A", timeout=5)
+    )
+    await _pump_until(lambda: bool(server._transport.sent))
+    message, target = server._transport.sent[0]
+    assert target == "client-A"
+    assert server.elicitation_system.pending_client_id(message["id"]) == "client-A"
+
+    await server.elicitation_system.cancel_request(message["id"], reason="cleanup")
+    with pytest.raises(MCPError):
+        await asyncio.wait_for(task, timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Wrong-client elicitation reply cannot resolve another client's request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_elicitation_reply_from_wrong_client_cannot_resolve():
+    """An elicitation reply from client B cannot resolve client A's pending
+    elicitation (handled=False, the request survives)."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(
+        server.elicitation_system.request_input(
+            "your name?", client_id="client-A", timeout=5
+        )
+    )
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+
+    accept = {"action": "accept", "content": {"answer": "Ada"}}
+    handled = await server._route_server_initiated_response(
+        rid,
+        {"jsonrpc": "2.0", "id": rid, "result": accept},
+        responding_client_id="client-B",
+    )
+    assert handled is False
+    assert not task.done()
+    assert rid in server.elicitation_system._pending_requests
+
+    # The bound client resolves it.
+    handled = await server._route_server_initiated_response(
+        rid,
+        {"jsonrpc": "2.0", "id": rid, "result": accept},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    response = await asyncio.wait_for(task, timeout=5)
+    assert response == {"answer": "Ada"}
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: a None responder cannot resolve ANY scoped entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_none_responder_cannot_resolve_scoped_roots():
+    """A None responding_client_id cannot resolve a scoped roots/list request."""
+    server = _server()
+    task = asyncio.create_task(server.request_client_roots("client-A", timeout=5))
+    await _pump_until(lambda: bool(server._pending_roots_requests))
+    req_id = next(iter(server._pending_roots_requests))
+
+    roots_result = {"roots": [{"uri": "file:///workspace"}]}
+    # None responder — fail closed on a scoped entry.
+    handled = await server._route_server_initiated_response(
+        req_id, {"jsonrpc": "2.0", "id": req_id, "result": roots_result}
+    )
+    assert handled is False
+    assert not task.done()
+    assert req_id in server._pending_roots_requests
+
+    # The bound client resolves it.
+    handled = await server._route_server_initiated_response(
+        req_id,
+        {"jsonrpc": "2.0", "id": req_id, "result": roots_result},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    roots = await asyncio.wait_for(task, timeout=5)
+    assert roots == [{"uri": "file:///workspace"}]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_none_responder_cannot_resolve_scoped_elicitation():
+    """A None responding_client_id cannot resolve a scoped elicitation request."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    task = asyncio.create_task(
+        server.elicitation_system.request_input(
+            "your name?", client_id="client-A", timeout=5
+        )
+    )
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+
+    accept = {"action": "accept", "content": {"answer": "Ada"}}
+    handled = await server._route_server_initiated_response(
+        rid, {"jsonrpc": "2.0", "id": rid, "result": accept}
+    )
+    assert handled is False
+    assert not task.done()
+    assert rid in server.elicitation_system._pending_requests
+
+    # Bound client resolves it — clean up the awaiter.
+    handled = await server._route_server_initiated_response(
+        rid,
+        {"jsonrpc": "2.0", "id": rid, "result": accept},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    response = await asyncio.wait_for(task, timeout=5)
+    assert response == {"answer": "Ada"}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_none_responder_cannot_resolve_scoped_sampling():
+    """A None responding_client_id cannot resolve a scoped sampling request."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"sampling": {}}}}
+    server.set_sampling_approver(lambda ctx: True)
+
+    task = asyncio.create_task(
+        server._handle_sampling_create_message(
+            # F4 routes sampling to the REQUESTER's own client — the requester's
+            # client_id is merged into params by the WS dispatch layer.
+            {"messages": [{"role": "user", "content": "hi"}], "client_id": "client-A"},
+            "orig-req",
+        )
+    )
+    await _pump_until(lambda: bool(server._transport.sent))
+    sampling_msg, target = server._transport.sent[0]
+    sampling_id = sampling_msg["id"]
+    assert target == "client-A"
+
+    completion = {"role": "assistant", "content": {"type": "text", "text": "hi!"}}
+    # None responder — fail closed on the scoped sampling entry.
+    handled = await server._route_server_initiated_response(
+        sampling_id, {"jsonrpc": "2.0", "id": sampling_id, "result": completion}
+    )
+    assert handled is False
+    assert not task.done()
+    assert sampling_id in server._pending_sampling_requests
+
+    # The bound target resolves it.
+    handled = await server._route_server_initiated_response(
+        sampling_id,
+        {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+        responding_client_id="client-A",
+    )
+    assert handled is True
+    result = await asyncio.wait_for(task, timeout=5)
+    assert result["result"] == completion
+    assert result["id"] == "orig-req"
+
+
+# ---------------------------------------------------------------------------
+# Unscoped requests keep permissive resolution (backward compatible)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_unscoped_elicitation_still_resolves_with_none_responder():
+    """An UNSCOPED elicitation (no bound client) is still resolvable by a None
+    responder — the fail-closed check applies ONLY to scoped entries."""
+    server = _server()
+    server.client_info = {"client-A": {"capabilities": {"elicitation": {}}}}
+    server.elicitation_system.bind_transport(server._transport.send_message)
+
+    # No client_id, no provider bound → unscoped.
+    task = asyncio.create_task(server.elicitation_system.request_input("q?", timeout=5))
+    await _pump_until(lambda: bool(server.elicitation_system._pending_requests))
+    rid = next(iter(server.elicitation_system._pending_requests))
+    assert server.elicitation_system.pending_client_id(rid) is None
+
+    accept = {"action": "accept", "content": {"answer": "Grace"}}
+    handled = await server._route_server_initiated_response(
+        rid, {"jsonrpc": "2.0", "id": rid, "result": accept}
+    )
+    assert handled is True
+    response = await asyncio.wait_for(task, timeout=5)
+    assert response == {"answer": "Grace"}

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w7_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w7_convergence.py
@@ -1,0 +1,89 @@
+"""#1712 convergence round-3 (Wave 7): concurrency-hardening regressions.
+
+All three were newly reachable once the WS transport began dispatching handlers
+CONCURRENTLY (Wave 6 F2). Each pins a fix so a future refactor cannot silently
+re-open it.
+"""
+
+import asyncio
+
+import pytest
+from kailash_mcp.server import MCPServer
+from kailash_mcp.transports.transports import WebSocketServerTransport
+
+
+class _FailTransport:
+    async def send_message(self, message, client_id=None):
+        raise RuntimeError("socket dropped mid-dispatch")
+
+    def has_client(self, client_id):
+        return True
+
+
+class _NoopTransport:
+    async def send_message(self, message, client_id=None):
+        return None
+
+    def has_client(self, client_id):
+        return True
+
+
+@pytest.mark.regression
+def test_progress_token_namespaced_by_request_id():
+    """F1: two CONCURRENT same-client calls reusing one progressToken value get
+    DISTINCT internal ProgressManager keys (namespaced by request_id), so they
+    cannot corrupt each other's progress under concurrent WS dispatch."""
+    server = MCPServer("w7")
+    server.client_info["cA"] = {}
+    server._transport = _NoopTransport()
+    params = {"_meta": {"progressToken": "1"}}
+    t1 = server._begin_progress(params, "cA", "op", "req-1")
+    t2 = server._begin_progress(params, "cA", "op", "req-2")
+    assert t1 is not None and t2 is not None
+    assert t1.value != t2.value  # request_id disambiguates the shared token "1"
+    assert "req-1" in t1.value and "req-2" in t2.value
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sampling_dispatch_send_failure_no_pending_leak():
+    """F2: a dispatch send failure drops the pending sampling entry from ALL
+    three maps (no leaked Future, no dead id seeding the FIFO deque)."""
+    server = MCPServer("w7")
+    server.set_sampling_approver(lambda ctx: True)
+    server.client_info = {"cA": {"capabilities": {"sampling": {}}}}
+    server._transport = _FailTransport()
+    result = await server._handle_sampling_create_message(
+        {"messages": [{"role": "user", "content": "hi"}], "client_id": "cA"},
+        "req-x",
+    )
+    assert result["error"]["code"] == -32603
+    assert server._pending_sampling_requests == {}
+    assert len(server._pending_sampling_order) == 0
+    assert server._pending_sampling_clients == {}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_roots_dispatch_send_failure_no_pending_leak():
+    """F2: a roots/list dispatch send failure drops the pending roots entry and
+    falls back to an empty list."""
+    server = MCPServer("w7")
+    server._transport = _FailTransport()
+    roots = await server.request_client_roots("cA", timeout=1.0)
+    assert roots == []
+    assert server._pending_roots_requests == {}
+    assert server._pending_roots_clients == {}
+
+
+@pytest.mark.regression
+def test_per_client_send_lock_shared_and_distinct():
+    """F3: the WS transport's send lock is ONE lock per client_id (shared by the
+    response path AND every server-initiated send), stable across calls and
+    distinct per client."""
+    transport = WebSocketServerTransport()
+    a1 = transport._get_send_lock("cA")
+    a2 = transport._get_send_lock("cA")
+    b1 = transport._get_send_lock("cB")
+    assert a1 is a2  # same client -> same lock (serializes all its sends)
+    assert a1 is not b1  # different clients -> independent locks

--- a/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
+++ b/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
@@ -121,12 +121,14 @@ class TestElicitationSystemCallSites:
         """Locks the ElicitationSystem init signature so a future refactor
         toward a different shape fails loudly.
 
-        MCP 2025-11-25 (gap E3) grew the constructor with two BACKWARD-COMPATIBLE
-        keyword-only params — ``server_identity`` (url-mode issuer binding) and
-        ``capability_provider`` (the client-elicitation-capability gate). Cross-SDK
-        parity relies on ``send`` remaining the FIRST POSITIONAL callable
-        (unchanged); the additions are keyword-only so every existing positional
-        caller ``ElicitationSystem(send)`` still binds identically.
+        MCP 2025-11-25 (gap E3) grew the constructor with BACKWARD-COMPATIBLE
+        keyword-only params — ``server_identity`` (url-mode issuer binding),
+        ``capability_provider`` (the client-elicitation-capability gate), and
+        (#1712 W6 FINDING 3) ``client_id_provider`` (resolves the client an
+        elicitation targets when raised from a tools/call). Cross-SDK parity
+        relies on ``send`` remaining the FIRST POSITIONAL callable (unchanged);
+        the additions are keyword-only so every existing positional caller
+        ``ElicitationSystem(send)`` still binds identically.
         """
         from kailash_mcp.advanced.features import ElicitationSystem
 
@@ -136,17 +138,18 @@ class TestElicitationSystemCallSites:
             "send",
             "server_identity",
             "capability_provider",
+            "client_id_provider",
         ], (
             f"ElicitationSystem.__init__ signature drifted: {sig}. "
             f"Cross-SDK parity relies on `send` staying the first positional "
             f"callable with the 2025-11-25 additions keyword-only."
         )
-        # ``send`` MUST remain a positional-or-keyword first param; the 2025-11-25
-        # additions MUST be keyword-only (so ElicitationSystem(send) is unchanged).
+        # ``send`` MUST remain a positional-or-keyword first param; the additions
+        # MUST be keyword-only (so ElicitationSystem(send) is unchanged).
         send_param = sig.parameters["send"]
         assert send_param.kind in (
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.POSITIONAL_ONLY,
         )
-        for name in ("server_identity", "capability_provider"):
+        for name in ("server_identity", "capability_provider", "client_id_provider"):
             assert sig.parameters[name].kind == inspect.Parameter.KEYWORD_ONLY

--- a/tests/unit/mcp_server/test_missing_handlers.py
+++ b/tests/unit/mcp_server/test_missing_handlers.py
@@ -409,22 +409,48 @@ class TestSamplingCreateMessage:
         }
         request_id = "test_123"
 
-        # Call handler
-        result = await server._handle_sampling_create_message(params, request_id)
+        # Under the async round-trip model the handler DISPATCHES to the capable
+        # client and AWAITS the client's reply — no immediate synchronous ack.
+        # Run it as a task, let the request be SENT, then feed the client's reply
+        # back through the response router and assert the completion is delivered
+        # to the ORIGINAL requester.
+        task = asyncio.create_task(
+            server._handle_sampling_create_message(params, request_id)
+        )
+        for _ in range(200):
+            await asyncio.sleep(0)
+            if server._transport.send_message.await_count:
+                break
+        else:
+            task.cancel()
+            raise AssertionError("sampling request was never dispatched")
 
-        # Verify response
-        assert result["jsonrpc"] == "2.0"
-        assert result["id"] == request_id
-        assert "result" in result
-        assert result["result"]["status"] == "sampling_requested"
-        assert "sampling_id" in result["result"]
-        assert result["result"]["target_client"] == client_id
-
-        # Verify message was sent
+        # Verify the request was dispatched to the capable client.
         server._transport.send_message.assert_called_once()
         sent_msg = server._transport.send_message.call_args[0][0]
         assert sent_msg["method"] == "sampling/createMessage"
         assert sent_msg["params"]["messages"] == params["messages"]
+        assert server._transport.send_message.call_args[1]["client_id"] == client_id
+
+        sampling_id = sent_msg["id"]
+        assert sampling_id in server._pending_sampling_requests
+
+        # The target client replies; the router resolves the awaiting Future.
+        completion = {"role": "assistant", "content": {"type": "text", "text": "Hi!"}}
+        handled = await server._route_server_initiated_response(
+            sampling_id,
+            {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+            responding_client_id=client_id,
+        )
+        assert handled is True
+
+        # The completion is delivered to the ORIGINAL requester and the pending
+        # map is drained.
+        result = await asyncio.wait_for(task, timeout=2)
+        assert result["jsonrpc"] == "2.0"
+        assert result["id"] == request_id
+        assert result["result"] == completion
+        assert sampling_id not in server._pending_sampling_requests
 
     @pytest.mark.asyncio
     async def test_sampling_no_capable_clients(self, server):
@@ -464,18 +490,42 @@ class TestSamplingCreateMessage:
         }
         request_id = "test_123"
 
-        # Call handler
-        result = await server._handle_sampling_create_message(params, request_id)
+        # Under the async round-trip model the pending entry is created WHILE the
+        # handler awaits the client reply (and drained on reply/timeout). Run the
+        # handler as a task, let the request be sent, then assert the tracking
+        # entry exists while the handler is still awaiting.
+        task = asyncio.create_task(
+            server._handle_sampling_create_message(params, request_id)
+        )
+        for _ in range(200):
+            await asyncio.sleep(0)
+            if server._transport.send_message.await_count:
+                break
+        else:
+            task.cancel()
+            raise AssertionError("sampling request was never dispatched")
 
-        # Get sampling ID
-        sampling_id = result["result"]["sampling_id"]
+        sampling_id = server._transport.send_message.call_args[0][0]["id"]
 
-        # Verify request is tracked
+        # Tracked WHILE the handler awaits the client reply.
+        assert not task.done()
         assert sampling_id in server._pending_sampling_requests
         pending = server._pending_sampling_requests[sampling_id]
         assert pending["original_request_id"] == request_id
         assert pending["client_id"] == client_id
         assert "timestamp" in pending
+
+        # Feeding the reply drains the pending entry and completes the handler.
+        completion = {"role": "assistant", "content": {"type": "text", "text": "ok"}}
+        handled = await server._route_server_initiated_response(
+            sampling_id,
+            {"jsonrpc": "2.0", "id": sampling_id, "result": completion},
+            responding_client_id=client_id,
+        )
+        assert handled is True
+        result = await asyncio.wait_for(task, timeout=2)
+        assert result["id"] == request_id
+        assert sampling_id not in server._pending_sampling_requests
 
     @pytest.mark.asyncio
     async def test_sampling_without_transport(self, server):


### PR DESCRIPTION
## Summary

Completes **#1712** (MCP 2025-11-25 spec-parity). The 2025-11-25 wire surface (`sampling/createMessage`, `elicitation/create`, `roots/list`, progress, cancellation, completion, logging) shipped in the 0.3.x line; **0.4.0 makes the server-initiated request/response lifecycle correct and concurrency-safe**. No new wire methods — this is a hardening release.

### Fixed
- **Single-client server-initiated round-trips no longer deadlock.** The native WebSocket server transport dispatches each inbound message in its own task, so the read loop keeps draining the socket while a tool handler awaits a server-initiated reply (sampling/elicitation/roots) arriving on the same connection. Previously the handler blocked until timeout.
- **Server-initiated replies route to the original requester** (sampling replies were previously droppable with a spurious `-32601`).
- **Replies are client-scoped fail-closed** — a mismatched responder is rejected, never silently routed; tool→client scope carried via contextvars.

### Security / hardening (newly reachable under concurrent dispatch)
- Per-client progress tokens namespaced by request id (no cross-delivery/eviction between two concurrent calls reusing one `progressToken`).
- Dispatch-send failure drops the pending request from every tracking map + cancels its future (no leaked future/FIFO entry).
- Every outbound send for a client serializes through one per-client lock (no interleaved frames).
- Pending-sampling map stays FIFO-bounded and is cleared on disconnect.

## Convergence
Four adversarial redteam rounds; each of rounds 1–3 surfaced the next layer (reply-dropped → deque-unpruned/WS-deadlock/scope-leak → progress-token/send-failure/send-lock). **Round-4 found no CRIT/HIGH/MED.** Round-4 was run in the main loop (the parallel subagent reviewers hit an account usage limit — errored returns are zero evidence, not a clean round, so they were not counted); substituted with the full mechanical battery + end-to-end read-verification of all three round-3 fix sites.

**Receipts:**
- `418` package tests + `645` core `tests/unit/mcp_server` tests pass; WS server-initiated round-trip e2e (`test_ws_server_initiated_roundtrip.py`) passes.
- `pytest --collect-only`: 418 collected, no errors. Stub/fallback sweep on the diff: clean.
- Version bumped in `pyproject.toml` + `__init__.py` (both `0.4.0`); Ruff clean; Black-formatted (line-length 88).

## ⚠️ Release gate note
Per `deployment.md`, the mandatory **security-reviewer** pass could not run this session (account usage limit blocked subagents). PyPI publication (a human-gated structural step per `build-repo-release-discipline.md` Rule 4) is **pending**: it needs (1) the security-reviewer audit, (2) TestPyPI validation (0.4.0 is a minor), (3) explicit release authorization. The code + version + CHANGELOG are ready to merge; the publish should follow once subagents are available.

## Related issues
Closes #1712 (on publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)