### PR TITLE
feat(kaizen): #1720 Wave-1b remainder — bedrock/hf tools, multimodal, embed remainder, mock transport, byok+reasoning

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -44,13 +44,20 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 import httpx
 
+from kaizen.llm.auth import ApiKey, ApiKeyBearer
 from kaizen.llm.deployment import (
     CompletionRequest,
     EmbedOptions,
     LlmDeployment,
     WireProtocol,
 )
-from kaizen.llm.errors import InvalidResponse, ProviderError, RateLimited, Timeout
+from kaizen.llm.errors import (
+    AuthError,
+    InvalidResponse,
+    ProviderError,
+    RateLimited,
+    Timeout,
+)
 from kaizen.llm.http_client import LlmHttpClient
 from kaizen.llm.redaction import redact_messages
 from kaizen.llm.wire_protocols import (
@@ -69,6 +76,33 @@ from kaizen.llm.wire_protocols import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class UnsupportedApiKeyOverride(AuthError):
+    """Raised by ``complete()``/``stream()`` when a per-request ``api_key=``
+    override (#1720 Wave-1b BYOK) is supplied but the deployment's auth
+    strategy has no well-defined "install this raw string instead" semantics.
+
+    Per-request BYOK is supported ONLY for ``ApiKeyBearer``-family
+    deployments — the three header kinds ``Authorization: Bearer`` /
+    ``X-Api-Key`` / ``X-Goog-Api-Key`` (``kaizen.llm.auth.bearer``). Every
+    other auth strategy (``AwsSigV4`` request signing, ``GcpOauth`` /
+    ``AzureEntra`` token refresh, ``AwsBearerToken``, ``StaticNone``,
+    ``Custom``) is REJECTED rather than silently ignored or sent under the
+    deployment's own credential — ``rules/zero-tolerance.md`` Rule 3 (no
+    silent fallbacks): a caller who explicitly asked for a different
+    credential and got the deployment's default instead is a security bug,
+    not a convenience.
+    """
+
+    def __init__(self, auth_strategy_kind: str) -> None:
+        self.auth_strategy_kind = auth_strategy_kind
+        super().__init__(
+            "per-request api_key= override is not supported for this "
+            f"deployment's auth strategy (auth_strategy_kind={auth_strategy_kind!r}); "
+            "only ApiKeyBearer-family deployments (Authorization: Bearer / "
+            "X-Api-Key / X-Goog-Api-Key) accept a per-request BYOK override"
+        )
 
 
 # Wire-protocol dispatch for embed(). Keyed by WireProtocol enum so a
@@ -902,7 +936,12 @@ class LlmClient:
         return payload, url
 
     async def _prepare_auth_headers(
-        self, url: str, body_bytes: bytes, *, stream: bool
+        self,
+        url: str,
+        body_bytes: bytes,
+        *,
+        stream: bool,
+        api_key: Optional[str] = None,
     ) -> tuple[Dict[str, str], Optional[str]]:
         """Run the deployment auth strategy and return (headers, auth_kind).
 
@@ -912,8 +951,34 @@ class LlmClient:
         strategies (AwsSigV4) that canonicalize over those fields work too.
         Endpoint ``required_headers`` (e.g. ``anthropic-version``) merge in
         via ``setdefault`` so auth never clobbers them.
+
+        ``api_key`` (#1720 Wave-1b BYOK): an OPTIONAL per-request credential
+        override. ``CompletionRequest`` deliberately carries no credential
+        field (it is the cross-SDK byte pre-image); BYOK threads through
+        here instead of through the request body. When set, the override is
+        installed via ``ApiKeyBearer.apply()`` — the SAME header-injection
+        mechanism the deployment's own static credential uses — for the
+        deployment's OWN header kind (``Authorization: Bearer`` /
+        ``X-Api-Key`` / ``X-Goog-Api-Key``), never a hand-rolled header name.
+        The deployment's own auth object is never mutated; the override is
+        per-call only. Deployments whose auth strategy is NOT
+        ``ApiKeyBearer`` (``AwsSigV4``, ``GcpOauth``, ``AzureEntra``,
+        ``AwsBearerToken``, ``StaticNone``, ``Custom``) raise
+        :class:`UnsupportedApiKeyOverride` — checked BEFORE the deployment's
+        own ``apply``/``apply_async`` runs, so a rejected override never
+        triggers an unnecessary token refresh (e.g. a live GCP OAuth call)
+        for a credential that would then be discarded. The raw key is never
+        logged: it is threaded directly into ``ApiKeyBearer``/``ApiKey``,
+        whose ``__repr__`` implementations expose only a fingerprint.
         """
         assert self._deployment is not None
+        auth = self._deployment.auth
+        auth_kind = (
+            auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
+        )
+        if api_key is not None and not isinstance(auth, ApiKeyBearer):
+            raise UnsupportedApiKeyOverride(auth_kind or type(auth).__name__)
+
         request: dict = {
             "method": "POST",
             "url": url,
@@ -921,17 +986,19 @@ class LlmClient:
             "body": body_bytes,
             "streaming": stream,
         }
-        auth = self._deployment.auth
-        apply_async = getattr(auth, "apply_async", None)
-        if callable(apply_async):
-            await apply_async(request)
+        if api_key is not None:
+            # isinstance-checked above: `auth` is an ApiKeyBearer, so
+            # `auth.kind` is a valid ApiKeyHeaderKind. Reuse
+            # ApiKeyBearer.apply() — never write the header name directly.
+            ApiKeyBearer(kind=auth.kind, key=ApiKey(api_key)).apply(request)
         else:
-            auth.apply(request)
+            apply_async = getattr(auth, "apply_async", None)
+            if callable(apply_async):
+                await apply_async(request)
+            else:
+                auth.apply(request)
         for k, v in self._deployment.endpoint.required_headers.items():
             request["headers"].setdefault(k, v)
-        auth_kind = (
-            auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
-        )
         return request["headers"], auth_kind
 
     async def complete(
@@ -953,6 +1020,7 @@ class LlmClient:
         presence_penalty: Optional[float] = None,
         n: Optional[int] = None,
         top_k: Optional[int] = None,
+        api_key: Optional[str] = None,
         http_client: Optional[LlmHttpClient] = None,
     ) -> Dict[str, Any]:
         """Issue a chat completion through the configured deployment.
@@ -983,6 +1051,14 @@ class LlmClient:
         later Wave-1b shard; passing a field to a not-yet-wired provider is a
         no-op for that field.
 
+        ``api_key`` (#1720 Wave-1b BYOK): an OPTIONAL per-request credential
+        override, applied ONLY to this call — the deployment's own
+        credential is untouched for every other call. It is NOT a
+        ``CompletionRequest`` field (that model is the cross-SDK byte
+        pre-image and must carry no secret); it threads straight into the
+        auth-header step. See :meth:`_prepare_auth_headers` for the header-
+        kind contract and the ``UnsupportedApiKeyOverride`` disposition.
+
         Raises:
             ValueError: ``messages`` empty of a resolvable model, or no
                 deployment configured.
@@ -991,6 +1067,8 @@ class LlmClient:
             InvalidResponse / ProviderError / RateLimited / Timeout: wire
                 failures with credential scrubbing.
             InvalidEndpoint: SSRF guard rejected the URL at DNS-resolve time.
+            UnsupportedApiKeyOverride: ``api_key`` was set but the
+                deployment's auth strategy is not ``ApiKeyBearer``.
         """
         if self._deployment is None:
             raise ValueError(
@@ -1034,7 +1112,7 @@ class LlmClient:
 
         try:
             headers, auth_kind = await self._prepare_auth_headers(
-                url, body_bytes, stream=False
+                url, body_bytes, stream=False, api_key=api_key
             )
             logger.info(
                 "llm.complete.start",
@@ -1131,6 +1209,7 @@ class LlmClient:
         presence_penalty: Optional[float] = None,
         n: Optional[int] = None,
         top_k: Optional[int] = None,
+        api_key: Optional[str] = None,
         http_client: Optional[LlmHttpClient] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Stream a chat completion as an async iterator of parsed chunks.
@@ -1154,6 +1233,11 @@ class LlmClient:
         Ollama (Bedrock-native + HuggingFace pending). They are forwarded
         unchanged on both the streaming path AND the ``streaming.enabled=False``
         buffered-``complete()`` fallback, so the two paths stay at parity.
+
+        ``api_key`` (#1720 Wave-1b BYOK): same per-request credential
+        override contract as :meth:`complete` — forwarded unchanged on BOTH
+        the buffered fallback and the real streaming send path, so BYOK
+        stays at parity across both.
         """
         if self._deployment is None:
             raise ValueError(
@@ -1182,6 +1266,7 @@ class LlmClient:
                 presence_penalty=presence_penalty,
                 n=n,
                 top_k=top_k,
+                api_key=api_key,
                 http_client=http_client,
             )
             yield result
@@ -1225,7 +1310,7 @@ class LlmClient:
         shaper = dispatch["shaper"]
         try:
             headers, auth_kind = await self._prepare_auth_headers(
-                url, body_bytes, stream=True
+                url, body_bytes, stream=True, api_key=api_key
             )
             logger.info(
                 "llm.stream.start",
@@ -1285,4 +1370,4 @@ class LlmClient:
             )
 
 
-__all__ = ["LlmClient"]
+__all__ = ["LlmClient", "UnsupportedApiKeyOverride"]

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -244,16 +244,26 @@ def _validate_completion_model(model: str) -> str:
 # security finding): the offline ``MockLlmHttpClient`` test path never
 # exercises real HTTP header parsing, so this was previously untested and
 # unguarded.
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f]")
+# C0 controls (\x00-\x1f) AND \x7f (DEL) — all outside RFC 7230 field-vchar
+# (VCHAR = 0x21-0x7e). \r/\n/\x00 are the CRLF-header-injection primitive; the
+# rest are rejected for completeness so this guard is the strict superset of the
+# transport's own header-grammar check (/redteam Round-2 completeness).
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def _validate_api_key_override(api_key: str) -> str:
     """Fail-closed validation of a per-request ``api_key=`` override before
     it is installed into a header. Raises :class:`InvalidApiKeyOverride` on
-    any control character. Mirrors ``_validate_completion_model``'s
-    fail-closed shape. Byte-preserving for valid keys (no transformation —
-    the provider sees the exact key)."""
-    if _CONTROL_CHAR_RE.search(api_key):
+    any control character (C0 + DEL) OR any non-ASCII character. Mirrors
+    ``_validate_completion_model``'s fail-closed shape. Byte-preserving for
+    valid keys (no transformation — the provider sees the exact key).
+
+    Non-ASCII is rejected here (rather than letting it fall through to an
+    opaque ``UnicodeEncodeError`` when httpx ascii-encodes the header value)
+    so EVERY malformed override surfaces as the SAME typed, fingerprint-only
+    error — an HTTP header value MUST be ASCII, so a non-ASCII api_key can
+    never be a valid credential (/redteam Round-2 completeness)."""
+    if _CONTROL_CHAR_RE.search(api_key) or not api_key.isascii():
         raise InvalidApiKeyOverride(api_key)
     return api_key
 

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -56,8 +56,10 @@ from kaizen.llm.redaction import redact_messages
 from kaizen.llm.wire_protocols import (
     anthropic_messages,
     bedrock_invoke,
+    cohere_embeddings,
     cohere_generate,
     google_generate_content,
+    huggingface_embeddings,
     huggingface_inference,
     mistral_chat,
     ollama_embeddings,
@@ -86,6 +88,24 @@ _EMBED_DISPATCH: dict = {
         "path": "/api/embed",
         "shaper": ollama_embeddings,
         "env_model_hint": "OLLAMA_EMBEDDING_MODEL",
+    },
+    # #1720 Wave-1b EMBED-REMAINDER — Cohere speaks its own wire family
+    # (WireProtocol.CohereGenerate) across both chat AND embeddings; the
+    # embed path is a fixed suffix (model travels in the JSON body, not the
+    # URL), same shape as OpenAiChat/OllamaNative above.
+    WireProtocol.CohereGenerate: {
+        "path": "/embed",
+        "shaper": cohere_embeddings,
+        "env_model_hint": "COHERE_EMBEDDING_MODEL",
+    },
+    # HuggingFace's feature-extraction endpoint carries the model in the URL
+    # path, NOT the body (mirrors HuggingFaceInference's chat path_template
+    # in _COMPLETE_DISPATCH below) -- `{model}` is substituted by
+    # `_build_embed_url`.
+    WireProtocol.HuggingFaceInference: {
+        "path": "/models/{model}",
+        "shaper": huggingface_embeddings,
+        "env_model_hint": "HUGGINGFACE_EMBEDDING_MODEL",
     },
 }
 
@@ -669,7 +689,7 @@ class LlmClient:
             if owns_client:
                 await http_client.aclose()
 
-    def _build_embed_url(self, suffix: str) -> str:
+    def _build_embed_url(self, suffix: str, model: Optional[str] = None) -> str:
         """Join ``endpoint.base_url`` + ``endpoint.path_prefix`` + ``suffix``.
 
         Kept explicit (not ``urllib.parse.urljoin``) because ``urljoin``
@@ -677,16 +697,42 @@ class LlmClient:
         ``path_prefix`` when ``suffix`` starts with ``/``. We always
         concatenate with a single separator so the produced URL matches
         the deployment's declared shape.
+
+        ``{model}`` in ``suffix`` is substituted with a fail-closed-validated
+        ``model`` (mirrors ``_build_completion_url``'s ``{model}``
+        substitution + ``_validate_completion_model`` check) -- only
+        HuggingFace's feature-extraction dispatch entry
+        (``"/models/{model}"``) carries the placeholder today, so every
+        other embed wire's ``suffix`` passes through unchanged (byte-
+        identical to the pre-#1720-EMBED-REMAINDER output). Any
+        ``endpoint.query_params`` are appended as a query string (Azure's
+        ``?api-version=`` reaching the embed URL, matching
+        ``_build_completion_url``'s existing behaviour).
         """
         assert self._deployment is not None
         endpoint = self._deployment.endpoint
         base = str(endpoint.base_url).rstrip("/")
         prefix = (endpoint.path_prefix or "").rstrip("/")
-        suffix_norm = suffix if suffix.startswith("/") else "/" + suffix
+        suffix_resolved = suffix
+        if "{model}" in suffix:
+            suffix_resolved = suffix.replace(
+                "{model}", _validate_completion_model(model or "")
+            )
+        suffix_norm = (
+            suffix_resolved
+            if suffix_resolved.startswith("/")
+            else "/" + suffix_resolved
+        )
         if prefix:
             prefix_norm = prefix if prefix.startswith("/") else "/" + prefix
-            return f"{base}{prefix_norm}{suffix_norm}"
-        return f"{base}{suffix_norm}"
+            url = f"{base}{prefix_norm}{suffix_norm}"
+        else:
+            url = f"{base}{suffix_norm}"
+        if endpoint.query_params:
+            from urllib.parse import urlencode
+
+            url = f"{url}?{urlencode(endpoint.query_params)}"
+        return url
 
     # -----------------------------------------------------------------
     # complete() / stream() — chat-completion send-path (#1717)

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -53,11 +53,11 @@ from kaizen.llm.deployment import (
 )
 from kaizen.llm.errors import (
     AuthError,
-    InvalidApiKeyOverride,
     InvalidResponse,
     ProviderError,
     RateLimited,
     Timeout,
+    _fingerprint,
 )
 from kaizen.llm.http_client import LlmHttpClient
 from kaizen.llm.redaction import redact_messages
@@ -103,6 +103,36 @@ class UnsupportedApiKeyOverride(AuthError):
             f"deployment's auth strategy (auth_strategy_kind={auth_strategy_kind!r}); "
             "only ApiKeyBearer-family deployments (Authorization: Bearer / "
             "X-Api-Key / X-Goog-Api-Key) accept a per-request BYOK override"
+        )
+
+
+class InvalidApiKeyOverride(AuthError):
+    """Raised when a per-request ``api_key=`` override (#1720 Wave-1b BYOK)
+    fails fail-closed validation BEFORE it is installed into a header.
+
+    /redteam Round-1/2 (#1720 Wave-1b security finding): a per-request
+    ``api_key`` containing a control character (``\\r`` / ``\\n`` / ``\\x00``
+    / other C0 / DEL) or a non-ASCII character is a CRLF-header-injection /
+    malformed-header surface -- :class:`kaizen.llm.auth.bearer.ApiKeyBearer`
+    installs the raw string directly into an HTTP header value with no
+    sanitization, and the offline ``MockLlmHttpClient`` test path never
+    exercises real header parsing, so the injection was previously untested
+    and unguarded. Mirrors ``_validate_completion_model``'s fail-closed
+    shape: reject BEFORE the value reaches anything that could act on it.
+
+    Co-located here (NOT in ``kaizen.llm.errors``) beside its sibling
+    :class:`UnsupportedApiKeyOverride` — both are client-layer BYOK-override
+    guards, not part of the cross-SDK-mirrored ``errors`` taxonomy. Only the
+    fingerprint (never the raw key) appears in any human-visible field.
+    """
+
+    def __init__(self, raw_credential: str) -> None:
+        self.fingerprint = _fingerprint(raw_credential)
+        super().__init__(
+            "per-request api_key= override rejected: contains a control "
+            "character (\\r, \\n, \\x00, other C0, or DEL) or a non-ASCII "
+            "character; refusing to install it into a request header "
+            f"(fingerprint={self.fingerprint})"
         )
 
 
@@ -1008,10 +1038,10 @@ class LlmClient:
 
         /redteam Round-1 (#1720 Wave-1b security finding): before ANY of the
         above, ``api_key`` is fail-closed-validated for control characters
-        (``\\r`` / ``\\n`` / ``\\x00`` / other C0 controls) via
+        (``\\r`` / ``\\n`` / ``\\x00`` / other C0 / DEL) or non-ASCII via
         :func:`_validate_api_key_override`, raising
-        :class:`kaizen.llm.errors.InvalidApiKeyOverride` on a match — closing
-        a CRLF-header-injection surface that was previously untested on the
+        :class:`InvalidApiKeyOverride` on a match — closing a
+        CRLF-header-injection surface that was previously untested on the
         offline ``MockLlmHttpClient`` path.
         """
         assert self._deployment is not None

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -53,6 +53,7 @@ from kaizen.llm.deployment import (
 )
 from kaizen.llm.errors import (
     AuthError,
+    InvalidApiKeyOverride,
     InvalidResponse,
     ProviderError,
     RateLimited,
@@ -232,6 +233,29 @@ def _validate_completion_model(model: str) -> str:
             "'..' or '//'); refusing to build the request URL"
         )
     return model
+
+
+# A per-request ``api_key=`` BYOK override (#1720 Wave-1b) is installed
+# directly into an HTTP header value via ``ApiKeyBearer.apply()`` with no
+# further sanitization. Any C0 control character (``\r`` / ``\n`` / ``\x00``
+# / 0x01-0x1F, excluding none) in that string is a CRLF-header-injection
+# surface — a caller-controlled ``\r\nX-Injected: value`` could smuggle an
+# extra header onto the outbound request. /redteam Round-1 (#1720 Wave-1b
+# security finding): the offline ``MockLlmHttpClient`` test path never
+# exercises real HTTP header parsing, so this was previously untested and
+# unguarded.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f]")
+
+
+def _validate_api_key_override(api_key: str) -> str:
+    """Fail-closed validation of a per-request ``api_key=`` override before
+    it is installed into a header. Raises :class:`InvalidApiKeyOverride` on
+    any control character. Mirrors ``_validate_completion_model``'s
+    fail-closed shape. Byte-preserving for valid keys (no transformation —
+    the provider sees the exact key)."""
+    if _CONTROL_CHAR_RE.search(api_key):
+        raise InvalidApiKeyOverride(api_key)
+    return api_key
 
 
 def _parse_stream_line(line: str, shaper: Any) -> Optional[Dict[str, Any]]:
@@ -582,9 +606,10 @@ class LlmClient:
         if dispatch is None:
             raise NotImplementedError(
                 f"LlmClient.embed does not yet support wire={wire.name!r}. "
-                "Supported: OpenAiChat (openai, groq, etc.), OllamaNative. "
-                "File an issue at terrene-foundation/kailash-py referencing "
-                "#462 to request another provider."
+                "Supported: OpenAiChat (openai, groq, etc.), OllamaNative, "
+                "CohereGenerate, HuggingFaceInference. File an issue at "
+                "terrene-foundation/kailash-py referencing #462 to request "
+                "another provider."
             )
 
         resolved_model = model or self._deployment.default_model
@@ -599,7 +624,7 @@ class LlmClient:
         path = dispatch["path"]
         payload = shaper.build_request_payload(texts, resolved_model, options)
 
-        url = self._build_embed_url(path)
+        url = self._build_embed_url(path, model=resolved_model)
 
         # LlmHttpClient owns SSRF (via SafeDnsResolver) + structured
         # logging. NEVER construct httpx.AsyncClient directly here.
@@ -970,12 +995,27 @@ class LlmClient:
         for a credential that would then be discarded. The raw key is never
         logged: it is threaded directly into ``ApiKeyBearer``/``ApiKey``,
         whose ``__repr__`` implementations expose only a fingerprint.
+
+        /redteam Round-1 (#1720 Wave-1b security finding): before ANY of the
+        above, ``api_key`` is fail-closed-validated for control characters
+        (``\\r`` / ``\\n`` / ``\\x00`` / other C0 controls) via
+        :func:`_validate_api_key_override`, raising
+        :class:`kaizen.llm.errors.InvalidApiKeyOverride` on a match — closing
+        a CRLF-header-injection surface that was previously untested on the
+        offline ``MockLlmHttpClient`` path.
         """
         assert self._deployment is not None
         auth = self._deployment.auth
         auth_kind = (
             auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
         )
+        if api_key is not None:
+            # /redteam Round-1 (#1720 Wave-1b security finding): fail-closed
+            # control-char validation BEFORE anything else runs — a
+            # CRLF-header-injection surface must be rejected before the
+            # unnecessary-refresh-avoidance check below, and long before
+            # ApiKeyBearer.apply() installs the raw string into a header.
+            _validate_api_key_override(api_key)
         if api_key is not None and not isinstance(auth, ApiKeyBearer):
             raise UnsupportedApiKeyOverride(auth_kind or type(auth).__name__)
 

--- a/packages/kailash-kaizen/src/kaizen/llm/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/errors.py
@@ -226,8 +226,9 @@ class InvalidApiKeyOverride(AuthError):
         self.fingerprint = _fingerprint(raw_credential)
         super().__init__(
             "per-request api_key= override rejected: contains a control "
-            f"character (\\r, \\n, \\x00, or other C0 control); refusing to "
-            f"install it into a request header (fingerprint={self.fingerprint})"
+            "character (\\r, \\n, \\x00, other C0, or DEL) or a non-ASCII "
+            "character; refusing to install it into a request header "
+            f"(fingerprint={self.fingerprint})"
         )
 
 

--- a/packages/kailash-kaizen/src/kaizen/llm/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/errors.py
@@ -204,6 +204,33 @@ class Expired(AuthError):
         super().__init__("credential expired; refresh required")
 
 
+class InvalidApiKeyOverride(AuthError):
+    """Raised when a per-request ``api_key=`` override (#1720 Wave-1b BYOK)
+    fails fail-closed validation BEFORE it is installed into a header.
+
+    /redteam Round-1 (#1720 Wave-1b security finding): a per-request
+    ``api_key`` containing a control character (``\\r`` / ``\\n`` / ``\\x00``
+    / any other C0 control) is a CRLF-header-injection surface --
+    :class:`kaizen.llm.auth.bearer.ApiKeyBearer` installs the raw string
+    directly into an HTTP header value with no sanitization, and the
+    offline ``MockLlmHttpClient`` test path never exercises real header
+    parsing, so the injection was previously untested and unguarded. This
+    mirrors ``client._validate_completion_model``'s fail-closed shape:
+    reject BEFORE the value reaches anything that could act on it.
+
+    Only the fingerprint (never the raw key) appears in any human-visible
+    field, matching :class:`Invalid` above.
+    """
+
+    def __init__(self, raw_credential: str) -> None:
+        self.fingerprint = _fingerprint(raw_credential)
+        super().__init__(
+            "per-request api_key= override rejected: contains a control "
+            f"character (\\r, \\n, \\x00, or other C0 control); refusing to "
+            f"install it into a request header (fingerprint={self.fingerprint})"
+        )
+
+
 class MissingCredential(AuthError):
     """No credential was discovered for the deployment.
 
@@ -348,6 +375,7 @@ __all__ = [
     "InvalidResponse",
     "AuthError",
     "Invalid",
+    "InvalidApiKeyOverride",
     "Expired",
     "MissingCredential",
     "ConfigError",

--- a/packages/kailash-kaizen/src/kaizen/llm/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/errors.py
@@ -204,34 +204,6 @@ class Expired(AuthError):
         super().__init__("credential expired; refresh required")
 
 
-class InvalidApiKeyOverride(AuthError):
-    """Raised when a per-request ``api_key=`` override (#1720 Wave-1b BYOK)
-    fails fail-closed validation BEFORE it is installed into a header.
-
-    /redteam Round-1 (#1720 Wave-1b security finding): a per-request
-    ``api_key`` containing a control character (``\\r`` / ``\\n`` / ``\\x00``
-    / any other C0 control) is a CRLF-header-injection surface --
-    :class:`kaizen.llm.auth.bearer.ApiKeyBearer` installs the raw string
-    directly into an HTTP header value with no sanitization, and the
-    offline ``MockLlmHttpClient`` test path never exercises real header
-    parsing, so the injection was previously untested and unguarded. This
-    mirrors ``client._validate_completion_model``'s fail-closed shape:
-    reject BEFORE the value reaches anything that could act on it.
-
-    Only the fingerprint (never the raw key) appears in any human-visible
-    field, matching :class:`Invalid` above.
-    """
-
-    def __init__(self, raw_credential: str) -> None:
-        self.fingerprint = _fingerprint(raw_credential)
-        super().__init__(
-            "per-request api_key= override rejected: contains a control "
-            "character (\\r, \\n, \\x00, other C0, or DEL) or a non-ASCII "
-            "character; refusing to install it into a request header "
-            f"(fingerprint={self.fingerprint})"
-        )
-
-
 class MissingCredential(AuthError):
     """No credential was discovered for the deployment.
 
@@ -376,7 +348,6 @@ __all__ = [
     "InvalidResponse",
     "AuthError",
     "Invalid",
-    "InvalidApiKeyOverride",
     "Expired",
     "MissingCredential",
     "ConfigError",

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -1748,6 +1748,13 @@ def azure_openai_preset(
     endpoint = Endpoint(
         base_url=f"https://{endpoint_host}",
         path_prefix=path_prefix,
+        # Azure REQUIRES ?api-version= on EVERY request URL — completion AND
+        # embed. Wiring it into endpoint.query_params (rather than only the
+        # completion adapter's docstring-promised append) means both
+        # _build_completion_url and _build_embed_url emit it, since both now
+        # append endpoint.query_params (#1720 Wave-1b embed-remainder). Without
+        # this an azure embed() call hits /embeddings with no api-version -> 400.
+        query_params={"api-version": api_version},
     )
     deployment = LlmDeployment(
         wire=WireProtocol.OpenAiChat,

--- a/packages/kailash-kaizen/src/kaizen/llm/reasoning_filter.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/reasoning_filter.py
@@ -31,11 +31,17 @@ from __future__ import annotations
 import re
 from typing import Any, Dict
 
-# Reasoning models that DON'T support `temperature` at all (o1, o3 families).
-# Ported verbatim from `OpenAIProvider._REASONING_MODEL_PATTERNS`.
+# Reasoning models that DON'T support `temperature` at all (o1, o3, o4
+# families). `^o4` added at /redteam Round-1 (#1720 Wave-1b) — o4-mini is an
+# o-series reasoning model (see `openai_chat._MAX_COMPLETION_TOKENS_MODEL_PREFIXES
+# = ("gpt-5", "o1", "o3", "o4")`) that rejects `temperature`/`top_p` outright
+# just like o1/o3; the original `_REASONING_MODEL_PATTERNS` (ported from the
+# legacy per-instance helper) omitted it, so every o4-mini call carrying a
+# caller-set `temperature` took a live HTTP 400.
 _REASONING_MODEL_PATTERNS = [
     r"^o1",
     r"^o3",
+    r"^o4",
 ]
 
 # Models that REQUIRE `temperature=1.0` (GPT-5 family).

--- a/packages/kailash-kaizen/src/kaizen/llm/reasoning_filter.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/reasoning_filter.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning-model sampling-param filter for OpenAI o1/o3/gpt-5 (#1720 Wave-1b).
+
+The four-axis ``openai_chat`` wire shaper (``build_request_payload``) only
+switches the token-limit field NAME (``max_tokens`` vs
+``max_completion_tokens``) by model family — it does NOT drop sampling
+params OpenAI's reasoning models reject outright. A caller passing
+``temperature`` to an o1/o3 model takes a live HTTP 400
+(``"temperature" is not supported with this model``); gpt-5 REQUIRES
+``temperature=1.0`` and 400s on anything else.
+
+This module ports the equivalent per-instance helpers from the legacy
+``kaizen.providers.llm.openai.OpenAIProvider``
+(``_is_reasoning_model`` / ``_requires_temperature_1`` /
+``_filter_reasoning_model_params``, see
+``src/kaizen/providers/llm/openai.py``) to module-level, provider-agnostic
+functions so the four-axis wire layer can reuse the exact same filtering
+behavior without depending on the legacy provider class.
+
+Model-family matching is on a documented PREFIX (``o1`` / ``o3`` / ``gpt-5``),
+not a full hardcoded model id — this is the ``rules/env-models.md`` carve-out
+for provider-API constraints (OpenAI's own reasoning-model naming scheme),
+not a hardcoded-model violation. Unknown / unmatched models are left
+untouched (byte-neutral passthrough).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+# Reasoning models that DON'T support `temperature` at all (o1, o3 families).
+# Ported verbatim from `OpenAIProvider._REASONING_MODEL_PATTERNS`.
+_REASONING_MODEL_PATTERNS = [
+    r"^o1",
+    r"^o3",
+]
+
+# Models that REQUIRE `temperature=1.0` (GPT-5 family).
+# Ported verbatim from `OpenAIProvider._TEMPERATURE_1_ONLY_PATTERNS`.
+_TEMPERATURE_1_ONLY_PATTERNS = [
+    r"^gpt-?5",
+]
+
+
+def is_reasoning_model(model: str) -> bool:
+    """True for OpenAI's o1/o3 reasoning-model family.
+
+    These models reject `temperature` / `top_p` / `frequency_penalty` /
+    `presence_penalty` outright (HTTP 400) — they do not clamp or ignore the
+    values, they refuse the request.
+    """
+    if not model:
+        return False
+    model_lower = model.lower()
+    return any(
+        re.search(pattern, model_lower, re.IGNORECASE)
+        for pattern in _REASONING_MODEL_PATTERNS
+    )
+
+
+def requires_temperature_1(model: str) -> bool:
+    """True for OpenAI's gpt-5 family, which requires `temperature=1.0`.
+
+    Unlike o1/o3, gpt-5 does not reject `temperature` outright — it rejects
+    any value OTHER than 1.0. `top_p` / `frequency_penalty` /
+    `presence_penalty` are still unsupported and dropped.
+    """
+    if not model:
+        return False
+    model_lower = model.lower()
+    return any(
+        re.search(pattern, model_lower, re.IGNORECASE)
+        for pattern in _TEMPERATURE_1_ONLY_PATTERNS
+    )
+
+
+def filter_reasoning_model_params(model: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop/force sampling params a reasoning-model family cannot accept.
+
+    * **gpt-5 family** (`requires_temperature_1`): drops `top_p` /
+      `frequency_penalty` / `presence_penalty` when present, and FORCES
+      `temperature` to `1.0` unconditionally (even when the caller never set
+      `temperature` — gpt-5 400s on the server-side default too).
+    * **o1/o3 family** (`is_reasoning_model`): drops `temperature` / `top_p`
+      / `frequency_penalty` / `presence_penalty` when present. Nothing is
+      added — the model simply does not accept these keys.
+    * **Any other model**: `params` is returned as a shallow COPY, unchanged
+      — the byte-neutral passthrough case. Ported behavior from the legacy
+      `OpenAIProvider._filter_reasoning_model_params` (see
+      `src/kaizen/providers/llm/openai.py`), which also returns the input
+      unmodified for non-reasoning models.
+
+    `params` itself is never mutated — every branch returns a new dict.
+    """
+    if requires_temperature_1(model):
+        filtered = dict(params)
+        for key in ("top_p", "frequency_penalty", "presence_penalty"):
+            filtered.pop(key, None)
+        filtered["temperature"] = 1.0
+        return filtered
+
+    if not is_reasoning_model(model):
+        return dict(params)
+
+    filtered = dict(params)
+    for key in ("temperature", "top_p", "frequency_penalty", "presence_penalty"):
+        filtered.pop(key, None)
+    return filtered
+
+
+__all__ = [
+    "is_reasoning_model",
+    "requires_temperature_1",
+    "filter_reasoning_model_params",
+]

--- a/packages/kailash-kaizen/src/kaizen/llm/testing/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/testing/__init__.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 from kaizen.llm.auth.bearer import StaticNone
 from kaizen.llm.deployment import Endpoint, LlmDeployment, WireProtocol
+from kaizen.llm.testing.mock_transport import MockLlmHttpClient, UnsupportedMockRequest
 
 
 def mock_preset(model: str = "mock-model") -> LlmDeployment:
@@ -94,4 +95,4 @@ def mock_preset(model: str = "mock-model") -> LlmDeployment:
     )
 
 
-__all__ = ["mock_preset"]
+__all__ = ["mock_preset", "MockLlmHttpClient", "UnsupportedMockRequest"]

--- a/packages/kailash-kaizen/src/kaizen/llm/testing/mock_transport.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/testing/mock_transport.py
@@ -1,0 +1,840 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""MockLlmHttpClient — deterministic, offline, in-process transport (#1720
+Wave-1b MOCK shard).
+
+The four-axis ``LlmClient`` (``kaizen.llm.client``) always sends real HTTP
+via ``LlmHttpClient`` (``kaizen.llm.http_client``) — every one of
+``complete()`` / ``stream()`` / ``embed()`` accepts an ``http_client=``
+injection parameter but has no offline in-process response path of its own.
+``MockLlmHttpClient`` is that path: a **Protocol-satisfying deterministic
+adapter** (per ``rules/testing.md`` § "3-Tier Testing" -- NOT a
+Tier-2/3-blocked mock) that exposes the SAME async surface
+``kaizen.llm.client.LlmClient`` calls on ``LlmHttpClient``
+(``post`` / ``get`` / ``request`` / ``stream_lines`` / ``aclose`` /
+``__aenter__`` / ``__aexit__`` / ``is_closed``) and returns DETERMINISTIC
+OpenAI-shaped JSON WITHOUT ever constructing an ``httpx.AsyncClient`` or
+opening a socket.
+
+Usage::
+
+    from kaizen.llm.testing import mock_preset, MockLlmHttpClient
+
+    client = LlmClient.from_deployment(mock_preset())
+    transport = MockLlmHttpClient()
+    result = await client.complete(messages, http_client=transport)
+    # -- zero network I/O; result is openai_chat.parse_response()'s
+    #    normalized {text, usage, stop_reason, model} dict.
+
+# Why this is a Protocol-satisfying adapter, not a blocked mock
+
+``rules/testing.md`` blocks ``unittest.mock`` / ``MagicMock`` / ``@patch``
+substitution in Tier 2/3 tests because those hide real infrastructure
+behaviour (connection handling, schema drift, transaction semantics) behind
+a stand-in that always agrees with the caller. ``MockLlmHttpClient`` is the
+documented exception: "a class satisfying a ``typing.Protocol`` at runtime
+with deterministic output is NOT a mock" (``rules/testing.md`` § "3-Tier
+Testing"). It implements the SAME method signatures
+``kaizen.llm.client.LlmClient`` calls, returns a SHAPE the production wire
+shapers (``openai_chat.parse_response`` / ``openai_embeddings.parse_response``)
+already consume unchanged, and its output is a pure function of its input
+(md5-seeded, no unseeded ``random``, no wall-clock dependence except a fixed
+constant ``created`` timestamp). It is a Tier-1 offline-by-construction test
+double for the wire boundary, not a Tier-2/3 substitute for real
+infrastructure.
+
+# Physical separation invariant (#788 pattern, extended)
+
+This module lives under ``kaizen.llm.testing`` -- the SAME physically
+separated, test-only package that houses ``mock_preset()``. The invariant
+``mock_preset.py``'s docstring documents (production code MUST NOT import
+``kaizen.llm.testing``; the import path is the deliberate red flag,
+grep-able via ``grep -rn 'kaizen.llm.testing' src/``) applies identically to
+``MockLlmHttpClient``. ``tests/unit/llm/test_mock_preset_isolation.py``
+extends its structural-defense suite to assert ``MockLlmHttpClient`` is
+absent from the production import surface (``kaizen.llm.client`` /
+``kaizen.llm.http_client`` / ``kaizen.llm.presets``).
+
+# Determinism contract
+
+Every response is a pure function of the request payload:
+
+* Chat completion text is chosen by ``_generate_contextual_response`` --
+  a deterministic keyword-shaped generator ported from the legacy
+  ``kaizen.providers.llm.mock.MockProvider`` (contextual math / reasoning /
+  planning / debate / JSON-shaped-agent-output responses). This IS
+  keyword-matching, but it is a TEST-DOUBLE response generator producing
+  canned test data -- not an agent decision path -- so
+  ``rules/agent-reasoning.md`` (LLM-first reasoning; no keyword routing in
+  AGENT decision logic) does not apply. No production agent ever runs this
+  code; it exists to give offline tests a stable, inspectable chat reply.
+* Embedding vectors are md5-seeded via a PER-CALL ``random.Random(seed)``
+  instance (never the process-global ``random`` module, so this transport
+  is safe to use concurrently and does not perturb any other test's
+  randomness), matching the legacy ``MockProvider.embed`` seeding contract
+  (``seed = md5(f"{model}:{text}")``) but scoped correctly.
+* The chat-completion ``id`` is also md5-derived from ``model`` + the last
+  user message -- deterministic, unlike the legacy provider's
+  process-hash-randomized ``hash(last_user_message)``.
+
+Given the SAME request payload, EVERY field of the response is byte-for-byte
+identical across calls and across processes (Python's hash randomization
+never enters the picture).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from types import TracebackType
+from typing import Any, AsyncIterator, Dict, List, Mapping, Optional
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Typed errors -- zero-tolerance Rule 3 (no silent fallback on an
+# unsupported/malformed request shape).
+# ---------------------------------------------------------------------------
+
+
+class UnsupportedMockRequest(ValueError):
+    """Raised when ``MockLlmHttpClient`` cannot determine, or does not
+    support, the requested wire shape.
+
+    Covers: a request body carrying neither ``content=`` bytes nor a
+    ``json=`` kwarg (nothing to parse), a body that is not valid JSON, a
+    body that is not a JSON object, or a URL whose path does not match one
+    of the two shapes ``mock_preset()``'s ``WireProtocol.OpenAiChat``
+    deployment ever targets (``.../chat/completions``,
+    ``.../embeddings``). Per ``rules/zero-tolerance.md`` Rule 3 this is a
+    LOUD typed error, never a fabricated 200 response.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Deterministic chat-completion text generator (ported from the legacy
+# kaizen.providers.llm.mock.MockProvider._generate_contextual_response).
+# Pure function of its inputs -- no randomness, no wall-clock dependence.
+# ---------------------------------------------------------------------------
+
+
+def _generate_contextual_response(
+    message_lower: str,
+    conversation_text: str,
+    has_images: bool,
+    original_message: str,
+) -> str:
+    if has_images:
+        return (
+            "I can see the image(s) you've provided. The image contains several "
+            "distinct elements that I can analyze for you. "
+            "[Mock vision response with detailed observation]"
+        )
+
+    if any(
+        pattern in message_lower
+        for pattern in [
+            "calculate",
+            "math",
+            "time",
+            "hour",
+            "minute",
+            "second",
+            "duration",
+        ]
+    ) or any(
+        op in message_lower
+        for op in ["+", "-", "*", "/", "plus", "minus", "times", "divide"]
+    ):
+        if (
+            "train" in conversation_text
+            and "travels" in conversation_text
+            and any(num in conversation_text for num in ["300", "450", "4"])
+        ):
+            return (
+                "Step 1: Calculate the train's speed\n"
+                "First, I need to find the train's speed using the given information.\n"
+                "Given: Distance = 300 km, Time = 4 hours\n"
+                "Speed = Distance / Time = 300 km / 4 hours = 75 km/hour\n\n"
+                "Step 2: Apply the speed to find time for new distance\n"
+                "Now I can use this speed to find how long it takes to travel 450 km.\n"
+                "Given: Speed = 75 km/hour, Distance = 450 km\n"
+                "Time = Distance / Speed = 450 km / 75 km/hour = 6 hours\n\n"
+                "Final Answer: 6 hours"
+            )
+        if (
+            "9" in message_lower
+            and "3" in message_lower
+            and ("-" in message_lower or "minus" in message_lower)
+        ) or (
+            "time" in message_lower
+            and any(num in message_lower for num in ["9", "3", "6"])
+        ):
+            return (
+                "Let me calculate this step by step:\n\n"
+                "1. Starting with 9\n2. Subtracting 3: 9 - 3 = 6\n"
+                "3. The result is 6\n\n"
+                "So the answer is 6 hours. This represents a time duration of 6 hours."
+            )
+        if any(
+            op in message_lower
+            for op in ["+", "-", "*", "/", "plus", "minus", "times", "divide"]
+        ):
+            return (
+                "I'll solve this mathematical problem step by step:\n\n"
+                "1. First, I'll identify the operation\n"
+                "2. Then apply the calculation\n"
+                "3. Finally, provide the result with explanation\n\n"
+                "The calculation shows a clear mathematical relationship."
+            )
+        if any(
+            tw in message_lower
+            for tw in ["time", "hour", "minute", "second", "duration"]
+        ):
+            return (
+                "I'll help you with this time calculation. Let me work through this systematically:\n\n"
+                "1. Identifying the time units involved\n"
+                "2. Performing the calculation\n"
+                "3. Providing the result in appropriate time format\n\n"
+                "Time calculations require careful attention to units and precision."
+            )
+        return (
+            "I'll help you with this calculation. Let me work through this "
+            "systematically to provide an accurate result with proper explanation "
+            "of the mathematical process."
+        )
+
+    if any(
+        p in message_lower
+        for p in [
+            "step by step",
+            "think through",
+            "reasoning",
+            "explain",
+            "how do",
+            "why does",
+        ]
+    ):
+        return (
+            "Let me think through this step by step:\n\n"
+            "1. **Understanding the problem**: I need to break down the key components\n"
+            "2. **Analyzing the context**: Looking at the relevant factors and constraints\n"
+            "3. **Reasoning process**: Working through the logical connections\n"
+            "4. **Arriving at conclusion**: Based on the systematic analysis\n\n"
+            "This step-by-step approach ensures thorough reasoning and accurate results."
+        )
+
+    if any(
+        p in message_lower
+        for p in ["plan", "action", "strategy", "approach", "implement", "execute"]
+    ):
+        return (
+            "**Thought**: I need to analyze this request and determine the best approach.\n\n"
+            "**Action**: Let me break this down into actionable steps:\n"
+            "1. Assess the current situation\n"
+            "2. Identify required resources and constraints\n"
+            "3. Develop a systematic plan\n"
+            "4. Execute with monitoring\n\n"
+            "**Observation**: This approach allows for systematic problem-solving with clear action items.\n\n"
+            "**Final Action**: Proceeding with the structured implementation plan."
+        )
+
+    if any(
+        p in message_lower
+        for p in ["analyze", "data", "pattern", "trend", "statistics"]
+    ):
+        return (
+            "Based on my analysis of the provided data, I can identify several key patterns:\n\n"
+            "- **Trend Analysis**: The data shows distinct patterns over time\n"
+            "- **Statistical Insights**: Key metrics indicate significant relationships\n"
+            "- **Pattern Recognition**: I've identified recurring themes and anomalies\n"
+            "- **Recommendations**: Based on this analysis, I suggest specific next steps"
+        )
+
+    if any(
+        p in message_lower
+        for p in ["create", "generate", "write", "compose", "design", "build"]
+    ):
+        return (
+            "I'll help you create that. Let me approach this systematically:\n\n"
+            "**Planning Phase**:\n- Understanding your requirements\n- Identifying key components needed\n\n"
+            "**Creation Process**:\n- Developing the core structure\n- Adding details and refinements\n\n"
+            "**Quality Assurance**:\n- Reviewing for completeness\n- Ensuring it meets your needs"
+        )
+
+    if "?" in message_lower or any(
+        p in message_lower
+        for p in ["what is", "how does", "why is", "when does", "where is"]
+    ):
+        return (
+            f"Regarding your question about '{original_message[:100]}...', here's a comprehensive answer:\n\n"
+            "The key points to understand are:\n"
+            "- **Primary concept**: This relates to fundamental principles\n"
+            "- **Practical application**: How this applies in real-world scenarios\n"
+            "- **Important considerations**: Factors to keep in mind\n"
+            "- **Next steps**: Recommendations for further exploration"
+        )
+
+    if any(
+        p in message_lower
+        for p in ["problem", "issue", "error", "fix", "solve", "troubleshoot"]
+    ):
+        return (
+            "I'll help you solve this problem systematically:\n\n"
+            "**Problem Analysis**:\n- Identifying the core issue\n- Understanding contributing factors\n\n"
+            "**Solution Development**:\n- Exploring potential approaches\n- Evaluating pros and cons\n\n"
+            "**Implementation Plan**:\n- Step-by-step resolution process\n- Monitoring and validation steps"
+        )
+
+    if any(
+        p in message_lower
+        for p in ["tool", "function", "call", "api", "service", "endpoint"]
+    ):
+        return (
+            "I'll help you with this tool/function call. Let me identify the appropriate tools "
+            "and execute them systematically:\n\n"
+            "**Tool Selection**: Identifying the best tools for this task\n"
+            "**Parameter Preparation**: Setting up the required parameters\n"
+            "**Execution**: Calling the tools with proper error handling\n"
+            "**Result Processing**: Interpreting and formatting the results\n\n"
+            "This ensures reliable tool execution with comprehensive error handling."
+        )
+
+    if any(
+        p in message_lower for p in ["code", "algorithm", "script", "program", "debug"]
+    ):
+        return (
+            "I'll help you with this technical implementation:\n\n"
+            "```\n# Technical solution approach\n"
+            "# 1. Understanding requirements\n"
+            "# 2. Designing the solution\n"
+            "# 3. Implementation details\n"
+            "# 4. Testing and validation\n```\n\n"
+            "This approach ensures robust, maintainable code with proper error handling."
+        )
+
+    if any(
+        p in message_lower
+        for p in ["explain", "teach", "learn", "understand", "clarify"]
+    ):
+        return (
+            "Let me explain this concept clearly:\n\n"
+            "**Foundation**: Starting with the basic principles\n"
+            "**Key Concepts**: The essential ideas you need to understand\n"
+            "**Examples**: Practical illustrations to make it concrete\n"
+            "**Application**: How to use this knowledge effectively\n\n"
+            "This explanation provides a solid foundation for understanding."
+        )
+
+    if any(
+        p in message_lower
+        for p in [
+            "argument",
+            "debate",
+            "position",
+            "for or against",
+            "key_points",
+            "evidence",
+            "argue about",
+            "topic to argue",
+        ]
+    ) or (
+        "topic" in message_lower
+        and ("for" in message_lower or "against" in message_lower)
+    ):
+        return json.dumps(
+            {
+                "argument": "This is a well-reasoned argument supporting the given position with logical analysis and evidence-based conclusions.",
+                "key_points": [
+                    "Point 1: Analysis of key factors",
+                    "Point 2: Supporting evidence and reasoning",
+                    "Point 3: Practical implications",
+                ],
+                "evidence": "Research and analysis support this position based on established principles and documented outcomes.",
+            }
+        )
+
+    if any(
+        p in message_lower
+        for p in ["judgment", "decision", "winner", "judge", "verdict"]
+    ):
+        return json.dumps(
+            {
+                "decision": "for",
+                "winner": "proponent",
+                "reasoning": "After careful analysis of both arguments, the proponent presented stronger evidence and more compelling logic.",
+                "confidence": 0.85,
+            }
+        )
+
+    if any(
+        p in message_lower
+        for p in ["rebuttal", "counterpoint", "counter argument", "rebut"]
+    ):
+        return json.dumps(
+            {
+                "rebuttal": "This rebuttal addresses the key weaknesses in the opposing argument with focused counterpoints.",
+                "counterpoints": [
+                    "Counter 1: Logical flaw in premise",
+                    "Counter 2: Missing evidence for claims",
+                    "Counter 3: Alternative interpretation",
+                ],
+                "strength": 0.75,
+            }
+        )
+
+    if any(
+        p in message_lower
+        for p in ["step1", "step2", "step3", "final_answer", "confidence"]
+    ):
+        return json.dumps(
+            {
+                "step1": "First, I identify and understand the problem components.",
+                "step2": "Next, I analyze the relevant factors and constraints.",
+                "step3": "Then, I develop a systematic approach to solve the problem.",
+                "step4": "I apply the method and verify intermediate results.",
+                "step5": "Finally, I synthesize the findings into a coherent answer.",
+                "final_answer": "Based on the step-by-step analysis, the answer is derived systematically.",
+                "confidence": 0.85,
+            }
+        )
+
+    if len(original_message) > 100:
+        return (
+            f"I understand you're asking about '{original_message[:100]}...'. "
+            "This is a complex topic that requires careful consideration of multiple factors. "
+            "Let me provide a thorough response that addresses your key concerns and offers actionable insights."
+        )
+    return (
+        f"I understand your request about '{original_message}'. "
+        "Based on the context and requirements, I can provide a comprehensive response "
+        "that addresses your specific needs with practical solutions and clear explanations."
+    )
+
+
+def _extract_last_user_message_and_conversation(
+    messages: List[Dict[str, Any]],
+) -> tuple[str, str, bool]:
+    """Port of the legacy MockProvider.chat() message-shape extraction.
+
+    Returns ``(last_user_message, conversation_text_lower, has_images)``.
+    Handles both plain-string ``content`` and multimodal
+    ``[{"type": "text"|"image"|"image_url", ...}]`` content lists.
+    """
+    full_conversation: List[str] = []
+    has_images = False
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else None
+        if role in ("user", "system", "assistant"):
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                text_parts: List[str] = []
+                for item in content:
+                    if not isinstance(item, dict):
+                        continue
+                    item_type = item.get("type")
+                    if item_type == "text":
+                        text_parts.append(item.get("text", ""))
+                    elif item_type in ("image", "image_url"):
+                        has_images = True
+                full_conversation.append(f"{role}: {' '.join(text_parts)}")
+            else:
+                full_conversation.append(f"{role}: {content}")
+
+    last_user_message = ""
+    for msg in reversed(messages):
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                text_parts = []
+                for item in content:
+                    if not isinstance(item, dict):
+                        continue
+                    item_type = item.get("type")
+                    if item_type == "text":
+                        text_parts.append(item.get("text", ""))
+                    elif item_type in ("image", "image_url"):
+                        has_images = True
+                last_user_message = " ".join(text_parts)
+            else:
+                last_user_message = (
+                    content if isinstance(content, str) else str(content)
+                )
+            break
+
+    conversation_text = " ".join(full_conversation).lower()
+    return last_user_message, conversation_text, has_images
+
+
+def _build_chat_completion_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a deterministic OpenAI ``chat.completion`` response body.
+
+    Consumed unchanged by ``kaizen.llm.wire_protocols.openai_chat.parse_response``.
+    """
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        raise UnsupportedMockRequest(
+            "MockLlmHttpClient: chat completion request missing a 'messages' "
+            f"list; got {type(messages).__name__ if messages is not None else 'None'}"
+        )
+    model = payload.get("model") or "mock-model"
+    last_user_message, conversation_text, has_images = (
+        _extract_last_user_message_and_conversation(messages)
+    )
+    message_lower = (last_user_message or "").lower()
+    response_content = _generate_contextual_response(
+        message_lower, conversation_text, has_images, last_user_message
+    )
+    deterministic_id = hashlib.md5(
+        f"{model}:{last_user_message}".encode("utf-8")
+    ).hexdigest()[:16]
+    completion_tokens = max(len(response_content) // 4, 1)
+    return {
+        "id": f"chatcmpl-mock-{deterministic_id}",
+        "object": "chat.completion",
+        "created": 1701234567,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": response_content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": completion_tokens,
+            "total_tokens": 100 + completion_tokens,
+        },
+    }
+
+
+def _split_preserving_whitespace(content: str) -> List[str]:
+    """Split ``content`` on whitespace boundaries, preserving separators, so
+    the concatenation of every returned piece reconstructs ``content``
+    byte-for-byte. Ported from the legacy ``MockProvider.stream_chat``.
+    """
+    pieces: List[str] = []
+    current = ""
+    for ch in content:
+        if ch.isspace() and current:
+            pieces.append(current)
+            current = ch
+        else:
+            current += ch
+    if current:
+        pieces.append(current)
+    if not pieces:
+        pieces = [content or ""]
+    return pieces
+
+
+# ---------------------------------------------------------------------------
+# Deterministic embeddings response builder.
+# ---------------------------------------------------------------------------
+
+
+def _deterministic_embedding(
+    model: str, text: str, dimensions: int, *, normalize: bool
+) -> List[float]:
+    """md5-seed a PER-CALL ``random.Random`` instance -- never the global
+    ``random`` module -- so this transport never perturbs another test's
+    randomness and stays deterministic under concurrent use.
+    """
+    seed_material = f"{model}:{text}".encode("utf-8")
+    seed = int(hashlib.md5(seed_material).hexdigest()[:8], 16)
+    rng = random.Random(seed)
+    vector = [rng.gauss(0.0, 1.0) for _ in range(dimensions)]
+    if normalize:
+        magnitude = sum(v * v for v in vector) ** 0.5
+        if magnitude > 0:
+            vector = [v / magnitude for v in vector]
+    return vector
+
+
+def _build_embeddings_response(
+    payload: Dict[str, Any], *, normalize: bool
+) -> Dict[str, Any]:
+    """Build a deterministic OpenAI ``embeddings`` response body.
+
+    Consumed unchanged by
+    ``kaizen.llm.wire_protocols.openai_embeddings.parse_response``.
+    """
+    texts = payload.get("input")
+    if not isinstance(texts, list) or not texts:
+        raise UnsupportedMockRequest(
+            "MockLlmHttpClient: embeddings request missing a non-empty "
+            f"'input' list; got {texts!r}"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise UnsupportedMockRequest(
+                f"MockLlmHttpClient: embeddings request 'input[{idx}]' must be "
+                f"str; got {type(t).__name__}"
+            )
+    model = payload.get("model") or "mock-embedding"
+    dimensions = payload.get("dimensions") or 1536
+    if not isinstance(dimensions, int) or dimensions <= 0:
+        raise UnsupportedMockRequest(
+            f"MockLlmHttpClient: embeddings request 'dimensions' must be a "
+            f"positive int; got {dimensions!r}"
+        )
+    data = []
+    for idx, text in enumerate(texts):
+        vector = _deterministic_embedding(model, text, dimensions, normalize=normalize)
+        data.append({"object": "embedding", "index": idx, "embedding": vector})
+    total_tokens = sum(max(len(t) // 4, 1) for t in texts)
+    return {
+        "object": "list",
+        "data": data,
+        "model": model,
+        "usage": {"prompt_tokens": total_tokens, "total_tokens": total_tokens},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Request-body extraction -- LlmClient.complete()/stream() pass a raw
+# `content=` byte-string body; LlmClient.embed() passes a `json=` dict.
+# Both are normalized to a plain dict here.
+# ---------------------------------------------------------------------------
+
+
+def _extract_request_payload(
+    *, content: Any = None, json_body: Any = None
+) -> Dict[str, Any]:
+    if json_body is not None:
+        if not isinstance(json_body, dict):
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient: json= body must be a dict; got "
+                f"{type(json_body).__name__}"
+            )
+        return json_body
+    if content is not None:
+        if isinstance(content, (bytes, bytearray)):
+            try:
+                decoded = content.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise UnsupportedMockRequest(
+                    "MockLlmHttpClient: content= body is not valid UTF-8"
+                ) from exc
+        elif isinstance(content, str):
+            decoded = content
+        else:
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient: content= body must be bytes or str; got "
+                f"{type(content).__name__}"
+            )
+        try:
+            obj = json.loads(decoded)
+        except ValueError as exc:
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient: content= body is not valid JSON"
+            ) from exc
+        if not isinstance(obj, dict):
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient: content= body must decode to a JSON object; "
+                f"got {type(obj).__name__}"
+            )
+        return obj
+    raise UnsupportedMockRequest(
+        "MockLlmHttpClient: request carries neither content= bytes nor a "
+        "json= dict -- cannot determine the response shape"
+    )
+
+
+def _url_path(url: str) -> str:
+    return url.split("?", 1)[0].rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# MockLlmHttpClient -- the offline in-process transport.
+# ---------------------------------------------------------------------------
+
+
+class MockLlmHttpClient:
+    """Deterministic, offline, in-process transport satisfying the same
+    async surface ``kaizen.llm.client.LlmClient`` calls on
+    ``kaizen.llm.http_client.LlmHttpClient``.
+
+    Constructed with NO real transport underneath -- ``post()`` / ``get()`` /
+    ``request()`` / ``stream_lines()`` never construct an
+    ``httpx.AsyncClient`` and never open a socket. Responses are built
+    in-process from ``httpx.Response(status_code=..., json=..., request=...)``
+    -- a pure Python object construction, not a network send.
+
+    Only the two shapes ``mock_preset()``'s ``WireProtocol.OpenAiChat``
+    deployment ever targets are supported: a chat-completions URL
+    (``.../chat/completions``) and an embeddings URL (``.../embeddings``).
+    Any other URL, or a request body ``MockLlmHttpClient`` cannot parse,
+    raises :class:`UnsupportedMockRequest` -- a typed error, never a
+    fabricated success response (``rules/zero-tolerance.md`` Rule 3).
+
+    Example::
+
+        from kaizen.llm import LlmClient
+        from kaizen.llm.testing import mock_preset, MockLlmHttpClient
+
+        client = LlmClient.from_deployment(mock_preset())
+        transport = MockLlmHttpClient()
+        result = await client.complete(
+            [{"role": "user", "content": "hello"}], http_client=transport,
+        )
+        assert result["text"]
+
+        vectors = await client.embed(["a", "b"], model="mock-embedding",
+                                      http_client=transport)
+        assert len(vectors) == 2
+    """
+
+    __slots__ = ("_closed", "_normalize")
+
+    def __init__(self, *, normalize: bool = True) -> None:
+        """``normalize``: L2-normalize embedding vectors (default ``True``,
+        matching the legacy ``MockProvider.embed`` contract). Set ``False``
+        to get raw (unnormalized) deterministic gaussian vectors -- useful
+        for tests asserting the normalization behavior itself.
+        """
+        self._closed = False
+        self._normalize = normalize
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    async def __aenter__(self) -> "MockLlmHttpClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Idempotent close -- mirrors ``LlmHttpClient.aclose()``."""
+        self._closed = True
+
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self.request("GET", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await self.request("POST", url, **kwargs)
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        content: Any = None,
+        auth_strategy_kind: Optional[str] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Build an in-process ``httpx.Response`` -- NO network I/O.
+
+        Mirrors ``LlmHttpClient.request()``'s signature. ``**kwargs`` may
+        carry ``json=`` (used by ``LlmClient.embed()``); ``content=`` (used
+        by ``LlmClient.complete()`` / ``stream()``) is a named parameter for
+        signature parity with the production client.
+        """
+        if self._closed:
+            raise RuntimeError(
+                "MockLlmHttpClient is closed; cannot issue new requests "
+                "(construct a new instance or avoid aclose() before reuse)"
+            )
+        if method.upper() != "GET":
+            payload = _extract_request_payload(
+                content=content, json_body=kwargs.get("json")
+            )
+            path = _url_path(url)
+            if path.endswith("/embeddings"):
+                body = _build_embeddings_response(payload, normalize=self._normalize)
+            elif path.endswith("/chat/completions"):
+                body = _build_chat_completion_response(payload)
+            else:
+                raise UnsupportedMockRequest(
+                    "MockLlmHttpClient does not support the requested endpoint "
+                    f"shape: {url!r}. Supported: '.../chat/completions' (OpenAI "
+                    "chat) and '.../embeddings' (OpenAI embeddings) -- the two "
+                    "shapes produced by mock_preset()'s WireProtocol.OpenAiChat "
+                    "deployment."
+                )
+        else:
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient does not support GET requests -- no "
+                "production kaizen.llm code path issues a GET through "
+                "LlmHttpClient today"
+            )
+        request_obj = httpx.Request(
+            method, url, headers=dict(headers) if headers else None
+        )
+        return httpx.Response(200, json=body, request=request_obj)
+
+    async def stream_lines(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        content: Any = None,
+        auth_strategy_kind: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Yield deterministic SSE ``data: {json}`` lines -- NO network I/O.
+
+        The concatenation of every yielded chunk's ``choices[0].delta.content``
+        reconstructs the SAME chat text ``request()``/``post()`` would return
+        for an equivalent non-streaming request against the same payload.
+        Terminates with a bare ``data: [DONE]`` sentinel line, matching the
+        OpenAI SSE contract ``kaizen.llm.client._parse_stream_line`` expects
+        (it strips the ``data:`` prefix and skips ``[DONE]``).
+        """
+        if self._closed:
+            raise RuntimeError(
+                "MockLlmHttpClient is closed; cannot issue new requests "
+                "(construct a new instance or avoid aclose() before reuse)"
+            )
+        payload = _extract_request_payload(
+            content=content, json_body=kwargs.get("json")
+        )
+        path = _url_path(url)
+        if not path.endswith("/chat/completions"):
+            raise UnsupportedMockRequest(
+                "MockLlmHttpClient.stream_lines only supports a "
+                f"'.../chat/completions' URL; got {url!r}"
+            )
+        chat_response = _build_chat_completion_response(payload)
+        full_content = chat_response["choices"][0]["message"]["content"]
+        model = chat_response["model"]
+        response_id = chat_response["id"]
+        created = chat_response["created"]
+
+        for piece in _split_preserving_whitespace(full_content):
+            chunk = {
+                "id": response_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {"index": 0, "delta": {"content": piece}, "finish_reason": None}
+                ],
+            }
+            yield f"data: {json.dumps(chunk)}"
+
+        final_chunk = {
+            "id": response_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": chat_response["usage"],
+        }
+        yield f"data: {json.dumps(final_chunk)}"
+        yield "data: [DONE]"
+
+
+__all__ = ["MockLlmHttpClient", "UnsupportedMockRequest"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/_content_parts.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/_content_parts.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical multimodal content-part translator (#1720 Wave-1b).
+
+The canonical content-part shape carried inside ``messages[i]["content"]``
+is OpenAI-shaped: a list of parts like ``{"type": "text", "text": ...}``
+and ``{"type": "image_url", "image_url": {"url": ...}}`` where the url is
+EITHER a base64 data-URI (``data:<media_type>;base64,<data>``) OR a remote
+``http(s)`` url.
+
+``openai_chat`` and ``mistral_chat`` pass this canonical shape through
+verbatim — no translation needed, because it already IS their wire shape.
+The three vision-capable non-OpenAI wires (``anthropic_messages``,
+``google_generate_content``, ``ollama_native``) each speak a DIFFERENT
+native image shape and translate via the functions in this module. The
+text-only wires (e.g. ``cohere_generate``) do not translate — they WARN and
+drop, per the observability contract (see ``cohere_generate`` module docs).
+
+This module is a pure, dumb-data translator: no I/O, no network, no
+provider SDK calls, and no LLM/keyword reasoning. Classifying a content
+part (text vs image, data-URI vs remote URL) is a STRUCTURAL data-format
+operation on a typed dict — parsing a well-known key/value shape, not
+natural-language reasoning about user intent — which is the "tool result
+parsing / output formatting" exception permitted by
+``rules/agent-reasoning.md`` § Permitted Deterministic Logic.
+
+Cross-SDK parity: this module's classification + per-target emission is
+intended to match the Rust SDK's equivalent multimodal translator shape.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+__all__ = [
+    "TextPart",
+    "ImagePart",
+    "ContentPart",
+    "parse_data_uri",
+    "is_remote_url",
+    "parse_content_part",
+    "guess_media_type",
+    "to_anthropic_block",
+    "to_gemini_part",
+    "to_ollama_images",
+]
+
+
+@dataclass(frozen=True)
+class TextPart:
+    """A plain text content part (``{"type": "text", "text": ...}``)."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ImagePart:
+    """Intermediate representation of an OpenAI ``image_url`` content part.
+
+    Exactly one of two shapes is populated, discriminated by
+    ``is_data_uri``:
+
+    * data-URI (``is_data_uri=True``) — ``media_type`` + ``data`` (the
+      base64 payload) are set; ``url`` is ``None``.
+    * remote http(s) URL (``is_data_uri=False``) — ``url`` is set;
+      ``media_type`` + ``data`` are ``None``.
+    """
+
+    is_data_uri: bool
+    media_type: Optional[str] = None
+    data: Optional[str] = None
+    url: Optional[str] = None
+
+
+ContentPart = Union[TextPart, ImagePart]
+
+
+def parse_data_uri(uri: str) -> Optional[Tuple[str, str]]:
+    """Split a ``data:<media_type>;base64,<data>`` URI into (media_type, data).
+
+    Returns ``None`` when ``uri`` is not a well-formed base64 data URI
+    (missing the ``data:`` scheme, missing the ``;base64,`` separator, or
+    either half empty). Pure string parsing only — the base64 payload
+    itself is never decoded or validated here; that is the receiving
+    provider's concern.
+    """
+    if not isinstance(uri, str) or not uri.startswith("data:"):
+        return None
+    rest = uri[len("data:") :]
+    if ";base64," not in rest:
+        return None
+    media_type, _, data = rest.partition(";base64,")
+    if not media_type or not data:
+        return None
+    return media_type, data
+
+
+def is_remote_url(url: str) -> bool:
+    """True when ``url`` is a remote ``http(s)`` URL (not a data URI)."""
+    return isinstance(url, str) and (
+        url.startswith("http://") or url.startswith("https://")
+    )
+
+
+def parse_content_part(block: Any) -> Optional[ContentPart]:
+    """Classify one OpenAI-shaped content-part dict into the intermediate form.
+
+    Recognizes:
+
+    * ``{"type": "text", "text": ...}`` -> :class:`TextPart`
+    * ``{"type": "image_url", "image_url": {"url": <data-URI or http(s)>}}``
+      -> :class:`ImagePart`
+
+    Returns ``None`` for any other shape (an unrecognized block type, a
+    malformed ``image_url`` sub-dict, or a url that is neither a base64
+    data-URI nor a remote http(s) url) — callers pass such blocks through
+    unchanged rather than treating ``None`` as an error.
+    """
+    if not isinstance(block, dict):
+        return None
+    block_type = block.get("type")
+    if block_type == "text":
+        text = block.get("text", "")
+        return TextPart(text=text if isinstance(text, str) else "")
+    if block_type == "image_url":
+        image_url = block.get("image_url")
+        url = image_url.get("url") if isinstance(image_url, dict) else None
+        if not isinstance(url, str):
+            return None
+        parsed = parse_data_uri(url)
+        if parsed is not None:
+            media_type, data = parsed
+            return ImagePart(is_data_uri=True, media_type=media_type, data=data)
+        if is_remote_url(url):
+            return ImagePart(is_data_uri=False, url=url)
+        return None
+    return None
+
+
+def guess_media_type(url: str) -> str:
+    """Best-effort MIME type guess for a remote image URL, from its extension.
+
+    Falls back to ``application/octet-stream`` when the extension is
+    unrecognized or absent. A remote ``http(s)`` image_url carries no
+    media-type metadata in the canonical OpenAI shape, yet Gemini's
+    ``fileData`` part requires a ``mimeType`` field — this is the
+    deterministic, structural guess (extension lookup only; no content
+    inspection, no network fetch).
+    """
+    guessed, _ = mimetypes.guess_type(url)
+    return guessed or "application/octet-stream"
+
+
+# --- Per-target emitters -----------------------------------------------
+
+
+def to_anthropic_block(part: ImagePart) -> Dict[str, Any]:
+    """Convert an :class:`ImagePart` to an Anthropic ``image`` content block.
+
+    Data-URI -> ``{"type": "image", "source": {"type": "base64",
+    "media_type": ..., "data": ...}}``. Remote url -> ``{"type": "image",
+    "source": {"type": "url", "url": ...}}`` (Anthropic's ``/v1/messages``
+    natively supports a ``url``-sourced image block).
+    """
+    if part.is_data_uri:
+        return {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": part.media_type,
+                "data": part.data,
+            },
+        }
+    return {
+        "type": "image",
+        "source": {"type": "url", "url": part.url},
+    }
+
+
+def to_gemini_part(part: ImagePart) -> Dict[str, Any]:
+    """Convert an :class:`ImagePart` to a Gemini ``inlineData``/``fileData`` part.
+
+    Data-URI -> ``{"inlineData": {"mimeType": ..., "data": ...}}``. Remote
+    url -> ``{"fileData": {"mimeType": ..., "fileUri": ...}}`` (Gemini
+    requires ``mimeType`` even for a ``fileData`` reference; see
+    :func:`guess_media_type`).
+    """
+    if part.is_data_uri:
+        return {"inlineData": {"mimeType": part.media_type, "data": part.data}}
+    return {
+        "fileData": {
+            "mimeType": guess_media_type(part.url or ""),
+            "fileUri": part.url,
+        }
+    }
+
+
+def to_ollama_images(parts: List[ImagePart]) -> List[str]:
+    """Convert data-URI :class:`ImagePart` entries to Ollama-native's ``images`` field.
+
+    Ollama's per-message ``images`` field is a bare list of base64 strings
+    (no media-type wrapper, no data-URI prefix) — so only data-URI parts
+    contribute an entry. A remote-URL :class:`ImagePart` has no base64
+    payload to emit here; fetching a remote image over the network is an
+    I/O operation and is explicitly out of scope for this pure translator
+    (callers that need remote-image support for Ollama MUST fetch and
+    re-encode BEFORE calling this function, and MUST log the drop when
+    they do not — see ``ollama_native.build_request_payload``).
+    """
+    return [p.data for p in parts if p.is_data_uri and p.data is not None]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/anthropic_messages.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any, Dict, List
 
 from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import _content_parts
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,51 @@ def _partition_messages(
     return system, rest
 
 
+def _translate_content_to_anthropic(content: Any) -> Any:
+    """Translate an OpenAI-shaped ``content`` field into Anthropic blocks.
+
+    A bare string passes through unchanged (Anthropic accepts a plain
+    string exactly like OpenAI). A content-part LIST is walked; any
+    ``image_url`` part is translated via ``_content_parts`` into
+    Anthropic's native ``image`` block (base64 ``source`` for a data-URI,
+    ``url`` ``source`` for a remote http(s) url); every other block
+    (``text``, or any block this translator does not recognize) passes
+    through unchanged. Returns the ORIGINAL ``content`` object when no
+    ``image_url`` part is present, so a text-only message stays
+    byte-identical to the pre-Wave-1b (multimodal) shape.
+    """
+    if not isinstance(content, list):
+        return content
+    translated: List[Any] = []
+    changed = False
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "image_url":
+            part = _content_parts.parse_content_part(block)
+            if isinstance(part, _content_parts.ImagePart):
+                translated.append(_content_parts.to_anthropic_block(part))
+                changed = True
+                continue
+        translated.append(block)
+    return translated if changed else content
+
+
+def _translate_message_to_anthropic(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``msg`` with its ``content`` translated for Anthropic.
+
+    Returns the ORIGINAL message dict (not a copy) when translation makes
+    no change, so a text-only request's message list stays identical
+    (same object identity for unchanged messages) to the pre-Wave-1b
+    output.
+    """
+    content = msg.get("content")
+    translated_content = _translate_content_to_anthropic(content)
+    if translated_content is content:
+        return msg
+    new_msg = dict(msg)
+    new_msg["content"] = translated_content
+    return new_msg
+
+
 def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     """Build the ``/v1/messages`` request body for Anthropic.
 
@@ -118,6 +164,9 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         raise TypeError("build_request_payload expects a CompletionRequest")
 
     system, rest = _partition_messages(request.messages)
+    # Wave-1b multimodal translation (image_url -> Anthropic image block),
+    # BEFORE setting payload["messages"] below (per the four-axis contract).
+    rest = [_translate_message_to_anthropic(msg) for msg in rest]
 
     max_tokens = (
         request.max_tokens if request.max_tokens is not None else _DEFAULT_MAX_TOKENS

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
@@ -161,6 +161,16 @@ def _build_mistral(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
     # body — this is the one native family with a documented structured
     # tools field. Guard on truthiness so an explicitly-set EMPTY list
     # (`tools=[]`) emits nothing (matches the sibling wire adapters).
+    #
+    # /redteam Round-1 (#1720 Wave-1b, documentation only, cross-provider-
+    # shape verify item): this `tools`/`tool_choice` body shape targets
+    # Mistral's OWN documented function-calling format, carried verbatim
+    # through Bedrock's InvokeModel body. Whether Bedrock actually routes
+    # tool-use for the mistral.* family via InvokeModel (this body) vs
+    # requires the separate Converse API is NOT independently verified
+    # against live AWS docs in this shard — flagged for verification before
+    # production reliance. No behavior change; no consumer of this path
+    # exists yet in this shard.
     if request.tools:
         body["tools"] = list(request.tools)
         tool_choice = request.tool_choice

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/bedrock_invoke.py
@@ -23,10 +23,19 @@ reasoning: the prefix dispatch routes on a provider-catalogue-defined model
 id, exactly the structural dispatch ``rules/agent-reasoning.md`` permits.
 
 See https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html.
+
+#1720 Wave-1b tool/tool_choice emission + tool_call parsing is added
+PER-FAMILY, conservatively (OMIT-DON'T-FAKE): only ``mistral.*`` has a
+documented ``tools``/``tool_choice`` field on the native InvokeModel body;
+``meta.*`` / ``amazon.*`` / ``cohere.*`` have none documented for the body
+shapes this shaper builds, so tools are deliberately OMITTED for those
+families (see the per-builder comments below for the family-specific
+rationale) rather than emitting a fake/speculative key.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Callable, Dict, List
 
@@ -39,12 +48,16 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_TOKENS = 512
 
 
-def _flatten_prompt(messages: List[Dict[str, Any]]) -> str:
+def _flatten_prompt(messages: List[Dict[str, Any]], family: str = "unknown") -> str:
     """Render OpenAI-style messages as a single prompt string.
 
     The native Bedrock (non-Anthropic) invoke schemas take a flat ``prompt``
     string, not a message array. Uses the widely-supported
     ``[ROLE] content`` convention and trails an ``[ASSISTANT]`` cue.
+
+    ``family`` (the Bedrock family label — "meta"/"amazon"/"mistral"/"cohere")
+    is used only to name the vision-unsupported family in the dropped-block
+    WARN log below; it does not affect the rendered prompt.
     """
     parts: List[str] = []
     for msg in messages:
@@ -57,6 +70,28 @@ def _flatten_prompt(messages: List[Dict[str, Any]]) -> str:
                     text_blocks.append(block.get("text", ""))
                 elif isinstance(block, str):
                     text_blocks.append(block)
+                else:
+                    # #1720 Wave-1b: an image or other non-text content block
+                    # cannot be represented in the flat `prompt` string these
+                    # native (non-Anthropic) Bedrock families accept — none of
+                    # meta./amazon./mistral./cohere. InvokeModel bodies this
+                    # shaper builds support multi-modal content. Previously
+                    # this was silently dropped; now it is a structured WARN
+                    # (observability.md Rule 7 / zero-tolerance Rule 3 — no
+                    # silent drops) naming the family as vision-unsupported.
+                    dropped_type = (
+                        block.get("type")
+                        if isinstance(block, dict)
+                        else type(block).__name__
+                    )
+                    logger.warning(
+                        "bedrock_invoke.non_text_block_dropped",
+                        extra={
+                            "family": family,
+                            "block_type": dropped_type,
+                            "reason": "vision_unsupported",
+                        },
+                    )
             content = "".join(text_blocks)
         parts.append(f"[{role}] {content}")
     parts.append("[ASSISTANT] ")
@@ -72,6 +107,15 @@ def _build_llama(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
         body["temperature"] = request.temperature
     if request.top_p is not None:
         body["top_p"] = request.top_p
+    # --- #1720 Wave-1b: tools deliberately OMITTED ---
+    # Bedrock's native Llama InvokeModel body has NO documented `tools` field
+    # (https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html)
+    # — the body is just {"prompt", "max_gen_len", "temperature", "top_p"}.
+    # Llama tool-use on Bedrock is prompt-level (the caller embeds tool
+    # definitions and instructions directly into the flattened prompt text);
+    # there is no structured wire field to populate. Emitting a fake `tools`
+    # key here would advertise a capability the InvokeModel API does not have
+    # (zero-tolerance Rule 2: no fake/speculative capability).
     return body
 
 
@@ -89,6 +133,13 @@ def _build_titan(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
         config["topP"] = request.top_p
     if request.stop:
         config["stopSequences"] = list(request.stop)
+    # --- #1720 Wave-1b: tools deliberately OMITTED ---
+    # Bedrock's native Titan InvokeModel body
+    # (https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html)
+    # has NO tools / function-calling field at all — Titan text models have no
+    # documented tool-use capability on Bedrock. Emitting a `tools` key would
+    # be a wholly fabricated feature the model/API does not support
+    # (zero-tolerance Rule 2: no fake/speculative capability).
     return {"inputText": prompt, "textGenerationConfig": config}
 
 
@@ -102,6 +153,37 @@ def _build_mistral(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
         body["top_p"] = request.top_p
     if request.stop:
         body["stop"] = list(request.stop)
+
+    # --- #1720 Wave-1b tool emission (Bedrock Mistral InvokeModel) ---
+    # Unlike Llama/Titan/Cohere above/below, Bedrock's native InvokeModel body
+    # for Mistral models (Mistral Large et al.) DOES accept the OpenAI-shaped
+    # `tools` list + a `tool_choice` string/object verbatim in the request
+    # body — this is the one native family with a documented structured
+    # tools field. Guard on truthiness so an explicitly-set EMPTY list
+    # (`tools=[]`) emits nothing (matches the sibling wire adapters).
+    if request.tools:
+        body["tools"] = list(request.tools)
+        tool_choice = request.tool_choice
+        # Mistral's Bedrock tool_choice vocabulary matches the direct Mistral
+        # API (mistral_chat.py): force-a-tool is "any" (NOT OpenAI's
+        # "required"). Map "required"->"any"; "auto"/"none"/"any" pass
+        # through; an unknown string falls back to the safe forced default
+        # "any". A dict is a named-tool forced selection and passes through
+        # verbatim (Mistral accepts the OpenAI-shaped object form). When
+        # tools are present but tool_choice is unset, default to "any" — the
+        # pinned Wave-1a legacy "force a tool"-when-tools default, expressed
+        # in Mistral's vocabulary (mirrors mistral_chat.py exactly).
+        if tool_choice is None:
+            body["tool_choice"] = "any"
+        elif isinstance(tool_choice, str):
+            if tool_choice == "required":
+                body["tool_choice"] = "any"
+            elif tool_choice in ("auto", "none", "any"):
+                body["tool_choice"] = tool_choice
+            else:
+                body["tool_choice"] = "any"
+        else:
+            body["tool_choice"] = tool_choice
     return body
 
 
@@ -115,6 +197,19 @@ def _build_cohere(request: CompletionRequest, prompt: str) -> Dict[str, Any]:
         body["p"] = request.top_p
     if request.stop:
         body["stop_sequences"] = list(request.stop)
+    # --- #1720 Wave-1b: tools deliberately OMITTED ---
+    # This builder targets Bedrock's classic Cohere Command InvokeModel body
+    # (prompt/max_tokens/temperature/p/stop_sequences — see the module
+    # docstring), which has no documented `tools` field
+    # (https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html).
+    # Cohere tool-use on Bedrock exists only for Command R / Command R+
+    # models via an entirely different chat-shaped InvokeModel body
+    # (`message` + `chat_history` + `tools` + `tool_results`, NOT `prompt`)
+    # that this conservative, prompt-based shard does not build. Emitting a
+    # `tools` key onto this prompt-based body would be silently ignored on
+    # a real classic-Command model and a malformed/rejected request on a
+    # Command R model — either way a fake/speculative capability, so it is
+    # deliberately omitted rather than guessed (zero-tolerance Rule 2).
     return body
 
 
@@ -127,11 +222,20 @@ _FAMILY_BUILDERS: Dict[str, Callable[[CompletionRequest, str], Dict[str, Any]]] 
     "cohere.": _build_cohere,
 }
 
+# Prefix → short family label, used only for the vision-unsupported log
+# context in _flatten_prompt (#1720 Wave-1b) — not part of the wire payload.
+_FAMILY_LABELS: Dict[str, str] = {
+    "meta.": "meta",
+    "amazon.": "amazon",
+    "mistral.": "mistral",
+    "cohere.": "cohere",
+}
+
 
 def _select_builder(
     model: str,
-) -> Callable[[CompletionRequest, str], Dict[str, Any]]:
-    """Pick the family body builder from the on-wire model-id prefix.
+) -> tuple[str, Callable[[CompletionRequest, str], Dict[str, Any]]]:
+    """Pick the family label + body builder from the on-wire model-id prefix.
 
     Bedrock inference-profile ids may carry a region prefix
     (``us.meta.llama3-...``); strip a leading ``<region>.`` segment before
@@ -143,14 +247,14 @@ def _select_builder(
             candidate.startswith(family_prefix)
             or f".{family_prefix}" in f".{candidate}"
         ):
-            return builder
+            return _FAMILY_LABELS[family_prefix], builder
     # Strip a single leading dotted segment (region for inference profiles)
     # and retry once.
     if "." in candidate:
         stripped = candidate.split(".", 1)[1]
         for family_prefix, builder in _FAMILY_BUILDERS.items():
             if stripped.startswith(family_prefix):
-                return builder
+                return _FAMILY_LABELS[family_prefix], builder
     raise ValueError(
         "bedrock_invoke.build_request_payload: could not map model id to a "
         "Bedrock family (expected a meta./amazon./mistral./cohere. prefix)"
@@ -167,9 +271,44 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     """
     if not isinstance(request, CompletionRequest):
         raise TypeError("build_request_payload expects a CompletionRequest")
-    prompt = _flatten_prompt(request.messages)
-    builder = _select_builder(request.model)
+    family, builder = _select_builder(request.model)
+    prompt = _flatten_prompt(request.messages, family=family)
     return builder(request, prompt)
+
+
+def _normalize_mistral_tool_call(tc: Dict[str, Any], index: int) -> Dict[str, Any]:
+    """Coerce one Bedrock-Mistral ``outputs[0].tool_calls`` entry into the
+    canonical normalized shape (shared with the openai/anthropic/google/
+    mistral_chat shards)::
+
+        {"id": <str>, "type": "function",
+         "function": {"name": <str>, "arguments": <str: JSON-encoded>}}
+
+    Bedrock's Mistral tool-call entries mirror the direct Mistral API's
+    OpenAI-shaped ``{"id", "function": {"name", "arguments"}}`` form, where
+    ``arguments`` is already a JSON string (see mistral_chat.py's
+    ``_normalize_tool_call``). Defensively coerce a dict/list ``arguments``
+    via ``json.dumps`` so the canonical "arguments is a JSON string"
+    invariant holds, and synthesize ``call_{index}`` when the provider omits
+    an id. Rebuilds a plain JSON-serializable dict so no provider SDK object
+    leaks into the parsed result.
+    """
+    function = tc.get("function")
+    function = function if isinstance(function, dict) else {}
+    arguments = function.get("arguments")
+    if isinstance(arguments, (dict, list)):
+        arguments = json.dumps(arguments)
+    call_id = tc.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        call_id = f"call_{index}"
+    return {
+        "id": call_id,
+        "type": tc.get("type", "function"),
+        "function": {
+            "name": function.get("name"),
+            "arguments": arguments,
+        },
+    }
 
 
 def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -179,8 +318,14 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     * Llama:   ``{"generation": "...", "prompt_token_count", "generation_token_count", "stop_reason"}``
     * Titan:   ``{"results": [{"outputText": "...", "completionReason": "..."}], "inputTextTokenCount"}``
-    * Mistral: ``{"outputs": [{"text": "...", "stop_reason": "..."}]}``
+    * Mistral: ``{"outputs": [{"text": "...", "stop_reason": "...", "tool_calls": [...]}]}``
     * Cohere:  ``{"generations": [{"text": "...", "finish_reason": "..."}]}``
+
+    #1720 Wave-1b: Mistral's ``outputs[0].tool_calls`` (present only for the
+    one native family with documented Bedrock tool support — see
+    ``_build_mistral``) is normalized into the canonical ``tool_calls`` shape
+    and surfaced under the ``"tool_calls"`` key ONLY when present, so a
+    plain-text response stays byte-identical to the pre-Wave-1b parsed shape.
     """
     if not isinstance(payload, dict):
         raise TypeError("parse_response expects a dict payload")
@@ -189,6 +334,7 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
     stop_reason: Any = None
     input_tokens: Any = None
     output_tokens: Any = None
+    tool_calls: Any = None
 
     if "generation" in payload:  # Llama
         gen = payload.get("generation")
@@ -215,6 +361,17 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
             if isinstance(out, str):
                 text = out
             stop_reason = first.get("stop_reason")
+            # #1720 Wave-1b: surface tool calls. Bedrock's Mistral InvokeModel
+            # response carries tool calls as `outputs[0].tool_calls` (a sibling
+            # key to `text`/`stop_reason`, the one native family with
+            # documented Bedrock tool support — see _build_mistral).
+            raw_tool_calls = first.get("tool_calls")
+            if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                tool_calls = [
+                    _normalize_mistral_tool_call(tc, i)
+                    for i, tc in enumerate(raw_tool_calls)
+                    if isinstance(tc, dict)
+                ]
     elif "generations" in payload:  # Cohere
         generations = payload.get("generations", []) or []
         if generations and isinstance(generations[0], dict):
@@ -224,7 +381,7 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
                 text = out
             stop_reason = first.get("finish_reason")
 
-    return {
+    result: Dict[str, Any] = {
         "text": text,
         "usage": {
             "input_tokens": input_tokens,
@@ -233,6 +390,9 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
         "stop_reason": stop_reason,
         "model": None,
     }
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    return result
 
 
 __all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_embeddings.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cohere Embeddings wire protocol shaper (#1720 Wave-1b EMBED-REMAINDER).
+
+Shapes the on-the-wire request/response for Cohere's ``POST /v1/embed``
+endpoint. Consumed by ``LlmClient.embed(...)`` via its Cohere dispatch path
+(``WireProtocol.CohereGenerate`` -- Cohere speaks one wire family across both
+chat AND embeddings; ``cohere_generate.py`` owns the ``/v1/chat`` shape, this
+module owns ``/v1/embed``).
+
+Request schema (Cohere v1 documented contract):
+
+* ``model`` (str)   -- required; e.g. ``"embed-english-v3.0"``.
+* ``texts`` (list of str)  -- required; one or more strings to embed. The
+  helper rejects empty lists at ``build_request_payload`` time to give a
+  typed error at the shaper boundary rather than a 400 from Cohere.
+* ``input_type`` (str, optional) -- REQUIRED by Cohere embed v3 models
+  (``search_document`` | ``search_query`` | ``classification`` |
+  ``clustering``); omitted for legacy (v2 and earlier) models that do not
+  accept it. Sourced from ``EmbedOptions.input_type`` -- emitted only when
+  the caller sets it, so a v2-model caller who never sets ``input_type``
+  gets a payload Cohere's v2 models accept unchanged.
+* ``truncate`` is deliberately NOT exposed here: ``EmbedOptions`` carries no
+  field for it (only ``dimensions`` / ``user`` / ``input_type`` /
+  ``normalize`` are cross-provider-shared today per #1720 Wave-1a) and
+  Cohere's server-side default (``END``) is a reasonable behavior for every
+  caller who does not opt in. Supporting it would mean growing the shared
+  ``EmbedOptions`` shape without a driving cross-SDK use case -- a follow-up
+  concern, not this shard's.
+
+Cohere's ``/v1/embed`` endpoint does NOT accept ``dimensions`` (vector size
+is fixed per model, unlike OpenAI's ``text-embedding-3-*`` family) or
+``user`` (no per-request caller-identifier concept on this endpoint) --
+both ``EmbedOptions`` fields are silently NOT emitted for this wire,
+matching Ollama's documented-contract-not-Kaizen-invention precedent in
+``ollama_embeddings.py``.
+
+Response schema (Cohere v1 documented contract):
+
+    {
+      "id": "...",
+      "texts": ["hello", "world"],
+      "embeddings": [[0.1, ...], [0.2, ...]],
+      "meta": {
+        "api_version": {"version": "1"},
+        "billed_units": {"input_tokens": 10}
+      },
+      "response_type": "embeddings_floats"
+    }
+
+``parse_response`` extracts the normalized ``{vectors, model, usage}`` view.
+Unlike OpenAI's ``data[].index``-ordered array, Cohere's ``embeddings`` list
+is returned in REQUEST order with no per-item index -- no sort is applied
+(same contract as ``ollama_embeddings.py``).
+
+Cross-SDK parity: this shaper's output for a fixed input is intended to be
+byte-identical to the kailash-rs Cohere embeddings payload builder. Per
+`rules/cross-sdk-inspection.md` Rule 4, at least one deterministic
+byte-shape pin test is committed in the Tier-1 suite
+(``tests/unit/llm/test_embed_remainder_shapers.py``); full sibling-SDK
+byte-vector pinning against the Rust SDK's ACTUAL output is NOT landed as
+of this shard (Wave-1b EMBED-REMAINDER) -- flagged as a follow-up cross-SDK
+lockstep item, not a blocking gap for this shard's scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+
+
+def build_request_payload(
+    texts: List[str],
+    model: str,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Build the ``/v1/embed`` request body for Cohere.
+
+    Mirrors ``openai_embeddings.build_request_payload``'s rejection
+    contract exactly:
+
+    * Rejects ``texts=[]`` with ``ValueError`` at the shaper boundary so
+      the caller gets a typed error before the HTTP round-trip.
+    * Rejects non-string elements in ``texts`` so a caller passing, e.g.,
+      ``[b"bytes"]`` fails with a shape error rather than a 400 echoing
+      the raw bytes.
+    * ``input_type`` is only written to the payload when the caller
+      actually set ``options.input_type`` -- callers targeting a v2 model
+      that rejects the field do NOT get a silent addition.
+    """
+    if not isinstance(texts, list):
+        raise TypeError(
+            f"build_request_payload expects texts: list[str]; got {type(texts).__name__}"
+        )
+    if not texts:
+        raise ValueError(
+            "build_request_payload requires at least one text; got empty list"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise TypeError(f"texts[{idx}] must be str; got {type(t).__name__}")
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            "build_request_payload requires a non-empty model string — "
+            "read from os.environ['COHERE_EMBEDDING_MODEL'] per rules/env-models.md"
+        )
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "texts": list(texts),
+    }
+    if options is not None:
+        if not isinstance(options, EmbedOptions):
+            raise TypeError(
+                f"options must be EmbedOptions; got {type(options).__name__}"
+            )
+        if options.input_type is not None:
+            payload["input_type"] = options.input_type
+    return payload
+
+
+def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract ``{vectors, model, usage}`` from a Cohere ``/v1/embed`` response.
+
+    Raises ``InvalidResponse`` with a stable ``reason`` when the payload
+    shape violates the documented contract. ``embeddings`` is returned in
+    request order (no per-item index field on this endpoint), so no sort
+    is applied -- unlike ``openai_embeddings.parse_response``.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"parse_response expects a dict payload; got {type(payload).__name__}"
+        )
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list):
+        raise InvalidResponse("cohere_embeddings: missing or non-list 'embeddings'")
+
+    vectors: List[List[float]] = []
+    for item in embeddings:
+        if not isinstance(item, list):
+            raise InvalidResponse("cohere_embeddings: 'embeddings' entry is not a list")
+        for v in item:
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
+                raise InvalidResponse(
+                    "cohere_embeddings: 'embeddings' entry contains non-numeric value"
+                )
+        vectors.append([float(v) for v in item])
+
+    meta = payload.get("meta") or {}
+    billed_units = meta.get("billed_units", {}) if isinstance(meta, dict) else {}
+    input_tokens = (
+        billed_units.get("input_tokens") if isinstance(billed_units, dict) else None
+    )
+    return {
+        "vectors": vectors,
+        "model": payload.get("model"),
+        "usage": {
+            "input_tokens": input_tokens,
+            # Cohere's embed endpoint reports one billed-units figure
+            # (input_tokens) -- there is no separate embedding "output" to
+            # bill, so total_tokens mirrors input_tokens (same convention
+            # as ollama_embeddings.parse_response's single-count usage).
+            "total_tokens": input_tokens,
+        },
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_generate.py
@@ -51,8 +51,13 @@ def _content_to_str(content: Any) -> str:
     """Flatten a message's ``content`` into a plain string.
 
     Cohere's chat_history entries take a single string per turn; content
-    blocks (vision) are not supported on this endpoint, so we concatenate
-    any text blocks and drop non-text blocks with a debug log.
+    blocks (vision, e.g. an OpenAI-shaped ``image_url`` part) are NOT
+    supported on this endpoint (Cohere v1 ``/chat`` is text-only) — we
+    concatenate any text blocks and drop non-text blocks. #1720 Wave-1b:
+    the drop is a WARNING (never DEBUG/silent) — a caller that sent an
+    image expects it to be seen; silently downgrading to DEBUG would hide
+    a real capability gap. See ``rules/observability.md`` Rule 7 /
+    zero-tolerance Rule 3 (no silent fallback).
     """
     if isinstance(content, str):
         return content
@@ -64,9 +69,13 @@ def _content_to_str(content: Any) -> str:
             elif isinstance(block, str):
                 parts.append(block)
             else:
-                logger.debug(
+                block_type = block.get("type") if isinstance(block, dict) else None
+                logger.warning(
                     "cohere_generate.non_text_block_dropped",
-                    extra={"block_type": type(block).__name__},
+                    extra={
+                        "block_type": type(block).__name__,
+                        "content_type": block_type,
+                    },
                 )
         return "".join(parts)
     return str(content)

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any, Dict, List
 
 from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import _content_parts
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +50,13 @@ def _extract_text_parts(content: Any) -> List[Dict[str, Any]]:
     """Turn a message's ``content`` field into Gemini ``parts`` list.
 
     OpenAI messages carry either a string or a list of content blocks;
-    Gemini expects a list of ``{text}`` / ``{inlineData}`` / etc. parts.
-    We pass through text blocks as ``{"text": ...}`` and leave non-text
-    block types unchanged (callers may inject ``inlineData`` for vision).
+    Gemini expects a list of ``{text}`` / ``{inlineData}`` / ``{fileData}``
+    / etc. parts. Text blocks pass through as ``{"text": ...}``. An
+    ``image_url`` block (OpenAI's canonical multimodal shape — a base64
+    data-URI or a remote http(s) url) is translated via ``_content_parts``
+    into Gemini's native ``inlineData`` (data-URI) / ``fileData`` (remote
+    url) part (#1720 Wave-1b). Any other block type is left unchanged
+    (callers may inject an already-Gemini-shaped part directly).
     """
     if isinstance(content, str):
         return [{"text": content}]
@@ -59,8 +64,15 @@ def _extract_text_parts(content: Any) -> List[Dict[str, Any]]:
         parts: List[Dict[str, Any]] = []
         for block in content:
             if isinstance(block, dict):
-                if block.get("type") == "text":
+                block_type = block.get("type")
+                if block_type == "text":
                     parts.append({"text": block.get("text", "")})
+                elif block_type == "image_url":
+                    part = _content_parts.parse_content_part(block)
+                    if isinstance(part, _content_parts.ImagePart):
+                        parts.append(_content_parts.to_gemini_part(part))
+                    else:
+                        parts.append(block)
                 else:
                     parts.append(block)
             elif isinstance(block, str):

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -146,8 +146,12 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     # supports JSON mode via responseMimeType, plus an optional responseSchema.
     # ONLY force JSON mode for the JSON response types — an OpenAI
     # ``{"type": "text"}`` must NOT be coerced into JSON (Gemini defaults to
-    # text, so emit nothing for it).
-    if request.response_format is not None:
+    # text, so emit nothing for it). /redteam Round-1 (#1720 Wave-1b):
+    # truthiness guard (not `is not None`) matches every sibling wire
+    # (openai_chat / anthropic_messages / ollama_native / etc.) — an
+    # explicitly-set EMPTY `response_format={}` emits nothing, same as an
+    # unset one.
+    if request.response_format:
         rf_type = request.response_format.get("type")
         if rf_type in ("json_object", "json_schema"):
             generation_config["responseMimeType"] = "application/json"

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_embeddings.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""HuggingFace Embeddings wire protocol shaper (#1720 Wave-1b EMBED-REMAINDER).
+
+Shapes the on-the-wire request/response for HuggingFace's feature-extraction
+Inference endpoint, ``POST /models/{model}`` -- the SAME URL shape
+``huggingface_inference.py``'s classic text-generation schema uses (the
+model is in the URL path, NOT the body); the request/response CONTENT
+differs because the task is embeddings, not generation.
+
+Request schema (HF feature-extraction batch form):
+
+    POST /models/{model}
+    {"inputs": ["text a", "text b"]}
+
+Always sends ``inputs`` as a list, even for a single-text call -- mirrors
+``ollama_embeddings.py``'s "always send the list form" precedent for
+forward-compatible, uniformly-shaped caller code.
+
+Response schema (feature-extraction; the shape varies by whether the
+hosted model has a built-in pooling layer):
+
+* **Pooled models** (most sentence-embedding models) return one vector per
+  input text directly: ``[[0.1, ...], [0.2, ...]]`` (batch x hidden_dim).
+* **Unpooled models** (raw transformer output, no pooling head) return
+  per-token vectors: ``[[[0.1, ...], [0.2, ...], ...], ...]`` (batch x
+  tokens x hidden_dim) -- ``parse_response`` UNWRAPS this by mean-pooling
+  across the token axis into a single sentence vector per input text, so
+  callers get a uniform ``list[list[float]]`` regardless of which shape the
+  hosted model emits.
+
+Optional unit-normalization (``EmbedOptions.normalize``) is applied
+CLIENT-SIDE as an ``parse_response`` post-processing step (L2 norm per
+vector) -- HF's classic serverless feature-extraction endpoint has no
+documented request-level ``normalize`` parameter (unlike the newer
+Text-Embeddings-Inference ``/embed`` server, which this shaper does NOT
+target), so normalization is done here rather than requested from the
+server.
+
+**Known scoped limitation (Wave-1b EMBED-REMAINDER):** ``LlmClient.embed()``
+calls ``shaper.parse_response(payload_json)`` with NO ``options`` argument
+for ANY wire (`client.py` is the shared dispatch surface all embed shapers
+go through, and threading ``options`` into that one call site is an
+orchestration-layer change touching every existing embedding shaper's
+signature -- out of this shard's scope, which is limited to
+`_EMBED_DISPATCH` + `_build_embed_url`). This module's ``parse_response``
+therefore accepts ``options`` as an OPTIONAL keyword argument (default
+``None``) so the normalize behavior is fully implemented and directly
+unit-testable; going through the live ``LlmClient.embed()`` HF dispatch
+today, normalize is a no-op because ``options`` never reaches this
+function. Wiring ``options`` through the shared dispatch call site for
+every embedding wire is a tracked follow-up, not introduced or worsened by
+this shard.
+
+Cross-SDK parity: this shaper's output for a fixed input is intended to be
+byte-identical to the kailash-rs HuggingFace embeddings payload builder.
+Per `rules/cross-sdk-inspection.md` Rule 4, at least one deterministic
+byte-shape pin test is committed in the Tier-1 suite
+(``tests/unit/llm/test_embed_remainder_shapers.py``); full sibling-SDK
+byte-vector pinning against the Rust SDK's ACTUAL output is NOT landed as
+of this shard -- flagged as a follow-up cross-SDK lockstep item.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+
+
+def build_request_payload(
+    texts: List[str],
+    model: str,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Build the HuggingFace feature-extraction request body.
+
+    Mirrors ``openai_embeddings.build_request_payload``'s rejection
+    contract exactly:
+
+    * Rejects ``texts=[]`` with ``ValueError`` at the shaper boundary.
+    * Rejects non-string elements in ``texts``.
+
+    ``model`` is validated (non-empty) but NOT written into the body --
+    HuggingFace's classic Inference API carries the model in the URL path
+    (``/models/{model}``), not the request JSON, matching
+    ``huggingface_inference.py``'s existing text-generation schema.
+    ``options`` is accepted for API symmetry with every other embedding
+    shaper but this endpoint has no request-level knob any current
+    ``EmbedOptions`` field maps to (``dimensions``/``user`` are OpenAI-only
+    concepts here; ``input_type`` is Cohere-only; ``normalize`` is applied
+    client-side in ``parse_response``, not requested from the server) --
+    so ``options`` is validated-and-ignored, not silently mis-typed through.
+    """
+    if not isinstance(texts, list):
+        raise TypeError(
+            f"build_request_payload expects texts: list[str]; got {type(texts).__name__}"
+        )
+    if not texts:
+        raise ValueError(
+            "build_request_payload requires at least one text; got empty list"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise TypeError(f"texts[{idx}] must be str; got {type(t).__name__}")
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            "build_request_payload requires a non-empty model string — "
+            "read from os.environ['HUGGINGFACE_EMBEDDING_MODEL'] per "
+            "rules/env-models.md"
+        )
+    if options is not None and not isinstance(options, EmbedOptions):
+        raise TypeError(f"options must be EmbedOptions; got {type(options).__name__}")
+
+    return {"inputs": list(texts)}
+
+
+def _validate_numeric_row(row: List[Any], vector_index: int) -> List[float]:
+    """Validate a flat list of numbers, rejecting bool (a subclass of int)."""
+    if not row:
+        raise InvalidResponse(
+            f"huggingface_embeddings: vectors[{vector_index}] is empty"
+        )
+    for v in row:
+        if not isinstance(v, (int, float)) or isinstance(v, bool):
+            raise InvalidResponse(
+                f"huggingface_embeddings: vectors[{vector_index}] contains "
+                "non-numeric value"
+            )
+    return [float(v) for v in row]
+
+
+def _unwrap_entry(entry: Any, vector_index: int) -> List[float]:
+    """Unwrap one response entry into a single sentence-embedding vector.
+
+    Handles both documented feature-extraction shapes:
+
+    * ``list[float]`` -- already a single pooled vector, used as-is.
+    * ``list[list[float]]`` -- per-token vectors (batch x tokens x
+      hidden_dim); mean-pooled across the token axis into one vector.
+    """
+    if not isinstance(entry, list):
+        raise InvalidResponse(
+            f"huggingface_embeddings: vectors[{vector_index}] is not a list"
+        )
+    if not entry:
+        raise InvalidResponse(
+            f"huggingface_embeddings: vectors[{vector_index}] is empty"
+        )
+    if isinstance(entry[0], list):
+        # Unpooled (token-level) response -- mean-pool across tokens.
+        token_vectors: List[List[float]] = []
+        for tvec in entry:
+            if not isinstance(tvec, list):
+                raise InvalidResponse(
+                    f"huggingface_embeddings: vectors[{vector_index}] has "
+                    "inconsistent nesting (mixed token/non-token entries)"
+                )
+            token_vectors.append(_validate_numeric_row(tvec, vector_index))
+        dim = len(token_vectors[0])
+        pooled = [0.0] * dim
+        for tvec in token_vectors:
+            if len(tvec) != dim:
+                raise InvalidResponse(
+                    f"huggingface_embeddings: vectors[{vector_index}] token "
+                    "vectors have mismatched dimensions"
+                )
+            for i, v in enumerate(tvec):
+                pooled[i] += v
+        n = len(token_vectors)
+        return [x / n for x in pooled]
+    return _validate_numeric_row(entry, vector_index)
+
+
+def _l2_normalize(vector: List[float]) -> List[float]:
+    """Return a unit-L2-norm copy of ``vector``. Zero vectors pass through."""
+    norm = sum(v * v for v in vector) ** 0.5
+    if norm == 0.0:
+        return list(vector)
+    return [v / norm for v in vector]
+
+
+def parse_response(
+    payload: Any,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Extract ``{vectors, model, usage}`` from a HuggingFace feature-extraction
+    response.
+
+    ``payload`` MUST be a JSON array (one entry per input text) -- the
+    classic feature-extraction endpoint returns a bare array, not an
+    object, so this shaper (unlike ``cohere_embeddings`` /
+    ``openai_embeddings``) type-checks for ``list`` at the top level.
+    Raises ``InvalidResponse`` with a stable ``reason`` when the payload
+    shape violates the documented contract.
+
+    ``options`` is an OPTIONAL keyword argument (see module docstring "Known
+    scoped limitation") -- when supplied with ``normalize=True``, every
+    returned vector is L2-normalized; when omitted (the shape
+    ``LlmClient.embed()`` calls this function with today), no normalization
+    is applied. Neither ``model`` nor ``usage`` token counts are present on
+    this endpoint's response, matching the ``None`` conventions already
+    established by ``huggingface_inference.parse_response``'s
+    text-generation list-response branch.
+    """
+    if options is not None and not isinstance(options, EmbedOptions):
+        raise TypeError(f"options must be EmbedOptions; got {type(options).__name__}")
+    if not isinstance(payload, list):
+        raise InvalidResponse(
+            "huggingface_embeddings: expected a JSON array of vectors "
+            f"(feature-extraction response); got {type(payload).__name__}"
+        )
+
+    vectors: List[List[float]] = [
+        _unwrap_entry(entry, idx) for idx, entry in enumerate(payload)
+    ]
+
+    if options is not None and options.normalize:
+        vectors = [_l2_normalize(v) for v in vectors]
+
+    return {
+        "vectors": vectors,
+        "model": None,
+        # Embed-contract usage shape ({input_tokens, total_tokens}) matches
+        # openai_embeddings / ollama_embeddings / cohere_embeddings -- NOT
+        # the chat-shaper {input_tokens, output_tokens} shape (embeddings
+        # have no "output" token count to bill separately).
+        "usage": {"input_tokens": None, "total_tokens": None},
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_inference.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_inference.py
@@ -33,9 +33,13 @@ See https://huggingface.co/docs/api-inference/detailed_parameters.
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any, Dict, List
 
 from kaizen.llm.deployment import CompletionRequest
+
+logger = logging.getLogger(__name__)
 
 
 def _flatten_messages_to_prompt(messages: List[Dict[str, Any]]) -> str:
@@ -52,13 +56,29 @@ def _flatten_messages_to_prompt(messages: List[Dict[str, Any]]) -> str:
         role = msg.get("role", "user").upper()
         content = msg.get("content", "")
         if isinstance(content, list):
-            # Flatten typed blocks, keep only text.
+            # Flatten typed blocks, keep only text. Non-text blocks (e.g.
+            # image_url / image content sent against a text-only classic
+            # text-generation endpoint) are dropped — previously silently,
+            # now logged at WARNING so the drop is observable rather than a
+            # silent content loss (zero-tolerance Rule 3 / observability
+            # Rule 7 — a warning is an error the framework chose to keep
+            # running through).
             text_blocks: List[str] = []
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "text":
                     text_blocks.append(block.get("text", ""))
                 elif isinstance(block, str):
                     text_blocks.append(block)
+                else:
+                    block_type = (
+                        block.get("type")
+                        if isinstance(block, dict)
+                        else type(block).__name__
+                    )
+                    logger.warning(
+                        "huggingface_inference.non_text_block_dropped",
+                        extra={"block_type": block_type},
+                    )
             content = "".join(text_blocks)
         parts.append(f"[{role}] {content}")
     parts.append("[ASSISTANT] ")
@@ -99,9 +119,42 @@ def build_request_payload(
             payload["stop"] = list(request.stop)
         if request.stream:
             payload["stream"] = True
+
+        # --- #1720 Wave-1b completion-shaping emission (chat-schema path ONLY) ---
+        # TGI / Inference Endpoints running the OpenAI-compatible chat schema
+        # accept the OpenAI `tools` + `tool_choice` shape verbatim. Guard on
+        # truthiness so an explicitly-set EMPTY list (`tools=[]`) emits
+        # nothing (matches the openai/anthropic/google/mistral/cohere
+        # adapters — the four-axis consistency contract). `tool_choice` is
+        # meaningless without tools, so it is emitted ONLY alongside a
+        # non-empty tools list.
+        #
+        # TGI's tool-calling support is grammar-constrained-decoding-based
+        # and MODEL-DEPENDENT — not every hosted model/deployment reliably
+        # honours a FORCED tool selection. CONSERVATIVELY default the unset
+        # case to `"auto"` (let the model decide whether to call a tool)
+        # rather than the OpenAI-family Wave-1a legacy `"required"` default
+        # (openai_chat / anthropic_messages / google_generate_content) — a
+        # forced-tool default that a TGI deployment without full grammar
+        # support could reject outright. An explicit caller-set tool_choice
+        # (including `"required"`) still passes through verbatim; this only
+        # changes the conservative UNSET default.
+        if request.tools:
+            payload["tools"] = list(request.tools)
+            payload["tool_choice"] = (
+                request.tool_choice if request.tool_choice is not None else "auto"
+            )
         return payload
 
-    # Classic text-generation schema.
+    # Classic text-generation schema: NO tools concept. TGI's classic
+    # `{inputs, parameters}` text-generation endpoint has no OpenAI-shaped
+    # tool-calling surface — no documented `tools`/`tool_choice` keys.
+    # Emitting them here would advertise a capability the endpoint does not
+    # have (zero-tolerance Rule 2: no fake capability), so `request.tools` /
+    # `request.tool_choice` are deliberately OMITTED on this path even when
+    # set. Callers that need tool calling against a TGI-backed model MUST
+    # use `use_chat_schema=True` (TGI / Inference Endpoints), which DOES
+    # emit them above.
     parameters: Dict[str, Any] = {}
     if request.temperature is not None:
         parameters["temperature"] = request.temperature
@@ -116,6 +169,39 @@ def build_request_payload(
     if parameters:
         body["parameters"] = parameters
     return body
+
+
+def _normalize_tool_call(tc: Dict[str, Any], index: int) -> Dict[str, Any]:
+    """Coerce one chat-schema ``message.tool_calls`` entry into the canonical
+    shape shared with the openai/anthropic/google/mistral/cohere shards::
+
+        {"id": <str>, "type": "function",
+         "function": {"name": <str>, "arguments": <str: JSON-encoded>}}
+
+    TGI's OpenAI-compatible chat endpoint is expected to return an
+    OpenAI-shaped entry (``arguments`` already a JSON string, ``id`` set);
+    defensively, if a deployment omits ``id`` or returns ``arguments`` as a
+    dict/list, synthesize ``call_{index}`` and ``json.dumps`` the arguments
+    so the canonical invariants hold regardless of deployment conformance.
+    Rebuilds a plain JSON-serializable dict so no provider SDK object leaks
+    into the parsed result.
+    """
+    function = tc.get("function")
+    function = function if isinstance(function, dict) else {}
+    arguments = function.get("arguments")
+    if isinstance(arguments, (dict, list)):
+        arguments = json.dumps(arguments)
+    tc_id = tc.get("id")
+    if not isinstance(tc_id, str) or not tc_id:
+        tc_id = f"call_{index}"
+    return {
+        "id": tc_id,
+        "type": tc.get("type", "function"),
+        "function": {
+            "name": function.get("name"),
+            "arguments": arguments,
+        },
+    }
 
 
 def parse_response(payload: Any) -> Dict[str, Any]:
@@ -152,6 +238,7 @@ def parse_response(payload: Any) -> Dict[str, Any]:
         choices = payload.get("choices", []) or []
         text = ""
         finish_reason: Any = None
+        tool_calls: Any = None
         if choices and isinstance(choices[0], dict):
             first = choices[0]
             finish_reason = first.get("finish_reason")
@@ -160,8 +247,24 @@ def parse_response(payload: Any) -> Dict[str, Any]:
                 content = message.get("content")
                 if isinstance(content, str):
                     text = content
+                # #1720 Wave-1b: surface tool calls. TGI's OpenAI-compatible
+                # chat endpoint may carry OpenAI-shaped `message.tool_calls`;
+                # normalize each into the canonical shape ([{"id", "type":
+                # "function", "function": {"name", "arguments"}}] with
+                # `arguments` a JSON-encoded string), shared with the
+                # openai/anthropic/google/mistral/cohere shards. Emit as
+                # plain JSON-serializable dicts, only when present — so a
+                # plain text response stays byte-identical to the
+                # pre-Wave-1b parsed shape.
+                raw_tool_calls = message.get("tool_calls")
+                if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                    tool_calls = [
+                        _normalize_tool_call(tc, index)
+                        for index, tc in enumerate(raw_tool_calls)
+                        if isinstance(tc, dict)
+                    ]
         usage = payload.get("usage", {}) or {}
-        return {
+        result: Dict[str, Any] = {
             "text": text,
             "usage": {
                 "input_tokens": usage.get("prompt_tokens"),
@@ -171,6 +274,9 @@ def parse_response(payload: Any) -> Dict[str, Any]:
             "stop_reason": finish_reason,
             "model": payload.get("model"),
         }
+        if tool_calls:
+            result["tool_calls"] = tool_calls
+        return result
 
     # Single-object text-generation response (rare but documented).
     generated = payload.get("generated_text")

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_inference.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_inference.py
@@ -29,6 +29,26 @@ Response (text-generation): ``[{"generated_text": "..."}]``.
 Response (chat): OpenAI-style ``{"choices": [{"message": {"content": ...}}]}``.
 
 See https://huggingface.co/docs/api-inference/detailed_parameters.
+
+**Known scoped limitation (/redteam Round-1, #1720 Wave-1b):** the chat-schema
+branch of ``build_request_payload`` (``use_chat_schema=True``) fully
+implements ``tools``/``tool_choice`` emission and is directly unit-tested.
+However, ``LlmClient`` ALWAYS calls this shaper with
+``use_chat_schema=False`` (the classic ``{inputs, parameters}`` path) --
+there is currently NO production mechanism (no HF chat-endpoint routing) for
+``LlmClient.complete()`` to reach the chat schema. Full chat-schema routing
+(resolving the HF router's dedicated chat-completions URL) is a separate,
+future shard and is deliberately NOT wired here.
+
+Until that routing lands, a caller who passes ``tools=`` (or
+``response_format=``) to a HuggingFace deployment through ``LlmClient``
+reaches ONLY the classic path, which has no OpenAI-shaped tool-calling or
+structured-output surface. Per ``rules/zero-tolerance.md`` Rule 3 (no silent
+fallbacks) / ``rules/observability.md`` Rule 7, dropping either field on the
+classic path emits a WARNING (never silently) -- the caller gets the
+classic tool-less/format-less body, not a hard failure, mirroring the
+image-content-block-drop pattern elsewhere in this module. Tracked follow-up:
+HF chat-endpoint routing so ``tools=`` reaches the chat schema in production.
 """
 
 from __future__ import annotations
@@ -155,6 +175,23 @@ def build_request_payload(
     # set. Callers that need tool calling against a TGI-backed model MUST
     # use `use_chat_schema=True` (TGI / Inference Endpoints), which DOES
     # emit them above.
+    #
+    # /redteam Round-1 (#1720 Wave-1b): `LlmClient` has NO production
+    # mechanism to reach the chat schema today (see module docstring "Known
+    # scoped limitation"), so a caller passing `tools=`/`response_format=`
+    # against an hf deployment silently lost them on this path. WARN — never
+    # silent — per rules/observability.md Rule 7 / zero-tolerance Rule 3.
+    if request.tools:
+        logger.warning(
+            "huggingface_inference.tools_dropped_classic_path",
+            extra={"tool_count": len(request.tools)},
+        )
+    if request.response_format:
+        logger.warning(
+            "huggingface_inference.response_format_dropped_classic_path",
+            extra={"response_format_type": request.response_format.get("type")},
+        )
+
     parameters: Dict[str, Any] = {}
     if request.temperature is not None:
         parameters["temperature"] = request.temperature

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
@@ -25,9 +25,13 @@ See https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-compl
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+import logging
+from typing import Any, Dict, List
 
 from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import _content_parts
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_json_schema(response_format: Dict[str, Any]) -> Dict[str, Any] | None:
@@ -44,6 +48,70 @@ def _extract_json_schema(response_format: Dict[str, Any]) -> Dict[str, Any] | No
         if isinstance(schema, dict):
             return schema
     return None
+
+
+def _translate_message_to_ollama(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate one OpenAI-shaped message into Ollama-native's shape.
+
+    Ollama's ``/api/chat`` message is ``{role, content: <str>, images:
+    [<base64>, ...]}`` — image parts live in a SEPARATE per-message field
+    as bare base64 strings, NOT inline in ``content`` (#1720 Wave-1b).
+
+    A message with NO ``image_url`` part in its content — a bare string,
+    OR a content-part list containing only text/other blocks — passes
+    through UNCHANGED (same object) so a text-only request stays
+    byte-identical to the pre-Wave-1b output. A message WITH >=1
+    ``image_url`` part has its text blocks joined into a single
+    ``content`` string and its data-URI image parts moved to the
+    ``images`` field.
+
+    A remote (non-data-URI) ``image_url`` cannot be translated without a
+    network fetch, which is out of scope for this pure wire shaper (see
+    ``_content_parts.to_ollama_images``); it is dropped from the request
+    with a WARNING log — never silently — per
+    ``rules/observability.md`` Rule 7 / zero-tolerance Rule 3.
+    """
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return msg
+    has_image_url = any(
+        isinstance(block, dict) and block.get("type") == "image_url"
+        for block in content
+    )
+    if not has_image_url:
+        return msg
+
+    text_parts: List[str] = []
+    image_parts: List[_content_parts.ImagePart] = []
+    remote_url_count = 0
+    for block in content:
+        part = _content_parts.parse_content_part(block)
+        if isinstance(part, _content_parts.TextPart):
+            text_parts.append(part.text)
+        elif isinstance(part, _content_parts.ImagePart):
+            if part.is_data_uri:
+                image_parts.append(part)
+            else:
+                remote_url_count += 1
+        elif isinstance(block, str):
+            text_parts.append(block)
+        # An unrecognized block (parse_content_part returned None and the
+        # block is not a bare str) has no Ollama-native slot and is
+        # dropped from `content` — only text + image blocks are
+        # representable in Ollama's message shape.
+
+    if remote_url_count:
+        logger.warning(
+            "ollama_native.remote_image_url_not_translated",
+            extra={"count": remote_url_count},
+        )
+
+    new_msg = dict(msg)
+    new_msg["content"] = "".join(text_parts)
+    images = _content_parts.to_ollama_images(image_parts)
+    if images:
+        new_msg["images"] = images
+    return new_msg
 
 
 def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
@@ -106,7 +174,9 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
 
     payload: Dict[str, Any] = {
         "model": request.model,
-        "messages": list(request.messages),
+        # Wave-1b multimodal translation: move image_url parts OUT of
+        # `content` into the per-message `images` field Ollama expects.
+        "messages": [_translate_message_to_ollama(msg) for msg in request.messages],
         # Ollama defaults `stream=True` server-side; we always pass the
         # caller's explicit choice so the HTTP client can pick the correct
         # reader (streaming JSONL vs single-JSON response).

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_native.py
@@ -84,6 +84,7 @@ def _translate_message_to_ollama(msg: Dict[str, Any]) -> Dict[str, Any]:
     text_parts: List[str] = []
     image_parts: List[_content_parts.ImagePart] = []
     remote_url_count = 0
+    dropped_block_count = 0
     for block in content:
         part = _content_parts.parse_content_part(block)
         if isinstance(part, _content_parts.TextPart):
@@ -95,15 +96,27 @@ def _translate_message_to_ollama(msg: Dict[str, Any]) -> Dict[str, Any]:
                 remote_url_count += 1
         elif isinstance(block, str):
             text_parts.append(block)
-        # An unrecognized block (parse_content_part returned None and the
-        # block is not a bare str) has no Ollama-native slot and is
-        # dropped from `content` — only text + image blocks are
-        # representable in Ollama's message shape.
+        else:
+            # An unrecognized/malformed block (parse_content_part returned
+            # None and the block is not a bare str -- e.g. an unknown
+            # `type`, or a malformed `image_url` sub-dict missing `url`) has
+            # no Ollama-native slot and is dropped from `content` -- only
+            # text + image blocks are representable in Ollama's message
+            # shape. /redteam Round-1 (#1720 Wave-1b): this branch
+            # previously fell through with NO log; counted + WARNed here,
+            # never silent, per rules/observability.md Rule 7 /
+            # zero-tolerance Rule 3.
+            dropped_block_count += 1
 
     if remote_url_count:
         logger.warning(
             "ollama_native.remote_image_url_not_translated",
             extra={"count": remote_url_count},
+        )
+    if dropped_block_count:
+        logger.warning(
+            "ollama_native.content_block_dropped",
+            extra={"count": dropped_block_count},
         )
 
     new_msg = dict(msg)

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -39,9 +39,13 @@ to its Rust counterpart's OpenAI chat payload builder.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict
 
 from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.reasoning_filter import filter_reasoning_model_params
+
+logger = logging.getLogger(__name__)
 
 # OpenAI's GPT-5 family and the o-series reasoning models REJECT `max_tokens`
 # with a hard HTTP 400 ("'max_tokens' is not supported with this model; use
@@ -66,6 +70,15 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     Emits the canonical OpenAI chat shape. Optional fields are written only
     when the caller set them so callers relying on server defaults do NOT
     get a silent override.
+
+    #1720 Wave-1b reasoning-model filter: before any sampling field is
+    written to the payload, ``temperature`` / ``top_p`` / ``frequency_penalty``
+    / ``presence_penalty`` are routed through
+    :func:`kaizen.llm.reasoning_filter.filter_reasoning_model_params`. o1/o3
+    reasoning models reject these fields outright (HTTP 400); gpt-5 requires
+    ``temperature == 1.0`` and rejects the others. Every other model family
+    is a byte-neutral passthrough — this shaper's output for a fixed
+    non-reasoning-model input is unchanged from before this filter existed.
     """
     if not isinstance(request, CompletionRequest):
         raise TypeError("build_request_payload expects a CompletionRequest")
@@ -74,10 +87,34 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         "model": request.model,
         "messages": list(request.messages),
     }
+
+    # Collect the caller-set sampling fields, THEN filter by model family —
+    # insertion into `payload` still happens at each field's ORIGINAL
+    # position below, so key order (and therefore JSON byte output) is
+    # unchanged for every model the filter leaves untouched.
+    sampling: Dict[str, Any] = {}
     if request.temperature is not None:
-        payload["temperature"] = request.temperature
+        sampling["temperature"] = request.temperature
     if request.top_p is not None:
-        payload["top_p"] = request.top_p
+        sampling["top_p"] = request.top_p
+    if request.frequency_penalty is not None:
+        sampling["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        sampling["presence_penalty"] = request.presence_penalty
+    filtered_sampling = filter_reasoning_model_params(request.model, sampling)
+    if filtered_sampling != sampling:
+        logger.debug(
+            "openai_chat.reasoning_model_params_filtered",
+            extra={
+                "before_keys": sorted(sampling),
+                "after_keys": sorted(filtered_sampling),
+            },
+        )
+
+    if "temperature" in filtered_sampling:
+        payload["temperature"] = filtered_sampling["temperature"]
+    if "top_p" in filtered_sampling:
+        payload["top_p"] = filtered_sampling["top_p"]
     if request.max_tokens is not None:
         payload[_token_limit_field(request.model)] = request.max_tokens
     if request.stop:
@@ -113,10 +150,14 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     # Truthiness guard: an empty ``logit_bias={}`` is a no-op — emit nothing.
     if request.logit_bias:
         payload["logit_bias"] = request.logit_bias
-    if request.frequency_penalty is not None:
-        payload["frequency_penalty"] = request.frequency_penalty
-    if request.presence_penalty is not None:
-        payload["presence_penalty"] = request.presence_penalty
+    # #1720 Wave-1b: frequency_penalty / presence_penalty already went through
+    # the reasoning-model filter above (dropped for o1/o3/gpt-5); emit here
+    # under their ORIGINAL key position so non-reasoning-model payloads keep
+    # byte-identical field order.
+    if "frequency_penalty" in filtered_sampling:
+        payload["frequency_penalty"] = filtered_sampling["frequency_penalty"]
+    if "presence_penalty" in filtered_sampling:
+        payload["presence_penalty"] = filtered_sampling["presence_penalty"]
     if request.n is not None:
         payload["n"] = request.n
     # top_k: intentionally NOT emitted — the OpenAI chat completions API does not

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_holistic_redteam.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_holistic_redteam.py
@@ -25,8 +25,7 @@ import pytest
 import respx
 
 from kaizen.llm import LlmClient
-from kaizen.llm.client import _validate_api_key_override
-from kaizen.llm.errors import InvalidApiKeyOverride
+from kaizen.llm.client import InvalidApiKeyOverride, _validate_api_key_override
 from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
 from kaizen.llm.presets import anthropic_preset, huggingface_preset
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_holistic_redteam.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_holistic_redteam.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b remainder — holistic multi-wave /redteam Round-2 hardening pins.
+
+Round-1 fixes (hf embed model=, o4 reasoning family, hf/ollama drop WARN,
+byok control-char guard, google truthiness) are each pinned in their own
+per-feature test file. This file pins the Round-2 completeness items whose
+regression would otherwise be invisible:
+
+* CRITICAL call-site pin — `LlmClient.embed()` end-to-end for the HuggingFace
+  `/models/{model}` wire (Round-1's fix was in the embed() CALL SITE; the
+  Round-1 per-shaper test exercised `_build_embed_url` in isolation and would
+  NOT catch a call-site revert).
+* embed() unsupported-wire message enumerates the newly-added wires.
+* the per-request `api_key=` override guard rejects DEL + non-ASCII with the
+  SAME typed `InvalidApiKeyOverride` (never an opaque `UnicodeEncodeError`),
+  fingerprint-only, and does NOT over-reject valid printable specials.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from kaizen.llm import LlmClient
+from kaizen.llm.client import _validate_api_key_override
+from kaizen.llm.errors import InvalidApiKeyOverride
+from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
+from kaizen.llm.presets import anthropic_preset, huggingface_preset
+
+_HF_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class _AllowAllResolver(SafeDnsResolver):
+    """Skip the real DNS lookup (test-only) so respx can intercept."""
+
+    __slots__ = ()
+
+    def check_host(self, host: str) -> None:
+        return None
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@respx.mock
+async def test_hf_embed_builds_model_url_end_to_end() -> None:
+    """client.embed() against a HuggingFace deployment must reach
+    /hf-inference/models/{model}. A regression to `_build_embed_url(path)`
+    (missing model=) raises ValueError before any request and fails here."""
+    expected_url = f"https://router.huggingface.co/hf-inference/models/{_HF_MODEL}"
+    route = respx.post(expected_url).mock(
+        return_value=httpx.Response(200, json=[[0.1, 0.2, 0.3]])
+    )
+    dep = huggingface_preset(api_key="hf_test_key", model=_HF_MODEL)
+    client = LlmClient.from_deployment(dep)
+    http = LlmHttpClient(deployment_preset=dep.wire.name, resolver=_AllowAllResolver())
+    try:
+        vectors = await client.embed(["hello"], model=_HF_MODEL, http_client=http)
+    finally:
+        await http.aclose()
+    assert route.called, "HF embed never reached the /models/{model} endpoint"
+    assert str(route.calls.last.request.url) == expected_url
+    assert vectors == [[0.1, 0.2, 0.3]]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_embed_unsupported_wire_message_lists_cohere_and_hf() -> None:
+    """A wire with no _EMBED_DISPATCH entry (AnthropicMessages) raises with a
+    message enumerating the supported wires, incl. the two added this wave."""
+    dep = anthropic_preset(api_key="sk-ant-test", model="claude-haiku-4-5")
+    client = LlmClient.from_deployment(dep)
+    with pytest.raises(NotImplementedError) as exc:
+        await client.embed(["x"], model="text-embedding-x")
+    msg = str(exc.value)
+    assert "CohereGenerate" in msg
+    assert "HuggingFaceInference" in msg
+
+
+@pytest.mark.regression
+def test_api_key_override_rejects_del_char() -> None:
+    with pytest.raises(InvalidApiKeyOverride) as exc:
+        _validate_api_key_override("sk-good\x7fbad")
+    # Fingerprint-only: the raw key never appears in the message.
+    assert "sk-good" not in str(exc.value)
+    assert "\x7f" not in str(exc.value)
+
+
+@pytest.mark.regression
+def test_api_key_override_rejects_non_ascii_with_typed_error() -> None:
+    # A non-ASCII key must raise the SAME typed error, NOT a raw
+    # UnicodeEncodeError from httpx's ascii header-encode downstream.
+    with pytest.raises(InvalidApiKeyOverride) as exc:
+        _validate_api_key_override("sk-café-key")
+    assert "caf" not in str(exc.value)
+
+
+@pytest.mark.regression
+def test_api_key_override_accepts_valid_printable_specials() -> None:
+    # Printable non-alphanumerics (@ # $ - _ .) are valid credential chars —
+    # the guard must NOT over-reject them.
+    key = "sk-Ab9_.-@#$%wxyz"
+    assert _validate_api_key_override(key) == key

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_wave1b_normalized_toolcalls_parity.py
@@ -14,7 +14,13 @@ response shape and asserts every adapter emits the identical canonical
 structure — same keys, same types, same logical name + parsed arguments,
 ``arguments`` always a JSON STRING. If any adapter drifts (e.g. returns
 ``arguments`` as a dict, or omits ``id``/``type``), this fails loudly — the
-cross-shard contract the three Wave-1b shards each implemented independently.
+cross-shard contract every Wave-1b adapter shard implemented independently.
+
+Covers all EIGHT tool-capable completion wires: openai_chat, anthropic_messages,
+google_generate_content, mistral_chat, cohere_generate, ollama_native, plus the
+two remainder adapters whose tool support is family/mode-conditional —
+bedrock_invoke (native tools only for the ``mistral.*`` Bedrock family) and
+huggingface_inference (tools only on the OpenAI-compatible chat schema).
 """
 
 import json
@@ -23,8 +29,10 @@ import pytest
 
 from kaizen.llm.wire_protocols import (
     anthropic_messages,
+    bedrock_invoke,
     cohere_generate,
     google_generate_content,
+    huggingface_inference,
     mistral_chat,
     ollama_native,
     openai_chat,
@@ -126,6 +134,52 @@ _OLLAMA_RESPONSE = {
     "done": True,
 }
 
+# Bedrock (native InvokeModel, mistral.* family): outputs[0].tool_calls, OpenAI-shaped
+# (arguments a JSON string). Only the mistral family carries native tools; meta/amazon/
+# cohere InvokeModel bodies have no tools surface (omitted, not faked).
+_BEDROCK_RESPONSE = {
+    "outputs": [
+        {
+            "text": "",
+            "stop_reason": "tool_calls",
+            "tool_calls": [
+                {
+                    "id": "call_bedrock_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "SF"}),
+                    },
+                }
+            ],
+        }
+    ]
+}
+
+# HuggingFace (OpenAI-compatible chat schema / TGI): choices[0].message.tool_calls.
+_HUGGINGFACE_RESPONSE = {
+    "choices": [
+        {
+            "message": {
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_hf_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "SF"}),
+                        },
+                    }
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    "model": "test-model",
+}
+
 _CASES = [
     ("openai_chat", openai_chat, _OPENAI_RESPONSE),
     ("anthropic_messages", anthropic_messages, _ANTHROPIC_RESPONSE),
@@ -133,6 +187,8 @@ _CASES = [
     ("mistral_chat", mistral_chat, _MISTRAL_RESPONSE),
     ("cohere_generate", cohere_generate, _COHERE_RESPONSE),
     ("ollama_native", ollama_native, _OLLAMA_RESPONSE),
+    ("bedrock_invoke", bedrock_invoke, _BEDROCK_RESPONSE),
+    ("huggingface_inference", huggingface_inference, _HUGGINGFACE_RESPONSE),
 ]
 
 
@@ -169,8 +225,8 @@ def test_each_adapter_emits_canonical_tool_call_shape(name, shaper, response):
 
 
 @pytest.mark.regression
-def test_all_three_adapters_agree_on_normalized_shape():
-    """The three adapters produce STRUCTURALLY IDENTICAL normalized tool_calls
+def test_all_adapters_agree_on_normalized_shape():
+    """ALL adapters produce STRUCTURALLY IDENTICAL normalized tool_calls
     (ignoring the provider-specific id value) for the same logical call."""
     normalized = {}
     for name, shaper, response in _CASES:
@@ -186,6 +242,7 @@ def test_all_three_adapters_agree_on_normalized_shape():
             },
         }
     shapes = list(normalized.values())
-    assert (
-        shapes[0] == shapes[1] == shapes[2]
+    # Every adapter (all 8) must agree — not just the first three.
+    assert all(
+        s == shapes[0] for s in shapes
     ), f"cross-adapter normalized-shape divergence: {normalized}"

--- a/packages/kailash-kaizen/tests/unit/llm/test_bedrock_invoke_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_bedrock_invoke_wave1b_emission.py
@@ -1,0 +1,466 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b — bedrock_invoke completion-shaping EMISSION + PARSE.
+
+Behavioral tests for the AWS Bedrock ``InvokeModel`` wire adapter's
+Wave-1b additions. Bedrock tool support on the native (non-Anthropic)
+InvokeModel body is PER-FAMILY and OMIT-DON'T-FAKE:
+
+* ``mistral.*`` — the one native family with a documented ``tools`` +
+  ``tool_choice`` field on the InvokeModel body (OpenAI-shaped tools,
+  Mistral tool_choice vocabulary — force-a-tool is ``"any"``, not
+  OpenAI's ``"required"``). EMITTED.
+* ``meta.*`` (Llama) / ``amazon.*`` (Titan) / ``cohere.*`` (classic
+  Cohere Command) — no documented tools field on the InvokeModel body
+  this shaper builds. Tools are deliberately OMITTED (key absent, never
+  a fake/empty placeholder).
+
+``parse_response`` normalizes Bedrock-Mistral's ``outputs[0].tool_calls``
+into the canonical shape shared with the other wire shards (``arguments``
+is always a JSON-encoded string; a missing id is synthesized as
+``call_{index}``), surfaced under the ``"tool_calls"`` key ONLY when
+present so a plain-text response stays byte-identical to the pre-Wave-1b
+parsed shape.
+
+Also covers the ``_flatten_prompt`` image/non-text content block drop,
+upgraded from a silent drop to a structured WARN log
+(observability.md Rule 7 / zero-tolerance Rule 3).
+
+All assertions are behavioral (construct -> call -> assert the produced
+dict / normalized tool_calls / log record), not source-grep. No real
+model names are hardcoded (env-models.md) — the tests use Bedrock-shaped
+but synthetic model ids (``meta.test-model``, ``mistral.test-model``, etc).
+"""
+
+import json
+import logging
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import bedrock_invoke
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+def _tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+
+# --------------------------------------------------------------------------
+# (a) mistral family emits tools + tool_choice mapping
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_mistral_emits_tools_verbatim():
+    """Mistral's Bedrock InvokeModel body carries `tools` verbatim (OpenAI
+    function-schema shape passthrough), same as mistral_chat.py."""
+    tools = _tools()
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=tools,
+        tool_choice="auto",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert payload["tools"] == tools
+    assert payload["tool_choice"] == "auto"
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_required_maps_to_any():
+    """OpenAI's forced-tool value 'required' MUST map to Mistral's 'any'."""
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="required",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_auto_none_any_pass_through():
+    """Mistral-native string values pass through unchanged."""
+    for choice in ("auto", "none", "any"):
+        request = CompletionRequest(
+            model="mistral.mistral-large-2407-v1:0",
+            messages=_base_messages(),
+            tools=_tools(),
+            tool_choice=choice,
+        )
+        payload = bedrock_invoke.build_request_payload(request)
+        assert payload["tool_choice"] == choice
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_unknown_string_falls_back_to_any():
+    """An unknown tool_choice string falls back to the safe forced default
+    'any' (never a shape Mistral would reject)."""
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="banana",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_named_tool_dict_passes_through():
+    """A named-tool forced-selection dict passes through verbatim."""
+    named = {"type": "function", "function": {"name": "get_weather"}}
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice=named,
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert payload["tool_choice"] == named
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_defaults_to_any_when_tools_set_and_choice_none():
+    """tools present + tool_choice unset -> tool_choice='any' (force a
+    tool), the pinned Wave-1a legacy default expressed in Mistral's
+    vocabulary."""
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=_tools(),
+        # tool_choice deliberately unset
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert payload["tool_choice"] == "any"
+
+
+# --------------------------------------------------------------------------
+# (b) meta/amazon OMIT tools (assert key absent) — cohere too
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_llama_omits_tools_even_when_set():
+    """meta.* (Llama) has no documented tools field on Bedrock InvokeModel —
+    tools MUST be absent from the payload even when the request sets them."""
+    request = CompletionRequest(
+        model="meta.llama3-70b-instruct-v1:0",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="auto",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+    # The Llama body shape is otherwise unaffected.
+    assert "prompt" in payload
+    assert "max_gen_len" in payload
+
+
+@pytest.mark.unit
+def test_titan_omits_tools_even_when_set():
+    """amazon.* (Titan) has no tools field at all on Bedrock InvokeModel —
+    tools MUST be absent from the payload even when the request sets them."""
+    request = CompletionRequest(
+        model="amazon.titan-text-express-v1",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="auto",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+    assert "textGenerationConfig" not in payload or "tools" not in payload.get(
+        "textGenerationConfig", {}
+    )
+    assert "inputText" in payload
+
+
+@pytest.mark.unit
+def test_cohere_omits_tools_even_when_set():
+    """cohere.* (classic Command, prompt-based) has no documented tools
+    field on Bedrock InvokeModel — tools MUST be absent even when set."""
+    request = CompletionRequest(
+        model="cohere.command-text-v14",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="auto",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+    assert "prompt" in payload
+
+
+# --------------------------------------------------------------------------
+# (c) empty tools=[] emits nothing (mistral family)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_mistral_empty_tools_emits_nothing():
+    """An explicitly-set EMPTY tools list emits neither tools nor
+    tool_choice (truthiness guard, not `is not None`)."""
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+        tools=[],
+        tool_choice="any",
+    )
+    payload = bedrock_invoke.build_request_payload(request)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+# --------------------------------------------------------------------------
+# (d) tool_choice-without-tools emits nothing (mistral family)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_mistral_tool_choice_not_emitted_without_tools():
+    """tool_choice is meaningless without tools — emitted ONLY alongside a
+    non-empty tools list. A standalone tool_choice (any value) is dropped."""
+    for choice in (
+        "none",
+        "required",
+        "auto",
+        "any",
+        {"type": "function", "function": {"name": "f"}},
+    ):
+        request = CompletionRequest(
+            model="mistral.mistral-large-2407-v1:0",
+            messages=_base_messages(),
+            tool_choice=choice,
+        )
+        payload = bedrock_invoke.build_request_payload(request)
+        assert (
+            "tool_choice" not in payload
+        ), f"tool_choice={choice!r} leaked without tools"
+        assert "tools" not in payload
+
+
+# --------------------------------------------------------------------------
+# (e) parse normalizes tool_calls with arguments as JSON string +
+#     synthesized id
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_response_surfaces_mistral_tool_calls_in_canonical_shape():
+    """A fake Bedrock-Mistral response with outputs[0].tool_calls parses
+    into the canonical normalized shape; arguments stays a JSON-encoded
+    string; entries are plain JSON-serializable dicts."""
+    arguments_json = json.dumps({"city": "Paris"})
+    response = {
+        "outputs": [
+            {
+                "text": "",
+                "stop_reason": "tool_calls",
+                "tool_calls": [
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": arguments_json,
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    parsed = bedrock_invoke.parse_response(response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments_json},
+        }
+    ]
+    tc = parsed["tool_calls"][0]
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+    # The result must be JSON-serializable (plain dicts, no SDK objects).
+    json.dumps(parsed)
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "tool_calls"
+
+
+@pytest.mark.unit
+def test_parse_response_coerces_dict_arguments_to_json_string():
+    """A non-conformant response returning `arguments` as a dict is coerced
+    to a JSON string so the canonical invariant holds."""
+    response = {
+        "outputs": [
+            {
+                "text": "",
+                "stop_reason": "tool_calls",
+                "tool_calls": [
+                    {
+                        "id": "call_xyz",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {"q": "kailash"}},
+                    }
+                ],
+            }
+        ]
+    }
+    parsed = bedrock_invoke.parse_response(response)
+    tc = parsed["tool_calls"][0]
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"q": "kailash"}
+
+
+@pytest.mark.unit
+def test_parse_response_synthesizes_id_when_provider_omits_it():
+    """When Bedrock-Mistral omits the tool-call id, synthesize `call_{i}`."""
+    response = {
+        "outputs": [
+            {
+                "text": "",
+                "stop_reason": "tool_calls",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    },
+                    {
+                        "type": "function",
+                        "function": {"name": "g", "arguments": "{}"},
+                    },
+                ],
+            }
+        ]
+    }
+    parsed = bedrock_invoke.parse_response(response)
+    assert parsed["tool_calls"][0]["id"] == "call_0"
+    assert parsed["tool_calls"][1]["id"] == "call_1"
+
+
+# --------------------------------------------------------------------------
+# (f) plain-text parse has no tool_calls key (byte-neutral)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_when_absent_mistral():
+    """No tool_calls in a Mistral response -> no 'tool_calls' key in the
+    parsed dict; the pre-Wave-1b {text, usage, stop_reason, model} shape is
+    unchanged (byte-neutral)."""
+    response = {"outputs": [{"text": "hello", "stop_reason": "stop"}]}
+    parsed = bedrock_invoke.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello"
+    assert set(parsed.keys()) == {"text", "usage", "stop_reason", "model"}
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_for_llama_titan_cohere():
+    """Non-Mistral family response shapes never carry tool_calls at all —
+    parse never surfaces the key for them."""
+    llama_response = {
+        "generation": "hi",
+        "stop_reason": "stop",
+        "prompt_token_count": 3,
+        "generation_token_count": 1,
+    }
+    titan_response = {
+        "results": [{"outputText": "hi", "completionReason": "FINISH"}],
+        "inputTextTokenCount": 3,
+    }
+    cohere_response = {"generations": [{"text": "hi", "finish_reason": "COMPLETE"}]}
+
+    for response in (llama_response, titan_response, cohere_response):
+        parsed = bedrock_invoke.parse_response(response)
+        assert "tool_calls" not in parsed
+        assert parsed["text"] == "hi"
+
+
+# --------------------------------------------------------------------------
+# (g) image-block drop logs a warning (caplog)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_flatten_prompt_drops_image_block_with_warning(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A non-text content block (e.g. an image) is dropped from the
+    flattened prompt AND logs a structured WARNING naming the family as
+    vision-unsupported — not a silent drop."""
+    request = CompletionRequest(
+        model="meta.llama3-70b-instruct-v1:0",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "data": "AAAA"},
+                    },
+                ],
+            }
+        ],
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.bedrock_invoke"
+    ):
+        payload = bedrock_invoke.build_request_payload(request)
+
+    # The image block never appears in the rendered prompt.
+    assert "describe this" in payload["prompt"]
+    assert "AAAA" not in payload["prompt"]
+
+    record = next(
+        (
+            r
+            for r in caplog.records
+            if r.message == "bedrock_invoke.non_text_block_dropped"
+        ),
+        None,
+    )
+    assert record is not None
+    assert record.levelno == logging.WARNING
+    assert record.family == "meta"
+    assert record.reason == "vision_unsupported"
+
+
+@pytest.mark.unit
+def test_flatten_prompt_no_warning_for_plain_text_messages(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A plain-text-only request never logs the dropped-block warning."""
+    request = CompletionRequest(
+        model="mistral.mistral-large-2407-v1:0",
+        messages=_base_messages(),
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.bedrock_invoke"
+    ):
+        bedrock_invoke.build_request_payload(request)
+
+    assert not any(
+        r.message == "bedrock_invoke.non_text_block_dropped" for r in caplog.records
+    )

--- a/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
@@ -39,6 +39,7 @@ from kaizen.llm.auth.aws import AwsBearerToken
 from kaizen.llm.auth.bearer import ApiKeyHeaderKind
 from kaizen.llm.client import UnsupportedApiKeyOverride
 from kaizen.llm.deployment import CompletionRequest, StreamingConfig
+from kaizen.llm.errors import InvalidApiKeyOverride
 from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
 from kaizen.llm.presets import (
     anthropic_preset,
@@ -244,6 +245,101 @@ async def test_prepare_auth_headers_rejects_override_for_gcp_oauth_without_refre
         await http.aclose()
     assert exc_info.value.auth_strategy_kind == "gcp_oauth"
     assert calls["n"] == 0  # never attempted a token refresh
+
+
+# ---------------------------------------------------------------------------
+# /redteam Round-1 FIX 5 (security) — control-char validation, fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_rejects_crlf_control_char_in_api_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A per-request api_key= containing \\r\\n is a CRLF-header-injection
+    surface: ApiKeyBearer.apply() installs the raw string into a header
+    with no sanitization. This MUST raise InvalidApiKeyOverride BEFORE the
+    header is ever constructed, and the raw key MUST NOT leak into the
+    exception message or the logs (fingerprint/type only)."""
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    injected_key = "sk-x\r\nX-Injected: v"
+    caplog.set_level(logging.DEBUG)
+    try:
+        with pytest.raises(InvalidApiKeyOverride) as exc_info:
+            await client._prepare_auth_headers(
+                "https://api.openai.com/v1/chat/completions",
+                b"{}",
+                stream=False,
+                api_key=injected_key,
+            )
+    finally:
+        await http.aclose()
+    assert injected_key not in str(exc_info.value)
+    assert "\r" not in str(exc_info.value)
+    assert "\n" not in str(exc_info.value)
+    for record in caplog.records:
+        assert injected_key not in record.getMessage()
+        assert injected_key not in repr(record.args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("control_char", ["\r", "\n", "\x00", "\x01", "\x1f"], ids=repr)
+async def test_prepare_auth_headers_rejects_every_c0_control_char(
+    control_char: str,
+) -> None:
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        with pytest.raises(InvalidApiKeyOverride):
+            await client._prepare_auth_headers(
+                "https://api.openai.com/v1/chat/completions",
+                b"{}",
+                stream=False,
+                api_key=f"sk-x{control_char}rest",
+            )
+    finally:
+        await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_control_char_check_precedes_unsupported_check() -> (
+    None
+):
+    """A control char is caught even for a non-ApiKeyBearer deployment —
+    the validation runs before the auth-strategy-support check, so a
+    malformed override never falls through to (or is masked by)
+    UnsupportedApiKeyOverride."""
+    dep = bedrock_claude_preset(_DEPLOYMENT_KEY, "us-east-1", "claude-sonnet-4-6")
+    client, http = _client(dep)
+    try:
+        with pytest.raises(InvalidApiKeyOverride):
+            await client._prepare_auth_headers(
+                "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/invoke",
+                b"{}",
+                stream=False,
+                api_key="sk-x\r\nX-Injected: v",
+            )
+    finally:
+        await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_accepts_key_with_no_control_chars() -> None:
+    """Byte-neutral: a normal (control-char-free) override is unaffected by
+    the new validation."""
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        headers, _ = await client._prepare_auth_headers(
+            "https://api.openai.com/v1/chat/completions",
+            b"{}",
+            stream=False,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert headers["Authorization"] == f"Bearer {_BYOK_KEY}"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
@@ -1,0 +1,464 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-request `api_key=` BYOK override tests (#1720 Wave-1b).
+
+Covers the `LlmClient.complete()` / `stream()` / `_prepare_auth_headers`
+per-request credential override:
+
+* `CompletionRequest` carries NO `api_key` field (cross-SDK byte pre-image
+  contract) — the override threads through kwargs into the auth-header step.
+* `ApiKeyBearer`-family deployments (Authorization: Bearer / X-Api-Key /
+  X-Goog-Api-Key) install the override via the SAME header mechanism the
+  deployment's static credential uses.
+* Deployments whose auth strategy is NOT `ApiKeyBearer` (AwsBearerToken,
+  GcpOauth, ...) raise `UnsupportedApiKeyOverride` — fail-closed, never a
+  silent fallback to the deployment's own credential.
+* The raw key is NEVER logged, at any log level.
+* `complete()` / `stream()` (both the real streaming send AND the
+  `streaming.enabled=False` buffered fallback) forward `api_key` unchanged.
+* Byte-neutral: `complete()`/`_prepare_auth_headers()` without `api_key` are
+  unaffected by the new kwarg's existence.
+
+All assertions are behavioral (call the function, inspect real headers on
+the wire via respx, or call `_prepare_auth_headers` directly) per
+`rules/testing.md` — no source-grep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+import respx
+
+from kaizen.llm import LlmClient
+from kaizen.llm.auth.aws import AwsBearerToken
+from kaizen.llm.auth.bearer import ApiKeyHeaderKind
+from kaizen.llm.client import UnsupportedApiKeyOverride
+from kaizen.llm.deployment import CompletionRequest, StreamingConfig
+from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
+from kaizen.llm.presets import (
+    anthropic_preset,
+    bedrock_claude_preset,
+    google_preset,
+    openai_preset,
+    vertex_claude_preset,
+)
+
+_BYOK_KEY = "sk-byok-caller-supplied-secret-9f8e7d6c"
+_DEPLOYMENT_KEY = "sk-deployment-static-secret-1a2b3c4d"
+
+
+class _AllowAllResolver(SafeDnsResolver):
+    """SafeDnsResolver that skips the real DNS lookup (test-only)."""
+
+    __slots__ = ()
+
+    def check_host(self, host: str) -> None:  # noqa: D401 - test stub resolver
+        return None
+
+
+def _client(dep):
+    http = LlmHttpClient(deployment_preset=dep.wire.name, resolver=_AllowAllResolver())
+    return LlmClient.from_deployment(dep), http
+
+
+def _fake_sa() -> dict:
+    return {
+        "type": "service_account",
+        "project_id": "my-test-project",
+        "private_key_id": "k",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----",
+        "client_email": "sa@my-test-project.iam.gserviceaccount.com",
+        "client_id": "i",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CompletionRequest carries no api_key field
+# ---------------------------------------------------------------------------
+
+
+def test_completion_request_has_no_api_key_field() -> None:
+    assert "api_key" not in CompletionRequest.model_fields
+
+
+def test_completion_request_rejects_api_key_kwarg() -> None:
+    with pytest.raises(Exception):
+        CompletionRequest(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key=_BYOK_KEY,  # type: ignore[call-arg]
+        )
+
+
+# ---------------------------------------------------------------------------
+# _prepare_auth_headers — ApiKeyBearer-family override installs correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_overrides_openai_bearer() -> None:
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        headers, auth_kind = await client._prepare_auth_headers(
+            "https://api.openai.com/v1/chat/completions",
+            b"{}",
+            stream=False,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert headers["Authorization"] == f"Bearer {_BYOK_KEY}"
+    assert _DEPLOYMENT_KEY not in headers["Authorization"]
+    assert auth_kind == "api_key"
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_overrides_anthropic_x_api_key() -> None:
+    dep = anthropic_preset(_DEPLOYMENT_KEY, "claude-3-5-sonnet-20241022")
+    client, http = _client(dep)
+    try:
+        headers, _ = await client._prepare_auth_headers(
+            "https://api.anthropic.com/v1/messages",
+            b"{}",
+            stream=False,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert headers["X-Api-Key"] == _BYOK_KEY
+    assert headers.get("Authorization") is None
+    # required_headers (anthropic-version) still merge in alongside the
+    # override — the override only touches the credential header.
+    assert headers["anthropic-version"] == "2023-06-01"
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_overrides_google_x_goog_api_key() -> None:
+    dep = google_preset(_DEPLOYMENT_KEY, "gemini-2.0-flash")
+    client, http = _client(dep)
+    try:
+        headers, _ = await client._prepare_auth_headers(
+            "https://generativelanguage.googleapis.com/v1beta/models/x:generateContent",
+            b"{}",
+            stream=False,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert headers["X-Goog-Api-Key"] == _BYOK_KEY
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_without_override_uses_deployment_credential() -> (
+    None
+):
+    """Byte-neutral: omitting `api_key` behaves exactly as before this shard."""
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        headers_default, kind_default = await client._prepare_auth_headers(
+            "https://api.openai.com/v1/chat/completions", b"{}", stream=False
+        )
+        headers_explicit_none, kind_explicit_none = await client._prepare_auth_headers(
+            "https://api.openai.com/v1/chat/completions",
+            b"{}",
+            stream=False,
+            api_key=None,
+        )
+    finally:
+        await http.aclose()
+    assert headers_default == {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {_DEPLOYMENT_KEY}",
+    }
+    assert headers_default == headers_explicit_none
+    assert kind_default == kind_explicit_none == "api_key"
+
+
+# ---------------------------------------------------------------------------
+# Non-ApiKeyBearer deployments reject the override (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_rejects_override_for_aws_bearer_token() -> None:
+    dep = bedrock_claude_preset(_DEPLOYMENT_KEY, "us-east-1", "claude-sonnet-4-6")
+    assert isinstance(dep.auth, AwsBearerToken)
+    client, http = _client(dep)
+    try:
+        with pytest.raises(UnsupportedApiKeyOverride) as exc_info:
+            await client._prepare_auth_headers(
+                "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/invoke",
+                b"{}",
+                stream=False,
+                api_key=_BYOK_KEY,
+            )
+    finally:
+        await http.aclose()
+    assert exc_info.value.auth_strategy_kind == "aws_bearer_token"
+    # The raw key must not leak into the exception message either.
+    assert _BYOK_KEY not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_prepare_auth_headers_rejects_override_for_gcp_oauth_without_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UnsupportedApiKeyOverride fires BEFORE the deployment's own auth runs,
+    so a rejected BYOK override never triggers a live GCP OAuth refresh for a
+    credential that would then be discarded.
+
+    `GcpOauth` is a `__slots__` class, so the spy is installed at the CLASS
+    level (an unbound function assigned to the class is called as a bound
+    method for any instance) rather than on `dep.auth` directly.
+    """
+    dep = vertex_claude_preset(
+        _fake_sa(), "my-proj-1234", "us-central1", "claude-3-5-sonnet"
+    )
+    client, http = _client(dep)
+
+    calls = {"n": 0}
+
+    async def spy(self, request):  # noqa: ANN001 - test spy, mirrors bound method
+        calls["n"] += 1
+        return request
+
+    monkeypatch.setattr(type(dep.auth), "apply_async", spy)
+
+    try:
+        with pytest.raises(UnsupportedApiKeyOverride) as exc_info:
+            await client._prepare_auth_headers(
+                "https://us-central1-aiplatform.googleapis.com/v1/x:rawPredict",
+                b"{}",
+                stream=False,
+                api_key=_BYOK_KEY,
+            )
+    finally:
+        await http.aclose()
+    assert exc_info.value.auth_strategy_kind == "gcp_oauth"
+    assert calls["n"] == 0  # never attempted a token refresh
+
+
+# ---------------------------------------------------------------------------
+# Raw key is NEVER logged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_byok_key_never_appears_in_logs(caplog: pytest.LogCaptureFixture) -> None:
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    caplog.set_level(logging.DEBUG)
+    try:
+        headers, _ = await client._prepare_auth_headers(
+            "https://api.openai.com/v1/chat/completions",
+            b"{}",
+            stream=False,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    # Sanity: the header really does carry the override (proves the test
+    # exercised the live-key path, not a no-op).
+    assert _BYOK_KEY in headers["Authorization"]
+    for record in caplog.records:
+        assert _BYOK_KEY not in record.getMessage()
+        assert _BYOK_KEY not in repr(record.args)
+        for value in getattr(record, "__dict__", {}).values():
+            assert _BYOK_KEY not in repr(value)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_byok_key_never_logged_through_full_complete_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "model": "gpt-4o",
+            },
+        )
+    )
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    caplog.set_level(logging.DEBUG)
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "ping"}],
+            http_client=http,
+            max_tokens=16,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert result["text"] == "pong"
+    for record in caplog.records:
+        assert _BYOK_KEY not in record.getMessage()
+        assert _BYOK_KEY not in repr(record.args)
+
+
+# ---------------------------------------------------------------------------
+# complete() / stream() thread api_key through the full send path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_installs_byok_override_on_the_wire() -> None:
+    route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "model": "gpt-4o",
+            },
+        )
+    )
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        result = await client.complete(
+            [{"role": "user", "content": "ping"}],
+            http_client=http,
+            max_tokens=16,
+            api_key=_BYOK_KEY,
+        )
+    finally:
+        await http.aclose()
+    assert result["text"] == "pong"
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == f"Bearer {_BYOK_KEY}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_without_api_key_is_byte_neutral_on_the_wire() -> None:
+    """Regression: complete() without `api_key=` still installs the
+    deployment's own static credential, unchanged by this shard."""
+    route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "model": "gpt-4o",
+            },
+        )
+    )
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    try:
+        await client.complete(
+            [{"role": "user", "content": "ping"}], http_client=http, max_tokens=16
+        )
+    finally:
+        await http.aclose()
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == f"Bearer {_DEPLOYMENT_KEY}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_installs_byok_override_on_the_real_streaming_send() -> None:
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o")
+    client, http = _client(dep)
+    sse = 'data: {"choices": [{"delta": {"content": "hi"}}]}\n\n' "data: [DONE]\n\n"
+    route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=sse
+        )
+    )
+    chunks = []
+    try:
+        async for chunk in client.stream(
+            [{"role": "user", "content": "ping"}],
+            http_client=http,
+            max_tokens=16,
+            api_key=_BYOK_KEY,
+        ):
+            chunks.append(chunk["text"])
+    finally:
+        await http.aclose()
+    assert chunks == ["hi"]
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == f"Bearer {_BYOK_KEY}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_stream_installs_byok_override_on_buffered_fallback() -> None:
+    """When `streaming.enabled=False`, `stream()` falls back to a buffered
+    `complete()` call — `api_key` MUST still reach the wire on that path."""
+    dep = openai_preset(_DEPLOYMENT_KEY, "gpt-4o").model_copy(
+        update={"streaming": StreamingConfig(enabled=False)}
+    )
+    client, http = _client(dep)
+    route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                "model": "gpt-4o",
+            },
+        )
+    )
+    chunks = []
+    try:
+        async for chunk in client.stream(
+            [{"role": "user", "content": "ping"}],
+            http_client=http,
+            max_tokens=16,
+            api_key=_BYOK_KEY,
+        ):
+            chunks.append(chunk["text"])
+    finally:
+        await http.aclose()
+    assert chunks == ["pong"]
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == f"Bearer {_BYOK_KEY}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_complete_raises_unsupported_override_before_any_http_call() -> None:
+    """A deployment whose auth cannot accept a bearer override raises before
+    any request is sent — no partial/leaked send."""
+    dep = bedrock_claude_preset(_DEPLOYMENT_KEY, "us-east-1", "claude-sonnet-4-6")
+    client, http = _client(dep)
+    route = respx.post(
+        "https://bedrock-runtime.us-east-1.amazonaws.com/model/"
+        "us.anthropic.claude-sonnet-4-6-v1%3A0/invoke"
+    ).mock(return_value=httpx.Response(200, json={}))
+    try:
+        with pytest.raises(UnsupportedApiKeyOverride):
+            await client.complete(
+                [{"role": "user", "content": "ping"}],
+                http_client=http,
+                max_tokens=16,
+                api_key=_BYOK_KEY,
+            )
+    finally:
+        await http.aclose()
+    assert route.call_count == 0
+
+
+def test_apikeybearer_header_kind_enum_matches_supported_kinds() -> None:
+    """Documentation-pin: the three header kinds this shard supports."""
+    assert {k.value for k in ApiKeyHeaderKind} == {
+        "Authorization_Bearer",
+        "X_Api_Key",
+        "X_Goog_Api_Key",
+    }

--- a/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_byok_per_request_api_key.py
@@ -37,9 +37,8 @@ import respx
 from kaizen.llm import LlmClient
 from kaizen.llm.auth.aws import AwsBearerToken
 from kaizen.llm.auth.bearer import ApiKeyHeaderKind
-from kaizen.llm.client import UnsupportedApiKeyOverride
+from kaizen.llm.client import InvalidApiKeyOverride, UnsupportedApiKeyOverride
 from kaizen.llm.deployment import CompletionRequest, StreamingConfig
-from kaizen.llm.errors import InvalidApiKeyOverride
 from kaizen.llm.http_client import LlmHttpClient, SafeDnsResolver
 from kaizen.llm.presets import (
     anthropic_preset,

--- a/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
@@ -21,7 +21,11 @@ from kaizen.llm import LlmClient
 from kaizen.llm.auth.azure import AzureEntra
 from kaizen.llm.deployment import EmbedOptions, WireProtocol
 from kaizen.llm.errors import InvalidResponse
-from kaizen.llm.presets import AZURE_OPENAI_DEFAULT_API_VERSION, azure_openai_preset
+from kaizen.llm.presets import (
+    AZURE_OPENAI_DEFAULT_API_VERSION,
+    azure_openai_preset,
+    huggingface_preset,
+)
 from kaizen.llm.wire_protocols import cohere_embeddings, huggingface_embeddings
 
 # ---------------------------------------------------------------------------
@@ -178,3 +182,27 @@ def test_non_azure_embed_url_has_no_query_string() -> None:
     client = LlmClient.from_deployment(dep)
     url = client._build_embed_url("/embeddings")
     assert "?" not in url
+
+
+# ---------------------------------------------------------------------------
+# /redteam Round-1 FIX 1 (CRITICAL) — HuggingFace embed 100% broken:
+# `_build_embed_url` was called with no `model=`, so the HuggingFace wire's
+# `"/models/{model}"` path suffix substituted an EMPTY string, and
+# `_validate_completion_model("")` raised ValueError on EVERY hf embed call.
+# This pins the exact call-site shape `embed()` now uses.
+# ---------------------------------------------------------------------------
+
+
+def test_hf_embed_url_carries_model_in_path() -> None:
+    dep = huggingface_preset(
+        api_key="hf_x", model="sentence-transformers/all-MiniLM-L6-v2"
+    )
+    client = LlmClient.from_deployment(dep)
+    # No ValueError — the exact regression: _build_embed_url called with no
+    # model= substituted "" into "{model}" and _validate_completion_model("")
+    # raised on every hf embed call.
+    url = client._build_embed_url(
+        "/models/{model}", model="sentence-transformers/all-MiniLM-L6-v2"
+    )
+    assert "sentence-transformers/all-MiniLM-L6-v2" in url
+    assert "{model}" not in url

--- a/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-1 unit tests for the #1720 Wave-1b EMBED-REMAINDER shard.
+
+Covers the two new embedding shapers (cohere / huggingface), the azure
+api-version URL fix (preset query_params + _build_embed_url append), and the
+_EMBED_DISPATCH wiring. Offline by construction — no network, no live keys.
+
+Behavioral asserts only (call build/parse, assert the payload/normalized
+shape) per rules/testing.md; no source-grep-as-assertion.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.auth.azure import AzureEntra
+from kaizen.llm.deployment import EmbedOptions, WireProtocol
+from kaizen.llm.errors import InvalidResponse
+from kaizen.llm.presets import AZURE_OPENAI_DEFAULT_API_VERSION, azure_openai_preset
+from kaizen.llm.wire_protocols import cohere_embeddings, huggingface_embeddings
+
+# ---------------------------------------------------------------------------
+# cohere_embeddings.build_request_payload
+# ---------------------------------------------------------------------------
+
+
+def test_cohere_build_minimal_shape() -> None:
+    payload = cohere_embeddings.build_request_payload(
+        ["hello", "world"], "embed-english-v3.0"
+    )
+    # Deterministic byte-shape pin: no input_type when options unset.
+    assert payload == {"model": "embed-english-v3.0", "texts": ["hello", "world"]}
+
+
+def test_cohere_build_emits_input_type_only_when_set() -> None:
+    opts = EmbedOptions(input_type="search_document")
+    payload = cohere_embeddings.build_request_payload(["q"], "embed-english-v3.0", opts)
+    assert payload["input_type"] == "search_document"
+    # dimensions / user are NOT emitted for Cohere even when set.
+    payload_no_it = cohere_embeddings.build_request_payload(
+        ["q"], "embed-english-v3.0", EmbedOptions(dimensions=256, user="u")
+    )
+    assert "input_type" not in payload_no_it
+    assert "dimensions" not in payload_no_it and "user" not in payload_no_it
+
+
+def test_cohere_build_rejects_empty_and_non_str() -> None:
+    with pytest.raises(ValueError):
+        cohere_embeddings.build_request_payload([], "embed-english-v3.0")
+    with pytest.raises(TypeError):
+        cohere_embeddings.build_request_payload([b"bytes"], "embed-english-v3.0")  # type: ignore[list-item]
+    with pytest.raises(ValueError):
+        cohere_embeddings.build_request_payload(["ok"], "")
+
+
+def test_cohere_parse_extracts_vectors_in_request_order() -> None:
+    resp = {
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+        "model": "embed-english-v3.0",
+        "meta": {"billed_units": {"input_tokens": 7}},
+    }
+    out = cohere_embeddings.parse_response(resp)
+    assert out["vectors"] == [[0.1, 0.2], [0.3, 0.4]]
+    assert out["model"] == "embed-english-v3.0"
+    assert out["usage"]["input_tokens"] == 7
+
+
+def test_cohere_parse_rejects_malformed() -> None:
+    with pytest.raises(InvalidResponse):
+        cohere_embeddings.parse_response({"embeddings": "nope"})
+    with pytest.raises(InvalidResponse):
+        cohere_embeddings.parse_response({"embeddings": [["x"]]})  # non-numeric
+    with pytest.raises(InvalidResponse):
+        cohere_embeddings.parse_response({"embeddings": [[True]]})  # bool rejected
+
+
+# ---------------------------------------------------------------------------
+# huggingface_embeddings.build_request_payload / parse_response
+# ---------------------------------------------------------------------------
+
+
+def test_hf_build_inputs_shape_model_not_in_body() -> None:
+    payload = huggingface_embeddings.build_request_payload(
+        ["a", "b"], "sentence-transformers/all-MiniLM-L6-v2"
+    )
+    # Deterministic byte-shape pin: model is URL-path only, not in the body.
+    assert payload == {"inputs": ["a", "b"]}
+
+
+def test_hf_build_rejects_empty_and_non_str() -> None:
+    with pytest.raises(ValueError):
+        huggingface_embeddings.build_request_payload([], "m")
+    with pytest.raises(TypeError):
+        huggingface_embeddings.build_request_payload([1], "m")  # type: ignore[list-item]
+
+
+def test_hf_parse_pooled_shape() -> None:
+    out = huggingface_embeddings.parse_response([[0.1, 0.2], [0.3, 0.4]])
+    assert out["vectors"] == [[0.1, 0.2], [0.3, 0.4]]
+    assert out["model"] is None
+
+
+def test_hf_parse_unpooled_mean_pools_tokens() -> None:
+    # One input text, two token vectors → mean-pool to one sentence vector.
+    out = huggingface_embeddings.parse_response([[[0.0, 2.0], [2.0, 4.0]]])
+    assert out["vectors"] == [[1.0, 3.0]]
+
+
+def test_hf_parse_normalizes_when_option_set() -> None:
+    out = huggingface_embeddings.parse_response(
+        [[3.0, 4.0]], EmbedOptions(normalize=True)
+    )
+    v = out["vectors"][0]
+    assert math.isclose(math.sqrt(v[0] ** 2 + v[1] ** 2), 1.0, rel_tol=1e-9)
+    # Without normalize, the raw vector passes through.
+    out_raw = huggingface_embeddings.parse_response([[3.0, 4.0]])
+    assert out_raw["vectors"] == [[3.0, 4.0]]
+
+
+def test_hf_parse_rejects_non_list_top_level() -> None:
+    with pytest.raises(InvalidResponse):
+        huggingface_embeddings.parse_response({"not": "an array"})
+
+
+# ---------------------------------------------------------------------------
+# _EMBED_DISPATCH wiring (structural: the two new wires are routable)
+# ---------------------------------------------------------------------------
+
+
+def test_embed_dispatch_wires_cohere_and_huggingface() -> None:
+    from kaizen.llm.client import _EMBED_DISPATCH
+
+    assert WireProtocol.CohereGenerate in _EMBED_DISPATCH
+    assert WireProtocol.HuggingFaceInference in _EMBED_DISPATCH
+    assert _EMBED_DISPATCH[WireProtocol.CohereGenerate]["shaper"] is cohere_embeddings
+    assert (
+        _EMBED_DISPATCH[WireProtocol.HuggingFaceInference]["shaper"]
+        is huggingface_embeddings
+    )
+
+
+# ---------------------------------------------------------------------------
+# Azure api-version — guards BOTH the preset AND _build_embed_url append.
+# ---------------------------------------------------------------------------
+
+
+def test_azure_preset_carries_api_version_query_param() -> None:
+    dep = azure_openai_preset(
+        "myresource", "gpt-4o-embed", AzureEntra(api_key="test-azure-api-key")
+    )
+    assert dep.endpoint.query_params == {
+        "api-version": AZURE_OPENAI_DEFAULT_API_VERSION
+    }
+
+
+def test_azure_embed_url_carries_api_version() -> None:
+    dep = azure_openai_preset(
+        "myresource", "gpt-4o-embed", AzureEntra(api_key="test-azure-api-key")
+    )
+    client = LlmClient.from_deployment(dep)
+    url = client._build_embed_url("/embeddings")
+    # The api-version MUST reach the embed URL (else Azure embed 400s).
+    assert "?api-version=" in url
+    assert AZURE_OPENAI_DEFAULT_API_VERSION in url
+    assert url.endswith(f"api-version={AZURE_OPENAI_DEFAULT_API_VERSION}")
+
+
+def test_non_azure_embed_url_has_no_query_string() -> None:
+    # Byte-neutrality: a deployment WITHOUT query_params emits no '?' suffix.
+    from kaizen.llm.deployment import LlmDeployment
+
+    dep = LlmDeployment.openai(api_key="sk-test", model="text-embedding-3-small")
+    client = LlmClient.from_deployment(dep)
+    url = client._build_embed_url("/embeddings")
+    assert "?" not in url

--- a/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
@@ -140,6 +140,19 @@ def test_response_format_json_schema_sets_response_schema():
     assert gen["responseSchema"] == schema
 
 
+def test_response_format_empty_dict_emits_no_generation_config_keys():
+    """/redteam Round-1 FIX 6a (#1720 Wave-1b): truthiness guard (not `is not
+    None`) matches every sibling wire — an explicitly-set EMPTY
+    `response_format={}` MUST emit nothing, same as an unset one."""
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={},
+    )
+    payload = gg.build_request_payload(req)
+    assert "generationConfig" not in payload
+
+
 def test_sampling_fields_merge_into_generation_config_without_clobber():
     req = CompletionRequest(
         model="test-model",

--- a/packages/kailash-kaizen/tests/unit/llm/test_huggingface_inference_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_huggingface_inference_wave1b_emission.py
@@ -1,0 +1,449 @@
+"""#1720 Wave-1b — huggingface_inference completion-shaping EMISSION + PARSE.
+
+Behavioral tests for the HuggingFace Inference wire adapter's Wave-1b
+additions. The module has TWO request shapes:
+
+* Classic text-generation (default) — ``{inputs, parameters}``. Has NO tools
+  concept; ``request.tools`` / ``request.tool_choice`` are deliberately
+  OMITTED on this path even when set (no fake capability).
+* Chat schema (``use_chat_schema=True``, TGI / Inference Endpoints) —
+  OpenAI-compatible. Accepts ``tools`` + ``tool_choice`` (truthiness guard on
+  tools; ``tool_choice`` emitted ONLY alongside non-empty tools; unset
+  default is the CONSERVATIVE ``"auto"`` — not the OpenAI-family legacy
+  ``"required"`` — because TGI's tool support is model-dependent).
+
+``parse_response`` surfaces ``choices[0].message.tool_calls`` (chat-schema
+branch only) under the ``"tool_calls"`` key in the canonical normalized
+shape (``arguments`` is a JSON-encoded string; a synthesized ``call_{i}`` id
+when the provider omits one). The classic list/``generated_text`` branch has
+no tool calls at all.
+
+Also covers: ``_flatten_messages_to_prompt`` now logs a WARNING (instead of
+silently dropping) when a non-text content block is present.
+
+All assertions are behavioral (construct -> call -> assert the produced
+dict/log record), not source-grep. No real model names are hardcoded
+(env-models.md) — the tests use ``"test-model"``.
+"""
+
+import json
+import logging
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import huggingface_inference
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+def _tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# build_request_payload — chat-schema path (use_chat_schema=True)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_chat_schema_emits_tools_and_defaults_tool_choice_to_auto():
+    """Chat-schema path emits `tools` verbatim; unset tool_choice defaults to
+    the CONSERVATIVE 'auto' (not the OpenAI-family legacy 'required')."""
+    tools = _tools()
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=tools,
+        # tool_choice deliberately unset
+    )
+    payload = huggingface_inference.build_request_payload(request, use_chat_schema=True)
+
+    assert payload["tools"] == tools
+    assert payload["tool_choice"] == "auto"
+
+
+@pytest.mark.unit
+def test_chat_schema_explicit_tool_choice_passes_through():
+    """An explicit caller-set tool_choice (including OpenAI's 'required')
+    passes through verbatim on the chat-schema path."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="required",
+    )
+    payload = huggingface_inference.build_request_payload(request, use_chat_schema=True)
+    assert payload["tool_choice"] == "required"
+
+
+@pytest.mark.unit
+def test_chat_schema_tool_choice_auto_and_none_pass_through():
+    """OpenAI-native 'auto' / 'none' string values pass through unchanged."""
+    for choice in ("auto", "none"):
+        request = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tools=_tools(),
+            tool_choice=choice,
+        )
+        payload = huggingface_inference.build_request_payload(
+            request, use_chat_schema=True
+        )
+        assert payload["tool_choice"] == choice
+
+
+@pytest.mark.unit
+def test_chat_schema_named_tool_dict_passes_through():
+    """A named-tool forced-selection dict passes through in the OpenAI-shaped
+    object form (chat schema is OpenAI-compatible)."""
+    named = {"type": "function", "function": {"name": "get_weather"}}
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice=named,
+    )
+    payload = huggingface_inference.build_request_payload(request, use_chat_schema=True)
+    assert payload["tool_choice"] == named
+
+
+@pytest.mark.unit
+def test_chat_schema_empty_tools_emits_nothing():
+    """An explicitly-set EMPTY tools list emits neither tools nor tool_choice
+    (truthiness guard, not `is not None`)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[],
+        tool_choice="auto",
+    )
+    payload = huggingface_inference.build_request_payload(request, use_chat_schema=True)
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+@pytest.mark.unit
+def test_chat_schema_tool_choice_not_emitted_without_tools():
+    """tool_choice is meaningless without tools — emitted ONLY alongside a
+    non-empty tools list. A standalone tool_choice (any value) is dropped."""
+    for choice in (
+        "none",
+        "required",
+        "auto",
+        {"type": "function", "function": {"name": "f"}},
+    ):
+        request = CompletionRequest(
+            model="test-model",
+            messages=_base_messages(),
+            tool_choice=choice,
+        )
+        payload = huggingface_inference.build_request_payload(
+            request, use_chat_schema=True
+        )
+        assert (
+            "tool_choice" not in payload
+        ), f"tool_choice={choice!r} leaked without tools"
+        assert "tools" not in payload
+
+
+@pytest.mark.unit
+def test_chat_schema_still_emits_existing_fields_alongside_tools():
+    """Tool emission does not disturb the pre-existing chat-schema fields."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=128,
+        stop=["END"],
+        stream=True,
+    )
+    payload = huggingface_inference.build_request_payload(request, use_chat_schema=True)
+    assert payload["model"] == "test-model"
+    assert payload["messages"] == _base_messages()
+    assert payload["temperature"] == 0.5
+    assert payload["top_p"] == 0.9
+    assert payload["max_tokens"] == 128
+    assert payload["stop"] == ["END"]
+    assert payload["stream"] is True
+    assert payload["tools"] == _tools()
+    assert payload["tool_choice"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# build_request_payload — classic text-generation path (default)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_classic_path_omits_tools_even_when_set():
+    """The classic {inputs, parameters} text-generation schema has NO tools
+    concept. request.tools / request.tool_choice MUST be omitted, never
+    faked, even when the caller set them."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+        tool_choice="required",
+    )
+    payload = huggingface_inference.build_request_payload(request)
+
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+    # The classic shape is unaffected — inputs is still built.
+    assert "inputs" in payload
+
+
+@pytest.mark.unit
+def test_classic_path_default_use_chat_schema_is_false():
+    """build_request_payload defaults to the classic shape (use_chat_schema
+    unset)."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+    )
+    payload = huggingface_inference.build_request_payload(request)
+    assert "model" not in payload  # classic shape carries no `model` key
+    assert "tools" not in payload
+
+
+# ---------------------------------------------------------------------------
+# parse_response — chat-schema tool_calls normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_response_surfaces_tool_calls_in_canonical_shape():
+    """A chat-schema response with message.tool_calls parses into the
+    canonical normalized shape; arguments stays a JSON-encoded string;
+    entries are plain JSON-serializable dicts."""
+    arguments_json = json.dumps({"city": "Paris"})
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": arguments_json,
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        "model": "test-model",
+    }
+
+    parsed = huggingface_inference.parse_response(response)
+
+    assert parsed["tool_calls"] == [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": arguments_json},
+        }
+    ]
+    tc = parsed["tool_calls"][0]
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+    # The result must be JSON-serializable (plain dicts, no SDK objects).
+    json.dumps(parsed)
+    assert parsed["text"] == ""
+    assert parsed["stop_reason"] == "tool_calls"
+    assert parsed["model"] == "test-model"
+    assert parsed["usage"] == {
+        "input_tokens": 5,
+        "output_tokens": 3,
+        "total_tokens": 8,
+    }
+
+
+@pytest.mark.unit
+def test_parse_response_synthesizes_call_id_when_missing():
+    """A tool_call entry with no `id` gets a synthesized `call_{index}` id."""
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": json.dumps({"city": "Rome"}),
+                            },
+                        },
+                        {
+                            "id": "call_explicit",
+                            "type": "function",
+                            "function": {
+                                "name": "get_time",
+                                "arguments": json.dumps({"tz": "UTC"}),
+                            },
+                        },
+                    ],
+                },
+            }
+        ],
+        "model": "test-model",
+    }
+    parsed = huggingface_inference.parse_response(response)
+    assert parsed["tool_calls"][0]["id"] == "call_0"
+    assert parsed["tool_calls"][1]["id"] == "call_explicit"
+
+
+@pytest.mark.unit
+def test_parse_response_coerces_dict_arguments_to_json_string():
+    """A non-conformant deployment returning `arguments` as a dict is
+    coerced to a JSON string so the canonical invariant holds."""
+    response = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": {"q": "kailash"},
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "model": "test-model",
+    }
+    parsed = huggingface_inference.parse_response(response)
+    tc = parsed["tool_calls"][0]
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"q": "kailash"}
+
+
+@pytest.mark.unit
+def test_parse_response_omits_tool_calls_key_when_absent_chat_schema():
+    """No tool_calls in a chat-schema response -> no 'tool_calls' key in the
+    parsed dict; the existing {text, usage, stop_reason, model} keys are
+    intact (plain-text parse stays byte-identical to pre-Wave-1b shape)."""
+    response = {
+        "choices": [{"finish_reason": "stop", "message": {"content": "hello"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "model": "test-model",
+    }
+    parsed = huggingface_inference.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello"
+    assert set(parsed.keys()) == {"text", "usage", "stop_reason", "model"}
+
+
+@pytest.mark.unit
+def test_parse_response_classic_list_shape_has_no_tool_calls():
+    """The classic list[{generated_text}] response shape has no tool calls
+    at all — never a 'tool_calls' key, regardless of content."""
+    response = [{"generated_text": "hello world"}]
+    parsed = huggingface_inference.parse_response(response)
+    assert "tool_calls" not in parsed
+    assert parsed["text"] == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _flatten_messages_to_prompt — image-drop now WARNs (not silent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_image_block_drop_logs_warning(caplog):
+    """A non-text content block (e.g. an image_url block) submitted against
+    the classic text-generation path is dropped, but now logs a WARNING
+    instead of silently disappearing."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                ],
+            }
+        ],
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        payload = huggingface_inference.build_request_payload(request)
+
+    # The text block survives; the image block is dropped from the prompt.
+    assert "describe this" in payload["inputs"]
+    assert "image_url" not in payload["inputs"]
+    # The drop is observable via a WARNING log record, not silent.
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 1
+    assert "non_text_block_dropped" in warning_records[0].message
+
+
+@pytest.mark.unit
+def test_text_only_blocks_emit_no_warning(caplog):
+    """A content-block list containing only text blocks emits no warning."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            }
+        ],
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        payload = huggingface_inference.build_request_payload(request)
+
+    assert "hello" in payload["inputs"]
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 0
+
+
+@pytest.mark.unit
+def test_plain_string_content_emits_no_warning(caplog):
+    """A plain string `content` (no block list) never triggers the drop
+    warning — the warning only fires for typed content-block lists."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        huggingface_inference.build_request_payload(request)
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 0

--- a/packages/kailash-kaizen/tests/unit/llm/test_huggingface_inference_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_huggingface_inference_wave1b_emission.py
@@ -210,6 +210,74 @@ def test_classic_path_omits_tools_even_when_set():
 
 
 @pytest.mark.unit
+def test_classic_path_tools_dropped_logs_warning_not_silent(caplog):
+    """/redteam Round-1 (#1720 Wave-1b): LlmClient has NO production
+    mechanism to reach the chat schema (see module docstring "Known scoped
+    limitation") -- every tools= call against an hf deployment lands on this
+    classic path. The drop MUST be observable (WARN), never silent, per
+    rules/observability.md Rule 7 / zero-tolerance Rule 3."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=_tools(),
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        payload = huggingface_inference.build_request_payload(
+            request, use_chat_schema=False
+        )
+
+    assert "tools" not in payload
+    assert any(
+        r.levelno == logging.WARNING
+        and "huggingface_inference.tools_dropped_classic_path" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_classic_path_response_format_dropped_logs_warning(caplog):
+    """Same drop-is-observable contract for response_format on the classic
+    path (no structured-output surface on {inputs, parameters})."""
+    request = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "json_object"},
+    )
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        payload = huggingface_inference.build_request_payload(
+            request, use_chat_schema=False
+        )
+
+    assert "response_format" not in payload
+    assert any(
+        r.levelno == logging.WARNING
+        and "huggingface_inference.response_format_dropped_classic_path" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_classic_path_no_tools_no_response_format_emits_no_warning(caplog):
+    """Byte-neutral: a plain classic-path call with no tools/response_format
+    emits neither warning."""
+    request = CompletionRequest(model="test-model", messages=_base_messages())
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.huggingface_inference"
+    ):
+        huggingface_inference.build_request_payload(request, use_chat_schema=False)
+
+    assert not any(
+        "tools_dropped_classic_path" in r.message
+        or "response_format_dropped_classic_path" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.unit
 def test_classic_path_default_use_chat_schema_is_false():
     """build_request_payload defaults to the classic shape (use_chat_schema
     unset)."""

--- a/packages/kailash-kaizen/tests/unit/llm/test_mock_preset_isolation.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_mock_preset_isolation.py
@@ -20,6 +20,8 @@ fails loudly here.
 from __future__ import annotations
 
 import importlib
+import re
+from pathlib import Path
 
 import pytest
 
@@ -209,3 +211,71 @@ def test_no_mock_aliased_classmethod_under_alternate_names(name: str) -> None:
         or not callable(getattr(LlmDeployment, name, None))
         or name not in {"mock", "Mock", "MOCK", "mock_preset"}
     ), f"LlmDeployment.{name} MUST NOT be a callable mock surface"
+
+
+# ---------------------------------------------------------------------------
+# Transport isolation (#1720 Wave-1b MOCK) -- MockLlmHttpClient extends the
+# same physical-separation invariant mock_preset() established: production
+# code under src/kaizen/ MUST NOT import kaizen.llm.testing (housing BOTH
+# mock_preset AND MockLlmHttpClient), and MockLlmHttpClient MUST be absent
+# from the production entry points (kaizen.llm.client / kaizen.llm.http_client
+# / kaizen.llm.presets) a downstream app would import for real HTTP traffic.
+# ---------------------------------------------------------------------------
+
+
+def test_grep_finds_no_production_importer_of_kaizen_llm_testing() -> None:
+    """Structural invariant: `kaizen.llm.testing` MUST NOT be imported from
+    any production module under `src/kaizen/`. The ONLY legitimate
+    self-references are files inside the `testing/` package itself. Mirrors
+    the module docstring's claim that this is `grep`-able
+    (`grep -rn 'kaizen.llm.testing' src/kaizen/`) -- this test IS that grep,
+    run mechanically instead of by hand.
+    """
+    src_root = Path(__file__).resolve().parents[3] / "src" / "kaizen"
+    assert src_root.is_dir(), f"expected src root at {src_root}"
+
+    pattern = re.compile(r"\bkaizen\.llm\.testing\b")
+    violations: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        rel = path.relative_to(src_root)
+        # The testing/ package's own files are allowed to self-reference
+        # (docstrings, __init__ exports, intra-package imports).
+        if rel.parts[:2] == ("llm", "testing"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if pattern.search(text):
+            violations.append(str(rel))
+
+    assert not violations, (
+        "Production modules under src/kaizen/ MUST NOT reference "
+        f"kaizen.llm.testing (found in: {violations})"
+    )
+
+
+def test_mock_llm_http_client_absent_from_production_import_surface() -> None:
+    """MockLlmHttpClient MUST NOT be reachable as an attribute of
+    kaizen.llm.client, kaizen.llm.http_client, or kaizen.llm.presets -- the
+    production entry points a downstream app imports for real LLM /
+    real-transport traffic. Test code that wants the deterministic offline
+    transport imports it explicitly from kaizen.llm.testing.
+    """
+    import kaizen.llm.client as client_module
+    import kaizen.llm.http_client as http_client_module
+    import kaizen.llm.presets as presets_module
+
+    for module in (client_module, http_client_module, presets_module):
+        assert not hasattr(module, "MockLlmHttpClient"), (
+            f"{module.__name__} MUST NOT expose MockLlmHttpClient "
+            "(test-only transport; import from kaizen.llm.testing instead)"
+        )
+
+
+def test_mock_llm_http_client_importable_only_from_testing_module() -> None:
+    """Sanity + red-flag-path assertion: the ONE legitimate import path for
+    MockLlmHttpClient is `kaizen.llm.testing` (re-exporting
+    `kaizen.llm.testing.mock_transport.MockLlmHttpClient`).
+    """
+    from kaizen.llm.testing import MockLlmHttpClient
+    from kaizen.llm.testing.mock_transport import MockLlmHttpClient as DirectImport
+
+    assert MockLlmHttpClient is DirectImport

--- a/packages/kailash-kaizen/tests/unit/llm/test_mock_transport.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_mock_transport.py
@@ -1,0 +1,421 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `MockLlmHttpClient` -- the offline in-process transport (#1720
+Wave-1b MOCK shard).
+
+Every test in this module runs with a structural guard
+(`_guard_no_real_network`) that patches `httpx.AsyncClient.send` to raise if
+ever invoked -- since `MockLlmHttpClient` never constructs an
+`httpx.AsyncClient`, the guard should never fire. Its presence converts a
+silent regression (someone swaps in the real `LlmHttpClient`, or a code path
+starts constructing a real transport) into an immediate, loud test failure.
+
+Covers (per the task brief):
+  1. `complete()` via `mock_preset()` + `MockLlmHttpClient` returns a
+     deterministic dict with NO network.
+  2. `stream()` concatenation == chat content + terminal `[DONE]` handled.
+  3. `embed()` deterministic vectors + dimension + L2-normalization.
+  4. Direct unit coverage of `MockLlmHttpClient`'s own typed-error /
+     lifecycle behavior (closed-transport reuse, unsupported request shapes).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.testing import MockLlmHttpClient, UnsupportedMockRequest, mock_preset
+
+
+@pytest.fixture(autouse=True)
+def _guard_no_real_network():
+    """Fail loudly if any test in this module attempts a real httpx send.
+
+    `MockLlmHttpClient` never constructs `httpx.AsyncClient`, so this patch
+    should never actually fire for a correctly-wired test. If it DOES fire,
+    something regressed to a real network path.
+    """
+    with patch(
+        "httpx.AsyncClient.send",
+        side_effect=AssertionError(
+            "MockLlmHttpClient tests must never reach a real network send"
+        ),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# 1. complete() -- deterministic, no network
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteViaMockTransport:
+    @pytest.mark.asyncio
+    async def test_complete_returns_deterministic_dict_without_network(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+        messages = [{"role": "user", "content": "What is the capital of France?"}]
+
+        result1 = await client.complete(messages, http_client=transport)
+        result2 = await client.complete(messages, http_client=transport)
+
+        assert result1 == result2
+        assert isinstance(result1["text"], str) and result1["text"]
+        assert result1["stop_reason"] == "stop"
+        assert result1["model"] == deployment.default_model
+        assert result1["usage"]["input_tokens"] == 100
+        assert result1["usage"]["output_tokens"] > 0
+        assert result1["usage"]["total_tokens"] == (
+            result1["usage"]["input_tokens"] + result1["usage"]["output_tokens"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_response_varies_with_input(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+
+        r1 = await client.complete(
+            [{"role": "user", "content": "hello there"}], http_client=transport
+        )
+        r2 = await client.complete(
+            [{"role": "user", "content": "calculate 9 - 3"}], http_client=transport
+        )
+
+        assert r1["text"] != r2["text"]
+
+    @pytest.mark.asyncio
+    async def test_complete_contextual_math_response_is_deterministic(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+        messages = [
+            {
+                "role": "user",
+                "content": "A train travels 300 km and then 450 km more, over 4 hours",
+            }
+        ]
+
+        result = await client.complete(messages, http_client=transport)
+
+        assert "75 km/hour" in result["text"]
+        # Determinism: a second identical call yields byte-identical text.
+        result_again = await client.complete(messages, http_client=transport)
+        assert result_again["text"] == result["text"]
+
+    @pytest.mark.asyncio
+    async def test_complete_across_two_fresh_transports_is_still_deterministic(
+        self,
+    ) -> None:
+        """No shared instance state, no process-hash-randomized id -- two
+        independently constructed transports produce byte-identical output
+        for the same input."""
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        messages = [
+            {"role": "user", "content": "explain step by step how gravity works"}
+        ]
+
+        r1 = await client.complete(messages, http_client=MockLlmHttpClient())
+        r2 = await client.complete(messages, http_client=MockLlmHttpClient())
+
+        assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# 2. stream() -- concatenation == complete() content, terminal handled
+# ---------------------------------------------------------------------------
+
+
+class TestStreamViaMockTransport:
+    @pytest.mark.asyncio
+    async def test_stream_concatenation_matches_complete_content(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+        messages = [
+            {"role": "user", "content": "Explain step by step how gravity works"}
+        ]
+
+        full = await client.complete(messages, http_client=transport)
+
+        chunks = []
+        async for chunk in client.stream(messages, http_client=transport):
+            chunks.append(chunk)
+
+        assert len(chunks) > 1, "expected multiple word-by-word streaming chunks"
+        concatenated = "".join(c.get("text", "") for c in chunks)
+        assert concatenated == full["text"]
+
+    @pytest.mark.asyncio
+    async def test_stream_terminal_chunk_carries_stop_reason(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+        messages = [{"role": "user", "content": "hi"}]
+
+        chunks = []
+        async for chunk in client.stream(messages, http_client=transport):
+            chunks.append(chunk)
+
+        # The [DONE] sentinel line is skipped by _parse_stream_line; the last
+        # yielded chunk is the terminal finish_reason="stop" frame.
+        assert chunks[-1]["stop_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_stream_is_deterministic_across_calls(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        messages = [{"role": "user", "content": "plan a systematic approach"}]
+
+        chunks1 = [
+            c async for c in client.stream(messages, http_client=MockLlmHttpClient())
+        ]
+        chunks2 = [
+            c async for c in client.stream(messages, http_client=MockLlmHttpClient())
+        ]
+
+        assert chunks1 == chunks2
+
+    @pytest.mark.asyncio
+    async def test_direct_stream_lines_yields_sse_frames_with_done_terminal(
+        self,
+    ) -> None:
+        """Exercise MockLlmHttpClient.stream_lines() directly (below the
+        LlmClient/_parse_stream_line layer) to assert the raw SSE framing
+        contract: 'data: {json}' lines, terminal 'data: [DONE]'."""
+        transport = MockLlmHttpClient()
+        body = (
+            b'{"model": "mock-model", "messages": [{"role": "user", "content": "hi"}]}'
+        )
+
+        lines = [
+            line
+            async for line in transport.stream_lines(
+                "POST",
+                "https://example.com/v1/chat/completions",
+                headers={"Content-Type": "application/json"},
+                content=body,
+            )
+        ]
+
+        assert lines[-1] == "data: [DONE]"
+        assert all(line.startswith("data: ") for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# 3. embed() -- deterministic vectors, dimension, L2-normalization
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedViaMockTransport:
+    @pytest.mark.asyncio
+    async def test_embed_deterministic_and_default_dimension(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+
+        v1 = await client.embed(
+            ["hello world"], model="mock-embedding", http_client=transport
+        )
+        v2 = await client.embed(
+            ["hello world"], model="mock-embedding", http_client=transport
+        )
+
+        assert v1 == v2
+        assert len(v1) == 1
+        assert len(v1[0]) == 1536
+
+    @pytest.mark.asyncio
+    async def test_embed_normalized_by_default(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+
+        vectors = await client.embed(
+            ["normalize me"], model="mock-embedding", http_client=transport
+        )
+
+        magnitude = sum(x * x for x in vectors[0]) ** 0.5
+        assert magnitude == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_embed_unnormalized_when_disabled(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient(normalize=False)
+
+        vectors = await client.embed(
+            ["raw vector please"], model="mock-embedding", http_client=transport
+        )
+
+        magnitude = sum(x * x for x in vectors[0]) ** 0.5
+        # A 1536-dim standard-gaussian vector's magnitude concentrates near
+        # sqrt(1536) ~= 39.2, nowhere near a normalized 1.0.
+        assert magnitude != pytest.approx(1.0, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_embed_respects_custom_dimensions_option(self) -> None:
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+
+        vectors = await client.embed(
+            ["a", "b"],
+            model="mock-embedding",
+            options=EmbedOptions(dimensions=384),
+            http_client=transport,
+        )
+
+        assert len(vectors) == 2
+        assert all(len(v) == 384 for v in vectors)
+        # Different input text -> different (md5-seeded) vector.
+        assert vectors[0] != vectors[1]
+
+    @pytest.mark.asyncio
+    async def test_embed_seed_scoped_per_call_no_global_random_mutation(self) -> None:
+        """The embedding RNG is a per-call `random.Random(seed)` instance,
+        never the process-global `random` module -- so using
+        MockLlmHttpClient must not perturb an unrelated caller's global
+        random state."""
+        import random
+
+        random.seed(42)
+        expected_next = random.random()
+        random.seed(42)
+
+        deployment = mock_preset()
+        client = LlmClient.from_deployment(deployment)
+        transport = MockLlmHttpClient()
+        await client.embed(
+            ["side effect check"], model="mock-embedding", http_client=transport
+        )
+
+        actual_next = random.random()
+        assert actual_next == expected_next
+
+
+# ---------------------------------------------------------------------------
+# 4. MockLlmHttpClient direct unit coverage -- lifecycle + typed errors
+# ---------------------------------------------------------------------------
+
+
+class TestMockLlmHttpClientDirect:
+    def test_exposes_llmhttpclient_interface(self) -> None:
+        transport = MockLlmHttpClient()
+        for method in ("post", "get", "request", "stream_lines", "aclose"):
+            assert callable(
+                getattr(transport, method, None)
+            ), f"MockLlmHttpClient missing callable {method}()"
+        assert transport.is_closed is False
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_on_exit(self) -> None:
+        async with MockLlmHttpClient() as transport:
+            assert transport.is_closed is False
+        assert transport.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_aclose_is_idempotent(self) -> None:
+        transport = MockLlmHttpClient()
+        await transport.aclose()
+        await transport.aclose()
+        assert transport.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_post_after_close_raises_runtime_error(self) -> None:
+        transport = MockLlmHttpClient()
+        await transport.aclose()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await transport.post(
+                "https://example.com/v1/chat/completions",
+                content=b'{"model": "m", "messages": []}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_stream_lines_after_close_raises_runtime_error(self) -> None:
+        transport = MockLlmHttpClient()
+        await transport.aclose()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            async for _ in transport.stream_lines(
+                "POST",
+                "https://example.com/v1/chat/completions",
+                content=b'{"model": "m", "messages": []}',
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_unsupported_endpoint_path_raises_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.post(
+                "https://example.com/v1/unsupported-endpoint",
+                content=b"{}",
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_without_content_or_json_raises_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.post("https://example.com/v1/chat/completions")
+
+    @pytest.mark.asyncio
+    async def test_request_with_malformed_json_body_raises_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.post(
+                "https://example.com/v1/chat/completions",
+                content=b"not valid json{{{",
+            )
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_missing_messages_raises_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.post(
+                "https://example.com/v1/chat/completions",
+                content=b'{"model": "mock-model"}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_embeddings_missing_input_raises_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.post(
+                "https://example.com/v1/embeddings",
+                content=b'{"model": "mock-embedding"}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_requests_raise_typed_error(self) -> None:
+        transport = MockLlmHttpClient()
+
+        with pytest.raises(UnsupportedMockRequest):
+            await transport.get("https://example.com/v1/models")
+
+    @pytest.mark.asyncio
+    async def test_post_returns_valid_httpx_response_shape(self) -> None:
+        transport = MockLlmHttpClient()
+
+        resp = await transport.post(
+            "https://example.com/v1/chat/completions",
+            content=b'{"model": "mock-model", "messages": [{"role": "user", "content": "hi"}]}',
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["object"] == "chat.completion"
+        assert body["choices"][0]["message"]["content"]
+        assert resp.headers.get("retry-after") is None

--- a/packages/kailash-kaizen/tests/unit/llm/test_multimodal_content_parts.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_multimodal_content_parts.py
@@ -1,0 +1,544 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-1b MULTIMODAL — ``_content_parts`` translator + per-wire coverage.
+
+Behavioral tests (construct -> call -> assert the produced dict/log record;
+no source-grep) for the canonical content-part translator and its three
+consuming wires:
+
+* ``_content_parts`` — the pure classify/emit functions in isolation.
+* ``anthropic_messages`` — OpenAI ``image_url`` -> Anthropic ``image`` block
+  (base64 ``source`` for a data-URI, ``url`` ``source`` for a remote url).
+* ``google_generate_content`` — OpenAI ``image_url`` -> Gemini ``inlineData``
+  (data-URI) / ``fileData`` (remote url) part.
+* ``ollama_native`` — OpenAI ``image_url`` -> Ollama-native's per-message
+  ``images`` field (bare base64 list), text stays in ``content``.
+* ``cohere_generate`` — text-only wire; a dropped image block now logs a
+  WARNING (was DEBUG pre-Wave-1b).
+
+Plus a byte-identity PIN: ``openai_chat`` and ``mistral_chat`` need NO
+translation because the canonical shape already IS their wire shape — this
+file imports both read-only and asserts their emitted ``messages`` field is
+byte-identical to the raw multimodal input.
+
+No real model names are hardcoded (env-models.md) — tests use
+``"test-model"``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import (
+    _content_parts,
+    anthropic_messages,
+    cohere_generate,
+    google_generate_content,
+    mistral_chat,
+    ollama_native,
+    openai_chat,
+)
+
+# --- Shared fixtures ------------------------------------------------------
+
+_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+_DATA_URI = f"data:image/png;base64,{_PNG_B64}"
+_REMOTE_URL = "https://example.com/images/cat.png"
+_REMOTE_URL_NO_EXT = "https://example.com/images/cat"
+
+
+def _data_uri_image_block():
+    return {"type": "image_url", "image_url": {"url": _DATA_URI}}
+
+
+def _remote_url_image_block():
+    return {"type": "image_url", "image_url": {"url": _REMOTE_URL}}
+
+
+def _text_block(text="What is in this image?"):
+    return {"type": "text", "text": text}
+
+
+def _base_request(messages, **overrides) -> CompletionRequest:
+    fields = {"model": "test-model", "messages": messages}
+    fields.update(overrides)
+    return CompletionRequest(**fields)
+
+
+# ===========================================================================
+# _content_parts — pure classify/emit functions
+# ===========================================================================
+
+
+class TestParseDataUri:
+    def test_valid_data_uri_splits_media_type_and_data(self):
+        result = _content_parts.parse_data_uri(_DATA_URI)
+        assert result == ("image/png", _PNG_B64)
+
+    def test_missing_data_scheme_returns_none(self):
+        assert _content_parts.parse_data_uri(_REMOTE_URL) is None
+
+    def test_missing_base64_marker_returns_none(self):
+        assert _content_parts.parse_data_uri("data:image/png,notbase64") is None
+
+    def test_empty_media_type_returns_none(self):
+        assert _content_parts.parse_data_uri("data:;base64,abcd") is None
+
+    def test_empty_data_returns_none(self):
+        assert _content_parts.parse_data_uri("data:image/png;base64,") is None
+
+    def test_non_string_input_returns_none(self):
+        assert _content_parts.parse_data_uri(None) is None  # type: ignore[arg-type]
+
+
+class TestIsRemoteUrl:
+    @pytest.mark.parametrize(
+        "url",
+        ["https://example.com/x.png", "http://example.com/x.png"],
+    )
+    def test_http_and_https_are_remote(self, url):
+        assert _content_parts.is_remote_url(url) is True
+
+    def test_data_uri_is_not_remote(self):
+        assert _content_parts.is_remote_url(_DATA_URI) is False
+
+    def test_non_string_is_not_remote(self):
+        assert _content_parts.is_remote_url(None) is False  # type: ignore[arg-type]
+
+
+class TestParseContentPart:
+    def test_text_block_returns_text_part(self):
+        part = _content_parts.parse_content_part(_text_block("hello"))
+        assert isinstance(part, _content_parts.TextPart)
+        assert part.text == "hello"
+
+    def test_text_block_missing_text_key_defaults_empty(self):
+        part = _content_parts.parse_content_part({"type": "text"})
+        assert isinstance(part, _content_parts.TextPart)
+        assert part.text == ""
+
+    def test_data_uri_image_block_returns_image_part(self):
+        part = _content_parts.parse_content_part(_data_uri_image_block())
+        assert isinstance(part, _content_parts.ImagePart)
+        assert part.is_data_uri is True
+        assert part.media_type == "image/png"
+        assert part.data == _PNG_B64
+        assert part.url is None
+
+    def test_remote_url_image_block_returns_image_part(self):
+        part = _content_parts.parse_content_part(_remote_url_image_block())
+        assert isinstance(part, _content_parts.ImagePart)
+        assert part.is_data_uri is False
+        assert part.url == _REMOTE_URL
+        assert part.media_type is None
+        assert part.data is None
+
+    def test_unrecognized_block_type_returns_none(self):
+        assert _content_parts.parse_content_part({"type": "tool_use"}) is None
+
+    def test_image_url_missing_url_key_returns_none(self):
+        assert (
+            _content_parts.parse_content_part({"type": "image_url", "image_url": {}})
+            is None
+        )
+
+    def test_image_url_malformed_not_data_or_remote_returns_none(self):
+        block = {"type": "image_url", "image_url": {"url": "ftp://example.com/x.png"}}
+        assert _content_parts.parse_content_part(block) is None
+
+    def test_non_dict_block_returns_none(self):
+        assert _content_parts.parse_content_part("just a string") is None
+
+
+class TestGuessMediaType:
+    def test_known_extension_png(self):
+        assert _content_parts.guess_media_type("https://x.com/a.png") == "image/png"
+
+    def test_known_extension_jpg(self):
+        assert _content_parts.guess_media_type("https://x.com/a.jpg") == "image/jpeg"
+
+    def test_unknown_extension_falls_back(self):
+        assert (
+            _content_parts.guess_media_type(_REMOTE_URL_NO_EXT)
+            == "application/octet-stream"
+        )
+
+
+class TestToAnthropicBlock:
+    def test_data_uri_emits_base64_source(self):
+        part = _content_parts.ImagePart(
+            is_data_uri=True, media_type="image/png", data=_PNG_B64
+        )
+        assert _content_parts.to_anthropic_block(part) == {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": _PNG_B64,
+            },
+        }
+
+    def test_remote_url_emits_url_source(self):
+        part = _content_parts.ImagePart(is_data_uri=False, url=_REMOTE_URL)
+        assert _content_parts.to_anthropic_block(part) == {
+            "type": "image",
+            "source": {"type": "url", "url": _REMOTE_URL},
+        }
+
+
+class TestToGeminiPart:
+    def test_data_uri_emits_inline_data(self):
+        part = _content_parts.ImagePart(
+            is_data_uri=True, media_type="image/png", data=_PNG_B64
+        )
+        assert _content_parts.to_gemini_part(part) == {
+            "inlineData": {"mimeType": "image/png", "data": _PNG_B64}
+        }
+
+    def test_remote_url_emits_file_data_with_guessed_mime_type(self):
+        part = _content_parts.ImagePart(is_data_uri=False, url=_REMOTE_URL)
+        assert _content_parts.to_gemini_part(part) == {
+            "fileData": {"mimeType": "image/png", "fileUri": _REMOTE_URL}
+        }
+
+    def test_remote_url_no_extension_falls_back_mime_type(self):
+        part = _content_parts.ImagePart(is_data_uri=False, url=_REMOTE_URL_NO_EXT)
+        result = _content_parts.to_gemini_part(part)
+        assert result["fileData"]["mimeType"] == "application/octet-stream"
+        assert result["fileData"]["fileUri"] == _REMOTE_URL_NO_EXT
+
+
+class TestToOllamaImages:
+    def test_filters_to_data_uri_base64_only(self):
+        data_part = _content_parts.ImagePart(
+            is_data_uri=True, media_type="image/png", data=_PNG_B64
+        )
+        remote_part = _content_parts.ImagePart(is_data_uri=False, url=_REMOTE_URL)
+        assert _content_parts.to_ollama_images([data_part, remote_part]) == [_PNG_B64]
+
+    def test_empty_list_returns_empty(self):
+        assert _content_parts.to_ollama_images([]) == []
+
+
+# ===========================================================================
+# anthropic_messages — image_url -> Anthropic image block
+# ===========================================================================
+
+
+class TestAnthropicMultimodalTranslation:
+    def test_data_uri_image_translated_to_base64_block(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _data_uri_image_block()],
+                }
+            ]
+        )
+        payload = anthropic_messages.build_request_payload(req)
+        content = payload["messages"][0]["content"]
+        assert content[0] == {"type": "text", "text": "hi"}
+        assert content[1] == {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": _PNG_B64,
+            },
+        }
+
+    def test_remote_url_image_translated_to_url_source(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _remote_url_image_block()],
+                }
+            ]
+        )
+        payload = anthropic_messages.build_request_payload(req)
+        content = payload["messages"][0]["content"]
+        assert content[1] == {
+            "type": "image",
+            "source": {"type": "url", "url": _REMOTE_URL},
+        }
+
+    def test_text_only_message_unchanged(self):
+        req = _base_request([{"role": "user", "content": "hello there"}])
+        payload = anthropic_messages.build_request_payload(req)
+        assert payload["messages"] == [{"role": "user", "content": "hello there"}]
+
+    def test_text_only_content_list_unchanged(self):
+        req = _base_request(
+            [{"role": "user", "content": [_text_block("hello"), _text_block("world")]}]
+        )
+        payload = anthropic_messages.build_request_payload(req)
+        assert payload["messages"][0]["content"] == [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "world"},
+        ]
+
+    def test_unrecognized_block_passes_through_unchanged(self):
+        weird_block = {"type": "tool_use", "id": "x", "name": "foo", "input": {}}
+        req = _base_request([{"role": "user", "content": [weird_block]}])
+        payload = anthropic_messages.build_request_payload(req)
+        assert payload["messages"][0]["content"] == [weird_block]
+
+
+# ===========================================================================
+# google_generate_content — image_url -> Gemini inlineData/fileData
+# ===========================================================================
+
+
+class TestGeminiMultimodalTranslation:
+    def test_data_uri_image_translated_to_inline_data(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _data_uri_image_block()],
+                }
+            ]
+        )
+        payload = google_generate_content.build_request_payload(req)
+        parts = payload["contents"][0]["parts"]
+        assert parts[0] == {"text": "hi"}
+        assert parts[1] == {"inlineData": {"mimeType": "image/png", "data": _PNG_B64}}
+
+    def test_remote_url_image_translated_to_file_data(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _remote_url_image_block()],
+                }
+            ]
+        )
+        payload = google_generate_content.build_request_payload(req)
+        parts = payload["contents"][0]["parts"]
+        assert parts[1] == {
+            "fileData": {"mimeType": "image/png", "fileUri": _REMOTE_URL}
+        }
+
+    def test_text_only_message_unchanged(self):
+        req = _base_request([{"role": "user", "content": "hello there"}])
+        payload = google_generate_content.build_request_payload(req)
+        assert payload["contents"][0]["parts"] == [{"text": "hello there"}]
+
+    def test_unrecognized_block_passes_through_unchanged(self):
+        weird_block = {"functionCall": {"name": "foo", "args": {}}}
+        req = _base_request([{"role": "assistant", "content": [weird_block]}])
+        payload = google_generate_content.build_request_payload(req)
+        assert payload["contents"][0]["parts"] == [weird_block]
+
+
+# ===========================================================================
+# ollama_native — image_url -> per-message `images` field
+# ===========================================================================
+
+
+class TestOllamaMultimodalTranslation:
+    def test_data_uri_image_moved_to_images_field(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _data_uri_image_block()],
+                }
+            ]
+        )
+        payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "hi"
+        assert msg["images"] == [_PNG_B64]
+
+    def test_multiple_data_uri_images_all_moved(self):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        _text_block("compare"),
+                        _data_uri_image_block(),
+                        _data_uri_image_block(),
+                    ],
+                }
+            ]
+        )
+        payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "compare"
+        assert msg["images"] == [_PNG_B64, _PNG_B64]
+
+    def test_text_only_string_content_unchanged(self):
+        req = _base_request([{"role": "user", "content": "hello there"}])
+        payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "hello there"
+        assert "images" not in msg
+
+    def test_text_only_content_list_unchanged(self):
+        blocks = [_text_block("hello"), _text_block("world")]
+        req = _base_request([{"role": "user", "content": blocks}])
+        payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        # No image_url part present -> content list passed through as-is.
+        assert msg["content"] == blocks
+        assert "images" not in msg
+
+    def test_remote_url_image_dropped_with_warning(self, caplog):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("describe"), _remote_url_image_block()],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.ollama_native"
+        ):
+            payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "describe"
+        assert "images" not in msg
+        assert any(
+            r.levelno == logging.WARNING
+            and "ollama_native.remote_image_url_not_translated" in r.message
+            for r in caplog.records
+        )
+
+    def test_mixed_data_uri_and_remote_url(self, caplog):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        _text_block("mixed"),
+                        _data_uri_image_block(),
+                        _remote_url_image_block(),
+                    ],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.ollama_native"
+        ):
+            payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "mixed"
+        assert msg["images"] == [_PNG_B64]
+        assert any(
+            "ollama_native.remote_image_url_not_translated" in r.message
+            for r in caplog.records
+        )
+
+
+# ===========================================================================
+# cohere_generate — text-only wire; drop now WARNs (was DEBUG)
+# ===========================================================================
+
+
+class TestCohereImageDropWarns:
+    def test_data_uri_image_block_dropped_with_warning(self, caplog):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _data_uri_image_block()],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.cohere_generate"
+        ):
+            payload = cohere_generate.build_request_payload(req)
+        # Only the text survives into Cohere's `message` field.
+        assert payload["message"] == "hi"
+        warn_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "cohere_generate.non_text_block_dropped" in r.message
+        ]
+        assert len(warn_records) == 1
+
+    def test_remote_url_image_block_dropped_with_warning(self, caplog):
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _remote_url_image_block()],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.cohere_generate"
+        ):
+            payload = cohere_generate.build_request_payload(req)
+        assert payload["message"] == "hi"
+        assert any(
+            r.levelno == logging.WARNING
+            and "cohere_generate.non_text_block_dropped" in r.message
+            for r in caplog.records
+        )
+
+    def test_no_image_no_warning(self, caplog):
+        req = _base_request([{"role": "user", "content": "plain text only"}])
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.cohere_generate"
+        ):
+            cohere_generate.build_request_payload(req)
+        assert not any(
+            "cohere_generate.non_text_block_dropped" in r.message
+            for r in caplog.records
+        )
+
+
+# ===========================================================================
+# Byte-identity pin: openai_chat + mistral_chat need NO translation
+# ===========================================================================
+
+
+class TestOpenAiAndMistralByteIdentityPin:
+    """openai_chat + mistral_chat pass ``messages`` through verbatim — the
+    canonical content-part shape already IS their wire shape. No code
+    change was made to either shaper in this shard; these tests PIN that
+    invariant against the raw multimodal input.
+    """
+
+    @staticmethod
+    def _multimodal_messages():
+        return [
+            {
+                "role": "user",
+                "content": [
+                    _text_block("What's in these images?"),
+                    _data_uri_image_block(),
+                    _remote_url_image_block(),
+                ],
+            }
+        ]
+
+    def test_openai_chat_messages_byte_identical_to_raw_input(self):
+        messages = self._multimodal_messages()
+        req = _base_request(messages)
+        payload = openai_chat.build_request_payload(req)
+        assert payload["messages"] == messages
+
+    def test_mistral_chat_messages_byte_identical_to_raw_input(self):
+        messages = self._multimodal_messages()
+        req = _base_request(messages)
+        payload = mistral_chat.build_request_payload(req)
+        assert payload["messages"] == messages
+
+    def test_openai_and_mistral_agree_on_multimodal_messages_shape(self):
+        messages = self._multimodal_messages()
+        req = _base_request(messages)
+        openai_payload = openai_chat.build_request_payload(req)
+        mistral_payload = mistral_chat.build_request_payload(req)
+        assert openai_payload["messages"] == mistral_payload["messages"] == messages

--- a/packages/kailash-kaizen/tests/unit/llm/test_multimodal_content_parts.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_multimodal_content_parts.py
@@ -437,6 +437,52 @@ class TestOllamaMultimodalTranslation:
             for r in caplog.records
         )
 
+    def test_malformed_image_url_block_dropped_with_warning(self, caplog):
+        """/redteam Round-1 (#1720 Wave-1b): a malformed image_url block
+        (missing `url`) has no Ollama-native slot and is dropped -- this
+        branch previously fell through with NO log. Must WARN, never
+        silent, per rules/observability.md Rule 7."""
+        malformed_block = {"type": "image_url", "image_url": {}}
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("describe"), malformed_block],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.ollama_native"
+        ):
+            payload = ollama_native.build_request_payload(req)
+        msg = payload["messages"][0]
+        assert msg["content"] == "describe"
+        assert "images" not in msg
+        assert any(
+            r.levelno == logging.WARNING
+            and "ollama_native.content_block_dropped" in r.message
+            for r in caplog.records
+        )
+
+    def test_no_malformed_block_no_content_block_dropped_warning(self, caplog):
+        """Byte-neutral: a data-URI-only message emits no
+        content_block_dropped warning."""
+        req = _base_request(
+            [
+                {
+                    "role": "user",
+                    "content": [_text_block("hi"), _data_uri_image_block()],
+                }
+            ]
+        )
+        with caplog.at_level(
+            logging.WARNING, logger="kaizen.llm.wire_protocols.ollama_native"
+        ):
+            ollama_native.build_request_payload(req)
+        assert not any(
+            "ollama_native.content_block_dropped" in r.message for r in caplog.records
+        )
+
 
 # ===========================================================================
 # cohere_generate — text-only wire; drop now WARNs (was DEBUG)

--- a/packages/kailash-kaizen/tests/unit/llm/test_reasoning_filter.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_reasoning_filter.py
@@ -41,9 +41,24 @@ from kaizen.llm.wire_protocols import openai_chat
 
 @pytest.mark.parametrize(
     "model",
-    ["o1", "o1-mini", "o1-preview", "o3", "o3-mini", "O1-MINI", "O3"],
+    [
+        "o1",
+        "o1-mini",
+        "o1-preview",
+        "o3",
+        "o3-mini",
+        "O1-MINI",
+        "O3",
+        # /redteam Round-1 (#1720 Wave-1b): o4-mini is an o-series reasoning
+        # model that rejects temperature/top_p just like o1/o3 — it was
+        # previously (wrongly) asserted FALSE here, letting every o4-mini
+        # call through with a live HTTP 400 on the wire.
+        "o4",
+        "o4-mini",
+        "O4-MINI",
+    ],
 )
-def test_is_reasoning_model_true_for_o1_o3_family(model: str) -> None:
+def test_is_reasoning_model_true_for_o1_o3_o4_family(model: str) -> None:
     assert is_reasoning_model(model) is True
 
 
@@ -56,7 +71,6 @@ def test_is_reasoning_model_true_for_o1_o3_family(model: str) -> None:
         "gpt-5-mini",
         "claude-3-5-sonnet",
         "",
-        "o4-mini",
     ],
 )
 def test_is_reasoning_model_false_for_non_o1_o3(model: str) -> None:
@@ -204,6 +218,20 @@ def test_openai_chat_payload_drops_sampling_for_o1_o3(model: str) -> None:
     # unrelated fields still emitted.
     assert payload["max_completion_tokens"] == 64
     assert payload["model"] == model
+
+
+def test_openai_chat_payload_drops_sampling_for_o4_mini() -> None:
+    """/redteam Round-1 (#1720 Wave-1b) regression: o4-mini is an o-series
+    reasoning model (openai_chat._MAX_COMPLETION_TOKENS_MODEL_PREFIXES
+    includes "o4") that rejects temperature/top_p with a live HTTP 400 —
+    before the `^o4` pattern was added, this payload would have carried
+    `temperature`/`top_p` straight through to the wire."""
+    req = _req("o4-mini", temperature=0.7, top_p=0.9, max_tokens=64)
+    payload = openai_chat.build_request_payload(req)
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert payload["max_completion_tokens"] == 64
+    assert payload["model"] == "o4-mini"
 
 
 @pytest.mark.parametrize("model", ["gpt-5", "gpt-5-mini", "gpt-5.6-sol"])

--- a/packages/kailash-kaizen/tests/unit/llm/test_reasoning_filter.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_reasoning_filter.py
@@ -1,0 +1,332 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning-model sampling-param filter tests (#1720 Wave-1b).
+
+Covers `kaizen.llm.reasoning_filter` (the module-level port of the legacy
+`OpenAIProvider._filter_reasoning_model_params` family) AND its wiring into
+`openai_chat.build_request_payload`:
+
+* o1/o3 reasoning models DROP temperature/top_p/frequency_penalty/
+  presence_penalty entirely.
+* gpt-5 FORCES temperature=1.0 and drops top_p/frequency_penalty/
+  presence_penalty.
+* Every other model is an untouched (byte-neutral) passthrough.
+* The four-axis `openai_chat` wire payload reflects the filter — including
+  preserving the EXACT pre-existing key order for the byte-neutral case.
+
+All assertions are behavioral (call the function / build the payload, assert
+the returned value) per `rules/testing.md` — no source-grep.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.reasoning_filter import (
+    filter_reasoning_model_params,
+    is_reasoning_model,
+    requires_temperature_1,
+)
+from kaizen.llm.wire_protocols import openai_chat
+
+
+# ---------------------------------------------------------------------------
+# is_reasoning_model / requires_temperature_1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["o1", "o1-mini", "o1-preview", "o3", "o3-mini", "O1-MINI", "O3"],
+)
+def test_is_reasoning_model_true_for_o1_o3_family(model: str) -> None:
+    assert is_reasoning_model(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-5",
+        "gpt-5-mini",
+        "claude-3-5-sonnet",
+        "",
+        "o4-mini",
+    ],
+)
+def test_is_reasoning_model_false_for_non_o1_o3(model: str) -> None:
+    assert is_reasoning_model(model) is False
+
+
+@pytest.mark.parametrize(
+    "model", ["gpt-5", "gpt-5-mini", "gpt5", "GPT-5", "gpt-5.6-sol"]
+)
+def test_requires_temperature_1_true_for_gpt5_family(model: str) -> None:
+    assert requires_temperature_1(model) is True
+
+
+@pytest.mark.parametrize(
+    "model", ["gpt-4o", "gpt-4-turbo", "o1", "o3-mini", "claude-3-5-sonnet", ""]
+)
+def test_requires_temperature_1_false_for_non_gpt5(model: str) -> None:
+    assert requires_temperature_1(model) is False
+
+
+def test_is_reasoning_model_false_for_falsy_model() -> None:
+    assert is_reasoning_model("") is False
+    assert is_reasoning_model(None) is False  # type: ignore[arg-type]
+
+
+def test_requires_temperature_1_false_for_falsy_model() -> None:
+    assert requires_temperature_1("") is False
+    assert requires_temperature_1(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# filter_reasoning_model_params
+# ---------------------------------------------------------------------------
+
+
+def test_o1_o3_drops_all_four_sampling_params_when_present() -> None:
+    params = {
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+    }
+    filtered = filter_reasoning_model_params("o1-mini", params)
+    assert filtered == {}
+    # original dict untouched — no in-place mutation.
+    assert params == {
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+    }
+
+
+def test_o3_drops_only_the_keys_present() -> None:
+    filtered = filter_reasoning_model_params("o3", {"temperature": 0.5})
+    assert filtered == {}
+
+
+def test_o1_o3_does_not_add_any_key() -> None:
+    filtered = filter_reasoning_model_params("o1", {})
+    assert filtered == {}
+
+
+def test_o1_o3_leaves_non_sampling_keys_untouched() -> None:
+    # filter_reasoning_model_params only knows about the 4 sampling keys —
+    # any other key in the dict (defensive: callers only ever pass sampling
+    # keys today) passes through unchanged.
+    filtered = filter_reasoning_model_params(
+        "o1", {"temperature": 0.7, "unrelated": "keep-me"}
+    )
+    assert filtered == {"unrelated": "keep-me"}
+
+
+def test_gpt5_forces_temperature_1_and_drops_top_p_and_penalties() -> None:
+    params = {
+        "temperature": 0.3,
+        "top_p": 0.8,
+        "frequency_penalty": 0.4,
+        "presence_penalty": 0.5,
+    }
+    filtered = filter_reasoning_model_params("gpt-5", params)
+    assert filtered == {"temperature": 1.0}
+    # original dict untouched.
+    assert params["temperature"] == 0.3
+
+
+def test_gpt5_forces_temperature_1_even_when_caller_never_set_it() -> None:
+    """gpt-5 400s on the server-side default too — force temperature=1.0
+    unconditionally, matching the legacy `OpenAIProvider` behavior."""
+    filtered = filter_reasoning_model_params("gpt-5", {})
+    assert filtered == {"temperature": 1.0}
+
+
+def test_gpt5_temperature_already_1_stays_1_and_drops_top_p() -> None:
+    filtered = filter_reasoning_model_params(
+        "gpt-5-mini", {"temperature": 1.0, "top_p": 0.7}
+    )
+    assert filtered == {"temperature": 1.0}
+
+
+def test_unknown_model_returns_unchanged_copy() -> None:
+    params = {"temperature": 0.7, "top_p": 0.9, "frequency_penalty": 0.1}
+    filtered = filter_reasoning_model_params("gpt-4o", params)
+    assert filtered == params
+    # A COPY — mutating the result must not mutate the caller's dict.
+    filtered["temperature"] = 999.0
+    assert params["temperature"] == 0.7
+
+
+def test_unknown_model_empty_params_returns_empty_dict() -> None:
+    assert filter_reasoning_model_params("gpt-4o", {}) == {}
+
+
+def test_empty_model_string_is_unknown_passthrough() -> None:
+    params = {"temperature": 0.5}
+    assert filter_reasoning_model_params("", params) == params
+
+
+# ---------------------------------------------------------------------------
+# openai_chat.build_request_payload wiring
+# ---------------------------------------------------------------------------
+
+
+def _req(model: str, **kwargs) -> CompletionRequest:
+    return CompletionRequest(
+        model=model, messages=[{"role": "user", "content": "hi"}], **kwargs
+    )
+
+
+@pytest.mark.parametrize("model", ["o1", "o1-mini", "o3", "o3-mini"])
+def test_openai_chat_payload_drops_sampling_for_o1_o3(model: str) -> None:
+    req = _req(
+        model,
+        temperature=0.7,
+        top_p=0.9,
+        frequency_penalty=0.2,
+        presence_penalty=0.3,
+        max_tokens=64,
+    )
+    payload = openai_chat.build_request_payload(req)
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+    # unrelated fields still emitted.
+    assert payload["max_completion_tokens"] == 64
+    assert payload["model"] == model
+
+
+@pytest.mark.parametrize("model", ["gpt-5", "gpt-5-mini", "gpt-5.6-sol"])
+def test_openai_chat_payload_forces_temperature_1_for_gpt5(model: str) -> None:
+    req = _req(
+        model,
+        temperature=0.2,
+        top_p=0.9,
+        frequency_penalty=0.2,
+        presence_penalty=0.3,
+    )
+    payload = openai_chat.build_request_payload(req)
+    assert payload["temperature"] == 1.0
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+
+
+def test_openai_chat_payload_forces_temperature_1_for_gpt5_even_unset() -> None:
+    req = _req("gpt-5")  # caller never set temperature at all
+    payload = openai_chat.build_request_payload(req)
+    assert payload["temperature"] == 1.0
+
+
+def test_openai_chat_payload_untouched_for_non_reasoning_model_with_sampling_set() -> (
+    None
+):
+    req = _req(
+        "gpt-4o",
+        temperature=0.6,
+        top_p=0.95,
+        frequency_penalty=0.1,
+        presence_penalty=0.2,
+    )
+    payload = openai_chat.build_request_payload(req)
+    assert payload["temperature"] == 0.6
+    assert payload["top_p"] == 0.95
+    assert payload["frequency_penalty"] == 0.1
+    assert payload["presence_penalty"] == 0.2
+
+
+def test_openai_chat_payload_byte_neutral_for_non_reasoning_model_unset_sampling() -> (
+    None
+):
+    """AC: for a NON-reasoning model with unset sampling, the payload MUST
+    stay byte-identical to the pre-filter shape."""
+    req = _req("gpt-4o", max_tokens=64)
+    payload = openai_chat.build_request_payload(req)
+    assert payload == {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+    }
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+    # And the exact serialized bytes are what a pre-filter build would have
+    # produced — key order matters for the cross-SDK byte-parity contract.
+    assert list(payload.keys()) == ["model", "messages", "max_tokens"]
+
+
+def test_openai_chat_payload_key_order_unchanged_full_featured_non_reasoning() -> None:
+    """Every #1720 Wave-1a/1b field set on a non-reasoning model preserves
+    the EXACT pre-filter key insertion order (byte-parity contract)."""
+    req = _req(
+        "gpt-4o",
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=64,
+        stop=["END"],
+        stream=True,
+        user="u1",
+        tools=[{"type": "function", "function": {"name": "f"}}],
+        response_format={"type": "json_object"},
+        seed=7,
+        logit_bias={"123": -100.0},
+        frequency_penalty=0.1,
+        presence_penalty=0.2,
+        n=2,
+    )
+    payload = openai_chat.build_request_payload(req)
+    assert list(payload.keys()) == [
+        "model",
+        "messages",
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "stop",
+        "stream",
+        "user",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "seed",
+        "logit_bias",
+        "frequency_penalty",
+        "presence_penalty",
+        "n",
+    ]
+    # And the whole payload round-trips through json.dumps without error —
+    # exercising the exact serialization the wire send-path performs.
+    json.dumps(payload)
+
+
+def test_openai_chat_payload_reasoning_model_key_order_has_no_gaps() -> None:
+    """o1 drops sampling keys entirely — the remaining keys keep their
+    relative order (no empty/None placeholders left behind)."""
+    req = _req(
+        "o1-mini",
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=64,
+        seed=7,
+        frequency_penalty=0.1,
+        presence_penalty=0.2,
+        n=2,
+    )
+    payload = openai_chat.build_request_payload(req)
+    assert list(payload.keys()) == [
+        "model",
+        "messages",
+        "max_completion_tokens",
+        "seed",
+        "n",
+    ]


### PR DESCRIPTION
## Summary

Completes **Wave 1b** of #1720 (retire legacy `providers/llm/` onto the four-axis `LlmClient`). This is the **additive** wave — nothing in production consumes `LlmClient.complete/stream` yet (verified: no `src/kaizen` import of `LlmClient` outside `/llm/`), so it regresses nothing. Six remaining shards, all file-disjoint, landed via parallel worktree agents + integration:

- **bedrock_invoke** — per-family tool emission + `outputs[].tool_calls` parse (`mistral.*` native; `meta`/`amazon`/`cohere` omitted — no native InvokeModel tools field, OMIT-don't-fake) + image-block-drop WARN.
- **huggingface_inference** — chat-schema (TGI) tool emission + parse; classic text-generation path omits tools (WARNs when tools are requested there) + image-drop WARN.
- **multimodal** — new `_content_parts.py` canonical translator + Anthropic / Gemini / Ollama image-part translation; Cohere drop upgraded DEBUG→WARN; OpenAI/Mistral byte-identity pinned (no code change).
- **embed remainder** — new `cohere_embeddings` (`/v1/embed`) + `huggingface_embeddings` (feature-extraction, pooled + mean-pooled) shapers, `_EMBED_DISPATCH` entries, and the Azure `?api-version=` fix (both completion AND embed URLs now append `endpoint.query_params`).
- **mock** — offline deterministic `MockLlmHttpClient` transport in `kaizen/llm/testing/` (Protocol-satisfying, physically isolated from the production surface).
- **byok + reasoning** — per-request `api_key=` override (never logged; fail-closed typed error when the deployment auth kind can't accept it; NOT a `CompletionRequest` field) + reasoning-model param filter (`o1`/`o3`/`o4` drop temperature/top_p/penalties; `gpt-5` force `temperature=1.0`).

All 8 tool-capable adapters conform to one canonical normalized `tool_calls` shape, pinned by `test_issue_1720_wave1b_normalized_toolcalls_parity.py` (extended 6→8; agreement assertion generalized to all-N).

## Testing

- **2047 kaizen LLM + regression tests pass**, 0 failures (7 warnings are the pre-existing intentional #1721 legacy-tier deprecation shims).
- ruff + black clean on all 27 changed files; `pytest --collect-only` exit 0.

## Redteam — converged (3 rounds, holistic multi-wave)

3 parallel lenses (code-correctness / security / provider-shape+closure-parity) over the union of all 6 shards:
- **Round 1** — found + fixed 7 defects: 1 CRITICAL (`embed()` missing `model=` → HuggingFace embed 100% broken), 2 HIGH (`o4` reasoning family missing → o4-mini 400; HF `complete()` silently dropped tools), 2 MED (ollama silent block-drop; api_key CRLF-injection surface), 2 LOW (google `response_format` truthiness; stale embed error message).
- **Round 2** — verified all 7 fixes correct; closed a MED test-depth gap (pinned the `embed()` call site end-to-end via respx, not `_build_embed_url` in isolation) + LOW security hardening (api_key guard now rejects DEL + non-ASCII → typed error, not opaque `UnicodeEncodeError`).
- **Round 3** — **CONVERGENCE: CLEAN**, no CRITICAL/HIGH/MED remaining.

## Verify-items (honest, unverified against live docs — additive, no consumer yet)

- **bedrock_invoke mistral tools**: whether Bedrock routes `mistral.*` tool-use via InvokeModel body vs the Converse API is flagged in-code for live-AWS-doc verification before production reliance.
- **mistral multimodal**: the OpenAI-compatible nested `image_url` byte-identity is assumed current; worth confirming against Mistral's live vision API.

## Follow-ups (NOT in this PR)

- **Waves 2–4 remain HUMAN-GATED at `/todos`**: dual-run behind `_provider_llm_response` → migrate consumers → delete legacy (irreversible).
- **Cross-SDK**: the CRITICAL embed `model=` bug + the BYOK CRLF guard are candidates for the same class in the Rust SDK — pending cross-repo authorization (not self-authorized).
- HuggingFace `complete()` chat-schema **routing** (making tool emission reachable, currently WARN + documented scoped-limitation) is a separate deployment-routing shard.

## Related issues

Part of #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)