### PR TITLE
feat(kaizen): #1720 Wave-1b batch-2 — mistral/cohere/ollama wire emission

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
@@ -34,14 +34,13 @@ stay in lockstep across releases.
 Provider capability vs client emission (IMPORTANT): these rows report what
 the **provider / wire protocol** supports — they do NOT assert that this
 SDK's four-axis ``LlmClient.complete()`` / ``stream()`` currently EMITS the
-feature. As of #1720 Wave-1a the ``CompletionRequest`` SHAPE carries the
-additive fields (``tools`` / ``tool_choice`` / ``response_format`` / extended
-sampling), but the wire adapters do not yet EMIT them — ``complete()`` /
-``stream()`` still send only the base fields to every wire. Per-adapter
-emission + parse is Wave 1b (legacy→four-axis consolidation, issue #1720). So
-``tools=True`` here means
-"the provider supports tool-calling", NOT "``complete()`` will send tools".
-Callers needing those features today use the ``kaizen.providers`` layer. The
+feature. As of #1720 the ``CompletionRequest`` SHAPE carries the additive
+fields (``tools`` / ``tool_choice`` / ``response_format`` / extended sampling),
+and per-wire EMISSION + tool_call PARSE is LIVE for OpenAI/Anthropic/Google/
+Mistral/Cohere/Ollama (Wave 1b); Bedrock-native + HuggingFace emission is a
+later shard. So ``tools=True`` here means
+"the provider supports tool-calling", NOT necessarily "``complete()`` will send
+tools on THIS wire yet" (check the wire against the Wave-1b rollout above). The
 rows stay provider-scoped (not client-scoped) BECAUSE they are the cross-SDK
 negotiation contract above — narrowing them to client-emission status would
 break the Rust byte-parity lock.

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -924,13 +924,18 @@ class LlmClient:
         and the per-model temperature floor are all data-driven — no provider
         branch in the caller path.
 
-        #1720 Wave-1a: the ``tools``, ``tool_choice``, ``response_format``,
-        ``seed``, ``logit_bias``, ``frequency_penalty``, ``presence_penalty``,
-        ``n``, and ``top_k`` kwargs are accepted onto the request SHAPE but are
-        NOT yet emitted by any wire — per-adapter emission + parse is Wave 1b.
-        Passing them today is a no-op (no error, no effect); until Wave 1b
-        lands, tool-calling / structured-output agent work goes through the
-        ``kaizen.providers`` layer.
+        #1720 completion-shaping kwargs (``tools``, ``tool_choice``,
+        ``response_format``, ``seed``, ``logit_bias``, ``frequency_penalty``,
+        ``presence_penalty``, ``n``, ``top_k``): the request SHAPE carries them
+        (Wave 1a) and per-wire EMISSION + tool_call PARSE is LIVE (Wave 1b) for
+        OpenAI (+ OpenAI-compatible), Anthropic (direct / Vertex / Bedrock),
+        Google Gemini (direct / Vertex), Mistral, Cohere, and Ollama. Each wire
+        emits only the fields the provider supports (unsupported fields are
+        omitted, never faked) and parses tool calls back into one canonical
+        shape ``[{id, type:"function", function:{name, arguments}}]``. Emission
+        for the remaining wires (Bedrock native families, HuggingFace) is a
+        later Wave-1b shard; passing a field to a not-yet-wired provider is a
+        no-op for that field.
 
         Raises:
             ValueError: ``messages`` empty of a resolvable model, or no
@@ -1098,11 +1103,11 @@ class LlmClient:
         lines; JSONL wires (Ollama / Bedrock) emit bare JSON objects per line.
         Both are handled: a ``data:`` prefix is stripped when present.
 
