### PR TITLE
feat(kaizen): four-axis multimodal file-path + high-level-audio input normalizer (#1817)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
+++ b/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
@@ -16,9 +16,31 @@ from kailash.runtime import AsyncLocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
 
 from kaizen.core.deprecation import deprecated
+from kaizen.nodes.ai.audio_utils import (
+    encode_audio,
+    get_audio_media_type,
+    validate_audio_size,
+)
 from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
+from kaizen.nodes.ai.vision_utils import (
+    encode_image,
+    get_media_type,
+    validate_image_size,
+)
 
 logger = logging.getLogger(__name__)
+
+# File-path keys a high-level multimodal input dict may carry (a local path,
+# NOT a data-URI or remote URL).
+_FILE_PATH_KEYS = (
+    "path",
+    "file_path",
+    "file",
+    "image_path",
+    "audio_path",
+    "image",
+    "audio",
+)
 
 # Allowlist regex for MCP tool names — validates before execution
 _TOOL_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.:-]{0,127}$")
@@ -38,8 +60,65 @@ def _classify_input_value(
     """
     import base64
 
-    # Already a structured content part dict (caller pre-built it)
+    # Structured content-part dict. Three cases handled here:
+    #  1. file-path / high-level image dict -> normalize to an image_url data-URI
+    #  2. file-path / high-level audio dict -> normalize to an input_audio block
+    #  3. already-wire-shaped dict (no file-path key) -> pass through verbatim
+    # Delegates ALL encoding/validation to the surviving vision/audio primitives.
     if isinstance(value, dict) and "type" in value:
+        dtype = value.get("type")
+
+        # Locate a local file path (a str that is not a data-URI / remote URL).
+        file_path = None
+        for _k in _FILE_PATH_KEYS:
+            _v = value.get(_k)
+            if (
+                isinstance(_v, str)
+                and _v
+                and not _v.startswith(("data:", "http://", "https://"))
+            ):
+                file_path = _v
+                break
+
+        if file_path is not None and dtype in ("image", "image_url"):
+            ok, err = validate_image_size(file_path)
+            if not ok:
+                raise ValueError(
+                    f"image input {file_path!r} failed size validation: {err}"
+                )
+            b64_data = encode_image(file_path)
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{get_media_type(file_path)};base64,{b64_data}",
+                },
+            }
+
+        if file_path is not None and dtype in ("audio", "input_audio"):
+            ok, err = validate_audio_size(file_path)
+            if not ok:
+                raise ValueError(
+                    f"audio input {file_path!r} failed size validation: {err}"
+                )
+            b64_data = encode_audio(file_path)
+            # Normalize the media-type subtype to the provider wire format
+            # (input_audio expects e.g. mp3 / wav / m4a, not the MIME subtype
+            # mpeg / mp4).
+            subtype = get_audio_media_type(file_path).split("/", 1)[-1]
+            wire_format = {
+                "mpeg": "mp3",
+                "mp4": "m4a",
+                "x-ms-wma": "wma",
+            }.get(subtype, subtype)
+            return {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": b64_data,
+                    "format": wire_format,
+                },
+            }
+
+        # Already-wire-shaped (or otherwise pre-built) content part.
         return value
 
     # Raw bytes -- detect media type and build a content part

--- a/packages/kailash-kaizen/tests/integration/test_issue_1817_multimodal_normalizer.py
+++ b/packages/kailash-kaizen/tests/integration/test_issue_1817_multimodal_normalizer.py
@@ -1,0 +1,150 @@
+"""Tier-2 integration tests for issue #1817: file-path multimodal normalizer.
+
+These tests write REAL image + audio files to disk and run them through the
+AsyncSingleShotStrategy multimodal classifier / message builder end-to-end.
+The vision/audio encoding primitives (encode_image / encode_audio /
+validate_* / get_*_media_type) are exercised for real -- NO mocking of the
+encoders (testing.md Tier 2).  The assertions verify the emitted provider
+wire-block shape a real LLM call would receive.
+"""
+
+import base64
+
+import pytest
+
+from kaizen.strategies.async_single_shot import (
+    AsyncSingleShotStrategy,
+    _classify_input_value,
+)
+
+
+def _make_agent(input_fields):
+    """Minimal duck-typed agent for _create_messages_from_inputs.
+
+    NOT a mock of any encoder -- just a plain object carrying the signature
+    input_fields the message builder reads.
+    """
+
+    class _Sig:
+        pass
+
+    class _Cfg:
+        pass
+
+    class _Agent:
+        pass
+
+    sig = _Sig()
+    sig.input_fields = input_fields
+    agent = _Agent()
+    agent.signature = sig
+    agent.config = _Cfg()  # no response_format attribute -> plain text path
+    return agent
+
+
+# A minimal-but-valid PNG (1x1) and a small WAV header, written to real files.
+_PNG_1x1 = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    b"+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+_WAV_BYTES = b"RIFF" + (36).to_bytes(4, "little") + b"WAVE" b"fmt " + (16).to_bytes(
+    4, "little"
+) + (1).to_bytes(2, "little") + (1).to_bytes(2, "little") + (8000).to_bytes(
+    4, "little"
+) + (
+    8000
+).to_bytes(
+    4, "little"
+) + (
+    1
+).to_bytes(
+    2, "little"
+) + (
+    8
+).to_bytes(
+    2, "little"
+) + b"data" + (
+    0
+).to_bytes(
+    4, "little"
+)
+
+
+@pytest.mark.integration
+def test_real_image_file_emits_image_url_wire_block(tmp_path):
+    """A real PNG on disk normalizes to a base64 image_url data-URI block."""
+    img = tmp_path / "picture.png"
+    img.write_bytes(_PNG_1x1)
+
+    block = _classify_input_value({"type": "image", "path": str(img)}, "Pic", {})
+
+    assert block["type"] == "image_url"
+    url = block["image_url"]["url"]
+    assert url.startswith("data:image/png;base64,")
+    # Real round-trip: the encoded payload decodes back to the on-disk bytes.
+    payload = base64.b64decode(url.split(",", 1)[1])
+    assert payload == _PNG_1x1
+
+
+@pytest.mark.integration
+def test_real_audio_file_emits_input_audio_wire_block(tmp_path):
+    """A real WAV on disk normalizes to an input_audio block with 'wav' format."""
+    clip = tmp_path / "sound.wav"
+    clip.write_bytes(_WAV_BYTES)
+
+    block = _classify_input_value({"type": "audio", "path": str(clip)}, "Snd", {})
+
+    assert block["type"] == "input_audio"
+    assert block["input_audio"]["format"] == "wav"
+    assert base64.b64decode(block["input_audio"]["data"]) == _WAV_BYTES
+
+
+@pytest.mark.integration
+def test_real_files_compose_into_multimodal_message(tmp_path):
+    """End-to-end: a text prompt + image file + audio file build one user message
+    whose content list carries a text part, an image_url part, and an
+    input_audio part -- the full shape a provider receives."""
+    img = tmp_path / "frame.png"
+    img.write_bytes(_PNG_1x1)
+    clip = tmp_path / "voice.wav"
+    clip.write_bytes(_WAV_BYTES)
+
+    strategy = AsyncSingleShotStrategy()
+    agent = _make_agent(
+        {
+            "prompt": {"desc": "Instruction"},
+            "image": {"desc": "An image"},
+            "audio": {"desc": "An audio clip"},
+        }
+    )
+    inputs = {
+        "prompt": "Describe the scene and transcribe the audio",
+        "image": {"type": "image", "path": str(img)},
+        "audio": {"type": "audio", "path": str(clip)},
+    }
+
+    messages = strategy._create_messages_from_inputs(agent, inputs)
+
+    assert len(messages) == 1
+    content = messages[0]["content"]
+    assert isinstance(content, list)
+    types = [part["type"] for part in content]
+    assert "text" in types
+    assert "image_url" in types
+    assert "input_audio" in types
+
+    img_part = next(p for p in content if p["type"] == "image_url")
+    assert img_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+    audio_part = next(p for p in content if p["type"] == "input_audio")
+    assert audio_part["input_audio"]["format"] == "wav"
+    assert base64.b64decode(audio_part["input_audio"]["data"]) == _WAV_BYTES
+
+
+@pytest.mark.integration
+def test_missing_real_file_fails_closed(tmp_path):
+    """A path pointing at no file fails CLOSED with a typed ValueError -- the
+    classifier never silently degrades a broken image path to text."""
+    missing = tmp_path / "does_not_exist.png"
+    with pytest.raises(ValueError, match="failed size validation"):
+        _classify_input_value({"type": "image", "path": str(missing)}, "X", {})

--- a/packages/kailash-kaizen/tests/regression/test_issue_410_multimodal.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_410_multimodal.py
@@ -135,6 +135,136 @@ class TestClassifyInputValue:
 
 
 # ===================================================================
+# _classify_input_value file-path + high-level dict tests (issue #1817)
+# ===================================================================
+
+
+class TestClassifyFilePathAndHighLevelDicts:
+    """Issue #1817: four-axis file-path + high-level-audio normalizer.
+
+    A dict with ``type`` in {image, image_url} / {audio, input_audio} carrying
+    a local FILE-PATH key must be normalized to the provider wire form by
+    delegating to the vision/audio encoding primitives.  Already-wire-shaped
+    dicts (no path key) pass through verbatim.
+    """
+
+    @pytest.mark.regression
+    def test_image_file_path_normalized_to_data_uri(self, tmp_path):
+        """A high-level image dict with a file path becomes an image_url block."""
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+        result = _classify_input_value({"type": "image", "path": str(img)}, "Photo", {})
+        assert result is not None
+        assert result["type"] == "image_url"
+        url = result["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        # The base64 payload must decode back to the original file bytes.
+        b64 = url.split(",", 1)[1]
+        assert base64.b64decode(b64) == img.read_bytes()
+
+    @pytest.mark.regression
+    def test_image_url_type_with_path_key_normalized(self, tmp_path):
+        """type 'image_url' + a local path key is still normalized (not passed through)."""
+        img = tmp_path / "shot.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)
+        result = _classify_input_value(
+            {"type": "image_url", "image_path": str(img)}, "Shot", {}
+        )
+        assert result["type"] == "image_url"
+        assert result["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    @pytest.mark.regression
+    def test_audio_file_path_normalized_to_input_audio(self, tmp_path):
+        """A high-level audio dict with a file path becomes an input_audio block."""
+        clip = tmp_path / "clip.mp3"
+        clip.write_bytes(b"ID3" + b"\x00" * 64)
+        result = _classify_input_value({"type": "audio", "path": str(clip)}, "Clip", {})
+        assert result is not None
+        assert result["type"] == "input_audio"
+        # mp3 -> media type audio/mpeg -> wire format normalized to "mp3".
+        assert result["input_audio"]["format"] == "mp3"
+        assert base64.b64decode(result["input_audio"]["data"]) == clip.read_bytes()
+
+    @pytest.mark.regression
+    def test_high_level_audio_m4a_format_normalized(self, tmp_path):
+        """.m4a -> media type audio/mp4 -> wire format normalized to 'm4a'."""
+        clip = tmp_path / "voice.m4a"
+        clip.write_bytes(b"\x00\x00\x00\x20ftypM4A " + b"\x00" * 32)
+        result = _classify_input_value(
+            {"type": "input_audio", "file": str(clip)}, "Voice", {}
+        )
+        assert result["type"] == "input_audio"
+        assert result["input_audio"]["format"] == "m4a"
+
+    @pytest.mark.regression
+    def test_audio_wav_format_passthrough_subtype(self, tmp_path):
+        """.wav -> audio/wav -> wire format 'wav' (no normalization needed)."""
+        clip = tmp_path / "sound.wav"
+        clip.write_bytes(b"RIFF" + b"\x00" * 4 + b"WAVE" + b"\x00" * 16)
+        result = _classify_input_value(
+            {"type": "audio", "audio_path": str(clip)}, "Sound", {}
+        )
+        assert result["input_audio"]["format"] == "wav"
+
+    @pytest.mark.regression
+    def test_missing_image_file_raises_typed_error(self):
+        """A missing/oversize image path fails CLOSED with a typed ValueError."""
+        with pytest.raises(ValueError, match="failed size validation"):
+            _classify_input_value(
+                {"type": "image", "path": "/no/such/file/x.png"}, "Photo", {}
+            )
+
+    @pytest.mark.regression
+    def test_missing_audio_file_raises_typed_error(self):
+        """A missing/oversize audio path fails CLOSED with a typed ValueError."""
+        with pytest.raises(ValueError, match="failed size validation"):
+            _classify_input_value(
+                {"type": "audio", "path": "/no/such/file/x.mp3"}, "Clip", {}
+            )
+
+    @pytest.mark.regression
+    def test_oversize_image_raises_typed_error(self, tmp_path, monkeypatch):
+        """An oversize file (validator returns not-ok) fails closed, no silent pass."""
+        import kaizen.strategies.async_single_shot as mod
+
+        img = tmp_path / "big.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        # Force the size validator to reject WITHOUT mocking the encoder.
+        monkeypatch.setattr(
+            mod, "validate_image_size", lambda p, **kw: (False, "too large")
+        )
+        with pytest.raises(ValueError, match="too large"):
+            _classify_input_value({"type": "image", "path": str(img)}, "Big", {})
+
+    @pytest.mark.regression
+    def test_wire_shaped_image_url_passthrough(self):
+        """An already-wire-shaped image_url dict (no path key) is returned verbatim."""
+        part = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/pic.png"},
+        }
+        result = _classify_input_value(part, "Image", {})
+        assert result is part  # exact same object, unchanged
+
+    @pytest.mark.regression
+    def test_wire_shaped_input_audio_passthrough(self):
+        """An already-wire-shaped input_audio dict is returned verbatim."""
+        part = {
+            "type": "input_audio",
+            "input_audio": {"data": "AAAA", "format": "mp3"},
+        }
+        result = _classify_input_value(part, "Audio", {})
+        assert result is part  # exact same object, unchanged
+
+    @pytest.mark.regression
+    def test_image_type_with_remote_url_not_treated_as_file(self):
+        """A remote http(s) URL is NOT a file path -> dict passes through verbatim."""
+        part = {"type": "image", "url": "https://example.com/remote.png"}
+        result = _classify_input_value(part, "Remote", {})
+        assert result is part
+
+
+# ===================================================================
 # _guess_media_type unit tests
 # ===================================================================
 


### PR DESCRIPTION
## Summary
The four-axis input classifier (`strategies/async_single_shot._classify_input_value`) returned file-path / high-level-audio dict shapes verbatim, shipping invalid wire blocks. Wired the surviving encoding primitives (`vision_utils`/`audio_utils`) into the dict branch: `{type:image|audio, <path>}` → validate-size (fail-closed typed error) → base64 → proper `image_url`/`input_audio` wire block, with audio-format normalization (mpeg→mp3, mp4→m4a). Already-wire-shaped dicts and the raw-bytes path are unchanged; remote URLs excluded.

## Tests
11 regression cases + a Tier-2 integration test (real PNG/WAV on disk, no encoder mocking). `37 passed`. All 4 invariants held.

## Note
No version/CHANGELOG here — bundled into a consolidated kaizen release with #1819/#1820.

## Related issues
Fixes #1817