### PR TITLE
feat(kaizen): #1720 Wave B1 — retire legacy LLM path onto four-axis LlmClient (consumer cutover)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -407,7 +407,17 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
                 "max_tokens": self.config.max_tokens or 500,
             }
         )
-        result = await client.complete(messages, model=model, **sampling_kwargs)
+        try:
+            result = await client.complete(messages, model=model, **sampling_kwargs)
+        except Exception as e:
+            # #1720 Wave-B1 redteam MED — sanitize provider errors at
+            # enforcement-surface parity with the B1a live path
+            # (llm_agent._provider_llm_response). A raw wire exception can echo
+            # a user-supplied config.base_url; scrub before it reaches
+            # _handle_error's logger / returned {"error": ...} surface.
+            from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
+
+            raise RuntimeError(sanitize_provider_error(e, "openai")) from e
         content = to_legacy_shape(result)["content"]
 
         if self.signature:

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -329,10 +329,21 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         return await AgentLoop.run_async(self, **inputs)
 
     async def _simple_execute_async(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Simple async execution using direct provider call (fallback)."""
-        from kaizen.providers.llm.openai import OpenAIProvider
+        """Simple async execution via the four-axis ``LlmClient`` (fallback).
 
-        provider = OpenAIProvider(use_async=True)
+        #1720 Wave-B1c: cut over from the legacy ``OpenAIProvider`` to the
+        four-axis path — ``resolve_deployment_for("openai", ...)`` ->
+        ``LlmClient.from_deployment(...)`` -> ``await client.complete(...)``.
+        The multimodal-input detection, the system-prompt prepend, the
+        config->env model resolution, and the return shape are unchanged;
+        the legacy ``response["content"]`` is read via ``to_legacy_shape``.
+        """
+        from kaizen.llm._legacy_shape import to_legacy_shape
+        from kaizen.llm.client import LlmClient
+        from kaizen.llm.deployment_resolver import resolve_deployment_for
+        from kaizen.nodes.ai.llm_agent import (
+            _sampling_kwargs_from_generation_config,
+        )
 
         messages = []
         system_prompt = self._generate_system_prompt()
@@ -367,23 +378,44 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
         messages.append({"role": "user", "content": user_content})
 
-        response = await provider.chat_async(
-            messages=messages,
-            model=self.config.model
+        # Model resolution unchanged: config -> DEFAULT_LLM_MODEL -> OPENAI_PROD_MODEL.
+        model = (
+            self.config.model
             or os.environ.get("DEFAULT_LLM_MODEL")
-            or os.environ.get("OPENAI_PROD_MODEL"),
-            generation_config={
+            or os.environ.get("OPENAI_PROD_MODEL")
+        )
+
+        # Four-axis path: resolve the OpenAI deployment (BYOK config.api_key /
+        # config.base_url honored; env OPENAI_API_KEY otherwise), then complete.
+        deployment = resolve_deployment_for(
+            "openai",
+            model=model,
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+        )
+        if deployment is None:
+            raise ValueError(
+                "_simple_execute_async: could not resolve an OpenAI four-axis "
+                "deployment; set OPENAI_API_KEY (or pass config.api_key)."
+            )
+        client = LlmClient.from_deployment(deployment)
+
+        # generation_config temperature/max_tokens -> four-axis sampling kwargs.
+        sampling_kwargs = _sampling_kwargs_from_generation_config(
+            {
                 "temperature": self.config.temperature or 0.7,
                 "max_tokens": self.config.max_tokens or 500,
-            },
+            }
         )
+        result = await client.complete(messages, model=model, **sampling_kwargs)
+        content = to_legacy_shape(result)["content"]
 
         if self.signature:
             output_fields = list(self.signature.output_fields.keys())
             if output_fields:
-                return {output_fields[0]: response["content"]}
+                return {output_fields[0]: content}
 
-        return {"response": response["content"]}
+        return {"response": content}
 
     def _simple_execute(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Fallback when no strategy is configured."""

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -327,6 +327,24 @@ def _parse_stream_line(line: str, shaper: Any) -> Optional[Dict[str, Any]]:
     return shaper.parse_response(obj)
 
 
+def _l2_normalize_vector(vector: List[float]) -> List[float]:
+    """Return a unit-L2-norm copy of ``vector`` (pure math).
+
+    This is the SINGLE client-side unit-normalization implementation. It is
+    applied UNIFORMLY across every embed wire by :meth:`LlmClient.embed` when
+    ``EmbedOptions.normalize`` is True (#1720 Wave-B1b, the folded F2-MEDIUM):
+    divide each component by the vector's L2 norm. A zero vector (norm == 0)
+    is returned UNCHANGED so normalization never divides by zero. There is no
+    per-shaper normalize copy — the HuggingFace shaper's former in-``parse_response``
+    normalize was removed so this is the only place normalization happens
+    (no double-normalize).
+    """
+    norm = sum(v * v for v in vector) ** 0.5
+    if norm == 0.0:
+        return list(vector)
+    return [v / norm for v in vector]
+
+
 class LlmClient:
     """Uniform client over an `LlmDeployment`.
 
@@ -566,6 +584,7 @@ class LlmClient:
         *,
         model: Optional[str] = None,
         options: Optional[EmbedOptions] = None,
+        timeout: Optional[float] = None,
         http_client: Optional[LlmHttpClient] = None,
     ) -> List[List[float]]:
         """Generate embedding vectors for ``texts`` via the configured deployment.
@@ -585,10 +604,20 @@ class LlmClient:
                 ``rules/env-models.md`` callers SHOULD read the model
                 from the environment (``OPENAI_EMBEDDING_MODEL``,
                 ``OLLAMA_EMBEDDING_MODEL``) rather than hardcoding.
-            options: Optional ``EmbedOptions`` (``dimensions`` / ``user``).
-                Accepted for every wire; individual wires may ignore
-                fields they do not support (Ollama ignores ``dimensions``
-                per its documented contract).
+            options: Optional ``EmbedOptions`` (``dimensions`` / ``user`` /
+                ``input_type`` / ``normalize``). Accepted for every wire;
+                individual wires may ignore fields they do not support
+                (Ollama ignores ``dimensions`` per its documented contract).
+                ``normalize=True`` L2-unit-normalizes every returned vector
+                UNIFORMLY, client-side, for EVERY wire (#1720 Wave-B1b); a
+                zero vector is returned unchanged. ``normalize`` unset / False
+                leaves the raw wire vectors byte-identical.
+            timeout: Optional per-request wire-call timeout, in seconds. When
+                set, it bounds THIS embedding request (threaded into the
+                underlying ``LlmHttpClient`` request the same way ``complete()``
+                bounds its send). When ``None`` (default), the transport's own
+                client-level timeout applies — byte-identical to the
+                pre-``timeout`` behavior.
             http_client: Optional pre-constructed ``LlmHttpClient`` — for
                 tests / advanced callers who want to share an HTTP pool
                 across multiple ``embed()`` calls. When ``None``, a
@@ -723,11 +752,19 @@ class LlmClient:
                 },
             )
 
