### PR TITLE
chore(release): kailash 2.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.55.0] - 2026-07-19
+
+### Added (Security)
+
+- **OIDC SSO enforces PKCE S256 + `nonce` validation on the authorization-code
+  flow (#1815).** `kailash.nodes.auth.sso` now generates an RFC 7636
+  `code_verifier` / `code_challenge` (S256) pair for every authorization
+  request and sends `code_challenge_method=S256`, closing the authorization-code
+  interception gap on public/native clients. A random `nonce` is minted at
+  authorization time and cached alongside the PKCE verifier; on token exchange,
+  the returned `id_token`'s `nonce` claim MUST be present and MUST match the
+  minted value via a constant-time comparison (`hmac.compare_digest`) — a
+  missing `id_token` or a `nonce` mismatch rejects the login. Closes the OIDC
+  id_token replay/injection defense gap.
+
 ## [2.54.0] - 2026-07-18
 
 ### Added

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,7 +2,7 @@
 Getting Started
 ===============
 
-Welcome to the Kailash SDK v2.54.0. This guide walks you through core concepts and
+Welcome to the Kailash SDK v2.55.0. This guide walks you through core concepts and
 patterns you will use in every Kailash project.
 
 Prerequisites

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Kailash SDK Documentation
    :target: https://www.python.org/downloads/
    :alt: Python Version
 
-.. image:: https://img.shields.io/badge/version-2.54.0-green.svg
+.. image:: https://img.shields.io/badge/version-2.55.0-green.svg
    :alt: SDK Version
 
 .. image:: https://img.shields.io/badge/trust-CARE%20%2F%20EATP-blueviolet.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.54.0"
+version = "2.55.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.54.0"
+__version__ = "2.55.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary
- Bump kailash (core) 2.54.0 → 2.55.0 (minor, security fix)
- Fixes #1815 — OIDC SSO enforces PKCE S256 (`code_challenge`/`code_verifier`) on the authorization-code flow and validates the id_token `nonce` claim against the minted value via a constant-time compare. Missing id_token or nonce mismatch now rejects the login.
- Version badges updated in `docs/index.rst` and `docs/getting_started.rst` per documentation.md.

## Related issues
Fixes #1815

## Test plan
- [x] `pre-commit run --files` clean (black, isort, ruff, Tier 1 unit tests, doc style)
- [ ] CI green on this branch
- [ ] Tag `v2.55.0` → `publish-pypi.yml` → verify live on PyPI