### PR TITLE
feat(kaizen): #1720 Wave-2 — dual-run shadow validation (fire-and-forget, flag-gated, flag-off byte-neutral)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/_legacy_shape.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/_legacy_shape.py
@@ -31,6 +31,7 @@ booleans, lengths, and counts.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Dict, List
 
 
@@ -98,6 +99,33 @@ def _safe_len(value: Any) -> int:
         return 1 if value else 0
 
 
+def _tool_call_name_hashes(tool_calls: Any) -> List[str]:
+    """Return a sorted list of short (8-hex-char) SHA-256 hashes of each
+    tool call's function ``name`` -- NEVER the raw name or arguments.
+
+    Used ONLY to detect a same-count-but-different-tool divergence (a
+    shadow selecting a different tool than the legacy path, with the same
+    call count, would otherwise false-report parity). The hash is a
+    one-way fingerprint: it lets ``diff_legacy_vs_fouraxis`` report "the
+    tool selection differs" without embedding the tool name itself in the
+    divergence description (``rules/observability.md`` § 8; this Wave's
+    governance -- no raw generated content/arguments/schema-revealing
+    identifiers in log output). Defensive on non-list / malformed entries.
+    """
+    hashes: List[str] = []
+    if not isinstance(tool_calls, list):
+        return hashes
+    for entry in tool_calls:
+        if not isinstance(entry, dict):
+            continue
+        function = entry.get("function")
+        name = function.get("name") if isinstance(function, dict) else None
+        if not isinstance(name, str) or not name:
+            continue
+        hashes.append(hashlib.sha256(name.encode("utf-8")).hexdigest()[:8])
+    return sorted(hashes)
+
+
 def diff_legacy_vs_fouraxis(
     legacy: Dict[str, Any], mapped_fouraxis: Dict[str, Any]
 ) -> List[str]:
@@ -150,6 +178,19 @@ def diff_legacy_vs_fouraxis(
                 "tool_calls: count mismatch "
                 f"(legacy_count={legacy_count}, four_axis_count={mapped_count})"
             )
+        else:
+            # Same count can still hide a divergence: the shadow may have
+            # selected a genuinely DIFFERENT tool. Compare hashed function
+            # names (never the raw name) so a different-tool selection is
+            # caught without leaking the tool name or its arguments into
+            # the divergence description / logs.
+            legacy_hashes = _tool_call_name_hashes(legacy_tool_calls)
+            mapped_hashes = _tool_call_name_hashes(mapped_tool_calls)
+            if legacy_hashes != mapped_hashes:
+                divergences.append(
+                    "tool_calls: name hash mismatch "
+                    f"(legacy_hashes={legacy_hashes}, four_axis_hashes={mapped_hashes})"
+                )
 
     # --- finish_reason ---------------------------------------------------
     if legacy.get("finish_reason") != mapped_fouraxis.get("finish_reason"):