-        #1720 Wave-1a: the ``tools`` … ``top_k`` kwargs are accepted onto the
-        request SHAPE but NOT yet emitted by any wire (Wave 1b). They are
-        forwarded unchanged on both the streaming path AND the
-        ``streaming.enabled=False`` buffered-``complete()`` fallback, so the two
-        paths stay at parity when Wave 1b lands emission.
+        #1720 completion-shaping kwargs (``tools`` … ``top_k``): per-wire
+        emission is LIVE (Wave 1b) for OpenAI/Anthropic/Google/Mistral/Cohere/
+        Ollama (Bedrock-native + HuggingFace pending). They are forwarded
+        unchanged on both the streaming path AND the ``streaming.enabled=False``
+        buffered-``complete()`` fallback, so the two paths stay at parity.
         """
         if self._deployment is None:
             raise ValueError(

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -465,21 +465,19 @@ class LlmDeployment(BaseModel):
         .. warning::
 
            This matrix reports the **provider / wire-protocol** capability
-           (for cross-SDK negotiation) — NOT what this SDK's four-axis
-           ``LlmClient.complete()`` / ``stream()`` currently EMITS. As of
-           #1720 Wave-1a the ``CompletionRequest`` SHAPE carries the additive
-           fields (``tools``, ``tool_choice``, ``response_format``, ``seed``,
-           ``logit_bias``, ``frequency_penalty``, ``presence_penalty``, ``n``,
-           ``top_k``), but the wire adapters do NOT yet EMIT them:
-           ``complete()`` / ``stream()`` still send only the base fields
-           (model, messages, temperature, top_p, max_tokens, stop, stream,
-           user) to every wire. Per-adapter emission + parse of the additive
-           fields is Wave 1b. So ``supports()["tools"] is True`` means "the
-           provider supports tool-calling", NOT "``complete()`` will send my
-           tools". Full request-feature emission is tracked in the
-           legacy→four-axis consolidation (issue #1720); until Wave 1b lands,
-           tool / structured-output / multimodal agent work goes through the
-           ``kaizen.providers`` layer.
+           (for cross-SDK negotiation) — NOT necessarily what this SDK's
+           four-axis ``LlmClient.complete()`` / ``stream()`` EMITS on a given
+           wire. As of #1720 the ``CompletionRequest`` SHAPE carries the
+           additive fields (``tools``, ``tool_choice``, ``response_format``,
+           ``seed``, ``logit_bias``, ``frequency_penalty``, ``presence_penalty``,
+           ``n``, ``top_k``), and per-wire EMISSION + tool_call PARSE is LIVE
+           (Wave 1b) for OpenAI/Anthropic/Google/Mistral/Cohere/Ollama; each
+           wire emits only the fields that provider supports (unsupported ones
+           are omitted, never faked). Emission for the remaining wires
+           (Bedrock-native families, HuggingFace) is a later Wave-1b shard. So
+           ``supports()["tools"] is True`` means "the provider supports
+           tool-calling", NOT necessarily "``complete()`` will send tools on
+           THIS wire yet" — check the wire against the Wave-1b rollout.
 
         Fail-closed default (``rules/security.md`` § Fail-Closed Security
         Defaults): manual constructions whose ``preset_name`` is ``None``

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
@@ -244,6 +244,13 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     #   top_k              -> `k`  (Cohere names top_k `k`, top_p `p`)
     if request.seed is not None:
         payload["seed"] = request.seed
+    # frequency_penalty / presence_penalty: Cohere v1 accepts a 0.0-1.0 range vs
+    # the OpenAI/Mistral -2.0..2.0 range. The adapter SHAPE-translates (field
+    # name) but does NOT value-translate/clamp — consistent with every other
+    # field (temperature ranges also differ across providers and are passed
+    # through unclamped); silently rescaling a caller's value would be a
+    # surprising per-field special case. An out-of-range value is the caller's
+    # to reconcile, not the wire adapter's to mutate.
     if request.frequency_penalty is not None:
         payload["frequency_penalty"] = request.frequency_penalty
     if request.presence_penalty is not None:

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
@@ -13,11 +13,25 @@ Cohere's ``/v1/chat`` schema differs from OpenAI:
 * ``max_tokens`` / ``temperature`` / ``p`` live at the top level.
 * Response: ``text`` at the top level; ``meta.billed_units.{input,output}_tokens``.
 
+Cohere v1 diverges from OpenAI on several documented field names used by the
+#1720 Wave-1b completion-shaping emission below:
+
+* top_k is ``k`` (top_p is ``p``) — NOT ``top_k`` / ``top_p``.
+* Tool schemas use ``parameter_definitions`` — a flat ``{param: {description,
+  type, required}}`` map with Python-style type names — NOT the OpenAI
+  function-schema. ``tool_choice`` does NOT exist on v1 ``/chat`` (forced
+  ``REQUIRED`` / ``NONE`` selection arrived only in the v2 ``/chat`` API,
+  which this adapter does not target) — so it is deliberately NOT emitted.
+* Structured output is ``response_format={"type": "json_object"[, "schema"]}``.
+* ``seed`` / ``frequency_penalty`` / ``presence_penalty`` are supported;
+  ``n`` and ``logit_bias`` are NOT (deliberately omitted, never faked).
+
 See https://docs.cohere.com/reference/chat.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, List
 
@@ -56,6 +70,75 @@ def _content_to_str(content: Any) -> str:
                 )
         return "".join(parts)
     return str(content)
+
+
+# JSON-schema primitive ``type`` -> Cohere v1 ``parameter_definitions`` type
+# name. Cohere v1 /chat tools use Python-style names ("str"/"int"/"float"/
+# "bool"/"list"/"dict"), NOT JSON-schema names ("string"/"integer"/...).
+_JSON_SCHEMA_TYPE_TO_COHERE = {
+    "string": "str",
+    "integer": "int",
+    "number": "float",
+    "boolean": "bool",
+    "array": "list",
+    "object": "dict",
+}
+
+
+def _cohere_param_type(json_type: Any) -> str:
+    """Map a JSON-schema ``type`` to a Cohere v1 ``parameter_definitions`` type."""
+    if isinstance(json_type, list):
+        # JSON schema permits a union-type list; take the first non-null entry.
+        for candidate in json_type:
+            if candidate != "null":
+                json_type = candidate
+                break
+    if not isinstance(json_type, str):
+        return "str"
+    return _JSON_SCHEMA_TYPE_TO_COHERE.get(json_type, json_type)
+
+
+def _to_parameter_definitions(parameters: Any) -> Dict[str, Any]:
+    """Translate an OpenAI JSON-schema ``parameters`` object into Cohere v1
+    ``parameter_definitions``.
+
+    OpenAI carries function params as a JSON-schema object
+    (``{"type": "object", "properties": {...}, "required": [...]}``); Cohere
+    v1's ``/chat`` tools use ``parameter_definitions`` — a flat map of
+    ``{<param>: {"description", "type", "required"}}`` with Python-style type
+    names. A missing / non-object ``parameters`` yields an empty map.
+    """
+    if not isinstance(parameters, dict):
+        return {}
+    properties = parameters.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+    required = parameters.get("required")
+    required_set = set(required) if isinstance(required, list) else set()
+    definitions: Dict[str, Any] = {}
+    for pname, pschema in properties.items():
+        pschema = pschema if isinstance(pschema, dict) else {}
+        definitions[pname] = {
+            "description": pschema.get("description", ""),
+            "type": _cohere_param_type(pschema.get("type")),
+            "required": pname in required_set,
+        }
+    return definitions
+
+
+def _extract_json_schema(response_format: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Pull a JSON schema out of an OpenAI-shaped ``response_format``.
+
+    OpenAI carries a schema under ``{"type": "json_schema", "json_schema":
+    {"schema": {...}}}``; a bare ``{"type": "json_object"}`` has none. Returns
+    the schema dict (Cohere ``response_format.schema``) or ``None`` when absent.
+    """
+    json_schema = response_format.get("json_schema")
+    if isinstance(json_schema, dict):
+        schema = json_schema.get("schema")
+        if isinstance(schema, dict):
+            return schema
+    return None
 
 
 def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
@@ -110,6 +193,68 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         payload["stop_sequences"] = list(request.stop)
     if request.stream:
         payload["stream"] = True
