### PR TITLE
feat(kaizen): #1720 Wave-1b — tool/structured/sampling wire emission (openai/anthropic/google)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
@@ -16,6 +16,7 @@ See https://docs.anthropic.com/en/api/messages for the canonical schema.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, List
 
@@ -146,6 +147,69 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     if request.user is not None:
         # Anthropic accepts `metadata.user_id` for per-tenant tracking.
         payload["metadata"] = {"user_id": request.user}
+
+    # Wave 1b — completion-shaping field translation (OpenAI shape -> Anthropic).
+    #
+    # tools: the shared CompletionRequest carries the OpenAI function-schema form
+    # ``[{"type": "function", "function": {"name", "description", "parameters"}}]``;
+    # Anthropic's ``/v1/messages`` expects ``[{"name", "description",
+    # "input_schema"}]``. Translate field-by-field only when tools is set.
+    if request.tools is not None:
+        payload["tools"] = [
+            {
+                "name": f["function"]["name"],
+                "description": f["function"].get("description", ""),
+                "input_schema": f["function"].get("parameters", {}),
+            }
+            for f in request.tools
+        ]
+        # tool_choice is only meaningful alongside tools. Map the OpenAI values to
+        # Anthropic's ``{"type": ...}`` shape:
+        #   "auto"     -> {"type": "auto"}
+        #   "required" -> {"type": "any"}  (Anthropic's "must call some tool")
+        #   "none"     -> omit tools entirely (drop the tools we just built)
+        #   forced-tool dict {"type":"function","function":{"name":X}}
+        #              -> {"type": "tool", "name": X}
+        #   None       -> {"type": "any"}  (legacy "required"-when-tools default)
+        tool_choice = request.tool_choice
+        if tool_choice is None:
+            payload["tool_choice"] = {"type": "any"}
+        elif isinstance(tool_choice, str):
+            if tool_choice == "auto":
+                payload["tool_choice"] = {"type": "auto"}
+            elif tool_choice == "required":
+                payload["tool_choice"] = {"type": "any"}
+            elif tool_choice == "none":
+                # "none" means "do not call a tool" — Anthropic expresses this by
+                # not offering tools at all. Drop the tools key we just set.
+                payload.pop("tools", None)
+            else:
+                # Unknown string — default to the tools-set "any" semantics rather
+                # than emitting a shape Anthropic would reject.
+                payload["tool_choice"] = {"type": "any"}
+        elif isinstance(tool_choice, dict):
+            # Forced-tool: {"type":"function","function":{"name":X}} -> {"type":"tool","name":X}
+            forced_name = tool_choice.get("function", {}).get("name")
+            if forced_name is not None:
+                payload["tool_choice"] = {"type": "tool", "name": forced_name}
+            else:
+                payload["tool_choice"] = {"type": "any"}
+
+    # top_k: Anthropic SUPPORTS top_k natively.
+    if request.top_k is not None:
+        payload["top_k"] = request.top_k
+
+    # response_format: Anthropic has NO native json_schema / response_format param.
+    # Structured output on Anthropic is achieved by forcing a tool (input_schema =
+    # the desired JSON schema) — OUT OF SCOPE for this shard (a future enhancement).
+    # We deliberately emit NOTHING here: inventing a bogus key would ship a feature
+    # Anthropic does not support (zero-tolerance: no fake feature).
+    #
+    # UNSUPPORTED by Anthropic /v1/messages — deliberately NOT emitted:
+    #   seed, logit_bias, frequency_penalty, presence_penalty, n
+    # (the shared CompletionRequest carries them for OpenAI-family wires only;
+    # emitting them here would be rejected or silently ignored by Anthropic.)
+
     return payload
 
 
@@ -162,16 +226,34 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
     content = payload.get("content", [])
     texts: List[str] = []
     raw_blocks: List[Dict[str, Any]] = []
+    tool_calls: List[Dict[str, Any]] = []
     if isinstance(content, list):
         for block in content:
             if isinstance(block, dict):
                 raw_blocks.append(block)
-                if block.get("type") == "text":
+                block_type = block.get("type")
+                if block_type == "text":
                     text_value = block.get("text", "")
                     if isinstance(text_value, str):
                         texts.append(text_value)
+                elif block_type == "tool_use":
+                    # Normalize the Anthropic tool_use block into the CANONICAL
+                    # tool-call shape shared with the openai/google wire shards:
+                    #   {"id", "type": "function",
+                    #    "function": {"name", "arguments": <JSON string>}}
+                    # ``arguments`` MUST be a json.dumps string of the input dict.
+                    tool_calls.append(
+                        {
+                            "id": block.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": block.get("name"),
+                                "arguments": json.dumps(block.get("input", {})),
+                            },
+                        }
+                    )
     usage = payload.get("usage", {}) or {}
