### PR TITLE
chore(kaizen-agents): gitignore task/session/memory test-scratch artifacts

### DIFF
--- a/packages/kaizen-agents/.gitignore
+++ b/packages/kaizen-agents/.gitignore
@@ -23,3 +23,28 @@ test_topic.txt
 Test.txt
 *voting*
 voting_decision.txt
+
+# #1779 follow-up: kaizen-agents delegate/orchestration/memory tests ALSO write
+# task/session/conversation/memory scratch artifacts to CWD without cleanup
+# (same pre-existing test-hygiene issue as the proposal/vote artifacts above).
+# Root-anchored (/) so they can NEVER shadow a real file under src/ or tests/.
+# Follow-up: those tests should use tmp_path.
+/can_handle.txt
+/conversation_history.txt
+/conversation_memory.txt
+/delegation_plan.txt
+/evaluation_results.json
+/favorite_color.txt
+/final_result.txt
+/memory.txt
+/session.txt
+/session_c.txt
+/session_memory.txt
+/summary.txt
+/user_message.txt
+/very_complex_task_error.txt
+/test_add.py
+/subtask_*_result.txt
+/task_*.txt
+/task_execution/
+/task_results/


### PR DESCRIPTION
Extends the existing kaizen-agents `.gitignore` proposal/vote block to also cover the task/session/conversation/memory scratch files that delegate/orchestration/memory tests write to CWD without cleanup (pre-existing test-hygiene issue). Root-anchored (`/`) patterns so they never shadow a real file under `src/` or `tests/`. Files left on disk — no bulk clean. Follow-up: those tests should use `tmp_path`.

No source/wheel change (`.gitignore` is not packaged) → no `/release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)