+
+    # --- #1720 Wave-1b completion-shaping emission (Cohere v1 /chat schema) ---
+    # This adapter targets Cohere's v1 /chat endpoint (see module docstring:
+    # message / chat_history / preamble / p). The field names below are the
+    # DOCUMENTED v1 names, which diverge from OpenAI (top_k is `k`; tool
+    # schemas use `parameter_definitions`).
+    #
+    # tools: translate the OpenAI function-schema list into Cohere v1's
+    # `[{name, description, parameter_definitions}]` shape. Guard on truthiness
+    # so an explicitly-set EMPTY list (`tools=[]`) emits nothing (matches the
+    # openai/anthropic/google empty-tools guard).
+    if request.tools:
+        payload["tools"] = [
+            {
+                "name": f["function"]["name"],
+                "description": f["function"].get("description", ""),
+                "parameter_definitions": _to_parameter_definitions(
+                    f["function"].get("parameters", {})
+                ),
+            }
+            for f in request.tools
+        ]
+        # tool_choice: Cohere's v1 /chat endpoint has NO tool_choice parameter —
+        # forced/`REQUIRED`/`NONE` selection arrived only in the v2 /chat API,
+        # which this adapter does NOT target. Emitting one would be a fake
+        # feature the v1 API rejects/ignores, so we deliberately emit NOTHING
+        # even when tools are set and tool_choice defaults to the legacy
+        # "required" intent (mirrors anthropic_messages' response_format
+        # omission — no fake feature). Do NOT invent a v1 tool_choice surface.
+
+    # response_format: Cohere v1 /chat supports JSON mode via
+    # `response_format={"type": "json_object"}` plus an optional `schema`. Only
+    # force JSON mode for the JSON response types — an OpenAI `{"type": "text"}`
+    # must NOT be coerced (v1 defaults to text, so emit nothing for it).
+    # Truthiness guard so an empty `response_format={}` (no `type`) emits nothing.
+    if request.response_format:
+        rf_type = request.response_format.get("type")
+        if rf_type in ("json_object", "json_schema"):
+            cohere_rf: Dict[str, Any] = {"type": "json_object"}
+            schema = _extract_json_schema(request.response_format)
+            if schema is not None:
+                cohere_rf["schema"] = schema
+            payload["response_format"] = cohere_rf
+
+    # Extended sampling — Cohere v1 /chat DOCUMENTED names:
+    #   seed               -> `seed`               (supported)
+    #   frequency_penalty  -> `frequency_penalty`  (supported)
+    #   presence_penalty   -> `presence_penalty`   (supported)
+    #   top_k              -> `k`  (Cohere names top_k `k`, top_p `p`)
+    if request.seed is not None:
+        payload["seed"] = request.seed
+    if request.frequency_penalty is not None:
+        payload["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        payload["presence_penalty"] = request.presence_penalty
+    if request.top_k is not None:
+        payload["k"] = request.top_k
+    # UNSUPPORTED by Cohere v1 /chat — deliberately NOT emitted (no fake feature):
+    #   n          — v1 /chat has no multi-generation `n`/`num_generations` param.
+    #   logit_bias — v1 /chat exposes no token-bias control.
+    # (the shared CompletionRequest carries them for OpenAI-family wires only.)
+
     return payload
 
 
@@ -122,7 +267,31 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         text_value = ""
     meta = payload.get("meta", {}) or {}
     billed_units = meta.get("billed_units", {}) if isinstance(meta, dict) else {}
-    return {
+
+    # #1720 Wave-1b: normalize Cohere v1 tool calls. The v1 /chat response
+    # carries `tool_calls` as `[{"name", "parameters": {...}}]` with NO per-call
+    # id — synthesize `call_{index}` (matching the google shard, which likewise
+    # has no native id) and json.dumps the parameters dict into the canonical
+    # `arguments` JSON STRING shared with openai/anthropic/google:
+    #   {"id", "type": "function", "function": {"name", "arguments": <JSON str>}}
+    tool_calls: List[Dict[str, Any]] = []
+    raw_tool_calls = payload.get("tool_calls")
+    if isinstance(raw_tool_calls, list):
+        for index, tc in enumerate(raw_tool_calls):
+            if not isinstance(tc, dict):
+                continue
+            tool_calls.append(
+                {
+                    "id": f"call_{index}",
+                    "type": "function",
+                    "function": {
+                        "name": tc.get("name"),
+                        "arguments": json.dumps(tc.get("parameters", {})),
+                    },
+                }
+            )
+
+    result: Dict[str, Any] = {
         "text": text_value,
         "usage": {
             "input_tokens": (
@@ -139,6 +308,11 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": payload.get("finish_reason"),
         "model": payload.get("model"),
     }
+    # Only surface tool_calls when ≥1 was present, so a plain text response
+    # stays byte-identical to the pre-Wave-1b parsed shape.
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/mistral_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/mistral_chat.py
@@ -17,7 +17,8 @@ Mistral-specific fields without polluting the canonical OpenAI shape.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+import json
+from typing import Any, Dict
 
 from kaizen.llm.deployment import CompletionRequest
 
@@ -51,7 +52,90 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         # in the request body as a tenant-tracking hint. Emitting it keeps
         # audit trails on the provider side linked to our caller id.
         payload["user"] = request.user
+
+    # --- #1720 Wave-1b completion-shaping emission (Mistral deltas from OpenAI) ---
+    # Tool / function calling: Mistral uses the OpenAI function-schema list, so
+    # `tools` passes through verbatim. Guard on truthiness so an explicitly-set
+    # EMPTY list (`tools=[]`) emits nothing. `tool_choice` is meaningless without
+    # tools, so it is emitted ONLY alongside a non-empty tools list (matching the
+    # openai/anthropic/google adapters — the four-axis consistency contract).
+    #
+    # Mistral's tool_choice vocabulary differs from OpenAI's: force-a-tool is
+    # "any" (NOT OpenAI's "required"). Map "required"->"any"; "auto"/"none"/"any"
+    # pass through; an unknown string falls back to "any" (the tools-set forced
+    # default, the same conservative choice the anthropic adapter makes). A dict
+    # is a named-tool forced selection: Mistral accepts the OpenAI-shaped
+    # {"type":"function","function":{"name":X}} object form, so it passes through.
+    # When tools are present but tool_choice is unset, default to "any" (the
+    # pinned Wave-1a legacy "force a tool"-when-tools default, in Mistral's
+    # vocabulary).
+    if request.tools:
+        payload["tools"] = list(request.tools)
+        tool_choice = request.tool_choice
+        if tool_choice is None:
+            payload["tool_choice"] = "any"
+        elif isinstance(tool_choice, str):
+            if tool_choice == "required":
+                payload["tool_choice"] = "any"
+            elif tool_choice in ("auto", "none", "any"):
+                payload["tool_choice"] = tool_choice
+            else:
+                payload["tool_choice"] = "any"
+        else:
+            payload["tool_choice"] = tool_choice
+    # Structured output: Mistral supports {"type": "json_object"} verbatim.
+    # Truthiness guard so an empty ``response_format={}`` (set but degenerate —
+    # no ``type``) emits nothing rather than a malformed key.
+    if request.response_format:
+        payload["response_format"] = request.response_format
+    # Extended sampling. Mistral's seed parameter is ``random_seed`` (NOT
+    # ``seed`` like OpenAI); frequency_penalty / presence_penalty / n share the
+    # OpenAI names.
+    if request.seed is not None:
+        payload["random_seed"] = request.seed
+    if request.frequency_penalty is not None:
+        payload["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        payload["presence_penalty"] = request.presence_penalty
+    if request.n is not None:
+        payload["n"] = request.n
+    # Deliberately OMITTED — Mistral's /v1/chat/completions does NOT support:
+    #   top_k      — not exposed by the Mistral chat API (it is an
+    #                Anthropic/Google/Cohere/Ollama-family field).
+    #   logit_bias — no Mistral equivalent.
+    # Emitting a bogus key for either would ship a feature Mistral does not have
+    # (zero-tolerance: no fake capability), so nothing is written for them.
     return payload
+
+
+def _normalize_tool_call(tc: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce one Mistral ``message.tool_calls`` entry into the canonical shape.
+
+    The canonical normalized shape (shared with the openai/anthropic/google
+    shards) is::
+
+        {"id": <str>, "type": "function",
+         "function": {"name": <str>, "arguments": <str: JSON-encoded>}}
+
+    Mistral returns the OpenAI-shaped entry where ``arguments`` is already a
+    JSON string. Defensively, if a Mistral response returns ``arguments`` as a
+    dict/list, coerce it via ``json.dumps`` so the canonical "arguments is a
+    JSON string" invariant holds. Rebuilds a plain JSON-serializable dict so no
+    provider SDK object leaks into the parsed result.
+    """
+    function = tc.get("function")
+    function = function if isinstance(function, dict) else {}
+    arguments = function.get("arguments")
+    if isinstance(arguments, (dict, list)):
+        arguments = json.dumps(arguments)
+    return {
+        "id": tc.get("id"),
+        "type": tc.get("type", "function"),
+        "function": {
+            "name": function.get("name"),
+            "arguments": arguments,
+        },
+    }
 
 
 def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -69,6 +153,7 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
     choices = payload.get("choices", []) or []
     text = ""
     finish_reason: Any = None
+    tool_calls: Any = None
     if choices and isinstance(choices[0], dict):
         first = choices[0]
         finish_reason = first.get("finish_reason")
@@ -77,8 +162,22 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
             content = message.get("content")
             if isinstance(content, str):
                 text = content
+            # #1720 Wave-1b: surface tool calls. Mistral returns OpenAI-shaped
+            # `message.tool_calls`; normalize each into the canonical shape
+            # ([{"id", "type": "function", "function": {"name", "arguments"}}]
+            # with `arguments` a JSON-encoded string), shared with the
+            # openai/anthropic/google shards. Emit as plain JSON-serializable
+            # dicts, only when present — so a plain text response stays
+            # byte-identical to the pre-Wave-1b parsed shape.
+            raw_tool_calls = message.get("tool_calls")
+            if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                tool_calls = [
+                    _normalize_tool_call(tc)
+                    for tc in raw_tool_calls
+                    if isinstance(tc, dict)
+                ]
     usage = payload.get("usage", {}) or {}
-    return {
+    result: Dict[str, Any] = {
         "text": text,
         "usage": {
             "input_tokens": usage.get("prompt_tokens"),
@@ -88,6 +187,9 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": finish_reason,
         "model": payload.get("model"),
     }
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
@@ -24,9 +24,26 @@ See https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-compl
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict
 
 from kaizen.llm.deployment import CompletionRequest
+
+
+def _extract_json_schema(response_format: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Pull a JSON schema out of an OpenAI-shaped ``response_format``.
+
+    OpenAI carries a schema under ``{"type": "json_schema", "json_schema":
+    {"schema": {...}}}``; a bare ``{"type": "json_object"}`` has none. Returns
+    the schema dict (Ollama accepts it directly as the ``format`` value) or
+    ``None`` when absent.
+    """
+    json_schema = response_format.get("json_schema")
+    if isinstance(json_schema, dict):
+        schema = json_schema.get("schema")
+        if isinstance(schema, dict):
+            return schema
+    return None
 
 
 def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
@@ -36,6 +53,27 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     server expects them (``num_predict``, ``stop``, ``temperature``,
     ``top_p``). Fields the caller left unset are omitted so the Ollama
     server uses its own defaults.
+
+    #1720 Wave-1b completion-shaping emission. Ollama's ``/api/chat`` schema
+    diverges from OpenAI's, so this shaper translates each field to Ollama's
+    native shape (verified against Ollama's API docs — the ``/api/chat``
+    endpoint):
+
+    * ``tools`` — Ollama accepts the SAME OpenAI function-schema list
+      (``[{"type":"function","function":{...}}]``), so tools pass through
+      verbatim. Guarded on truthiness (an explicit ``tools=[]`` emits nothing).
+    * ``tool_choice`` — Ollama's ``/api/chat`` has NO tool_choice parameter; it
+      is OMITTED (never invented — the "omit unsupported, never fake" rule).
+    * ``response_format`` — Ollama uses a top-level ``format`` key, NOT
+      ``response_format``. ``{"type":"json_object"}`` -> ``format:"json"``; a
+      ``json_schema`` -> ``format:<schema object>`` (newer Ollama accepts a JSON
+      schema directly). A ``{"type":"text"}`` (or any other type) emits nothing
+      (Ollama defaults to free text).
+    * Extended sampling (``seed``/``top_k``/``frequency_penalty``/
+      ``presence_penalty``) lives UNDER the ``options`` object using Ollama's own
+      option names, MERGED into the existing options dict (never clobbering
+      temperature/top_p/num_predict/stop). ``n`` (multiple completions) and
+      ``logit_bias`` have no Ollama equivalent and are OMITTED.
     """
     if not isinstance(request, CompletionRequest):
         raise TypeError("build_request_payload expects a CompletionRequest")
@@ -52,6 +90,20 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     if request.stop:
         options["stop"] = list(request.stop)
 
+    # Wave-1b extended sampling: MERGE into the existing options dict under
+    # Ollama's native option names — never clobber temperature/top_p/etc.
+    if request.seed is not None:
+        options["seed"] = request.seed
+    if request.top_k is not None:
+        options["top_k"] = request.top_k
+    if request.frequency_penalty is not None:
+        options["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        options["presence_penalty"] = request.presence_penalty
+    # n: Ollama /api/chat returns a single message — no multi-completion knob.
+    #    OMITTED (do NOT fabricate a request-level completion count).
+    # logit_bias: Ollama has no per-token bias parameter. OMITTED.
+
     payload: Dict[str, Any] = {
         "model": request.model,
         "messages": list(request.messages),
@@ -62,6 +114,26 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     }
     if options:
         payload["options"] = options
+
+    # tools -> Ollama accepts the OpenAI function-schema list verbatim. Guard on
+    # truthiness so an explicitly-set EMPTY list (`tools=[]`) emits nothing.
+    if request.tools:
+        payload["tools"] = list(request.tools)
+    # tool_choice: Ollama's /api/chat has NO tool_choice parameter. OMITTED —
+    # do NOT invent one (the four-axis "omit unsupported, never fake" rule).
+
+    # response_format -> Ollama's top-level `format` key. json_object -> "json";
+    # json_schema -> the schema object directly. Truthiness guard so an empty
+    # `response_format={}` (set but degenerate — no `type`) emits nothing.
+    if request.response_format:
+        rf_type = request.response_format.get("type")
+        if rf_type == "json_object":
+            payload["format"] = "json"
+        elif rf_type == "json_schema":
+            schema = _extract_json_schema(request.response_format)
+            payload["format"] = schema if schema is not None else "json"
+        # any other type (e.g. "text") -> emit nothing; Ollama defaults to text.
+
     return payload
 
 
@@ -73,16 +145,52 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
     are JSONL lines of the same shape with ``done: false`` until the last
     chunk — this shaper handles one object at a time so the caller can
     accumulate across a stream.
+
+    #1720 Wave-1b: surface tool calls. Ollama emits ``message.tool_calls`` as
+    ``[{"function": {"name": <str>, "arguments": <dict>}}]`` — with NO call id
+    and ``arguments`` a DICT (unlike OpenAI's JSON-encoded string). This shaper
+    normalizes to the canonical shape shared with the openai/anthropic/google
+    shards (``arguments`` a JSON-encoded string, a synthesized ``call_{i}`` id),
+    only when ≥1 tool call is present.
     """
     if not isinstance(payload, dict):
         raise TypeError("parse_response expects a dict payload")
     message = payload.get("message", {}) or {}
     text = ""
+    tool_calls: list[Dict[str, Any]] = []
     if isinstance(message, dict):
         content = message.get("content")
         if isinstance(content, str):
             text = content
-    return {
+        raw_tool_calls = message.get("tool_calls")
+        if isinstance(raw_tool_calls, list):
+            for index, tc in enumerate(raw_tool_calls):
+                if not isinstance(tc, dict):
+                    continue
+                function = tc.get("function")
+                function = function if isinstance(function, dict) else {}
+                arguments = function.get("arguments")
+                # Ollama gives arguments as a DICT; json.dumps to the canonical
+                # JSON-string form. A provider that already sent a string is
+                # passed through unchanged.
+                if isinstance(arguments, (dict, list)):
+                    arguments = json.dumps(arguments)
+                # Ollama supplies no call id — carry it if a variant sent one,
+                # else synthesize `call_{index}` (matches the google shard).
+                call_id = tc.get("id")
+                if call_id is None:
+                    call_id = f"call_{index}"
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": function.get("name"),
+                            "arguments": arguments,
+                        },
+                    }
+                )
+    result: Dict[str, Any] = {
         "text": text,
         "usage": {
             "input_tokens": payload.get("prompt_eval_count"),
@@ -92,6 +200,11 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "model": payload.get("model"),
         "done": payload.get("done", False),
     }
+    # Only surface tool_calls when ≥1 is present; a tool-less response keeps the
+    # pre-#1720 parsed keys unchanged.
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
@@ -23,7 +23,10 @@ import pytest
 
 from kaizen.llm.wire_protocols import (
     anthropic_messages,
+    cohere_generate,
     google_generate_content,
+    mistral_chat,
+    ollama_native,
     openai_chat,
 )
 
@@ -81,10 +84,55 @@ _GOOGLE_RESPONSE = {
     "modelVersion": "test-model",
 }
 
+# Mistral: OpenAI-compatible choices[].message.tool_calls (arguments is a JSON string).
+_MISTRAL_RESPONSE = {
+    "choices": [
+        {
+            "message": {
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_mistral_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "SF"}),
+                        },
+                    }
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    "model": "test-model",
+}
+
+# Cohere v1 /chat: top-level tool_calls [{name, parameters}] — no per-call id, params is a dict.
+_COHERE_RESPONSE = {
+    "tool_calls": [{"name": "get_weather", "parameters": {"city": "SF"}}],
+    "finish_reason": "COMPLETE",
+}
+
+# Ollama /api/chat: message.tool_calls [{function:{name, arguments}}] — arguments a dict, no id.
+_OLLAMA_RESPONSE = {
+    "message": {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"function": {"name": "get_weather", "arguments": {"city": "SF"}}}
+        ],
+    },
+    "done": True,
+}
+
 _CASES = [
     ("openai_chat", openai_chat, _OPENAI_RESPONSE),
     ("anthropic_messages", anthropic_messages, _ANTHROPIC_RESPONSE),
     ("google_generate_content", google_generate_content, _GOOGLE_RESPONSE),
+    ("mistral_chat", mistral_chat, _MISTRAL_RESPONSE),
+    ("cohere_generate", cohere_generate, _COHERE_RESPONSE),
+    ("ollama_native", ollama_native, _OLLAMA_RESPONSE),
 ]
 
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_redteam_fixes.py
@@ -16,7 +16,10 @@ import pytest
 from kaizen.llm.deployment import CompletionRequest
 from kaizen.llm.wire_protocols import (
     anthropic_messages,
+    cohere_generate,
     google_generate_content,
+    mistral_chat,
+    ollama_native,
     openai_chat,
 )
 
@@ -68,8 +71,15 @@ def test_gemini_response_format_text_does_not_force_json():
 @pytest.mark.regression
 @pytest.mark.parametrize(
     "shaper",
-    [openai_chat, anthropic_messages, google_generate_content],
-    ids=["openai", "anthropic", "google"],
+    [
+        openai_chat,
+        anthropic_messages,
+        google_generate_content,
+        mistral_chat,
+        cohere_generate,
+        ollama_native,
+    ],
+    ids=["openai", "anthropic", "google", "mistral", "cohere", "ollama"],
 )
 def test_empty_tools_list_emits_nothing(shaper):
     """Finding 3 (+ round-2 gap) — tools=[] (set but empty) emits no tools +
@@ -86,8 +96,15 @@ def test_empty_tools_list_emits_nothing(shaper):
 @pytest.mark.regression
 @pytest.mark.parametrize(
     "shaper",
-    [openai_chat, anthropic_messages, google_generate_content],
-    ids=["openai", "anthropic", "google"],
+    [
+        openai_chat,
+        anthropic_messages,
+        google_generate_content,
+        mistral_chat,
+        cohere_generate,
+        ollama_native,
+    ],
+    ids=["openai", "anthropic", "google", "mistral", "cohere", "ollama"],
 )
 @pytest.mark.parametrize("tools", [None, []], ids=["none", "empty"])
 def test_tool_choice_set_without_tools_emits_no_forced_selection(shaper, tools):
@@ -104,8 +121,15 @@ def test_tool_choice_set_without_tools_emits_no_forced_selection(shaper, tools):
 @pytest.mark.regression
 @pytest.mark.parametrize(
     "shaper",
-    [openai_chat, anthropic_messages, google_generate_content],
-    ids=["openai", "anthropic", "google"],
+    [
+        openai_chat,
+        anthropic_messages,
+        google_generate_content,
+        mistral_chat,
+        cohere_generate,
+        ollama_native,
+    ],
+    ids=["openai", "anthropic", "google", "mistral", "cohere", "ollama"],
 )
 def test_empty_collection_fields_emit_nothing(shaper):
     """Round-4 observation B — a set-but-empty collection field (``response_format={}``,

--- a/packages/kailash-kaizen/tests/unit/llm/test_cohere_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_cohere_generate_wave1b_emission.py
@@ -1,0 +1,334 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b — cohere_generate tool emission + tool-call parse.
+
+Behavioral coverage for the CohereGenerate (v1 ``/chat``) wire adapter's
+completion-shaping translation (OpenAI-shaped ``CompletionRequest`` fields ->
+Cohere v1 ``/chat`` schema) and the canonical tool-call parse.
+
+Cohere v1 diverges from OpenAI on documented field names:
+
+* tools -> ``[{name, description, parameter_definitions}]`` (Python-style
+  parameter types), NOT the OpenAI function-schema.
+* ``tool_choice`` does NOT exist on v1 ``/chat`` (v2-only) -> NEVER emitted.
+* structured output -> ``response_format={"type": "json_object"[, "schema"]}``.
+* top_k -> ``k``; ``seed`` / ``frequency_penalty`` / ``presence_penalty``
+  supported.
+* ``n`` and ``logit_bias`` are UNSUPPORTED -> NEVER emitted.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import cohere_generate
+
+
+def _base_request(**overrides) -> CompletionRequest:
+    fields = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    fields.update(overrides)
+    return CompletionRequest(**fields)
+
+
+def _all_keys(obj) -> set:
+    found = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            found.add(k)
+            found |= _all_keys(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            found |= _all_keys(v)
+    return found
+
+
+# --- Emission: tools -> Cohere v1 parameter_definitions shape -----------------
+
+
+def test_tools_translated_to_cohere_v1_shape():
+    req = _base_request(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "days": {"type": "integer"},
+                        },
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        top_k=40,
+    )
+    payload = cohere_generate.build_request_payload(req)
+
+    assert payload["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Look up the weather",
+            "parameter_definitions": {
+                "city": {
+                    "description": "City name",
+                    "type": "str",
+                    "required": True,
+                },
+                "days": {
+                    "description": "",
+                    "type": "int",
+                    "required": False,
+                },
+            },
+        }
+    ]
+    # Cohere names top_k `k`.
+    assert payload["k"] == 40
+    # top_p stays `p` (existing behavior, not clobbered by top_k).
+    assert "top_k" not in _all_keys(payload)
+
+
+def test_tools_missing_description_and_parameters_default():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f"}}],
+    )
+    payload = cohere_generate.build_request_payload(req)
+    assert payload["tools"] == [
+        {"name": "f", "description": "", "parameter_definitions": {}}
+    ]
+
+
+def test_json_schema_type_mapping_covers_families():
+    req = _base_request(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "s": {"type": "string"},
+                            "i": {"type": "integer"},
+                            "n": {"type": "number"},
+                            "b": {"type": "boolean"},
+                            "a": {"type": "array"},
+                            "o": {"type": "object"},
+                        },
+                    },
+                },
+            }
+        ],
+    )
+    payload = cohere_generate.build_request_payload(req)
+    defs = payload["tools"][0]["parameter_definitions"]
+    assert defs["s"]["type"] == "str"
+    assert defs["i"]["type"] == "int"
+    assert defs["n"]["type"] == "float"
+    assert defs["b"]["type"] == "bool"
+    assert defs["a"]["type"] == "list"
+    assert defs["o"]["type"] == "dict"
+
+
+# --- Emission: empty-collection truthiness guards -----------------------------
+
+
+def test_empty_tools_list_emits_nothing():
+    req = _base_request(tools=[])
+    payload = cohere_generate.build_request_payload(req)
+    assert "tools" not in payload
+
+
+def test_empty_response_format_emits_nothing():
+    req = _base_request(response_format={})
+    payload = cohere_generate.build_request_payload(req)
+    assert "response_format" not in payload
+
+
+def test_empty_logit_bias_emits_nothing():
+    # logit_bias is unsupported on v1 anyway; empty must also be silent.
+    req = _base_request(logit_bias={})
+    payload = cohere_generate.build_request_payload(req)
+    assert "logit_bias" not in _all_keys(payload)
+
+
+# --- Emission: tool_choice is NEVER emitted (v2-only feature) ------------------
+
+
+@pytest.mark.parametrize("choice", ["auto", "required", "none", None])
+def test_tool_choice_never_emitted_even_with_tools(choice):
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice=choice,
+    )
+    payload = cohere_generate.build_request_payload(req)
+    # Cohere v1 /chat has no tool_choice parameter — must never appear.
+    assert "tool_choice" not in _all_keys(payload)
+    # ...but the tools themselves are still emitted.
+    assert "tools" in payload
+
+
+def test_forced_tool_dict_choice_still_omits_tool_choice():
+    req = _base_request(
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice={"type": "function", "function": {"name": "f"}},
+    )
+    payload = cohere_generate.build_request_payload(req)
+    assert "tool_choice" not in _all_keys(payload)
+
+
+# --- Emission: response_format -> Cohere JSON mode ----------------------------
+
+
+def test_response_format_json_object():
+    req = _base_request(response_format={"type": "json_object"})
+    payload = cohere_generate.build_request_payload(req)
+    assert payload["response_format"] == {"type": "json_object"}
+
+
+def test_response_format_json_schema_carries_schema():
+    schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
+    req = _base_request(
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"schema": schema},
+        }
+    )
+    payload = cohere_generate.build_request_payload(req)
+    assert payload["response_format"] == {"type": "json_object", "schema": schema}
+
+
+def test_response_format_text_type_not_coerced():
+    # OpenAI {"type": "text"} must NOT force JSON mode (v1 defaults to text).
+    req = _base_request(response_format={"type": "text"})
+    payload = cohere_generate.build_request_payload(req)
+    assert "response_format" not in payload
+
+
+# --- Emission: sampling fields use Cohere's documented names ------------------
+
+
+def test_sampling_fields_emitted_with_cohere_names():
+    req = _base_request(
+        seed=7,
+        frequency_penalty=0.5,
+        presence_penalty=0.25,
+        top_k=30,
+    )
+    payload = cohere_generate.build_request_payload(req)
+    assert payload["seed"] == 7
+    assert payload["frequency_penalty"] == 0.5
+    assert payload["presence_penalty"] == 0.25
+    assert payload["k"] == 30
+
+
+# --- Emission: unsupported fields are NEVER emitted ---------------------------
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("n", 3),
+        ("logit_bias", {"123": -1.0}),
+    ],
+)
+def test_unsupported_fields_never_emitted(field, value):
+    req = _base_request(**{field: value})
+    payload = cohere_generate.build_request_payload(req)
+    assert field not in _all_keys(payload), (
+        f"cohere_generate emitted unsupported field {field!r} — Cohere v1 "
+        f"/chat does not accept it."
+    )
+
+
+def test_unset_new_fields_never_appear():
+    # A plain request emits none of the Wave-1b keys.
+    payload = cohere_generate.build_request_payload(_base_request())
+    leaked = _all_keys(payload) & {
+        "tools",
+        "tool_choice",
+        "response_format",
+        "seed",
+        "logit_bias",
+        "frequency_penalty",
+        "presence_penalty",
+        "n",
+        "k",
+    }
+    assert not leaked, f"unset Wave-1b field(s) leaked: {sorted(leaked)}"
+
+
+# --- Parse: Cohere v1 tool_calls -> canonical tool_calls ----------------------
+
+
+def test_tool_calls_parse_to_canonical_shape():
+    fake_response = {
+        "text": "",
+        "tool_calls": [
+            {"name": "get_weather", "parameters": {"city": "Paris", "unit": "c"}},
+        ],
+        "finish_reason": "COMPLETE",
+        "model": "test-model",
+        "meta": {"billed_units": {"input_tokens": 10, "output_tokens": 5}},
+    }
+    parsed = cohere_generate.parse_response(fake_response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_0",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": json.dumps({"city": "Paris", "unit": "c"}),
+            },
+        }
+    ]
+    # arguments MUST be a JSON string, not the raw dict.
+    args = parsed["tool_calls"][0]["function"]["arguments"]
+    assert isinstance(args, str)
+    assert json.loads(args) == {"city": "Paris", "unit": "c"}
+
+    # Existing parsed keys unchanged.
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "COMPLETE"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {"input_tokens": 10, "output_tokens": 5}
+
+
+def test_multiple_tool_calls_all_parsed_with_synthesized_ids():
+    fake_response = {
+        "tool_calls": [
+            {"name": "a", "parameters": {"x": 1}},
+            {"name": "b", "parameters": {}},
+        ],
+    }
+    parsed = cohere_generate.parse_response(fake_response)
+    assert [tc["id"] for tc in parsed["tool_calls"]] == ["call_0", "call_1"]
+    assert all(isinstance(tc["id"], str) and tc["id"] for tc in parsed["tool_calls"])
+    assert parsed["tool_calls"][1]["function"]["arguments"] == json.dumps({})
+
+
+def test_no_tool_calls_omits_tool_calls_key():
+    fake_response = {
+        "text": "just text",
+        "meta": {"billed_units": {"input_tokens": 1, "output_tokens": 1}},
+    }
+    parsed = cohere_generate.parse_response(fake_response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "just text"
+
+
+def test_missing_parameters_defaults_to_empty_json_object():
+    fake_response = {"tool_calls": [{"name": "f"}]}
+    parsed = cohere_generate.parse_response(fake_response)
+    assert parsed["tool_calls"][0]["function"]["arguments"] == json.dumps({})
+    assert parsed["tool_calls"][0]["function"]["name"] == "f"

--- a/packages/kailash-kaizen/tests/unit/llm/test_mistral_chat_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_mistral_chat_wave1b_emission.py
@@ -1,0 +1,321 @@
+"""#1720 Wave-1b — mistral_chat completion-shaping EMISSION + PARSE.
+
+Behavioral tests for the Mistral chat wire adapter's Wave-1b additions.
+Mistral's ``/v1/chat/completions`` is OpenAI-schema-compatible with a handful
+of provider-specific deltas the emission MUST honour:
+
+* ``tools`` — OpenAI function-schema list, verbatim passthrough (truthiness
+  guard so ``tools=[]`` emits nothing).
+* ``tool_choice`` — Mistral's forced-tool value is ``"any"`` (NOT OpenAI's
+  ``"required"``); the adapter maps ``"required"->"any"``, passes
+  ``"auto"/"none"/"any"`` through, defaults to ``"any"`` when tools are set +
+  choice unset, and emits ``tool_choice`` ONLY alongside a non-empty tools list.
+* ``response_format`` — ``{"type": "json_object"}`` verbatim passthrough
+  (truthiness guard).
+* ``seed`` — emitted under Mistral's ``random_seed`` key (NOT ``seed``);
+  ``frequency_penalty`` / ``presence_penalty`` / ``n`` share the OpenAI names.
+* ``top_k`` and ``logit_bias`` — UNSUPPORTED by Mistral → NEVER emitted.
+
+``parse_response`` surfaces ``choices[0].message.tool_calls`` under the
+``"tool_calls"`` key in the canonical normalized shape (``arguments`` is a
+JSON-encoded string), as plain JSON-serializable dicts.
+
+All assertions are behavioral (construct → call → assert the produced dict),
+not source-grep. No real model names are hardcoded (env-models.md) — the tests
+use ``"test-model"``.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import mistral_chat
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.unit
+def test_emits_tools_response_format_and_sampling_fields():
+    """Set fields emit under Mistral's key names with the right values; seed is
+    written under ``random_seed`` (the Mistral delta)."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=tools,
+        tool_choice="auto",
+        response_format={"type": "json_object"},
+        seed=7,
+        frequency_penalty=0.5,
+        presence_penalty=0.25,
+        n=2,
+    )
+    payload = mistral_chat.build_request_payload(request)
+
+    assert payload["tools"] == tools
+    # Explicit tool_choice is honored ("auto" passes through).
+    assert payload["tool_choice"] == "auto"
+    assert payload["response_format"] == {"type": "json_object"}
+    # Mistral's seed parameter is `random_seed`, NOT `seed`.
+    assert payload["random_seed"] == 7
+    assert "seed" not in payload
+    assert payload["frequency_penalty"] == 0.5
+    assert payload["presence_penalty"] == 0.25
+    assert payload["n"] == 2
+
+
+@pytest.mark.unit
+def test_tool_choice_required_maps_to_any():
+    """OpenAI's forced-tool value 'required' MUST map to Mistral's 'any'."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice="required",
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+@pytest.mark.unit
+def test_tool_choice_defaults_to_any_when_tools_set_and_choice_none():
+    """The pinned Wave-1a legacy default expressed in Mistral's vocabulary:
+    tools present + tool_choice unset → tool_choice='any' (force a tool)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        # tool_choice deliberately unset
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+@pytest.mark.unit
+def test_tool_choice_auto_none_any_pass_through():
+    """Mistral-native string values pass through unchanged."""
+    for choice in ("auto", "none", "any"):
+        request = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+            tool_choice=choice,
+        )
+        payload = mistral_chat.build_request_payload(request)
+        assert payload["tool_choice"] == choice
+
+
+@pytest.mark.unit
+def test_tool_choice_unknown_string_falls_back_to_any():
+    """An unknown tool_choice string falls back to the safe forced default
+    'any' (never a shape Mistral would reject)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        tool_choice="banana",
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+@pytest.mark.unit
+def test_tool_choice_named_tool_dict_passes_through():
+    """A named-tool forced-selection dict passes through in the OpenAI-shaped
+    object form Mistral accepts."""
+    named = {"type": "function", "function": {"name": "get_weather"}}
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[
+            {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+        ],
+        tool_choice=named,
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert payload["tool_choice"] == named
+
+
+@pytest.mark.unit
+def test_empty_tools_emits_nothing():
+    """An explicitly-set EMPTY tools list emits neither tools nor tool_choice
+    (truthiness guard, not `is not None`)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[],
+        tool_choice="any",
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+@pytest.mark.unit
+def test_tool_choice_not_emitted_without_tools():
+    """tool_choice is meaningless without tools — emitted ONLY alongside a
+    non-empty tools list. A standalone tool_choice (any value) is dropped."""
+    for choice in (
+        "none",
+        "required",
+        "auto",
+        "any",
+        {"type": "function", "function": {"name": "f"}},
+    ):
+        request = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tool_choice=choice,
+        )
+        payload = mistral_chat.build_request_payload(request)
+        assert (
+            "tool_choice" not in payload
+        ), f"tool_choice={choice!r} leaked without tools"
+        assert "tools" not in payload
+
+
+@pytest.mark.unit
+def test_empty_response_format_emits_nothing():
+    """An empty response_format={} (set but degenerate) emits nothing."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={},
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert "response_format" not in payload
+
+
+@pytest.mark.unit
+def test_top_k_is_never_emitted():
+    """Mistral's chat API does not support top_k — it MUST NOT appear in the
+    payload even when the CompletionRequest carries it."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        top_k=40,
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert "top_k" not in payload
+
+
+@pytest.mark.unit
+def test_logit_bias_is_never_emitted():
+    """Mistral has no logit_bias equivalent — it MUST NOT appear in the payload
+    even when the CompletionRequest carries it."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        logit_bias={"123": -1.0},
+    )
+    payload = mistral_chat.build_request_payload(request)
+    assert "logit_bias" not in payload
+
+
+@pytest.mark.unit
+def test_parse_response_surfaces_tool_calls_in_canonical_shape():
+    """A fake Mistral response with message.tool_calls parses into the canonical
+    normalized shape; arguments stays a JSON-encoded string; entries are plain
+    JSON-serializable dicts."""
+    arguments_json = json.dumps({"city": "Paris"})
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": arguments_json,
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        "model": "test-model",
+    }
+
+    parsed = mistral_chat.parse_response(response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments_json},
+        }
+    ]
+    tc = parsed["tool_calls"][0]
+    # arguments is a JSON-encoded string, not a dict.
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+    # The result must be JSON-serializable (plain dicts, no SDK objects).
+    json.dumps(parsed)
+    # Existing keys are unchanged.
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "tool_calls"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {
+        "input_tokens": 5,
+        "output_tokens": 3,
+        "total_tokens": 8,
+    }
+
+
+@pytest.mark.unit
+def test_parse_response_coerces_dict_arguments_to_json_string():
+    """A non-conformant Mistral response returning ``arguments`` as a dict is
+    coerced to a JSON string so the canonical invariant holds."""
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": {"q": "kailash"},
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "model": "test-model",
+    }
+    parsed = mistral_chat.parse_response(response)
+    tc = parsed["tool_calls"][0]
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"q": "kailash"}
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_when_absent():
+    """No tool_calls in the response → no 'tool_calls' key in the parsed dict;
+    the existing {text, usage, stop_reason, model} keys are intact."""
+    response = {
+        "choices": [{"finish_reason": "stop", "message": {"content": "hello"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "model": "test-model",
+    }
+    parsed = mistral_chat.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello"
+    assert set(parsed.keys()) == {"text", "usage", "stop_reason", "model"}

--- a/packages/kailash-kaizen/tests/unit/llm/test_ollama_native_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_ollama_native_wave1b_emission.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b — ollama_native completion-shaping EMISSION + PARSE.
+
+Behavioral tests for the Ollama Native wire adapter's Wave-1b additions:
+
+* ``build_request_payload`` EMITS the completion-shaping fields, translated to
+  Ollama's ``/api/chat`` schema:
+    - ``tools`` -> top-level ``tools`` (OpenAI function-schema passthrough).
+    - ``tool_choice`` -> OMITTED (Ollama has no such parameter — never faked).
+    - ``response_format`` -> top-level ``format`` ("json" for json_object; the
+      schema object for json_schema).
+    - ``seed``/``top_k``/``frequency_penalty``/``presence_penalty`` -> merged
+      into ``options`` under Ollama's native names, never clobbering
+      temperature/top_p/num_predict/stop.
+    - ``n`` / ``logit_bias`` -> OMITTED (no Ollama equivalent).
+* ``parse_response`` surfaces ``message.tool_calls`` (Ollama gives
+  ``function.arguments`` as a DICT and no call id) in the canonical normalized
+  shape: ``arguments`` json.dumps'd to a string, a synthesized ``call_{i}`` id.
+
+All assertions are behavioral (construct -> call -> assert the produced dict),
+not source-grep. No real model names are hardcoded (env-models.md) — the tests
+use ``"test-model"``.
+"""
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import ollama_native
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.unit
+def test_emits_tools_passthrough_and_omits_tool_choice():
+    """tools pass through verbatim (OpenAI function-schema); tool_choice is
+    OMITTED because Ollama's /api/chat has no such parameter."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=tools,
+        tool_choice="required",  # set, but Ollama has no tool_choice — must drop
+    )
+    payload = ollama_native.build_request_payload(request)
+
+    assert payload["tools"] == tools
+    assert "tool_choice" not in payload
+
+
+@pytest.mark.unit
+def test_empty_tools_list_emits_nothing():
+    """An explicitly-set empty tools list emits no tools key (truthiness guard)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[],
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+@pytest.mark.unit
+def test_response_format_json_object_maps_to_format_json():
+    """{"type": "json_object"} -> Ollama's top-level format: "json"."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "json_object"},
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert payload["format"] == "json"
+    # Not emitted under the OpenAI key name.
+    assert "response_format" not in payload
+
+
+@pytest.mark.unit
+def test_response_format_json_schema_maps_to_format_schema_object():
+    """A json_schema response_format -> Ollama format set to the schema object."""
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "loc", "schema": schema},
+        },
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert payload["format"] == schema
+
+
+@pytest.mark.unit
+def test_response_format_json_schema_without_schema_falls_back_to_json():
+    """A json_schema type carrying no extractable schema falls back to "json"
+    (still forces structured output rather than emitting a malformed format)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "json_schema"},
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert payload["format"] == "json"
+
+
+@pytest.mark.unit
+def test_response_format_text_type_emits_nothing():
+    """A non-JSON response_format type must NOT force json mode — Ollama
+    defaults to free text, so no format key is emitted."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "text"},
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert "format" not in payload
+
+
+@pytest.mark.unit
+def test_empty_response_format_emits_nothing():
+    """An empty response_format={} (no type) emits nothing (truthiness guard)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={},
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert "format" not in payload
+
+
+@pytest.mark.unit
+def test_sampling_fields_merge_into_options_under_ollama_names():
+    """seed/top_k/frequency_penalty/presence_penalty land under options with
+    Ollama's native names, MERGED with the pre-existing temperature/top_p/etc.
+    without clobbering them."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=128,
+        stop=["END"],
+        seed=7,
+        top_k=40,
+        frequency_penalty=0.5,
+        presence_penalty=0.25,
+    )
+    payload = ollama_native.build_request_payload(request)
+    options = payload["options"]
+
+    # Pre-existing options preserved (not clobbered by the merge).
+    assert options["temperature"] == 0.7
+    assert options["top_p"] == 0.9
+    assert options["num_predict"] == 128
+    assert options["stop"] == ["END"]
+    # Wave-1b sampling merged under Ollama's native option names.
+    assert options["seed"] == 7
+    assert options["top_k"] == 40
+    assert options["frequency_penalty"] == 0.5
+    assert options["presence_penalty"] == 0.25
+
+
+@pytest.mark.unit
+def test_n_and_logit_bias_are_never_emitted():
+    """Ollama supports neither multiple completions (n) nor logit_bias — both
+    MUST be absent from the payload (and never leak into options)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        n=3,
+        logit_bias={"123": -1.0},
+    )
+    payload = ollama_native.build_request_payload(request)
+    assert "n" not in payload
+    assert "logit_bias" not in payload
+    # No options dict is created solely from unsupported fields.
+    assert "n" not in payload.get("options", {})
+    assert "logit_bias" not in payload.get("options", {})
+
+
+@pytest.mark.unit
+def test_parse_response_normalizes_dict_arguments_and_synthesizes_id():
+    """Ollama returns tool_calls with function.arguments as a DICT and no call
+    id; parse normalizes arguments to a JSON string and synthesizes call_{i}."""
+    response = {
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "Paris"},
+                    }
+                }
+            ],
+        },
+        "model": "test-model",
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 5,
+        "eval_count": 3,
+    }
+
+    parsed = ollama_native.parse_response(response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_0",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": json.dumps({"city": "Paris"}),
+            },
+        }
+    ]
+    tc = parsed["tool_calls"][0]
+    # arguments is a JSON-encoded string, not a dict.
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+    # The result is JSON-serializable (plain dicts, no SDK objects).
+    json.dumps(parsed)
+    # Existing keys unchanged.
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "stop"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {"input_tokens": 5, "output_tokens": 3}
+
+
+@pytest.mark.unit
+def test_parse_response_multiple_tool_calls_get_sequential_ids():
+    """Two tool calls with no ids get call_0 and call_1."""
+    response = {
+        "message": {
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "a", "arguments": {"x": 1}}},
+                {"function": {"name": "b", "arguments": {"y": 2}}},
+            ],
+        },
+        "done": True,
+    }
+    parsed = ollama_native.parse_response(response)
+    ids = [tc["id"] for tc in parsed["tool_calls"]]
+    assert ids == ["call_0", "call_1"]
+    assert parsed["tool_calls"][1]["function"]["arguments"] == json.dumps({"y": 2})
+
+
+@pytest.mark.unit
+def test_parse_response_preserves_provider_supplied_id_and_string_arguments():
+    """A variant that already sent an id + string arguments is passed through
+    unchanged (no double-encoding, no id overwrite)."""
+    args_str = json.dumps({"city": "Berlin"})
+    response = {
+        "message": {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_native_xyz",
+                    "function": {"name": "get_weather", "arguments": args_str},
+                }
+            ],
+        },
+        "done": True,
+    }
+    parsed = ollama_native.parse_response(response)
+    tc = parsed["tool_calls"][0]
+    assert tc["id"] == "call_native_xyz"
+    # Already a string -> not re-encoded.
+    assert tc["function"]["arguments"] == args_str
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_when_absent():
+    """No tool_calls in the response -> no 'tool_calls' key; the pre-#1720
+    parsed keys are intact."""
+    response = {
+        "message": {"role": "assistant", "content": "hello"},
+        "model": "test-model",
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 1,
+        "eval_count": 1,
+    }
+    parsed = ollama_native.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello"
+    assert set(parsed.keys()) == {"text", "usage", "stop_reason", "model", "done"}


