### PR TITLE
docs(workspace): capture F-TESTHYG deferral + follow-up

### DIFF
--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -48,7 +48,7 @@ Next session: START the Wave 2 handoff section below.
 - **Wave 1C** — PR #1810 FRECON: 4 stale workspaces → `workspaces/_archive/`.
 - **Wave 2 /analyze** — PR #1811 persisted `01-analysis/1720-wave2-delete-scoping.md`.
 - **Filed** rs#1945 (cross-SDK #1720 legacy-provider retirement + BYOK parity; grant journal/0005).
-- **Wave 1A** (tests→tmp_path) — testing-specialist agent still running; merge its PR when it lands.
+- **Wave 1A** (tests→tmp_path) — agent hit a session limit mid-investigation; DEFERRED as INCREMENTAL (real fix is src-level discovered-root redirect, captured in `04-validate/f-testhyg-followup.md`; orphaned worktree cleaned; `.gitignore` #1808 mitigates the symptom).
 
 ## Outstanding ledger (forest) — value-ranked
 
@@ -57,7 +57,7 @@ Next session: START the Wave 2 handoff section below.
 | **F1720C** | **#1720 Wave 2 — DELETE legacy `providers/llm` (subsumes #1803)** | #1720 tracker (terminal goal) | **SCOPED (01-analysis/1720-wave2-delete-scoping.md); DEFERRED to fresh session — see Wave 2 handoff below** |
 | F1803 | gate legacy/multimodal/azure provider layer | #1779 follow-up | **SUBSUMED by F1720C delete** (deleted layer needs no gate) |
 | F1782 | loom Gate-2 rule sync | sync-artifact policy | **DONE** — merged (safety-verified) |
-| F-TESTHYG | kaizen-agents tests → `tmp_path` | test-hygiene | **IN FLIGHT** — Wave 1A agent running; merge its PR |
+| F-TESTHYG | kaizen-agents test-scratch root writes | test-hygiene | **DEFERRED** (INCREMENTAL) — Wave 1A agent hit session limit; found the real fix is src-level (discovered-root writes, not just CWD); chdir-fixture partial captured. See `04-validate/f-testhyg-followup.md`; `.gitignore` #1808 mitigates. Revisit `after-milestone:1720-wave2` |
 | FRECON | archive 4 stale workspaces | value-prioritization MUST-4 | **DONE** — PR #1810 |
 | F-LOOMCANON | Canonicalize release-hazards #1 (dependencies.md pin-floor) + #3 (deployment.md interdependent-minors TestPyPI) | journal/0003; loom rule fleet | OPEN — loom /codify (not this repo) |
 | FVERT | Vertex-Claude/Gemini LIVE validation | #1717 headline path | BLOCKED — GCP creds not in .env |

--- a/workspaces/issue-1720-llm-consolidation/04-validate/f-testhyg-followup.md
+++ b/workspaces/issue-1720-llm-consolidation/04-validate/f-testhyg-followup.md
@@ -1,0 +1,55 @@
+# F-TESTHYG follow-up — kaizen-agents test-scratch root writes (DEFERRED)
+
+Wave 1A agent (2026-07-18) hit a session limit mid-investigation. Captured here
+so a fresh session starts ahead. **Symptom already mitigated** by the `.gitignore`
+band-aid (PR #1808) — this is the real fix behind it.
+
+## Finding (agent investigation, verified)
+
+The kaizen-agents scratch files split into TWO classes:
+
+1. **CWD-relative writes** (`proposal*.txt`, `task_*.txt`, `memory.txt`,
+   `session*.txt`, `delegation_plan.txt`, `evaluation_results.json`, …) — computed
+   at runtime from task/session/proposal keys, written relative to the current
+   working directory. Run from the package root → land beside the source tree.
+   **A `monkeypatch.chdir(tmp_path)` autouse fixture catches this class** (below).
+
+2. **Discovered/absolute-root writes** (`consensus_<hash>.json`,
+   `detailed_proposal.txt`, `proposal_evaluation.txt`) — these landed at the
+   package root **even with the chdir fixture active** (observed in the agent's
+   worktree). So some kaizen-agents code DISCOVERS a project root (not CWD) and
+   writes there during real-LLM runs. The chdir fixture does NOT catch this class.
+
+## Partial fix (agent-authored, NOT merged — the chdir fixture)
+
+```python
+# packages/kaizen-agents/tests/conftest.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd_scratch(tmp_path, monkeypatch):
+    """Route CWD-relative scratch writes into an isolated auto-cleaned temp dir."""
+    monkeypatch.chdir(tmp_path)
+```
+
+Catches class 1 only. Left un-merged: (a) incomplete (class 2 still leaks),
+(b) shipping a partial fix adds little over the .gitignore band-aid.
+
+## Real fix (fresh session — src-level)
+
+Locate the root-discovery logic in kaizen-agents that writes class-2 scratch
+(`grep -rn "consensus_\|detailed_proposal\|proposal_evaluation\|_find.*root\|project_root" packages/kaizen-agents/src`)
+and either (a) route it through an env-var workspace-root knob the tests set to
+`tmp_path`, or (b) fix the code to write CWD-relative (then the chdir fixture
+covers everything). Touches src → its own redteam + a kaizen-agents release.
+
+## product-completion-first disposition (INCREMENTAL defer, 4 conditions)
+
+- (i) **Blocking-safety:** does NOT touch any shipped/success path; scratch is
+  test-run litter, not a runtime defect. `.gitignore` (#1808) prevents commits.
+- (ii) **Value-anchor:** test-hygiene per the owner's minor-note ("address the
+  scratch litter"); the real fix removes the band-aid dependency.
+- (iii) **Acceptance:** after a kaizen-agents test run, `git status` shows ZERO
+  new scratch at the package root WITHOUT relying on `.gitignore`.
+- (iv) **Revisit trigger:** `after-milestone:1720-wave2` (bundle with the Wave-2
+  kaizen-agents release, since both touch kaizen-agents src + release).


### PR DESCRIPTION
Wave 1A agent session-limited mid-investigation; captured its finding (real fix is src-level discovered-root redirect, not tests-only) + the partial chdir fixture + product-completion-first INCREMENTAL deferral (4 conditions; .gitignore #1808 mitigates). Workspace-only → no /release. Refs #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)