### PR TITLE
chore(release): kailash-nexus 2.12.1

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Nexus Changelog
 
+## [2.12.1] — 2026-07-19 — Webhook signature verification fails closed (#1814)
+
+### Fixed (Security)
+
+- **`WebhookTransport.verify_signature` / `verify_signature_for_request` now
+  fail closed when no signing secret is configured (#1814).** Previously,
+  reaching either verification method with a signature but no secret
+  configured returned `True` — accepting ANY signature as valid, including
+  a forged or absent one. Both methods now raise
+  `ValueError("Cannot verify signature: no secret configured")` instead,
+  matching the existing fail-closed behavior of `compute_signature`.
+  **Behavior change:** any
+  caller relying on the prior fail-open default (an unconfigured secret
+  silently accepting all webhooks) now gets a typed `ValueError` at
+  verification time — configure a signing secret, or catch the error to
+  reject the request explicitly.
+
 ## [2.12.0] — 2026-07-13 — HTTP metrics label bounding + core-gateway route coverage (#1708)
 
 Part of the coordinated 5-package #1708 observability release. Requires

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.12.0"
+version = "2.12.1"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -117,7 +117,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 __all__ = [
     # Core
     "Nexus",


### PR DESCRIPTION
## Summary
- Bump kailash-nexus 2.12.0 → 2.12.1 (patch, security fix)
- Fixes #1814 — `WebhookTransport.verify_signature` / `verify_signature_for_request` now fail closed (raise `ValueError`) when no signing secret is configured, instead of returning `True` and accepting any signature. Behavior change: callers relying on the prior fail-open default now get a typed error.

## Related issues
Fixes #1814

## Test plan
- [x] `pre-commit run --files` clean (black, isort, ruff, Tier 1 unit tests, doc style)
- [ ] CI green on this branch
- [ ] Tag `nexus-v2.12.1` → `publish-pypi.yml` → verify live on PyPI