### PR DESCRIPTION
## Summary

Second Wave-1b batch of the #1720 consolidation: three more wire adapters emit + parse the completion-shaping fields. Built as 3 parallel worktree shards (disjoint files), integrated here.

| Adapter | Notes |
|---|---|
| `mistral_chat` | OpenAI-compatible; force-tool value is `"any"` (not `"required"`); seed → `random_seed`; top_k/logit_bias omitted (unsupported) |
| `cohere_generate` | Cohere **v1** `/chat`; tools → `parameter_definitions` shape w/ JSON-schema→Python type mapping; top_k → `k`; `tool_choice` omitted (v2-only — not faked) |
| `ollama_native` | `/api/chat`; response_format → top-level `format`; sampling under `options`; `tool_choice`/`n`/`logit_bias` omitted (no Ollama equivalent) |

All three apply the batch-1 redteam lessons up-front: truthy empty-collection guards, forced-selection only alongside non-empty tools, canonical JSON-string `arguments`, and **omit-don't-fake** for unsupported capabilities.

## Canonical contract — now pinned across all 6 adapters

`test_issue_1720_wave1b_normalized_toolcalls_parity.py` feeds each of the **6** adapters (openai/anthropic/google/mistral/cohere/ollama) an equivalent native tool call and asserts they all produce the identical normalized shape `[{id, type:"function", function:{name, arguments:<JSON string>}}]`. The empty-tools / tool_choice-without-tools / empty-collection guards are likewise parametrized over all 6.

## Byte-neutrality preserved

Every field emitted only when truthy; Wave-1a `test_unset_new_fields_never_appear_in_payload` pins stay green across all wires.

## Tests

- 3 per-adapter emission suites (mistral 14, ollama 13, cohere 22) + the 6-adapter parity + guard pins.
- Full LLM + regression suite green (**1830 passed**); pre-commit green.

## Scope / follow-ups

`bedrock_invoke` (per-family tool support varies) and `huggingface` (TGI-limited) deferred to careful individual scoping. Then multimodal + mock preset + embed remainder + byok. Cohere v2 upgrade (for real `tool_choice`) noted as a separate larger shard. Waves 2–4 remain human-gated.

## Related issues

Part of #1720. Cross-SDK parity tracked at the Rust SDK (filed this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)