+            # #1720 Wave-B1b: a caller-supplied ``timeout`` bounds THIS wire
+            # call (legacy embed passed ``timeout`` through to the provider);
+            # thread it into the httpx request only when set so an unset
+            # timeout is byte-identical to the transport's client-level default.
+            post_kwargs: dict = {}
+            if timeout is not None:
+                post_kwargs["timeout"] = timeout
             resp = await http_client.post(
                 url,
                 headers=request["headers"],
                 json=payload,
                 auth_strategy_kind=auth_kind,
+                **post_kwargs,
             )
         except httpx.TimeoutException as exc:
             logger.error(
@@ -768,18 +805,28 @@ class LlmClient:
                 raise InvalidResponse(
                     f"{wire.name.lower()}_embeddings: response was not valid JSON"
                 ) from exc
-            # #1720 Wave-A parity (F2): thread ``options`` into the embed
-            # shaper so ``EmbedOptions.normalize`` is honored. Only
-            # ``huggingface_embeddings`` consumes it (L2-normalizes the
-            # returned vectors); openai/cohere/ollama accept-and-ignore it for
-            # dispatch symmetry. Previously omitted here -> normalize was a
-            # silent no-op on the HuggingFace embed wire (zero-tolerance 3c).
+            # ``options`` is threaded into every embed shaper for dispatch
+            # symmetry; the shapers consume the REQUEST-shaping fields
+            # (openai ``dimensions``/``user``, cohere ``input_type``) and
+            # ignore the rest. ``EmbedOptions.normalize`` is NOT a per-shaper
+            # concern anymore: it is applied UNIFORMLY below, client-side, for
+            # EVERY wire (#1720 Wave-B1b, folded F2-MEDIUM) — the former
+            # HuggingFace-only in-``parse_response`` normalize was removed so
+            # there is ONE normalize implementation and no double-normalize.
             parsed = shaper.parse_response(payload_json, options)
             vectors = parsed["vectors"]
             if not isinstance(vectors, list):
                 raise InvalidResponse(
                     f"{wire.name.lower()}_embeddings: parse_response returned non-list vectors"
                 )
+            # #1720 Wave-B1b: single, uniform, client-side L2 unit-normalization
+            # for EVERY wire when ``normalize=True``. Pure math (divide each
+            # vector by its L2 norm); a zero vector is returned unchanged.
+            # ``normalize`` unset / False -> vectors are byte-identical to the
+            # raw wire output (zero-tolerance Rule 3c: the documented kwarg is
+            # consumed by this branch, never accepted-and-dropped).
+            if options is not None and options.normalize:
+                vectors = [_l2_normalize_vector(v) for v in vectors]
             logger.info(
                 "llm.embed.ok",
                 extra={

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/cohere_embeddings.py
@@ -133,8 +133,9 @@ def parse_response(payload: Dict[str, Any], options: Any = None) -> Dict[str, An
     ``options`` is accepted for dispatch symmetry with every embed shaper
     (the shared ``LlmClient.embed`` call site threads it uniformly, #1720
     Wave-A parity) and is intentionally IGNORED here: Cohere applies no
-    post-parse normalization. Only ``huggingface_embeddings`` consumes
-    ``options`` at parse time (``EmbedOptions.normalize``).
+    post-parse normalization. NO embed shaper consumes
+    ``EmbedOptions.normalize`` at parse time — ``LlmClient.embed`` applies L2
+    normalization uniformly, client-side, for every wire (#1720 Wave-B1).
     """
     if not isinstance(payload, dict):
         raise TypeError(

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -29,6 +29,33 @@ logger = logging.getLogger(__name__)
 _TOOL_CHOICE_MODE = {"auto": "AUTO", "required": "ANY", "none": "NONE"}
 
 
+def _map_finish_reason(raw: Any) -> Any:
+    """Value-map a Gemini ``finishReason`` onto the legacy lowercase form.
+
+    #1720 Wave-B1a — behavior-neutral migration of the FULL legacy value-map
+    from ``kaizen.providers.llm.google.GoogleGeminiProvider`` (which lowercases
+    the raw Gemini reason and buckets it): ``tool``/``function`` -> ``"tool_calls"``,
+    ``max``/``length`` -> ``"length"``, ``safety`` -> ``"content_filter"``, and
+    every other recognised reason (``STOP`` etc.) -> ``"stop"``. Matching the
+    legacy substring-on-lowercase logic exactly means a consumer testing
+    ``finish_reason == "stop"`` sees the SAME value on both the legacy and the
+    four-axis path (the pre-cutover divergence was the raw ``"STOP"`` casing).
+
+    A ``None`` finishReason (no candidate / field absent) passes through as
+    ``None`` — the wire only had a value to map when the provider sent one.
+    """
+    if raw is None:
+        return None
+    fr = str(raw).lower()
+    if "tool" in fr or "function" in fr:
+        return "tool_calls"
+    if "max" in fr or "length" in fr:
+        return "length"
+    if "safety" in fr:
+        return "content_filter"
+    return "stop"
+
+
 def _role_from_openai(role: str) -> str:
     """Map OpenAI role names to Gemini role names.
 
@@ -285,7 +312,11 @@ def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
             "output_tokens": usage.get("candidatesTokenCount"),
             "total_tokens": usage.get("totalTokenCount"),
         },
-        "stop_reason": finish_reason,
+        # #1720 Wave-B1a — value-map the raw Gemini finishReason onto the legacy
+        # lowercase form ('STOP' -> 'stop', 'MAX_TOKENS' -> 'length', 'SAFETY' ->
+        # 'content_filter', tool/function -> 'tool_calls'), behaviour-neutral with
+        # kaizen.providers.llm.google. Previously emitted the raw provider value.
+        "stop_reason": _map_finish_reason(finish_reason),
         "model": payload.get("modelVersion"),
     }
     # Only surface tool_calls when ≥1 functionCall part is present; a

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -41,11 +41,14 @@ def _map_finish_reason(raw: Any) -> Any:
     ``finish_reason == "stop"`` sees the SAME value on both the legacy and the
     four-axis path (the pre-cutover divergence was the raw ``"STOP"`` casing).
 
-    A ``None`` finishReason (no candidate / field absent) passes through as
-    ``None`` — the wire only had a value to map when the provider sent one.
+    A ``None`` finishReason (no candidate / field absent) maps to ``"stop"`` —
+    legacy ``GoogleGeminiProvider`` initialises ``finish_reason = "stop"`` and
+    never emits ``None`` (including on the streaming path), so ``"stop"`` is the
+    faithful legacy floor for an absent reason (#1720 Wave-B1 redteam LOW —
+    full finish_reason parity).
     """
     if raw is None:
-        return None
+        return "stop"
     fr = str(raw).lower()
     if "tool" in fr or "function" in fr:
         return "tool_calls"

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/huggingface_embeddings.py
@@ -30,28 +30,17 @@ hosted model has a built-in pooling layer):
   callers get a uniform ``list[list[float]]`` regardless of which shape the
   hosted model emits.
 
-Optional unit-normalization (``EmbedOptions.normalize``) is applied
-CLIENT-SIDE as an ``parse_response`` post-processing step (L2 norm per
-vector) -- HF's classic serverless feature-extraction endpoint has no
-documented request-level ``normalize`` parameter (unlike the newer
+Unit-normalization (``EmbedOptions.normalize``) is NOT applied here. As of
+#1720 Wave-B1b it is applied UNIFORMLY, client-side, for EVERY embed wire by
+``LlmClient.embed`` (a single L2-norm implementation, ``_l2_normalize_vector``)
+rather than per-shaper -- HF's classic serverless feature-extraction endpoint
+has no documented request-level ``normalize`` parameter (unlike the newer
 Text-Embeddings-Inference ``/embed`` server, which this shaper does NOT
-target), so normalization is done here rather than requested from the
-server.
-
-**Known scoped limitation (Wave-1b EMBED-REMAINDER):** ``LlmClient.embed()``
-calls ``shaper.parse_response(payload_json)`` with NO ``options`` argument
-for ANY wire (`client.py` is the shared dispatch surface all embed shapers
-go through, and threading ``options`` into that one call site is an
-orchestration-layer change touching every existing embedding shaper's
-signature -- out of this shard's scope, which is limited to
-`_EMBED_DISPATCH` + `_build_embed_url`). This module's ``parse_response``
-therefore accepts ``options`` as an OPTIONAL keyword argument (default
-``None``) so the normalize behavior is fully implemented and directly
-unit-testable; going through the live ``LlmClient.embed()`` HF dispatch
-today, normalize is a no-op because ``options`` never reaches this
-function. Wiring ``options`` through the shared dispatch call site for
-every embedding wire is a tracked follow-up, not introduced or worsened by
-this shard.
+target), so it is done client-side, but at the shared dispatch layer rather
+than in this shaper (the former HuggingFace-only copy was removed so there is
+ONE normalize implementation and no double-normalize). ``parse_response`` here
+accepts ``options`` only for dispatch-signature symmetry with every other
+embed shaper and validates its type; it does NOT consume ``normalize``.
 
 Cross-SDK parity: this shaper's output for a fixed input is intended to be
 byte-identical to the kailash-rs HuggingFace embeddings payload builder.
@@ -91,8 +80,9 @@ def build_request_payload(
     shaper but this endpoint has no request-level knob any current
     ``EmbedOptions`` field maps to (``dimensions``/``user`` are OpenAI-only
     concepts here; ``input_type`` is Cohere-only; ``normalize`` is applied
-    client-side in ``parse_response``, not requested from the server) --
-    so ``options`` is validated-and-ignored, not silently mis-typed through.
+    UNIFORMLY client-side in ``LlmClient.embed``, not requested from the
+    server) -- so ``options`` is validated-and-ignored, not silently
+    mis-typed through.
     """
     if not isinstance(texts, list):
         raise TypeError(
@@ -174,14 +164,6 @@ def _unwrap_entry(entry: Any, vector_index: int) -> List[float]:
     return _validate_numeric_row(entry, vector_index)
 
 
-def _l2_normalize(vector: List[float]) -> List[float]:
-    """Return a unit-L2-norm copy of ``vector``. Zero vectors pass through."""
-    norm = sum(v * v for v in vector) ** 0.5
-    if norm == 0.0:
-        return list(vector)
-    return [v / norm for v in vector]
-
-
 def parse_response(
     payload: Any,
     options: EmbedOptions | None = None,
@@ -196,14 +178,16 @@ def parse_response(
     Raises ``InvalidResponse`` with a stable ``reason`` when the payload
     shape violates the documented contract.
 
-    ``options`` is an OPTIONAL keyword argument (see module docstring "Known
-    scoped limitation") -- when supplied with ``normalize=True``, every
-    returned vector is L2-normalized; when omitted (the shape
-    ``LlmClient.embed()`` calls this function with today), no normalization
-    is applied. Neither ``model`` nor ``usage`` token counts are present on
-    this endpoint's response, matching the ``None`` conventions already
-    established by ``huggingface_inference.parse_response``'s
-    text-generation list-response branch.
+    ``options`` is an OPTIONAL keyword argument accepted ONLY for
+    dispatch-signature symmetry with every other embed shaper; its type is
+    validated but no field is consumed here. ``EmbedOptions.normalize`` is
+    applied UNIFORMLY, client-side, by ``LlmClient.embed`` for EVERY wire
+    (#1720 Wave-B1b), NOT in this shaper -- the former HuggingFace-only
+    normalize was removed so there is one normalize implementation and no
+    double-normalize. Neither ``model`` nor ``usage`` token counts are present
+    on this endpoint's response, matching the ``None`` conventions already
+    established by ``huggingface_inference.parse_response``'s text-generation
+    list-response branch.
     """
     if options is not None and not isinstance(options, EmbedOptions):
         raise TypeError(f"options must be EmbedOptions; got {type(options).__name__}")
@@ -216,9 +200,6 @@ def parse_response(
     vectors: List[List[float]] = [
         _unwrap_entry(entry, idx) for idx, entry in enumerate(payload)
     ]
-
-    if options is not None and options.normalize:
-        vectors = [_l2_normalize(v) for v in vectors]
 
     return {
         "vectors": vectors,

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_embeddings.py
@@ -100,8 +100,9 @@ def parse_response(payload: Dict[str, Any], options: Any = None) -> Dict[str, An
     ``options`` is accepted for dispatch symmetry with every embed shaper
     (the shared ``LlmClient.embed`` call site threads it uniformly, #1720
     Wave-A parity) and is intentionally IGNORED here: Ollama applies no
-    post-parse normalization. Only ``huggingface_embeddings`` consumes
-    ``options`` at parse time (``EmbedOptions.normalize``).
+    post-parse normalization. NO embed shaper consumes
+    ``EmbedOptions.normalize`` at parse time — ``LlmClient.embed`` applies L2
+    normalization uniformly, client-side, for every wire (#1720 Wave-B1).
     """
     if not isinstance(payload, dict):
         raise TypeError(

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_embeddings.py
@@ -112,8 +112,9 @@ def parse_response(payload: Dict[str, Any], options: Any = None) -> Dict[str, An
     (the shared ``LlmClient.embed`` call site threads it uniformly, #1720
     Wave-A parity) and is intentionally IGNORED here: OpenAI honors
     ``dimensions`` at the request level and applies no post-parse
-    normalization. Only ``huggingface_embeddings`` consumes ``options`` at
-    parse time (``EmbedOptions.normalize``).
+    normalization. NO embed shaper consumes ``EmbedOptions.normalize`` at
+    parse time — ``LlmClient.embed`` applies L2 normalization uniformly,
+    client-side, for every wire (#1720 Wave-B1).
     """
     if not isinstance(payload, dict):
         raise TypeError(

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
@@ -716,7 +716,14 @@ class EmbeddingGeneratorNode(Node):
                 text, provider, model, dimensions, timeout, max_retries
             )
         except Exception as e:
-            raise RuntimeError(f"Provider {provider} error: {str(e)}") from e
+            # #1720 Wave-B1 redteam MED — sanitize provider errors at
+            # enforcement-surface parity with the B1a live completion path
+            # (llm_agent._provider_llm_response). The four-axis embed wire
+            # re-raises a raw httpx exception whose text can echo a
+            # user-supplied base_url; scrub before it reaches the caller.
+            from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
+
+            raise RuntimeError(sanitize_provider_error(e, provider)) from e
 
     def _run_embed_coro(self, coro):
         """Run an async ``LlmClient.embed`` coroutine from this sync node method.
@@ -786,22 +793,19 @@ class EmbeddingGeneratorNode(Node):
             except Exception as e:
                 raise RuntimeError(f"Ollama embedding error: {str(e)}")
 
-        # Default dimensions for other providers
-        default_dimensions = {
-            "openai": {"text-embedding-3-large": 3072, "text-embedding-3-small": 1536},
-            "huggingface": {"all-MiniLM-L6-v2": 384, "all-mpnet-base-v2": 768},
-            "azure": {"text-embedding-3-large": 3072},
-            "cohere": {"embed-english-v3.0": 1024},
-        }
-
-        actual_dimensions = dimensions or default_dimensions.get(provider, {}).get(
-            model, 1536
-        )
-
-        # For now, other providers use mock embeddings
-        # In real implementation, this would call the actual provider APIs
-        return self._generate_mock_embedding(
-            f"{provider}:{model}:{text}", actual_dimensions
+        # A non-ollama provider reaching this fallback means its four-axis
+        # deployment could NOT be resolved (missing/unavailable credential) or
+        # the four-axis LLM layer failed to import. Legacy raised here rather
+        # than returning data — #1720 Wave-B1 redteam HIGH: a silent mock
+        # embedding fed into a similarity / RAG pipeline is fake data reported
+        # as a real provider result (zero-tolerance Rule 2 + observability
+        # Rule 3 `mode=fake`). Restore the loud raise, matching the B1a/B1c
+        # None-deployment disposition (both raise). The explicit `provider ==
+        # "mock"` mode (handled by the caller, not this fallback) is the only
+        # sanctioned mock-embedding path.
+        raise RuntimeError(
+            f"Provider {provider} is not available. Check dependencies and "
+            f"configuration."
         )
 
     def _chunk_text(self, text: str, chunk_size: int) -> list[str]:

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
@@ -656,45 +656,111 @@ class EmbeddingGeneratorNode(Node):
         timeout: int,
         max_retries: int,
     ) -> list[float]:
-        """Generate embedding using external provider."""
+        """Generate an embedding via the four-axis ``LlmClient`` (#1720 Wave-B1b).
+
+        Resolves the legacy ``provider`` name to a four-axis ``LlmDeployment``
+        through the shared ``resolve_deployment_for`` surface, then issues a
+        real embedding request via ``LlmClient.from_deployment_sync(...).embed``
+        and returns the first (and only) vector.
+
+        Provider-specific fields the legacy path set are threaded through
+        ``EmbedOptions``: ``dimensions`` (openai only), and ``input_type`` set
+        to ``"search_document"`` for cohere (Cohere v3 embed requires it). The
+        four-axis HuggingFace embed wire already targets its feature-extraction
+        API path (``/models/{model}``), so no per-request ``use_api`` toggle is
+        needed. ``timeout`` bounds the wire call (legacy semantics).
+
+        When the resolver returns ``None`` (no four-axis mapping, or a required
+        credential / base_url could not be resolved -- already logged at DEBUG
+        by the resolver, e.g. ollama with no base_url on this node), the legacy
+        ``_fallback_provider_embedding`` path is used so those providers keep
+        working. The ``except ImportError`` fallback and the ``except Exception``
+        -> ``RuntimeError`` wrapper are preserved from the legacy contract.
+        """
         try:
-            from kaizen.providers.registry import get_provider
+            from kaizen.llm import LlmClient, resolve_deployment_for
+            from kaizen.llm.deployment import EmbedOptions
 
-            # Get the provider instance
-            provider_instance = get_provider(provider, "embeddings")
-
-            # Check if provider is available
-            if not provider_instance.is_available():
-                raise RuntimeError(
-                    f"Provider {provider} is not available. Check dependencies and configuration."
+            deployment = resolve_deployment_for(provider, model)
+            if deployment is None:
+                # No four-axis mapping / unresolved credential (resolver already
+                # logged a DEBUG reason). Preserve legacy coverage for providers
+                # the four-axis path cannot resolve from the node's inputs.
+                return self._fallback_provider_embedding(
+                    text, provider, model, dimensions, timeout, max_retries
                 )
 
-            # Prepare kwargs for the provider
-            kwargs = {"model": model, "timeout": timeout}
-
-            # Add dimensions if specified and provider supports it
-            if dimensions and provider in ["openai"]:
-                kwargs["dimensions"] = dimensions
-
-            # Provider-specific parameters
+            option_kwargs: dict[str, Any] = {}
+            # dimensions is only honored by openai (mirrors the legacy path).
+            if dimensions and provider == "openai":
+                option_kwargs["dimensions"] = dimensions
+            # Cohere v3 embed REQUIRES an input_type; legacy set search_document.
             if provider == "cohere":
-                kwargs["input_type"] = "search_document"
-            elif provider == "huggingface":
-                kwargs["use_api"] = True  # Default to API for consistency
+                option_kwargs["input_type"] = "search_document"
+            options = EmbedOptions(**option_kwargs) if option_kwargs else None
 
-            # Generate embedding
-            embeddings = provider_instance.embed([text], **kwargs)
+            client = LlmClient.from_deployment_sync(deployment)
 
-            # Return the first (and only) embedding
-            return embeddings[0] if embeddings else []
+            async def _call_embed() -> list[list[float]]:
+                return await client.embed(
+                    [text], model=model, options=options, timeout=float(timeout)
+                )
+
+            vectors = self._run_embed_coro(_call_embed())
+            return vectors[0] if vectors else []
 
         except ImportError:
-            # Fallback to the original implementation if ai_providers not available
+            # Fallback to the original implementation if the four-axis LLM
+            # layer is not importable.
             return self._fallback_provider_embedding(
                 text, provider, model, dimensions, timeout, max_retries
             )
         except Exception as e:
             raise RuntimeError(f"Provider {provider} error: {str(e)}") from e
+
+    def _run_embed_coro(self, coro):
+        """Run an async ``LlmClient.embed`` coroutine from this sync node method.
+
+        ``LlmClient.embed`` is async (``rules/patterns.md`` § async/sync); the
+        node's ``run()`` is the synchronous Node interface and may be invoked
+        from a sync runtime OR from inside an already-running event loop (an
+        async runtime). A bare ``asyncio.run`` raises "event loop is already
+        running" in the latter case, so this bridge runs the coroutine on a
+        fresh loop in a dedicated thread when a loop is already running, and
+        uses ``asyncio.run`` only when there is none -- the same shape
+        ``llm_agent._run_async_in_sync_context`` uses. Errors are re-raised on
+        the calling thread (never swallowed).
+        """
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running event loop on this thread -- safe to own one here.
+            return asyncio.run(coro)
+
+        # A loop is already running; run the coroutine on a fresh loop in a
+        # separate thread so event loops are never nested.
+        import threading
+
+        box: dict[str, Any] = {}
+
+        def _run_in_thread() -> None:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                box["result"] = new_loop.run_until_complete(coro)
+            except BaseException as exc:  # re-raised below; never swallowed
+                box["error"] = exc
+            finally:
+                new_loop.close()
+
+        thread = threading.Thread(target=_run_in_thread)
+        thread.start()
+        thread.join()
+        if "error" in box:
+            raise box["error"]
+        return box["result"]
 
     def _fallback_provider_embedding(
         self,

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -2329,36 +2329,106 @@ Final Answer: 6 hours"""
         Args:
             api_key: Optional per-request API key override for BYOK scenarios.
             base_url: Optional per-request base URL override.
+
+        #1720 Wave-B1a — LIVE CUTOVER. This method now returns the four-axis
+        ``kaizen.llm.client.LlmClient`` result (mapped onto the legacy shape via
+        ``kaizen.llm._legacy_shape.to_legacy_shape``) as the PRIMARY response.
+        The provider->deployment mapping is resolved through the shared
+        ``kaizen.llm.deployment_resolver.resolve_deployment_for`` (the same
+        surface the Wave-2 dual-run shadow and the parity harness use), and the
+        BYOK ``api_key`` / ``base_url`` per-request overrides thread straight
+        into it (the resolver validates control-char/CRLF/non-ASCII keys —
+        ``rules/security.md`` § Enforcement-Surface Parity). ``azure_ai_foundry``
+        has NO confirmed four-axis wire (``resolve_deployment_for`` raises
+        ``UnsupportedDeploymentProvider``), so it falls back to the legacy
+        ``get_provider(...).chat(...)`` path for that provider ONLY; every other
+        provider goes four-axis. The now-redundant dual-run shadow dispatch was
+        removed from this success path (the four-axis path is now load-bearing,
+        so a second four-axis call would be a pure duplicate); the shadow
+        worker/dispatch/resolver definitions are retained for their direct unit
+        tests.
         """
         try:
-            from kaizen.providers.registry import get_provider
+            from kaizen.llm.deployment_resolver import (
+                UnsupportedDeploymentProvider,
+                resolve_deployment_for,
+            )
 
-            # Get the provider instance
-            provider_instance = get_provider(provider)
-
-            # Check if provider is available (skip if per-request key provided)
-            if not api_key and not provider_instance.is_available():
-                raise RuntimeError(
-                    f"Provider {provider} is not available. Check dependencies and configuration."
+            # SCOPE-OUT (#1720 Wave-B1a): azure_ai_foundry has no confirmed
+            # four-axis wire; resolve_deployment_for raises
+            # UnsupportedDeploymentProvider for it. Keep that provider ONLY on
+            # the legacy get_provider(...).chat(...) path until a wire lands.
+            # BYOK overrides are validated inside resolve_deployment_for (the
+            # sibling enforcement surface to LlmClient.complete's api_key guard).
+            try:
+                deployment = resolve_deployment_for(
+                    provider, model, api_key=api_key, base_url=base_url
+                )
+            except UnsupportedDeploymentProvider:
+                return self._legacy_provider_chat(
+                    provider,
+                    model,
+                    messages,
+                    tools,
+                    generation_config,
+                    api_key=api_key,
+                    base_url=base_url,
                 )
 
-            # Build chat kwargs with optional per-request overrides
-            chat_kwargs = {
-                "messages": messages,
-                "model": model,
-                "generation_config": generation_config,
-                "tools": tools,
-            }
-            if api_key:
-                chat_kwargs["api_key"] = api_key
-            if base_url:
-                chat_kwargs["base_url"] = base_url
+            # is_available() gate parity (invariant #1): a None deployment means
+            # the credential / base_url could not be resolved — the four-axis
+            # equivalent of legacy ``is_available() is False``. Match legacy:
+            # raise the same RuntimeError rather than silently succeeding.
+            # resolve_deployment_for already tried the per-request api_key
+            # override AND the provider's own env var before returning None, so
+            # this branch is exactly "no credential AND no per-request key".
+            if deployment is None:
+                raise RuntimeError(
+                    f"Provider {provider} is not available. "
+                    "Check dependencies and configuration."
+                )
 
-            # Call the provider
-            response = provider_instance.chat(**chat_kwargs)
+            from kaizen.llm._legacy_shape import to_legacy_shape
+            from kaizen.llm.client import LlmClient
 
-            # Ensure usage totals are calculated. Custom providers may emit
-            # None counters (see issue #487); coerce to 0 before arithmetic.
+            client = LlmClient.from_deployment_sync(deployment)
+            sampling_kwargs = _sampling_kwargs_from_generation_config(generation_config)
+            four_axis_tools = tools if tools else None
+
+            # Stream-aware per-provider tool_choice default (invariant #3).
+            # Legacy ``.chat()`` injects tool_choice="required" for openai (and
+            # "auto" for azure/docker) when tools are present and unset; the
+            # four-axis complete() defaults to None. Reproduce the legacy default
+            # through the shared helper and emit it only when not None. stream is
+            # left at the helper's False default — this method has ALWAYS driven
+            # the legacy non-streaming ``.chat()`` path (never ``stream_chat``),
+            # so keeping the non-stream default (openai -> "required") preserves
+            # the current streaming behavior exactly.
+            explicit_tool_choice = sampling_kwargs.pop("tool_choice", None)
+            effective_tool_choice = _legacy_tool_choice_default(
+                provider, four_axis_tools, explicit_tool_choice
+            )
+            if effective_tool_choice is not None:
+                sampling_kwargs["tool_choice"] = effective_tool_choice
+
+            async def _call_complete():
+                return await client.complete(
+                    messages,
+                    model=model,
+                    tools=four_axis_tools,
+                    **sampling_kwargs,
+                )
+
+            # complete() is async; this Node.run path is sync and MAY be invoked
+            # from inside an already-running event loop (rules/patterns.md
+            # async/sync). The shared helper runs the coroutine on a fresh thread
+            # when a loop is active, else via asyncio.run().
+            four_axis_response = self._run_async_in_sync_context(_call_complete())
+            response = to_legacy_shape(four_axis_response)
+
+            # #487 usage total-coercion (invariant #2): when total_tokens is
+            # falsy, derive it from the coerced parts. to_legacy_shape always
+            # emits a usage dict with the three keys, so this coercion applies.
             if response.get("usage"):
                 usage = response["usage"]
                 if not usage.get("total_tokens"):
@@ -2366,34 +2436,10 @@ Final Answer: 6 hours"""
                     completion = usage.get("completion_tokens") or 0
                     usage["total_tokens"] = prompt + completion
 
-            # #1720 Wave-2 — dispatch the four-axis LlmClient shadow
-            # fire-and-forget alongside the legacy response above, for
-            # validation. Gated behind KAIZEN_LLM_DUAL_RUN (falsey/unset by
-            # default); the flag-OFF path above this line is completely
-            # untouched and this call is a pure no-op when the flag is off
-            # (`_dual_run_enabled()` short-circuits before any four-axis
-            # code runs). The dispatch starts a DAEMON thread and returns
-            # IMMEDIATELY without `.join()`/`.result()` — the shadow NEVER
-            # adds latency to the `response` returned below (redteam HIGH:
-            # a synchronous shadow call here previously added up to
-            # `_DUAL_RUN_TIMEOUT_SECONDS` of latency to the LIVE response,
-            # x5 inside the tool-execution loop in `run()`).
-            if _dual_run_enabled():
-                self._dispatch_dual_run_shadow(
-                    provider=provider,
-                    model=model,
-                    messages=messages,
-                    tools=tools,
-                    generation_config=generation_config,
-                    api_key=api_key,
-                    base_url=base_url,
-                    legacy_response=response,
-                )
-
             return response
 
         except ImportError:
-            # Fallback to the original fallback method
+            # Four-axis (or legacy) provider stack unavailable — mock fallback.
             return self._fallback_llm_response(
                 provider, model, messages, tools, generation_config
             )
@@ -2403,6 +2449,63 @@ Final Answer: 6 hours"""
 
             self.logger.error("Provider %s error: %s", provider, e, exc_info=True)
             raise RuntimeError(sanitize_provider_error(e, provider)) from e
+
+    def _legacy_provider_chat(
+        self,
+        provider: str,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        generation_config: dict,
+        api_key: str = None,
+        base_url: str = None,
+    ) -> dict[str, Any]:
+        """Legacy provider-registry chat path (#1720 Wave-B1a).
+
+        Retained ONLY for providers with no confirmed four-axis wire — currently
+        ``azure_ai_foundry`` (which ``resolve_deployment_for`` rejects with
+        ``UnsupportedDeploymentProvider``). Every other provider is served by the
+        four-axis ``LlmClient`` in ``_provider_llm_response``. Preserves the
+        legacy ``is_available()`` gate (invariant #1) and the #487 usage
+        total-coercion (invariant #2) byte-for-byte. Exceptions propagate to the
+        caller's ``except ImportError`` / ``except Exception`` handlers (invariants
+        #5 and #6).
+        """
+        from kaizen.providers.registry import get_provider
+
+        provider_instance = get_provider(provider)
+
+        # Check if provider is available (skip if per-request key provided)
+        if not api_key and not provider_instance.is_available():
+            raise RuntimeError(
+                f"Provider {provider} is not available. Check dependencies and configuration."
+            )
+
+        # Build chat kwargs with optional per-request overrides
+        chat_kwargs = {
+            "messages": messages,
+            "model": model,
+            "generation_config": generation_config,
+            "tools": tools,
+        }
+        if api_key:
+            chat_kwargs["api_key"] = api_key
+        if base_url:
+            chat_kwargs["base_url"] = base_url
+
+        # Call the provider
+        response = provider_instance.chat(**chat_kwargs)
+
+        # Ensure usage totals are calculated. Custom providers may emit
+        # None counters (see issue #487); coerce to 0 before arithmetic.
+        if response.get("usage"):
+            usage = response["usage"]
+            if not usage.get("total_tokens"):
+                prompt = usage.get("prompt_tokens") or 0
+                completion = usage.get("completion_tokens") or 0
+                usage["total_tokens"] = prompt + completion
+
+        return response
 
     def _dispatch_dual_run_shadow(
         self,

--- a/packages/kailash-kaizen/tests/parity/test_parity_plane_b_response_parse.py
+++ b/packages/kailash-kaizen/tests/parity/test_parity_plane_b_response_parse.py
@@ -102,16 +102,17 @@ def test_plain_completion_parse_parity(fixture, wire, legacy_driver):
     ), f"{fixture}: four-axis parse diverges from legacy parse on shared bytes"
 
 
-def test_google_parse_parity_documents_finish_reason_casing_delta():
-    """Google plain-completion: content + tool_calls + usage parse identically,
-    but finish_reason CASING diverges (WAVE-B FINDING #2).
+def test_google_parse_parity_finish_reason_value_map():
+    """Google plain-completion parses IDENTICALLY on both stacks, finish_reason
+    INCLUDED (#1720 Wave-B1a — the DECISION-1A value-map cutover).
 
-    Legacy ``GoogleGeminiProvider.chat`` lowercases the Gemini ``finishReason``
-    ('STOP' -> 'stop'); the four-axis ``google_generate_content`` wire preserves
-    the raw provider value ('STOP'). A consumer testing ``finish_reason == "stop"``
-    would break for Gemini on four-axis. This pins the CURRENT divergence so the
-    Wave-B cutover consciously decides: normalize four-axis to lowercase
-    (behavior-neutral) OR accept the raw-value change. NOT a harness bug.
+    Previously the four-axis ``google_generate_content`` wire emitted the RAW
+    Gemini ``finishReason`` ('STOP') while legacy ``GoogleGeminiProvider.chat``
+    value-mapped it to the lowercase legacy form ('stop') — a documented Wave-B
+    finish_reason divergence. Wave-B1a ports the FULL legacy value-map
+    (STOP -> 'stop', MAX_TOKENS/length -> 'length', SAFETY -> 'content_filter',
+    tool/function -> 'tool_calls') into the wire's parse step, so both stacks now
+    yield the SAME value. This asserts that parity (was: documented the delta).
     """
     canned = load_fixture("google_response")
     four_axis = four_axis_normalized(google_generate_content, canned)
@@ -119,13 +120,11 @@ def test_google_parse_parity_documents_finish_reason_casing_delta():
         drive_legacy_google(canned, model="parity-gemini", messages=_MSGS)[0]
     )
 
-    # Everything EXCEPT finish_reason matches on the shared bytes.
-    assert four_axis["content"] == legacy["content"]
-    assert four_axis["tool_calls"] == legacy["tool_calls"]
-    assert four_axis["usage"] == legacy["usage"]
-    # The pinned casing divergence — fails loudly if either side changes.
-    assert legacy["finish_reason"] == "stop"  # legacy lowercases
-    assert four_axis["finish_reason"] == "STOP"  # four-axis preserves raw
+    # Full parse-contract parity on the shared bytes — finish_reason included.
+    assert four_axis == legacy
+    # Explicit: both value-map the raw 'STOP' onto the legacy lowercase 'stop'.
+    assert legacy["finish_reason"] == "stop"
+    assert four_axis["finish_reason"] == "stop"
 
 
 # Tool-bearing cells where the LEGACY provider genuinely parses tool_calls

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1_redteam_fixes.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1_redteam_fixes.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B1 inter-wave redteam fixes — behavioral regressions.
+
+Pins the fixes the holistic Wave-B1 redteam surfaced against the merged
+cutover, so a future refactor cannot silently reintroduce them:
+
+* **HIGH (F1)** — ``EmbeddingGeneratorNode._generate_provider_embedding`` on an
+  UNRESOLVABLE credential provider (e.g. openai with no key -> resolver returns
+  ``None``) MUST RAISE (legacy parity + matching the B1a/B1c None-deployment
+  disposition), NOT silently return a mock embedding reported as a real provider
+  result (zero-tolerance Rule 2 / observability Rule 3). The sanctioned mock path
+  is ONLY the explicit ``provider == "mock"`` mode, which this fallback never
+  serves. The ollama fallback (real ``ollama.embeddings`` call) is UNCHANGED —
+  proven here to confirm the fix is scoped to credential providers.
+* **MED** — both the embed error wrapper (``_generate_provider_embedding``) and
+  the ``BaseAgent._simple_execute_async`` completion path route provider errors
+  through ``sanitize_provider_error`` at enforcement-surface parity with the B1a
+  live path (``llm_agent._provider_llm_response``) — a raw wire exception can
+  echo a user-supplied ``base_url``.
+* **LOW** — the google ``_map_finish_reason`` maps an absent/``None`` reason to
+  ``"stop"`` (legacy ``GoogleGeminiProvider`` initialises ``"stop"`` and never
+  emits ``None``), completing finish_reason parity.
+
+Tier-1 offline + deterministic (no network, no live keys). Behavioral asserts
+per ``rules/testing.md`` § "Behavioral Regression Tests Over Source-Grep".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import kaizen.llm as kllm
+import kaizen.llm.client as llm_client_mod
+import kaizen.llm.deployment_resolver as resolver_mod
+import kaizen.nodes.ai.error_sanitizer as sanitizer_mod
+from kaizen.core.base_agent import BaseAgent
+from kaizen.llm.wire_protocols.google_generate_content import _map_finish_reason
+from kaizen.nodes.ai.embedding_generator import EmbeddingGeneratorNode
+
+_OPENAI_MODEL = "fixture-openai-embed"
+
+
+# ---------------------------------------------------------------------------
+# HIGH (F1) — credential provider with an unresolvable deployment RAISES,
+# does NOT silently return a mock embedding.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_embed_missing_credential_raises_not_silent_mock(monkeypatch):
+    """openai with resolver -> None RAISES RuntimeError (legacy parity), never
+    returns a fabricated mock vector fed into a similarity/RAG pipeline."""
+    monkeypatch.setattr(kllm, "resolve_deployment_for", lambda *a, **k: None)
+
+    node = EmbeddingGeneratorNode()
+    with pytest.raises(RuntimeError):
+        node._generate_provider_embedding("hello", "openai", _OPENAI_MODEL, None, 60, 3)
+
+
+@pytest.mark.regression
+def test_embed_ollama_fallback_preserved_when_unresolved(monkeypatch):
+    """The fix is SCOPED: ollama still falls back to the real ``ollama.embeddings``
+    call on an unresolved deployment (base_url legitimately unresolvable from node
+    inputs) — only credential providers raise."""
+    monkeypatch.setattr(kllm, "resolve_deployment_for", lambda *a, **k: None)
+
+    class _FakeOllama:
+        @staticmethod
+        def embeddings(model: str, prompt: str) -> Dict[str, Any]:
+            return {"embedding": [0.11, 0.22, 0.33]}
+
+    monkeypatch.setitem(sys.modules, "ollama", _FakeOllama())
+
+    node = EmbeddingGeneratorNode()
+    vector = node._generate_provider_embedding(
+        "hello", "ollama", "fixture-ollama", None, 60, 3
+    )
+    assert vector == [0.11, 0.22, 0.33]
+
+
+# ---------------------------------------------------------------------------
+# MED — provider errors are sanitized at parity on the embed + base_agent paths.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingEmbedClient:
+    @classmethod
+    def from_deployment_sync(
+        cls, deployment: Any, **kwargs: Any
+    ) -> "_RaisingEmbedClient":
+        return cls()
+
+    async def embed(self, texts, **kwargs):  # noqa: D401
+        raise RuntimeError("wire failed at http://user:pass@host:443/v1")
+
+
+@pytest.mark.regression
+def test_embed_error_routes_through_sanitizer(monkeypatch):
+    """The embed except wrapper routes provider errors through
+    ``sanitize_provider_error`` (not raw ``str(e)``)."""
+    sentinel = "SANITIZED-EMBED-MESSAGE"
+    monkeypatch.setattr(kllm, "resolve_deployment_for", lambda *a, **k: object())
+    monkeypatch.setattr(kllm, "LlmClient", _RaisingEmbedClient)
+    monkeypatch.setattr(
+        sanitizer_mod, "sanitize_provider_error", lambda e, provider: sentinel
+    )
+
+    node = EmbeddingGeneratorNode()
+    with pytest.raises(RuntimeError, match=sentinel):
+        node._generate_provider_embedding("hi", "openai", _OPENAI_MODEL, None, 60, 3)
+
+
+@dataclass
+class _AgentConfig:
+    llm_provider: str = "openai"
+    model: Optional[str] = "cfg-model"
+    temperature: float = 0.3
+    max_tokens: int = 128
+
+
+class _RaisingCompleteClient:
+    @classmethod
+    def from_deployment(
+        cls, deployment: Any, **kwargs: Any
+    ) -> "_RaisingCompleteClient":
+        return cls()
+
+    async def complete(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        raise RuntimeError("wire failed at http://user:pass@host:443/v1")
+
+
+@pytest.mark.regression
+def test_base_agent_error_routes_through_sanitizer(monkeypatch):
+    """``BaseAgent._simple_execute_async`` sanitizes provider errors at parity
+    with the B1a live path — a raw wire exception echoing config.base_url must be
+    scrubbed before reaching ``_handle_error``'s log/return surface."""
+    sentinel = "SANITIZED-COMPLETE-MESSAGE"
+    monkeypatch.setattr(
+        resolver_mod, "resolve_deployment_for", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(llm_client_mod, "LlmClient", _RaisingCompleteClient)
+    monkeypatch.setattr(
+        sanitizer_mod, "sanitize_provider_error", lambda e, provider: sentinel
+    )
+
+    agent = BaseAgent(config=_AgentConfig(), signature=None, mcp_servers=[])
+    agent.signature = None
+    with pytest.raises(RuntimeError, match=sentinel):
+        asyncio.run(agent._simple_execute_async({"q": "hi"}))
+
+
+# ---------------------------------------------------------------------------
+# LOW — google finish_reason None -> "stop" (legacy floor) + full value-map.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "stop"),
+        ("STOP", "stop"),
+        ("MAX_TOKENS", "length"),
+        ("SAFETY", "content_filter"),
+        ("tool", "tool_calls"),
+        ("function_call", "tool_calls"),
+        ("RECITATION", "stop"),
+    ],
+)
+def test_google_map_finish_reason_full_parity(raw, expected):
+    """The google finish_reason value-map matches legacy exactly, including the
+    ``None`` -> ``"stop"`` legacy floor (legacy never emits ``None``)."""
+    assert _map_finish_reason(raw) == expected

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B1a — LLMAgentNode live-cutover regression (behavioral).
+
+Wave-B1a promoted ``LLMAgentNode._provider_llm_response`` from the legacy
+``get_provider(...).chat(...)`` path to the four-axis ``kaizen.llm.client.
+LlmClient`` path (mapped onto the legacy response shape via
+``kaizen.llm._legacy_shape.to_legacy_shape``). These tests DRIVE the method
+(never grep source), Tier-1 offline + deterministic, using the SAME shared
+canned-bytes injection the parity harness uses (``tests/parity/_harness.py``):
+
+* (a) an openai-family provider returns the FOUR-AXIS-mapped shape parsed from
+  shared canned bytes through the real ``openai_chat`` wire → ``to_legacy_shape``;
+* (b) ``azure_ai_foundry`` (no confirmed four-axis wire) STILL routes to the
+  legacy ``get_provider(...).chat(...)`` path;
+* (c) the #487 usage total-coercion still fires on the four-axis path (a falsy
+  ``total_tokens`` is recomputed from the parts);
+* (d) the stream-aware per-provider ``tool_choice`` default still yields
+  ``"required"`` for openai + tools present + no explicit choice.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from kaizen.llm import LlmClient, resolve_deployment_for
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+from tests.parity._harness import CapturingTransport, load_fixture
+
+pytestmark = pytest.mark.regression
+
+_MSGS = [{"role": "user", "content": "What is the capital of France?"}]
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def _fake_four_axis_client(complete_impl) -> MagicMock:
+    """A fake ``LlmClient`` whose ``complete`` is the supplied async callable."""
+    client = MagicMock()
+    client.complete = complete_impl
+    return client
+
+
+# ---------------------------------------------------------------------------
+# (a) openai-family provider -> four-axis-mapped shape from shared canned bytes.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_llm_response_returns_four_axis_mapped_shape_for_openai(monkeypatch):
+    """`_provider_llm_response(provider="openai")` returns the four-axis result
+    mapped onto the legacy shape, parsed from shared canned openai bytes through
+    the REAL openai_chat wire routed via CapturingTransport (offline)."""
+    canned = load_fixture("openai_response")
+
+    # Build a REAL four-axis client for the openai deployment, then route its
+    # send path through the offline CapturingTransport (the harness's injection
+    # style). A placeholder api_key satisfies the resolver (no secret; never
+    # sent — the transport is stubbed). rules/security.md § No Hardcoded Secrets.
+    deployment = resolve_deployment_for(
+        "openai", "gpt-4o-mini", api_key="sk-b1a-parity-placeholder"
+    )
+    assert deployment is not None
+    real_client = LlmClient.from_deployment(deployment)
+    transport = CapturingTransport(canned)
+    orig_complete = real_client.complete
+
+    async def _complete_via_transport(messages: List[Dict[str, Any]], **kw: Any):
+        kw.pop("http_client", None)
+        return await orig_complete(messages, http_client=transport, **kw)
+
+    monkeypatch.setattr(real_client, "complete", _complete_via_transport)
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: real_client),
+    )
+
+    agent = LLMAgentNode()
+    response = agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=_MSGS,
+        tools=[],
+        generation_config={},
+    )
+
+    # The canned openai bytes parsed through the four-axis wire + to_legacy_shape.
+    assert response["content"] == "The capital of France is Paris."
+    assert response["finish_reason"] == "stop"
+    assert response["usage"] == {
+        "prompt_tokens": 12,
+        "completion_tokens": 7,
+        "total_tokens": 19,
+    }
+    # The offline transport actually served the request (no network occurred).
+    assert len(transport.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) azure_ai_foundry STILL routes to the legacy get_provider chat path.
+# ---------------------------------------------------------------------------
+
+
+def test_azure_ai_foundry_routes_legacy_provider_chat(monkeypatch):
+    """`azure_ai_foundry` has no confirmed four-axis wire (resolve raises
+    UnsupportedDeploymentProvider), so `_provider_llm_response` falls back to
+    the legacy `get_provider(...).chat(...)` path for that provider ONLY."""
+    legacy_calls: dict = {}
+
+    class _FoundryStub:
+        def is_available(self) -> bool:
+            return True
+
+        def chat(self, **kwargs: Any) -> dict:
+            legacy_calls["chat"] = kwargs
+            return {
+                "content": "legacy foundry answer",
+                "role": "assistant",
+                "model": kwargs["model"],
+                "tool_calls": [],
+                "finish_reason": "stop",
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                },
+            }
+
+    monkeypatch.setattr(
+        "kaizen.providers.registry.get_provider",
+        lambda name, **kw: _FoundryStub(),
+    )
+    # If the four-axis path were (wrongly) taken, this would blow up loudly.
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(
+            lambda cls, *a, **kw: (_ for _ in ()).throw(
+                AssertionError("four-axis path taken for azure_ai_foundry")
+            )
+        ),
+    )
+
+    agent = LLMAgentNode()
+    response = agent._provider_llm_response(
+        provider="azure_ai_foundry",
+        model="phi-4",
+        messages=_MSGS,
+        tools=[],
+        generation_config={},
+    )
+
+    assert legacy_calls, "legacy get_provider(...).chat(...) was never called"
+    assert response["content"] == "legacy foundry answer"
+
+
+# ---------------------------------------------------------------------------
+# (c) #487 usage total-coercion still fires on the four-axis path.
+# ---------------------------------------------------------------------------
+
+
+def test_usage_total_coercion_fires_on_four_axis_path(monkeypatch):
+    """A four-axis response with a FALSY `total_tokens` gets it recomputed from
+    the parts by the #487 coercion, AFTER `to_legacy_shape` (invariant #2)."""
+
+    async def _complete(*_a: Any, **_kw: Any) -> dict:
+        return {
+            "text": "coerced",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            # total_tokens is 0 (falsy, not None) -> to_legacy_shape keeps 0 ->
+            # _provider_llm_response's #487 coercion sets it to 8 + 4 = 12.
+            "usage": {"input_tokens": 8, "output_tokens": 4, "total_tokens": 0},
+        }
+
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: _fake_four_axis_client(_complete)),
+    )
+
+    agent = LLMAgentNode()
+    response = agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=_MSGS,
+        tools=[],
+        generation_config={},
+    )
+
+    assert response["usage"]["prompt_tokens"] == 8
+    assert response["usage"]["completion_tokens"] == 4
+    assert response["usage"]["total_tokens"] == 12  # recomputed, not the 0
+
+
+# ---------------------------------------------------------------------------
+# (d) stream-aware tool_choice default -> "required" for openai + tools + unset.
+# ---------------------------------------------------------------------------
+
+
+def test_tool_choice_default_required_for_openai_tools_present_unset(monkeypatch):
+    """Legacy `.chat()` injects tool_choice="required" for openai when tools are
+    present and no explicit choice is given; the cutover reproduces it via the
+    shared `_legacy_tool_choice_default` helper (invariant #3)."""
+    captured: dict = {}
+
+    async def _complete(messages: List[Dict[str, Any]], **kw: Any) -> dict:
+        captured.update(kw)
+        return {
+            "text": "ok",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: _fake_four_axis_client(_complete)),
+    )
+
+    agent = LLMAgentNode()
+    agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=_MSGS,
+        tools=_TOOLS,
+        generation_config={},  # no explicit tool_choice
+    )
+
+    assert captured.get("tool_choice") == "required"
+
+
+def test_tool_choice_default_none_when_no_tools(monkeypatch):
+    """No tools present -> no tool_choice is injected (legacy skips the block)."""
+    captured: dict = {"sentinel": True}
+
+    async def _complete(messages: List[Dict[str, Any]], **kw: Any) -> dict:
+        captured["kw"] = kw
+        return {
+            "text": "ok",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: _fake_four_axis_client(_complete)),
+    )
+
+    agent = LLMAgentNode()
+    agent._provider_llm_response(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=_MSGS,
+        tools=[],
+        generation_config={},
+    )
+
+    assert "tool_choice" not in captured["kw"]

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1b_embed_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1b_embed_cutover.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B1b — embedding path cutover onto the four-axis ``LlmClient``.
+
+Pins the behavioral contract of the embed cutover shard:
+
+* ``EmbeddingGeneratorNode._generate_provider_embedding`` returns a vector via
+  the four-axis embed path (``resolve_deployment_for`` -> ``from_deployment_sync``
+  -> ``embed`` -> first vector) for openai.
+* ``LlmClient.embed(..., options=EmbedOptions(normalize=True))`` returns UNIT
+  vectors (L2 norm ~= 1.0) UNIFORMLY for openai AND ollama AND cohere -- the
+  folded F2-MEDIUM applies one client-side normalize for EVERY wire (not the
+  former HuggingFace-only copy).
+* ``normalize`` unset / ``None`` leaves the returned vectors BYTE-IDENTICAL to
+  the raw wire output for every wire (additive-neutrality).
+* A zero vector is returned UNCHANGED under ``normalize=True`` (norm==0 guard).
+* The new ``timeout`` kwarg on ``LlmClient.embed`` is accepted and THREADED into
+  the underlying ``LlmHttpClient`` request (proven by an injected transport that
+  records the ``timeout`` it receives); omitting it injects no ``timeout`` kwarg.
+
+Tier-1 offline + deterministic: every wire call is served by a Protocol-
+satisfying canned-bytes transport (``rules/testing.md`` § "Protocol Adapters" --
+NOT a mock), the same shared-canned-bytes injection style the #1720 parity
+harness uses. No network, no live credentials, no env mutation.
+Behavioral asserts (call ``embed`` / the node method, assert the returned
+vectors) per ``rules/testing.md`` § "Behavioral Regression Tests Over
+Source-Grep".
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import httpx
+import pytest
+
+from kaizen.llm import LlmClient, resolve_deployment_for
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.nodes.ai.embedding_generator import EmbeddingGeneratorNode
+
+# Synthetic offline fixtures — deterministic literals are required to assert
+# exact returned vectors; env-sourced models/keys would make the pin
+# non-deterministic (and no live call is made — the transport is canned).
+_OPENAI_MODEL = "fixture-openai-embed"
+_OLLAMA_MODEL = "fixture-ollama-embed"
+_COHERE_MODEL = "fixture-cohere-embed"
+
+
+def _openai_body(vec: list[float]) -> dict:
+    return {
+        "data": [{"index": 0, "embedding": vec}],
+        "model": "fixture-model",
+        "usage": {"prompt_tokens": 1, "total_tokens": 1},
+    }
+
+
+def _ollama_body(vec: list[float]) -> dict:
+    return {"embeddings": [vec], "model": "fixture-model"}
+
+
+def _cohere_body(vec: list[float]) -> dict:
+    return {"embeddings": [vec], "model": "fixture-model"}
+
+
+class _CannedEmbedTransport:
+    """Protocol-satisfying offline transport: replays a FIXED embeddings body
+    and RECORDS the ``timeout`` kwarg each ``post`` receives.
+
+    Satisfies the ``LlmHttpClient`` surface ``LlmClient.embed`` calls (``post``
+    + ``aclose``); never opens a socket. An injected transport is owned by the
+    caller, so ``embed`` never closes it -- ``aclose`` is provided for contract
+    completeness only.
+    """
+
+    def __init__(self, body: Any) -> None:
+        self._body = body
+        self.timeouts: list[Any] = []
+        self.calls: list[dict[str, Any]] = []
+        self._closed = False
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.timeouts.append(kwargs.get("timeout"))
+        self.calls.append(
+            {
+                "url": url,
+                "json": kwargs.get("json"),
+                "timeout": kwargs.get("timeout"),
+            }
+        )
+        return httpx.Response(200, json=self._body, request=httpx.Request("POST", url))
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+
+# Per-wire (provider, model, api_key, base_url, body-builder) matrix. api_key /
+# base_url are passed EXPLICITLY to resolve_deployment_for so no env var is read
+# (no env-mutation, no lock needed per rules/testing.md § env serialization).
+_WIRES = [
+    ("openai", _OPENAI_MODEL, "sk-fixture", None, _openai_body),
+    ("ollama", _OLLAMA_MODEL, None, "http://localhost:11434", _ollama_body),
+    ("cohere", _COHERE_MODEL, "co-fixture", None, _cohere_body),
+]
+
+
+def _client_for(provider: str, api_key, base_url, model: str) -> LlmClient:
+    deployment = resolve_deployment_for(
+        provider, model, api_key=api_key, base_url=base_url
+    )
+    assert deployment is not None, (
+        f"resolve_deployment_for({provider!r}) returned None; the wire must "
+        "resolve for the embed cutover matrix"
+    )
+    return LlmClient.from_deployment(deployment)
+
+
+# ---------------------------------------------------------------------------
+# (b) UNIFORM client-side normalize — openai AND ollama AND cohere
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider,model,api_key,base_url,body_fn", _WIRES)
+async def test_embed_normalize_true_unit_vectors_every_wire(
+    provider, model, api_key, base_url, body_fn
+):
+    """``EmbedOptions(normalize=True)`` L2-unit-normalizes the returned vector
+    for EVERY wire (uniform client-side, not HF-only). [3, 4] -> [0.6, 0.8]."""
+    client = _client_for(provider, api_key, base_url, model)
+    transport = _CannedEmbedTransport(body_fn([3.0, 4.0]))
+
+    vectors = await client.embed(
+        ["x"], model=model, options=EmbedOptions(normalize=True), http_client=transport
+    )
+
+    v = vectors[0]
+    assert math.isclose(math.hypot(v[0], v[1]), 1.0, rel_tol=1e-9)
+    assert math.isclose(v[0], 0.6, rel_tol=1e-9)
+    assert math.isclose(v[1], 0.8, rel_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# (c) normalize unset / None -> byte-identical raw wire output, every wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider,model,api_key,base_url,body_fn", _WIRES)
+async def test_embed_normalize_none_byte_identical_raw(
+    provider, model, api_key, base_url, body_fn
+):
+    """No options AND ``EmbedOptions(normalize=None)`` both leave the raw wire
+    vector untouched (additive-neutrality)."""
+    client = _client_for(provider, api_key, base_url, model)
+
+    no_opts = await client.embed(
+        ["x"], model=model, http_client=_CannedEmbedTransport(body_fn([3.0, 4.0]))
+    )
+    assert no_opts == [[3.0, 4.0]]
+
+    explicit_none = await client.embed(
+        ["x"],
+        model=model,
+        options=EmbedOptions(normalize=None),
+        http_client=_CannedEmbedTransport(body_fn([3.0, 4.0])),
+    )
+    assert explicit_none == [[3.0, 4.0]]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_embed_normalize_true_zero_vector_unchanged():
+    """A zero vector (L2 norm == 0) is returned UNCHANGED under normalize=True
+    (the norm==0 guard divides nothing)."""
+    client = _client_for("openai", "sk-fixture", None, _OPENAI_MODEL)
+    transport = _CannedEmbedTransport(_openai_body([0.0, 0.0, 0.0]))
+
+    vectors = await client.embed(
+        ["x"],
+        model=_OPENAI_MODEL,
+        options=EmbedOptions(normalize=True),
+        http_client=transport,
+    )
+    assert vectors[0] == [0.0, 0.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# (d) timeout kwarg accepted + threaded into the http client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_embed_timeout_threaded_to_http_client():
+    """A caller-supplied ``timeout`` reaches the injected http client's
+    request; omitting it injects NO ``timeout`` kwarg (byte-neutral)."""
+    client = _client_for("openai", "sk-fixture", None, _OPENAI_MODEL)
+
+    with_timeout = _CannedEmbedTransport(_openai_body([1.0, 2.0]))
+    await client.embed(
+        ["x"], model=_OPENAI_MODEL, timeout=12.5, http_client=with_timeout
+    )
+    assert with_timeout.timeouts == [12.5]
+
+    without_timeout = _CannedEmbedTransport(_openai_body([1.0, 2.0]))
+    await client.embed(["x"], model=_OPENAI_MODEL, http_client=without_timeout)
+    assert without_timeout.timeouts == [None]
+
+
+# ---------------------------------------------------------------------------
+# (a) EmbeddingGeneratorNode cutover — four-axis embed path for openai
+# ---------------------------------------------------------------------------
+
+
+class _CannedEmbedClient(LlmClient):
+    """``LlmClient`` subclass that injects the canned transport into ``embed``
+    so the node's four-axis embed path runs fully offline. The node calls
+    ``LlmClient.from_deployment_sync(...).embed(...)`` with NO http_client;
+    this subclass supplies it, exercising the REAL embed parse end-to-end."""
+
+    _canned_body: Any = None
+
+    async def embed(self, texts, **kwargs):  # type: ignore[override]
+        kwargs.setdefault("http_client", _CannedEmbedTransport(self._canned_body))
+        return await super().embed(texts, **kwargs)
+
+
+@pytest.mark.regression
+def test_node_generate_provider_embedding_uses_four_axis_path(monkeypatch):
+    """``EmbeddingGeneratorNode._generate_provider_embedding`` returns a vector
+    through the four-axis embed path (resolver -> from_deployment_sync ->
+    embed -> first vector) for openai. Both ``resolve_deployment_for`` and
+    ``LlmClient`` are patched on the ``kaizen.llm`` module the node imports from
+    (the node does a function-local ``from kaizen.llm import ...``), keeping the
+    test offline WITHOUT mutating any env var."""
+    import kaizen.llm as kllm
+
+    real_deployment = resolve_deployment_for(
+        "openai", _OPENAI_MODEL, api_key="sk-fixture"
+    )
+    assert real_deployment is not None
+
+    _CannedEmbedClient._canned_body = _openai_body([3.0, 4.0, 0.0])
+    monkeypatch.setattr(kllm, "resolve_deployment_for", lambda *a, **k: real_deployment)
+    monkeypatch.setattr(kllm, "LlmClient", _CannedEmbedClient)
+
+    node = EmbeddingGeneratorNode()
+    vector = node._generate_provider_embedding(
+        "hello", "openai", _OPENAI_MODEL, None, 60, 3
+    )
+
+    assert vector == [3.0, 4.0, 0.0]
+
+
+@pytest.mark.regression
+def test_node_generate_provider_embedding_cohere_sets_input_type(monkeypatch):
+    """The node threads the cohere ``input_type="search_document"`` field into
+    ``EmbedOptions`` (Cohere v3 embed requires it) — asserted via the request
+    body the injected transport records."""
+    import kaizen.llm as kllm
+
+    real_deployment = resolve_deployment_for(
+        "cohere", _COHERE_MODEL, api_key="co-fixture"
+    )
+    assert real_deployment is not None
+
+    captured = _CannedEmbedTransport(_cohere_body([0.1, 0.2]))
+
+    class _Client(LlmClient):
+        async def embed(self, texts, **kwargs):  # type: ignore[override]
+            kwargs.setdefault("http_client", captured)
+            return await super().embed(texts, **kwargs)
+
+    monkeypatch.setattr(kllm, "resolve_deployment_for", lambda *a, **k: real_deployment)
+    monkeypatch.setattr(kllm, "LlmClient", _Client)
+
+    node = EmbeddingGeneratorNode()
+    node._generate_provider_embedding("hi", "cohere", _COHERE_MODEL, None, 60, 3)
+
+    assert captured.calls, "the cohere embed request never reached the transport"
+    assert captured.calls[0]["json"].get("input_type") == "search_document"

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1c_base_agent_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1c_base_agent_cutover.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B1c — BaseAgent._simple_execute_async four-axis cutover.
+
+``BaseAgent._simple_execute_async`` used to construct the legacy
+``OpenAIProvider(use_async=True)`` directly and call ``provider.chat_async``.
+Wave-B1c cuts it over to the four-axis path:
+``resolve_deployment_for("openai", ...)`` -> ``LlmClient.from_deployment(...)``
+-> ``await client.complete(messages, model=..., **sampling_kwargs)`` and reads
+the assistant text via ``to_legacy_shape(result)["content"]``.
+
+These regression tests PIN the invariants the cutover MUST preserve, offline +
+deterministic (no network, no live keys) by injecting a fake ``LlmClient`` and
+a sentinel deployment:
+
+* (a) return shape — ``{"response": text}`` with no signature output fields,
+  ``{output_fields[0]: text}`` with a signature — sourced from the four-axis
+  ``complete()`` result's ``text`` via ``to_legacy_shape`` (real, un-patched);
+* (b) multimodal input still produces a structured content list in the user
+  ``messages`` entry fed to ``complete`` (the ``_classify_input_value`` loop is
+  unchanged);
+* (c) model resolution honours ``config.model`` -> ``DEFAULT_LLM_MODEL`` ->
+  ``OPENAI_PROD_MODEL``.
+
+Behavioral asserts (call the method, assert the returned/forwarded values) per
+rules/testing.md § "Behavioral Regression Tests Over Source-Grep".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import kaizen.llm.client as llm_client_mod
+import kaizen.llm.deployment_resolver as resolver_mod
+from kaizen.core.base_agent import BaseAgent
+from kaizen.signatures import InputField, OutputField, Signature
+
+# Env vars the model-resolution chain reads; serialize mutation of them through
+# one module-scope lock per rules/testing.md § "Serialize Env-Var-Mutating
+# Tests Via Module Lock".
+_ENV_LOCK = threading.Lock()
+_MODEL_ENV_VARS = ("DEFAULT_LLM_MODEL", "OPENAI_PROD_MODEL")
+
+# 1x1 PNG magic-byte prefix — _classify_input_value guesses image/png from this,
+# producing an image_url content part (offline; no real image needed).
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+
+
+class _AnswerSignature(Signature):
+    """A signature with one output field, to pin the field-keyed return shape."""
+
+    question: str = InputField(desc="A question")
+    answer: str = OutputField(desc="The answer")
+
+
+class _FakeLlmClient:
+    """A canned four-axis client capturing the ``complete`` call for asserts.
+
+    ``from_deployment`` is the classmethod the method under test uses to build
+    the client; it stashes the constructed instance on the class so the test
+    can inspect the recorded ``complete`` call afterwards.
+    """
+
+    canned_text = "FOUR-AXIS-ASSISTANT-TEXT"
+    last_instance: Optional["_FakeLlmClient"] = None
+
+    def __init__(self) -> None:
+        self.complete_calls: List[SimpleNamespace] = []
+
+    @classmethod
+    def from_deployment(cls, deployment: Any, **kwargs: Any) -> "_FakeLlmClient":
+        inst = cls()
+        inst.deployment = deployment
+        cls.last_instance = inst
+        return inst
+
+    async def complete(
+        self, messages: List[Dict[str, Any]], *, model: Optional[str] = None, **kwargs
+    ) -> Dict[str, Any]:
+        self.complete_calls.append(
+            SimpleNamespace(messages=messages, model=model, kwargs=kwargs)
+        )
+        # Four-axis shaper result shape: to_legacy_shape maps ``text`` -> ``content``.
+        return {
+            "text": type(self).canned_text,
+            "usage": {"input_tokens": 1, "output_tokens": 2},
+            "stop_reason": "stop",
+            "model": model,
+        }
+
+
+@dataclass
+class _AgentConfig:
+    """Minimal domain config; auto-converted to BaseAgentConfig by BaseAgent."""
+
+    llm_provider: str = "openai"
+    model: Optional[str] = "cfg-model"
+    temperature: float = 0.3
+    max_tokens: int = 128
+
+
+def _make_agent(config: _AgentConfig, signature: Optional[Signature]) -> BaseAgent:
+    # mcp_servers=[] keeps init fully offline (no builtin-MCP auto-discovery).
+    return BaseAgent(config=config, signature=signature, mcp_servers=[])
+
+
+@pytest.fixture
+def _fouraxis_seam(monkeypatch):
+    """Inject the fake four-axis client + a sentinel deployment resolver.
+
+    Both are patched on their owning modules; ``_simple_execute_async`` imports
+    them at call time (``from kaizen.llm.client import LlmClient`` etc.), so the
+    module-attribute patch is what the method resolves.
+    """
+    sentinel_deployment = object()
+
+    def _fake_resolve(provider, model, *, api_key=None, base_url=None):
+        # Record nothing here; the model assert reads the forwarded complete()
+        # call. Returning a non-None sentinel means "deployment resolved".
+        return sentinel_deployment
+
+    monkeypatch.setattr(resolver_mod, "resolve_deployment_for", _fake_resolve)
+    monkeypatch.setattr(llm_client_mod, "LlmClient", _FakeLlmClient)
+    _FakeLlmClient.last_instance = None
+    return SimpleNamespace(deployment=sentinel_deployment)
+
+
+@pytest.mark.regression
+def test_return_shape_response_key_without_signature(_fouraxis_seam):
+    """No signature output fields -> ``{"response": <assistant text>}``."""
+    agent = _make_agent(_AgentConfig(), signature=None)
+    # The DefaultSignature has an ``output`` field, so pass a signature-less
+    # agent by clearing the signature to exercise the else-branch explicitly.
+    agent.signature = None
+
+    result = asyncio.run(agent._simple_execute_async({"question": "hi"}))
+
+    assert result == {"response": _FakeLlmClient.canned_text}
+
+
+@pytest.mark.regression
+def test_return_shape_field_key_with_signature(_fouraxis_seam):
+    """A signature with output fields -> ``{output_fields[0]: <assistant text>}``."""
+    agent = _make_agent(_AgentConfig(), signature=_AnswerSignature())
+
+    result = asyncio.run(agent._simple_execute_async({"question": "hi"}))
+
+    assert list(agent.signature.output_fields.keys())[0] == "answer"
+    assert result == {"answer": _FakeLlmClient.canned_text}
+
+
+@pytest.mark.regression
+def test_multimodal_input_builds_structured_content_list(_fouraxis_seam):
+    """Multimodal input -> the user message ``content`` is a structured list."""
+    agent = _make_agent(_AgentConfig(), signature=None)
+    agent.signature = None
+
+    asyncio.run(
+        agent._simple_execute_async({"caption": "look at this", "image": _PNG_BYTES})
+    )
+
+    call = _FakeLlmClient.last_instance.complete_calls[0]
+    user_msg = call.messages[-1]
+    assert user_msg["role"] == "user"
+    content = user_msg["content"]
+    assert isinstance(content, list)
+    # A text part for the string field + an image_url part for the PNG bytes.
+    types = [part.get("type") for part in content]
+    assert "text" in types
+    assert "image_url" in types
+
+
+@pytest.mark.regression
+def test_model_resolution_honours_config_then_env_order(_fouraxis_seam, monkeypatch):
+    """config.model -> DEFAULT_LLM_MODEL -> OPENAI_PROD_MODEL, in that order."""
+    with _ENV_LOCK:
+        for var in _MODEL_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+        # 1. config.model wins.
+        agent = _make_agent(_AgentConfig(model="cfg-model"), signature=None)
+        agent.signature = None
+        monkeypatch.setenv("DEFAULT_LLM_MODEL", "env-default")
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "env-prod")
+        asyncio.run(agent._simple_execute_async({"q": "x"}))
+        assert _FakeLlmClient.last_instance.complete_calls[0].model == "cfg-model"
+
+        # 2. config.model None -> DEFAULT_LLM_MODEL.
+        agent = _make_agent(_AgentConfig(model=None), signature=None)
+        agent.signature = None
+        monkeypatch.setenv("DEFAULT_LLM_MODEL", "env-default")
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "env-prod")
+        asyncio.run(agent._simple_execute_async({"q": "x"}))
+        assert _FakeLlmClient.last_instance.complete_calls[0].model == "env-default"
+
+        # 3. config.model None + DEFAULT unset -> OPENAI_PROD_MODEL.
+        agent = _make_agent(_AgentConfig(model=None), signature=None)
+        agent.signature = None
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "env-prod")
+        asyncio.run(agent._simple_execute_async({"q": "x"}))
+        assert _FakeLlmClient.last_instance.complete_calls[0].model == "env-prod"

--- a/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
@@ -13,8 +13,6 @@ shape) per rules/testing.md; no source-grep-as-assertion.
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from kaizen.llm import LlmClient
@@ -115,13 +113,19 @@ def test_hf_parse_unpooled_mean_pools_tokens() -> None:
     assert out["vectors"] == [[1.0, 3.0]]
 
 
