### PR TITLE
docs(codify): #1779 governance-required posture docs + release-cycle codify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.54.0] - 2026-07-18
+
 ### Added
 
 - **`governance_required` posture for direct LLM egress (#1779, EATP D6 parity;

--- a/docs/core/trust.rst
+++ b/docs/core/trust.rst
@@ -288,6 +288,62 @@ Nexus Integration
 Nexus multi-channel deployments can enforce trust at the API gateway level.
 See :doc:`../frameworks/nexus`.
 
+Governance-Required Posture
+===========================
+
+The ``governance_required`` posture (added in kailash 2.54.0, #1779) makes
+direct LLM egress **fail-closed**: when the posture is active, a bare
+un-governed client or agent that would make a real LLM call is refused at
+construction instead of silently sending the request. It is an **opt-OUT**
+posture -- **OFF by default**, so adopting it is a zero-back-compat change.
+
+Resolution (most-specific wins):
+
+1. programmatic override -- :func:`kailash.set_governance_required` (``True`` /
+   ``False`` / ``None`` to clear)
+2. environment variable ``KAILASH_GOVERNANCE_REQUIRED`` -- truthy in
+   ``{1, true, yes, on}`` (case-insensitive)
+3. default **OFF** -- an unset *or unrecognized* value resolves OFF, byte-identical
+   to pre-2.54.0 behaviour.
+
+.. code-block:: python
+
+   import kailash
+
+   # Read the current posture (False by default)
+   kailash.is_governance_required()          # -> False
+
+   # Turn it on for this process (or set KAILASH_GOVERNANCE_REQUIRED=1)
+   kailash.set_governance_required(True)
+   kailash.is_governance_required()          # -> True
+
+When the posture is active, constructing a bare un-governed client/agent that
+would make **real** egress raises :class:`kailash.UngovernedEgressRefused`
+(a ``PactError``) at construction, and -- defense-in-depth -- again at
+real-transport binding. Two exemptions short-circuit the refusal:
+
+- **explicit opt-out** -- pass ``ungoverned=True`` on any construction surface
+  (``LlmClient``, ``Agent``, ``LLMAgentNode``, ``EmbeddingGeneratorNode``);
+- **mock / deterministic** -- mock-preset deployments are exempt by class
+  identity, never a network probe.
+
+Enforcement lives in Kaizen (framework-first: core ``kailash`` owns the posture
+state + the typed error; Kaizen owns the client and enforces). It fires at every
+egress chokepoint: the four-axis ``LlmClient`` (all constructors + a lazy
+re-check on ``embed`` / ``complete`` / ``stream``), ``Agent``, ``LLMAgentNode``
+(both node-config builders + the legacy provider-chat fallback),
+``EmbeddingGeneratorNode`` (four-axis + ollama fallback), ``BaseAgent``, and the
+``kaizen-agents`` orchestration + delegate/adapter layer.
+
+.. note::
+
+   **Non-coverage.** The posture does NOT yet gate direct standalone use of the
+   legacy ``kaizen.providers.llm.*`` provider layer, the vision/multimodal
+   providers, or the standalone Azure backends -- those construct provider
+   clients outside the gated four-axis/adapter surfaces. Do NOT treat the
+   posture as a hard egress boundary for those paths. Comprehensive gating of
+   that provider/backend layer is tracked as a follow-up (#1803).
+
 Best Practices
 ==============
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,7 +2,7 @@
 Getting Started
 ===============
 
-Welcome to the Kailash SDK v0.12.5. This guide walks you through core concepts and
+Welcome to the Kailash SDK v2.54.0. This guide walks you through core concepts and
 patterns you will use in every Kailash project.
 
 Prerequisites

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Kailash SDK Documentation
    :target: https://www.python.org/downloads/
    :alt: Python Version
 
-.. image:: https://img.shields.io/badge/version-0.12.5-green.svg
+.. image:: https://img.shields.io/badge/version-2.54.0-green.svg
    :alt: SDK Version
 
 .. image:: https://img.shields.io/badge/trust-CARE%20%2F%20EATP-blueviolet.svg

--- a/workspaces/issue-1720-llm-consolidation/journal/0003-DISCOVERY-release-hazards-1779.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0003-DISCOVERY-release-hazards-1779.md
@@ -1,0 +1,75 @@
+# DISCOVERY — three release hazards from the #1779 governance_required cycle
+
+Surfaced 2026-07-18 while releasing kailash 2.54.0 / kailash-kaizen 2.35.0 /
+kaizen-agents 0.10.0. All three are reusable release-engineering lessons; #1 is
+general (loom-canonicalization candidate), #2/#3 are monorepo-CI/PyPI-specific.
+
+## Hazard 1 — a fail-closed gate that imports a same-release symbol needs a pin floor at that release (GENERAL)
+
+`kaizen.llm.governance_gate` does `from kailash import is_governance_required`
+(new in kailash **2.54.0**) on **every** LlmClient/Agent construction, and it is
+**fail-closed**: if the import raises, `active = True` → refuse. kaizen 2.35.0
+pinned `kailash>=2.50.0`. That combination means an **old-kailash (<2.54.0) +
+new-kaizen** install resolves the import to `ImportError` → the gate refuses
+**every** egress **even under the default OFF posture** — a silent hard break
+for a partial upgrade.
+
+- **Rule:** when a guard imports a symbol added in the SAME coordinated release
+  AND fails closed on import error, the manifest pin MUST floor at that release
+  (`kailash>=2.54.0`, not `>=2.50.0`). This is stricter than the usual
+  "declared = imported" (`dependencies.md`) because the fail-closed behavior
+  turns a loose floor into a runtime refusal, not just an `ImportError` at the
+  call site.
+- **Fix landed:** PR #1804 — bumped kaizen `kailash>=2.50.0`→`>=2.54.0` and
+  kaizen-agents `kailash-kaizen>=2.25.1`→`>=2.35.0`.
+- **Loom candidate:** a `dependencies.md` clause — "a fail-closed guard importing
+  a same-release symbol floors its pin at that release."
+
+## Hazard 2 — local editable sibling MUST be installed before any package that pins it (monorepo CI)
+
+`test-kailash-kaizen.yml` installed editable `kaizen-agents` **before** editable
+`kailash-kaizen`. When uv installed kaizen-agents and saw `kailash-kaizen>=2.35.0`,
+it resolved that pin against **PyPI** (latest 2.34.2) — "no solution found" —
+because the local editable 2.35.0 was not yet installed. Latent before the pin
+bump (the old `>=2.25.1` was satisfiable from PyPI, so it silently pulled a PyPI
+kaizen that the later editable install overwrote).
+
+- **Rule:** in monorepo CI, install a local editable package **before** any
+  sibling that pins it, so the pin resolves against the in-repo version.
+- **Fix landed:** PR #1804 — reordered the install step; added a NOTE comment.
+  `example-validation.yml` already had the correct order.
+
+## Hazard 3 — TestPyPI validation of interdependent minors needs dependency-order dispatch + `--index-strategy unsafe-best-match`
+
+Validating three interdependent minors on TestPyPI (the deployment.md MUST for
+minors) required two non-obvious things:
+
+1. **Dependency-order dispatch** — publish kailash 2.54.0 to TestPyPI first so
+   kaizen 2.35.0's `kailash>=2.54.0` pin resolves there (not against prod PyPI,
+   which lagged at 2.53.0), then kaizen, then kaizen-agents.
+2. **`--index-strategy unsafe-best-match`** — the package under test lives on
+   TestPyPI but its third-party deps live on prod PyPI; uv's default first-index
+   strategy fails to resolve across the two indexes. `unsafe-best-match` makes
+   uv consider all indexes for all packages.
+
+Verify command shape:
+
+```
+uv pip install --refresh --index-strategy unsafe-best-match \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ "<pkg>==<ver>"
+```
+
+Also: a verify loop must capture uv's real exit code — `uv pip install ... | tail`
+masks it (pipe exit = tail's), so a failed install can print a false "OK".
+
+- **Rule:** TestPyPI validation of interdependent packages = dependency-order
+  dispatch + `unsafe-best-match` + real-exit-code capture.
+- **Loom candidate:** a `deployment.md` TestPyPI-validation clause for
+  interdependent multi-package releases.
+
+## Also confirmed this cycle
+
+- PyPI `info.version` cache lag: kaizen showed 2.34.2 for minutes after 2.35.0
+  published; the version-specific `/pypi/<pkg>/<ver>/json` endpoint + a clean
+  install both confirmed 2.35.0 live (matches `build-repo-release-discipline.md`).

--- a/workspaces/issue-1720-llm-consolidation/journal/0004-DECISION-codify-1779-docs.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0004-DECISION-codify-1779-docs.md
@@ -1,0 +1,54 @@
+# DECISION — /codify for the #1779 release cycle (docs + knowledge capture)
+
+Date: 2026-07-18. Repo class: BUILD (`name = "kailash"`). Coordination OFF
+(un-enrolled public repo) → no codify lease needed.
+
+## What was codified
+
+1. **`docs/core/trust.rst`** — added a "Governance-Required Posture" section
+   documenting the new public API (`is_governance_required` /
+   `set_governance_required` / `UngovernedEgressRefused`, `KAILASH_GOVERNANCE_REQUIRED`
+   env, `ungoverned=True` opt-out), the resolution order, the enforcement
+   chokepoints, and the honest **non-coverage** note (legacy providers /
+   multimodal / standalone azure — tracked #1803). Mandatory Step-5 user doc for
+   the new public API; every symbol verified live this session.
+
+2. **`CHANGELOG.md`** — moved the shipped `[Unreleased]` block to a dated
+   `## [2.54.0] - 2026-07-18` section (release hygiene the tag-publish workflow
+   does not do). Both the #1779 Added and the legacy-`from_env` Deprecated entry
+   (shipped kaizen 2.32.0, 2026-07-14 — also stale under Unreleased) moved; each
+   entry self-attributes its version/issue in-text.
+
+3. **`docs/index.rst` + `docs/getting_started.rst`** — fixed stale SDK version
+   badges `0.12.5` → `2.54.0` (pre-existing drift; `documentation.md` requires
+   these track pyproject on a version bump).
+
+## Knowledge capture
+
+The three release hazards are captured in `0003-DISCOVERY-release-hazards-1779.md`
+(read by the next `codify-backlog` cycle). Hazard #1 (fail-closed guard importing
+a same-release symbol → pin floors at that release) and Hazard #3 (interdependent-
+minors TestPyPI validation) are flagged as loom-canonicalization candidates for a
+future `dependencies.md` / `deployment.md` clause. Not appended to the 96KB
+`latest.yaml` this cycle (append risk vs. marginal value; the journal is the
+reliable inheritance path).
+
+## Violations triage (16 unaddressed since anchor)
+
+- **15× `repo-scope-discipline/MUST-NOT-1`** — the hook flags every `gh --repo`
+  call. On inspection: (a) `--repo terrene-foundation/kailash-py` from within
+  kailash-py is the **canonical current repo**, not cross-repo (hook
+  over-flags the `--repo` flag); (b) `--repo esperie-enterprise/kailash-rs`
+  entries are **authorized cross-SDK filings** with journaled grants (this
+  session's rs#1932/#1933 + prior sessions' rs#1881). No rule change warranted;
+  these are hook false-positives / grant-backed actions.
+- **1× `git/commit-message-claim-accuracy` [advisory]** — a `/sweep`+`/wrapup`
+  workspace commit subject flagged for claim language; advisory, workspace-only,
+  no action.
+
+## Anchor
+
+`learning-codified.json::last_codified` advanced to 2026-07-18 to bound the next
+cycle's delta. The 2211-item backlog is dominated by test_pattern/framework_selection
+telemetry (not individually codify-actionable); the actionable delta was the
+release-cycle docs + the three hazards above.


### PR DESCRIPTION
`/codify` close-out for the shipped #1779 release (kailash 2.54.0 / kaizen 2.35.0 / kaizen-agents 0.10.0).

**Docs (user-facing):**
- `docs/core/trust.rst` — new "Governance-Required Posture" section: the public API (`is_governance_required` / `set_governance_required` / `UngovernedEgressRefused`, `ungoverned=True`, `KAILASH_GOVERNANCE_REQUIRED`), resolution order, enforcement chokepoints, and the honest **non-coverage** note (legacy/multimodal/azure → #1803). Every symbol verified live this session.
- `docs/index.rst` + `docs/getting_started.rst` — stale SDK version badge `0.12.5` → `2.54.0` (documentation.md: version refs track pyproject).

**Release hygiene:**
- `CHANGELOG.md` — `[Unreleased]` → `[2.54.0] - 2026-07-18` (dating already-published content; **no new release triggered** — 2.54.0 is already on PyPI).

**Knowledge capture:**
- `journal/0003-DISCOVERY` — three release hazards (fail-closed-guard same-release pin-floor; monorepo-CI local-editable install order; interdependent-minors TestPyPI dispatch + `unsafe-best-match`). #1 and #3 flagged as loom-canonicalization candidates.
- `journal/0004-DECISION` — codify record + 16-violation triage (repo-scope hook false-positives / grant-backed cross-SDK filings).

No source/wheel change; no new rules authored (BUILD repo — lessons route to loom). Docs/workspace + CHANGELOG-bookkeeping only → no `/release`.

## Related issues
Refs #1779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)