### PR TITLE
release: kailash-kaizen 2.34.0 — #1720 LLM consolidation (+ pre-release redteam fixes)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -80,6 +80,15 @@ OpenAIProvider`) and `kaizen.providers.embedding.<mod>`, the `LLMProvider`
   `provider == "mock"` mode only). (5) Google `finish_reason` value-map parity
   (`STOP`→`stop`, `MAX_TOKENS`→`length`, `SAFETY`→`content_filter`, tool→`tool_calls`)
   is preserved on the four-axis google wire.
+- **Pre-release red-team fixes (#1720 2.34.0).** (6) `LLMAgentNode` no longer
+  returns a fabricated completion when the provider stack fails to import — the
+  `ImportError` branch now raises loudly (parity with the embedding path's
+  unresolvable-provider raise; no silent mock returned as a real answer). The
+  fabricating `_fallback_llm_response` method was removed. (7) Provider errors
+  are now routed through `sanitize_provider_error` before reaching the LOG
+  surface on the completion path (previously logged raw via `exc_info=True`) —
+  a URL-embedded credential in a raw provider exception can no longer leak into
+  server logs.
 
 ## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
 

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.34.0] — 2026-07-17 — #1720 LLM consolidation: live paths on four-axis `LlmClient`
+
+### Changed
+
+- **Live LLM chat and embedding paths now route through the four-axis `LlmClient`
+  instead of the legacy `providers/llm/` registry (#1720 Wave-B1, PR #1789).**
+  `LLMAgentNode._provider_llm_response`, `EmbeddingGeneratorNode._generate_provider_embedding`,
+  and `BaseAgent._simple_execute_async` were cut over from
+  `providers.registry.get_provider(...).chat/embed(...)` to
+  `resolve_deployment_for(...)` → `LlmClient.complete` / `LlmClient.embed` →
+  `to_legacy_shape`. The cutover is behavior-neutral, gated by an offline parity
+  harness across the dual-mappable provider matrix. `azure_ai_foundry`
+  intentionally remains on the legacy `.chat()` path (Decision-2A); every other
+  provider now runs on the consolidated four-axis client.
+- **`production/metrics.py` no longer imports `providers.registry` (#1720 Wave-B2b,
+  PR #1791).** The provider-name registry (`PROVIDERS` frozenset + model-prefix
+  map) was extracted to a registry-independent module (`providers/provider_names.py`),
+  decoupling the Prometheus metrics label-bounding (and a bare `import kaizen`)
+  from the legacy registry at runtime.
+
+### Added
+
+- **Four-axis embedding wires and the legacy-shape bridge (#1720 Waves 1–2/A).**
+  New `LlmClient` embedding wire protocols for cohere and HuggingFace
+  (`wire_protocols/cohere_embeddings.py`, `wire_protocols/huggingface_embeddings.py`);
+  a `to_legacy_shape` adapter (`llm/_legacy_shape.py`) reproducing the legacy
+  provider response envelope so the cutover is behavior-neutral; a shared
+  `resolve_deployment_for` deployment resolver (`llm/deployment_resolver.py`) with
+  azure / azure_openai mapping; and an offline `mock_transport` harness
+  (`llm/testing/mock_transport.py`) that drives the parity matrix without live
+  credentials. Existing chat wires (openai, bedrock, google, mistral, ollama,
+  HuggingFace inference, cohere generate) were extended to complete the
+  consolidated provider matrix.
+- **`LlmClient.embed` accepts a `timeout` kwarg** at parity with the legacy
+  embedding path, and applies `EmbedOptions.normalize` uniformly across every
+  embedding wire (previously a silent no-op on all wires except HuggingFace).
+
 ### Deprecated
 
 - **Legacy provider re-exports from the `kaizen.nodes.ai` and `kaizen.providers`
@@ -25,7 +62,24 @@ OpenAIProvider`) and `kaizen.providers.embedding.<mod>`, the `LLMProvider`
   base from `kaizen.providers.base`, and the registry accessors from
   `kaizen.providers.registry`. The symbols remain in each barrel's `__all__`
   (the public contract is unchanged — only the access path warns). Removal is
-  scheduled for Wave-C of #1720.
+  scheduled for Wave-C of #1720 (a following minor release, so these shims live
+  through ≥1 published minor cycle first).
+
+### Fixed
+
+- **Foundation and Wave-B1 red-team fixes (#1720).** (1) The legacy per-provider
+  `tool_choice` default is now stream-aware — the dual-run shadow threads the live
+  `streaming` mode so the four-axis streaming tool path reproduces legacy
+  `stream_chat`'s per-provider `"auto"`/`"required"` value. (2) `EmbedOptions.normalize`
+  now reaches the HuggingFace embed wire through `LlmClient.embed`. (3) BYOK
+  hardening: `resolve_deployment_for` validates a caller-supplied `api_key`
+  (control-char / CRLF / non-ASCII) at parity with `LlmClient.complete`, closing a
+  header-injection surface on the promoted live path. (4) The embedding cutover no
+  longer silently returns a mock embedding on an unresolvable credential provider —
+  the legacy loud raise is restored (the sanctioned mock path stays the explicit
+  `provider == "mock"` mode only). (5) Google `finish_reason` value-map parity
+  (`STOP`→`stop`, `MAX_TOKENS`→`length`, `SAFETY`→`content_filter`, tool→`tool_calls`)
+  is preserved on the four-axis google wire.
 
 ## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
 

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -88,7 +88,10 @@ OpenAIProvider`) and `kaizen.providers.embedding.<mod>`, the `LLMProvider`
   are now routed through `sanitize_provider_error` before reaching the LOG
   surface on the completion path (previously logged raw via `exc_info=True`) —
   a URL-embedded credential in a raw provider exception can no longer leak into
-  server logs.
+  server logs. (8) Same-class sibling on the MCP retrieval path: the
+  `_retrieve_mcp_context` connection-failure log lines now route through
+  `sanitize_provider_error` (they previously logged the raw exception while a
+  sanitized copy was computed for the return).
 
 ## [2.33.1] — 2026-07-15 — RAG verification-parse hardening (#1755)
 

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.33.1"
+version = "2.34.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.33.1"
+__version__ = "2.34.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -1572,15 +1572,19 @@ class LLMAgentNode(Node):
                         )
                     except Exception as e:
                         error_type = type(e).__name__
