### PR TITLE
fix(nexus): webhook signature verification fails closed when no secret configured (#1814)

### DIFF
--- a/packages/kailash-nexus/src/nexus/transports/webhook.py
+++ b/packages/kailash-nexus/src/nexus/transports/webhook.py
@@ -499,10 +499,15 @@ class WebhookTransport(Transport):
 
         Returns:
             True if the signature is valid, False otherwise.
+
+        Raises:
+            ValueError: If no secret is configured. Reaching verification
+                with a signature but no secret is a misconfiguration: the
+                signature cannot be checked, so verification MUST fail closed
+                rather than accept any payload. Mirrors compute_signature.
         """
         if self._secret is None:
-            # No secret configured — verification is vacuously true
-            return True
+            raise ValueError("Cannot verify signature: no secret configured")
 
         ok = self._signer.verify(
             secret=self._secret,
@@ -542,9 +547,13 @@ class WebhookTransport(Transport):
 
         Returns:
             True if the signature is valid, False otherwise.
+
+        Raises:
+            ValueError: If no secret is configured. Fails closed rather than
+                accepting any payload+signature (mirrors compute_signature).
         """
         if self._secret is None:
-            return True
+            raise ValueError("Cannot verify signature: no secret configured")
 
         ok = self._signer.verify(
             secret=self._secret,

--- a/packages/kailash-nexus/tests/regression/test_issue_1814_webhook_fail_closed.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1814_webhook_fail_closed.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 regression test for issue #1814.
+
+Webhook signature verification MUST fail closed when no secret is
+configured. Before the fix, ``WebhookTransport.verify_signature`` and
+``verify_signature_for_request`` returned ``True`` when ``self._secret``
+was ``None`` — accepting ANY forged payload+signature reaching the verify
+path (a fail-open signature bypass on webhook ingress).
+
+The fix mirrors the existing ``compute_signature`` guard: reaching a
+verify entry point with a signature but no secret is a misconfiguration,
+so verification raises ``ValueError`` rather than returning ``True``.
+
+This exercises the real ``WebhookTransport`` + the real
+``HmacSha256Signer`` (no mocking of the code under test, per
+``rules/testing.md`` § Tier 2):
+
+- No secret configured + a forged payload/signature → REJECTED (raises
+  ``ValueError``), for BOTH ``verify_signature`` and
+  ``verify_signature_for_request``.
+- Secret configured + a forged signature → returns ``False`` (unchanged).
+- Secret configured + a valid signature → returns ``True`` (unchanged).
+
+Note ``receive()`` semantics are intentionally UNCHANGED and out of scope:
+it guards the verify call with ``if self._secret is not None`` and so
+never reaches the new raise on the unsigned-receive path. That path stays
+covered by the pre-existing unit test
+``test_receive_no_secret_skips_verification``.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+
+from nexus.transports.webhook import WebhookTransport
+
+
+def _make_signature(secret: str, payload_bytes: bytes) -> str:
+    """Compute the canonical HMAC-SHA256 signature the signer expects."""
+    mac = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+@pytest.mark.regression
+def test_verify_signature_no_secret_rejects_forged_payload():
+    """No secret + forged signature → raises, never fail-open True (#1814)."""
+    transport = WebhookTransport()  # no secret configured
+    forged_payload = b'{"event": "payment.completed", "amount": 1000000}'
+    forged_signature = "sha256=" + "0" * 64
+
+    with pytest.raises(ValueError, match="no secret configured"):
+        transport.verify_signature(forged_payload, forged_signature)
+
+
+@pytest.mark.regression
+def test_verify_signature_for_request_no_secret_rejects_forged_payload():
+    """No secret + forged signature (URL-canonical path) → raises (#1814)."""
+    transport = WebhookTransport()  # no secret configured
+    forged_payload = b'{"event": "payment.completed", "amount": 1000000}'
+    forged_signature = "sha256=" + "0" * 64
+
+    with pytest.raises(ValueError, match="no secret configured"):
+        transport.verify_signature_for_request(
+            url="https://example.com/webhooks/inbound",
+            payload_bytes=forged_payload,
+            signature=forged_signature,
+        )
+
+
+@pytest.mark.regression
+def test_verify_signature_secret_configured_rejects_forged_signature():
+    """Secret configured + forged signature → False (unchanged behaviour)."""
+    secret = "test-webhook-secret-key"
+    transport = WebhookTransport(secret=secret)
+    payload = b'{"event": "user.created"}'
+
+    assert transport.verify_signature(payload, "sha256=deadbeef") is False
+
+
+@pytest.mark.regression
+def test_verify_signature_secret_configured_accepts_valid_signature():
+    """Secret configured + valid signature → True (unchanged behaviour)."""
+    secret = "test-webhook-secret-key"
+    transport = WebhookTransport(secret=secret)
+    payload = b'{"event": "user.created"}'
+    valid_signature = _make_signature(secret, payload)
+
+    assert transport.verify_signature(payload, valid_signature) is True

--- a/packages/kailash-nexus/tests/unit/transports/test_webhook.py
+++ b/packages/kailash-nexus/tests/unit/transports/test_webhook.py
@@ -150,9 +150,25 @@ class TestSignatureVerification:
         tampered = b'{"event": "user.deleted"}'
         assert transport.verify_signature(tampered, sig) is False
 
-    def test_verify_no_secret_always_true(self, transport_no_secret):
-        """Without a secret, verification is vacuously true."""
-        assert transport_no_secret.verify_signature(b"anything", "sha256=bogus") is True
+    def test_verify_no_secret_fails_closed(self, transport_no_secret):
+        """Without a secret, verification fails closed (issue #1814).
+
+        A caller reaching verify_signature with a signature but no secret is
+        a misconfiguration: the signature cannot be checked, so verification
+        MUST raise rather than accept any payload (fail-open bypass). Mirrors
+        compute_signature's existing no-secret guard.
+        """
+        with pytest.raises(ValueError, match="no secret configured"):
+            transport_no_secret.verify_signature(b"anything", "sha256=bogus")
+
+    def test_verify_for_request_no_secret_fails_closed(self, transport_no_secret):
+        """verify_signature_for_request also fails closed with no secret (#1814)."""
+        with pytest.raises(ValueError, match="no secret configured"):
+            transport_no_secret.verify_signature_for_request(
+                url="https://example.com/webhook",
+                payload_bytes=b"anything",
+                signature="sha256=bogus",
+            )
 
     def test_signature_deterministic(self, transport):
         payload = b"consistent"


### PR DESCRIPTION
## Summary
`WebhookTransport.verify_signature` / `verify_signature_for_request` returned `True` for any payload+signature when no signing secret was configured — a signature-verification bypass on the webhook ingress. They now `raise ValueError` (mirroring the existing `compute_signature` no-secret guard), failing closed. `receive()`'s intentional unsigned-webhook mode is unchanged (out of scope).

## Tests
- Rewrote `test_verify_no_secret_always_true` → asserts the fail-closed contract (orphan-detection Rule 4a).
- New Tier-2 regression `test_issue_1814_webhook_fail_closed.py` (forged payload rejected with no secret; forged→False / valid→True with a secret).
- `69 passed` (unit + regression).

## Review
security-reviewer: no residual bypass in the public verify path; no timing/swallow issue.

## Related issues
Fixes #1814