### PR TITLE
fix(auth): enforce OIDC id_token nonce + add PKCE S256 to SSO auth-code flow (#1815)

### DIFF
--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -432,12 +432,55 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "relay_state": kwargs.get("relay_state"),
         }
 
+    @staticmethod
+    def _pkce_pair() -> tuple[str, str]:
+        """Generate a PKCE (RFC 7636) ``code_verifier`` / ``code_challenge`` pair.
+
+        The verifier is a high-entropy secret retained by the client; the
+        challenge is its S256 (SHA-256, base64url, no padding) transform sent on
+        the authorization request. Binding the two proves the client that later
+        redeems the authorization code is the same one that requested it,
+        closing the auth-code interception attack on public clients.
+        """
+        code_verifier = secrets.token_urlsafe(64)
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        return code_verifier, code_challenge
+
+    @staticmethod
+    def _decode_id_token_claims(id_token: str) -> Dict[str, Any]:
+        """Decode the (base64url) payload segment of a JWT id_token.
+
+        This reads the claims WITHOUT verifying the signature — it is used ONLY
+        to compare the ``nonce`` claim against the value minted at authorization
+        time (a replay/injection defense layered on the provider's own token
+        validation). It MUST NOT be relied on as authentication evidence beyond
+        the nonce match.
+        """
+        parts = id_token.split(".")
+        if len(parts) < 2:
+            raise ValueError("Invalid id_token: not a JWT (missing payload segment)")
+        payload_segment = parts[1]
+        # Restore base64url padding stripped by the encoder.
+        padding = "=" * (-len(payload_segment) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(payload_segment + padding)
+            return json.loads(decoded)
+        except (ValueError, json.JSONDecodeError) as e:
+            raise ValueError(f"Invalid id_token: undecodable payload ({e})")
+
     async def _initiate_oauth(
         self, provider: str, redirect_uri: str, **kwargs
     ) -> Dict[str, Any]:
         """Initiate OAuth 2.0 / OIDC authentication flow."""
         # Generate state parameter for CSRF protection
         state = secrets.token_urlsafe(32)
+
+        # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
+        code_verifier, code_challenge = self._pkce_pair()
 
         # OAuth parameters
         auth_params = {
@@ -446,6 +489,8 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "redirect_uri": redirect_uri,
             "scope": self.oauth_settings.get("scope", "openid profile email"),
             "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
 
         # Add OIDC-specific parameters
@@ -463,6 +508,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
             "nonce": auth_params.get("nonce"),
+            "code_verifier": code_verifier,
         }
 
         return {
@@ -490,6 +536,9 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # Generate state for CSRF protection
         state = secrets.token_urlsafe(32)
 
+        # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
+        code_verifier, code_challenge = self._pkce_pair()
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("azure_client_id"),
@@ -497,6 +546,8 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "scope": "openid profile email User.Read",
             "state": state,
             "response_mode": "query",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
 
         auth_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?{urlencode(auth_params)}"
@@ -507,6 +558,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
             "tenant_id": tenant_id,
+            "code_verifier": code_verifier,
         }
 
         return {
@@ -521,6 +573,9 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         """Initiate Google Workspace authentication."""
         state = secrets.token_urlsafe(32)
 
+        # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
+        code_verifier, code_challenge = self._pkce_pair()
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("google_client_id"),
@@ -528,6 +583,8 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "scope": "openid profile email",
             "state": state,
             "access_type": "offline",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
 
         auth_url = (
@@ -538,6 +595,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "provider": "google",
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
         }
 
         return {
@@ -551,12 +609,17 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         """Initiate Okta authentication."""
         state = secrets.token_urlsafe(32)
 
+        # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
+        code_verifier, code_challenge = self._pkce_pair()
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("okta_client_id"),
             "redirect_uri": redirect_uri,
             "scope": "openid profile email groups",
             "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
 
         okta_domain = self.oauth_settings.get("okta_domain")
@@ -567,6 +630,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
             "okta_domain": okta_domain,
+            "code_verifier": code_verifier,
         }
 
         return {
@@ -621,6 +685,28 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # Exchange code for tokens
         token_result = await self._exchange_oauth_code(provider, auth_code, cached_data)
 
+        # OIDC nonce enforcement (id_token replay/injection defense).
+        # When a nonce was minted at authorization time, the returned id_token
+        # MUST be present and its ``nonce`` claim MUST match the minted value.
+        # This is layered on the provider's own token validation; it does not
+        # weaken it — a mismatch fails closed with a typed error.
+        expected_nonce = cached_data.get("nonce")
+        if expected_nonce is not None:
+            id_token = token_result.get("id_token")
+            if not id_token:
+                raise ValueError(
+                    "OIDC nonce was minted but the token response carried no "
+                    "id_token — cannot verify nonce; rejecting authentication"
+                )
+            claims = self._decode_id_token_claims(id_token)
+            returned_nonce = claims.get("nonce")
+            if returned_nonce != expected_nonce:
+                raise ValueError(
+                    "OIDC nonce mismatch — id_token nonce claim does not match "
+                    "the value minted at authorization time; rejecting "
+                    "authentication (possible id_token replay/injection)"
+                )
+
         # Get user info
         user_info = await self._get_oauth_user_info(
             provider, token_result["access_token"]
@@ -662,6 +748,13 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "client_id": self.oauth_settings.get(f"{provider}_client_id"),
             "client_secret": self.oauth_settings.get(f"{provider}_client_secret"),
         }
+
+        # PKCE (RFC 7636) — return the code_verifier bound to this authorization
+        # request so the token endpoint can confirm proof-of-possession. Guarded
+        # for presence to stay backward-safe if a cached entry predates PKCE.
+        code_verifier = cached_data.get("code_verifier")
+        if code_verifier:
+            token_data["code_verifier"] = code_verifier
 
         # Determine token endpoint
         if provider == "azure":

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -15,6 +15,7 @@ Enterprise-grade SSO implementation supporting multiple protocols:
 import asyncio
 import base64
 import hashlib
+import hmac
 import json
 import secrets
 import time
@@ -468,9 +469,15 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         padding = "=" * (-len(payload_segment) % 4)
         try:
             decoded = base64.urlsafe_b64decode(payload_segment + padding)
-            return json.loads(decoded)
+            claims = json.loads(decoded)
         except (ValueError, json.JSONDecodeError) as e:
             raise ValueError(f"Invalid id_token: undecodable payload ({e})")
+        if not isinstance(claims, dict):
+            # A valid-JSON but non-object payload (e.g. "123", "[]") has no
+            # claims to read; fail closed with a typed error rather than let
+            # a later ``claims.get(...)`` raise an opaque AttributeError.
+            raise ValueError("Invalid id_token: payload is not a JSON object")
+        return claims
 
     async def _initiate_oauth(
         self, provider: str, redirect_uri: str, **kwargs
@@ -700,7 +707,11 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 )
             claims = self._decode_id_token_claims(id_token)
             returned_nonce = claims.get("nonce")
-            if returned_nonce != expected_nonce:
+            # Constant-time compare (defense-in-depth; the one-shot state pop
+            # already bounds attempts). A missing/non-string claim fails closed.
+            if not isinstance(returned_nonce, str) or not hmac.compare_digest(
+                returned_nonce, expected_nonce
+            ):
                 raise ValueError(
                     "OIDC nonce mismatch — id_token nonce claim does not match "
                     "the value minted at authorization time; rejecting "

--- a/tests/regression/test_issue_1815_oidc_nonce_pkce.py
+++ b/tests/regression/test_issue_1815_oidc_nonce_pkce.py
@@ -1,0 +1,188 @@
+"""Regression tests for issue #1815 — OIDC SSO nonce enforcement + PKCE S256.
+
+Two HIGH-severity security gaps in the Core SDK ``SSOAuthenticationNode``:
+
+1. Nonce minted but not enforced. ``_initiate_oauth`` minted an OIDC ``nonce``
+   and cached it, but ``_handle_oauth_callback`` never decoded the returned
+   ``id_token`` nor compared its ``nonce`` claim to the cached value — the
+   minted nonce was dead, leaving the flow open to id_token replay/injection.
+
+2. PKCE S256 absent on the authorization-code flow. No ``code_challenge`` /
+   ``code_challenge_method`` was emitted on the authorize request and no
+   ``code_verifier`` was sent at token exchange — the auth code was
+   interceptable (no proof-of-possession binding).
+
+These tests pin the fixed behavior:
+- callback REJECTS (typed ValueError) when the returned id_token nonce claim
+  does NOT match the minted nonce, and when the id_token is absent though a
+  nonce was minted; ACCEPTS when it matches.
+- PKCE round-trip: ``_initiate_oauth`` emits ``code_challenge`` +
+  ``code_challenge_method=S256``; the cached ``code_verifier`` flows into
+  ``_exchange_oauth_code``; the verifier S256-hashes to the emitted challenge.
+"""
+
+import base64
+import hashlib
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+pytestmark = pytest.mark.regression
+
+
+def _s256(verifier: str) -> str:
+    """RFC 7636 S256 transform of a PKCE code_verifier."""
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def _make_id_token(claims: dict) -> str:
+    """Build an unsigned-shape JWT (header.payload.signature) for tests.
+
+    Only the base64url payload segment is load-bearing here — the nonce check
+    reads the ``nonce`` claim; it does not (and must not) treat this token as
+    signature-validated evidence beyond the nonce match.
+    """
+
+    def _seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    header = _seg({"alg": "RS256", "typ": "JWT"})
+    payload = _seg(claims)
+    return f"{header}.{payload}.sig"
+
+
+def _make_node() -> SSOAuthenticationNode:
+    return SSOAuthenticationNode(
+        name="sso_test",
+        enable_jit_provisioning=False,  # skip audit-logger path; isolate the nonce gate
+        oauth_settings={
+            "client_id": "test-client",
+            "auth_endpoint": "https://idp.example.com/oauth2/authorize",
+            "token_endpoint": "https://idp.example.com/oauth2/token",
+            "userinfo_endpoint": "https://idp.example.com/oauth2/userinfo",
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Nonce enforcement
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_nonce_mismatch():
+    """Callback MUST reject when id_token nonce != minted nonce."""
+    node = _make_node()
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+    state = init["state"]
+
+    async def fake_exchange(provider, auth_code, cached_data):
+        return {
+            "access_token": "test_access_token",
+            "token_type": "Bearer",
+            "id_token": _make_id_token({"sub": "u1", "nonce": "ATTACKER-INJECTED"}),
+        }
+
+    node._exchange_oauth_code = fake_exchange
+
+    with pytest.raises(ValueError, match="nonce"):
+        await node._handle_oauth_callback(
+            "oidc", {"state": state, "code": "auth-code-123"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_missing_id_token_when_nonce_minted():
+    """When a nonce was minted, an id_token MUST be present; absence rejects."""
+    node = _make_node()
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+    state = init["state"]
+
+    async def fake_exchange(provider, auth_code, cached_data):
+        # No id_token at all.
+        return {"access_token": "test_access_token", "token_type": "Bearer"}
+
+    node._exchange_oauth_code = fake_exchange
+
+    with pytest.raises(ValueError):
+        await node._handle_oauth_callback(
+            "oidc", {"state": state, "code": "auth-code-123"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_callback_accepts_matching_nonce():
+    """Callback MUST succeed when the id_token nonce matches the minted nonce."""
+    node = _make_node()
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+    state = init["state"]
+    minted_nonce = node.provider_cache[state]["nonce"]
+    assert minted_nonce  # sanity: nonce was actually minted
+
+    async def fake_exchange(provider, auth_code, cached_data):
+        return {
+            "access_token": "test_access_token",
+            "token_type": "Bearer",
+            "id_token": _make_id_token({"sub": "u1", "nonce": minted_nonce}),
+        }
+
+    async def fake_userinfo(provider, access_token):
+        return {"sub": "u1", "email": "user@example.com", "name": "User"}
+
+    node._exchange_oauth_code = fake_exchange
+    node._get_oauth_user_info = fake_userinfo
+
+    result = await node._handle_oauth_callback(
+        "oidc", {"state": state, "code": "auth-code-123"}
+    )
+    assert result["authenticated"] is True
+
+
+# --------------------------------------------------------------------------- #
+# PKCE S256 round-trip
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_initiate_oauth_emits_pkce_challenge():
+    """_initiate_oauth MUST emit code_challenge + code_challenge_method=S256
+    and cache the code_verifier that hashes to the challenge."""
+    node = _make_node()
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+
+    qs = parse_qs(urlparse(init["auth_url"]).query)
+    assert qs.get("code_challenge_method") == ["S256"]
+    challenge = qs["code_challenge"][0]
+
+    verifier = node.provider_cache[init["state"]]["code_verifier"]
+    assert verifier  # verifier stored in cache
+
+    # The emitted challenge MUST be the S256 transform of the cached verifier.
+    assert challenge == _s256(verifier)
+
+
+@pytest.mark.asyncio
+async def test_exchange_sends_cached_code_verifier():
+    """The cached code_verifier MUST flow into the token-exchange request."""
+    node = _make_node()
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+    cached = node.provider_cache.pop(init["state"])
+    expected_verifier = cached["code_verifier"]
+
+    captured = {}
+
+    async def fake_http(**kwargs):
+        captured.update(kwargs)
+        return {"success": True, "response": {"access_token": "x"}}
+
+    node.http_client.async_run = fake_http
+
+    await node._exchange_oauth_code("oidc", "auth-code-123", cached)
+
+    token_data = captured["data"]
+    assert token_data["code_verifier"] == expected_verifier

--- a/tests/regression/test_issue_1815_oidc_nonce_pkce.py
+++ b/tests/regression/test_issue_1815_oidc_nonce_pkce.py
@@ -186,3 +186,22 @@ async def test_exchange_sends_cached_code_verifier():
 
     token_data = captured["data"]
     assert token_data["code_verifier"] == expected_verifier
+
+
+def test_decode_id_token_rejects_non_object_payload():
+    """A valid-JSON but non-object id_token payload fails closed with a typed
+    ValueError (not an opaque AttributeError from a later ``claims.get``)."""
+    import base64 as _b64
+    import json as _json
+
+    from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+    for non_object in (123, [1, 2], "just-a-string", True):
+        payload = (
+            _b64.urlsafe_b64encode(_json.dumps(non_object).encode())
+            .rstrip(b"=")
+            .decode()
+        )
+        token = f"header.{payload}.sig"
+        with pytest.raises(ValueError, match="not a JSON object"):
+            SSOAuthenticationNode._decode_id_token_claims(token)


### PR DESCRIPTION
## Summary
`SSOAuthenticationNode` minted an OIDC `nonce` but never validated it, and the authorization-code flow had no PKCE. Fix (one file, `src/kailash/nodes/auth/sso.py`; the Kaizen subclass inherits it):
- `_pkce_pair()` (S256); all OIDC initiators emit `code_challenge`+`code_challenge_method=S256` and cache `code_verifier`; token exchange forwards it.
- Callback decodes the id_token and rejects (typed `ValueError`) on a nonce mismatch / missing id_token when a nonce was minted.
- Redteam hardening: constant-time nonce compare (`hmac.compare_digest`); non-object id_token payload fails closed with a typed error.

## Tests
TDD (red confirmed first). New `tests/regression/test_issue_1815_oidc_nonce_pkce.py` (nonce-mismatch reject, PKCE round-trip, non-object-payload guard). `6 regression + 16 unit + 11 sibling passed`.

## Review
security-reviewer: tightening-only, no new accept path. Follow-ups tracked: provider-suite PKCE parity; full id_token JWKS validation (nonce currently reads an unverified token but can only reject).

## Related issues
Fixes #1815