--- a/packages/kailash-kaizen/src/kaizen/llm/_legacy_shape.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/_legacy_shape.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-2 — legacy/four-axis response shape reconciliation.
+
+Pure, side-effect-free helpers used by the dual-run shadow validation in
+``kaizen.nodes.ai.llm_agent.LLMAgentNode._provider_llm_response``. Neither
+function performs I/O, logging, or raises on malformed input — they are
+defensive on missing/None keys so the shadow path (which must NEVER affect
+the live response) can call them unconditionally.
+
+Two shapes are reconciled:
+
+* **Legacy** (``kaizen.providers.*`` ``chat()`` return value):
+  ``{content, tool_calls, finish_reason, usage: {prompt_tokens,
+  completion_tokens, total_tokens}, model, ...}``.
+* **Four-axis** (``kaizen.llm.client.LlmClient.complete()`` return value):
+  ``{text, tool_calls?, stop_reason, usage: {input_tokens, output_tokens,
+  total_tokens}, model}``.
+
+``to_legacy_shape`` maps a four-axis result onto legacy field names so the
+two can be diffed field-by-field with ``diff_legacy_vs_fouraxis``. Neither
+function is ever fed back into the live response — the shadow path exists
+purely to compare, log, and discard.
+
+Per ``rules/observability.md`` § 8 and this Wave's governance, divergence
+descriptions returned by ``diff_legacy_vs_fouraxis`` MUST NOT embed raw
+generated text, tool-call arguments, or any secret — only field names,
+booleans, lengths, and counts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def to_legacy_shape(four_axis: Dict[str, Any]) -> Dict[str, Any]:
+    """Map an ``LlmClient.complete()`` result onto legacy response field names.
+
+    Defensive on a non-dict / partially-populated input — every read goes
+    through ``.get()`` with a safe default. ``total_tokens`` is computed
+    from the coerced input/output counts when the four-axis usage dict
+    omits it (mirrors the existing coercion in ``_provider_llm_response``
+    for the live legacy path, issue #487).
+    """
+    if not isinstance(four_axis, dict):
+        four_axis = {}
+
+    usage_in = four_axis.get("usage")
+    if not isinstance(usage_in, dict):
+        usage_in = {}
+
+    prompt_tokens = usage_in.get("input_tokens")
+    completion_tokens = usage_in.get("output_tokens")
+    total_tokens = usage_in.get("total_tokens")
+    if total_tokens is None:
+        total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+    legacy: Dict[str, Any] = {
+        "content": four_axis.get("text"),
+        "finish_reason": four_axis.get("stop_reason"),
+        "model": four_axis.get("model"),
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+    # tool_calls is passed through verbatim ONLY when the four-axis result
+    # carries it — mirrors the legacy shape's optional key, never fabricated.
+    if "tool_calls" in four_axis:
+        legacy["tool_calls"] = four_axis.get("tool_calls")
+
+    return legacy
+
+
+def _safe_text_repr(value: Any) -> str:
+    """Normalize a text-shaped value for equality comparison.
+
+    Used ONLY to detect a mismatch and to report its length — the returned
+    string itself is never embedded in a divergence description (governance:
+    no raw generated content in log output).
+    """
+    if isinstance(value, str):
+        return value
+    # Non-string content (e.g. a provider SDK object) — coerce defensively.
+    try:
+        return str(value)
+    except Exception:
+        return repr(value)
+
+
+def _safe_len(value: Any) -> int:
+    """Return ``len(value)`` for a list-shaped value, tolerating non-lists."""
+    try:
+        return len(value)
+    except TypeError:
+        return 1 if value else 0
+
+
+def diff_legacy_vs_fouraxis(
+    legacy: Dict[str, Any], mapped_fouraxis: Dict[str, Any]
+) -> List[str]:
+    """Return field-level divergence descriptions between the two shapes.
+
+    Empty list == parity. Every description names the FIELD plus a
+    boolean/length/count-level mismatch signal — never the raw generated
+    text, tool-call arguments, or any credential (``rules/observability.md``
+    § 8; this Wave's governance). Defensive on non-dict input.
+    """
+    if not isinstance(legacy, dict):
+        legacy = {}
+    if not isinstance(mapped_fouraxis, dict):
+        mapped_fouraxis = {}
+
+    divergences: List[str] = []
+
+    # --- content -----------------------------------------------------
+    # Equality is checked on the normalized text (never printed); the
+    # divergence string reports only presence + length, per governance
+    # (no raw generated content in log output).
+    legacy_content = legacy.get("content")
+    mapped_content = mapped_fouraxis.get("content")
+    legacy_is_none = legacy_content is None
+    mapped_is_none = mapped_content is None
+    legacy_text = "" if legacy_is_none else _safe_text_repr(legacy_content)
+    mapped_text = "" if mapped_is_none else _safe_text_repr(mapped_content)
+    if legacy_is_none != mapped_is_none or legacy_text != mapped_text:
+        divergences.append(
+            "content: text mismatch "
+            f"(legacy_present={not legacy_is_none}, legacy_len={len(legacy_text)}, "
+            f"four_axis_present={not mapped_is_none}, four_axis_len={len(mapped_text)})"
+        )
+
+    # --- tool_calls ----------------------------------------------------
+    legacy_tool_calls = legacy.get("tool_calls")
+    mapped_tool_calls = mapped_fouraxis.get("tool_calls")
+    legacy_has_tools = bool(legacy_tool_calls)
+    mapped_has_tools = bool(mapped_tool_calls)
+    if legacy_has_tools != mapped_has_tools:
+        divergences.append(
+            "tool_calls: presence mismatch "
+            f"(legacy_present={legacy_has_tools}, four_axis_present={mapped_has_tools})"
+        )
+    elif legacy_has_tools and mapped_has_tools:
+        legacy_count = _safe_len(legacy_tool_calls)
+        mapped_count = _safe_len(mapped_tool_calls)
+        if legacy_count != mapped_count:
+            divergences.append(
+                "tool_calls: count mismatch "
+                f"(legacy_count={legacy_count}, four_axis_count={mapped_count})"
+            )
+
+    # --- finish_reason ---------------------------------------------------
+    if legacy.get("finish_reason") != mapped_fouraxis.get("finish_reason"):
+        divergences.append("finish_reason: value mismatch")
+
+    # --- usage / token counts --------------------------------------------
+    legacy_usage = legacy.get("usage")
+    if not isinstance(legacy_usage, dict):
+        legacy_usage = {}
+    mapped_usage = mapped_fouraxis.get("usage")
+    if not isinstance(mapped_usage, dict):
+        mapped_usage = {}
+
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        legacy_value = legacy_usage.get(key)
+        mapped_value = mapped_usage.get(key)
+        if legacy_value != mapped_value:
+            divergences.append(
+                f"usage.{key}: count mismatch "
+                f"(legacy={legacy_value!r}, four_axis={mapped_value!r})"
+            )
+
+    return divergences
+
+
+__all__ = ["to_legacy_shape", "diff_legacy_vs_fouraxis"]

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -1,10 +1,12 @@
 """Advanced LLM Agent node with LangChain integration and MCP support."""
 
 import asyncio
-import concurrent.futures
+import copy
+import hashlib
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -27,6 +29,18 @@ logger = logging.getLogger(__name__)
 # reversible: gated entirely behind the `KAIZEN_LLM_DUAL_RUN` env var
 # (falsey/unset by default), and every failure mode in the shadow path is
 # caught and logged, never propagated to the caller.
+#
+# Fire-and-forget: the shadow is dispatched onto a daemon background thread
+# (`LLMAgentNode._dispatch_dual_run_shadow`) and the LIVE legacy response
+# returns immediately — the live path NEVER blocks on the shadow's network
+# call or its bounded timeout. See `LLMAgentNode._run_llm_dual_run_shadow`
+# for the worker itself (kept directly callable for unit tests).
+#
+# SECURITY / COST NOTE: enabling this flag fires a SECOND real outbound LLM
+# call per gated request (the shadow's `LlmClient.complete()`). Fire-and-
+# forget removes the shadow from the live path's LATENCY budget, but the
+# doubled COST and doubled token usage against the upstream provider remain
+# — this is opt-in validation-only traffic, not a free observability tap.
 # ---------------------------------------------------------------------------
 
 _DUAL_RUN_ENV_VAR = "KAIZEN_LLM_DUAL_RUN"
@@ -36,8 +50,11 @@ _DUAL_RUN_TIMEOUT_SECONDS = 30.0
 
 # Cheap observability signal: how many dual-run shadow comparisons have
 # logged a divergence since process start. Not persisted; a metrics hook can
-# be wired in later without changing the call site.
+# be wired in later without changing the call site. The shadow now runs on
+# a daemon thread per request, so increments are genuinely concurrent —
+# guarded by `_dual_run_divergence_lock` (redteam MED finding).
 _dual_run_divergence_count = 0
+_dual_run_divergence_lock = threading.Lock()
 
 # generation_config keys that map 1:1 onto LlmClient.complete() sampling
 # kwargs (both shapes were designed against the same #1720 Wave-1a field
@@ -63,7 +80,17 @@ def _dual_run_enabled() -> bool:
     """True when the #1720 Wave-2 dual-run shadow is enabled.
 
     Falsey/unset by default. The shadow path this gate wraps NEVER changes
-    the live response — see `LLMAgentNode._run_llm_dual_run_shadow`.
+    the live response — see `LLMAgentNode._run_llm_dual_run_shadow`. The
+    shadow is dispatched fire-and-forget on a daemon thread
+    (`LLMAgentNode._dispatch_dual_run_shadow`), so enabling this flag adds
+    NO latency to the live response path.
+
+    SECURITY / COST: enabling this flag fires a SECOND real outbound LLM
+    call per gated request (the four-axis shadow's `LlmClient.complete()`
+    against the SAME upstream provider). The doubled latency budget is off
+    the live path, but the doubled COST and doubled token usage are not —
+    this is opt-in validation-only traffic; do not enable in cost-sensitive
+    production traffic without accounting for 2x spend.
     """
     raw = os.environ.get(_DUAL_RUN_ENV_VAR, "")
     return raw.strip().lower() in _DUAL_RUN_TRUTHY_VALUES
@@ -95,9 +122,17 @@ def _shadow_deployment_for(
 
     Maps the legacy `provider` name (`kaizen.providers.registry.PROVIDERS`)
     onto the matching four-axis preset builder in `kaizen.llm.presets`.
-    Returns `None` (never raises) when the provider has no four-axis
-    mapping, or a required credential/base_url cannot be resolved — the
-    caller treats `None` as "shadow skipped, already logged at DEBUG".
+    Returns `None` when the provider has no four-axis mapping, or a
+    required credential/base_url cannot be resolved — the caller treats
+    `None` as "shadow skipped, already logged at DEBUG".
+
+    This function does NOT guarantee never-raises: the preset factories
+    (`openai_preset`, `anthropic_preset`, etc.) validate their own
+    arguments and MAY raise (e.g. `ValueError` on an invalid model name or
+    a malformed `api_key`). Callers MUST NOT rely on `None` as the only
+    failure signal — `_run_llm_dual_run_shadow`'s outer
+    `except BaseException` around this call is what actually makes the
+    shadow non-load-bearing, not this function's own contract.
 
     `api_key` mirrors the legacy provider's own resolution: when the caller
     did not pass a per-request override, the same `<PROVIDER>_API_KEY` env
@@ -161,31 +196,6 @@ def _shadow_deployment_for(
         extra={"provider": provider, "reason": "unmapped_provider"},
     )
     return None
-
-
-def _run_coro_in_isolated_thread(
-    coro_factory: Callable[[], Any], *, timeout_seconds: float
-) -> Any:
-    """Run `coro_factory()` to completion on a dedicated worker thread with
-    its own fresh event loop, bounded by `timeout_seconds`.
-
-    `_provider_llm_response` is a SYNC method that may itself be invoked
-    from inside an already-running asyncio event loop (an async Nexus
-    handler, a pytest-asyncio test, an agent loop) — a bare `asyncio.run()`
-    on the caller's thread would raise `RuntimeError: asyncio.run() cannot
-    be called from a running event loop` (`rules/patterns.md` § async/sync).
-    A one-worker `ThreadPoolExecutor` gives the coroutine a thread with NO
-    ambient loop, so `asyncio.run()` inside the worker is always safe.
-
-    The executor is shut down with `wait=False` so a timed-out call never
-    blocks the caller on the abandoned worker thread.
-    """
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    try:
-        future = executor.submit(lambda: asyncio.run(coro_factory()))
-        return future.result(timeout=timeout_seconds)
-    finally:
-        executor.shutdown(wait=False)
 
 
 @dataclass
@@ -2398,15 +2408,20 @@ Final Answer: 6 hours"""
                     completion = usage.get("completion_tokens") or 0
                     usage["total_tokens"] = prompt + completion
 
-            # #1720 Wave-2 — shadow-run the four-axis LlmClient alongside the
-            # legacy response above for validation. Gated behind
-            # KAIZEN_LLM_DUAL_RUN (falsey/unset by default); the flag-OFF
-            # path above this line is completely untouched and this call is
-            # a pure no-op when the flag is off (`_dual_run_enabled()`
-            # short-circuits before any four-axis code runs). NEVER affects
-            # the `response` returned below.
+            # #1720 Wave-2 — dispatch the four-axis LlmClient shadow
+            # fire-and-forget alongside the legacy response above, for
+            # validation. Gated behind KAIZEN_LLM_DUAL_RUN (falsey/unset by
+            # default); the flag-OFF path above this line is completely
+            # untouched and this call is a pure no-op when the flag is off
+            # (`_dual_run_enabled()` short-circuits before any four-axis
+            # code runs). The dispatch starts a DAEMON thread and returns
+            # IMMEDIATELY without `.join()`/`.result()` — the shadow NEVER
+            # adds latency to the `response` returned below (redteam HIGH:
+            # a synchronous shadow call here previously added up to
+            # `_DUAL_RUN_TIMEOUT_SECONDS` of latency to the LIVE response,
+            # x5 inside the tool-execution loop in `run()`).
             if _dual_run_enabled():
-                self._run_llm_dual_run_shadow(
+                self._dispatch_dual_run_shadow(
                     provider=provider,
                     model=model,
                     messages=messages,
@@ -2431,6 +2446,97 @@ Final Answer: 6 hours"""
             self.logger.error("Provider %s error: %s", provider, e, exc_info=True)
             raise RuntimeError(sanitize_provider_error(e, provider)) from e
 
+    def _dispatch_dual_run_shadow(
+        self,
+        *,
+        provider: str,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        generation_config: dict,
+        api_key: str | None,
+        base_url: str | None,
+        legacy_response: dict,
+    ) -> "threading.Thread | None":
+        """#1720 Wave-2 redteam (HIGH) — fire-and-forget dispatch of
+        `_run_llm_dual_run_shadow` onto a daemon background thread.
+
+        Starts the shadow worker and returns IMMEDIATELY — never
+        `.join()`-ed, never `.result()`-ed here. The live legacy response
+        `_provider_llm_response` already computed is NEVER delayed by the
+        shadow's network call or its bounded `_DUAL_RUN_TIMEOUT_SECONDS`
+        timeout. Previously the shadow ran synchronously inline before
+        `return response`, and `_run_coro_in_isolated_thread` inside it did
+        a blocking `future.result(timeout=30s)` — adding up to 30s of
+        latency to the LIVE response (x5 inside the tool-execution loop).
+        That defeated the entire shadow design; this method is the fix.
+
+        Every mutable argument the daemon thread will read is
+        `copy.deepcopy()`'d on THIS (caller) thread BEFORE the thread
+        starts. This matters because the caller mutates the SAME objects
+        immediately after `_provider_llm_response` returns —
+        `LLMAgentNode.run()`'s tool-execution loop appends to the very
+        `messages` list passed in here, and sets
+        `response["tool_execution_rounds"]` on the very dict passed in as
+        `legacy_response`. Without the deep copy, the daemon thread's read
+        could race those mutations. The snapshot makes the daemon thread's
+        view a frozen point-in-time copy that can never observe — or be
+        corrupted by — a mutation the live path makes after this method
+        returns.
+
+        `daemon=True` is intentional (redteam MED-3): an in-flight shadow
+        thread MUST NOT block interpreter shutdown the way a non-daemon
+        thread would.
+
+        Dispatch itself (the deep copy, the `Thread` construction) is
+        wrapped in the same non-load-bearing contract as the shadow worker
+        — any `BaseException` here (other than `KeyboardInterrupt` /
+        `SystemExit`) is caught, logged, and swallowed so a dispatch-time
+        failure can never propagate into `_provider_llm_response`'s
+        `return response`.
+
+        Returns the started `Thread` (or `None` if dispatch itself failed)
+        for test observability — e.g. asserting `.daemon is True` or
+        `.join()`-ing to wait for completion deterministically. The
+        production call site in `_provider_llm_response` discards the
+        return value; NOT joining it is precisely what makes this
+        fire-and-forget.
+        """
+        try:
+            snapshot = copy.deepcopy(
+                {
+                    "messages": messages,
+                    "tools": tools,
+                    "generation_config": generation_config,
+                    "legacy_response": legacy_response,
+                }
+            )
+            thread = threading.Thread(
+                target=self._run_llm_dual_run_shadow,
+                kwargs={
+                    "provider": provider,
+                    "model": model,
+                    "messages": snapshot["messages"],
+                    "tools": snapshot["tools"],
+                    "generation_config": snapshot["generation_config"],
+                    "api_key": api_key,
+                    "base_url": base_url,
+                    "legacy_response": snapshot["legacy_response"],
+                },
+                daemon=True,
+                name="kaizen-llm-dual-run-shadow",
+            )
+            thread.start()
+            return thread
+        except BaseException as exc:
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+            self.logger.warning(
+                "llm.dual_run.dispatch_error",
+                extra={"provider": provider, "error_class": type(exc).__name__},
+            )
+            return None
+
     def _run_llm_dual_run_shadow(
         self,
         *,
@@ -2446,14 +2552,30 @@ Final Answer: 6 hours"""
         """#1720 Wave-2 — shadow-run the four-axis `LlmClient` alongside the
         legacy provider response and log divergences.
 
-        Only ever invoked from `_provider_llm_response` when
-        `KAIZEN_LLM_DUAL_RUN` is truthy. This method NEVER raises, NEVER
-        mutates `legacy_response`, and NEVER changes what the caller
-        returns — every failure mode (unmapped provider, missing
-        credential, wire error, timeout) is caught and logged, never
-        propagated. De-risks the Wave-3 cutover by validating the four-axis
-        path produces equivalent output for real traffic before it becomes
-        load-bearing.
+        Runs on the daemon thread `_dispatch_dual_run_shadow` starts
+        (production path) — kept directly callable (synchronous, blocking)
+        for unit tests exercising the comparison logic without the
+        threading indirection. This method NEVER raises, NEVER mutates
+        `legacy_response`, and NEVER changes what `_provider_llm_response`
+        already returned to its caller — every failure mode (unmapped
+        provider, missing credential, wire error, timeout, even a
+        `BaseException` like `asyncio.CancelledError`) is caught and
+        logged, never propagated. De-risks the Wave-3 cutover by
+        validating the four-axis path produces equivalent output for real
+        traffic before it becomes load-bearing.
+
+        Runs `LlmClient.complete()` via `asyncio.run()` on whichever thread
+        this method executes on. In production that thread is always the
+        fresh daemon thread `_dispatch_dual_run_shadow` just started, which
+        has no ambient event loop, so a bare `asyncio.run()` here is always
+        safe — even though `_provider_llm_response` itself may have been
+        called from inside an already-running event loop
+        (`rules/patterns.md` § async/sync). The daemon-thread dispatch IS
+        the isolation; this method no longer needs a nested
+        thread-in-thread helper for it. The coroutine itself is bounded by
+        `asyncio.wait_for(..., timeout=_DUAL_RUN_TIMEOUT_SECONDS)` so a
+        hung provider is cancelled near the timeout instead of riding the
+        HTTP client's own (potentially longer) timeout.
         """
         global _dual_run_divergence_count
         correlation_id = uuid.uuid4().hex
@@ -2471,17 +2593,18 @@ Final Answer: 6 hours"""
             sampling_kwargs = _sampling_kwargs_from_generation_config(generation_config)
             shadow_tools = tools if tools else None
 
-            def _call_shadow():
-                return client.complete(
-                    messages,
-                    model=model,
-                    tools=shadow_tools,
-                    **sampling_kwargs,
+            async def _call_shadow():
+                return await asyncio.wait_for(
+                    client.complete(
+                        messages,
+                        model=model,
+                        tools=shadow_tools,
+                        **sampling_kwargs,
+                    ),
+                    timeout=_DUAL_RUN_TIMEOUT_SECONDS,
                 )
 
-            four_axis_response = _run_coro_in_isolated_thread(
-                _call_shadow, timeout_seconds=_DUAL_RUN_TIMEOUT_SECONDS
-            )
+            four_axis_response = asyncio.run(_call_shadow())
 
             from kaizen.llm._legacy_shape import (
                 diff_legacy_vs_fouraxis,
@@ -2492,7 +2615,8 @@ Final Answer: 6 hours"""
             divergences = diff_legacy_vs_fouraxis(legacy_response, mapped)
 
             if divergences:
-                _dual_run_divergence_count += 1
+                with _dual_run_divergence_lock:
+                    _dual_run_divergence_count += 1
                 self.logger.warning(
                     "llm.dual_run.divergence",
                     extra={
@@ -2511,12 +2635,20 @@ Final Answer: 6 hours"""
                         "correlation_id": correlation_id,
                     },
                 )
-        except Exception as exc:
+        except BaseException as exc:
             # Non-load-bearing: the shadow's only job is to observe. A
             # failure here MUST NEVER affect the live legacy response the
             # caller already computed — the live path's own error handling
-            # (the except blocks around this method) is completely
-            # untouched by anything that happens in this method.
+            # (the except blocks around _provider_llm_response) is
+            # completely untouched by anything that happens in this
+            # method. Caught as BaseException (not Exception) so that
+            # asyncio.CancelledError (a BaseException subclass, NOT an
+            # Exception subclass) and any other BaseException only log and
+            # never escape this daemon thread. KeyboardInterrupt/SystemExit
+            # are structural process-control signals, not shadow-path
+            # failures — re-raise them.
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
             self.logger.warning(
                 "llm.dual_run.shadow_error",
                 extra={

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -1,14 +1,191 @@
 """Advanced LLM Agent node with LangChain integration and MCP support."""
 
+import asyncio
+import concurrent.futures
 import json
+import logging
+import os
 import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Literal
+from typing import Any, Callable, Dict, List, Literal
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 
 from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# #1720 Wave-2 — dual-run shadow validation (KAIZEN_LLM_DUAL_RUN)
+#
+# Runs the four-axis `kaizen.llm.client.LlmClient` in SHADOW alongside the
+# legacy provider path in `LLMAgentNode._provider_llm_response`, compares
+# outputs, and logs divergences — while the legacy result is STILL what gets
+# returned. Zero user-visible change; de-risks the Wave-3 cutover. Additive +
+# reversible: gated entirely behind the `KAIZEN_LLM_DUAL_RUN` env var
+# (falsey/unset by default), and every failure mode in the shadow path is
+# caught and logged, never propagated to the caller.
+# ---------------------------------------------------------------------------
+
+_DUAL_RUN_ENV_VAR = "KAIZEN_LLM_DUAL_RUN"
+# Matches the truthy-token set already used by KaizenConfig._parse_bool.
+_DUAL_RUN_TRUTHY_VALUES = frozenset({"true", "1", "yes", "on", "enabled"})
+_DUAL_RUN_TIMEOUT_SECONDS = 30.0
+
+# Cheap observability signal: how many dual-run shadow comparisons have
+# logged a divergence since process start. Not persisted; a metrics hook can
+# be wired in later without changing the call site.
+_dual_run_divergence_count = 0
+
+# generation_config keys that map 1:1 onto LlmClient.complete() sampling
+# kwargs (both shapes were designed against the same #1720 Wave-1a field
+# set — see tests/regression/test_issue_1720_wave1a_additive_neutrality.py).
+_GENERATION_CONFIG_SAMPLING_KEYS = (
+    "temperature",
+    "top_p",
+    "max_tokens",
+    "stop",
+    "user",
+    "tool_choice",
+    "response_format",
+    "seed",
+    "logit_bias",
+    "frequency_penalty",
+    "presence_penalty",
+    "n",
+    "top_k",
+)
+
+
+def _dual_run_enabled() -> bool:
+    """True when the #1720 Wave-2 dual-run shadow is enabled.
+
+    Falsey/unset by default. The shadow path this gate wraps NEVER changes
+    the live response — see `LLMAgentNode._run_llm_dual_run_shadow`.
+    """
+    raw = os.environ.get(_DUAL_RUN_ENV_VAR, "")
+    return raw.strip().lower() in _DUAL_RUN_TRUTHY_VALUES
+
+
+def _sampling_kwargs_from_generation_config(
+    generation_config: dict | None,
+) -> dict[str, Any]:
+    """Map the legacy `generation_config` dict onto `LlmClient.complete()`
+    sampling kwargs — only keys both shapes recognise AND that are actually
+    set. Pure, defensive on a non-dict input.
+    """
+    if not isinstance(generation_config, dict):
+        return {}
+    return {
+        key: generation_config[key]
+        for key in _GENERATION_CONFIG_SAMPLING_KEYS
+        if generation_config.get(key) is not None
+    }
+
+
+def _shadow_deployment_for(
+    provider: str,
+    model: str,
+    api_key: str | None,
+    base_url: str | None,
+):
+    """Resolve a four-axis `LlmDeployment` for the #1720 Wave-2 dual-run shadow.
+
+    Maps the legacy `provider` name (`kaizen.providers.registry.PROVIDERS`)
+    onto the matching four-axis preset builder in `kaizen.llm.presets`.
+    Returns `None` (never raises) when the provider has no four-axis
+    mapping, or a required credential/base_url cannot be resolved — the
+    caller treats `None` as "shadow skipped, already logged at DEBUG".
+
+    `api_key` mirrors the legacy provider's own resolution: when the caller
+    did not pass a per-request override, the same `<PROVIDER>_API_KEY` env
+    var the legacy provider itself reads (`rules/env-models.md`) is tried
+    before giving up.
+    """
+    from kaizen.llm.presets import (
+        anthropic_preset,
+        cohere_preset,
+        docker_model_runner_preset,
+        google_preset,
+        huggingface_preset,
+        ollama_preset,
+        openai_preset,
+        perplexity_preset,
+    )
+
+    provider_key = (provider or "").strip().lower()
+
+    api_key_preset_map: dict[str, tuple[Callable[..., Any], str]] = {
+        "openai": (openai_preset, "OPENAI_API_KEY"),
+        "anthropic": (anthropic_preset, "ANTHROPIC_API_KEY"),
+        "google": (google_preset, "GOOGLE_API_KEY"),
+        "gemini": (google_preset, "GOOGLE_API_KEY"),
+        "cohere": (cohere_preset, "COHERE_API_KEY"),
+        "huggingface": (huggingface_preset, "HUGGINGFACE_API_KEY"),
+        "perplexity": (perplexity_preset, "PERPLEXITY_API_KEY"),
+        "pplx": (perplexity_preset, "PERPLEXITY_API_KEY"),
+    }
+    base_url_preset_map: dict[str, Callable[..., Any]] = {
+        "ollama": ollama_preset,
+        "docker": docker_model_runner_preset,
+    }
+
+    if provider_key in api_key_preset_map:
+        factory, env_var = api_key_preset_map[provider_key]
+        resolved_key = api_key or os.environ.get(env_var, "").strip() or None
+        if not resolved_key:
+            logger.debug(
+                "llm.dual_run.shadow_skipped",
+                extra={"provider": provider, "reason": "missing_api_key"},
+            )
+            return None
+        kwargs: dict[str, Any] = {}
+        if base_url:
+            kwargs["base_url"] = base_url
+        return factory(resolved_key, model, **kwargs)
+
+    if provider_key in base_url_preset_map:
+        if not base_url:
+            logger.debug(
+                "llm.dual_run.shadow_skipped",
+                extra={"provider": provider, "reason": "missing_base_url"},
+            )
+            return None
+        factory = base_url_preset_map[provider_key]
+        return factory(base_url, model)
+
+    logger.debug(
+        "llm.dual_run.shadow_skipped",
+        extra={"provider": provider, "reason": "unmapped_provider"},
+    )
+    return None
+
+
+def _run_coro_in_isolated_thread(
+    coro_factory: Callable[[], Any], *, timeout_seconds: float
+) -> Any:
+    """Run `coro_factory()` to completion on a dedicated worker thread with
+    its own fresh event loop, bounded by `timeout_seconds`.
+
+    `_provider_llm_response` is a SYNC method that may itself be invoked
+    from inside an already-running asyncio event loop (an async Nexus
+    handler, a pytest-asyncio test, an agent loop) — a bare `asyncio.run()`
+    on the caller's thread would raise `RuntimeError: asyncio.run() cannot
+    be called from a running event loop` (`rules/patterns.md` § async/sync).
+    A one-worker `ThreadPoolExecutor` gives the coroutine a thread with NO
+    ambient loop, so `asyncio.run()` inside the worker is always safe.
+
+    The executor is shut down with `wait=False` so a timed-out call never
+    blocks the caller on the abandoned worker thread.
+    """
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(lambda: asyncio.run(coro_factory()))
+        return future.result(timeout=timeout_seconds)
+    finally:
+        executor.shutdown(wait=False)
 
 
 @dataclass
@@ -2221,6 +2398,25 @@ Final Answer: 6 hours"""
                     completion = usage.get("completion_tokens") or 0
                     usage["total_tokens"] = prompt + completion
 
+            # #1720 Wave-2 — shadow-run the four-axis LlmClient alongside the
+            # legacy response above for validation. Gated behind
+            # KAIZEN_LLM_DUAL_RUN (falsey/unset by default); the flag-OFF
+            # path above this line is completely untouched and this call is
+            # a pure no-op when the flag is off (`_dual_run_enabled()`
+            # short-circuits before any four-axis code runs). NEVER affects
+            # the `response` returned below.
+            if _dual_run_enabled():
+                self._run_llm_dual_run_shadow(
+                    provider=provider,
+                    model=model,
+                    messages=messages,
+                    tools=tools,
+                    generation_config=generation_config,
+                    api_key=api_key,
+                    base_url=base_url,
+                    legacy_response=response,
+                )
+
             return response
 
         except ImportError:
@@ -2234,6 +2430,101 @@ Final Answer: 6 hours"""
 
             self.logger.error("Provider %s error: %s", provider, e, exc_info=True)
             raise RuntimeError(sanitize_provider_error(e, provider)) from e
+
+    def _run_llm_dual_run_shadow(
+        self,
+        *,
+        provider: str,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        generation_config: dict,
+        api_key: str | None,
+        base_url: str | None,
+        legacy_response: dict,
+    ) -> None:
+        """#1720 Wave-2 — shadow-run the four-axis `LlmClient` alongside the
+        legacy provider response and log divergences.
+
+        Only ever invoked from `_provider_llm_response` when
+        `KAIZEN_LLM_DUAL_RUN` is truthy. This method NEVER raises, NEVER
+        mutates `legacy_response`, and NEVER changes what the caller
+        returns — every failure mode (unmapped provider, missing
+        credential, wire error, timeout) is caught and logged, never
+        propagated. De-risks the Wave-3 cutover by validating the four-axis
+        path produces equivalent output for real traffic before it becomes
+        load-bearing.
+        """
+        global _dual_run_divergence_count
+        correlation_id = uuid.uuid4().hex
+        try:
+            deployment = _shadow_deployment_for(
+                provider=provider, model=model, api_key=api_key, base_url=base_url
+            )
+            if deployment is None:
+                # Already logged a DEBUG shadow_skipped reason.
+                return
+
+            from kaizen.llm.client import LlmClient
+
+            client = LlmClient.from_deployment_sync(deployment)
+            sampling_kwargs = _sampling_kwargs_from_generation_config(generation_config)
+            shadow_tools = tools if tools else None
+
+            def _call_shadow():
+                return client.complete(
+                    messages,
+                    model=model,
+                    tools=shadow_tools,
+                    **sampling_kwargs,
+                )
+
+            four_axis_response = _run_coro_in_isolated_thread(
+                _call_shadow, timeout_seconds=_DUAL_RUN_TIMEOUT_SECONDS
+            )
+
+            from kaizen.llm._legacy_shape import (
+                diff_legacy_vs_fouraxis,
+                to_legacy_shape,
+            )
+
+            mapped = to_legacy_shape(four_axis_response)
+            divergences = diff_legacy_vs_fouraxis(legacy_response, mapped)
+
+            if divergences:
+                _dual_run_divergence_count += 1
+                self.logger.warning(
+                    "llm.dual_run.divergence",
+                    extra={
+                        "provider": provider,
+                        "model": model,
+                        "divergences": divergences,
+                        "correlation_id": correlation_id,
+                    },
+                )
+            else:
+                self.logger.debug(
+                    "llm.dual_run.parity",
+                    extra={
+                        "provider": provider,
+                        "model": model,
+                        "correlation_id": correlation_id,
+                    },
+                )
+        except Exception as exc:
+            # Non-load-bearing: the shadow's only job is to observe. A
+            # failure here MUST NEVER affect the live legacy response the
+            # caller already computed — the live path's own error handling
+            # (the except blocks around this method) is completely
+            # untouched by anything that happens in this method.
+            self.logger.warning(
+                "llm.dual_run.shadow_error",
+                extra={
+                    "provider": provider,
+                    "error_class": type(exc).__name__,
+                    "correlation_id": correlation_id,
+                },
+            )
 
     def _fallback_llm_response(
         self,

--- a/packages/kailash-kaizen/tests/unit/llm/test_legacy_shape.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_legacy_shape.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-2 — `kaizen.llm._legacy_shape` pure-function tests.
+
+Covers the legacy/four-axis response shape reconciliation used by the
+dual-run shadow validation in
+``kaizen.nodes.ai.llm_agent.LLMAgentNode._run_llm_dual_run_shadow``:
+
+* ``to_legacy_shape`` — maps an ``LlmClient.complete()`` result onto legacy
+  response field names (token-key remap, ``tool_calls`` passthrough).
+* ``diff_legacy_vs_fouraxis`` — field-level divergence detection, empty list
+  on parity, and (governance requirement) divergence strings that never
+  embed raw generated text, tool-call arguments, or any credential.
+
+Both functions are pure (no I/O); these are plain Tier-1 unit tests.
+"""
+
+from __future__ import annotations
+
+from kaizen.llm._legacy_shape import diff_legacy_vs_fouraxis, to_legacy_shape
+
+# ---------------------------------------------------------------------------
+# to_legacy_shape
+# ---------------------------------------------------------------------------
+
+
+def test_to_legacy_shape_maps_text_and_stop_reason():
+    four_axis = {
+        "text": "pong",
+        "stop_reason": "stop",
+        "model": "gpt-4o-mini",
+        "usage": {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+    }
+    legacy = to_legacy_shape(four_axis)
+    assert legacy["content"] == "pong"
+    assert legacy["finish_reason"] == "stop"
+    assert legacy["model"] == "gpt-4o-mini"
+
+
+def test_to_legacy_shape_remaps_token_keys():
+    four_axis = {
+        "text": "pong",
+        "stop_reason": "stop",
+        "model": "gpt-4o-mini",
+        "usage": {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+    }
+    legacy = to_legacy_shape(four_axis)
+    assert legacy["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 2,
+        "total_tokens": 7,
+    }
+
+
+def test_to_legacy_shape_computes_total_tokens_when_absent():
+    four_axis = {
+        "text": "pong",
+        "stop_reason": "stop",
+        "model": "gpt-4o-mini",
+        "usage": {"input_tokens": 5, "output_tokens": 2},
+    }
+    legacy = to_legacy_shape(four_axis)
+    assert legacy["usage"]["total_tokens"] == 7
+
+
+def test_to_legacy_shape_computes_total_tokens_with_missing_counts():
+    four_axis = {"text": "pong", "stop_reason": "stop", "usage": {}}
+    legacy = to_legacy_shape(four_axis)
+    assert legacy["usage"] == {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": 0,
+    }
+
+
+def test_to_legacy_shape_passes_tool_calls_through_when_present():
+    four_axis = {
+        "text": "",
+        "stop_reason": "tool_calls",
+        "usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7},
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }
+        ],
+    }
+    legacy = to_legacy_shape(four_axis)
+    assert legacy["tool_calls"] == four_axis["tool_calls"]
+
+
+def test_to_legacy_shape_omits_tool_calls_key_when_absent():
+    four_axis = {"text": "hi", "stop_reason": "stop", "usage": {}}
+    legacy = to_legacy_shape(four_axis)
+    assert "tool_calls" not in legacy
+
+
+def test_to_legacy_shape_defensive_on_missing_keys():
+    # Pure defensiveness: no exception on a bare/partial dict.
+    assert to_legacy_shape({}) == {
+        "content": None,
+        "finish_reason": None,
+        "model": None,
+        "usage": {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": 0,
+        },
+    }
+
+
+def test_to_legacy_shape_defensive_on_non_dict_input():
+    assert to_legacy_shape(None) == to_legacy_shape({})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# diff_legacy_vs_fouraxis
+# ---------------------------------------------------------------------------
+
+_BASE_LEGACY = {
+    "content": "pong",
+    "finish_reason": "stop",
+    "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+}
+_BASE_MAPPED = {
+    "content": "pong",
+    "finish_reason": "stop",
+    "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+}
+
+
+def test_diff_returns_empty_list_on_parity():
+    assert diff_legacy_vs_fouraxis(_BASE_LEGACY, _BASE_MAPPED) == []
+
+
+def test_diff_detects_content_mismatch():
+    mapped = dict(_BASE_MAPPED, content="ping")
+    divergences = diff_legacy_vs_fouraxis(_BASE_LEGACY, mapped)
+    assert any(d.startswith("content:") for d in divergences)
+
+
+def test_diff_detects_content_presence_mismatch():
+    mapped = dict(_BASE_MAPPED, content=None)
+    divergences = diff_legacy_vs_fouraxis(_BASE_LEGACY, mapped)
+    assert any(d.startswith("content:") for d in divergences)
+
+
+def test_diff_detects_tool_calls_presence_mismatch():
+    legacy = dict(_BASE_LEGACY, tool_calls=[{"id": "1"}])
+    mapped = dict(_BASE_MAPPED)  # no tool_calls key
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert any(d.startswith("tool_calls:") for d in divergences)
+
+
+def test_diff_detects_tool_calls_count_mismatch():
+    legacy = dict(_BASE_LEGACY, tool_calls=[{"id": "1"}, {"id": "2"}])
+    mapped = dict(_BASE_MAPPED, tool_calls=[{"id": "1"}])
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert any("tool_calls" in d and "count" in d for d in divergences)
+
+
+def test_diff_tool_calls_parity_when_both_present_and_equal_count():
+    legacy = dict(_BASE_LEGACY, tool_calls=[{"id": "1"}])
+    mapped = dict(_BASE_MAPPED, tool_calls=[{"id": "1", "type": "function"}])
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert not any(d.startswith("tool_calls:") for d in divergences)
+
+
+def test_diff_detects_finish_reason_mismatch():
+    mapped = dict(_BASE_MAPPED, finish_reason="length")
+    divergences = diff_legacy_vs_fouraxis(_BASE_LEGACY, mapped)
+    assert "finish_reason: value mismatch" in divergences
+
+
+def test_diff_detects_token_count_mismatch():
+    mapped = dict(
+        _BASE_MAPPED,
+        usage={"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    )
+    divergences = diff_legacy_vs_fouraxis(_BASE_LEGACY, mapped)
+    assert any(d.startswith("usage.completion_tokens:") for d in divergences)
+    assert any(d.startswith("usage.total_tokens:") for d in divergences)
+    assert not any(d.startswith("usage.prompt_tokens:") for d in divergences)
+
+
+def test_diff_defensive_on_non_dict_input():
+    assert diff_legacy_vs_fouraxis(None, None) == []  # type: ignore[arg-type]
+
+
+def test_diff_defensive_on_missing_usage_key():
+    assert diff_legacy_vs_fouraxis({"content": "hi"}, {"content": "hi"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Governance: divergence strings NEVER embed raw content / secrets.
+# ---------------------------------------------------------------------------
+
+_SECRET_CANARY = "sk-super-secret-api-key-do-not-leak"
+_RAW_CONTENT_CANARY = "THE-EXACT-GENERATED-RESPONSE-TEXT-CANARY"
+
+
+def test_diff_divergence_strings_never_contain_raw_content_or_secrets():
+    legacy = {
+        "content": f"{_RAW_CONTENT_CANARY}-legacy {_SECRET_CANARY}",
+        "finish_reason": "stop",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "arguments": f'{{"key": "{_SECRET_CANARY}"}}',
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+    }
+    mapped = {
+        "content": f"{_RAW_CONTENT_CANARY}-four-axis-different",
+        "finish_reason": "length",
+        # tool_calls presence differs too (absent here).
+        "usage": {"prompt_tokens": 90, "completion_tokens": 40, "total_tokens": 130},
+    }
+
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+
+    # Sanity: the fixture actually produced multiple divergences to check.
+    assert len(divergences) >= 4
+
+    joined = "\n".join(divergences)
+    assert _SECRET_CANARY not in joined
+    assert _RAW_CONTENT_CANARY not in joined
+    assert legacy["content"] not in joined
+    assert mapped["content"] not in joined

--- a/packages/kailash-kaizen/tests/unit/llm/test_legacy_shape.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_legacy_shape.py
@@ -168,6 +168,135 @@ def test_diff_tool_calls_parity_when_both_present_and_equal_count():
     assert not any(d.startswith("tool_calls:") for d in divergences)
 
 
+# ---------------------------------------------------------------------------
+# #1720 Wave-2 redteam FIX 5 — hashed tool-name comparison.
+#
+# Same tool_calls COUNT with a DIFFERENT selected tool previously
+# false-reported parity (only presence + count were compared). The hash
+# comparison catches the divergence WITHOUT embedding the tool name itself
+# in the divergence string.
+# ---------------------------------------------------------------------------
+
+
+def test_diff_detects_tool_name_hash_mismatch_at_same_count():
+    legacy = dict(
+        _BASE_LEGACY,
+        tool_calls=[
+            {
+                "id": "1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"},
+            }
+        ],
+    )
+    mapped = dict(
+        _BASE_MAPPED,
+        tool_calls=[
+            {
+                "id": "1",
+                "type": "function",
+                "function": {"name": "send_email", "arguments": "{}"},
+            }
+        ],
+    )
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert any(d.startswith("tool_calls: name hash mismatch") for d in divergences)
+
+
+def test_diff_tool_name_hash_parity_when_names_match_regardless_of_arguments():
+    legacy = dict(
+        _BASE_LEGACY,
+        tool_calls=[
+            {
+                "id": "1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"},
+            }
+        ],
+    )
+    mapped = dict(
+        _BASE_MAPPED,
+        tool_calls=[
+            {
+                "id": "2",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"unit": "c"}'},
+            }
+        ],
+    )
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert not any(d.startswith("tool_calls:") for d in divergences)
+
+
+def test_diff_tool_name_hash_parity_is_order_insensitive():
+    legacy = dict(
+        _BASE_LEGACY,
+        tool_calls=[
+            {"function": {"name": "a_tool"}},
+            {"function": {"name": "b_tool"}},
+        ],
+    )
+    mapped = dict(
+        _BASE_MAPPED,
+        tool_calls=[
+            {"function": {"name": "b_tool"}},
+            {"function": {"name": "a_tool"}},
+        ],
+    )
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    assert not any(d.startswith("tool_calls:") for d in divergences)
+
+
+def test_diff_tool_name_hash_mismatch_divergence_string_leaks_only_hashes():
+    """Governance no-leak proof for FIX 5: the divergence string for a
+    name-hash mismatch carries 8-hex-char hashes and NEVER the raw tool
+    names (which may themselves be schema-revealing / sensitive)."""
+    legacy = {
+        "content": "pong",
+        "finish_reason": "stop",
+        "tool_calls": [
+            {
+                "id": "1",
+                "type": "function",
+                "function": {
+                    "name": "delete_production_database",
+                    "arguments": "{}",
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+    }
+    mapped = {
+        "content": "pong",
+        "finish_reason": "stop",
+        "tool_calls": [
+            {
+                "id": "1",
+                "type": "function",
+                "function": {"name": "get_weather_forecast", "arguments": "{}"},
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+    }
+
+    divergences = diff_legacy_vs_fouraxis(legacy, mapped)
+    name_hash_divergences = [
+        d for d in divergences if d.startswith("tool_calls: name hash mismatch")
+    ]
+    assert len(name_hash_divergences) == 1
+
+    joined = "\n".join(divergences)
+    assert "delete_production_database" not in joined
+    assert "get_weather_forecast" not in joined
+
+    # The hashes themselves ARE present -- 8 lowercase-hex-char tokens.
+    import re
+
+    hash_tokens = re.findall(r"\b[0-9a-f]{8}\b", name_hash_divergences[0])
+    assert len(hash_tokens) == 2
+    assert hash_tokens[0] != hash_tokens[1]
+
+
 def test_diff_detects_finish_reason_mismatch():
     mapped = dict(_BASE_MAPPED, finish_reason="length")
     divergences = diff_legacy_vs_fouraxis(_BASE_LEGACY, mapped)

--- a/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
@@ -1,0 +1,458 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-2 — dual-run shadow validation tests for
+``LLMAgentNode._provider_llm_response`` (``KAIZEN_LLM_DUAL_RUN``).
+
+Covers:
+
+* **Flag-off byte-neutrality** — the #1 invariant: a Wave-2 shadow MUST NOT
+  change production behavior when disabled. Proven by patching the shadow
+  entry point and asserting it is never called, AND asserting the returned
+  response is byte-identical to the provider's raw ``chat()`` output (plus
+  the pre-existing usage-total coercion, unchanged from before this Wave).
+* **Shadow-exception isolation** — a failure anywhere in the shadow path
+  (unmapped provider, deployment build failure, wire error, timeout) is
+  caught and logged; the live legacy response is always returned unchanged.
+* **Isolated-thread execution** — the shadow runs its own event loop on a
+  separate thread even when the caller itself is inside a running event
+  loop (the exact scenario a bare ``asyncio.run()`` on the caller's thread
+  would break).
+* **respx end-to-end parity / divergence** — a full ``_provider_llm_response``
+  call with both the legacy provider and the four-axis shadow hitting a
+  respx-mocked HTTP boundary, asserting parity logs no divergence WARN and
+  a real difference logs exactly one.
+
+Tier 1 except where noted; the respx tests exercise a real (mocked-at-the-
+wire) send path, matching the precedent set by
+``tests/unit/llm/test_completion_wire_respx.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import respx
+
+import kaizen.llm.http_client as _http_client_mod
+import kaizen.nodes.ai.llm_agent as llm_agent_mod
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+# ---------------------------------------------------------------------------
+# Env-var serialization (rules/testing.md § "Serialize Env-Var-Mutating
+# Tests Via Module Lock"). This module mutates KAIZEN_LLM_DUAL_RUN and
+# OPENAI_API_KEY.
+# ---------------------------------------------------------------------------
+
+_ENV_LOCK = threading.Lock()
+_ENV_VARS = ("KAIZEN_LLM_DUAL_RUN", "OPENAI_API_KEY")
+
+
+@pytest.fixture
+def _env_serialized(monkeypatch: pytest.MonkeyPatch):
+    with _ENV_LOCK:
+        for var in _ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        yield
+
+
+class _StubProvider:
+    """Deterministic legacy provider stub — no network, no credentials."""
+
+    def __init__(self, content: str = "hello from stub"):
+        self._content = content
+
+    def is_available(self) -> bool:
+        return True
+
+    def chat(self, **kwargs) -> dict:
+        return {
+            "id": "stub-1",
+            "content": self._content,
+            "role": "assistant",
+            "model": kwargs["model"],
+            "tool_calls": [],
+            "finish_reason": "stop",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+
+def _patch_stub_provider(
+    monkeypatch: pytest.MonkeyPatch, content: str = "hello from stub"
+):
+    monkeypatch.setattr(
+        "kaizen.providers.registry.get_provider",
+        lambda name, **kw: _StubProvider(content),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag-off byte-neutrality (the #1 invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_dual_run_flag_off_shadow_never_runs(monkeypatch, _env_serialized):
+    """`KAIZEN_LLM_DUAL_RUN` unset -> `_run_llm_dual_run_shadow` is never
+    called (patch the four-axis entry point and assert not called)."""
+    _patch_stub_provider(monkeypatch)
+    shadow_mock = MagicMock()
+    monkeypatch.setattr(LLMAgentNode, "_run_llm_dual_run_shadow", shadow_mock)
+
+    agent = LLMAgentNode()
+    agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+    )
+
+    shadow_mock.assert_not_called()
+
+
+def test_dual_run_flag_off_response_is_byte_identical(monkeypatch, _env_serialized):
+    """The returned response with the flag OFF is byte-identical to the
+    provider's raw `chat()` output plus the pre-existing (pre-#1720)
+    usage-total coercion — proving the Wave-2 addition changes nothing on
+    the live path when disabled."""
+    _patch_stub_provider(monkeypatch)
+    monkeypatch.setattr(LLMAgentNode, "_run_llm_dual_run_shadow", MagicMock())
+
+    agent = LLMAgentNode()
+    response = agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+    )
+
+    assert response == {
+        "id": "stub-1",
+        "content": "hello from stub",
+        "role": "assistant",
+        "model": "gpt-4o-mini",
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+@pytest.mark.parametrize("raw_value", ["false", "0", "no", "off", "disabled", ""])
+def test_dual_run_enabled_false_for_non_truthy_values(monkeypatch, raw_value):
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", raw_value)
+    assert llm_agent_mod._dual_run_enabled() is False
+
+
+@pytest.mark.parametrize(
+    "raw_value", ["true", "1", "yes", "on", "enabled", "TRUE", " 1 "]
+)
+def test_dual_run_enabled_true_for_truthy_values(monkeypatch, raw_value):
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", raw_value)
+    assert llm_agent_mod._dual_run_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Shadow-exception isolation — flag ON, four-axis path raises.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_run_shadow_exception_never_propagates(
+    monkeypatch, _env_serialized, caplog
+):
+    """Flag ON; the four-axis deployment resolution explodes. The live
+    legacy response is STILL returned unchanged, and the failure is logged
+    (not swallowed silently, not raised)."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("shadow deployment resolution exploded")
+
+    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", _boom)
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        response = agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+        )
+
+    assert response["content"] == "hello from stub"
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert len(shadow_error_records) == 1
+    assert shadow_error_records[0].error_class == "RuntimeError"
+
+
+def test_dual_run_shadow_timeout_never_propagates(monkeypatch, _env_serialized, caplog):
+    """A shadow call that exceeds the bounded timeout is caught and logged
+    -- never raised, never affects the returned legacy response."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    def _hang(*args, **kwargs):
+        import time
+
+        time.sleep(5)
+
+    monkeypatch.setattr(llm_agent_mod, "_run_coro_in_isolated_thread", _hang)
+    monkeypatch.setattr(
+        llm_agent_mod,
+        "_shadow_deployment_for",
+        lambda **kw: object(),  # any non-None sentinel; complete() is never reached
+    )
+    # Bound the test's own patience, independent of the production timeout
+    # constant.
+    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 30.0)
+
+    agent = LLMAgentNode()
+    response = agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+    )
+    assert response["content"] == "hello from stub"
+
+
+def test_dual_run_shadow_unmapped_provider_skips_without_warning(
+    monkeypatch, _env_serialized, caplog
+):
+    """A provider with no four-axis preset mapping is skipped at DEBUG --
+    no WARNING, live response unaffected.
+
+    Uses an arbitrary unmapped provider NAME (not `mock`) resolved via a
+    patched provider registry -- `mock` itself is globally replaced by
+    `tests/conftest.py`'s `KaizenMockProvider` (a Core-SDK-only mock without
+    `is_available()`), an unrelated pre-existing test-infra fixture this
+    test must not depend on.
+    """
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
+        with caplog.at_level(logging.DEBUG, logger="kaizen.nodes.ai.llm_agent"):
+            response = agent._provider_llm_response(
+                provider="totally-unmapped-provider-xyz",
+                model="mock-model",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                generation_config={},
+            )
+
+    assert response["content"] is not None
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records == []
+    skipped_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_skipped"
+    ]
+    assert len(skipped_records) == 1
+    assert skipped_records[0].reason == "unmapped_provider"
+
+
+def test_dual_run_isolated_thread_runs_under_an_active_caller_event_loop(
+    monkeypatch, _env_serialized, caplog
+):
+    """The shadow MUST run correctly even when `_provider_llm_response` is
+    invoked from a caller thread that already has an active asyncio event
+    loop (an async Nexus handler, a pytest-asyncio test, an agent loop) --
+    the exact case a bare `asyncio.run()` on the caller thread cannot
+    handle (`RuntimeError: asyncio.run() cannot be called from a running
+    event loop`)."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    calls: list[int] = []
+
+    async def _fake_complete(*args, **kwargs):
+        calls.append(1)
+        return {
+            "text": "hello from stub",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+
+    fake_client = MagicMock()
+    fake_client.complete = _fake_complete
+    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", lambda **kw: object())
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: fake_client),
+    )
+
+    agent = LLMAgentNode()
+
+    async def _run_inside_active_loop():
+        # This coroutine itself IS the active event loop the sync
+        # _provider_llm_response call runs under.
+        return agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+        )
+
+    import asyncio
+
+    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
+        response = asyncio.run(_run_inside_active_loop())
+
+    assert response["content"] == "hello from stub"
+    assert calls == [1]  # the shadow's complete() genuinely ran
+    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
+    assert len(parity_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# respx end-to-end: real (mocked-at-the-wire) legacy + shadow calls.
+# ---------------------------------------------------------------------------
+
+
+class _AllowAllResolver(_http_client_mod.SafeDnsResolver):
+    """No-op SSRF DNS resolver — test-only, mirrors
+    tests/unit/llm/test_completion_wire_respx.py's `_AllowAllResolver`."""
+
+    __slots__ = ()
+
+    def check_host(self, host: str) -> None:  # noqa: D401 - test stub resolver
+        return None
+
+
+@pytest.fixture(autouse=False)
+def _no_real_dns(monkeypatch):
+    """Skip the SSRF guard's real DNS lookup for the shadow's internally
+    -constructed `LlmHttpClient` (it has no seam to inject a resolver
+    without changing production code, unlike the direct-`LlmClient` tests)."""
+    monkeypatch.setattr(
+        _http_client_mod.SafeDnsResolver, "check_host", lambda self, host: None
+    )
+
+
+_OPENAI_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
+
+
+@respx.mock
+def test_dual_run_respx_parity_logs_no_divergence(
+    monkeypatch, _env_serialized, caplog, _no_real_dns
+):
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-parity")
+
+    payload = {
+        "id": "chatcmpl-1",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        "model": "gpt-4o-mini",
+    }
+    respx.post(_OPENAI_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
+        response = agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[],
+            generation_config={"temperature": 0.0},
+        )
+
+    assert response["content"] == "pong"
+
+    divergence_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.divergence"
+    ]
+    assert divergence_records == []
+    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
+    assert len(parity_records) == 1
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert shadow_error_records == []
+
+
+@respx.mock
+def test_dual_run_respx_divergence_logs_exactly_one_warning(
+    monkeypatch, _env_serialized, caplog, _no_real_dns
+):
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-divergence")
+
+    legacy_payload = {
+        "id": "chatcmpl-1",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        "model": "gpt-4o-mini",
+    }
+    # A genuinely different four-axis response: different content AND a
+    # different finish_reason.
+    shadow_payload = {
+        "id": "chatcmpl-2",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "pong-but-different"},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 9, "total_tokens": 14},
+        "model": "gpt-4o-mini",
+    }
+    respx.post(_OPENAI_COMPLETIONS_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=legacy_payload),
+            httpx.Response(200, json=shadow_payload),
+        ]
+    )
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
+        response = agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[],
+            generation_config={"temperature": 0.0},
+        )
+
+    # Live response is STILL the legacy one, untouched by the shadow.
+    assert response["content"] == "pong"
+    assert response["finish_reason"] == "stop"
+
+    divergence_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.divergence"
+    ]
+    assert len(divergence_records) == 1
+    divergences = divergence_records[0].divergences
+    assert any(d.startswith("content:") for d in divergences)
+    assert any(d.startswith("finish_reason:") for d in divergences)
+    # No raw generated text leaked into the log line's structured payload.
+    joined = "\n".join(divergences)
+    assert "pong" not in joined
+    assert "pong-but-different" not in joined
+
+    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
+    assert parity_records == []