-def test_hf_parse_normalizes_when_option_set() -> None:
+def test_hf_parse_does_not_normalize_normalize_moved_to_client() -> None:
+    """#1720 Wave-B1b: the HuggingFace-only in-``parse_response`` normalize was
+    REMOVED. ``EmbedOptions.normalize`` is now applied UNIFORMLY, client-side,
+    by ``LlmClient.embed`` for every wire (one implementation, no
+    double-normalize). The shaper therefore returns RAW vectors even when
+    ``normalize=True`` is passed -- ``options`` is accepted for dispatch-
+    signature symmetry only."""
     out = huggingface_embeddings.parse_response(
         [[3.0, 4.0]], EmbedOptions(normalize=True)
     )
-    v = out["vectors"][0]
-    assert math.isclose(math.sqrt(v[0] ** 2 + v[1] ** 2), 1.0, rel_tol=1e-9)
-    # Without normalize, the raw vector passes through.
+    # RAW passthrough — the shaper no longer normalizes (the client does).
+    assert out["vectors"] == [[3.0, 4.0]]
+    # Byte-identical to the no-options path.
     out_raw = huggingface_embeddings.parse_response([[3.0, 4.0]])
     assert out_raw["vectors"] == [[3.0, 4.0]]
 

--- a/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
@@ -272,8 +272,10 @@ def test_parse_function_call_to_canonical_tool_calls():
     # arguments MUST be a JSON-encoded STRING, not a dict.
     assert isinstance(call["function"]["arguments"], str)
     assert json.loads(call["function"]["arguments"]) == {"city": "Paris", "unit": "c"}
