### PR TITLE
test(kaizen): #1779 cover governance-gate fail-closed posture-read branch

### DIFF
--- a/packages/kailash-kaizen/tests/unit/llm/test_governance_required_gate.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_governance_required_gate.py
@@ -529,3 +529,44 @@ def test_embedding_fallback_off_posture_byte_identical() -> None:
         raise AssertionError("OFF posture must not gate")
     except Exception:
         pass
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed: a posture-read error is treated as ACTIVE (invariant 5)
+# --------------------------------------------------------------------------- #
+
+
+def test_enforce_fail_closed_when_posture_read_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If is_governance_required() raises, the gate MUST treat the posture as
+    # ACTIVE and refuse — never silently allow ungoverned egress (invariant 5,
+    # governance_gate.py:99-108). Security-reviewer flagged this branch as the
+    # one release-cycle test gap; here is the direct coverage.
+    from kaizen.llm.governance_gate import enforce_governance_posture
+
+    def _boom() -> bool:
+        raise RuntimeError("posture backend unavailable")
+
+    monkeypatch.setattr(kailash, "is_governance_required", _boom)
+    with pytest.raises(UngovernedEgressRefused):
+        enforce_governance_posture(
+            is_mock=False, ungoverned=False, surface="LlmClient"
+        )
+
+
+def test_enforce_fail_closed_exemptions_short_circuit_before_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ungoverned=True and is_mock=True short-circuit BEFORE the posture read, so
+    # a raising reader is never reached — the exemptions still allow even when
+    # the posture backend is unavailable.
+    from kaizen.llm.governance_gate import enforce_governance_posture
+
+    def _boom() -> bool:
+        raise RuntimeError("must not be reached when exempt")
+
+    monkeypatch.setattr(kailash, "is_governance_required", _boom)
+    # Neither raises despite the poisoned reader (exemptions short-circuit).
+    enforce_governance_posture(is_mock=False, ungoverned=True, surface="LlmClient")
+    enforce_governance_posture(is_mock=True, ungoverned=False, surface="Agent")


### PR DESCRIPTION
Test-only fast-follow to the #1779 release. The security-reviewer's pre-publish audit flagged one test gap: the governance gate's fail-closed branch (`is_governance_required()` raising → posture treated ACTIVE → refuse, invariant 5, `governance_gate.py:99-108`) had no direct coverage.

Adds two Tier-1 unit tests:
- `test_enforce_fail_closed_when_posture_read_raises` — a poisoned reader forces refusal.
- `test_enforce_fail_closed_exemptions_short_circuit_before_read` — `ungoverned=True` / mock exempt before the read is reached.

Full gate file: 37 passed. No source/wheel change → build-repo-release-discipline test-only carve-out (no `/release`).

## Related issues
Refs #1779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)