-    return {
+    result: Dict[str, Any] = {
         "text": "".join(texts),
         "raw_blocks": raw_blocks,
         "usage": {
@@ -181,6 +263,11 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": payload.get("stop_reason"),
         "model": payload.get("model"),
     }
+    # Only surface tool_calls when at least one tool_use block was present, so a
+    # plain text response stays byte-identical to the pre-Wave-1b parsed shape.
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
@@ -153,8 +153,10 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     # tools: the shared CompletionRequest carries the OpenAI function-schema form
     # ``[{"type": "function", "function": {"name", "description", "parameters"}}]``;
     # Anthropic's ``/v1/messages`` expects ``[{"name", "description",
-    # "input_schema"}]``. Translate field-by-field only when tools is set.
-    if request.tools is not None:
+    # "input_schema"}]``. Guard on truthiness so an explicitly-set EMPTY list
+    # (``tools=[]``) emits nothing rather than an empty ``tools`` + a forced
+    # ``tool_choice`` the API would reject.
+    if request.tools:
         payload["tools"] = [
             {
                 "name": f["function"]["name"],

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -150,8 +150,12 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         payload["systemInstruction"] = {"parts": system_parts}
 
     # tools -> Gemini top-level `tools` with functionDeclarations, translating
-    # the OpenAI function-schema form to Gemini's shape.
-    if request.tools is not None:
+    # the OpenAI function-schema form to Gemini's shape. Guard on truthiness so
+    # an explicitly-set EMPTY list (`tools=[]`) emits nothing — emitting
+    # `tools:[{functionDeclarations:[]}]` + a forced `toolConfig` mode:ANY would
+    # be a degenerate forced-call-with-no-functions request (matches the
+    # openai/anthropic empty-tools guard).
+    if request.tools:
         payload["tools"] = [
             {
                 "functionDeclarations": [

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -16,12 +16,16 @@ See https://ai.google.dev/api/generate-content for the canonical schema.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, List
 
 from kaizen.llm.deployment import CompletionRequest
 
 logger = logging.getLogger(__name__)
+
+# OpenAI tool_choice string mode -> Gemini function_calling_config mode.
+_TOOL_CHOICE_MODE = {"auto": "AUTO", "required": "ANY", "none": "NONE"}
 
 
 def _role_from_openai(role: str) -> str:
@@ -110,12 +114,96 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     if request.stop:
         generation_config["stopSequences"] = list(request.stop)
 
+    # Wave-1b completion-shaping fields (all Optional, byte-neutral when unset).
+    # top_k / seed / n / frequency_penalty / presence_penalty MERGE into the
+    # existing generationConfig above — never clobber temperature/top_p/max.
+    if request.top_k is not None:
+        generation_config["topK"] = request.top_k
+    if request.seed is not None:
+        generation_config["seed"] = request.seed
+    if request.n is not None:
+        # Gemini names OpenAI's `n` (candidate count) `candidateCount`.
+        generation_config["candidateCount"] = request.n
+    if request.frequency_penalty is not None:
+        generation_config["frequencyPenalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        generation_config["presencePenalty"] = request.presence_penalty
+    # logit_bias: Gemini's generateContent has no equivalent — DO NOT emit it.
+
+    # response_format -> Gemini structured-output on generationConfig. Gemini
+    # supports JSON mode via responseMimeType, plus an optional responseSchema.
+    if request.response_format is not None:
+        generation_config["responseMimeType"] = "application/json"
+        schema = _extract_json_schema(request.response_format)
+        if schema is not None:
+            generation_config["responseSchema"] = schema
+
     payload: Dict[str, Any] = {"contents": contents}
     if generation_config:
         payload["generationConfig"] = generation_config
     if system_parts is not None:
         payload["systemInstruction"] = {"parts": system_parts}
+
+    # tools -> Gemini top-level `tools` with functionDeclarations, translating
+    # the OpenAI function-schema form to Gemini's shape.
+    if request.tools is not None:
+        payload["tools"] = [
+            {
+                "functionDeclarations": [
+                    {
+                        "name": fn["function"]["name"],
+                        "description": fn["function"].get("description", ""),
+                        "parameters": fn["function"].get("parameters", {}),
+                    }
+                    for fn in request.tools
+                ]
+            }
+        ]
+        # tool_choice -> Gemini tool_config.function_calling_config.mode. Only
+        # emitted when tools are set (a mode with no tools is meaningless).
+        tool_config = _tool_config_from_choice(request.tool_choice)
+        if tool_config is not None:
+            payload["tool_config"] = tool_config
+
     return payload
+
+
+def _extract_json_schema(response_format: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Pull a JSON schema out of an OpenAI-shaped ``response_format``.
+
+    OpenAI carries a schema under ``{"type": "json_schema", "json_schema":
+    {"schema": {...}}}``; a bare ``{"type": "json_object"}`` has none. Returns
+    the schema dict (Gemini ``responseSchema``) or ``None`` when absent.
+    """
+    json_schema = response_format.get("json_schema")
+    if isinstance(json_schema, dict):
+        schema = json_schema.get("schema")
+        if isinstance(schema, dict):
+            return schema
+    return None
+
+
+def _tool_config_from_choice(tool_choice: Any) -> Dict[str, Any] | None:
+    """Translate an OpenAI ``tool_choice`` to a Gemini ``tool_config``.
+
+    OpenAI ``"auto"``/``"required"``/``"none"`` map to Gemini modes
+    ``AUTO``/``ANY``/``NONE``. A forced-tool dict
+    (``{"type": "function", "function": {"name": ...}}``) maps to ``ANY`` plus
+    ``allowed_function_names``. When tools are set but ``tool_choice`` is unset,
+    the default is ``ANY`` (legacy "required" semantics).
+    """
+    if isinstance(tool_choice, dict):
+        fn = tool_choice.get("function", {})
+        name = fn.get("name") if isinstance(fn, dict) else None
+        config: Dict[str, Any] = {"mode": "ANY"}
+        if name is not None:
+            config["allowed_function_names"] = [name]
+        return {"function_calling_config": config}
+    if isinstance(tool_choice, str):
+        mode = _TOOL_CHOICE_MODE.get(tool_choice, "ANY")
+        return {"function_calling_config": {"mode": mode}}
+    # tool_choice is None but tools are set -> default to ANY (required).
+    return {"function_calling_config": {"mode": "ANY"}}
 
 
 def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -134,6 +222,7 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         raise TypeError("parse_response expects a dict payload")
     candidates = payload.get("candidates", []) or []
     texts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
     finish_reason: Any = None
     if candidates and isinstance(candidates[0], dict):
         first = candidates[0]
@@ -141,14 +230,30 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         content = first.get("content", {})
         parts = content.get("parts", []) if isinstance(content, dict) else []
         if isinstance(parts, list):
-            for part in parts:
-                if isinstance(part, dict):
-                    text_value = part.get("text")
-                    if isinstance(text_value, str):
-                        texts.append(text_value)
+            for index, part in enumerate(parts):
+                if not isinstance(part, dict):
+                    continue
+                text_value = part.get("text")
+                if isinstance(text_value, str):
+                    texts.append(text_value)
+                # Gemini emits tool invocations as ``functionCall`` parts with
+                # no call id; synthesize ``call_{index}`` and JSON-encode args
+                # into the canonical normalized shape shared with openai/anthropic.
+                function_call = part.get("functionCall")
+                if isinstance(function_call, dict):
+                    tool_calls.append(
+                        {
+                            "id": f"call_{index}",
+                            "type": "function",
+                            "function": {
+                                "name": function_call.get("name"),
+                                "arguments": json.dumps(function_call.get("args", {})),
+                            },
+                        }
+                    )
 
     usage = payload.get("usageMetadata", {}) or {}
-    return {
+    result: Dict[str, Any] = {
         "text": "".join(texts),
         "usage": {
             "input_tokens": usage.get("promptTokenCount"),
@@ -158,6 +263,11 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": finish_reason,
         "model": payload.get("modelVersion"),
     }
+    # Only surface tool_calls when ≥1 functionCall part is present; a
+    # tool-less response keeps the pre-#1720 parsed keys unchanged.
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -132,11 +132,16 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
 
     # response_format -> Gemini structured-output on generationConfig. Gemini
     # supports JSON mode via responseMimeType, plus an optional responseSchema.
+    # ONLY force JSON mode for the JSON response types — an OpenAI
+    # ``{"type": "text"}`` must NOT be coerced into JSON (Gemini defaults to
+    # text, so emit nothing for it).
     if request.response_format is not None:
-        generation_config["responseMimeType"] = "application/json"
-        schema = _extract_json_schema(request.response_format)
-        if schema is not None:
-            generation_config["responseSchema"] = schema
+        rf_type = request.response_format.get("type")
+        if rf_type in ("json_object", "json_schema"):
+            generation_config["responseMimeType"] = "application/json"
+            schema = _extract_json_schema(request.response_format)
+            if schema is not None:
+                generation_config["responseSchema"] = schema
 
     payload: Dict[str, Any] = {"contents": contents}
     if generation_config:
@@ -159,11 +164,11 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
                 ]
             }
         ]
-        # tool_choice -> Gemini tool_config.function_calling_config.mode. Only
+        # tool_choice -> Gemini toolConfig.functionCallingConfig.mode. Only
         # emitted when tools are set (a mode with no tools is meaningless).
         tool_config = _tool_config_from_choice(request.tool_choice)
         if tool_config is not None:
-            payload["tool_config"] = tool_config
+            payload["toolConfig"] = tool_config
 
     return payload
 
@@ -189,7 +194,7 @@ def _tool_config_from_choice(tool_choice: Any) -> Dict[str, Any] | None:
     OpenAI ``"auto"``/``"required"``/``"none"`` map to Gemini modes
     ``AUTO``/``ANY``/``NONE``. A forced-tool dict
     (``{"type": "function", "function": {"name": ...}}``) maps to ``ANY`` plus
-    ``allowed_function_names``. When tools are set but ``tool_choice`` is unset,
+    ``allowedFunctionNames``. When tools are set but ``tool_choice`` is unset,
     the default is ``ANY`` (legacy "required" semantics).
     """
     if isinstance(tool_choice, dict):
@@ -197,13 +202,13 @@ def _tool_config_from_choice(tool_choice: Any) -> Dict[str, Any] | None:
         name = fn.get("name") if isinstance(fn, dict) else None
         config: Dict[str, Any] = {"mode": "ANY"}
         if name is not None:
-            config["allowed_function_names"] = [name]
-        return {"function_calling_config": config}
+            config["allowedFunctionNames"] = [name]
+        return {"functionCallingConfig": config}
     if isinstance(tool_choice, str):
         mode = _TOOL_CHOICE_MODE.get(tool_choice, "ANY")
-        return {"function_calling_config": {"mode": mode}}
+        return {"functionCallingConfig": {"mode": mode}}
     # tool_choice is None but tools are set -> default to ANY (required).
-    return {"function_calling_config": {"mode": "ANY"}}
+    return {"functionCallingConfig": {"mode": "ANY"}}
 
 
 def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -85,7 +85,61 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         payload["stream"] = True
     if request.user is not None:
         payload["user"] = request.user
+
+    # --- #1720 Wave-1b completion-shaping emission (OpenAI is the canonical shape) ---
+    # Tool / function calling: `tools` is already the OpenAI function-schema list,
+    # emitted verbatim. When tools are present, `tool_choice` defaults to the
+    # legacy "required" semantics (a pinned Wave-1a decision) unless the caller
+    # set it explicitly; when no tools are present, `tool_choice` is emitted only
+    # if the caller set it.
+    if request.tools is not None:
+        payload["tools"] = list(request.tools)
+        payload["tool_choice"] = (
+            request.tool_choice if request.tool_choice is not None else "required"
+        )
+    elif request.tool_choice is not None:
+        payload["tool_choice"] = request.tool_choice
+    # Structured output: OpenAI-native, verbatim passthrough.
+    if request.response_format is not None:
+        payload["response_format"] = request.response_format
+    # Extended sampling: each passthrough under the same key name when set.
+    if request.seed is not None:
+        payload["seed"] = request.seed
+    if request.logit_bias is not None:
+        payload["logit_bias"] = request.logit_bias
+    if request.frequency_penalty is not None:
+        payload["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        payload["presence_penalty"] = request.presence_penalty
+    if request.n is not None:
+        payload["n"] = request.n
+    # top_k: intentionally NOT emitted — the OpenAI chat completions API does not
+    # support top_k (it is an Anthropic/Google/Cohere/Mistral/Ollama family field).
     return payload
+
+
+def _normalize_tool_call(tc: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce one OpenAI ``message.tool_calls`` entry into the canonical shape.
+
+    The canonical normalized shape (shared with the anthropic/google shards) is::
+
+        {"id": <str>, "type": "function",
+         "function": {"name": <str>, "arguments": <str: JSON-encoded>}}
+
+    OpenAI already returns this shape (``arguments`` is already a JSON string),
+    so this rebuilds a plain, JSON-serializable dict from the response entry —
+    guaranteeing no provider SDK object leaks into the parsed result.
+    """
+    function = tc.get("function")
+    function = function if isinstance(function, dict) else {}
+    return {
+        "id": tc.get("id"),
+        "type": tc.get("type", "function"),
+        "function": {
+            "name": function.get("name"),
+            "arguments": function.get("arguments"),
+        },
+    }
 
 
 def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -100,6 +154,7 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
     choices = payload.get("choices", []) or []
     text = ""
     finish_reason: Any = None
+    tool_calls: Any = None
     if choices and isinstance(choices[0], dict):
         first = choices[0]
         finish_reason = first.get("finish_reason")
@@ -111,8 +166,21 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
             content = message.get("content")
             if isinstance(content, str):
                 text = content
+            # #1720 Wave-1b: surface tool calls. OpenAI already returns
+            # `message.tool_calls` in the canonical normalized shape
+            # ([{"id", "type": "function", "function": {"name", "arguments"}}]
+            # with `arguments` a JSON-encoded string), shared with the
+            # anthropic/google shards. Pass through as plain JSON-serializable
+            # dicts (never SDK objects), only when present.
+            raw_tool_calls = message.get("tool_calls")
+            if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                tool_calls = [
+                    _normalize_tool_call(tc)
+                    for tc in raw_tool_calls
+                    if isinstance(tc, dict)
+                ]
     usage = payload.get("usage", {}) or {}
-    return {
+    result: Dict[str, Any] = {
         "text": text,
         "usage": {
             "input_tokens": usage.get("prompt_tokens"),
@@ -122,6 +190,9 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": finish_reason,
         "model": payload.get("model"),
     }
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -90,18 +90,17 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     # --- #1720 Wave-1b completion-shaping emission (OpenAI is the canonical shape) ---
     # Tool / function calling: `tools` is already the OpenAI function-schema list,
     # emitted verbatim. Guard on truthiness so an explicitly-set EMPTY list
-    # (`tools=[]`) emits nothing — emitting `"tools": []` + `tool_choice:
-    # "required"` would be an invalid request (required with no tools → 400).
-    # When tools are present, `tool_choice` defaults to the legacy "required"
-    # semantics (a pinned Wave-1a decision) unless the caller set it explicitly;
-    # when no tools are present, `tool_choice` is emitted only if the caller set it.
+    # (`tools=[]`) emits nothing. `tool_choice` is meaningless without tools (a
+    # forced `"required"`/named choice with no tools is an invalid request), so
+    # it is emitted ONLY alongside a non-empty tools list — matching the
+    # anthropic/google adapters (the four-axis consistency contract). When tools
+    # are present, `tool_choice` defaults to the legacy "required" semantics (a
+    # pinned Wave-1a decision) unless the caller set it explicitly.
     if request.tools:
         payload["tools"] = list(request.tools)
         payload["tool_choice"] = (
             request.tool_choice if request.tool_choice is not None else "required"
         )
-    elif request.tool_choice is not None:
-        payload["tool_choice"] = request.tool_choice
     # Structured output: OpenAI-native, verbatim passthrough.
     if request.response_format is not None:
         payload["response_format"] = request.response_format

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -38,6 +38,7 @@ to its Rust counterpart's OpenAI chat payload builder.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict
 
 from kaizen.llm.deployment import CompletionRequest
@@ -88,11 +89,13 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
 
     # --- #1720 Wave-1b completion-shaping emission (OpenAI is the canonical shape) ---
     # Tool / function calling: `tools` is already the OpenAI function-schema list,
-    # emitted verbatim. When tools are present, `tool_choice` defaults to the
-    # legacy "required" semantics (a pinned Wave-1a decision) unless the caller
-    # set it explicitly; when no tools are present, `tool_choice` is emitted only
-    # if the caller set it.
-    if request.tools is not None:
+    # emitted verbatim. Guard on truthiness so an explicitly-set EMPTY list
+    # (`tools=[]`) emits nothing — emitting `"tools": []` + `tool_choice:
+    # "required"` would be an invalid request (required with no tools → 400).
+    # When tools are present, `tool_choice` defaults to the legacy "required"
+    # semantics (a pinned Wave-1a decision) unless the caller set it explicitly;
+    # when no tools are present, `tool_choice` is emitted only if the caller set it.
+    if request.tools:
         payload["tools"] = list(request.tools)
         payload["tool_choice"] = (
             request.tool_choice if request.tool_choice is not None else "required"
@@ -129,15 +132,23 @@ def _normalize_tool_call(tc: Dict[str, Any]) -> Dict[str, Any]:
     OpenAI already returns this shape (``arguments`` is already a JSON string),
     so this rebuilds a plain, JSON-serializable dict from the response entry —
     guaranteeing no provider SDK object leaks into the parsed result.
+
+    Defensive: this wire also serves OpenAI-COMPATIBLE providers (Groq,
+    Together, Fireworks, OpenRouter, DeepSeek, …). A non-conformant one may
+    return ``arguments`` as a dict rather than a JSON string; coerce it so the
+    canonical "arguments is a JSON string" invariant holds across the fleet.
     """
     function = tc.get("function")
     function = function if isinstance(function, dict) else {}
+    arguments = function.get("arguments")
+    if isinstance(arguments, (dict, list)):
+        arguments = json.dumps(arguments)
     return {
         "id": tc.get("id"),
         "type": tc.get("type", "function"),
         "function": {
             "name": function.get("name"),
-            "arguments": function.get("arguments"),
+            "arguments": arguments,
         },
     }
 

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -101,13 +101,17 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         payload["tool_choice"] = (
             request.tool_choice if request.tool_choice is not None else "required"
         )
-    # Structured output: OpenAI-native, verbatim passthrough.
-    if request.response_format is not None:
+    # Structured output: OpenAI-native, verbatim passthrough. Truthiness guard so
+    # an empty ``response_format={}`` (set but degenerate — no ``type``) emits
+    # nothing rather than a malformed key (same empty-collection discipline as
+    # the tools guard).
+    if request.response_format:
         payload["response_format"] = request.response_format
     # Extended sampling: each passthrough under the same key name when set.
     if request.seed is not None:
         payload["seed"] = request.seed
-    if request.logit_bias is not None:
+    # Truthiness guard: an empty ``logit_bias={}`` is a no-op — emit nothing.
+    if request.logit_bias:
         payload["logit_bias"] = request.logit_bias
     if request.frequency_penalty is not None:
         payload["frequency_penalty"] = request.frequency_penalty

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
@@ -1,0 +1,143 @@
+"""#1720 Wave-1b — cross-adapter normalized tool_calls parity.
+
+The whole point of the four-axis abstraction: a caller of ``LlmClient.complete``
+gets the SAME normalized ``tool_calls`` shape no matter which provider served
+the request. Each wire adapter (openai_chat / anthropic_messages /
+google_generate_content) parses its provider's native tool-call representation
+into ONE canonical shape:
+
+    [{"id": <str>, "type": "function",
+      "function": {"name": <str>, "arguments": <str: JSON-encoded>}}]
+
+This test feeds each adapter an EQUIVALENT tool call in that provider's native
+response shape and asserts every adapter emits the identical canonical
+structure — same keys, same types, same logical name + parsed arguments,
+``arguments`` always a JSON STRING. If any adapter drifts (e.g. returns
+``arguments`` as a dict, or omits ``id``/``type``), this fails loudly — the
+cross-shard contract the three Wave-1b shards each implemented independently.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.wire_protocols import (
+    anthropic_messages,
+    google_generate_content,
+    openai_chat,
+)
+
+# One logical tool call — "get_weather({\"city\": \"SF\"})" — expressed in each
+# provider's NATIVE response shape.
+_OPENAI_RESPONSE = {
+    "choices": [
+        {
+            "message": {
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_openai_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "SF"}),
+                        },
+                    }
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    "model": "test-model",
+}
+
+_ANTHROPIC_RESPONSE = {
+    "content": [
+        {
+            "type": "tool_use",
+            "id": "toolu_anthropic_1",
+            "name": "get_weather",
+            "input": {"city": "SF"},
+        }
+    ],
+    "stop_reason": "tool_use",
+    "usage": {"input_tokens": 1, "output_tokens": 1},
+    "model": "test-model",
+}
+
+_GOOGLE_RESPONSE = {
+    "candidates": [
+        {
+            "content": {
+                "parts": [
+                    {"functionCall": {"name": "get_weather", "args": {"city": "SF"}}}
+                ]
+            },
+            "finishReason": "STOP",
+        }
+    ],
+    "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1},
+    "modelVersion": "test-model",
+}
+
+_CASES = [
+    ("openai_chat", openai_chat, _OPENAI_RESPONSE),
+    ("anthropic_messages", anthropic_messages, _ANTHROPIC_RESPONSE),
+    ("google_generate_content", google_generate_content, _GOOGLE_RESPONSE),
+]
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("name, shaper, response", _CASES, ids=[c[0] for c in _CASES])
+def test_each_adapter_emits_canonical_tool_call_shape(name, shaper, response):
+    """Each adapter parses its native tool call into the canonical shape."""
+    parsed = shaper.parse_response(response)
+    assert "tool_calls" in parsed, f"{name} did not surface tool_calls"
+    tcs = parsed["tool_calls"]
+    assert isinstance(tcs, list) and len(tcs) == 1, f"{name}: expected 1 tool_call"
+    tc = tcs[0]
+    # Canonical structure
+    assert set(tc.keys()) == {
+        "id",
+        "type",
+        "function",
+    }, f"{name}: wrong top keys {tc.keys()}"
+    assert tc["type"] == "function", f"{name}: type must be 'function'"
+    assert isinstance(tc["id"], str) and tc["id"], f"{name}: id must be a non-empty str"
+    fn = tc["function"]
+    assert set(fn.keys()) == {
+        "name",
+        "arguments",
+    }, f"{name}: wrong function keys {fn.keys()}"
+    assert fn["name"] == "get_weather", f"{name}: name mismatch"
+    # arguments MUST be a JSON STRING (OpenAI convention) that decodes to the args
+    assert isinstance(
+        fn["arguments"], str
+    ), f"{name}: arguments must be a JSON string, not {type(fn['arguments'])}"
+    assert json.loads(fn["arguments"]) == {
+        "city": "SF"
+    }, f"{name}: arguments payload mismatch"
+
+
+@pytest.mark.regression
+def test_all_three_adapters_agree_on_normalized_shape():
+    """The three adapters produce STRUCTURALLY IDENTICAL normalized tool_calls
+    (ignoring the provider-specific id value) for the same logical call."""
+    normalized = {}
+    for name, shaper, response in _CASES:
+        tc = shaper.parse_response(response)["tool_calls"][0]
+        # Replace the provider id with a placeholder so we compare structure+payload.
+        normalized[name] = {
+            "type": tc["type"],
+            "id_is_str": isinstance(tc["id"], str) and bool(tc["id"]),
+            "function": {
+                "name": tc["function"]["name"],
+                "arguments_decoded": json.loads(tc["function"]["arguments"]),
+                "arguments_is_str": isinstance(tc["function"]["arguments"], str),
+            },
+        }
+    shapes = list(normalized.values())
+    assert (
+        shapes[0] == shapes[1] == shapes[2]
+    ), f"cross-adapter normalized-shape divergence: {normalized}"

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
@@ -1,0 +1,104 @@
+"""#1720 Wave-1b — /redteam finding fixes (PR #1776).
+
+Pins the four fixes the Wave-1b convergence round surfaced:
+1. Gemini camelCase tool keys (toolConfig / functionCallingConfig / allowedFunctionNames).
+2. Gemini response_format text-mode: {"type":"text"} must NOT force JSON mode.
+3. Empty-but-set tools=[] emits nothing on openai + anthropic (no invalid
+   required-with-no-tools request).
+4. openai_chat defensive arguments coercion for OpenAI-COMPATIBLE providers that
+   return tool-call arguments as a dict rather than a JSON string.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import (
+    anthropic_messages,
+    google_generate_content,
+    openai_chat,
+)
+
+
+def _req(**kw):
+    base: dict = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(kw)
+    return CompletionRequest(**base)
+
+
+_TOOL = {"type": "function", "function": {"name": "f", "parameters": {}}}
+
+
+@pytest.mark.regression
+def test_gemini_tool_keys_are_camelcase():
+    """Finding 1 — Gemini tool_config keys use camelCase (documented shape)."""
+    payload = google_generate_content.build_request_payload(
+        _req(tools=[_TOOL], tool_choice="required")
+    )
+    assert "toolConfig" in payload, "must use camelCase toolConfig"
+    assert "tool_config" not in payload
+    fcc = payload["toolConfig"]["functionCallingConfig"]
+    assert fcc["mode"] == "ANY"
+    # forced-tool → allowedFunctionNames camelCase
+    forced = google_generate_content.build_request_payload(
+        _req(tools=[_TOOL], tool_choice={"type": "function", "function": {"name": "f"}})
+    )
+    assert "allowedFunctionNames" in forced["toolConfig"]["functionCallingConfig"]
+
+
+@pytest.mark.regression
+def test_gemini_response_format_text_does_not_force_json():
+    """Finding 2 — a text response_format must NOT set responseMimeType."""
+    payload = google_generate_content.build_request_payload(
+        _req(response_format={"type": "text"})
+    )
+    gc = payload.get("generationConfig", {})
+    assert "responseMimeType" not in gc, "text response_format must not force JSON mode"
+    # json_object DOES force it
+    payload_json = google_generate_content.build_request_payload(
+        _req(response_format={"type": "json_object"})
+    )
+    assert payload_json["generationConfig"]["responseMimeType"] == "application/json"
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "shaper", [openai_chat, anthropic_messages], ids=["openai", "anthropic"]
+)
+def test_empty_tools_list_emits_nothing(shaper):
+    """Finding 3 — tools=[] (set but empty) emits no tools + no forced choice."""
+    payload = shaper.build_request_payload(_req(tools=[]))
+    assert "tools" not in payload, "empty tools list must not emit a tools key"
+    assert "tool_choice" not in payload, "must not force tool_choice with no tools"
+
+
+@pytest.mark.regression
+def test_openai_coerces_dict_arguments_to_json_string():
+    """Finding 4 — an OpenAI-compatible provider returning arguments as a dict
+    is coerced to a JSON string (canonical contract holds fleet-wide)."""
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            # non-conformant: arguments as a dict, not a JSON string
+                            "function": {"name": "f", "arguments": {"city": "SF"}},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+    parsed = openai_chat.parse_response(response)
+    args = parsed["tool_calls"][0]["function"]["arguments"]
+    assert isinstance(args, str), "dict arguments must be coerced to a JSON string"
+    assert json.loads(args) == {"city": "SF"}

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
@@ -102,6 +102,21 @@ def test_tool_choice_set_without_tools_emits_no_forced_selection(shaper, tools):
 
 
 @pytest.mark.regression
+@pytest.mark.parametrize(
+    "shaper",
+    [openai_chat, anthropic_messages, google_generate_content],
+    ids=["openai", "anthropic", "google"],
+)
+def test_empty_collection_fields_emit_nothing(shaper):
+    """Round-4 observation B — a set-but-empty collection field (``response_format={}``,
+    ``logit_bias={}``) must NOT emit a degenerate key on any adapter (same
+    empty-collection discipline as the tools guard; the emptiness leak class)."""
+    payload = shaper.build_request_payload(_req(response_format={}, logit_bias={}))
+    assert "response_format" not in payload
+    assert "logit_bias" not in payload
+
+
+@pytest.mark.regression
 def test_openai_coerces_dict_arguments_to_json_string():
     """Finding 4 — an OpenAI-compatible provider returning arguments as a dict
     is coerced to a JSON string (canonical contract holds fleet-wide)."""

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
@@ -67,13 +67,20 @@ def test_gemini_response_format_text_does_not_force_json():
 
 @pytest.mark.regression
 @pytest.mark.parametrize(
-    "shaper", [openai_chat, anthropic_messages], ids=["openai", "anthropic"]
+    "shaper",
+    [openai_chat, anthropic_messages, google_generate_content],
+    ids=["openai", "anthropic", "google"],
 )
 def test_empty_tools_list_emits_nothing(shaper):
-    """Finding 3 — tools=[] (set but empty) emits no tools + no forced choice."""
+    """Finding 3 (+ round-2 gap) — tools=[] (set but empty) emits no tools +
+    no forced tool-choice/config on ALL THREE adapters. Round-2 caught that the
+    Gemini adapter had missed this same-class guard."""
     payload = shaper.build_request_payload(_req(tools=[]))
     assert "tools" not in payload, "empty tools list must not emit a tools key"
+    # openai/anthropic use `tool_choice`; gemini uses `toolConfig` — neither
+    # forced-selection surface may appear with no tools.
     assert "tool_choice" not in payload, "must not force tool_choice with no tools"
+    assert "toolConfig" not in payload, "must not force toolConfig with no tools"
 
 
 @pytest.mark.regression

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
@@ -84,6 +84,24 @@ def test_empty_tools_list_emits_nothing(shaper):
 
 
 @pytest.mark.regression
+@pytest.mark.parametrize(
+    "shaper",
+    [openai_chat, anthropic_messages, google_generate_content],
+    ids=["openai", "anthropic", "google"],
+)
+@pytest.mark.parametrize("tools", [None, []], ids=["none", "empty"])
+def test_tool_choice_set_without_tools_emits_no_forced_selection(shaper, tools):
+    """Round-3 gap — a tool_choice/forced selection with tools unset OR empty
+    must NOT be emitted on ANY adapter (tool_choice is meaningless without
+    tools; a forced 'required' with no tools is an invalid request). All three
+    adapters MUST agree — the four-axis consistency contract."""
+    payload = shaper.build_request_payload(_req(tools=tools, tool_choice="required"))
+    assert "tool_choice" not in payload, "tool_choice leaked without tools"
+    assert "toolConfig" not in payload, "toolConfig leaked without tools"
+    assert "tools" not in payload
+
+
+@pytest.mark.regression
 def test_openai_coerces_dict_arguments_to_json_string():
     """Finding 4 — an OpenAI-compatible provider returning arguments as a dict
     is coerced to a JSON string (canonical contract holds fleet-wide)."""

--- a/packages/kailash-kaizen/tests/unit/llm/test_anthropic_messages_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_anthropic_messages_wave1b_emission.py
@@ -1,0 +1,229 @@
+"""#1720 Wave-1b — anthropic_messages tool emission + tool_use parse.
+
+Behavioral coverage for the AnthropicMessages wire adapter's completion-shaping
+translation (OpenAI-shaped CompletionRequest fields -> Anthropic /v1/messages
+schema) and the canonical tool_use -> tool_calls parse.
+
+Anthropic supports ``tools`` (shape ``{name, description, input_schema}``),
+``tool_choice`` (``{"type": ...}``), and ``top_k`` natively; it does NOT support
+``response_format`` / ``seed`` / ``logit_bias`` / ``frequency_penalty`` /
+``presence_penalty`` / ``n`` — those MUST never appear in the payload.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import anthropic_messages
+
+
+def _base_request(**overrides) -> CompletionRequest:
+    fields = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    fields.update(overrides)
+    return CompletionRequest(**fields)
+
+
+def _all_keys(obj) -> set:
+    found = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            found.add(k)
+            found |= _all_keys(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            found |= _all_keys(v)
+    return found
+
+
+# --- Emission: tools -> Anthropic input_schema shape --------------------------
+
+
+def test_tools_translated_to_anthropic_shape():
+    req = _base_request(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+        tool_choice="required",
+        top_k=40,
+    )
+    payload = anthropic_messages.build_request_payload(req)
+
+    assert payload["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Look up the weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+    # "required" maps to Anthropic's {"type": "any"}.
+    assert payload["tool_choice"] == {"type": "any"}
+    # Anthropic supports top_k natively.
+    assert payload["top_k"] == 40
+
+
+def test_tools_missing_description_and_parameters_default():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f"}}],
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    assert payload["tools"] == [{"name": "f", "description": "", "input_schema": {}}]
+
+
+def test_tool_choice_default_when_tools_set_is_any():
+    # tools set, tool_choice unset -> legacy "required" semantics: {"type": "any"}.
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    assert payload["tool_choice"] == {"type": "any"}
+
+
+def test_tool_choice_auto():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice="auto",
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    assert payload["tool_choice"] == {"type": "auto"}
+
+
+def test_tool_choice_none_omits_tools():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice="none",
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    # "none" -> Anthropic offers no tools; both keys are absent.
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+def test_tool_choice_forced_tool_dict():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice={"type": "function", "function": {"name": "f"}},
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    assert payload["tool_choice"] == {"type": "tool", "name": "f"}
+
+
+def test_top_k_emitted_without_tools():
+    req = _base_request(top_k=25)
+    payload = anthropic_messages.build_request_payload(req)
+    assert payload["top_k"] == 25
+
+
+# --- Emission: unsupported fields are NEVER emitted ---------------------------
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("seed", 7),
+        ("logit_bias", {"123": -1.0}),
+        ("frequency_penalty", 0.5),
+        ("presence_penalty", 0.25),
+        ("n", 2),
+        ("response_format", {"type": "json_object"}),
+    ],
+)
+def test_unsupported_fields_never_emitted(field, value):
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        **{field: value},
+    )
+    payload = anthropic_messages.build_request_payload(req)
+    assert field not in _all_keys(payload), (
+        f"anthropic_messages emitted unsupported field {field!r} — Anthropic "
+        f"/v1/messages does not accept it."
+    )
+
+
+def test_response_format_emits_no_bogus_key():
+    # Anthropic has no response_format param; setting it must add NO new key vs
+    # a request that omits it (honest: no fake feature).
+    with_rf = _base_request(response_format={"type": "json_object"})
+    without_rf = _base_request()
+    assert anthropic_messages.build_request_payload(
+        with_rf
+    ) == anthropic_messages.build_request_payload(without_rf)
+
+
+# --- Parse: tool_use block -> canonical tool_calls ----------------------------
+
+
+def test_tool_use_block_parses_to_canonical_shape():
+    fake_response = {
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "toolu_abc123",
+                "name": "get_weather",
+                "input": {"city": "Paris", "unit": "c"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "model": "test-model",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+    parsed = anthropic_messages.parse_response(fake_response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "toolu_abc123",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": json.dumps({"city": "Paris", "unit": "c"}),
+            },
+        }
+    ]
+    # arguments MUST be a JSON string, not the raw dict.
+    args = parsed["tool_calls"][0]["function"]["arguments"]
+    assert isinstance(args, str)
+    assert json.loads(args) == {"city": "Paris", "unit": "c"}
+
+    # Existing parsed keys are unchanged.
+    assert parsed["text"] == "Let me check."
+    assert parsed["stop_reason"] == "tool_use"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {"input_tokens": 10, "output_tokens": 5}
+    # tool_use block is still passed through on raw_blocks.
+    assert any(b.get("type") == "tool_use" for b in parsed["raw_blocks"])
+
+
+def test_multiple_tool_use_blocks_all_parsed():
+    fake_response = {
+        "content": [
+            {"type": "tool_use", "id": "t1", "name": "a", "input": {"x": 1}},
+            {"type": "tool_use", "id": "t2", "name": "b", "input": {}},
+        ],
+    }
+    parsed = anthropic_messages.parse_response(fake_response)
+    assert [tc["id"] for tc in parsed["tool_calls"]] == ["t1", "t2"]
+    assert parsed["tool_calls"][1]["function"]["arguments"] == json.dumps({})
+
+
+def test_no_tool_use_block_omits_tool_calls_key():
+    fake_response = {"content": [{"type": "text", "text": "just text"}]}
+    parsed = anthropic_messages.parse_response(fake_response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "just text"

--- a/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
@@ -68,7 +68,7 @@ def test_tool_config_default_any_when_tools_set_no_choice():
         tools=[{"type": "function", "function": {"name": "f"}}],
     )
     payload = gg.build_request_payload(req)
-    assert payload["tool_config"] == {"function_calling_config": {"mode": "ANY"}}
+    assert payload["toolConfig"] == {"functionCallingConfig": {"mode": "ANY"}}
 
 
 def test_tool_choice_string_modes_map_to_gemini():
@@ -84,7 +84,7 @@ def test_tool_choice_string_modes_map_to_gemini():
             tool_choice=openai_choice,
         )
         payload = gg.build_request_payload(req)
-        assert payload["tool_config"]["function_calling_config"]["mode"] == gemini_mode
+        assert payload["toolConfig"]["functionCallingConfig"]["mode"] == gemini_mode
 
 
 def test_forced_tool_dict_maps_to_any_with_allowed_names():
@@ -95,9 +95,9 @@ def test_forced_tool_dict_maps_to_any_with_allowed_names():
         tool_choice={"type": "function", "function": {"name": "get_weather"}},
     )
     payload = gg.build_request_payload(req)
-    cfg = payload["tool_config"]["function_calling_config"]
+    cfg = payload["toolConfig"]["functionCallingConfig"]
     assert cfg["mode"] == "ANY"
-    assert cfg["allowed_function_names"] == ["get_weather"]
+    assert cfg["allowedFunctionNames"] == ["get_weather"]
 
 
 def test_tool_config_absent_when_no_tools():
@@ -109,7 +109,7 @@ def test_tool_config_absent_when_no_tools():
     )
     payload = gg.build_request_payload(req)
     assert "tools" not in payload
-    assert "tool_config" not in payload
+    assert "toolConfig" not in payload
 
 
 def test_response_format_json_object_sets_response_mime_type():
@@ -213,7 +213,7 @@ def test_full_wave1b_request_shapes_all_surfaces():
     # Gemini-shaped tools.
     assert payload["tools"][0]["functionDeclarations"][0]["name"] == "f"
     # Default ANY tool_config.
-    assert payload["tool_config"]["function_calling_config"]["mode"] == "ANY"
+    assert payload["toolConfig"]["functionCallingConfig"]["mode"] == "ANY"
     gen = payload["generationConfig"]
     assert gen["temperature"] == 0.3  # not clobbered
     assert gen["responseMimeType"] == "application/json"

--- a/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
@@ -1,0 +1,305 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b — google_generate_content emission + parse behavioral tests.
+
+Covers the OpenAI-shaped ``CompletionRequest`` -> Gemini translation for the
+Wave-1b completion-shaping fields (tools, tool_choice, response_format, top_k,
+seed, n, frequency_penalty, presence_penalty), the logit_bias non-emission, the
+generationConfig MERGE (no clobber), and the functionCall -> canonical
+normalized ``tool_calls`` parse. Wire adapter serves both GoogleGenerateContent
+and VertexGenerateContent wires (same shaper).
+"""
+
+import json
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import google_generate_content as gg
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+def test_tools_translated_to_gemini_function_declarations():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+    )
+    payload = gg.build_request_payload(req)
+
+    assert "tools" in payload
+    decls = payload["tools"][0]["functionDeclarations"]
+    assert decls[0]["name"] == "get_weather"
+    assert decls[0]["description"] == "Look up the weather"
+    assert decls[0]["parameters"]["properties"]["city"]["type"] == "string"
+
+
+def test_tool_description_and_parameters_default_when_absent():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f"}}],
+    )
+    payload = gg.build_request_payload(req)
+    decl = payload["tools"][0]["functionDeclarations"][0]
+    assert decl["name"] == "f"
+    assert decl["description"] == ""
+    assert decl["parameters"] == {}
+
+
+def test_tool_config_default_any_when_tools_set_no_choice():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f"}}],
+    )
+    payload = gg.build_request_payload(req)
+    assert payload["tool_config"] == {"function_calling_config": {"mode": "ANY"}}
+
+
+def test_tool_choice_string_modes_map_to_gemini():
+    for openai_choice, gemini_mode in [
+        ("auto", "AUTO"),
+        ("required", "ANY"),
+        ("none", "NONE"),
+    ]:
+        req = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tools=[{"type": "function", "function": {"name": "f"}}],
+            tool_choice=openai_choice,
+        )
+        payload = gg.build_request_payload(req)
+        assert payload["tool_config"]["function_calling_config"]["mode"] == gemini_mode
+
+
+def test_forced_tool_dict_maps_to_any_with_allowed_names():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    payload = gg.build_request_payload(req)
+    cfg = payload["tool_config"]["function_calling_config"]
+    assert cfg["mode"] == "ANY"
+    assert cfg["allowed_function_names"] == ["get_weather"]
+
+
+def test_tool_config_absent_when_no_tools():
+    # tool_choice with no tools is meaningless -> neither key emitted.
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tool_choice="required",
+    )
+    payload = gg.build_request_payload(req)
+    assert "tools" not in payload
+    assert "tool_config" not in payload
+
+
+def test_response_format_json_object_sets_response_mime_type():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "json_object"},
+    )
+    payload = gg.build_request_payload(req)
+    gen = payload["generationConfig"]
+    assert gen["responseMimeType"] == "application/json"
+    assert "responseSchema" not in gen  # bare json_object has no schema
+
+
+def test_response_format_json_schema_sets_response_schema():
+    schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "resp", "schema": schema},
+        },
+    )
+    payload = gg.build_request_payload(req)
+    gen = payload["generationConfig"]
+    assert gen["responseMimeType"] == "application/json"
+    assert gen["responseSchema"] == schema
+
+
+def test_sampling_fields_merge_into_generation_config_without_clobber():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=128,
+        top_k=40,
+        seed=7,
+        n=2,
+        frequency_penalty=0.5,
+        presence_penalty=0.25,
+    )
+    payload = gg.build_request_payload(req)
+    gen = payload["generationConfig"]
+
+    # Pre-#1720 keys survive (no clobber).
+    assert gen["temperature"] == 0.7
+    assert gen["topP"] == 0.9
+    assert gen["maxOutputTokens"] == 128
+    # Wave-1b sampling keys merged in with Gemini names.
+    assert gen["topK"] == 40
+    assert gen["seed"] == 7
+    assert gen["candidateCount"] == 2  # Gemini's name for `n`
+    assert gen["frequencyPenalty"] == 0.5
+    assert gen["presencePenalty"] == 0.25
+
+
+def test_logit_bias_never_emitted():
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        logit_bias={"123": -1.0},
+        top_k=5,
+    )
+    payload = gg.build_request_payload(req)
+
+    def _all_keys(obj):
+        found = set()
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                found.add(k)
+                found |= _all_keys(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                found |= _all_keys(v)
+        return found
+
+    keys = _all_keys(payload)
+    assert "logit_bias" not in keys
+    assert "logitBias" not in keys
+    # top_k still merged (Gemini supports it), so the request is not a no-op.
+    assert payload["generationConfig"]["topK"] == 5
+
+
+def test_full_wave1b_request_shapes_all_surfaces():
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        temperature=0.3,
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice=None,  # default -> ANY
+        response_format={"type": "json_schema", "json_schema": {"schema": schema}},
+        top_k=32,
+        seed=11,
+        n=3,
+    )
+    payload = gg.build_request_payload(req)
+
+    # Gemini-shaped tools.
+    assert payload["tools"][0]["functionDeclarations"][0]["name"] == "f"
+    # Default ANY tool_config.
+    assert payload["tool_config"]["function_calling_config"]["mode"] == "ANY"
+    gen = payload["generationConfig"]
+    assert gen["temperature"] == 0.3  # not clobbered
+    assert gen["responseMimeType"] == "application/json"
+    assert gen["responseSchema"] == schema
+    assert gen["topK"] == 32
+    assert gen["seed"] == 11
+    assert gen["candidateCount"] == 3
+
+
+def test_parse_function_call_to_canonical_tool_calls():
+    fake_gemini_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"text": "Let me check."},
+                        {
+                            "functionCall": {
+                                "name": "get_weather",
+                                "args": {"city": "Paris", "unit": "c"},
+                            }
+                        },
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 8,
+            "totalTokenCount": 13,
+        },
+        "modelVersion": "test-model",
+    }
+    parsed = gg.parse_response(fake_gemini_response)
+
+    assert parsed["text"] == "Let me check."
+    assert "tool_calls" in parsed
+    call = parsed["tool_calls"][0]
+    assert call["id"] == "call_1"  # synthesized from part index
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "get_weather"
+    # arguments MUST be a JSON-encoded STRING, not a dict.
+    assert isinstance(call["function"]["arguments"], str)
+    assert json.loads(call["function"]["arguments"]) == {"city": "Paris", "unit": "c"}
+    # Existing parsed keys unchanged.
+    assert parsed["stop_reason"] == "STOP"
+    assert parsed["usage"]["total_tokens"] == 13
+
+
+def test_parse_function_call_with_no_args_encodes_empty_object():
+    fake = {
+        "candidates": [{"content": {"parts": [{"functionCall": {"name": "noop"}}]}}]
+    }
+    parsed = gg.parse_response(fake)
+    call = parsed["tool_calls"][0]
+    assert call["id"] == "call_0"
+    assert call["function"]["arguments"] == "{}"
+
+
+def test_parse_text_only_response_has_no_tool_calls_key():
+    fake = {
+        "candidates": [
+            {"content": {"parts": [{"text": "just text"}]}, "finishReason": "STOP"}
+        ]
+    }
+    parsed = gg.parse_response(fake)
+    assert parsed["text"] == "just text"
+    assert "tool_calls" not in parsed  # only present when ≥1 functionCall part
+
+
+def test_parse_multiple_function_calls_synthesize_distinct_ids():
+    fake = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "a", "args": {"i": 1}}},
+                        {"functionCall": {"name": "b", "args": {"i": 2}}},
+                    ]
+                }
+            }
+        ]
+    }
+    parsed = gg.parse_response(fake)
+    ids = [c["id"] for c in parsed["tool_calls"]]
+    assert ids == ["call_0", "call_1"]
+    assert parsed["tool_calls"][0]["function"]["name"] == "a"
+    assert parsed["tool_calls"][1]["function"]["name"] == "b"