-    # Existing parsed keys unchanged.
-    assert parsed["stop_reason"] == "STOP"
+    # #1720 Wave-B1a — the wire now value-maps the raw Gemini finishReason onto
+    # the legacy lowercase form ('STOP' -> 'stop'), matching
+    # kaizen.providers.llm.google (behaviour-neutral cutover, DECISION-1A).
+    assert parsed["stop_reason"] == "stop"
     assert parsed["usage"]["total_tokens"] == 13
 
 

--- a/packages/kailash-kaizen/tests/unit/llm/test_session2_wire_protocols.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_session2_wire_protocols.py
@@ -128,7 +128,10 @@ def test_google_parse_response_extracts_first_candidate_text() -> None:
     parsed = google_generate_content.parse_response(raw)
     assert parsed["text"] == "hi there"
     assert parsed["usage"]["input_tokens"] == 5
-    assert parsed["stop_reason"] == "STOP"
+    # #1720 Wave-B1a — the wire value-maps the raw Gemini finishReason onto the
+    # legacy lowercase form ('STOP' -> 'stop'), matching
+    # kaizen.providers.llm.google (behaviour-neutral cutover, DECISION-1A).
+    assert parsed["stop_reason"] == "stop"
 
 
 def test_google_payload_rejects_non_request() -> None:

