### PR TITLE
test(kaizen): #1720 Wave-B prep — OpenAI-compat parity coverage + cross-SDK BYOK draft

### DIFF
--- a/packages/kailash-kaizen/tests/parity/_harness.py
+++ b/packages/kailash-kaizen/tests/parity/_harness.py
@@ -288,8 +288,17 @@ def drive_legacy_openai_family(
     messages: List[Dict[str, Any]],
     tools: Optional[List[Dict[str, Any]]] = None,
     generation_config: Optional[Dict[str, Any]] = None,
+    api_key: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Drive an openai-SDK-based legacy provider (openai / docker / perplexity)."""
+    """Drive an openai-SDK-based legacy provider (openai / docker / perplexity).
+
+    ``api_key`` is an OPTIONAL per-request override forwarded to ``chat()``.
+    It is only needed for providers whose ``chat()`` resolves a credential
+    (e.g. Perplexity reads ``PERPLEXITY_API_KEY`` BEFORE building the — here
+    mocked — ``openai.OpenAI`` client, so an offline parity run must supply a
+    dummy). The key is never sent on the wire (the client is stubbed); it
+    exists only to reach the parse path. openai/docker do not require it.
+    """
     from openai.types.chat import ChatCompletion
 
     recorder = _Captured(ChatCompletion.model_validate(canned))
@@ -303,14 +312,18 @@ def drive_legacy_openai_family(
     class _StubClient:
         chat = _Chat()
 
+    chat_kwargs: Dict[str, Any] = dict(
+        messages=messages,
+        model=model,
+        generation_config=generation_config or {},
+        tools=tools or [],
+    )
+    if api_key is not None:
+        chat_kwargs["api_key"] = api_key
+
     provider = provider_cls()
     with mock.patch("openai.OpenAI", return_value=_StubClient()):
-        legacy = provider.chat(
-            messages=messages,
-            model=model,
-            generation_config=generation_config or {},
-            tools=tools or [],
-        )
+        legacy = provider.chat(**chat_kwargs)
     return legacy, recorder.kwargs
 
 

--- a/packages/kailash-kaizen/tests/parity/test_parity_plane_b_response_parse.py
+++ b/packages/kailash-kaizen/tests/parity/test_parity_plane_b_response_parse.py
@@ -29,7 +29,9 @@ from kaizen.llm.wire_protocols import (
     google_generate_content,
     openai_chat,
 )
+from kaizen.providers.llm.docker import DockerModelRunnerProvider
 from kaizen.providers.llm.openai import OpenAIProvider
+from kaizen.providers.llm.perplexity import PerplexityProvider
 
 from ._harness import (
     drive_legacy_anthropic,
@@ -59,6 +61,32 @@ _PLAIN_CELLS = [
         anthropic_messages,
         lambda c: drive_legacy_anthropic(c, model="parity-claude", messages=_MSGS),
         id="anthropic-plain",
+    ),
+    # OpenAI-compat wires (#1720 Wave-B gate-coverage extension): docker +
+    # perplexity legacy providers drive the openai SDK (`openai.OpenAI`,
+    # `client.chat.completions.create`) and their four-axis preset maps to the
+    # `OpenAiChat` wire, so plain-completion parse MUST be byte-identical to
+    # openai on the shared canned bytes. Closes the plane-B coverage gap the
+    # Wave-A parity findings flagged as "extension pending" for these wires.
+    pytest.param(
+        "openai_response",
+        openai_chat,
+        lambda c: drive_legacy_openai_family(
+            DockerModelRunnerProvider, c, model="parity-model", messages=_MSGS
+        ),
+        id="docker-plain",
+    ),
+    pytest.param(
+        "openai_response",
+        openai_chat,
+        lambda c: drive_legacy_openai_family(
+            PerplexityProvider,
+            c,
+            model="parity-model",
+            messages=_MSGS,
+            api_key="parity-dummy-key",  # offline: reaches parse path; never sent
+        ),
+        id="perplexity-plain",
     ),
 ]
 

--- a/workspaces/issue-1720-llm-consolidation/cross-sdk-byok-draft-UNFILED.md
+++ b/workspaces/issue-1720-llm-consolidation/cross-sdk-byok-draft-UNFILED.md
@@ -1,0 +1,70 @@
+# DRAFT — Cross-SDK issue for the Rust SDK four-axis LLM client (NOT YET FILED)
+
+**Status: UNFILED.** Filing needs explicit user authorization + the five
+`repo-scope-discipline` conditions (user-initiated + explicit+specific +
+confirmed + journaled-before-acting + scoped). This is the scrubbed body,
+ready to file on the word "go". Target repo resolves via `build.rs`
+(`loom-links.local.json`), label `cross-sdk`.
+
+Scrubbed per `upstream-issue-hygiene.md` MUST-2: SDK-API surface only — no
+downstream/consumer context, internal paths, workspace IDs, or finding tags.
+
+---
+
+## Title
+
+`feat(llm): validate per-request BYOK api_key for header-injection at parity across both BYOK entry points`
+
+## Affected API
+
+The four-axis LLM client's per-request **BYOK (bring-your-own-key)** paths that
+install a caller-supplied `api_key` into an outbound HTTP header value. There are
+(at least) two such entry points that MUST be at parity:
+
+1. the direct per-request override on the completion call (the `complete(...,
+api_key=...)` analogue);
+2. the deployment-resolution path that accepts a caller-supplied `api_key` and
+   bakes it into the deployment's auth strategy (the analogue of resolving a
+   provider name → deployment with an override key).
+
+## Summary
+
+A per-request `api_key` is installed verbatim into an HTTP header (e.g.
+`Authorization: Bearer <key>` / `api-key: <key>`). If one BYOK entry point
+validates the key for control characters / CRLF / non-ASCII before header
+install but the sibling entry point does not, a caller-supplied key containing
+`\r\n` is a CRLF header-injection surface on the unguarded path
+(`"\r\nX-Injected: value"` smuggles an extra header), while the guarded path
+rejects it. The two entry points MUST fail closed identically, routing through a
+SINGLE shared validator (not two copies that can drift).
+
+## Expected vs actual
+
+- **Expected:** every BYOK entry point that turns a caller-supplied `api_key`
+  into a header value rejects — fail-closed, before install — any key containing
+  a C0 control char (`\x00`–`\x1f`), DEL (`\x7f`), or a non-ASCII character
+  (an HTTP header value must be ASCII). The error is typed and fingerprints the
+  key, never echoing it.
+- **Actual (to verify in the Rust client):** confirm whether BOTH entry points
+  validate, or whether only the direct-override path does while the
+  deployment-resolution path installs the raw key unvalidated.
+
+## Severity
+
+MEDIUM–HIGH — header-injection surface on a caller-controlled per-request key;
+gated behind an application routing untrusted input into a per-request key.
+
+## Acceptance criteria
+
+- [ ] Both BYOK entry points reject a `\r\n` / control-char / non-ASCII
+      `api_key` with the same typed error, before any header install.
+- [ ] Both route through ONE shared validation function (no divergent copy).
+- [ ] The error fingerprints the key (never echoes the raw secret in message/log).
+- [ ] A regression test pins both entry points against a CRLF/NUL/DEL/non-ASCII
+      key, plus a valid-key accept case.
+
+## Cross-SDK alignment
+
+Python equivalent: kailash-py #1720 (four-axis LLM consolidation); the parity
+fix routed the deployment-resolution BYOK path through the same control-char
+validator the direct-override path already used.


### PR DESCRIPTION
## Summary

Non-gated Wave-B gate-evidence prep (test-only + workspace docs); the consumer-cutover shards remain at the human `/todos` gate.

- **Parity coverage** — extends plane-B response-parse parity to the OpenAI-compat wires **docker** + **perplexity** (both drive the openai SDK and map to the `OpenAiChat` four-axis wire). Confirmed byte-identical to openai on shared canned bytes; closes the "extension pending" gap the Wave-A parity findings named. 42 parity tests pass.
- **Cross-SDK BYOK draft** — a scrubbed, UNFILED issue draft for the Rust SDK four-axis client's per-request BYOK header-injection parity (the Rust equivalent of this cycle's security fix). Awaiting explicit authorization to file (not filed here).

## Testing

Full `tests/parity` suite green (42 passed). Harness change is an optional `api_key` passthrough for offline Perplexity (dummy key, never sent — no env mutation).

## Related issues

Part of #1720. Wave B/C implementation remains human-gated at `/todos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)