--- a/packages/kailash-kaizen/tests/unit/llm/test_openai_chat_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_openai_chat_wave1b_emission.py
@@ -87,16 +87,28 @@ def test_tool_choice_not_emitted_when_no_tools_and_unset():
 
 
 @pytest.mark.unit
-def test_tool_choice_emitted_when_set_without_tools():
-    """An explicitly-set tool_choice is emitted even when tools is None."""
-    request = CompletionRequest(
-        model="test-model",
-        messages=_base_messages(),
-        tool_choice="none",
-    )
-    payload = openai_chat.build_request_payload(request)
-    assert payload["tool_choice"] == "none"
-    assert "tools" not in payload
+def test_tool_choice_not_emitted_without_tools():
+    """tool_choice is meaningless without tools — emitted ONLY alongside a
+    non-empty tools list, matching the anthropic/google adapters (four-axis
+    consistency). A standalone tool_choice (even the benign 'none') is dropped;
+    a forced 'required'/named choice with no tools would be an invalid request.
+    (Round-3 convergence fix on PR #1776.)"""
+    for choice in (
+        "none",
+        "required",
+        "auto",
+        {"type": "function", "function": {"name": "f"}},
+    ):
+        request = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tool_choice=choice,
+        )
+        payload = openai_chat.build_request_payload(request)
+        assert (
+            "tool_choice" not in payload
+        ), f"tool_choice={choice!r} leaked without tools"
+        assert "tools" not in payload
 
 
 @pytest.mark.unit