--- a/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/test_llm_agent_dual_run_shadow.py
@@ -1,48 +1,38 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-"""#1720 Wave-2 — dual-run shadow validation tests for
-``LLMAgentNode._provider_llm_response`` (``KAIZEN_LLM_DUAL_RUN``).
+"""#1720 dual-run shadow WORKER/DISPATCH tests (``KAIZEN_LLM_DUAL_RUN``).
 
-Covers:
+**#1720 Wave-B1a note — the live-path dispatch was RETIRED.** The Wave-2
+dual-run shadow existed to validate the four-axis ``LlmClient`` path alongside
+the legacy provider path in ``LLMAgentNode._provider_llm_response`` BEFORE the
+four-axis path was load-bearing. Wave-B1a promoted the four-axis path to the
+PRIMARY live response, so a second four-axis shadow call from the live success
+path became a pure duplicate and was removed. The shadow WORKER
+(``_run_llm_dual_run_shadow``), its fire-and-forget DISPATCH
+(``_dispatch_dual_run_shadow``), the ``_shadow_deployment_for`` resolver seam,
+and the ``_dual_run_enabled`` / divergence-counter machinery are RETAINED (other
+tests import them, per the Wave-B1a cutover instruction) — so the tests below
+that exercise those RETAINED primitives DIRECTLY still hold. The tests that used
+to assert the shadow dispatched FROM ``_provider_llm_response`` (flag-off
+byte-neutrality, live-path-never-delayed, respx end-to-end parity, etc.) were
+removed with the dispatch they covered — that behavior no longer exists.
 