+                        # Sanitize before logging — an MCP transport error can
+                        # echo a URL-embedded credential onto the log surface
+                        # (rules/security.md "No secrets in logs"; #1720 release
+                        # redteam MED-1 sibling on the MCP path).
+                        sanitized_msg = sanitize_provider_error(e, "MCP")
                         self.logger.error(
                             "MCP server '%s' connection failed (%s): %s",
                             server_config.get("name", "unknown"),
                             error_type,
-                            e,
+                            sanitized_msg,
                         )
 
                         # Provide helpful error messages based on exception type
-                        sanitized_msg = sanitize_provider_error(e, "MCP")
                         if "coroutine" in str(e).lower() and "await" in str(e).lower():
                             self.logger.error(
                                 "This appears to be an async/await issue. Please report this bug to the Kailash SDK team."
@@ -1613,7 +1617,9 @@ class LLMAgentNode(Node):
                 pass
             except Exception as e:
                 self.logger.error(
-                    f"Unexpected error in MCP retrieval: {type(e).__name__}: {e}"
+                    "Unexpected error in MCP retrieval [%s]: %s",
+                    type(e).__name__,
+                    sanitize_provider_error(e, "MCP"),
                 )
                 self.logger.info("Falling back to mock MCP implementation.")
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -1207,10 +1207,14 @@ class LLMAgentNode(Node):
             # If hook didn't raise, return error response
             from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 
-            self.logger.error("LLM agent error: %s", e, exc_info=True)
+            sanitized = sanitize_provider_error(e, provider)
+            # Log the SANITIZED message (not raw ``e`` / ``exc_info``) — the raw
+            # exception can echo a URL-embedded credential onto the log surface
+            # (rules/security.md "No secrets in logs"; #1720 release redteam MED-1).
+            self.logger.error("LLM agent error [%s]: %s", type(e).__name__, sanitized)
             return {
                 "success": False,
-                "error": sanitize_provider_error(e, provider),
+                "error": sanitized,
                 "error_type": type(e).__name__,
                 "provider": provider,
                 "model": model,
@@ -2438,17 +2442,31 @@ Final Answer: 6 hours"""
 
             return response
 
-        except ImportError:
-            # Four-axis (or legacy) provider stack unavailable — mock fallback.
-            return self._fallback_llm_response(
-                provider, model, messages, tools, generation_config
-            )
+        except ImportError as e:
+            # An import failure in the four-axis / legacy provider stack is a
+            # real environment error, NOT a reason to fabricate a completion.
+            # Surface it loudly — parity with the embedding path's
+            # unresolvable-provider raise; no silent mock returned as a real
+            # answer (rules/zero-tolerance.md Rule 2/3; #1720 release redteam
+            # MED-2).
+            raise RuntimeError(
+                f"LLM provider stack unavailable for provider {provider!r}: {e}"
+            ) from e
         except Exception as e:
-            # Re-raise provider errors with sanitized message
+            # Re-raise provider errors with a sanitized message. Log the
+            # SANITIZED message (not raw ``e`` / ``exc_info``) — a raw provider
+            # exception or its chained cause can echo a URL-embedded credential
+            # onto the log surface (rules/security.md "No secrets in logs";
+            # #1720 release redteam MED-1). The sanitized message + exception
+            # class name are enough to triage without the credential-bearing
+            # traceback.
             from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 
-            self.logger.error("Provider %s error: %s", provider, e, exc_info=True)
-            raise RuntimeError(sanitize_provider_error(e, provider)) from e
+            sanitized = sanitize_provider_error(e, provider)
+            self.logger.error(
+                "Provider %s error [%s]: %s", provider, type(e).__name__, sanitized
+            )
+            raise RuntimeError(sanitized) from e
 
     def _legacy_provider_chat(
         self,
@@ -2743,31 +2761,6 @@ Final Answer: 6 hours"""
                     "correlation_id": correlation_id,
                 },
             )
