### PR TITLE
release: kailash-kaizen 2.34.0 — #1720 LLM consolidation

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.34.0] — 2026-07-17 — #1720 LLM consolidation: live paths on four-axis `LlmClient`
+
+### Changed
+
+- **Live LLM chat and embedding paths now route through the four-axis `LlmClient`
+  instead of the legacy `providers/llm/` registry (#1720 Wave-B1, PR #1789).**
+  `LLMAgentNode._provider_llm_response`, `EmbeddingGeneratorNode._generate_provider_embedding`,
+  and `BaseAgent._simple_execute_async` were cut over from
+  `providers.registry.get_provider(...).chat/embed(...)` to
+  `resolve_deployment_for(...)` → `LlmClient.complete` / `LlmClient.embed` →
+  `to_legacy_shape`. The cutover is behavior-neutral, gated by an offline parity
+  harness across the dual-mappable provider matrix. `azure_ai_foundry`
+  intentionally remains on the legacy `.chat()` path (Decision-2A); every other
+  provider now runs on the consolidated four-axis client.
+- **`production/metrics.py` no longer imports `providers.registry` (#1720 Wave-B2b,
+  PR #1791).** The provider-name registry (`PROVIDERS` frozenset + model-prefix
+  map) was extracted to a registry-independent module (`providers/provider_names.py`),
+  decoupling the Prometheus metrics label-bounding (and a bare `import kaizen`)
+  from the legacy registry at runtime.
+
+### Added
+
+- **Four-axis embedding wires and the legacy-shape bridge (#1720 Waves 1–2/A).**
+  New `LlmClient` embedding wire protocols for cohere and HuggingFace
+  (`wire_protocols/cohere_embeddings.py`, `wire_protocols/huggingface_embeddings.py`);
+  a `to_legacy_shape` adapter (`llm/_legacy_shape.py`) reproducing the legacy
+  provider response envelope so the cutover is behavior-neutral; a shared
+  `resolve_deployment_for` deployment resolver (`llm/deployment_resolver.py`) with
+  azure / azure_openai mapping; and an offline `mock_transport` harness
+  (`llm/testing/mock_transport.py`) that drives the parity matrix without live
+  credentials. Existing chat wires (openai, bedrock, google, mistral, ollama,
+  HuggingFace inference, cohere generate) were extended to complete the
+  consolidated provider matrix.
+- **`LlmClient.embed` accepts a `timeout` kwarg** at parity with the legacy
+  embedding path, and applies `EmbedOptions.normalize` uniformly across every
+  embedding wire (previously a silent no-op on all wires except HuggingFace).
+
 ### Deprecated
 
 - **Legacy provider re-exports from the `kaizen.nodes.ai` and `kaizen.providers`
@@ -25,7 +62,24 @@ OpenAIProvider`) and `kaizen.providers.embedding.<mod>`, the `LLMProvider`
   base from `kaizen.providers.base`, and the registry accessors from
   `kaizen.providers.registry`. The symbols remain in each barrel's `__all__`
   (the public contract is unchanged — only the access path warns). Removal is
-  scheduled for Wave-C of #1720.
+  scheduled for Wave-C of #1720 (a following minor release, so these shims live
+  through ≥1 published minor cycle first).
+
+### Fixed
+
+- **Foundation and Wave-B1 red-team fixes (#1720).** (1) The legacy per-provider
+  `tool_choice` default is now stream-aware — the dual-run shadow threads the live
+  `streaming` mode so the four-axis streaming tool path reproduces legacy
+  `stream_chat`'s per-provider `"auto"`/`"required"` value. (2) `EmbedOptions.normalize`
+  now reaches the HuggingFace embed wire through `LlmClient.embed`. (3) BYOK
+  hardening: `resolve_deployment_for` validates a caller-supplied `api_key`
+  (control-char / CRLF / non-ASCII) at parity with `LlmClient.complete`, closing a
+  header-injection surface on the promoted live path. (4) The embedding cutover no
+  longer silently returns a mock embedding on an unresolvable credential provider —
+  the legacy loud raise is restored (the sanctioned mock path stays the explicit
+  `provider == "mock"` mode only). (5) Google `finish_reason` value-map parity
+  (`STOP`→`stop`, `MAX_TOKENS`→`length`, `SAFETY`→`content_filter`, tool→`tool_calls`)
+  is preserved on the four-axis google wire.
 
 ## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
 

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.33.1"
+version = "2.34.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.33.1"
+__version__ = "2.34.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Cuts **kailash-kaizen 2.34.0** — the first published minor carrying the #1720 LLM-provider consolidation (all code already merged + red-team-converged on main via PRs #1789/#1791).

- **Changed:** live LLM chat + embedding paths (`LLMAgentNode`, `EmbeddingGeneratorNode`, `BaseAgent`) route through the four-axis `LlmClient` instead of the legacy `providers/llm/` registry (Wave-B1); `azure_ai_foundry` stays on the legacy path (Decision-2A). `production/metrics.py` decoupled from `providers.registry` (Wave-B2b).
- **Added:** cohere/HuggingFace embedding wires, `to_legacy_shape` bridge, shared `resolve_deployment_for` resolver, offline `mock_transport` parity harness; `LlmClient.embed` gains `timeout` + uniform `normalize`.
- **Deprecated:** legacy barrel re-exports (`kaizen.nodes.ai` / `kaizen.providers`) are now PEP 562 DeprecationWarning shims (Wave-B2a).
- **Fixed:** foundation + Wave-B1 red-team fixes (stream-aware tool_choice, normalize→HF embed, BYOK api_key validation, restored loud-raise on unresolvable embed credential, google finish_reason parity).

**Why this release now:** zero-tolerance 6a requires the barrel deprecation shims to live through ≥1 published minor cycle before the Wave-C legacy delete. This publish is the Wave-C prerequisite. Publish authorized by the owner this session.

Branch is **metadata-only** (version ×2 + CHANGELOG) → auto-skips the PR-gate matrix per the `release/*` convention.

## Related issues

Part of #1720.