-* **Flag-off byte-neutrality** — the #1 invariant: a Wave-2 shadow MUST NOT
-  change production behavior when disabled. Proven by patching the shadow
-  dispatch entry point and asserting it is never called, AND asserting the
-  returned response is byte-identical to the provider's raw ``chat()``
-  output (plus the pre-existing usage-total coercion, unchanged from before
-  this Wave).
-* **Fire-and-forget dispatch (Wave-2 redteam FIX 1, HIGH)** —
-  ``_provider_llm_response`` NEVER blocks on the shadow: a hung shadow
-  ``complete()`` call does not delay the live response, the dispatched
-  worker runs on a **daemon** thread, and the shadow can never mutate the
-  response the caller already has (a deep-copied snapshot is what the
-  worker actually reads).
-* **Shadow-exception isolation** — a failure anywhere in the shadow path
-  (unmapped provider, deployment build failure, wire error, timeout,
-  cancellation) is caught and logged; the live legacy response is always
-  returned unchanged. Broadened to ``BaseException`` (FIX 3) so
-  ``asyncio.CancelledError`` is caught too.
-* **Isolated-thread execution** — the shadow runs its own event loop on a
-  separate (daemon, dispatched) thread even when the caller itself is
-  inside a running event loop (the exact scenario a bare ``asyncio.run()``
-  on the caller's thread would break).
-* **respx end-to-end parity / divergence** — a full ``_provider_llm_response``
-  call with both the legacy provider and the four-axis shadow hitting a
-  respx-mocked HTTP boundary, asserting parity logs no divergence WARN and
-  a real difference logs exactly one.
+Retained coverage:
 
-Tier 1 except where noted; the respx tests exercise a real (mocked-at-the-
-wire) send path, matching the precedent set by
-``tests/unit/llm/test_completion_wire_respx.py``.
+* **``_dual_run_enabled`` truthy-token parsing** — the env-flag gate.
+* **Fire-and-forget dispatch** — ``_dispatch_dual_run_shadow`` starts the worker
+  on a **daemon** thread and returns the ``Thread`` for test observability.
+* **Shadow-worker exception isolation** — a failure anywhere in the worker
+  (timeout, cancellation, deployment build failure) is caught (``BaseException``
+  so ``asyncio.CancelledError`` is caught too) and logged, never raised;
+  ``KeyboardInterrupt``/``SystemExit`` still re-raise.
+* **Bounded timeout** — the worker wraps ``complete()`` in
+  ``asyncio.wait_for(..., timeout=_DUAL_RUN_TIMEOUT_SECONDS)``.
+* **Concurrent divergence counter** — lock-guarded ``+= 1`` under N threads.
 
-Since the shadow now dispatches onto a background daemon thread
-(``_dispatch_dual_run_shadow``), every test that asserts on the shadow's
-LOG side effects joins the dispatched thread (found via
-``threading.enumerate()`` by its fixed thread name) before inspecting
-``caplog`` — otherwise the assertion would race the still-running daemon
-thread. Tests that assert the LIVE path is NOT delayed deliberately do
-**not** join before measuring elapsed time (that is the entire point).
+Tier 1: no network; the shadow's four-axis client is stubbed via
+``_patch_shadow_client``.
 """
 
 from __future__ import annotations
@@ -53,11 +43,8 @@ import threading
 import time
 from unittest.mock import MagicMock
 
-import httpx
 import pytest
-import respx
 
-import kaizen.llm.http_client as _http_client_mod
 import kaizen.nodes.ai.llm_agent as llm_agent_mod
 from kaizen.nodes.ai.llm_agent import LLMAgentNode
 
@@ -125,110 +112,9 @@ def _patch_shadow_client(monkeypatch: pytest.MonkeyPatch, complete_coro):
     return fake_client
 
 
-@pytest.fixture
-def _shadow_dispatch_capture(monkeypatch: pytest.MonkeyPatch):
-    """Capture every `Thread` `_dispatch_dual_run_shadow` starts during a
-    test, via monkeypatch-wrapping the REAL method (production behavior is
-    unchanged; the wrapper just records the returned `Thread`).
-
-    Deliberately NOT `threading.enumerate()`-based: a mocked shadow (no
-    real network) can start AND finish before the test gets a chance to
-    enumerate live threads again, so a fast-completing thread would
-    already be gone from `enumerate()` by the time the assertion runs --
-    a genuine, observed race in this exact test file (three tests flaked
-    intermittently on the enumerate-based approach depending on how fast
-    the mocked `complete()` resolved). Capturing the `Thread` OBJECT
-    itself sidesteps the race entirely: `.join()` on an already-finished
-    thread returns immediately, so joining a captured thread is always
-    safe regardless of whether it has already completed.
-    """
-    original = LLMAgentNode._dispatch_dual_run_shadow
-    captured: list[threading.Thread] = []
-
-    def _wrapped(self, **kwargs):
-        thread = original(self, **kwargs)
-        if thread is not None:
-            captured.append(thread)
-        return thread
-
-    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", _wrapped)
-    return captured
-
-
-def _call_and_join_shadow(
-    agent: LLMAgentNode,
-    captured: list[threading.Thread],
-    *,
-    join_timeout: float = 5.0,
-    **kwargs,
-):
-    """Call `_provider_llm_response` and deterministically wait for the
-    dual-run shadow's dispatched daemon thread (if any) — read from
-    `captured`, the `_shadow_dispatch_capture` fixture's list — to finish
-    before the caller inspects `caplog` / mutation state.
-
-    The shadow is fire-and-forget in production — this helper exists ONLY
-    to make test assertions about the shadow's side effects
-    (log lines, response-mutation absence) deterministic rather than racy.
-    """
-    before_len = len(captured)
-    response = agent._provider_llm_response(**kwargs)
-    threads = captured[before_len:]
-    for t in threads:
-        t.join(timeout=join_timeout)
-    return response, threads
-
-
 # ---------------------------------------------------------------------------
-# Flag-off byte-neutrality (the #1 invariant)
+# _dual_run_enabled truthy-token parsing (the env-flag gate).
 # ---------------------------------------------------------------------------
-
-
-def test_dual_run_flag_off_shadow_never_runs(monkeypatch, _env_serialized):
-    """`KAIZEN_LLM_DUAL_RUN` unset -> `_dispatch_dual_run_shadow` (the
-    shadow's entry point from `_provider_llm_response`) is never called."""
-    _patch_stub_provider(monkeypatch)
-    dispatch_mock = MagicMock()
-    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", dispatch_mock)
-
-    agent = LLMAgentNode()
-    agent._provider_llm_response(
-        provider="openai",
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=[],
-        generation_config={},
-    )
-
-    dispatch_mock.assert_not_called()
-
-
-def test_dual_run_flag_off_response_is_byte_identical(monkeypatch, _env_serialized):
-    """The returned response with the flag OFF is byte-identical to the
-    provider's raw `chat()` output plus the pre-existing (pre-#1720)
-    usage-total coercion — proving the Wave-2 addition changes nothing on
-    the live path when disabled."""
-    _patch_stub_provider(monkeypatch)
-    monkeypatch.setattr(LLMAgentNode, "_dispatch_dual_run_shadow", MagicMock())
-
-    agent = LLMAgentNode()
-    response = agent._provider_llm_response(
-        provider="openai",
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=[],
-        generation_config={},
-    )
-
-    assert response == {
-        "id": "stub-1",
-        "content": "hello from stub",
-        "role": "assistant",
-        "model": "gpt-4o-mini",
-        "tool_calls": [],
-        "finish_reason": "stop",
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
 
 
 @pytest.mark.parametrize("raw_value", ["false", "0", "no", "off", "disabled", ""])
@@ -246,72 +132,8 @@ def test_dual_run_enabled_true_for_truthy_values(monkeypatch, raw_value):
 
 
 # ---------------------------------------------------------------------------
-# FIX 1 (HIGH) — fire-and-forget: the shadow MUST NEVER block the live path.
+# Fire-and-forget dispatch — daemon thread, returned for observability.
 # ---------------------------------------------------------------------------
-
-
-def test_dual_run_live_path_returns_immediately_despite_hung_shadow(
-    monkeypatch, _env_serialized, _shadow_dispatch_capture
-):
-    """THE fire-and-forget proof: with the flag ON and the shadow's
-    `complete()` stubbed to hang well past the (monkeypatched-small) dual-
-    run timeout, `_provider_llm_response` still returns in a fraction of a
-    second — the LIVE path is NEVER delayed by the shadow.
-
-    Before FIX 1, the shadow ran synchronously inline before `return
-    response`, and `_run_coro_in_isolated_thread` inside it did a blocking
-    `future.result(timeout=30s)` — a hang here would have blocked the live
-    response for up to `_DUAL_RUN_TIMEOUT_SECONDS` (x5 inside the
-    tool-execution loop). This test would have taken >=0.2s (the bounded
-    timeout below) — or 30s at the production default — under the old
-    behavior; it now takes milliseconds.
-
-    The elapsed-time assertion below (the actual proof) happens BEFORE the
-    thread is joined — joining only happens at the very end, purely for
-    test hygiene (an un-joined daemon thread that logs a WARNING slightly
-    later would otherwise leak into a LATER test's `caplog` capture
-    window, since `LLMAgentNode`'s logger name is shared across
-    instances). The join does not weaken the proof.
-    """
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-    # Bound the shadow's own patience so the background daemon thread this
-    # test dispatches exits quickly instead of lingering for the
-    # production default of 30s.
-    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.2)
-
-    dispatched = threading.Event()
-
-    async def _hang_past_timeout(*args, **kwargs):
-        dispatched.set()
-        await asyncio.sleep(2.0)  # far longer than the bounded shadow timeout
-
-    _patch_shadow_client(monkeypatch, _hang_past_timeout)
-
-    agent = LLMAgentNode()
-    start = time.monotonic()
-    response = agent._provider_llm_response(
-        provider="openai",
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=[],
-        generation_config={},
-    )
-    elapsed = time.monotonic() - start
-
-    assert response["content"] == "hello from stub"
-    assert elapsed < 1.0, (
-        f"_provider_llm_response took {elapsed:.3f}s with a hung shadow -- "
-        f"the live path must return in milliseconds (fire-and-forget)"
-    )
-    # Sanity: the shadow genuinely dispatched (not skipped) -- proves the
-    # fast return above is because of fire-and-forget, not because the
-    # shadow never ran at all.
-    assert dispatched.wait(timeout=2.0), "the shadow thread never started"
-
-    # Test hygiene ONLY (see docstring) -- the proof above already ran.
-    assert len(_shadow_dispatch_capture) == 1
-    _shadow_dispatch_capture[0].join(timeout=5.0)
 
 
 def test_dual_run_dispatch_starts_a_daemon_thread(monkeypatch, _env_serialized):
@@ -350,196 +172,20 @@ def test_dual_run_dispatch_starts_a_daemon_thread(monkeypatch, _env_serialized):
     assert not thread.is_alive()
 
 
-def test_dual_run_dispatch_never_mutates_the_live_response(
-    monkeypatch, _env_serialized, _shadow_dispatch_capture
-):
-    """FIX 1(c): regardless of the shadow's outcome (a real divergence
-    here), the `response` dict `_provider_llm_response` already returned to
-    its caller is NEVER mutated by the shadow — proven by snapshotting the
-    dict immediately and asserting it is unchanged after the dispatched
-    shadow thread finishes."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    async def _diverge(*args, **kwargs):
-        return {
-            "text": "totally different content",
-            "stop_reason": "length",
-            "model": "gpt-4o-mini",
-            "usage": {
-                "input_tokens": 999,
-                "output_tokens": 999,
-                "total_tokens": 1998,
-            },
-        }
-
-    _patch_shadow_client(monkeypatch, _diverge)
-
-    agent = LLMAgentNode()
-    response, threads = _call_and_join_shadow(
-        agent,
-        _shadow_dispatch_capture,
-        provider="openai",
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=[],
-        generation_config={},
-    )
-    assert len(threads) == 1
-
-    assert response == {
-        "id": "stub-1",
-        "content": "hello from stub",
-        "role": "assistant",
-        "model": "gpt-4o-mini",
-        "tool_calls": [],
-        "finish_reason": "stop",
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
-
-
-def test_dual_run_dispatch_deepcopies_snapshot_immune_to_post_call_mutation(
-    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
-):
-    """FIX 1: the daemon thread reads a `copy.deepcopy()` snapshot of
-    `messages`/`legacy_response`, taken on the CALLER's thread BEFORE the
-    thread starts. `LLMAgentNode.run()`'s tool-execution loop mutates the
-    SAME `messages` list object (appends) and the SAME `response` dict
-    (sets a key) immediately after `_provider_llm_response` returns — this
-    test reproduces that exact mutation and proves the shadow's `complete()`
-    call observed the ORIGINAL 1-message snapshot, not the post-call
-    2-message mutated list, AND that the comparison completes cleanly (a
-    genuine parity log, never a shadow_error)."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    received: dict = {}
-
-    async def _fake_complete(messages_arg, *args, **kwargs):
-        received["messages_len"] = len(messages_arg)
-        return {
-            "text": "hello from stub",
-            "stop_reason": "stop",
-            "model": "gpt-4o-mini",
-            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
-        }
-
-    _patch_shadow_client(monkeypatch, _fake_complete)
-
-    agent = LLMAgentNode()
-    messages = [{"role": "user", "content": "hi"}]
-
-    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response = agent._provider_llm_response(
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=messages,
-            tools=[],
-            generation_config={},
-        )
-        # Reproduce exactly what `run()`'s tool-execution loop does
-        # immediately after this call returns: mutate the SAME objects.
-        messages.append({"role": "assistant", "content": "mutated after call"})
-        response["tool_execution_rounds"] = 1
-
-        assert len(_shadow_dispatch_capture) == 1
-        _shadow_dispatch_capture[0].join(timeout=5.0)
-        assert not _shadow_dispatch_capture[0].is_alive()
-
-    assert received["messages_len"] == 1  # the frozen snapshot, not 2
-
-    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
-    assert len(parity_records) == 1
-    shadow_error_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
-    ]
-    assert shadow_error_records == []
-
-
-def test_dual_run_dispatch_error_never_propagates_to_live_path(
-    monkeypatch, _env_serialized, caplog
-):
-    """A failure in dispatch ITSELF (the `copy.deepcopy()` / `Thread`
-    construction inside `_dispatch_dual_run_shadow`, not the worker) is
-    caught and logged, never raised into `_provider_llm_response`."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    def _boom(*args, **kwargs):
-        raise RuntimeError("deep copy exploded")
-
-    monkeypatch.setattr(llm_agent_mod.copy, "deepcopy", _boom)
-
-    agent = LLMAgentNode()
-    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
-        response = agent._provider_llm_response(
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=[],
-            generation_config={},
-        )
-
-    assert response["content"] == "hello from stub"
-    dispatch_error_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.dispatch_error"
-    ]
-    assert len(dispatch_error_records) == 1
-    assert dispatch_error_records[0].error_class == "RuntimeError"
-
-
 # ---------------------------------------------------------------------------
-# Shadow-exception isolation — flag ON, four-axis path raises/hangs/cancels.
+# Shadow-worker exception isolation + bounded timeout (worker called direct).
 # ---------------------------------------------------------------------------
-
-
-def test_dual_run_shadow_exception_never_propagates(
-    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
-):
-    """Flag ON; the four-axis deployment resolution explodes. The live
-    legacy response is STILL returned unchanged, and the failure is logged
-    (not swallowed silently, not raised) once the dispatched shadow thread
-    finishes."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    def _boom(*args, **kwargs):
-        raise RuntimeError("shadow deployment resolution exploded")
-
-    monkeypatch.setattr(llm_agent_mod, "_shadow_deployment_for", _boom)
-
-    agent = LLMAgentNode()
-    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
-        response, threads = _call_and_join_shadow(
-            agent,
-            _shadow_dispatch_capture,
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=[],
-            generation_config={},
-        )
-        assert len(threads) == 1
-
-    assert response["content"] == "hello from stub"
-    shadow_error_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
-    ]
-    assert len(shadow_error_records) == 1
-    assert shadow_error_records[0].error_class == "RuntimeError"
 
 
 def test_dual_run_shadow_worker_bounds_a_hung_provider_and_logs_error(
     monkeypatch, _env_serialized, caplog
 ):
