### PR TITLE
fix(kaizen): four-axis Gemini wire — strip responseMimeType/responseSchema when tools present (#1819)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -181,13 +181,28 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     # (openai_chat / anthropic_messages / ollama_native / etc.) — an
     # explicitly-set EMPTY `response_format={}` emits nothing, same as an
     # unset one.
-    if request.response_format:
+    #
+    # #1819 (gh#357 legacy guard, ported to the four-axis wire): Gemini rejects
+    # a request that carries BOTH responseMimeType/responseSchema AND tools
+    # (functionDeclarations) with a 400. The legacy paths dropped structured
+    # output when tools were present on Gemini (base_agent.py:126-134,
+    # workflow_generator.py:376-380); mirror that here — suppress the
+    # response_format block when tools are set, WARNing so the drop is not
+    # silent (zero-tolerance Rule 3). Function-calling is used alone; the tools
+    # block below still emits.
+    if request.response_format and not request.tools:
         rf_type = request.response_format.get("type")
         if rf_type in ("json_object", "json_schema"):
             generation_config["responseMimeType"] = "application/json"
             schema = _extract_json_schema(request.response_format)
             if schema is not None:
                 generation_config["responseSchema"] = schema
+    elif request.response_format and request.tools:
+        logger.warning(
+            "google_generate_content: response_format suppressed — Gemini rejects "
+            "responseMimeType/responseSchema combined with tools (gh#357/#1819); "
+            "using function-calling only."
+        )
 
     payload: Dict[str, Any] = {"contents": contents}
     if generation_config:

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_generate_content.py
@@ -197,7 +197,14 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
             schema = _extract_json_schema(request.response_format)
             if schema is not None:
                 generation_config["responseSchema"] = schema
-    elif request.response_format and request.tools:
+    elif (
+        request.response_format
+        and request.tools
+        and request.response_format.get("type") in ("json_object", "json_schema")
+    ):
+        # Only WARN when a JSON structured-output mode was genuinely dropped;
+        # response_format={"type":"text"} emits nothing structured regardless of
+        # tools, so warning there would misleadingly claim a suppression.
         logger.warning(
             "google_generate_content: response_format suppressed — Gemini rejects "
             "responseMimeType/responseSchema combined with tools (gh#357/#1819); "

--- a/packages/kailash-kaizen/tests/regression/test_issue_1819_gemini_tools_guard.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1819_gemini_tools_guard.py
@@ -121,3 +121,30 @@ def test_tools_alone_emits_tools_no_structured_output():
     gen = payload.get("generationConfig", {})
     assert "responseMimeType" not in gen
     assert "responseSchema" not in gen
+
+
+@pytest.mark.regression
+def test_text_response_format_plus_tools_does_not_warn(caplog):
+    """(d) response_format={"type":"text"} + tools → no responseMimeType
+    (text is Gemini's default, nothing structured to emit) AND no suppression
+    WARN — the guard must not claim a suppression that never happened."""
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[_tool()],
+        response_format={"type": "text"},
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.google_generate_content"
+    ):
+        payload = gg.build_request_payload(req)
+
+    assert "tools" in payload
+    gen = payload.get("generationConfig", {})
+    assert "responseMimeType" not in gen
+    assert "responseSchema" not in gen
+    # Nothing structured was requested -> the WARN must NOT fire (log accuracy).
+    assert not any(
+        "response_format suppressed" in rec.getMessage() for rec in caplog.records
+    ), "text response_format must not trigger a suppression WARN"

--- a/packages/kailash-kaizen/tests/regression/test_issue_1819_gemini_tools_guard.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1819_gemini_tools_guard.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1819 regression — Gemini four-axis wire must not emit responseMimeType/
+responseSchema together with tools.
+
+The four-axis ``google_generate_content`` shaper emitted the structured-output
+generationConfig keys (``responseMimeType`` / ``responseSchema``) and the
+top-level ``tools`` block independently, with no cross-check. When a
+``CompletionRequest`` carried BOTH a JSON ``response_format`` AND tools, Gemini's
+``generateContent`` endpoint 400s on the combination. The legacy paths dropped
+structured output when tools were present on Gemini (gh#357,
+base_agent.py:126-134 / workflow_generator.py:376-380); the wave-cutover to the
+four-axis wire did not carry that guard down to the shaper.
+
+Fix: gate the response_format block on tools being ABSENT, and WARN when
+suppressing (no silent drop, zero-tolerance Rule 3). Assertions are on the
+payload SHAPE (behavioral), not a source grep.
+"""
+
+import logging
+
+import pytest
+
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.wire_protocols import google_generate_content as gg
+
+
+def _base_messages():
+    return [{"role": "user", "content": "hi"}]
+
+
+def _tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Look up the weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+
+
+@pytest.mark.regression
+def test_tools_plus_response_format_suppresses_structured_output(caplog):
+    """(a) tools + response_format → tools present, NO responseMimeType/
+    responseSchema, and a WARN logged for the suppression."""
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[_tool()],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "resp",
+                "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+        },
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.google_generate_content"
+    ):
+        payload = gg.build_request_payload(req)
+
+    # Tools survive (function-calling only).
+    assert "tools" in payload
+    assert payload["tools"][0]["functionDeclarations"][0]["name"] == "get_weather"
+
+    # Structured-output keys are suppressed — this is what Gemini 400s on.
+    gen = payload.get("generationConfig", {})
+    assert "responseMimeType" not in gen
+    assert "responseSchema" not in gen
+
+    # Suppression is NOT silent (zero-tolerance Rule 3).
+    assert any(
+        "response_format suppressed" in rec.getMessage()
+        and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    ), "expected a WARN naming the response_format suppression"
+
+
+@pytest.mark.regression
+def test_response_format_alone_still_emits_structured_output(caplog):
+    """(b) response_format alone (no tools) → responseMimeType present; the
+    guard must not over-suppress the normal structured-output path."""
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        response_format={"type": "json_object"},
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="kaizen.llm.wire_protocols.google_generate_content"
+    ):
+        payload = gg.build_request_payload(req)
+
+    gen = payload["generationConfig"]
+    assert gen["responseMimeType"] == "application/json"
+    # No tools were requested -> no suppression WARN.
+    assert not any(
+        "response_format suppressed" in rec.getMessage() for rec in caplog.records
+    )
+
+
+@pytest.mark.regression
+def test_tools_alone_emits_tools_no_structured_output():
+    """(c) tools alone → tools present, no responseMimeType (nothing to
+    suppress; structured output was never requested)."""
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        tools=[_tool()],
+    )
+    payload = gg.build_request_payload(req)
+
+    assert "tools" in payload
+    gen = payload.get("generationConfig", {})
+    assert "responseMimeType" not in gen
+    assert "responseSchema" not in gen

--- a/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_google_generate_wave1b_emission.py
@@ -208,7 +208,10 @@ def test_logit_bias_never_emitted():
     assert payload["generationConfig"]["topK"] == 5
 
 
-def test_full_wave1b_request_shapes_all_surfaces():
+def test_full_wave1b_request_shapes_all_surfaces_with_tools():
+    """#1819: with tools present, structured-output (responseMimeType/
+    responseSchema) MUST be suppressed — Gemini 400s on tools + structured
+    output together (gh#357). Every OTHER surface still shapes normally."""
     schema = {"type": "object", "properties": {"x": {"type": "string"}}}
     req = CompletionRequest(
         model="test-model",
@@ -223,12 +226,39 @@ def test_full_wave1b_request_shapes_all_surfaces():
     )
     payload = gg.build_request_payload(req)
 
-    # Gemini-shaped tools.
+    # Gemini-shaped tools present.
     assert payload["tools"][0]["functionDeclarations"][0]["name"] == "f"
     # Default ANY tool_config.
     assert payload["toolConfig"]["functionCallingConfig"]["mode"] == "ANY"
     gen = payload["generationConfig"]
     assert gen["temperature"] == 0.3  # not clobbered
+    # #1819: structured-output keys ABSENT when tools are present.
+    assert "responseMimeType" not in gen
+    assert "responseSchema" not in gen
+    assert gen["topK"] == 32
+    assert gen["seed"] == 11
+    assert gen["candidateCount"] == 3
+
+
+def test_full_wave1b_request_shapes_all_surfaces_no_tools():
+    """Companion to the tools case: WITHOUT tools, the SAME sampling/structured
+    surfaces shape normally — the #1819 guard must not over-suppress."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    req = CompletionRequest(
+        model="test-model",
+        messages=_base_messages(),
+        temperature=0.3,
+        response_format={"type": "json_schema", "json_schema": {"schema": schema}},
+        top_k=32,
+        seed=11,
+        n=3,
+    )
+    payload = gg.build_request_payload(req)
+
+    assert "tools" not in payload
+    gen = payload["generationConfig"]
+    assert gen["temperature"] == 0.3
+    # No tools -> structured output present.
     assert gen["responseMimeType"] == "application/json"
     assert gen["responseSchema"] == schema
     assert gen["topK"] == 32


### PR DESCRIPTION
## Summary
`google_generate_content.build_request_payload` emitted `tools` and `responseMimeType`/`responseSchema` together → Gemini 400. Ported the mutual-exclusion guard (real legacy guard is gh#357, not #340 as the issue text says): the structured-output block is gated on `not request.tools`, and when both are present a WARN names the dropped structured-output. Redteam fix: the WARN only fires when a JSON mode (`json_object`/`json_schema`) was genuinely dropped — not for `type=text`.

## Tests
Rewrote the unit test that asserted the buggy coexistence (orphan-detection 4a); new `tests/regression/test_issue_1819_gemini_tools_guard.py` asserts payload shape for tools+json / json-alone / tools-alone / text+tools. `21 passed`.

## Note
No version/CHANGELOG here — bundled into a consolidated kaizen release with #1817/#1820.

## Related issues
Fixes #1819