--- a/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
@@ -8,16 +8,25 @@ Covers:
 
 * **Flag-off byte-neutrality** — the #1 invariant: a Wave-2 shadow MUST NOT
   change production behavior when disabled. Proven by patching the shadow
-  entry point and asserting it is never called, AND asserting the returned
-  response is byte-identical to the provider's raw ``chat()`` output (plus
-  the pre-existing usage-total coercion, unchanged from before this Wave).
+  dispatch entry point and asserting it is never called, AND asserting the
+  returned response is byte-identical to the provider's raw ``chat()``
+  output (plus the pre-existing usage-total coercion, unchanged from before
+  this Wave).
+* **Fire-and-forget dispatch (Wave-2 redteam FIX 1, HIGH)** —
+  ``_provider_llm_response`` NEVER blocks on the shadow: a hung shadow
+  ``complete()`` call does not delay the live response, the dispatched
+  worker runs on a **daemon** thread, and the shadow can never mutate the
+  response the caller already has (a deep-copied snapshot is what the
+  worker actually reads).
 * **Shadow-exception isolation** — a failure anywhere in the shadow path
-  (unmapped provider, deployment build failure, wire error, timeout) is
-  caught and logged; the live legacy response is always returned unchanged.
+  (unmapped provider, deployment build failure, wire error, timeout,
+  cancellation) is caught and logged; the live legacy response is always
+  returned unchanged. Broadened to ``BaseException`` (FIX 3) so
+  ``asyncio.CancelledError`` is caught too.
 * **Isolated-thread execution** — the shadow runs its own event loop on a