-    """FIX 2: real timeout-bound proof for the shadow WORKER itself (not a
-    monkeypatch of the isolation mechanism, which was a no-op w.r.t. the
-    actual behavior). `_run_llm_dual_run_shadow` wraps the shadow's
-    `complete()` coroutine in `asyncio.wait_for(...,
-    timeout=_DUAL_RUN_TIMEOUT_SECONDS)` — a provider that never responds is
-    cancelled near the bounded timeout (not left to run indefinitely), the
-    resulting `TimeoutError` is caught, and the failure is logged — never
-    raised out of the worker."""
+    """FIX 2: real timeout-bound proof for the shadow WORKER itself.
+    `_run_llm_dual_run_shadow` wraps the shadow's `complete()` coroutine in
+    `asyncio.wait_for(..., timeout=_DUAL_RUN_TIMEOUT_SECONDS)` — a provider
+    that never responds is cancelled near the bounded timeout (not left to run
+    indefinitely), the resulting `TimeoutError` is caught, and the failure is
+    logged — never raised out of the worker."""
     monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
     _patch_stub_provider(monkeypatch)
     monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.1)
@@ -575,147 +221,6 @@ def test_dual_run_shadow_worker_bounds_a_hung_provider_and_logs_error(
     ]
     assert len(shadow_error_records) == 1
     assert shadow_error_records[0].error_class == "TimeoutError"
-
-
-def test_dual_run_shadow_timeout_never_propagates_through_dispatch(
-    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
-):
-    """End-to-end (dispatch-level) sibling of the worker-level timeout
-    test: with the flag ON and a hung shadow, `_provider_llm_response`
-    returns the live response unaffected, and once the dispatched daemon
-    thread's bounded timeout elapses, exactly one `shadow_error` is
-    logged -- never raised, never affecting `response`."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-    monkeypatch.setattr(llm_agent_mod, "_DUAL_RUN_TIMEOUT_SECONDS", 0.1)
-
-    async def _hang(*args, **kwargs):
-        await asyncio.sleep(30)
-
-    _patch_shadow_client(monkeypatch, _hang)
-
-    agent = LLMAgentNode()
-    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
-        response, threads = _call_and_join_shadow(
-            agent,
-            _shadow_dispatch_capture,
-            join_timeout=5.0,
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=[],
-            generation_config={},
-        )
-        assert len(threads) == 1
-        assert not threads[0].is_alive()
-
-    assert response["content"] == "hello from stub"
-    shadow_error_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
-    ]
-    assert len(shadow_error_records) == 1
-    assert shadow_error_records[0].error_class == "TimeoutError"
-
-
-def test_dual_run_shadow_unmapped_provider_skips_without_warning(
-    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
-):
-    """A provider with no four-axis preset mapping is skipped at DEBUG --
-    no WARNING, live response unaffected.
-
-    Uses an arbitrary unmapped provider NAME (not `mock`) resolved via a
-    patched provider registry -- `mock` itself is globally replaced by
-    `tests/conftest.py`'s `KaizenMockProvider` (a Core-SDK-only mock without
-    `is_available()`), an unrelated pre-existing test-infra fixture this
-    test must not depend on.
-    """
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    agent = LLMAgentNode()
-    # The provider->deployment resolution (and its shadow_skipped DEBUG log)
-    # was promoted to `kaizen.llm.deployment_resolver` in #1720 Wave-A; the
-    # skip line now emits under that module's logger, not llm_agent's.
-    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        with caplog.at_level(logging.DEBUG, logger="kaizen.llm.deployment_resolver"):
-            response, threads = _call_and_join_shadow(
-                agent,
-                _shadow_dispatch_capture,
-                provider="totally-unmapped-provider-xyz",
-                model="mock-model",
-                messages=[{"role": "user", "content": "hi"}],
-                tools=[],
-                generation_config={},
-            )
-            assert len(threads) == 1
-
-    assert response["content"] is not None
-    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert warning_records == []
-    skipped_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.shadow_skipped"
-    ]
-    assert len(skipped_records) == 1
-    assert skipped_records[0].reason == "unmapped_provider"
-
-
-def test_dual_run_isolated_thread_runs_under_an_active_caller_event_loop(
-    monkeypatch, _env_serialized, caplog, _shadow_dispatch_capture
-):
-    """The shadow MUST run correctly even when `_provider_llm_response` is
-    invoked from a caller thread that already has an active asyncio event
-    loop (an async Nexus handler, a pytest-asyncio test, an agent loop) --
-    the exact case a bare `asyncio.run()` on the caller thread cannot
-    handle (`RuntimeError: asyncio.run() cannot be called from a running
-    event loop`). The dispatched daemon thread provides the isolation now,
-    not a nested thread-in-thread helper inside the worker."""
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    _patch_stub_provider(monkeypatch)
-
-    calls: list[int] = []
-
-    async def _fake_complete(*args, **kwargs):
-        calls.append(1)
-        return {
-            "text": "hello from stub",
-            "stop_reason": "stop",
-            "model": "gpt-4o-mini",
-            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
-        }
-
-    _patch_shadow_client(monkeypatch, _fake_complete)
-
-    agent = LLMAgentNode()
-
-    async def _run_inside_active_loop():
-        # This coroutine itself IS the active event loop the sync
-        # _provider_llm_response call runs under.
-        return agent._provider_llm_response(
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=[],
-            generation_config={},
-        )
-
-    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response = asyncio.run(_run_inside_active_loop())
-
-        assert len(_shadow_dispatch_capture) == 1
-        _shadow_dispatch_capture[0].join(timeout=5.0)
-        assert not _shadow_dispatch_capture[0].is_alive()
-
-    assert response["content"] == "hello from stub"
-    assert calls == [1]  # the shadow's complete() genuinely ran
-    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
-    assert len(parity_records) == 1
-
-
-# ---------------------------------------------------------------------------
-# FIX 3 (LOW) — the shadow's exception boundary is BaseException, not
-# Exception, so asyncio.CancelledError (a BaseException subclass) and
-# similar are caught too; KeyboardInterrupt/SystemExit still re-raise.
-# ---------------------------------------------------------------------------
 
 
 def test_dual_run_shadow_catches_cancelled_error_as_baseexception(
@@ -785,8 +290,8 @@ def test_dual_run_shadow_reraises_keyboardinterrupt_and_systemexit(
 
 
 # ---------------------------------------------------------------------------
-# FIX 6 (LOW) — the divergence counter is now genuinely concurrent
-# (multiple daemon threads); it MUST be lock-guarded.
+# FIX 6 (LOW) — the divergence counter is genuinely concurrent (multiple
+# daemon threads); it MUST be lock-guarded.
 # ---------------------------------------------------------------------------
 
 
@@ -922,151 +427,3 @@ def test_dual_run_divergence_counter_is_thread_safe_under_concurrent_shadows(
         assert not t.is_alive()
 
     assert llm_agent_mod._dual_run_divergence_count == before + n_workers
-
-
-# ---------------------------------------------------------------------------
-# respx end-to-end: real (mocked-at-the-wire) legacy + shadow calls.
-# ---------------------------------------------------------------------------
-
-
-class _AllowAllResolver(_http_client_mod.SafeDnsResolver):
-    """No-op SSRF DNS resolver — test-only, mirrors
-    tests/unit/llm/test_completion_wire_respx.py's `_AllowAllResolver`."""
-
-    __slots__ = ()
-
-    def check_host(self, host: str) -> None:  # noqa: D401 - test stub resolver
-        return None
-
-
-@pytest.fixture(autouse=False)
-def _no_real_dns(monkeypatch):
-    """Skip the SSRF guard's real DNS lookup for the shadow's internally
-    -constructed `LlmHttpClient` (it has no seam to inject a resolver
-    without changing production code, unlike the direct-`LlmClient` tests)."""
-    monkeypatch.setattr(
-        _http_client_mod.SafeDnsResolver, "check_host", lambda self, host: None
-    )
-
-
-_OPENAI_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
-
-
-@respx.mock
-def test_dual_run_respx_parity_logs_no_divergence(
-    monkeypatch, _env_serialized, caplog, _no_real_dns, _shadow_dispatch_capture
-):
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-parity")
-
-    payload = {
-        "id": "chatcmpl-1",
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "pong"},
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
-        "model": "gpt-4o-mini",
-    }
-    respx.post(_OPENAI_COMPLETIONS_URL).mock(
-        return_value=httpx.Response(200, json=payload)
-    )
-
-    agent = LLMAgentNode()
-    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response, threads = _call_and_join_shadow(
-            agent,
-            _shadow_dispatch_capture,
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "ping"}],
-            tools=[],
-            generation_config={"temperature": 0.0},
-        )
-        assert len(threads) == 1
-
-    assert response["content"] == "pong"
-
-    divergence_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.divergence"
-    ]
-    assert divergence_records == []
-    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
-    assert len(parity_records) == 1
-    shadow_error_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.shadow_error"
-    ]
-    assert shadow_error_records == []
-
-
-@respx.mock
-def test_dual_run_respx_divergence_logs_exactly_one_warning(
-    monkeypatch, _env_serialized, caplog, _no_real_dns, _shadow_dispatch_capture
-):
-    monkeypatch.setenv("KAIZEN_LLM_DUAL_RUN", "true")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dual-run-divergence")
-
-    legacy_payload = {
-        "id": "chatcmpl-1",
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "pong"},
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
-        "model": "gpt-4o-mini",
-    }
-    # A genuinely different four-axis response: different content AND a
-    # different finish_reason.
-    shadow_payload = {
-        "id": "chatcmpl-2",
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "pong-but-different"},
-                "finish_reason": "length",
-            }
-        ],
-        "usage": {"prompt_tokens": 5, "completion_tokens": 9, "total_tokens": 14},
-        "model": "gpt-4o-mini",
-    }
-    respx.post(_OPENAI_COMPLETIONS_URL).mock(
-        side_effect=[
-            httpx.Response(200, json=legacy_payload),
-            httpx.Response(200, json=shadow_payload),
-        ]
-    )
-
-    agent = LLMAgentNode()
-    with caplog.at_level(logging.DEBUG, logger=agent.logger.name):
-        response, threads = _call_and_join_shadow(
-            agent,
-            _shadow_dispatch_capture,
-            provider="openai",
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": "ping"}],
-            tools=[],
-            generation_config={"temperature": 0.0},
-        )
-        assert len(threads) == 1
-
-    # Live response is STILL the legacy one, untouched by the shadow.
-    assert response["content"] == "pong"
-    assert response["finish_reason"] == "stop"
-
-    divergence_records = [
-        r for r in caplog.records if r.message == "llm.dual_run.divergence"
-    ]
-    assert len(divergence_records) == 1
-    divergences = divergence_records[0].divergences
-    assert any(d.startswith("content:") for d in divergences)
-    assert any(d.startswith("finish_reason:") for d in divergences)
-    # No raw generated text leaked into the log line's structured payload.
-    joined = "\n".join(divergences)
-    assert "pong" not in joined
-    assert "pong-but-different" not in joined
-
-    parity_records = [r for r in caplog.records if r.message == "llm.dual_run.parity"]
-    assert parity_records == []

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -114,32 +114,56 @@ def _make_fake_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
     return provider
 
 