--- a/packages/kailash-kaizen/tests/unit/llm/test_openai_chat_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_openai_chat_wave1b_emission.py
@@ -1,0 +1,182 @@
+"""#1720 Wave-1b — openai_chat completion-shaping EMISSION + PARSE.
+
+Behavioral tests for the OpenAI chat wire adapter's Wave-1b additions:
+
+* ``build_request_payload`` EMITS the completion-shaping fields
+  (``tools``/``tool_choice``/``response_format``/``seed``/``logit_bias``/
+  ``frequency_penalty``/``presence_penalty``/``n``) when set, with OpenAI's
+  canonical key names; preserves the legacy ``tool_choice="required"``-when-
+  tools-present default; and NEVER emits ``top_k`` (unsupported by the OpenAI
+  chat API).
+* ``parse_response`` surfaces ``choices[0].message.tool_calls`` under the
+  ``"tool_calls"`` key in the canonical normalized shape (``arguments`` is a
+  JSON-encoded string), as plain JSON-serializable dicts.
+
+All assertions are behavioral (construct → call → assert the produced dict),
+not source-grep. No real model names are hardcoded (env-models.md) — the tests
+use ``"test-model"``.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import openai_chat
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.unit
+def test_emits_tools_response_format_and_sampling_fields():
+    """Set fields emit under OpenAI's canonical key names with right values."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=tools,
+        tool_choice="auto",
+        response_format={"type": "json_object"},
+        seed=7,
+        logit_bias={"123": -1.0},
+        frequency_penalty=0.5,
+        presence_penalty=0.25,
+        n=2,
+    )
+    payload = openai_chat.build_request_payload(request)
+
+    assert payload["tools"] == tools
+    # Explicit tool_choice is honored (not overridden by the "required" default).
+    assert payload["tool_choice"] == "auto"
+    assert payload["response_format"] == {"type": "json_object"}
+    assert payload["seed"] == 7
+    assert payload["logit_bias"] == {"123": -1.0}
+    assert payload["frequency_penalty"] == 0.5
+    assert payload["presence_penalty"] == 0.25
+    assert payload["n"] == 2
+
+
+@pytest.mark.unit
+def test_tool_choice_defaults_to_required_when_tools_set_and_choice_none():
+    """The pinned Wave-1a legacy default: tools present + tool_choice unset →
+    tool_choice='required'."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        # tool_choice deliberately unset
+    )
+    payload = openai_chat.build_request_payload(request)
+    assert payload["tool_choice"] == "required"
+
+
+@pytest.mark.unit
+def test_tool_choice_not_emitted_when_no_tools_and_unset():
+    """No tools + no explicit tool_choice → tool_choice key is absent."""
+    request = CompletionRequest(model="test-model", messages=_base_messages())
+    payload = openai_chat.build_request_payload(request)
+    assert "tool_choice" not in payload
+    assert "tools" not in payload
+
+
+@pytest.mark.unit
+def test_tool_choice_emitted_when_set_without_tools():
+    """An explicitly-set tool_choice is emitted even when tools is None."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tool_choice="none",
+    )
+    payload = openai_chat.build_request_payload(request)
+    assert payload["tool_choice"] == "none"
+    assert "tools" not in payload
+
+
+@pytest.mark.unit
+def test_top_k_is_never_emitted():
+    """OpenAI chat API does not support top_k — it MUST NOT appear in the
+    payload even when the CompletionRequest carries it."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        top_k=40,
+    )
+    payload = openai_chat.build_request_payload(request)
+    assert "top_k" not in payload
+
+
+@pytest.mark.unit
+def test_parse_response_surfaces_tool_calls_in_canonical_shape():
+    """A fake OpenAI response with message.tool_calls parses into the canonical
+    normalized shape; arguments stays a JSON-encoded string; entries are plain
+    JSON-serializable dicts."""
+    arguments_json = json.dumps({"city": "Paris"})
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": arguments_json,
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        "model": "test-model",
+    }
+
+    parsed = openai_chat.parse_response(response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments_json},
+        }
+    ]
+    tc = parsed["tool_calls"][0]
+    # arguments is a JSON-encoded string, not a dict.
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+    # The result must be JSON-serializable (plain dicts, no SDK objects).
+    json.dumps(parsed)
+    # Existing keys are unchanged.
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "tool_calls"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {
+        "input_tokens": 5,
+        "output_tokens": 3,
+        "total_tokens": 8,
+    }
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_when_absent():
+    """No tool_calls in the response → no 'tool_calls' key in the parsed dict;
+    the existing {text, usage, stop_reason, model} keys are intact."""
+    response = {
+        "choices": [{"finish_reason": "stop", "message": {"content": "hello"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "model": "test-model",
+    }
+    parsed = openai_chat.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello"
+    assert set(parsed.keys()) == {"text", "usage", "stop_reason", "model"}


### PR DESCRIPTION
## Summary

Wave-1b of the #1720 consolidation: the three highest-value wire adapters now **emit + parse** the completion-shaping fields Wave-1a (#1775) added to `CompletionRequest`. Built as 3 parallel worktree shards (one adapter each, disjoint files), integrated here.

| Adapter | Emits | Parses |
|---|---|---|
| `openai_chat` | tools (verbatim), tool_choice (legacy `required` default), response_format, seed/logit_bias/frequency_penalty/presence_penalty/n; **top_k omitted** (unsupported) | `message.tool_calls` → canonical shape |
| `anthropic_messages` | tools→`{name,description,input_schema}`, tool_choice→`{type:auto\|any\|tool}`, **top_k**; sampling fields + response_format omitted (no Anthropic native param — no fake key) | `tool_use` blocks → canonical shape |
| `google_generate_content` (+Vertex) | tools→`functionDeclarations`, tool_config mode, response_format→`responseMimeType`/`responseSchema`, topK/seed/candidateCount/penalties merged into `generationConfig`; logit_bias omitted | `functionCall` parts → canonical shape |

## Canonical normalized `tool_calls` contract

Every adapter parses its provider's native tool call into ONE shape so a `LlmClient.complete` caller is provider-agnostic:
```
[{"id": <str>, "type": "function", "function": {"name": <str>, "arguments": <str: JSON-encoded>}}]
```
Pinned by `test_issue_1720_wave1b_normalized_toolcalls_parity.py` — feeds each adapter an equivalent native call and asserts structural identity (arguments always a JSON string).

## Byte-neutrality preserved

Every field is emitted only when set (`is not None` guards) — the Wave-1a `test_unset_new_fields_never_appear_in_payload` pins stay green across all wires. Nothing changes for a request that sets no new field.

## Tests

- 3 per-adapter emission suites (openai 7, anthropic 17, google 15) + the cross-adapter parity suite.
- Full LLM + regression suite green (**1751 passed** on the integration branch); pre-commit green.

## Scope / follow-ups (next Wave-1b waves)

Remaining adapters (bedrock/mistral/cohere/ollama/hf), **multimodal** content-parts, the **mock** preset, **embed** remainder (cohere/hf/azure), and per-request **byok** are deferred to subsequent waves. Waves 2–4 (dual-run → migrate consumers → delete legacy) remain human-gated.

## Related issues

Part of #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)