### PR TITLE
docs(rules): codify fire-and-forget shadow/dual-run pattern

### DIFF
--- a/.claude/rules/patterns.md
+++ b/.claude/rules/patterns.md
@@ -142,6 +142,40 @@ km.register(result, name="demo")  # RuntimeError: This event loop is already run
 
 Origin: kailash-ml-audit session 2026-04-23 — W33c async/sync inconsistency caught by end-to-end README regression test.
 
+## Shadow / Dual-Run / Canary Paths Are Fire-And-Forget (MUST)
+
+When a primary code path is instrumented with a SECOND implementation running alongside it to COMPARE or MEASURE — a dual-run shadow, a canary, a migration parity check, an A/B validation — the shadow MUST be **fire-and-forget**: dispatched on a `daemon=True` thread the primary NEVER joins, awaits, or blocks on. The shadow MUST NOT be able to add latency to, delay, or break the primary path. It MUST (a) read a `copy.deepcopy` SNAPSHOT of the inputs/result taken on the caller thread (never the live object the primary returns, which the caller may mutate), (b) bound its own work with a timeout INSIDE the thread, (c) catch `BaseException` (re-raising only `KeyboardInterrupt`/`SystemExit`) so every failure only logs, and (d) be flag-gated OFF by default. The comparison/divergence log MUST carry only field names, counts/lengths, and hashes — never raw content or credentials.
+
+```python
+# DO — fire-and-forget: the primary returns immediately; the shadow can't touch it
+def primary(self, *args) -> dict:
+    result = self._legacy(*args)              # live path, unchanged
+    if _shadow_enabled():
+        snap = copy.deepcopy({"args": args, "result": result})   # snapshot on caller thread
+        threading.Thread(target=self._shadow_worker, kwargs=snap,
+                         daemon=True).start()  # NEVER joined
+    return result                              # returns NOW, zero shadow latency
+
+# DO NOT — synchronous shadow blocks the live return for the shadow round-trip
+def primary(self, *args) -> dict:
+    result = self._legacy(*args)
+    fut = pool.submit(self._shadow_async, *args)
+    fut.result(timeout=30)                     # BLOCKS the caller up to 30s (×N in a loop)
+    return result
+```
+
+**BLOCKED rationalizations:**
+
+- "The shadow has a timeout, so it's bounded" (a bounded BLOCK is still a block — 30s × N loop rounds on the live path)
+- "It runs alongside, so it's non-blocking" ("alongside" means a separate thread the caller does NOT await — a joined future is sequential)
+- "The shadow needs the result, so I have to wait for it" (deepcopy the result into the thread; the caller never waits)
+- "A ThreadPoolExecutor is cleaner" (its workers are non-daemon and block process exit at shutdown; a fire-and-forget daemon thread does not)
+- "`except Exception` is enough" (`asyncio.CancelledError` is a `BaseException`, not an `Exception` — it escapes and can reach the caller)
+
+**Why:** A shadow that blocks the primary is no longer a shadow — it imports the shadow's full round-trip latency (multiplied by every loop iteration) into the production path, the exact opposite of the zero-primary-impact the design promises. Fire-and-forget on a daemon thread reading a deepcopy snapshot is the only shape where a hung, slow, or crashing shadow provably cannot affect the live return.
+
+Origin: kaizen #1720 Wave-2 dual-run redteam (2026-07-16) — a four-axis-vs-legacy shadow was dispatched synchronously with `future.result(timeout=30s)`, adding up to 30s × 5 tool-loop rounds of latency to live LLM responses; the redteam HIGH was fixed by the fire-and-forget daemon-thread refactor (proven by a hung-shadow live-return-latency test).
+
 ## Callable Module + Subpackage Coexistence (MUST — PEP 562)
 
 When a package exports BOTH a top-level callable (`pkg.foo` imported from `_wrappers` or similar) AND contains a subpackage of the same name (`pkg/foo/`), Python's import machinery unconditionally sets `pkg.foo` to the subpackage module the moment ANYTHING runs `from pkg.foo import <X>` — silently shadowing the callable. In test-collection order, this surfaces as `AssertionError: pkg.foo MUST be callable (got module)` after an unrelated test imports the subpackage.

