### PR TITLE
feat(kaizen): #1720 Wave B2 — delete-gate prep (barrel deprecation shims + name-registry extraction)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [Unreleased]
+
+### Deprecated
+
+- **Legacy provider re-exports from the `kaizen.nodes.ai` and `kaizen.providers`
+  barrels are deprecated (#1720).** The provider classes `LLMProvider`,
+  `AnthropicProvider`, `AzureAIFoundryProvider`, `DockerModelRunnerProvider`,
+  `GoogleGeminiProvider`, `MockProvider`, `OllamaProvider`, `OpenAIProvider`,
+  `PerplexityProvider` (plus the embedding providers `CohereProvider`,
+  `HuggingFaceProvider` on the `kaizen.providers` barrel) and the registry
+  accessors `PROVIDERS`, `get_provider`, `get_available_providers` are no longer
+  eagerly re-exported from these two barrels. They are now lazy PEP 562
+  `__getattr__` shims: importing any of them from the barrel (e.g.
+  `from kaizen.nodes.ai import OpenAIProvider` or
+  `from kaizen.providers import OpenAIProvider`) now emits a `DeprecationWarning`
+  and resolves the real class. A bare `import kaizen.nodes.ai` /
+  `import kaizen.providers` does **not** warn — only attribute access does.
+  Migrate to the canonical module imports: provider classes from
+  `kaizen.providers.llm.<mod>` (e.g. `from kaizen.providers.llm.openai import
+OpenAIProvider`) and `kaizen.providers.embedding.<mod>`, the `LLMProvider`
+  base from `kaizen.providers.base`, and the registry accessors from
+  `kaizen.providers.registry`. The symbols remain in each barrel's `__all__`
+  (the public contract is unchanged — only the access path warns). Removal is
+  scheduled for Wave-C of #1720.
+
 ## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
 
 ### Fixed
@@ -9,7 +34,7 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 - **`SelfCorrectingRAGNode` crashed or looped on ill-formed LLM confidence
   (#1755).** Post-2.33.0 the RAG advanced-node parsers consume real LLM output,
   so `_parse_verification_response` sits on a live path. It validated field
-  *presence* only: a `confidence` returned as a string raised an uncaught
+  _presence_ only: a `confidence` returned as a string raised an uncaught
   `TypeError` at the numeric gate in `run()`, and a `NaN` confidence
   (`json.loads` accepts the bare `NaN` literal) never met the gate — forcing the
   self-correction loop to run to `max_corrections` every time. Every score field

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/__init__.py
@@ -1,18 +1,69 @@
 """AI and ML nodes for the Kailash SDK."""
 
-# Import A2A communication nodes
-# Import from canonical provider locations (SPEC-02)
-from kaizen.providers.base import LLMProvider
-from kaizen.providers.llm.anthropic import AnthropicProvider
-from kaizen.providers.llm.azure import AzureAIFoundryProvider
-from kaizen.providers.llm.docker import DockerModelRunnerProvider
-from kaizen.providers.llm.google import GoogleGeminiProvider
-from kaizen.providers.llm.mock import MockProvider
-from kaizen.providers.llm.ollama import OllamaProvider
-from kaizen.providers.llm.openai import OpenAIProvider
-from kaizen.providers.llm.perplexity import PerplexityProvider
-from kaizen.providers.registry import PROVIDERS, get_available_providers, get_provider
+import importlib
+import warnings
+from typing import TYPE_CHECKING
 
+# ---------------------------------------------------------------------------
+# Legacy provider re-exports — deprecated (#1720; removed in Wave-C).
+#
+# These provider classes and registry accessors used to be eagerly re-exported
+# here from their canonical ``kaizen.providers.*`` locations (SPEC-02). They are
+# now lazy DeprecationWarning shims (PEP 562 ``__getattr__``): attribute ACCESS
+# warns and resolves the real symbol, while a bare ``import kaizen.nodes.ai``
+# does NOT warn. Import providers from ``kaizen.providers.llm.<mod>`` /
+# ``kaizen.providers.registry`` (or the ``kaizen.providers`` barrel) instead.
+# ---------------------------------------------------------------------------
+_LEGACY_PROVIDER_MODULES: dict[str, str] = {
+    "LLMProvider": "kaizen.providers.base",
+    "AnthropicProvider": "kaizen.providers.llm.anthropic",
+    "AzureAIFoundryProvider": "kaizen.providers.llm.azure",
+    "DockerModelRunnerProvider": "kaizen.providers.llm.docker",
+    "GoogleGeminiProvider": "kaizen.providers.llm.google",
+    "MockProvider": "kaizen.providers.llm.mock",
+    "OllamaProvider": "kaizen.providers.llm.ollama",
+    "OpenAIProvider": "kaizen.providers.llm.openai",
+    "PerplexityProvider": "kaizen.providers.llm.perplexity",
+    "PROVIDERS": "kaizen.providers.registry",
+    "get_available_providers": "kaizen.providers.registry",
+    "get_provider": "kaizen.providers.registry",
+}
+
+if TYPE_CHECKING:
+    # Analyzer-only imports so pyright / CodeQL py/undefined-export / Sphinx
+    # autodoc still resolve the legacy names kept in ``__all__`` below.
+    from kaizen.providers.base import LLMProvider
+    from kaizen.providers.llm.anthropic import AnthropicProvider
+    from kaizen.providers.llm.azure import AzureAIFoundryProvider
+    from kaizen.providers.llm.docker import DockerModelRunnerProvider
+    from kaizen.providers.llm.google import GoogleGeminiProvider
+    from kaizen.providers.llm.mock import MockProvider
+    from kaizen.providers.llm.ollama import OllamaProvider
+    from kaizen.providers.llm.openai import OpenAIProvider
+    from kaizen.providers.llm.perplexity import PerplexityProvider
+    from kaizen.providers.registry import (
+        PROVIDERS,
+        get_available_providers,
+        get_provider,
+    )
+
+
+def __getattr__(name: str) -> object:
+    """Lazily resolve deprecated legacy provider re-exports (PEP 562)."""
+    module_path = _LEGACY_PROVIDER_MODULES.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    warnings.warn(
+        f"Importing {name} from {__name__} is deprecated and will be removed "
+        f"in a future release (#1720); import from {module_path} instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    module = importlib.import_module(module_path)
+    return getattr(module, name)
+
+
+# Import A2A communication nodes
 from .a2a import A2AAgentNode, A2ACoordinatorNode, SharedMemoryPoolNode
 from .agents import ChatAgent, FunctionCallingAgent, PlanningAgent, RetrievalAgent
 from .embedding_generator import EmbeddingGeneratorNode

--- a/packages/kailash-kaizen/src/kaizen/production/metrics.py
+++ b/packages/kailash-kaizen/src/kaizen/production/metrics.py
@@ -47,7 +47,7 @@ from prometheus_client import Counter as PromCounter
 from prometheus_client import Histogram as PromHistogram
 from prometheus_client import generate_latest
 
-from kaizen.providers.registry import _MODEL_PREFIX_MAP, PROVIDERS
+from kaizen.providers.provider_names import MODEL_PREFIX_MAP, PROVIDER_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +84,11 @@ _DEFAULT_DURATION_BUCKETS: Sequence[float] = (
     60.0,
 )
 
-# Canonical bounded provider enum — reuses the SAME registry the provider
-# resolver uses (kaizen.providers.registry.PROVIDERS) so this module carries
-# no parallel provider-name list.
-_BOUNDED_PROVIDERS = frozenset(PROVIDERS.keys())
+# Canonical bounded provider enum — reuses the SAME pure-data name registry
+# the provider resolver is built on (kaizen.providers.provider_names) so this
+# pure-Prometheus module carries no parallel provider-name list AND does not
+# transitively eager-load any provider class.
+_BOUNDED_PROVIDERS = PROVIDER_NAMES
 
 
 def _bound_provider_label(provider: str) -> str:
@@ -108,15 +109,16 @@ def _bound_model_label(model: str) -> str:
     """Bound the ``model`` label to a known model-family prefix.
 
     Reuses the canonical model-prefix -> provider-family table from
-    ``kaizen.providers.registry`` (the same structural mapping the provider
-    resolver uses) so this module carries no parallel model-family list.
-    Arbitrary/unknown model strings — and raw per-release model identifiers
-    that would otherwise be unbounded cardinality — collapse to ``_other``.
+    ``kaizen.providers.provider_names`` (the same structural mapping the
+    provider resolver is built on) so this module carries no parallel
+    model-family list. Arbitrary/unknown model strings — and raw per-release
+    model identifiers that would otherwise be unbounded cardinality — collapse
+    to ``_other``.
     """
     if not model:
         return _OTHER_LABEL
     normalized = model.strip().lower()
-    for prefixes, family in _MODEL_PREFIX_MAP:
+    for prefixes, family in MODEL_PREFIX_MAP:
         if normalized.startswith(prefixes):
             return family
     return _OTHER_LABEL

--- a/packages/kailash-kaizen/src/kaizen/providers/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/__init__.py
@@ -16,15 +16,16 @@ Legacy Ollama-specific providers (OllamaProvider from the older
 # Base classes and types
 # ---------------------------------------------------------------------------
 
+import importlib
+import warnings
+from typing import TYPE_CHECKING
+
 from kaizen.providers.base import (
     BaseAIProvider,
     EmbeddingProvider,
-    LLMProvider,
     UnifiedAIProvider,
 )
 from kaizen.providers.cost import CostConfig, CostTracker, ModelPricing
-from kaizen.providers.embedding.cohere import CohereProvider
-from kaizen.providers.embedding.huggingface import HuggingFaceProvider
 from kaizen.providers.errors import (
     AuthenticationError,
     CapabilityNotSupportedError,
@@ -34,15 +35,6 @@ from kaizen.providers.errors import (
     RateLimitError,
     UnknownProviderError,
 )
-from kaizen.providers.llm.anthropic import AnthropicProvider
-from kaizen.providers.llm.azure import AzureAIFoundryProvider
-from kaizen.providers.llm.docker import DockerModelRunnerProvider
-from kaizen.providers.llm.google import GoogleGeminiProvider
-from kaizen.providers.llm.mock import MockProvider
-from kaizen.providers.llm.ollama import OllamaProvider
-from kaizen.providers.llm.openai import OpenAIProvider
-from kaizen.providers.llm.perplexity import PerplexityProvider
-from kaizen.providers.registry import PROVIDERS, get_available_providers, get_provider
 from kaizen.providers.types import (
     ChatResponse,
     Message,
@@ -51,6 +43,72 @@ from kaizen.providers.types import (
     TokenUsage,
     ToolCall,
 )
+
+# ---------------------------------------------------------------------------
+# Legacy provider re-exports — deprecated (#1720; removed in Wave-C).
+#
+# The provider classes and registry accessors below used to be eagerly
+# re-exported here from their canonical ``kaizen.providers.*`` submodules
+# (SPEC-02). They are now lazy DeprecationWarning shims (PEP 562
+# ``__getattr__``): attribute ACCESS warns and resolves the real symbol, while
+# a bare ``import kaizen.providers`` does NOT warn. Import providers from their
+# canonical modules (``kaizen.providers.llm.<mod>``,
+# ``kaizen.providers.embedding.<mod>``, ``kaizen.providers.base`` for the
+# ``LLMProvider`` base, ``kaizen.providers.registry`` for the accessors)
+# instead.
+# ---------------------------------------------------------------------------
+_LEGACY_PROVIDER_MODULES: dict[str, str] = {
+    "LLMProvider": "kaizen.providers.base",
+    "OpenAIProvider": "kaizen.providers.llm.openai",
+    "AnthropicProvider": "kaizen.providers.llm.anthropic",
+    "GoogleGeminiProvider": "kaizen.providers.llm.google",
+    "OllamaProvider": "kaizen.providers.llm.ollama",
+    "DockerModelRunnerProvider": "kaizen.providers.llm.docker",
+    "AzureAIFoundryProvider": "kaizen.providers.llm.azure",
+    "PerplexityProvider": "kaizen.providers.llm.perplexity",
+    "MockProvider": "kaizen.providers.llm.mock",
+    "CohereProvider": "kaizen.providers.embedding.cohere",
+    "HuggingFaceProvider": "kaizen.providers.embedding.huggingface",
+    "PROVIDERS": "kaizen.providers.registry",
+    "get_provider": "kaizen.providers.registry",
+    "get_available_providers": "kaizen.providers.registry",
+}
+
+if TYPE_CHECKING:
+    # Analyzer-only imports so pyright / CodeQL py/undefined-export / Sphinx
+    # autodoc still resolve the legacy names kept in ``__all__`` below.
+    from kaizen.providers.base import LLMProvider
+    from kaizen.providers.embedding.cohere import CohereProvider
+    from kaizen.providers.embedding.huggingface import HuggingFaceProvider
+    from kaizen.providers.llm.anthropic import AnthropicProvider
+    from kaizen.providers.llm.azure import AzureAIFoundryProvider
+    from kaizen.providers.llm.docker import DockerModelRunnerProvider
+    from kaizen.providers.llm.google import GoogleGeminiProvider
+    from kaizen.providers.llm.mock import MockProvider
+    from kaizen.providers.llm.ollama import OllamaProvider
+    from kaizen.providers.llm.openai import OpenAIProvider
+    from kaizen.providers.llm.perplexity import PerplexityProvider
+    from kaizen.providers.registry import (
+        PROVIDERS,
+        get_available_providers,
+        get_provider,
+    )
+
+
+def __getattr__(name: str) -> object:
+    """Lazily resolve deprecated legacy provider re-exports (PEP 562)."""
+    module_path = _LEGACY_PROVIDER_MODULES.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    warnings.warn(
+        f"Importing {name} from {__name__} is deprecated and will be removed "
+        f"in a future release (#1720); import from {module_path} instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    module = importlib.import_module(module_path)
+    return getattr(module, name)
+
 
 # ---------------------------------------------------------------------------
 # Provider implementations

--- a/packages/kailash-kaizen/src/kaizen/providers/provider_names.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/provider_names.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-data provider NAME registry — zero provider-class imports.
+
+This module carries ONLY declared literals: the canonical set of provider
+NAMES and the model-name-prefix -> provider-family dispatch table. It imports
+NO provider classes (``kaizen.providers.llm.*`` / ``kaizen.providers.base`` /
+``kaizen.providers.registry``), so a pure-Prometheus consumer such as
+``kaizen.production.metrics`` can bound its ``model``/``provider`` labels
+against these names WITHOUT eager-loading every provider class transitively.
+
+``kaizen.providers.registry`` imports the prefix map from here (single
+source of truth) and builds the name -> CLASS ``PROVIDERS`` dict on top of it;
+this module is the name-only half that has no class dependency.
+
+The prefix dispatch is declared structural data (config-branching, permitted
+by ``agent-reasoning.md`` exception 5), NOT semantic classification of user
+intent — it is a pure string-prefix table extended by new providers, never a
+keyword classifier taught to an LLM.
+"""
+
+from __future__ import annotations
+
+# Canonical set of provider NAMES. MUST stay consistent with the keys of
+# ``kaizen.providers.registry.PROVIDERS`` (the name -> class dict); that module
+# asserts equality at load as a drift tripwire.
+PROVIDER_NAMES: frozenset[str] = frozenset(
+    {
+        "ollama",
+        "openai",
+        "anthropic",
+        "cohere",
+        "huggingface",
+        "mock",
+        "azure",
+        "azure_openai",
+        "azure_ai_foundry",
+        "docker",
+        "google",
+        "gemini",
+        "perplexity",
+        "pplx",
+    }
+)
+
+
+# SPEC-02 §3.1 — model-name prefix dispatch.
+#
+# This is a declared structural mapping, NOT a classification of user intent.
+# Every tuple on the left is a set of model-id prefixes owned by the provider
+# on the right. New providers extend this table; the resolver's prefix scan
+# has no keyword reasoning.
+MODEL_PREFIX_MAP: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("gpt-", "o1-", "o3-", "o4-", "o1", "o3", "o4-mini", "ft:gpt"), "openai"),
+    (("claude-",), "anthropic"),
+    (("gemini-",), "google"),
+    (
+        (
+            "llama",
+            "mistral",
+            "mixtral",
+            "qwen",
+            "phi-",
+            "phi3",
+            "phi4",
+            "codellama",
+            "deepseek",
+        ),
+        "ollama",
+    ),
+    (("ai/",), "docker"),
+    (
+        (
+            "sonar",
+            "sonar-",
+        ),
+        "perplexity",
+    ),
+    (("mock-", "mock"), "mock"),
+)
+
+# Backward-compatible alias for the underscore name used by
+# ``kaizen.providers.registry`` (and its unit tests) before the extraction.
+_MODEL_PREFIX_MAP = MODEL_PREFIX_MAP

--- a/packages/kailash-kaizen/src/kaizen/providers/registry.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/registry.py
@@ -33,6 +33,11 @@ from kaizen.providers.llm.mock import MockProvider
 from kaizen.providers.llm.ollama import OllamaProvider
 from kaizen.providers.llm.openai import OpenAIProvider
 from kaizen.providers.llm.perplexity import PerplexityProvider
+from kaizen.providers.provider_names import (
+    _MODEL_PREFIX_MAP,
+    MODEL_PREFIX_MAP,
+    PROVIDER_NAMES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,40 +74,22 @@ PROVIDERS: dict[str, type | str] = {
 }
 
 
-# SPEC-02 §3.1 — model-name prefix dispatch.
-#
-# This is a declared structural mapping, NOT a classification of user intent.
-# Every tuple on the left is a set of model-id prefixes owned by the provider
-# on the right. New providers extend this table; the function below is a
-# pure prefix scan with no keyword reasoning.
-_MODEL_PREFIX_MAP: tuple[tuple[tuple[str, ...], str], ...] = (
-    (("gpt-", "o1-", "o3-", "o4-", "o1", "o3", "o4-mini", "ft:gpt"), "openai"),
-    (("claude-",), "anthropic"),
-    (("gemini-",), "google"),
-    (
-        (
-            "llama",
-            "mistral",
-            "mixtral",
-            "qwen",
-            "phi-",
-            "phi3",
-            "phi4",
-            "codellama",
-            "deepseek",
-        ),
-        "ollama",
-    ),
-    (("ai/",), "docker"),
-    (
-        (
-            "sonar",
-            "sonar-",
-        ),
-        "perplexity",
-    ),
-    (("mock-", "mock"), "mock"),
+# Drift tripwire: the pure-data name registry (kaizen.providers.provider_names)
+# and this name -> class dict MUST enumerate the SAME provider names. A plain
+# assert over declared config data (NOT agent reasoning) — if a provider is
+# added to one and not the other, fail loudly at import instead of silently
+# diverging the metrics label bound (which reuses PROVIDER_NAMES) from the
+# resolver's actual class map.
+assert set(PROVIDERS.keys()) == PROVIDER_NAMES, (
+    "provider name drift: kaizen.providers.registry.PROVIDERS keys "
+    f"{sorted(PROVIDERS.keys())} != kaizen.providers.provider_names.PROVIDER_NAMES "
+    f"{sorted(PROVIDER_NAMES)}"
 )
+
+
+# SPEC-02 §3.1 model-name prefix dispatch (_MODEL_PREFIX_MAP / MODEL_PREFIX_MAP)
+# is the single source in kaizen.providers.provider_names, imported above. It
+# is a declared structural mapping, NOT a classification of user intent.
 
 
 def _resolve_provider_class(name: str) -> type:

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b2_metrics_registry_decoupled.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b2_metrics_registry_decoupled.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B2 integration invariant — metrics is decoupled from the legacy
+provider registry AT RUNTIME.
+
+This is a WAVE-level property that holds ONLY with BOTH B2 shards applied:
+
+* **B2b** repointed ``production/metrics.py`` off ``providers.registry`` onto the
+  pure-data ``providers.provider_names`` module (source-level decoupling), AND
+* **B2a** converted the ``nodes/ai/__init__`` + ``providers/__init__`` barrels to
+  lazy PEP 562 ``__getattr__`` shims, so ``import kaizen`` no longer eager-loads
+  the registry (which the barrels previously imported at module top).
+
+Together they make ``import kaizen.production.metrics`` load NEITHER the legacy
+``providers.registry`` NOR any ``providers.llm.*`` provider class. This matters
+for the Wave-C delete: once the registry / ``providers/llm/`` are deleted,
+``metrics.py`` (a pure-Prometheus module) must not have dragged them in.
+
+Asserted in a FRESH subprocess so the result is order-independent — an unrelated
+test importing a provider earlier in the same interpreter cannot mask a
+regression here (rules/testing.md § deterministic + isolated).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# Probe: import ONLY metrics in a clean interpreter, then inspect sys.modules.
+_PROBE = """
+import kaizen.production.metrics
+import sys
+registry = "kaizen.providers.registry" in sys.modules
+llm_classes = sorted(k for k in sys.modules if k.startswith("kaizen.providers.llm."))
+print("REGISTRY", registry)
+print("LLM", ",".join(llm_classes))
+"""
+
+
+@pytest.mark.regression
+def test_importing_metrics_does_not_load_registry_or_provider_classes():
+    """`import kaizen.production.metrics` must not pull in the legacy registry
+    or any provider class (Wave-C delete-safety invariant)."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert (
+        proc.returncode == 0
+    ), f"probe crashed:\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    out = proc.stdout
+    assert "REGISTRY False" in out, (
+        "importing kaizen.production.metrics loaded kaizen.providers.registry — "
+        "the B2 metrics/registry decoupling has regressed (a barrel or an "
+        f"eager import re-coupled them).\nprobe stdout:\n{out}"
+    )
+    assert "LLM \n" in out or out.rstrip().endswith("LLM"), (
+        "importing kaizen.production.metrics loaded a providers.llm.* provider "
+        f"class — decoupling regressed.\nprobe stdout:\n{out}"
+    )
+
+
+@pytest.mark.regression
+def test_bare_import_kaizen_does_not_eager_load_registry():
+    """Bare `import kaizen` must not eager-load the registry (B2a lazified the
+    barrels that previously imported it at module top)."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import kaizen, sys; print('REGISTRY', 'kaizen.providers.registry' in sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"probe crashed: {proc.stderr!r}"
+    assert "REGISTRY False" in proc.stdout, (
+        "bare `import kaizen` eager-loaded kaizen.providers.registry — the B2a "
+        f"barrel lazification has regressed.\nprobe stdout:\n{proc.stdout}"
+    )

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b2a_barrel_deprecation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b2a_barrel_deprecation.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 Wave-B2a — barrel legacy-provider deprecation shims (behavioral).
+
+The `kaizen.nodes.ai` and `kaizen.providers` barrels used to eagerly re-export
+the legacy provider classes + registry accessors from their canonical
+`kaizen.providers.*` locations. Wave-B2a converts those legacy re-exports to
+lazy PEP 562 ``__getattr__`` DeprecationWarning shims (zero-tolerance Rule 6a:
+public-API removal needs a deprecation cycle; this STARTS the clock — Wave-C
+removes them). The public contract is unchanged: every legacy name stays in
+``__all__`` and resolves to the same real symbol; only the barrel access PATH
+now warns.
+
+This pins the behavioral contract so a refactor cannot silently drop the
+warning, break identity, or eagerly re-inline the symbols:
+
+* Accessing a legacy provider (e.g. ``OpenAIProvider``) via either barrel emits
+  a ``DeprecationWarning`` AND returns the real class (identity-equal to the
+  canonical-module symbol).
+* The registry accessors (``PROVIDERS`` / ``get_provider`` /
+  ``get_available_providers``) warn + resolve the same way.
+* A NON-legacy eager export (``EmbeddingGeneratorNode``, ``BaseAIProvider``)
+  does NOT warn — only the shimmed legacy names do.
+* A bare ``import`` of the barrel does NOT warn (only attribute access does).
+* Every legacy name remains in each barrel's ``__all__``.
+* An unknown attribute raises ``AttributeError`` (no silent stub).
+
+Tier-1 offline + deterministic (no network, no live keys). Behavioral asserts
+per ``rules/testing.md`` § "Behavioral Regression Tests Over Source-Grep".
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+import kaizen.nodes.ai as nodes_ai
+import kaizen.providers as providers
+
+pytestmark = pytest.mark.regression
+
+
+# Legacy name -> canonical module, per barrel.
+_NODES_AI_LEGACY = {
+    "LLMProvider": "kaizen.providers.base",
+    "AnthropicProvider": "kaizen.providers.llm.anthropic",
+    "AzureAIFoundryProvider": "kaizen.providers.llm.azure",
+    "DockerModelRunnerProvider": "kaizen.providers.llm.docker",
+    "GoogleGeminiProvider": "kaizen.providers.llm.google",
+    "MockProvider": "kaizen.providers.llm.mock",
+    "OllamaProvider": "kaizen.providers.llm.ollama",
+    "OpenAIProvider": "kaizen.providers.llm.openai",
+    "PerplexityProvider": "kaizen.providers.llm.perplexity",
+    "PROVIDERS": "kaizen.providers.registry",
+    "get_provider": "kaizen.providers.registry",
+    "get_available_providers": "kaizen.providers.registry",
+}
+
+_PROVIDERS_LEGACY = {
+    **_NODES_AI_LEGACY,
+    "CohereProvider": "kaizen.providers.embedding.cohere",
+    "HuggingFaceProvider": "kaizen.providers.embedding.huggingface",
+}
+
+# The test harness (tests/conftest.py, module scope) deliberately rebinds
+# ``kaizen.providers.MockProvider = KaizenMockProvider`` for unit tests, so under
+# the harness ``MockProvider`` is a REAL attribute on the ``kaizen.providers``
+# module dict and the PEP 562 shim never fires for it (nor does it resolve to the
+# canonical class). That override is a harness artifact, not a shim defect — the
+# shim warns + resolves correctly in a clean interpreter. The ``nodes.ai`` barrel
+# is NOT patched by conftest, so ``MockProvider`` shim behavior is still fully
+# covered there; here it is excluded ONLY from the ``kaizen.providers``
+# warn+resolve parametrization (it remains in the ``__all__`` contract check).
+_PROVIDERS_CONFTEST_PATCHED = {"MockProvider"}
+_PROVIDERS_LEGACY_WARNS = {
+    k: v for k, v in _PROVIDERS_LEGACY.items() if k not in _PROVIDERS_CONFTEST_PATCHED
+}
+
+
+def _canonical(name: str, module_path: str) -> object:
+    return getattr(importlib.import_module(module_path), name)
+
+
+# --------------------------------------------------------------------------
+# (a) nodes.ai — access warns AND returns the real class (identity-equal).
+# --------------------------------------------------------------------------
+
+
+def test_nodes_ai_openai_provider_warns_and_resolves_real_class() -> None:
+    with pytest.warns(DeprecationWarning, match=r"kaizen\.nodes\.ai.*#1720"):
+        resolved = nodes_ai.OpenAIProvider
+
+    from kaizen.providers.llm.openai import OpenAIProvider as Canonical
+
+    assert resolved is Canonical
+
+
+@pytest.mark.parametrize(("name", "module_path"), sorted(_NODES_AI_LEGACY.items()))
+def test_nodes_ai_every_legacy_name_warns_and_resolves(
+    name: str, module_path: str
+) -> None:
+    with pytest.warns(DeprecationWarning, match=r"deprecated.*#1720"):
+        resolved = getattr(nodes_ai, name)
+    assert resolved is _canonical(name, module_path)
+
+
+# --------------------------------------------------------------------------
+# (b) providers — access warns AND returns the real class (identity-equal).
+# --------------------------------------------------------------------------
+
+
+def test_providers_openai_provider_warns_and_resolves_real_class() -> None:
+    with pytest.warns(DeprecationWarning, match=r"kaizen\.providers.*#1720"):
+        resolved = providers.OpenAIProvider
+
+    from kaizen.providers.llm.openai import OpenAIProvider as Canonical
+
+    assert resolved is Canonical
+
+
+@pytest.mark.parametrize(
+    ("name", "module_path"), sorted(_PROVIDERS_LEGACY_WARNS.items())
+)
+def test_providers_every_legacy_name_warns_and_resolves(
+    name: str, module_path: str
+) -> None:
+    with pytest.warns(DeprecationWarning, match=r"deprecated.*#1720"):
+        resolved = getattr(providers, name)
+    assert resolved is _canonical(name, module_path)
+
+
+# --------------------------------------------------------------------------
+# (c) NON-legacy eager exports do NOT warn.
+# --------------------------------------------------------------------------
+
+
+def test_nodes_ai_non_legacy_export_does_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        # Eagerly-imported node — accessing it must not touch __getattr__.
+        assert nodes_ai.EmbeddingGeneratorNode is not None
+
+
+def test_providers_non_legacy_export_does_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        # BaseAIProvider stays eager (only LLMProvider was shimmed).
+        assert providers.BaseAIProvider is not None
+        assert providers.EmbeddingProvider is not None
+
+
+# --------------------------------------------------------------------------
+# (d) Every legacy name stays in __all__ (public contract unchanged).
+# --------------------------------------------------------------------------
+
+
+def test_nodes_ai_all_still_contains_every_legacy_name() -> None:
+    missing = [n for n in _NODES_AI_LEGACY if n not in nodes_ai.__all__]
+    assert not missing, f"legacy names dropped from kaizen.nodes.ai.__all__: {missing}"
+
+
+def test_providers_all_still_contains_every_legacy_name() -> None:
+    missing = [n for n in _PROVIDERS_LEGACY if n not in providers.__all__]
+    assert not missing, f"legacy names dropped from kaizen.providers.__all__: {missing}"
+
+
+# --------------------------------------------------------------------------
+# (e) Registry accessors warn + resolve (explicit coverage of the (e) item).
+# --------------------------------------------------------------------------
+
+
+def test_nodes_ai_registry_accessors_warn_and_resolve() -> None:
+    from kaizen.providers.registry import (
+        PROVIDERS as CanonPROVIDERS,
+        get_provider as canon_get_provider,
+    )
+
+    with pytest.warns(DeprecationWarning, match=r"#1720"):
+        assert nodes_ai.PROVIDERS is CanonPROVIDERS
+    with pytest.warns(DeprecationWarning, match=r"#1720"):
+        assert nodes_ai.get_provider is canon_get_provider
+
+
+def test_providers_registry_accessors_warn_and_resolve() -> None:
+    from kaizen.providers.registry import (
+        PROVIDERS as CanonPROVIDERS,
+        get_provider as canon_get_provider,
+    )
+
+    with pytest.warns(DeprecationWarning, match=r"#1720"):
+        assert providers.PROVIDERS is CanonPROVIDERS
+    with pytest.warns(DeprecationWarning, match=r"#1720"):
+        assert providers.get_provider is canon_get_provider
+
+
+# --------------------------------------------------------------------------
+# Robustness: unknown attribute raises AttributeError (no silent stub).
+# --------------------------------------------------------------------------
+
+
+def test_nodes_ai_unknown_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        _ = nodes_ai.DefinitelyNotAProvider
+
+
+def test_providers_unknown_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        _ = providers.DefinitelyNotAProvider

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b2b_name_registry.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b2b_name_registry.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression pins for #1720 Wave B2b — pure-data provider NAME registry.
+
+Wave B2b extracted the provider NAME set and the model-prefix dispatch table
+off ``kaizen.providers.registry`` (which eager-loads every provider CLASS) into
+a pure-data module ``kaizen.providers.provider_names``, so that
+``kaizen.production.metrics`` — a pure-Prometheus module — bounds its
+``model``/``provider`` labels against the pure-data names WITHOUT its OWN source
+importing ``kaizen.providers.registry`` (and hence without SOURCE-level coupling
+to the provider classes).
+
+These tests pin the invariants the extraction actually guarantees:
+
+(a) ``PROVIDER_NAMES`` stays consistent with the ``PROVIDERS`` class-map keys
+    (the drift tripwire the extraction depends on).
+(b) ``MODEL_PREFIX_MAP`` still maps the known family prefixes it always did.
+(c) SOURCE-LEVEL zero-coupling — AST-parse the two touched files and assert
+    (i) ``provider_names.py`` imports NOTHING from ``kaizen.providers.llm.*`` /
+        ``kaizen.providers.base`` / ``kaizen.providers.registry`` (pure
+        literals — the CRITICAL requirement), AND
+    (ii) ``metrics.py`` no longer imports ``kaizen.providers.registry`` at all.
+    Plus an in-process check that ``provider_names`` exposes no provider class.
+(d) ``metrics``'s label-bounding functions behave identically post-extraction.
+
+RUNTIME ``sys.modules`` decoupling (asserting ``kaizen.providers.registry`` is
+absent after importing ``metrics``/``provider_names`` in a fresh subprocess) is
+DELIBERATELY NOT asserted here: it is NOT achievable by this extraction, because
+the ROOT package ``kaizen/__init__.py`` eager-imports ``kaizen.nodes.ai``, whose
+``__init__`` eager-imports ``kaizen.providers.registry`` + ``llm.openai`` — so
+``import kaizen`` (which precedes ANY ``kaizen.*`` import) already loads the
+registry regardless of this module's imports. Achieving the runtime decoupling
+requires lazifying ``kaizen/__init__.py`` (the whole top-level public API), a
+separate, far larger change. This test pins the source-level contract the
+extraction owns; the runtime-graph blocker is a distinct concern surfaced to the
+plan.
+
+All offline — no network, no model calls.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# (a) PROVIDER_NAMES stays consistent with the PROVIDERS class-map keys.
+# ---------------------------------------------------------------------------
+def test_provider_names_matches_registry_provider_keys():
+    """The pure-data name set equals the resolver's name -> class dict keys."""
+    from kaizen.providers.provider_names import PROVIDER_NAMES
+    from kaizen.providers.registry import PROVIDERS
+
+    assert PROVIDER_NAMES == set(PROVIDERS.keys())
+
+
+def test_provider_names_is_the_expected_fourteen():
+    """Pin the exact 14-name set so an accidental add/drop fails loudly."""
+    from kaizen.providers.provider_names import PROVIDER_NAMES
+
+    assert PROVIDER_NAMES == frozenset(
+        {
+            "ollama",
+            "openai",
+            "anthropic",
+            "cohere",
+            "huggingface",
+            "mock",
+            "azure",
+            "azure_openai",
+            "azure_ai_foundry",
+            "docker",
+            "google",
+            "gemini",
+            "perplexity",
+            "pplx",
+        }
+    )
+    assert len(PROVIDER_NAMES) == 14
+
+
+# ---------------------------------------------------------------------------
+# (b) MODEL_PREFIX_MAP still maps the known family prefixes.
+# ---------------------------------------------------------------------------
+def _family_for_prefix(prefix_map, model: str) -> str | None:
+    normalized = model.strip().lower()
+    for prefixes, family in prefix_map:
+        if normalized.startswith(prefixes):
+            return family
+    return None
+
+
+def test_model_prefix_map_known_mappings():
+    """gpt- -> openai, claude- -> anthropic, gemini- -> google (and more)."""
+    from kaizen.providers.provider_names import MODEL_PREFIX_MAP
+
+    assert _family_for_prefix(MODEL_PREFIX_MAP, "gpt-4o") == "openai"
+    assert _family_for_prefix(MODEL_PREFIX_MAP, "claude-3-opus") == "anthropic"
+    assert _family_for_prefix(MODEL_PREFIX_MAP, "gemini-2.5-flash") == "google"
+    assert _family_for_prefix(MODEL_PREFIX_MAP, "llama3") == "ollama"
+    assert _family_for_prefix(MODEL_PREFIX_MAP, "totally-unknown-model") is None
+
+
+def test_model_prefix_map_underscore_alias_is_same_object():
+    """The backward-compat _MODEL_PREFIX_MAP alias IS the public map."""
+    from kaizen.providers import provider_names
+
+    assert provider_names._MODEL_PREFIX_MAP is provider_names.MODEL_PREFIX_MAP
+
+
+def test_registry_underscore_alias_matches_pure_data_source():
+    """registry.py re-exports the same prefix map (single source of truth)."""
+    from kaizen.providers import provider_names, registry
+
+    assert registry._MODEL_PREFIX_MAP is provider_names.MODEL_PREFIX_MAP
+
+
+# ---------------------------------------------------------------------------
+# (c) SOURCE-LEVEL zero-coupling contract (AST import audit).
+# ---------------------------------------------------------------------------
+_FORBIDDEN_PROVIDER_NAMES_IMPORT_PREFIXES = (
+    "kaizen.providers.llm",
+    "kaizen.providers.base",
+    "kaizen.providers.registry",
+)
+
+
+def _module_source_imports(module) -> set[str]:
+    """Return the set of dotted module names imported by ``module``'s SOURCE.
+
+    Parses the file (not the runtime object) so ``from a.b import c`` yields
+    ``a.b`` and ``import a.b`` yields ``a.b``.
+    """
+    source = Path(module.__file__).read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                imported.add(node.module)
+    return imported
+
+
+def test_provider_names_source_has_zero_provider_class_imports():
+    """CRITICAL: provider_names.py imports nothing from llm.*/base/registry."""
+    from kaizen.providers import provider_names
+
+    imported = _module_source_imports(provider_names)
+    offenders = {
+        name
+        for name in imported
+        if name.startswith(_FORBIDDEN_PROVIDER_NAMES_IMPORT_PREFIXES)
+    }
+    assert not offenders, (
+        "provider_names.py must be pure literals (zero provider-class imports); "
+        f"found forbidden imports: {sorted(offenders)}"
+    )
+
+
+def test_metrics_source_no_longer_imports_registry():
+    """metrics.py no longer imports kaizen.providers.registry at the source."""
+    import kaizen.production.metrics as metrics
+
+    imported = _module_source_imports(metrics)
+    assert "kaizen.providers.registry" not in imported, (
+        "metrics.py must not import kaizen.providers.registry; found it in "
+        f"{sorted(i for i in imported if i.startswith('kaizen.providers'))}"
+    )
+    # ...and it DOES source the pure-data name registry instead.
+    assert "kaizen.providers.provider_names" in imported
+
+
+def test_provider_names_module_exposes_no_provider_class():
+    """No attribute on the pure-data module is a provider class."""
+    from kaizen.providers import provider_names
+    from kaizen.providers.base import BaseProvider
+
+    for name in dir(provider_names):
+        value = getattr(provider_names, name)
+        assert not (
+            isinstance(value, type) and issubclass(value, BaseProvider)
+        ), f"provider_names leaked a provider class via attribute {name!r}"
+
+
+# ---------------------------------------------------------------------------
+# (d) metrics label-bounding still behaves identically post-extraction.
+# ---------------------------------------------------------------------------
+def test_metrics_bound_provider_label_behaves_identically():
+    from kaizen.production.metrics import _OTHER_LABEL, _bound_provider_label
+
+    assert _bound_provider_label("openai") == "openai"
+    assert _bound_provider_label("  Anthropic ") == "anthropic"
+    assert _bound_provider_label("gemini") == "gemini"
+    assert _bound_provider_label("not-a-provider") == _OTHER_LABEL
+    assert _bound_provider_label("") == _OTHER_LABEL
+
+
+def test_metrics_bound_model_label_behaves_identically():
+    from kaizen.production.metrics import _OTHER_LABEL, _bound_model_label
+
+    assert _bound_model_label("gpt-4o") == "openai"
+    assert _bound_model_label("claude-3-opus-20240229") == "anthropic"
+    assert _bound_model_label("gemini-2.5-flash") == "google"
+    assert _bound_model_label("unknown-model-xyz") == _OTHER_LABEL
+    assert _bound_model_label("") == _OTHER_LABEL
+
+
+def test_bounded_providers_is_the_pure_data_name_set():
+    """metrics._BOUNDED_PROVIDERS is now the pure-data PROVIDER_NAMES."""
+    from kaizen.production.metrics import _BOUNDED_PROVIDERS
+    from kaizen.providers.provider_names import PROVIDER_NAMES
+
+    assert _BOUNDED_PROVIDERS is PROVIDER_NAMES


### PR DESCRIPTION
## What & why

Wave B2 of #1720 — makes the eventual Wave-C legacy DELETE safe and reviewable. Two disjoint-file parallel-worktree shards, integrated on `feat/1720-wave-b2`.

| Shard | Change |
|---|---|
| **B2a** | Convert the `nodes/ai/__init__` + `providers/__init__` barrels' legacy-provider re-exports (provider classes + `PROVIDERS`/`get_provider`/`get_available_providers`) to lazy PEP 562 `__getattr__` **DeprecationWarning shims** (`zero-tolerance` 6a — no hard drop; symbols stay in `__all__` + a `TYPE_CHECKING` block for static analysis). Non-legacy node exports stay eager. CHANGELOG migration entry added; **no version bump**. This starts the deprecation clock that *gates* the Wave-C removal timeline. |
| **B2b** | Extract the pure-data provider-name registry (`PROVIDER_NAMES` frozenset + `MODEL_PREFIX_MAP`) into a new `providers/provider_names.py` (zero provider-class imports); `registry.py` sources it single-source with a `assert set(PROVIDERS.keys()) == PROVIDER_NAMES` drift tripwire; `production/metrics.py` repointed off `providers.registry`. |

## Emergent win — runtime decoupling (both shards together)

Neither shard achieves it alone (B2b honestly flagged this from its isolated pre-B2a worktree), but **together**: `import kaizen.production.metrics` — and even bare `import kaizen` — no longer loads `providers.registry` or any `providers.llm.*` provider class. B2a's barrel lazification broke the eager chain; B2b removed metrics' own import. Pinned by a subprocess-based, order-independent integration invariant (`test_issue_1720_b2_metrics_registry_decoupled.py`). This is the Wave-C delete-safety property: `metrics.py` will survive the registry delete.

## Inter-wave redteam — CONVERGED (2 consecutive clean rounds)

reviewer + security-reviewer + closure-parity, errored-reviewer evidence gate honored. **Round-1: all three dimensions CLEAN, zero findings**; **round-2: CLEAN** (fresh adversarial re-verification on the unchanged tree — shim completeness 14↔14 / 12↔12, byte-identical `MODEL_PREFIX_MAP`, `import`-does-not-re-couple probes, static `__getattr__`-map security surface, metrics label-cardinality DoS guard preserved).

## Tests

- 3 new regression files (barrel-deprecation behavioral + name-registry AST/drift + metrics-decoupled subprocess invariant), all `@pytest.mark.regression`, offline.
- Integrated wave: 1694 passed; **14,739 collected** (collection gate exit 0); ruff clean.

## Deprecation-warning disposition

20 test files import legacy providers via the barrels → ~34 **non-fatal** `DeprecationWarnings` (the `filterwarnings` config has no `error`). These are the *intended* deprecation signal, emitted only by the legacy-provider **test** files that Wave C deletes/rewrites (`orphan-detection` Rule 4) — **Deferred to the Wave-C test sweep**, not premature-churned. Zero src files import via the warn path.

## Refined Wave-C residual (closure-verified)

After B2, the ONLY live-path coupling to the delete target (`providers/llm/` + `providers.registry`) is: **(A)** `llm_agent.py::_legacy_provider_chat` — the `azure_ai_foundry` legacy fallback (Decision-2A scope-out, intended) + **(B)** the barrels' own `_LEGACY_PROVIDER_MODULES` shim maps (which *are* the delete target). `metrics.py` is now decoupled; the ollama/docker embed fallback was confirmed **not** coupled (uses `import ollama` directly / raises).

## Related issues

Part of #1720. Wave C (DELETE `providers/llm/` + `registry.py`, except the azure_ai_foundry residual) remains a separate **irreversible human structural gate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)