### PR TITLE
fix(kaizen-agents): resolve model defaults from .env (#1825, 0.11.1)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] — 2026-07-19 — env-models: model defaults resolve from .env (#1825)
+
+### Fixed
+
+- **Hardcoded LLM model defaults now resolve from `.env` (#1825, env-models
+  rule).** Executable `model="gpt-4"` / `model: str = "gpt-4"` /
+  `.get("model", "gpt-3.5-turbo")` defaults across the package (the `api`
+  config layer — `AgentConfig.model`, the `CapabilityPresets`, `from_preset`,
+  `get_recommended_configuration` — plus the specialized-agent convenience
+  functions, `patterns`/`workflows` config fallbacks) now resolve the default
+  model from the environment via a shared helper
+  (`kaizen_agents._model_env.resolve_default_model`:
+  `OPENAI_PROD_MODEL` → `DEFAULT_LLM_MODEL` → `gpt-4o`), so a deployment's
+  configured model is honored instead of a pinned literal. Provider-intrinsic
+  defaults (the runtime adapters) and task-intrinsic defaults (the vision
+  model, the intent-detection model, the code-review preset's Claude
+  recommendation) are preserved as documented module-level constants
+  overridable via provider/task-scoped env vars (`KAIZEN_OPENAI_MODEL`,
+  `KAIZEN_GEMINI_MODEL`, `KAIZEN_CLAUDE_MODEL`, `KAIZEN_VISION_MODEL`,
+  `KAIZEN_INTENT_MODEL`, `KAIZEN_CODE_REVIEW_MODEL`) — the env-models
+  "Provider-Intrinsic Named-Constant Defaults" carve-out. No public API
+  signatures changed (defaults moved from a literal to `None`-resolves-from-env);
+  explicit `model=` arguments are unaffected. Regression test pins the
+  resolution order and asserts no executable hardcoded default remains.
+
 ## [0.11.0] — 2026-07-19 — StreamingAgent token-streaming cutover to the four-axis LlmClient (#1720 Wave-2b)
 
 ### Changed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.0"
+version = "0.11.1"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/packages/kaizen-agents/src/kaizen_agents/_model_env.py
+++ b/packages/kaizen-agents/src/kaizen_agents/_model_env.py
@@ -1,0 +1,31 @@
+"""Shared default-model resolution — ``.env`` is the single source of truth.
+
+Per the env-models rule, model names MUST come from the environment, never a
+hardcoded literal at a call site. This module is the ONE place the default
+model is resolved, reused by the LLM client and the ``api`` config layer so the
+resolution logic never drifts across the package.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Provider-intrinsic final fallback used ONLY when neither environment variable
+# is set. Documented module-level named constant (env-models carve-out):
+# overridable via ``OPENAI_PROD_MODEL`` / ``DEFAULT_LLM_MODEL`` below.
+_FALLBACK_MODEL = "gpt-4o"
+
+
+def resolve_default_model() -> str:
+    """Resolve the default model name from the environment.
+
+    Priority:
+        1. ``OPENAI_PROD_MODEL``
+        2. ``DEFAULT_LLM_MODEL``
+        3. ``"gpt-4o"`` (provider-intrinsic final fallback)
+    """
+    return (
+        os.environ.get("OPENAI_PROD_MODEL")
+        or os.environ.get("DEFAULT_LLM_MODEL")
+        or _FALLBACK_MODEL
+    )

--- a/packages/kaizen-agents/src/kaizen_agents/agents/multi_modal/vision_agent.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/multi_modal/vision_agent.py
@@ -8,7 +8,8 @@ document extraction with RAG chunking.
 Uses .run() method for standardized execution interface.
 """
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +27,14 @@ from kaizen.providers.ollama_vision_provider import (
 )
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.signatures.multi_modal import ImageField, MultiModalSignature
+
+# Task-intrinsic default: VisionAgent requires a vision-capable model, NOT a
+# general text model, so the provider-agnostic ``resolve_default_model`` is the
+# wrong modality here. Documented module-level named constant (env-models
+# "Provider-Intrinsic Named-Constant Defaults" carve-out): overridable via the
+# task-scoped ``KAIZEN_VISION_MODEL`` env var, never chained to the general
+# default-model variable.
+_DEFAULT_VISION_MODEL = "llava:13b"
 
 
 class VisionQASignature(MultiModalSignature, Signature):
@@ -50,7 +59,11 @@ class VisionAgentConfig:
 
     # Vision settings (existing - unchanged)
     llm_provider: str = "ollama"
-    model: str = "llava:13b"
+    model: str = field(
+        default_factory=lambda: os.environ.get(
+            "KAIZEN_VISION_MODEL", _DEFAULT_VISION_MODEL
+        )
+    )
     temperature: float = 0.7
     max_images: int = 5
     auto_resize: bool = True

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/batch_processing.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/batch_processing.py
@@ -39,6 +39,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from kailash.nodes.base import NodeMetadata
 
+from kaizen_agents._model_env import resolve_default_model
+
 if TYPE_CHECKING:
     from kaizen.tools.registry import ToolRegistry
 from kaizen.core.base_agent import BaseAgent
@@ -271,7 +273,7 @@ async def process_batch_quick(
     items: list[str],
     max_concurrent: int = 10,
     llm_provider: str = "openai",
-    model: str = "gpt-3.5-turbo",
+    model: str | None = None,
 ) -> list[dict[str, Any]]:
     """
     Quick batch processing with default configuration.
@@ -294,6 +296,9 @@ async def process_batch_quick(
         ... ]))
         >>> print(f"Processed {len(results)} items")
     """
+    if model is None:
+        model = resolve_default_model()
+
     agent = BatchProcessingAgent(
         max_concurrent=max_concurrent, llm_provider=llm_provider, model=model
     )

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/human_approval.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/human_approval.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from kailash.nodes.base import NodeMetadata
 
+from kaizen_agents._model_env import resolve_default_model
+
 if TYPE_CHECKING:
     from kaizen.tools.registry import ToolRegistry
 from kaizen.core.base_agent import BaseAgent
@@ -292,7 +294,7 @@ async def approve_decision(
     prompt: str,
     approval_callback: Callable[[dict[str, Any]], tuple[bool, str]] | None = None,
     llm_provider: str = "openai",
-    model: str = "gpt-4",
+    model: str | None = None,
 ) -> dict[str, Any]:
     """
     Quick decision approval with default configuration.
@@ -319,6 +321,9 @@ async def approve_decision(
         ... ))
         >>> print(f"Approved: {result['_human_approved']}")
     """
+    if model is None:
+        model = resolve_default_model()
+
     agent = HumanApprovalAgent(
         approval_callback=approval_callback, llm_provider=llm_provider, model=model
     )

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/self_reflection.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/self_reflection.py
@@ -34,6 +34,8 @@ from kaizen.core.base_agent import BaseAgent
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.strategies.multi_cycle import MultiCycleStrategy
 
+from kaizen_agents._model_env import resolve_default_model
+
 
 class ReflectionSignature(Signature):
     """Signature for self-reflection cycle."""
@@ -328,7 +330,7 @@ def reflect_and_improve(
     max_cycles: int = 3,
     improvement_threshold: float = 0.8,
     llm_provider: str = "openai",
-    model: str = "gpt-3.5-turbo",
+    model: str | None = None,
 ) -> dict[str, Any]:
     """
     Quick self-reflection with default configuration.
@@ -354,6 +356,9 @@ def reflect_and_improve(
         >>> print(f"Quality: {result['quality_score']}")
         >>> print(f"Cycles: {len(result['reflection_history'])}")
     """
+    if model is None:
+        model = resolve_default_model()
+
     agent = SelfReflectionAgent(
         max_cycles=max_cycles,
         improvement_threshold=improvement_threshold,

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/streaming_chat.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/streaming_chat.py
@@ -42,6 +42,8 @@ from kaizen.core.base_agent import BaseAgent
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.strategies.streaming import StreamingStrategy
 
+from kaizen_agents._model_env import resolve_default_model
+
 
 class ChatSignature(Signature):
     """Signature for streaming chat interactions."""
@@ -268,7 +270,7 @@ class StreamingChatAgent(BaseAgent):
 async def stream_chat(
     message: str,
     llm_provider: str = "openai",
-    model: str = "gpt-3.5-turbo",
+    model: str | None = None,
     chunk_size: int = 1,
 ) -> AsyncIterator[str]:
     """
@@ -293,6 +295,9 @@ async def stream_chat(
         ...
         >>> asyncio.run(demo())
     """
+    if model is None:
+        model = resolve_default_model()
+
     agent = StreamingChatAgent(
         llm_provider=llm_provider, model=model, streaming=True, chunk_size=chunk_size
     )

--- a/packages/kaizen-agents/src/kaizen_agents/api/config.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/config.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from kaizen_agents._model_env import resolve_default_model
+
 from kaizen_agents.api.types import (
     AgentCapabilities,
     ExecutionMode,
@@ -191,8 +193,9 @@ class AgentConfig:
 
     # === Core Configuration ===
 
-    model: str = "gpt-4"
-    """Primary model to use."""
+    model: str = field(default_factory=resolve_default_model)
+    """Primary model to use. Defaults to the .env-resolved model
+    (OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> gpt-4o)."""
 
     provider: str | None = None
     """LLM provider. None for auto-detection based on model."""
@@ -429,7 +432,7 @@ class AgentConfig:
 
         # Map preset config to AgentConfig fields
         return cls(
-            model=preset_config.get("model", "gpt-4"),
+            model=preset_config.get("model") or resolve_default_model(),
             execution_mode=ExecutionMode(preset_config.get("execution_mode", "single")),
             max_cycles=preset_config.get("max_cycles", 100),
             max_turns=preset_config.get("max_turns", 50),

--- a/packages/kaizen-agents/src/kaizen_agents/api/presets.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/presets.py
@@ -5,7 +5,22 @@ This module provides pre-configured capability combinations for common use cases
 Presets are the recommended starting point for most users.
 """
 
+import os
 from typing import Any
+
+from kaizen_agents._model_env import resolve_default_model
+
+# The code-review preset default is provider-intrinsic (Claude excels at code
+# review). Documented module-level constant, overridable via
+# KAIZEN_CODE_REVIEW_MODEL (env-models "Provider-Intrinsic Named-Constant
+# Defaults" carve-out) — NOT resolved through the general text resolver, which
+# would drop the deliberate Claude recommendation.
+_DEFAULT_CODE_REVIEW_MODEL = "claude-3-opus"
+
+
+def _resolve_code_review_model() -> str:
+    """Resolve the code-review preset default (Claude, env-overridable)."""
+    return os.environ.get("KAIZEN_CODE_REVIEW_MODEL", _DEFAULT_CODE_REVIEW_MODEL)
 
 
 class CapabilityPresets:
@@ -31,7 +46,7 @@ class CapabilityPresets:
 
     @staticmethod
     def qa_assistant(
-        model: str = "gpt-4",
+        model: str | None = None,
         **overrides,
     ) -> dict[str, Any]:
         """
@@ -54,7 +69,7 @@ class CapabilityPresets:
             result = agent.run("What is IRP?")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "single",
             "memory": "stateless",
             "tool_access": "none",
@@ -66,7 +81,7 @@ class CapabilityPresets:
 
     @staticmethod
     def tutor(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_turns: int = 50,
         **overrides,
     ) -> dict[str, Any]:
@@ -92,7 +107,7 @@ class CapabilityPresets:
             result = agent.chat("Can you give me an example?")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "multi",
             "memory": "session",
             "tool_access": "none",
@@ -104,7 +119,7 @@ class CapabilityPresets:
 
     @staticmethod
     def researcher(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_cycles: int = 50,
         **overrides,
     ) -> dict[str, Any]:
@@ -129,7 +144,7 @@ class CapabilityPresets:
             result = agent.run("Analyze the authentication module and identify security issues")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "autonomous",
             "memory": "session",
             "tool_access": "read_only",
@@ -141,7 +156,7 @@ class CapabilityPresets:
 
     @staticmethod
     def developer(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_cycles: int = 100,
         **overrides,
     ) -> dict[str, Any]:
@@ -166,7 +181,7 @@ class CapabilityPresets:
             result = agent.run("Implement a REST API endpoint for user authentication")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "autonomous",
             "memory": "session",
             "tool_access": "constrained",
@@ -178,7 +193,7 @@ class CapabilityPresets:
 
     @staticmethod
     def admin(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_cycles: int = 100,
         **overrides,
     ) -> dict[str, Any]:
@@ -206,7 +221,7 @@ class CapabilityPresets:
             result = agent.run("Deploy the new version to staging")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "autonomous",
             "memory": "persistent",
             "tool_access": "full",
@@ -218,7 +233,7 @@ class CapabilityPresets:
 
     @staticmethod
     def chat_assistant(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_turns: int = 100,
         memory_path: str | None = None,
         **overrides,
@@ -247,7 +262,7 @@ class CapabilityPresets:
             result = agent.chat("What's my favorite color?")  # Remembers!
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "multi",
             "memory": "persistent",
             "memory_path": memory_path or "./data/chat_memory",
@@ -260,7 +275,7 @@ class CapabilityPresets:
 
     @staticmethod
     def data_analyst(
-        model: str = "gpt-4",
+        model: str | None = None,
         max_cycles: int = 50,
         **overrides,
     ) -> dict[str, Any]:
@@ -285,7 +300,7 @@ class CapabilityPresets:
             result = agent.run("Analyze sales.csv and create a summary report")
         """
         config = {
-            "model": model,
+            "model": model or resolve_default_model(),
             "execution_mode": "autonomous",
             "memory": "session",
             "tool_access": "constrained",
@@ -305,7 +320,9 @@ class CapabilityPresets:
 
     @staticmethod
     def code_reviewer(
-        model: str = "claude-3-opus",  # Claude excels at code review
+        model: (
+            str | None
+        ) = None,  # default resolves to KAIZEN_CODE_REVIEW_MODEL / claude-3-opus
         max_cycles: int = 30,
         **overrides,
     ) -> dict[str, Any]:
@@ -330,7 +347,7 @@ class CapabilityPresets:
             result = agent.run("Review the authentication module for security issues")
         """
         config = {
-            "model": model,
+            "model": model or _resolve_code_review_model(),
             "execution_mode": "autonomous",
             "memory": "session",
             "tool_access": "read_only",

--- a/packages/kaizen-agents/src/kaizen_agents/api/validation.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/validation.py
@@ -7,6 +7,8 @@ All errors include remediation suggestions to help users fix configuration issue
 
 from typing import Any
 
+from kaizen_agents._model_env import resolve_default_model
+
 from kaizen_agents.api.types import (
     AgentCapabilities,
     ExecutionMode,
@@ -527,7 +529,7 @@ def validate_execution_mode_for_task(
 
 def get_recommended_configuration(
     task: str,
-    model: str = "gpt-4",
+    model: str | None = None,
 ) -> dict[str, Any]:
     """
     Get recommended configuration based on task description.
@@ -546,6 +548,7 @@ def get_recommended_configuration(
         # Returns: {"execution_mode": "autonomous", "tool_access": "constrained", ...}
     """
     task_lower = task.lower()
+    model = model or resolve_default_model()
 
     # Default recommendation
     config = {

--- a/packages/kaizen-agents/src/kaizen_agents/journey/core.py
+++ b/packages/kaizen-agents/src/kaizen_agents/journey/core.py
@@ -42,6 +42,7 @@ Usage:
     session = await journey.start()
 """
 
+import os
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
@@ -57,6 +58,11 @@ if TYPE_CHECKING:
     from kaizen_agents.patterns.pipeline import Pipeline
 
 from kaizen_agents.journey.behaviors import ReturnBehavior
+
+# Task-intrinsic default: a deliberately small model chosen for the low-latency
+# intent-classification task (NOT the provider-agnostic prod model). Documented
+# module-level constant, overridable via the KAIZEN_INTENT_MODEL env var.
+_DEFAULT_INTENT_MODEL = "gpt-4o-mini"
 
 # ============================================================================
 # Data Classes (REQ-JC-005)
@@ -84,7 +90,11 @@ class JourneyConfig:
     """
 
     # Intent detection
-    intent_detection_model: str = "gpt-4o-mini"
+    intent_detection_model: str = field(
+        default_factory=lambda: os.environ.get(
+            "KAIZEN_INTENT_MODEL", _DEFAULT_INTENT_MODEL
+        )
+    )
     intent_confidence_threshold: float = 0.7
     intent_cache_ttl_seconds: int = 300
 

--- a/packages/kaizen-agents/src/kaizen_agents/journey/intent.py
+++ b/packages/kaizen-agents/src/kaizen_agents/journey/intent.py
@@ -50,6 +50,7 @@ References:
 import hashlib
 import json
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
@@ -60,6 +61,11 @@ if TYPE_CHECKING:
     from kaizen_agents.journey.transitions import IntentTrigger
 
 logger = logging.getLogger(__name__)
+
+# Task-intrinsic default: a deliberately small model chosen for the low-latency
+# intent-classification task (NOT the provider-agnostic prod model). Documented
+# module-level constant, overridable via the KAIZEN_INTENT_MODEL env var.
+_DEFAULT_INTENT_MODEL = "gpt-4o-mini"
 
 
 # ============================================================================
@@ -190,7 +196,7 @@ class IntentDetector:
 
     def __init__(
         self,
-        model: str = "gpt-4o-mini",
+        model: str | None = None,
         llm_provider: str = "openai",
         cache_ttl_seconds: int = 300,
         confidence_threshold: float = 0.7,
@@ -200,12 +206,15 @@ class IntentDetector:
         Initialize IntentDetector.
 
         Args:
-            model: LLM model for classification
+            model: LLM model for classification. Defaults to the task-intrinsic
+                intent model (KAIZEN_INTENT_MODEL env var, else gpt-4o-mini).
             llm_provider: LLM provider (openai, ollama, etc.)
             cache_ttl_seconds: Cache TTL in seconds
             confidence_threshold: Minimum confidence for valid match
             max_cache_size: Maximum cache entries before eviction
         """
+        if model is None:
+            model = os.environ.get("KAIZEN_INTENT_MODEL", _DEFAULT_INTENT_MODEL)
         self.model = model
         self.llm_provider = llm_provider
         self.cache_ttl_seconds = cache_ttl_seconds

--- a/packages/kaizen-agents/src/kaizen_agents/patterns/core/patterns.py
+++ b/packages/kaizen-agents/src/kaizen_agents/patterns/core/patterns.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from kailash.workflow.builder import WorkflowBuilder
+from kaizen_agents._model_env import resolve_default_model
 from kaizen_agents.workflows.consensus import ConsensusWorkflow
 from kaizen_agents.workflows.debate import DebateWorkflow, EnterpriseDebateWorkflow
 from kaizen_agents.workflows.supervisor_worker import SupervisorWorkerWorkflow
@@ -402,7 +403,7 @@ class TeamCoordinationPattern(CoordinationPattern):
         # Add each team member as A2A agent node
         for i, member in enumerate(team.members):
             agent_config = {
-                "model": member.config.get("model", "gpt-3.5-turbo"),
+                "model": member.config.get("model") or resolve_default_model(),
                 "generation_config": member.config.get(
                     "generation_config",
                     {

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/claude_code.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/claude_code.py
@@ -36,6 +36,11 @@ from kaizen_agents.runtime_adapters.tool_mapping import MCPToolMapper
 
 logger = logging.getLogger(__name__)
 
+# Provider-intrinsic default (this adapter IS Claude). Documented module-level
+# named constant, overridable via the KAIZEN_CLAUDE_MODEL env var. NOT chained
+# to the provider-agnostic default resolver — a non-Claude model here is wrong.
+_DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
 
 class ClaudeCodeAdapter(BaseRuntimeAdapter):
     """Adapter that delegates to Claude Code SDK.
@@ -75,7 +80,7 @@ class ClaudeCodeAdapter(BaseRuntimeAdapter):
         max_tokens: int = 8192,
         timeout_seconds: float = 300,
         allowed_commands: list[str] | None = None,
-        model: str = "claude-sonnet-4-20250514",
+        model: str | None = None,
     ):
         """Initialize the ClaudeCodeAdapter.
 
@@ -104,6 +109,8 @@ class ClaudeCodeAdapter(BaseRuntimeAdapter):
         self.max_tokens = max_tokens
         self.timeout_seconds = timeout_seconds
         self.allowed_commands = allowed_commands
+        if model is None:
+            model = os.environ.get("KAIZEN_CLAUDE_MODEL", _DEFAULT_MODEL)
         self.model = model
 
         # Session tracking

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/gemini_cli.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/gemini_cli.py
@@ -31,6 +31,11 @@ from kaizen_agents.runtime_adapters.tool_mapping import GeminiToolMapper
 
 logger = logging.getLogger(__name__)
 
+# Provider-intrinsic default (this adapter IS Gemini). Documented module-level
+# named constant, overridable via the KAIZEN_GEMINI_MODEL env var. NOT chained
+# to the provider-agnostic default resolver — a non-Gemini model here is wrong.
+_DEFAULT_MODEL = "gemini-1.5-pro"
+
 
 class GeminiCLIAdapter(BaseRuntimeAdapter):
     """Adapter that delegates to Google Gemini API.
@@ -65,7 +70,7 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "gemini-1.5-pro",
+        model: str | None = None,
         enable_code_execution: bool = False,
         custom_tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.7,
@@ -100,6 +105,8 @@ class GeminiCLIAdapter(BaseRuntimeAdapter):
         super().__init__()
 
         self.api_key = api_key or os.environ.get("GOOGLE_API_KEY")
+        if model is None:
+            model = os.environ.get("KAIZEN_GEMINI_MODEL", _DEFAULT_MODEL)
         self.model = model
         self.enable_code_execution = enable_code_execution
         self.custom_tools = custom_tools or []

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/openai_codex.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/openai_codex.py
@@ -30,6 +30,11 @@ from kaizen_agents.runtime_adapters.tool_mapping import OpenAIToolMapper
 
 logger = logging.getLogger(__name__)
 
+# Provider-intrinsic default (this adapter IS OpenAI). Documented module-level
+# named constant, overridable via the KAIZEN_OPENAI_MODEL env var. NOT chained
+# to the provider-agnostic default resolver — a non-OpenAI model here is wrong.
+_DEFAULT_MODEL = "gpt-4o"
+
 
 class OpenAICodexAdapter(BaseRuntimeAdapter):
     """Adapter that delegates to OpenAI Responses API.
@@ -70,7 +75,7 @@ class OpenAICodexAdapter(BaseRuntimeAdapter):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "gpt-4o",
+        model: str | None = None,
         enable_code_interpreter: bool = True,
         enable_file_search: bool = False,
         custom_tools: list[dict[str, Any]] | None = None,
@@ -104,6 +109,8 @@ class OpenAICodexAdapter(BaseRuntimeAdapter):
         super().__init__()
 
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if model is None:
+            model = os.environ.get("KAIZEN_OPENAI_MODEL", _DEFAULT_MODEL)
         self.model = model
         self.enable_code_interpreter = enable_code_interpreter
         self.enable_file_search = enable_file_search

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/types.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/types.py
@@ -9,11 +9,17 @@ Defines the core types for the native autonomous agent implementation:
 - PermissionMode: Tool permission modes
 """
 
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
+
+# Provider-intrinsic default for the native (OpenAI-backed) autonomous runtime.
+# Documented module-level named constant, overridable via the KAIZEN_OPENAI_MODEL
+# env var. NOT chained to the provider-agnostic default resolver.
+_DEFAULT_MODEL = "gpt-4o"
 
 
 class AutonomousPhase(Enum):
@@ -79,7 +85,9 @@ class AutonomousConfig:
 
     # LLM settings
     llm_provider: str = "openai"
-    model: str = "gpt-4o"
+    model: str = field(
+        default_factory=lambda: os.environ.get("KAIZEN_OPENAI_MODEL", _DEFAULT_MODEL)
+    )
     temperature: float = 0.7
 
     # Execution limits

--- a/packages/kaizen-agents/src/kaizen_agents/workflows/consensus.py
+++ b/packages/kaizen-agents/src/kaizen_agents/workflows/consensus.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from kailash.workflow.builder import WorkflowBuilder
 
+from kaizen_agents._model_env import resolve_default_model
+
 logger = logging.getLogger(__name__)
 
 
@@ -104,7 +106,7 @@ class ConsensusWorkflow:
         # Add each agent as A2A agent node
         for i, agent in enumerate(self.agents):
             agent_config = {
-                "model": agent.config.get("model", "gpt-3.5-turbo"),
+                "model": agent.config.get("model") or resolve_default_model(),
                 "generation_config": agent.config.get(
                     "generation_config",
                     {

--- a/packages/kaizen-agents/src/kaizen_agents/workflows/debate.py
+++ b/packages/kaizen-agents/src/kaizen_agents/workflows/debate.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from kailash.workflow.builder import WorkflowBuilder
 
+from kaizen_agents._model_env import resolve_default_model
+
 logger = logging.getLogger(__name__)
 
 
@@ -100,7 +102,7 @@ class DebateWorkflow:
         # Add each agent as A2A agent node
         for i, agent in enumerate(self.agents):
             agent_config = {
-                "model": agent.config.get("model", "gpt-3.5-turbo"),
+                "model": agent.config.get("model") or resolve_default_model(),
                 "generation_config": agent.config.get(
                     "generation_config",
                     {

--- a/packages/kaizen-agents/src/kaizen_agents/workflows/supervisor_worker.py
+++ b/packages/kaizen-agents/src/kaizen_agents/workflows/supervisor_worker.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from kailash.workflow.builder import WorkflowBuilder
 
+from kaizen_agents._model_env import resolve_default_model
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,7 +161,7 @@ class SupervisorWorkerWorkflow:
         # Add each worker as A2A agent node
         for i, worker in enumerate(self.workers):
             worker_config = {
-                "model": worker.config.get("model", "gpt-3.5-turbo"),
+                "model": worker.config.get("model") or resolve_default_model(),
                 "generation_config": worker.config.get(
                     "generation_config",
                     {

--- a/packages/kaizen-agents/tests/regression/test_env_models_defaults.py
+++ b/packages/kaizen-agents/tests/regression/test_env_models_defaults.py
@@ -1,0 +1,103 @@
+"""Regression: model defaults resolve from .env, never a hardcoded literal.
+
+Issue #1825 — the env-models rule requires model names to come from the
+environment (``OPENAI_PROD_MODEL`` -> ``DEFAULT_LLM_MODEL`` -> ``gpt-4o``), not
+inline ``model="gpt-4"`` executable defaults. These tests pin the resolution
+behaviour so a future edit that re-hardcodes a default fails loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen_agents._model_env import resolve_default_model
+
+pytestmark = pytest.mark.regression
+
+
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+
+
+def test_resolve_default_model_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 1. OPENAI_PROD_MODEL wins.
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "prod-model")
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", "fallback-model")
+    assert resolve_default_model() == "prod-model"
+
+    # 2. DEFAULT_LLM_MODEL when prod is unset.
+    monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+    assert resolve_default_model() == "fallback-model"
+
+    # 3. gpt-4o final fallback when neither is set.
+    _clear_model_env(monkeypatch)
+    assert resolve_default_model() == "gpt-4o"
+
+
+def test_agent_config_model_defaults_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kaizen_agents.api.config import AgentConfig
+
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "config-env-model")
+    assert AgentConfig().model == "config-env-model"
+    # Never the retired hardcoded default.
+    assert AgentConfig().model != "gpt-4"
+
+
+def test_preset_model_defaults_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kaizen_agents.api.presets import CapabilityPresets
+
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "preset-env-model")
+    assert CapabilityPresets.qa_assistant()["model"] == "preset-env-model"
+    assert CapabilityPresets.researcher()["model"] == "preset-env-model"
+
+
+def test_code_reviewer_preset_is_provider_intrinsic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # code_reviewer is provider-intrinsic (Claude excels at review): it does NOT
+    # follow the general resolver, and is overridable via KAIZEN_CODE_REVIEW_MODEL.
+    from kaizen_agents.api.presets import CapabilityPresets
+
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "some-openai-model")
+    monkeypatch.delenv("KAIZEN_CODE_REVIEW_MODEL", raising=False)
+    assert CapabilityPresets.code_reviewer()["model"] == "claude-3-opus"
+
+    monkeypatch.setenv("KAIZEN_CODE_REVIEW_MODEL", "claude-custom")
+    assert CapabilityPresets.code_reviewer()["model"] == "claude-custom"
+
+
+def test_get_recommended_configuration_defaults_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kaizen_agents.api.validation import get_recommended_configuration
+
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "reco-env-model")
+    cfg = get_recommended_configuration("summarize this document")
+    assert cfg["model"] == "reco-env-model"
+
+
+def test_no_executable_hardcoded_gpt4_defaults() -> None:
+    """Structural: no executable ``model: str = "gpt-4"`` / ``.get("model", "gpt-4")``
+    default remains in kaizen_agents source (docstrings + carve-out constants excluded).
+    """
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[2] / "src" / "kaizen_agents"
+    pattern = re.compile(r'model:\s*str\s*=\s*"gpt|\.get\("model",\s*"gpt')
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        for i, line in enumerate(py.read_text().splitlines(), 1):
+            stripped = line.lstrip()
+            if (
+                stripped.startswith("#")
+                or stripped.startswith("...")
+                or "_DEFAULT" in line
+            ):
+                continue
+            if pattern.search(line):
+                offenders.append(f"{py.relative_to(src)}:{i}: {stripped}")
+    assert not offenders, "executable hardcoded-model defaults found:\n" + "\n".join(
+        offenders
+    )

--- a/packages/kaizen-agents/tests/unit/api/test_config.py
+++ b/packages/kaizen-agents/tests/unit/api/test_config.py
@@ -150,7 +150,11 @@ class TestAgentConfigCreation:
         """Test creating with defaults."""
         config = AgentConfig()
 
-        assert config.model == "gpt-4"
+        # Default model is resolved from .env (env-models rule, #1825), not a
+        # hardcoded literal.
+        from kaizen_agents._model_env import resolve_default_model
+
+        assert config.model == resolve_default_model()
         assert config.execution_mode == ExecutionMode.SINGLE
         assert config.max_cycles == 100
         assert config.max_turns == 50


### PR DESCRIPTION
## Summary

Resolves the env-models violation class surfaced by the #1720 Wave-2 holistic red-team: executable hardcoded model defaults (`model="gpt-4"`, `model: str = "gpt-4"`, `.get("model", "gpt-3.5-turbo")`) across `kaizen-agents` pinned a deprecated model and blocked per-environment model selection.

## Approach

- New shared helper `kaizen_agents._model_env.resolve_default_model()` — single source of truth (`OPENAI_PROD_MODEL` → `DEFAULT_LLM_MODEL` → `gpt-4o`).
- **General-purpose text defaults** → resolve via the helper (api config layer: `AgentConfig.model`, `CapabilityPresets`, `from_preset`, `get_recommended_configuration`; specialized-agent convenience fns; patterns/workflows fallbacks).
- **Provider-intrinsic** (runtime adapters) and **task-intrinsic** (vision, intent-detection, code-review) defaults → documented module-level constants overridable via provider/task-scoped env vars (`KAIZEN_OPENAI_MODEL`, `KAIZEN_GEMINI_MODEL`, `KAIZEN_CLAUDE_MODEL`, `KAIZEN_VISION_MODEL`, `KAIZEN_INTENT_MODEL`, `KAIZEN_CODE_REVIEW_MODEL`) — the env-models named-constant carve-out, so no wrong cross-provider default is forced.

No public signatures changed (literal defaults → `None`-resolves-from-env); explicit `model=` args unaffected.

## Testing

- New regression test (`tests/regression/test_env_models_defaults.py`, 6 tests) pins the resolution order + a structural "no executable hardcoded default remains" check.
- Updated one test that pinned the old `"gpt-4"` default.
- Targeted local gate: 803 passed across api/journey/orchestration/adapters/regression.
- Residual grep clean — zero executable hardcoded-model defaults remain.

## Related issues

Fixes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)