-  separate thread even when the caller itself is inside a running event
-  loop (the exact scenario a bare ``asyncio.run()`` on the caller's thread
-  would break).
+  separate (daemon, dispatched) thread even when the caller itself is
+  inside a running event loop (the exact scenario a bare ``asyncio.run()``
+  on the caller's thread would break).
 * **respx end-to-end parity / divergence** — a full ``_provider_llm_response``
   call with both the legacy provider and the four-axis shadow hitting a
   respx-mocked HTTP boundary, asserting parity logs no divergence WARN and
@@ -26,12 +35,22 @@ Covers:
 Tier 1 except where noted; the respx tests exercise a real (mocked-at-the-
 wire) send path, matching the precedent set by
 ``tests/unit/llm/test_completion_wire_respx.py``.
+
+Since the shadow now dispatches onto a background daemon thread
+(``_dispatch_dual_run_shadow``), every test that asserts on the shadow's
+LOG side effects joins the dispatched thread (found via
+``threading.enumerate()`` by its fixed thread name) before inspecting
+``caplog`` — otherwise the assertion would race the still-running daemon
+thread. Tests that assert the LIVE path is NOT delayed deliberately do
+**not** join before measuring elapsed time (that is the entire point).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
+import time
 from unittest.mock import MagicMock
 
 import httpx
@@ -50,6 +69,8 @@ from kaizen.nodes.ai.llm_agent import LLMAgentNode
 
 _ENV_LOCK = threading.Lock()
 _ENV_VARS = ("KAIZEN_LLM_DUAL_RUN", "OPENAI_API_KEY")
+
+_SHADOW_THREAD_NAME = "kaizen-llm-dual-run-shadow"
 
 
 @pytest.fixture
@@ -90,17 +111,85 @@ def _patch_stub_provider(
     )
 
 
+def _patch_shadow_client(monkeypatch: pytest.MonkeyPatch, complete_coro):
+    """Patch the four-axis shadow's deployment resolution + client
+    construction so `_run_llm_dual_run_shadow` calls `complete_coro`
+    (an `async def`) instead of touching real credentials/network."""
+    fake_client = MagicMock()
+    fake_client.complete = complete_coro
+    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", lambda **kw: object())
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: fake_client),
+    )
+    return fake_client
+
+
+@pytest.fixture
+def _shadow_dispatch_capture(monkeypatch: pytest.MonkeyPatch):
+    """Capture every `Thread` `_dispatch_dual_run_shadow` starts during a
+    test, via monkeypatch-wrapping the REAL method (production behavior is
+    unchanged; the wrapper just records the returned `Thread`).
+
+    Deliberately NOT `threading.enumerate()`-based: a mocked shadow (no
+    real network) can start AND finish before the test gets a chance to
+    enumerate live threads again, so a fast-completing thread would
+    already be gone from `enumerate()` by the time the assertion runs --
+    a genuine, observed race in this exact test file (three tests flaked
+    intermittently on the enumerate-based approach depending on how fast
+    the mocked `complete()` resolved). Capturing the `Thread` OBJECT
+    itself sidesteps the race entirely: `.join()` on an already-finished
+    thread returns immediately, so joining a captured thread is always
+    safe regardless of whether it has already completed.
+    """
+    original = LLMAgentNode._dispatch_dual_run_shadow
+    captured: list[threading.Thread] = []
+
+    def _wrapped(self, **kwargs):
+        thread = original(self, **kwargs)
+        if thread is not None:
+            captured.append(thread)
+        return thread
+
+    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", _wrapped)
+    return captured
+
+
+def _call_and_join_shadow(
+    agent: LLMAgentNode,
+    captured: list[threading.Thread],
+    *,
+    join_timeout: float = 5.0,
+    **kwargs,
+):
+    """Call `_provider_llm_response` and deterministically wait for the
+    dual-run shadow's dispatched daemon thread (if any) — read from
+    `captured`, the `_shadow_dispatch_capture` fixture's list — to finish
+    before the caller inspects `caplog` / mutation state.
+
+    The shadow is fire-and-forget in production — this helper exists ONLY
+    to make test assertions about the shadow's side effects
+    (log lines, response-mutation absence) deterministic rather than racy.
+    """
+    before_len = len(captured)
+    response = agent._provider_llm_response(**kwargs)
+    threads = captured[before_len:]
+    for t in threads:
+        t.join(timeout=join_timeout)
+    return response, threads
+
+
 # ---------------------------------------------------------------------------
 # Flag-off byte-neutrality (the #1 invariant)
 # ---------------------------------------------------------------------------
 
 
 def test_dual_run_flag_off_shadow_never_runs(monkeypatch, _env_serialized):