-def _make_unavailable_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
-    """A provider that reports itself unavailable — the genuine no-LLM deployment.
+def _fake_four_axis_response(**_: Any) -> dict:
+    """A deterministic four-axis ``LlmClient.complete()`` response.
 
-    ``LLMAgentNode._provider_llm_response`` raises ``RuntimeError`` (before any
-    network call) when ``is_available()`` is False and no per-request api_key is
-    supplied, which drives each advanced-RAG node's ``try/except`` rule-based
-    fallback. Used by the one test whose whole point is the no-LLM path (issue
-    #1736), overriding the module autouse content-stub.
+    ``kaizen.llm._legacy_shape.to_legacy_shape`` maps ``text`` -> ``content``, so
+    this yields the same normalized shape ``_fake_chat_response`` did on the
+    legacy path (issue #1736 offline determinism, preserved across the #1720
+    Wave-B1a four-axis cutover of ``LLMAgentNode._provider_llm_response``).
     """
-    provider = MagicMock()
-    provider.is_available.return_value = False
-    return provider
+    return {
+        "text": _MOCK_CONTENT,
+        "stop_reason": "stop",
+        "model": "mock-model",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _make_fake_four_axis_client(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """A fake ``LlmClient`` whose async ``complete()`` returns the canned dict."""
+    client = MagicMock()
+
+    async def _complete(*_a: Any, **_kw: Any) -> dict:
+        return _fake_four_axis_response()
+
+    client.complete = _complete
+    return client
 
 
 @pytest.fixture(autouse=True)
 def _stub_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub the kaizen provider registry seam for this module only (issue #1736).
+    """Stub the four-axis LLM seam for this module only (issue #1736).
 
     ``kaizen.nodes.rag.advanced`` constructs ``LLMAgentNode(provider="openai",
-    ...)`` directly for its four LLM-backed steps. ``LLMAgentNode.
-    _provider_llm_response()`` resolves the provider via
-    ``kaizen.providers.registry.get_provider(name)`` and calls
-    ``provider.chat(...)`` — the real network seam. Stubbing it here (module-
-    scoped, NOT a directory-wide conftest) keeps every other file in
-    ``tests/unit/rag/`` byte-for-byte unaffected, per issue #1736 scope.
+    ...)`` directly for its four LLM-backed steps. Since the #1720 Wave-B1a live
+    cutover, ``LLMAgentNode._provider_llm_response()`` resolves a four-axis
+    deployment via ``kaizen.llm.deployment_resolver.resolve_deployment_for`` and
+    calls ``kaizen.llm.client.LlmClient.complete(...)`` — the real network seam.
+    Stubbing it here (module-scoped, NOT a directory-wide conftest) with a
+    sentinel deployment + fake client keeps every other file in
+    ``tests/unit/rag/`` byte-for-byte unaffected, per issue #1736 scope. The
+    legacy ``get_provider`` seam is also stubbed for the one no-LLM test that
+    overrides the four-axis resolver.
     """
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(_make_fake_four_axis_client),
+    )
     monkeypatch.setattr(
         "kaizen.providers.registry.get_provider",
         _make_fake_provider,
@@ -467,15 +491,18 @@ class TestHyDENode:
         """With no LLM available the rule-based fallback yields >=1 hypothesis.
 
         This test's whole point is the genuine NO-LLM path, so it explicitly
-        overrides the module autouse content-stub with an *unavailable* provider
-        (``is_available()`` -> False). That drives ``_generate_hypotheses``'s
-        ``try/except`` rule-based fallback (the documented behavior) rather than
-        the mocked-completion path the other tests exercise — offline either way,
-        no network (issue #1736).
+        overrides the module autouse four-axis stub with an UNRESOLVABLE
+        deployment (``resolve_deployment_for`` -> ``None``). Since the #1720
+        Wave-B1a cutover, that is the four-axis equivalent of legacy
+        ``is_available() is False``: ``LLMAgentNode._provider_llm_response``
+        raises ``RuntimeError`` (before any network call), which drives
+        ``_generate_hypotheses``'s ``try/except`` rule-based fallback (the
+        documented behavior) rather than the mocked-completion path the other
+        tests exercise — offline either way, no network (issue #1736).
         """
         with patch(
-            "kaizen.providers.registry.get_provider",
-            side_effect=_make_unavailable_provider,
+            "kaizen.llm.deployment_resolver.resolve_deployment_for",
+            return_value=None,
         ):
             result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
         # The rule-based fallback ("A comprehensive answer to '<query>'…") — NOT a

--- a/packages/kailash-kaizen/tests/unit/strategies/conftest.py
+++ b/packages/kailash-kaizen/tests/unit/strategies/conftest.py
@@ -23,14 +23,21 @@ weakening any behavioral assertion (cycle counts, dict shape, tool-call
 handling, termination logic all still exercise real strategy code against a
 real, deterministic completion).
 
-Two independent call paths reach a live provider from this test directory
-and are both stubbed:
+Three independent call paths reach a live provider from this test directory
+and are all stubbed:
 
-1. **Registry path** -- ``LLMAgentNode._provider_llm_response()`` ->
-   ``kaizen.providers.registry.get_provider(name)`` -> ``provider.chat(...)``.
-   Used by every strategy that runs through ``LocalRuntime`` + ``LLMAgentNode``
-   (``MultiCycleStrategy``, ``SingleShotStrategy``'s workflow path, etc).
-2. **Legacy direct-instantiation path** -- ``BaseAgent._simple_execute_async``
+1. **Four-axis path (#1720 Wave-B1a live cutover)** --
+   ``LLMAgentNode._provider_llm_response()`` now resolves a four-axis
+   deployment via ``kaizen.llm.deployment_resolver.resolve_deployment_for``
+   and calls ``kaizen.llm.client.LlmClient.complete(...)`` (the legacy
+   ``get_provider(...).chat(...)`` seam is retained only for
+   ``azure_ai_foundry``). Stubbed by patching ``resolve_deployment_for`` to a
+   sentinel deployment and ``LlmClient.from_deployment_sync`` to a fake client
+   whose ``complete()`` returns a deterministic four-axis response.
+2. **Registry path** -- ``kaizen.providers.registry.get_provider(name)`` ->
+   ``provider.chat(...)``. Retained for the azure_ai_foundry legacy branch and
+   any other code path still resolving through the registry.
+3. **Legacy direct-instantiation path** -- ``BaseAgent._simple_execute_async``
    imports ``kaizen.providers.llm.openai.OpenAIProvider`` directly and calls
    ``.chat_async()``, bypassing the registry entirely.
 
@@ -91,9 +98,49 @@ def _make_fake_provider(*_args: Any, **_kwargs: Any) -> MagicMock:
     return provider
 
 
+def _fake_four_axis_response(**_: Any) -> dict:
+    """A deterministic four-axis ``LlmClient.complete()`` response.
+
+    ``kaizen.llm._legacy_shape.to_legacy_shape`` maps ``text`` -> ``content`` and
+    ``input_tokens``/``output_tokens`` -> ``prompt_tokens``/``completion_tokens``,
+    so this yields the same normalized shape ``_fake_chat_response`` did on the
+    legacy path (issue #1736 offline determinism, preserved across the #1720
+    Wave-B1a four-axis cutover).
+    """
+    return {
+        "text": _MOCK_CONTENT,
+        "stop_reason": "stop",
+        "model": "mock-model",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _make_fake_four_axis_client(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """A fake ``LlmClient`` whose async ``complete()`` returns the canned dict."""
+    client = MagicMock()
+
+    async def _complete(*_a: Any, **_kw: Any) -> dict:
+        return _fake_four_axis_response()
+
+    client.complete = _complete
+    return client
+
+
 @pytest.fixture(autouse=True)
 def _stub_llm_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub both the registry seam and the legacy direct-instantiation seam."""
+    """Stub the four-axis seam, the registry seam, and the legacy direct-
+    instantiation seam so every strategy test runs offline + deterministic."""
+    # #1720 Wave-B1a — the four-axis live path is what LLMAgentNode now drives.
+    # Sentinel deployment + fake client keeps it offline regardless of env keys.
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(_make_fake_four_axis_client),
+    )
+
     monkeypatch.setattr(
         "kaizen.providers.registry.get_provider",
         _make_fake_provider,


### PR DESCRIPTION
## What & why

Wave B1 of #1720 — promote the four-axis `LlmClient` from a validated shadow to the **primary live path** across all three legacy LLM/embed consumers, retiring `providers/llm/` on every live path except the scoped-out `azure_ai_foundry` (Decision-2A). Behavior-neutral migration behind the offline parity harness.

Three disjoint-file shards, developed in parallel worktrees, integrated with zero conflicts:

| Shard | Cutover |
|---|---|
| **B1a** | `LLMAgentNode._provider_llm_response` → `resolve_deployment_for`→`complete`→`to_legacy_shape` (promotes the dual-run shadow to primary; removes the now-redundant shadow dispatch from the success path). Folds Decision-1A: the FULL legacy google `finish_reason` value-map (`STOP`→`stop`, `MAX_TOKENS`→`length`, `SAFETY`→`content_filter`, tool→`tool_calls`) into the four-axis google wire. |
| **B1b** | `EmbeddingGeneratorNode._generate_provider_embedding` → `LlmClient.embed`; adds a `timeout` kwarg and applies `EmbedOptions.normalize` **uniformly** client-side (removes the HF-only copy — no double-normalize). |
| **B1c** | `BaseAgent._simple_execute_async` → four-axis (openai-only). |

Invariants preserved across the cutover: `is_available()` gate, #487 usage total-coercion, stream-aware `tool_choice` default, BYOK api_key control-char/CRLF/non-ASCII validation on the live path, `ImportError` fallback, provider-error sanitization.

## Inter-wave redteam — CONVERGED (2 consecutive clean rounds)

Holistic 3-dimension redteam (reviewer + security-reviewer + closure-parity), errored-reviewer evidence gate honored.

- **Round 1** found 1 HIGH + 2 MED + 3 LOW → all fixed in `d87ecf799`:
  - **HIGH** — `_generate_provider_embedding` silently returned a **mock embedding** (reported `success=True` as a real provider) when a credential provider's deployment was unresolvable; the cutover widened the mock fallback's reachability. Restored the loud raise (legacy parity); the sanctioned mock path stays the explicit `provider=="mock"` mode only.
  - **MED ×2** (enforcement-surface parity) — embed except + `_simple_execute_async` now route provider errors through the shared `sanitize_provider_error`, matching the B1a live path.
  - **LOW** — google `_map_finish_reason(None)`→`"stop"` (legacy floor); 3 sibling embed-shaper docstrings corrected (normalize is now uniform).
- **Round 2 CLEAN**, **Round 3 CLEAN** — all findings verified fixed, fresh adversarial passes found no new defect; double-wrap confirmed legacy-parity-consistent.

## Tests

- 11 new behavioral redteam-fix regressions + 20 shard-cutover regressions (offline, deterministic, shared canned bytes).
- Full suite green from integrated main: **666 passed** (parity + all #1720 regressions), **14,691 collected** (collection gate exit 0), 1,976 nodes/llm + 1,135 rag/strategies green. ruff clean.

## Wave-C residual (feed-forward, unchanged by this wave)

Legacy runtime coupling remaining after B1 (all documented, none new): `azure_ai_foundry` legacy chat fallback; ollama/docker embed fallback (needs `base_url`/`api_key` node params); `metrics.py` name-registry import (B2b); the 2 re-export barrels. 35 test files reference the legacy surface (Wave-C sweep budget).

## Non-blocking follow-ups surfaced by the redteam (NOT introduced by this wave)

1. Legacy `azure_ai_foundry` `.chat()` lacks the CRLF/non-ASCII api_key guard the four-axis path now has (enforcement-surface-parity asymmetry, confined to the one legacy provider). The cutover is a **net** security gain. Fold into the `azure_ai_foundry` Foundry-wire capability item.
2. `_run_async_in_sync_context` (unchanged since 2026-03-11) has a latent RuntimeError-remap edge; B1a grows its risk surface but it's unreachable on the live path (LLM error taxonomy is Exception-based, not RuntimeError).
3. Pre-existing `structured_output_mode='auto'` FutureWarning (`async_single_shot.py`) — separate deprecation workstream.

Note on the sanitizer threat-model scope: `sanitize_provider_error` scrubs credential-**bearing** URL forms (`user:pass@host`) + key patterns, not a bare `base_url` — correct for the per-request-BYOK-echoed-to-same-caller model (not cross-tenant).

## Related issues

Part of #1720 (retire `providers/llm/` → four-axis `LlmClient`). Wave C (DELETE) remains a separate human gate (irreversible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)