### PR TITLE
fix(deps): #1779 tighten kaizen/kaizen-agents pins to versions providing the new imports

### DIFF
--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -248,7 +248,11 @@ jobs:
           # Sibling packages kaizen's import graph pulls in at collection time.
           uv pip install -e "packages/kailash-nexus" --python .venv/bin/python
           uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
-          uv pip install -e "packages/kaizen-agents" --python .venv/bin/python
+          # NOTE: kailash-kaizen (below) MUST be installed BEFORE kaizen-agents:
+          # kaizen-agents pins kailash-kaizen>=2.35.0, and if the local editable
+          # kaizen is not yet present uv resolves that pin against PyPI (which lags
+          # the in-repo version) and fails "no solution found". Local-first ordering
+          # makes the in-repo editable kaizen satisfy the pin.
           # LLM-provider extras the wire/auth tests exercise: bedrock (botocore
           # SigV4), vertex (google-auth OAuth/WIF), providers-azure (Entra),
           # providers-google (google-genai), providers-tokens (tiktoken).
@@ -258,6 +262,9 @@ jobs:
           # hard top-level import of these extras' deps (they are optional
           # extras, absent from the base install, hence a local-only pass before).
           uv pip install -e "packages/kailash-kaizen[dev,bedrock,vertex,providers-azure,providers-google,providers-tokens,observability,rag]" --python .venv/bin/python
+          # kaizen-agents installed AFTER kailash-kaizen so its kailash-kaizen>=2.35.0
+          # pin resolves against the local editable kaizen (see NOTE above).
+          uv pip install -e "packages/kaizen-agents" --python .venv/bin/python
           # src/kaizen/core/autonomy/observability/tracing_manager.py hard-imports
           # opentelemetry.exporter.otlp.proto.grpc, which the [observability] extra
           # does NOT ship — install it explicitly so every test that transitively

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # SDKs, observability, PostgreSQL, RAG numerics) remain lazy-loaded or
     # scoped to optional subsystems behind extras.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.50.0",
+    "kailash>=2.54.0",  # governance_gate imports kailash.is_governance_required (new in 2.54.0)
     "kailash-mcp>=0.2.4",       # core/base_agent.py:32 module-scope MCPClient
     "pydantic>=2.0.0",          # llm/deployment.py + auth modules
     "typing-extensions>=4.5.0", # core/schema_factory.py

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     #   `kailash` core), not the separate `kailash-pact` package.
     # ─────────────────────────────────────────────────────────────
     "kailash>=2.14.0",
-    "kailash-kaizen>=2.25.1",
+    "kailash-kaizen>=2.35.0",  # imports kaizen.llm.governance_gate (new in 2.35.0)
     "openai>=1.30.0",
     "httpx>=0.27.0",
     # Provider SDKs imported at runtime by the delegate / runtime adapters.


### PR DESCRIPTION
Metadata-only dependency-pin correctness fix (no source change), split from #1802 per the pin-audit done at release time.

`kailash-kaizen 2.35.0`'s `governance_gate` imports `kailash.is_governance_required` (new in kailash **2.54.0**) on every construction; the gate is **fail-closed on import error**, so an old-kailash + new-kaizen combo would refuse all egress even under the default OFF posture. Pin `kailash>=2.50.0` → `>=2.54.0`.

`kaizen-agents 0.10.0` imports `kaizen.llm.governance_gate` (new in `kailash-kaizen 2.35.0`); pin `kailash-kaizen>=2.25.1` → `>=2.35.0`.

Per dependencies.md § "Declared = Imported". Both pyproject files TOML-validated. Fresh installs already resolve latest; these pins make the requirement explicit and prevent a silent partial-upgrade break.

## Related issues
Refs #1779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)