-    """`KAIZEN_LLM_DUAL_RUN` unset -> `_run_llm_dual_run_shadow` is never
-    called (patch the four-axis entry point and assert not called)."""
+    """`KAIZEN_LLM_DUAL_RUN` unset -> `_dispatch_dual_run_shadow` (the
+    shadow's entry point from `_provider_llm_response`) is never called."""
     _patch_stub_provider(monkeypatch)
-    shadow_mock = MagicMock()
-    monkeypatch.setattr(LLMAgentNode, "_run_llm_dual_run_shadow", shadow_mock)
+    dispatch_mock = MagicMock()
+    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", dispatch_mock)
 
     agent = LLMAgentNode()
     agent._provider_llm_response(
@@ -111,7 +200,7 @@ def test_dual_run_flag_off_shadow_never_runs(monkeypatch, _env_serialized):
         generation_config={},
     )
 
-    shadow_mock.assert_not_called()
+    dispatch_mock.assert_not_called()
 
 
 def test_dual_run_flag_off_response_is_byte_identical(monkeypatch, _env_serialized):
@@ -120,7 +209,7 @@ def test_dual_run_flag_off_response_is_byte_identical(monkeypatch, _env_serializ
     usage-total coercion — proving the Wave-2 addition changes nothing on
     the live path when disabled."""
     _patch_stub_provider(monkeypatch)
-    monkeypatch.setattr(LLMAgentNode, "_run_llm_dual_run_shadow", MagicMock())
+    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", MagicMock())
 
     agent = LLMAgentNode()
     response = agent._provider_llm_response(
@@ -157,23 +246,229 @@ def test_dual_run_enabled_true_for_truthy_values(monkeypatch, raw_value):
 
 
 # ---------------------------------------------------------------------------
-# Shadow-exception isolation — flag ON, four-axis path raises.
+# FIX 1 (HIGH) — fire-and-forget: the shadow MUST NEVER block the live path.
 # ---------------------------------------------------------------------------
 
 
-def test_dual_run_shadow_exception_never_propagates(
+def test_dual_run_live_path_returns_immediately_despite_hung_shadow(
+    monkeypatch, _env_serialized, _shadow_dispatch_capture
+):
+    """THE fire-and-forget proof: with the flag ON and the shadow's
+    `complete()` stubbed to hang well past the (monkeypatched-small) dual-
+    run timeout, `_provider_llm_response` still returns in a fraction of a
+    second — the LIVE path is NEVER delayed by the shadow.
+
+    Before FIX 1, the shadow ran synchronously inline before `return
+    response`, and `_run_coro_in_isolated_thread` inside it did a blocking
+    `future.result(timeout=30s)` — a hang here would have blocked the live
+    response for up to `_DUAL_RUN_TIMEOUT_SECONDS` (x5 inside the
+    tool-execution loop). This test would have taken >=0.2s (the bounded
+    timeout below) — or 30s at the production default — under the old
+    behavior; it now takes milliseconds.
+
+    The elapsed-time assertion below (the actual proof) happens BEFORE the
+    thread is joined — joining only happens at the very end, purely for
+    test hygiene (an un-joined daemon thread that logs a WARNING slightly
+    later would otherwise leak into a LATER test's `caplog` capture
+    window, since `LLMAgentNode`'s logger name is shared across
+    instances). The join does not weaken the proof.
+    """
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+    # Bound the shadow's own patience so the background daemon thread this
+    # test dispatches exits quickly instead of lingering for the
+    # production default of 30s.
+    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.2)
+
+    dispatched = threading.Event()
+
+    async def _hang_past_timeout(*args, **kwargs):
+        dispatched.set()
+        await asyncio.sleep(2.0)  # far longer than the bounded shadow timeout
+
+    _patch_shadow_client(monkeypatch, _hang_past_timeout)
+
+    agent = LLMAgentNode()
+    start = time.monotonic()
+    response = agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+    )
+    elapsed = time.monotonic() - start
+
+    assert response["content"] == "hello from stub"
+    assert elapsed < 1.0, (
+        f"_provider_llm_response took {elapsed:.3f}s with a hung shadow -- "
+        f"the live path must return in milliseconds (fire-and-forget)"
+    )
+    # Sanity: the shadow genuinely dispatched (not skipped) -- proves the
+    # fast return above is because of fire-and-forget, not because the
+    # shadow never ran at all.
+    assert dispatched.wait(timeout=2.0), "the shadow thread never started"
+
+    # Test hygiene ONLY (see docstring) -- the proof above already ran.
+    assert len(_shadow_dispatch_capture) == 1
+    _shadow_dispatch_capture[0].join(timeout=5.0)
+
+
+def test_dual_run_dispatch_starts_a_daemon_thread(monkeypatch, _env_serialized):
+    """MED-3 proof: `_dispatch_dual_run_shadow` starts the shadow worker on
+    a `daemon=True` thread — an in-flight shadow MUST NOT block interpreter
+    shutdown the way a non-daemon thread would."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+
+    async def _fake_complete(*args, **kwargs):
+        return {
+            "text": "hello from stub",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+
+    _patch_shadow_client(monkeypatch, _fake_complete)
+
+    agent = LLMAgentNode()
+    thread = agent._dispatch_dual_run_shadow(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+        api_key=None,
+        base_url=None,
+        legacy_response={"content": "hello from stub"},
+    )
+
+    assert thread is not None
+    assert isinstance(thread, threading.Thread)
+    assert thread.daemon is True
+    assert thread.name == _SHADOW_THREAD_NAME
+    thread.join(timeout=5.0)
+    assert not thread.is_alive()
+
+
+def test_dual_run_dispatch_never_mutates_the_live_response(
+    monkeypatch, _env_serialized, _shadow_dispatch_capture
+):
+    """FIX 1(c): regardless of the shadow's outcome (a real divergence
+    here), the `response` dict `_provider_llm_response` already returned to
+    its caller is NEVER mutated by the shadow — proven by snapshotting the
+    dict immediately and asserting it is unchanged after the dispatched
+    shadow thread finishes."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    async def _diverge(*args, **kwargs):
+        return {
+            "text": "totally different content",
+            "stop_reason": "length",
+            "model": "gpt-4o-mini",
+            "usage": {
+                "input_tokens": 999,
+                "output_tokens": 999,
+                "total_tokens": 1998,
+            },
+        }
+
+    _patch_shadow_client(monkeypatch, _diverge)
+
+    agent = LLMAgentNode()
+    response, threads = _call_and_join_shadow(
+        agent,
+        _shadow_dispatch_capture,
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        generation_config={},
+    )
+    assert len(threads) == 1
+
+    assert response == {
+        "id": "stub-1",
+        "content": "hello from stub",
+        "role": "assistant",
+        "model": "gpt-4o-mini",
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def test_dual_run_dispatch_deepcopies_snapshot_immune_to_post_call_mutation(
+    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
+):
+    """FIX 1: the daemon thread reads a `copy.deepcopy()` snapshot of
+    `messages`/`legacy_response`, taken on the CALLER's thread BEFORE the
+    thread starts. `LLMAgentNode.run()`'s tool-execution loop mutates the
+    SAME `messages` list object (appends) and the SAME `response` dict
+    (sets a key) immediately after `_provider_llm_response` returns — this
+    test reproduces that exact mutation and proves the shadow's `complete()`
+    call observed the ORIGINAL 1-message snapshot, not the post-call
+    2-message mutated list, AND that the comparison completes cleanly (a
+    genuine parity log, never a shadow_error)."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    received: dict = {}
+
+    async def _fake_complete(messages_arg, *args, **kwargs):
+        received["messages_len"] = len(messages_arg)
+        return {
+            "text": "hello from stub",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+
+    _patch_shadow_client(monkeypatch, _fake_complete)
+
+    agent = LLMAgentNode()
+    messages = [{"role": "user", "content": "hi"}]
+
+    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
+        response = agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=messages,
+            tools=[],
+            generation_config={},
+        )
+        # Reproduce exactly what `run()`'s tool-execution loop does
+        # immediately after this call returns: mutate the SAME objects.
+        messages.append({"role": "assistant", "content": "mutated after call"})
+        response["tool_execution_rounds"] = 1
+
+        assert len(_shadow_dispatch_capture) == 1
+        _shadow_dispatch_capture[0].join(timeout=5.0)
+        assert not _shadow_dispatch_capture[0].is_alive()
+
+    assert received["messages_len"] == 1  # the frozen snapshot, not 2
+
+    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
+    assert len(parity_records) == 1
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert shadow_error_records == []
+
+
+def test_dual_run_dispatch_error_never_propagates_to_live_path(
     monkeypatch, _env_serialized, caplog
 ):
-    """Flag ON; the four-axis deployment resolution explodes. The live
-    legacy response is STILL returned unchanged, and the failure is logged
-    (not swallowed silently, not raised)."""
+    """A failure in dispatch ITSELF (the `copy.deepcopy()` / `Thread`
+    construction inside `_dispatch_dual_run_shadow`, not the worker) is
+    caught and logged, never raised into `_provider_llm_response`."""
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     _patch_stub_provider(monkeypatch)
 
     def _boom(*args, **kwargs):
-        raise RuntimeError("shadow deployment resolution exploded")
+        raise RuntimeError("deep copy exploded")
 
-    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", _boom)
+    monkeypatch.setattr(llm_agent_mod.copy, "deepcopy", _boom)
 
     agent = LLMAgentNode()
     with caplog.at_level(logging.WARNING, logger=agent.logger.name):
@@ -186,6 +481,47 @@ def test_dual_run_shadow_exception_never_propagates(
         )
 
     assert response["content"] == "hello from stub"
+    dispatch_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.dispatch_error"
+    ]
+    assert len(dispatch_error_records) == 1
+    assert dispatch_error_records[0].error_class == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Shadow-exception isolation — flag ON, four-axis path raises/hangs/cancels.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_run_shadow_exception_never_propagates(
+    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
+):
+    """Flag ON; the four-axis deployment resolution explodes. The live
+    legacy response is STILL returned unchanged, and the failure is logged
+    (not swallowed silently, not raised) once the dispatched shadow thread
+    finishes."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("shadow deployment resolution exploded")
+
+    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", _boom)
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        response, threads = _call_and_join_shadow(
+            agent,
+            _shadow_dispatch_capture,
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+        )
+        assert len(threads) == 1
+
+    assert response["content"] == "hello from stub"
     shadow_error_records = [
         r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
     ]
@@ -193,40 +529,96 @@ def test_dual_run_shadow_exception_never_propagates(
     assert shadow_error_records[0].error_class == "RuntimeError"
 
 
-def test_dual_run_shadow_timeout_never_propagates(monkeypatch, _env_serialized, caplog):
-    """A shadow call that exceeds the bounded timeout is caught and logged
-    -- never raised, never affects the returned legacy response."""
+def test_dual_run_shadow_worker_bounds_a_hung_provider_and_logs_error(
+    monkeypatch, _env_serialized, caplog
+):
+    """FIX 2: real timeout-bound proof for the shadow WORKER itself (not a
+    monkeypatch of the isolation mechanism, which was a no-op w.r.t. the
+    actual behavior). `_run_llm_dual_run_shadow` wraps the shadow's
+    `complete()` coroutine in `asyncio.wait_for(...,
+    timeout=_DUAL_RUN_TIMEOUT_SECONDS)` — a provider that never responds is
+    cancelled near the bounded timeout (not left to run indefinitely), the
+    resulting `TimeoutError` is caught, and the failure is logged — never
+    raised out of the worker."""
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     _patch_stub_provider(monkeypatch)
+    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.1)
 
-    def _hang(*args, **kwargs):
-        import time
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(30)  # far longer than the bounded timeout above
 
-        time.sleep(5)
-
-    monkeypatch.setattr(llm_agent_mod, "_run_coro_in_isolated_thread", _hang)
-    monkeypatch.setattr(
-        llm_agent_mod,
-        "_shadow_deployment_for",
-        lambda **kw: object(),  # any non-None sentinel; complete() is never reached
-    )
-    # Bound the test's own patience, independent of the production timeout
-    # constant.
-    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 30.0)
+    _patch_shadow_client(monkeypatch, _hang)
 
     agent = LLMAgentNode()
-    response = agent._provider_llm_response(
-        provider="openai",
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=[],
-        generation_config={},
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        start = time.monotonic()
+        # Call the worker directly -- Tier 1, no threading indirection --
+        # to prove the BOUND itself works, independent of dispatch.
+        agent._run_llm_dual_run_shadow(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+            api_key=None,
+            base_url=None,
+            legacy_response={"content": "hello from stub"},
+        )
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0, (
+        f"shadow worker took {elapsed:.2f}s -- asyncio.wait_for should have "
+        f"cancelled the hung provider near the 0.1s bound"
     )
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert len(shadow_error_records) == 1
+    assert shadow_error_records[0].error_class == "TimeoutError"
+
+
+def test_dual_run_shadow_timeout_never_propagates_through_dispatch(
+    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
+):
+    """End-to-end (dispatch-level) sibling of the worker-level timeout
+    test: with the flag ON and a hung shadow, `_provider_llm_response`
+    returns the live response unaffected, and once the dispatched daemon
+    thread's bounded timeout elapses, exactly one `shadow_error` is
+    logged -- never raised, never affecting `response`."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.1)
+
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(30)
+
+    _patch_shadow_client(monkeypatch, _hang)
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        response, threads = _call_and_join_shadow(
+            agent,
+            _shadow_dispatch_capture,
+            join_timeout=5.0,
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+        )
+        assert len(threads) == 1
+        assert not threads[0].is_alive()
+
     assert response["content"] == "hello from stub"
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert len(shadow_error_records) == 1
+    assert shadow_error_records[0].error_class == "TimeoutError"
 
 
 def test_dual_run_shadow_unmapped_provider_skips_without_warning(
-    monkeypatch, _env_serialized, caplog
+    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
 ):
     """A provider with no four-axis preset mapping is skipped at DEBUG --
     no WARNING, live response unaffected.
@@ -243,13 +635,16 @@ def test_dual_run_shadow_unmapped_provider_skips_without_warning(
     agent = LLMAgentNode()
     with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
         with caplog.at_level(logging.DEBUG, logger="kaizen.nodes.ai.llm_agent"):
-            response = agent._provider_llm_response(
+            response, threads = _call_and_join_shadow(
+                agent,
+                _shadow_dispatch_capture,
                 provider="totally-unmapped-provider-xyz",
                 model="mock-model",
                 messages=[{"role": "user", "content": "hi"}],
                 tools=[],
                 generation_config={},
             )
+            assert len(threads) == 1
 
     assert response["content"] is not None
     warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
@@ -262,14 +657,15 @@ def test_dual_run_shadow_unmapped_provider_skips_without_warning(
 
 
 def test_dual_run_isolated_thread_runs_under_an_active_caller_event_loop(
-    monkeypatch, _env_serialized, caplog
+    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
 ):
     """The shadow MUST run correctly even when `_provider_llm_response` is
     invoked from a caller thread that already has an active asyncio event
     loop (an async Nexus handler, a pytest-asyncio test, an agent loop) --
     the exact case a bare `asyncio.run()` on the caller thread cannot
     handle (`RuntimeError: asyncio.run() cannot be called from a running
-    event loop`)."""
+    event loop`). The dispatched daemon thread provides the isolation now,
+    not a nested thread-in-thread helper inside the worker."""
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     _patch_stub_provider(monkeypatch)
 
@@ -284,13 +680,7 @@ def test_dual_run_isolated_thread_runs_under_an_active_caller_event_loop(
             "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
         }
 
-    fake_client = MagicMock()
-    fake_client.complete = _fake_complete
-    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", lambda **kw: object())
-    monkeypatch.setattr(
-        "kaizen.llm.client.LlmClient.from_deployment_sync",
-        classmethod(lambda cls, *a, **kw: fake_client),
-    )
+    _patch_shadow_client(monkeypatch, _fake_complete)
 
     agent = LLMAgentNode()
 
@@ -305,15 +695,230 @@ def test_dual_run_isolated_thread_runs_under_an_active_caller_event_loop(
             generation_config={},
         )
 
-    import asyncio
-
     with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
         response = asyncio.run(_run_inside_active_loop())
+
+        assert len(_shadow_dispatch_capture) == 1
+        _shadow_dispatch_capture[0].join(timeout=5.0)
+        assert not _shadow_dispatch_capture[0].is_alive()
 
     assert response["content"] == "hello from stub"
     assert calls == [1]  # the shadow's complete() genuinely ran
     parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
     assert len(parity_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 (LOW) — the shadow's exception boundary is BaseException, not
+# Exception, so asyncio.CancelledError (a BaseException subclass) and
+# similar are caught too; KeyboardInterrupt/SystemExit still re-raise.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_run_shadow_catches_cancelled_error_as_baseexception(
+    monkeypatch, _env_serialized, caplog
+):
+    """`asyncio.CancelledError` is a `BaseException` subclass, NOT an
+    `Exception` subclass. FIX 3 broadens the shadow worker's exception
+    boundary to `BaseException` so a cancellation raised inside the
+    shadow's own coroutine only logs `llm.dual_run.shadow_error` -- it must
+    never escape the worker."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    async def _cancel(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    _patch_shadow_client(monkeypatch, _cancel)
+
+    agent = LLMAgentNode()
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        # Must not raise -- this is the assertion.
+        agent._run_llm_dual_run_shadow(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+            api_key=None,
+            base_url=None,
+            legacy_response={"content": "hello from stub"},
+        )
+
+    shadow_error_records = [
+        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
+    ]
+    assert len(shadow_error_records) == 1
+    assert shadow_error_records[0].error_class == "CancelledError"
+
+
+@pytest.mark.parametrize("signal_exc", [KeyboardInterrupt, SystemExit])
+def test_dual_run_shadow_reraises_keyboardinterrupt_and_systemexit(
+    monkeypatch, _env_serialized, signal_exc
+):
+    """KeyboardInterrupt/SystemExit are structural process-control signals,
+    NOT shadow-path failures -- FIX 3's `except BaseException` re-raises
+    them instead of swallowing them like any other shadow error."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    def _boom(*args, **kwargs):
+        raise signal_exc()
+
+    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", _boom)
+
+    agent = LLMAgentNode()
+    with pytest.raises(signal_exc):
+        agent._run_llm_dual_run_shadow(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            generation_config={},
+            api_key=None,
+            base_url=None,
+            legacy_response={"content": "hello from stub"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# FIX 6 (LOW) — the divergence counter is now genuinely concurrent
+# (multiple daemon threads); it MUST be lock-guarded.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_run_divergence_counter_lock_exists():
+    assert isinstance(llm_agent_mod._dual_run_divergence_lock, type(threading.Lock()))
+
+
+class _SpyLock:
+    """Wraps a real `threading.Lock`, counting `__enter__`/`__exit__`
+    calls -- used to prove `_dual_run_divergence_count += 1` in
+    `_run_llm_dual_run_shadow` actually ACQUIRES
+    `_dual_run_divergence_lock` on every divergence report.
+
+    A raw concurrent-stress assertion on a bare module-global `+= 1`
+    cannot reliably force a lost-update race on every platform/GIL build
+    (a plain `LOAD_GLOBAL`/`BINARY_ADD`/`STORE_GLOBAL` sequence is short
+    enough that CPython's GIL rarely preempts mid-sequence at small N,
+    verified empirically: 25 unguarded concurrent increments through the
+    real worker code path landed correctly in 5/5 local trials). Spying on
+    the lock itself is deterministic regardless of scheduling.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.enter_count = 0
+        self.exit_count = 0
+
+    def __enter__(self):
+        self.enter_count += 1
+        return self._lock.__enter__()
+
+    def __exit__(self, *exc_info):
+        self.exit_count += 1
+        return self._lock.__exit__(*exc_info)
+
+
+def test_dual_run_divergence_counter_increment_acquires_the_lock(
+    monkeypatch, _env_serialized
+):
+    """FIX 6 (deterministic proof): `_dual_run_divergence_count += 1` MUST
+    acquire `_dual_run_divergence_lock` on every divergence report --
+    proven by wrapping the real module-level lock with a spy and asserting
+    it is entered/exited exactly once per divergence, for N concurrent
+    shadow workers."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    spy_lock = _SpyLock()
+    monkeypatch.setattr(llm_agent_mod, "_dual_run_divergence_lock", spy_lock)
+
+    async def _diverge(*args, **kwargs):
+        return {
+            "text": "different from legacy",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+
+    _patch_shadow_client(monkeypatch, _diverge)
+
+    agent = LLMAgentNode()
+    before = llm_agent_mod._dual_run_divergence_count
+    n_workers = 10
+    threads = [
+        threading.Thread(
+            target=agent._run_llm_dual_run_shadow,
+            kwargs=dict(
+                provider="openai",
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                generation_config={},
+                api_key=None,
+                base_url=None,
+                legacy_response={"content": "hello from stub"},
+            ),
+        )
+        for _ in range(n_workers)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive()
+
+    assert llm_agent_mod._dual_run_divergence_count == before + n_workers
+    assert spy_lock.enter_count == n_workers
+    assert spy_lock.exit_count == n_workers
+
+
+def test_dual_run_divergence_counter_is_thread_safe_under_concurrent_shadows(
+    monkeypatch, _env_serialized
+):
+    """Secondary sanity check (see `_SpyLock` docstring for why this alone
+    is not a reliable regression test): N concurrent shadow workers each
+    reporting a divergence MUST land a final counter of exactly N."""
+    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
+    _patch_stub_provider(monkeypatch)
+
+    async def _diverge(*args, **kwargs):
+        return {
+            "text": "different from legacy",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+
+    _patch_shadow_client(monkeypatch, _diverge)
+
+    agent = LLMAgentNode()
+    before = llm_agent_mod._dual_run_divergence_count
+    n_workers = 25
+    threads = [
+        threading.Thread(
+            target=agent._run_llm_dual_run_shadow,
+            kwargs=dict(
+                provider="openai",
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                generation_config={},
+                api_key=None,
+                base_url=None,
+                legacy_response={"content": "hello from stub"},
+            ),
+        )
+        for _ in range(n_workers)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive()
+
+    assert llm_agent_mod._dual_run_divergence_count == before + n_workers
 
 
 # ---------------------------------------------------------------------------
@@ -346,7 +951,7 @@ _OPENAI_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
 
 @respx.mock
 def test_dual_run_respx_parity_logs_no_divergence(
-    monkeypatch, _env_serialized, caplog, _no_real_dns
+    monkeypatch, _env_serialized, caplog, _no_real_dns, _shadow_dispatch_capture
 ):
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-parity")
@@ -368,13 +973,16 @@ def test_dual_run_respx_parity_logs_no_divergence(
 
     agent = LLMAgentNode()
     with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response = agent._provider_llm_response(
+        response, threads = _call_and_join_shadow(
+            agent,
+            _shadow_dispatch_capture,
             provider="openai",
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": "ping"}],
             tools=[],
             generation_config={"temperature": 0.0},
         )
+        assert len(threads) == 1
 
     assert response["content"] == "pong"
 
@@ -392,7 +1000,7 @@ def test_dual_run_respx_parity_logs_no_divergence(
 
 @respx.mock
 def test_dual_run_respx_divergence_logs_exactly_one_warning(
-    monkeypatch, _env_serialized, caplog, _no_real_dns
+    monkeypatch, _env_serialized, caplog, _no_real_dns, _shadow_dispatch_capture
 ):
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-divergence")
@@ -430,13 +1038,16 @@ def test_dual_run_respx_divergence_logs_exactly_one_warning(
 
     agent = LLMAgentNode()
     with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response = agent._provider_llm_response(
+        response, threads = _call_and_join_shadow(
+            agent,
+            _shadow_dispatch_capture,
             provider="openai",
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": "ping"}],
             tools=[],
             generation_config={"temperature": 0.0},
         )
+        assert len(threads) == 1
 
     # Live response is STILL the legacy one, untouched by the shadow.
     assert response["content"] == "pong"


### PR DESCRIPTION
## Summary

**Wave 2** of #1720 — runs the four-axis `LlmClient` in **shadow** alongside the legacy provider behind `_provider_llm_response`, diffs outputs, and logs divergences — while still returning the legacy result. This de-risks Wave 3 (the real cutover) by measuring four-axis parity on real traffic first. Additive + reversible.

- **Flag-gated + OFF by default** (`KAIZEN_LLM_DUAL_RUN`). When unset, `_provider_llm_response` is byte-identical to before — no thread, no shadow, zero overhead. This is the #1 invariant, pinned by tests.
- **Fire-and-forget**: the shadow runs on a `daemon=True` thread that the live path never joins — so enabling the flag adds **zero latency** to production responses (a hung shadow cannot delay the live return, proven by test). It reads a `deepcopy` snapshot so it can never race with the caller mutating the returned dict.
- **`_legacy_shape.py`** maps four-axis `{text, stop_reason, usage:{input/output_tokens}, tool_calls?}` → legacy `{content, finish_reason, tool_calls, usage:{prompt/completion/total_tokens}}` and diffs field-by-field.
- **No secret/content leakage**: divergence logs carry only field names, booleans/lengths/counts, and **sha256[:8] hashes** of tool names — never raw prompt text, tool arguments, or credentials (pinned by a canary test). Any shadow failure only logs `error_class` (never `str(e)`).

## Testing

- **2136 kaizen LLM + regression + cross_sdk_parity + dual-run tests pass**, 0 failures. ruff/black clean.
- Fire-and-forget proof: `test_dual_run_live_path_returns_immediately_despite_hung_shadow` (hung shadow, bounded elapsed, shadow-actually-dispatched).
- Flag-off byte-neutrality: `test_dual_run_flag_off_response_is_byte_identical`.

## Redteam — converged (2 rounds)

- **R1** (correctness + security): security CLEAN; correctness found a **HIGH** — the shadow originally *blocked* the live return (synchronous `future.result(timeout=30s)`), adding up to 30s (×5 in the tool loop) of latency when enabled. Fixed via the fire-and-forget daemon-thread refactor + BaseException guard + hashed tool-name diff + locked counter + doubled-cost doc.
- **R2**: **CONVERGENCE CLEAN** — all fixes verified; only LOW/informational residue (bounded in-process deepcopy; opt-in daemon fan-out — both acceptable for a validation-only flag).

## Cost note

Enabling `KAIZEN_LLM_DUAL_RUN` fires a **second** real outbound LLM call per gated request (doubled cost/token spend; latency is off the live path). Opt-in validation only.

## Follow-ups (NOT in this PR — human-gated)

- **Wave 3** — migrate consumers one at a time (llm_agent → base_agent → embedding_generator → registry). `/todos` gate.
- **Wave 4** — DELETE legacy `providers/llm/` (irreversible). `/todos` gate + release-pipeline regression green.

## Related issues

Part of #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)