-
-    def _fallback_llm_response(
-        self,
-        provider: str,
-        model: str,
-        messages: list[dict],
-        tools: list[dict],
-        generation_config: dict,
-    ) -> dict[str, Any]:
-        """Generate LLM response using direct API calls (mock implementation)."""
-        return {
-            "id": "fallback_response_456",
-            "content": f"Direct API response from {provider} {model}",
-            "role": "assistant",
-            "model": model,
-            "provider": provider,
-            "langchain_used": False,
-            "tool_calls": [],
-            "finish_reason": "stop",
-            "usage": {
-                "prompt_tokens": 200,
-                "completion_tokens": 50,
-                "total_tokens": 250,
-            },
-        }
 
     def _update_conversation_memory(
         self,

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_release_2340_redteam.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_release_2340_redteam.py
@@ -90,3 +90,35 @@ def test_provider_error_log_is_sanitized_no_credential_leak(monkeypatch, caplog)
     # AND the log surface carries no raw credential (the MED-1 fix — the log
     # previously used raw ``e`` + ``exc_info=True``).
     assert secret not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# MED-1 sibling — the MCP retrieval path sanitizes its connection-error log.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_mcp_connection_error_log_is_sanitized_no_credential_leak(caplog):
+    """The MCP per-server connection-failure path (``_retrieve_mcp_context``) was
+    the same-class sibling of MED-1: it logged the raw exception while a
+    sanitized copy was computed two lines later for the return. Confirm a
+    URL-embedded credential in an MCP transport error does not reach the log."""
+    secret = "MCPSECRETCANARY0123456789"
+
+    class _FakeMCPClient:
+        async def list_resources(self, server_config):
+            raise RuntimeError(f"connect failed at https://user:{secret}@mcp.host/v1")
+
+    node = LLMAgentNode()
+    # Setting ``_mcp_client`` makes ``use_real_mcp`` True and supplies the client,
+    # so ``list_resources`` drives the per-server ``except Exception`` log path.
+    node._mcp_client = _FakeMCPClient()
+
+    with caplog.at_level(logging.ERROR):
+        node._retrieve_mcp_context(
+            [{"name": "s1", "transport": "http", "url": "https://mcp.host"}],
+            ["resource://x/y"],
+            {},
+        )
+
+    assert secret not in caplog.text

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_release_2340_redteam.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_release_2340_redteam.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 kaizen 2.34.0 pre-release redteam fixes — behavioral regressions.
+
+Pins the two MEDIUM findings the mandatory pre-release security review surfaced
+against the merged four-axis cutover (``llm_agent._provider_llm_response`` +
+outer ``run`` handler), so a future refactor cannot silently reintroduce them:
+
+* **MED-2** — an ``ImportError`` in the four-axis / legacy provider stack MUST
+  RAISE loudly (parity with the embedding path's unresolvable-provider raise),
+  NOT return a fabricated completion presented as a real provider answer
+  (``rules/zero-tolerance.md`` Rule 2/3, ``rules/observability.md`` Rule 3). The
+  fabricating ``_fallback_llm_response`` method is deleted outright
+  (``rules/orphan-detection.md`` Rule 3).
+* **MED-1** — a provider error whose message embeds a URL credential MUST be
+  routed through ``sanitize_provider_error`` before it reaches the LOG surface
+  (previously logged raw via ``exc_info=True`` — the caller-facing raise was
+  sanitized but the server log was not). ``rules/security.md`` § "No secrets in
+  logs".
+
+Tier-1 offline + deterministic (no network, no live keys). Behavioral asserts
+per ``rules/testing.md`` § "Behavioral Regression Tests Over Source-Grep".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import kaizen.llm.deployment_resolver as resolver_mod
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# MED-2 — import failure RAISES, does NOT fabricate a completion.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_provider_import_failure_raises_not_fabricated_completion(monkeypatch):
+    """An ``ImportError`` in the provider stack surfaces as a loud ``RuntimeError``
+    — never a fabricated ``{"content": "Direct API response from ..."}`` dict
+    that a caller would consume as a real LLM answer."""
+
+    def _raise_import(*args, **kwargs):
+        raise ImportError("provider stack import failed")
+
+    monkeypatch.setattr(resolver_mod, "resolve_deployment_for", _raise_import)
+
+    node = LLMAgentNode()
+    with pytest.raises(RuntimeError, match="provider stack unavailable"):
+        node._provider_llm_response("openai", "gpt-x", _MESSAGES, [], {})
+
+
+@pytest.mark.regression
+def test_fabricated_fallback_method_removed():
+    """The fabricating ``_fallback_llm_response`` method is deleted, so no future
+    refactor can silently route the import-failure branch back to fake data."""
+    assert not hasattr(LLMAgentNode, "_fallback_llm_response")
+
+
+# ---------------------------------------------------------------------------
+# MED-1 — provider error is sanitized before it reaches the LOG surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_provider_error_log_is_sanitized_no_credential_leak(monkeypatch, caplog):
+    """A provider error whose message embeds a URL credential is sanitized both
+    in the raised message AND on the log surface — the raw credential must not
+    reach either (previously ``exc_info=True`` logged the raw exception)."""
+    secret = "SUPERSECRETCRED0123456789"
+
+    def _raise_with_cred(*args, **kwargs):
+        raise RuntimeError(f"wire failed at https://user:{secret}@host:443/v1")
+
+    monkeypatch.setattr(resolver_mod, "resolve_deployment_for", _raise_with_cred)
+
+    node = LLMAgentNode()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as excinfo:
+            node._provider_llm_response("openai", "gpt-x", _MESSAGES, [], {})
+
+    # The raised (caller-facing) message is sanitized.
+    assert secret not in str(excinfo.value)
+    # AND the log surface carries no raw credential (the MED-1 fix — the log
+    # previously used raw ``e`` + ``exc_info=True``).
+    assert secret not in caplog.text


### PR DESCRIPTION
## Summary

Cuts **kailash-kaizen 2.34.0** — the first published minor carrying the #1720 LLM-provider consolidation (Waves 1–2/A/B1/B2, merged + red-team-converged on main via #1789/#1791). Supersedes #1794 (which was metadata-only on a `release/*` branch); this PR additionally carries two code fixes surfaced by the mandatory pre-release security review, so it runs the full matrix.

**Consolidation (already on main, now released):**
- Live LLM chat + embedding paths route through the four-axis `LlmClient` (Wave-B1); `azure_ai_foundry` stays legacy (Decision-2A). Barrel re-exports → PEP 562 DeprecationWarning shims (Wave-B2). `metrics.py` decoupled from `providers.registry`.

**Pre-release redteam fixes (this PR, same bug class the release fixes on the embedding path — fixed in-cycle per zero-tolerance Rule 1 + autonomous-execution Rule 4):**
- **MED-2:** `LLMAgentNode._provider_llm_response` no longer returns a fabricated completion on the four-axis `ImportError` branch — it raises loudly (parity with the embedding path); the fabricating `_fallback_llm_response` method is deleted.
- **MED-1:** provider errors on the completion path (2 log sites) are routed through `sanitize_provider_error` before logging (previously raw via `exc_info=True`) — no URL-embedded credential can leak to server logs.
- 3 behavioral regression tests pin both fixes.

**Why this release:** zero-tolerance 6a requires the barrel deprecation shims to live through ≥1 published minor before the Wave-C legacy delete. Publish authorized by the owner this session.

## Related issues

Part of #1720.