--- a/workspaces/issue-1720-llm-consolidation/journal/0001-DECISION-codify-fire-and-forget-shadow-pattern.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0001-DECISION-codify-fire-and-forget-shadow-pattern.md
@@ -1,0 +1,59 @@
+---
+type: DECISION
+date: 2026-07-16
+topic: Focused /codify — fire-and-forget shadow pattern + Wave-1/2 kaizen traps
+---
+
+# DECISION — Focused /codify (fire-and-forget shadow pattern)
+
+## Directive
+
+User: "check if we need to /codify since its been some time since we did that" →
+assessment surfaced ONE genuinely-new cross-project pattern + two kaizen-specific
+traps → user "approved" the focused codify (the fire-and-forget-shadow pattern +
+the 2 kaizen notes).
+
+## Cascade-valuable learning codified (cross-project)
+
+**Shadow / dual-run / canary paths are fire-and-forget.** A validation path that
+runs a second implementation alongside the primary (to compare/measure) MUST be
+dispatched on a daemon thread the primary never joins — reading a deepcopy
+snapshot, bounding its own work, catching BaseException, flag-gated OFF by
+default — so a hung/slow/crashing shadow provably cannot add latency to, delay,
+or break the primary. Landed as a new MUST section in `.claude/rules/patterns.md`
+("Shadow / Dual-Run / Canary Paths Are Fire-And-Forget"), the file's natural home
+for the SDK's async/threading disciplines (path-scoped `**/*.py`; NOT baseline, NOT
+on the self-referential-codify allowlist, so neither the multi-agent self-ref gate
+nor the rule-authoring Rule-10 proximity-band gate fires).
+
+Origin: this session's #1720 Wave-2 dual-run redteam surfaced it as a HIGH — a
+four-axis-vs-legacy shadow dispatched synchronously with `future.result(timeout=30s)`
+added up to 30s × 5 tool-loop rounds of latency to live LLM responses; fixed by
+the fire-and-forget daemon-thread refactor, proven by a hung-shadow live-return
+latency test.
+
+## Kaizen-specific traps (recorded here per wave-loop G2 — lightweight, NOT rule edits)
+
+1. **Local verify scope MUST include `tests/cross_sdk_parity/`.** CI caught a
+   cross-SDK error-taxonomy failure (`test_no_python_only_errors_leak_public_surface`)
+   that the `tests/unit/llm/ tests/regression/` local scope missed — a new public
+   error (`InvalidApiKeyOverride`) in `kaizen.llm.errors` not present in the Rust
+   taxonomy. When touching kaizen LLM code, run
+   `pytest tests/unit/llm/ tests/regression/ tests/cross_sdk_parity/` locally
+   before pushing.
+2. **Client-layer BYOK-override errors belong in `client.py`, not `errors.py`.**
+   The `kaizen.llm.errors` module is the cross-SDK-mirrored error taxonomy (scanned
+   by `test_no_python_only_errors_leak_public_surface` for parity with Rust). Client-
+   layer guards (`UnsupportedApiKeyOverride`, `InvalidApiKeyOverride`) live in
+   `client.py` beside their call sites — subclassing `AuthError`, catchable by
+   consumers via the parent — NOT in the mirrored `errors.py` module (which would
+   demand a Rust counterpart or a leading-underscore private rename).
+
+## Distribution
+
+`patterns.md` is already manifest-registered (a synced `.claude/rules/` artifact),
+so its distribution fate is declared — the pattern cascades to downstream consumers
+on the next loom `/sync-from-build` ingest of the rule diff (knowledge-cascade-routing
+MUST-2 satisfied). The 2 kaizen traps are workspace-local (kaizen-repo-specific), so
+they stay here per wave-loop G2 (journal capture for non-cross-project learnings), not
+a rule edit.


### PR DESCRIPTION
## Summary

Focused `/codify` of the one cross-project learning from this session's #1720 Wave-2 dual-run redteam: a **shadow / dual-run / canary path MUST be fire-and-forget** — dispatched on a daemon thread the primary never joins, reading a `deepcopy` snapshot, bounding its own work, catching `BaseException`, flag-gated off by default — so a hung/slow/crashing shadow provably cannot add latency to or break the primary path.

Landed as a new MUST section in `.claude/rules/patterns.md` (the file's async/threading-discipline home). Journal `0001` records the codify + 2 kaizen-specific traps (include `tests/cross_sdk_parity/` in local verify scope; client-layer BYOK errors live in `client.py`, not the cross-SDK-mirrored `errors.py`).

## Scope notes

- `patterns.md` is path-scoped (`**/*.py`), **not** baseline and **not** on the self-referential-codify allowlist → neither the multi-agent self-ref gate nor the rule-authoring Rule-10 proximity-band gate fires.
- Matches the file's existing async/threading section style (MUST + DO/DO-NOT + BLOCKED + Why + Origin).

## Origin

The pattern was a real Wave-2 redteam HIGH: a synchronous shadow (`future.result(timeout=30s)`) added 30s × 5 tool-loop rounds of latency to live LLM responses; fixed by the fire-and-forget daemon-thread refactor (kaizen #1720 Wave 2, PR #1780).

🤖 Generated with [Claude Code](https://claude.com/claude-code)