### PR TITLE
fix(cost): repair test assertions stale against #1844/#1845's env-first model defaults

### DIFF
--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
@@ -29,7 +29,6 @@ import pytest
 
 from kaizen.llm import LlmClient, resolve_deployment_for
 from kaizen.nodes.ai.llm_agent import LLMAgentNode
-
 from tests.parity._harness import CapturingTransport, load_fixture
 
 pytestmark = pytest.mark.regression
@@ -94,6 +93,15 @@ def test_provider_llm_response_returns_four_axis_mapped_shape_for_openai(monkeyp
         messages=_MSGS,
         tools=[],
         generation_config={},
+        # Same placeholder as the up-front `resolve_deployment_for` call above:
+        # `_provider_llm_response` re-resolves the deployment internally (its
+        # own `resolve_deployment_for(provider, model, api_key=api_key, ...)`
+        # call), so without an explicit override it falls back to the
+        # provider's env var (`OPENAI_API_KEY`) — which #1845's cost-guard
+        # withholds by default in a bare pytest run. The placeholder keeps this
+        # offline/canned-bytes test hermetic regardless of ambient env state
+        # (no secret; never sent — the transport is stubbed).
+        api_key="sk-b1a-parity-placeholder",
     )
 
     # The canned openai bytes parsed through the four-axis wire + to_legacy_shape.

--- a/packages/kailash-kaizen/tests/unit/examples/test_agent_as_client.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_agent_as_client.py
@@ -49,6 +49,7 @@ ResultSynthesisSignature = agent_as_client_example.ResultSynthesisSignature
 
 # Production MCP infrastructure - kailash_mcp
 from kailash_mcp import MCPClient
+
 from kaizen.memory import SharedMemoryPool
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class TestMCPClientConfig:
         config = MCPClientConfig()
 
         assert config.llm_provider == "openai"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.temperature == 0.7
         assert config.max_tokens == 1000
         assert config.connection_timeout == 30  # Default is 30 seconds

--- a/packages/kailash-kaizen/tests/unit/examples/test_agent_as_server.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_agent_as_server.py
@@ -48,6 +48,7 @@ TextAnalysisSignature = agent_as_server_example.TextAnalysisSignature
 
 # Production MCP infrastructure - kailash_mcp
 from kailash_mcp import MCPServer
+
 from kaizen.memory import SharedMemoryPool
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ class TestMCPServerAgentConfig:
         config = MCPServerAgentConfig()
 
         assert config.llm_provider == "openai"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.server_name == "kaizen-qa-agent"
         assert config.server_port == 18090
         assert config.server_host == "0.0.0.0"  # Binds to all interfaces

--- a/packages/kailash-kaizen/tests/unit/examples/test_agentic_rag.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_agentic_rag.py
@@ -245,7 +245,7 @@ class TestConfigurationOptions:
         config = AgenticRAGConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.max_iterations == 3
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_compliance_monitoring.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_compliance_monitoring.py
@@ -302,7 +302,7 @@ class TestConfigurationOptions:
         config = ComplianceConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.severity_threshold == "medium"
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_customer_service.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_customer_service.py
@@ -293,7 +293,7 @@ class TestConfigurationOptions:
         config = CustomerServiceConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.auto_response is True
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_data_reporting.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_data_reporting.py
@@ -303,7 +303,7 @@ class TestConfigurationOptions:
         config = DataReportingConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.output_format == "pdf"
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_document_analysis.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_document_analysis.py
@@ -331,7 +331,7 @@ class TestConfigurationOptions:
         config = DocumentAnalysisConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.analysis_depth == "standard"
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_federated_rag.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_federated_rag.py
@@ -317,7 +317,7 @@ class TestConfigurationOptions:
         config = FederatedRAGConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.max_sources == 5
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_graph_rag.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_graph_rag.py
@@ -249,7 +249,7 @@ class TestConfigurationOptions:
         config = GraphRAGConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.max_hops == 2
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_multi_hop_rag.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_multi_hop_rag.py
@@ -249,7 +249,7 @@ class TestConfigurationOptions:
         config = MultiHopRAGConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.max_hops == 3
 
     def test_custom_config(self):

--- a/packages/kailash-kaizen/tests/unit/examples/test_self_correcting_rag.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_self_correcting_rag.py
@@ -261,7 +261,7 @@ class TestConfigurationOptions:
         config = SelfCorrectingRAGConfig()
 
         assert config.llm_provider == "mock"
-        assert config.model == "gpt-3.5-turbo"
+        assert config.model == "gpt-4o-mini"
         assert config.max_corrections == 3
 
     def test_custom_config(self):

--- a/packages/kaizen-agents/tests/unit/agents/specialized/test_code_generation_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/specialized/test_code_generation_agent.py
@@ -140,15 +140,22 @@ class TestCodeGenerationAgentInitialization:
         assert agent.codegen_config.include_tests is False
         assert agent.codegen_config.include_documentation is False
 
-    def test_default_configuration_values(self):
+    def test_default_configuration_values(self, monkeypatch):
         """Test that defaults are set correctly."""
         from kaizen_agents.agents.specialized.code_generation import CodeGenerationAgent
+
+        # Isolate from the ambient .env: model resolution is env-first
+        # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+        # provider-intrinsic fallback), so this pins the fallback deterministically.
+        monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
 
         agent = CodeGenerationAgent()
 
         # LLM defaults
         assert agent.codegen_config.llm_provider == "openai"
-        assert agent.codegen_config.model == "gpt-4o-mini"  # Code-specific default
+        assert agent.codegen_config.model == "gpt-4o"  # shared env-first fallback
         assert agent.codegen_config.temperature == 0.2  # Lower for deterministic code
         assert agent.codegen_config.max_tokens == 8000
 
@@ -461,13 +468,22 @@ class TestCodeGenerationAgentConfiguration:
 
         assert isinstance(config.provider_config, dict)
 
-    def test_default_model_is_gpt_4o_mini(self):
-        """Test that default model is gpt-4o-mini for better code quality."""
+    def test_default_model_is_gpt_4o_mini(self, monkeypatch):
+        """Test the fallback model when no env override is configured.
+
+        Model resolution is env-first (KAIZEN_MODEL -> OPENAI_PROD_MODEL ->
+        DEFAULT_LLM_MODEL -> the shared provider-intrinsic fallback); this test
+        isolates from the ambient .env to pin the fallback deterministically.
+        """
         from kaizen_agents.agents.specialized.code_generation import CodeGenConfig
+
+        monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
 
         config = CodeGenConfig()
 
-        assert config.model == "gpt-4o-mini"
+        assert config.model == "gpt-4o"
 
 
 # ============================================================================

--- a/packages/kaizen-agents/tests/unit/agents/specialized/test_memory_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/specialized/test_memory_agent.py
@@ -133,15 +133,22 @@ class TestMemoryAgentInitialization:
         assert agent.memory_config.temperature == 0.3
         assert agent.memory_config.max_history_turns == 5
 
-    def test_default_configuration_values(self):
+    def test_default_configuration_values(self, monkeypatch):
         """Test that defaults are set correctly."""
         from kaizen_agents.agents.specialized.memory_agent import MemoryAgent
+
+        # Isolate from the ambient .env: model resolution is env-first
+        # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+        # provider-intrinsic fallback), so this pins the fallback deterministically.
+        monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
 
         agent = MemoryAgent()
 
         # LLM defaults
         assert agent.memory_config.llm_provider == "openai"
-        assert agent.memory_config.model == "gpt-3.5-turbo"
+        assert agent.memory_config.model == "gpt-4o"  # shared env-first fallback
         assert isinstance(agent.memory_config.temperature, float)
         assert isinstance(agent.memory_config.max_tokens, int)
 

--- a/packages/kaizen-agents/tests/unit/agents/specialized/test_rag_research_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/specialized/test_rag_research_agent.py
@@ -148,15 +148,22 @@ class TestRAGResearchAgentInitialization:
         assert agent.rag_config.similarity_threshold == 0.6
         assert agent.rag_config.embedding_model == "all-mpnet-base-v2"
 
-    def test_default_configuration_values(self):
+    def test_default_configuration_values(self, monkeypatch):
         """Test that defaults are set correctly."""
         from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+
+        # Isolate from the ambient .env: model resolution is env-first
+        # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+        # provider-intrinsic fallback), so this pins the fallback deterministically.
+        monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
 
         agent = RAGResearchAgent()
 
         # LLM defaults
         assert agent.rag_config.llm_provider == "openai"
-        assert agent.rag_config.model == "gpt-3.5-turbo"
+        assert agent.rag_config.model == "gpt-4o"  # shared env-first fallback
         assert isinstance(agent.rag_config.temperature, float)
         assert isinstance(agent.rag_config.max_tokens, int)
 

--- a/packages/kaizen-agents/tests/unit/agents/test_pev_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/test_pev_agent.py
@@ -265,13 +265,20 @@ def test_early_exit_on_verification_success():
 # ============================================================================
 
 
-def test_pev_config_defaults():
+def test_pev_config_defaults(monkeypatch):
     """Test PEVAgentConfig default values"""
+    # Isolate from the ambient .env: model resolution is env-first
+    # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+    # provider-intrinsic fallback), so this pins the fallback deterministically.
+    monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+
     config = PEVAgentConfig()
 
     # Verify default values
     assert config.llm_provider == "openai"
-    assert config.model == "gpt-4"
+    assert config.model == "gpt-4o"  # shared env-first fallback
     assert config.temperature == 0.7
     assert config.max_iterations == 5
     assert config.verification_strictness == "medium"

--- a/packages/kaizen-agents/tests/unit/agents/test_planning_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/test_planning_agent.py
@@ -52,13 +52,20 @@ def test_planning_agent_has_run_method():
     assert callable(agent.run)
 
 
-def test_planning_config_defaults():
+def test_planning_config_defaults(monkeypatch):
     """Test PlanningConfig default values."""
+    # Isolate from the ambient .env: model resolution is env-first
+    # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+    # provider-intrinsic fallback), so this pins the fallback deterministically.
+    monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+
     config = PlanningConfig()
 
     # Verify default values
     assert config.llm_provider == "openai"
-    assert config.model == "gpt-4"
+    assert config.model == "gpt-4o"  # shared env-first fallback
     assert config.temperature == 0.7
     assert config.max_plan_steps == 10
     assert config.validation_mode == "strict"

--- a/packages/kaizen-agents/tests/unit/agents/test_tot_agent.py
+++ b/packages/kaizen-agents/tests/unit/agents/test_tot_agent.py
@@ -287,13 +287,20 @@ def test_execution_error_fallback():
 # ============================================================================
 
 
-def test_tot_config_defaults():
+def test_tot_config_defaults(monkeypatch):
     """Test ToTAgentConfig default values"""
+    # Isolate from the ambient .env: model resolution is env-first
+    # (KAIZEN_MODEL -> OPENAI_PROD_MODEL -> DEFAULT_LLM_MODEL -> the shared
+    # provider-intrinsic fallback), so this pins the fallback deterministically.
+    monkeypatch.delenv("KAIZEN_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+
     config = ToTAgentConfig()
 
     # Verify default values
     assert config.llm_provider == "openai"
-    assert config.model == "gpt-4"
+    assert config.model == "gpt-4o"  # shared env-first fallback
     assert config.temperature == 0.9  # Higher for diversity
     assert config.num_paths == 5
     assert config.max_paths == 20


### PR DESCRIPTION
## Summary

Release-prep verification for the kailash-kaizen 2.37.1 / kaizen-agents 0.11.2
patch cut surfaced 17 test-only files that broke as a same-class side effect
of the already-merged #1844/#1845 cost fix (8fcaf3153), which none of that
PR's own targeted regression runs covered:

- **11 kailash-kaizen example `test_default_config` tests** (agent-as-server,
  agentic-rag, compliance-monitoring, customer-service, data-reporting,
  document-analysis, graph-rag, federated-rag, multi-hop-rag,
  self-correcting-rag, plus the already-fixed agent-as-client) asserted the
  OLD hardcoded `"gpt-3.5-turbo"` model default; the merged commit changed the
  live default to `"gpt-4o-mini"` in each example's `workflow.py` but only
  updated one sibling test in the same commit.
- **1 kailash-kaizen offline regression test**
  (`test_issue_1720_b1a_live_cutover.py`) broke because #1845's cost-guard now
  withholds `OPENAI_API_KEY` by default in a bare `pytest` run, and this
  canned-bytes/no-network test's internal `resolve_deployment_for` call relied
  on that env var being present. Threaded the same placeholder `api_key`
  already used elsewhere in the test into the second call site.
- **6 kaizen-agents specialized-agent default-value tests**
  (`CodeGenConfig`/`MemoryConfig`/`PEVAgentConfig`/`PlanningConfig`/
  `ToTAgentConfig`) asserted a hardcoded literal; those configs now resolve
  via the shared `resolve_default_model()` (env-first), so on any deployment
  whose `.env` sets `OPENAI_PROD_MODEL` (this one included) the assertion
  failed against that value. Isolated each test from ambient env via
  `monkeypatch.delenv` and pinned the deterministic fallback (`"gpt-4o"`).

Test-only diff — no `src/` change, no version bump (see the companion
`release/kaizen-v2.37.1-agents-v0.11.2` branch for that).

## Verification

- `packages/kailash-kaizen/tests/unit` + `tests/regression`: **11702 passed,
  0 failed, 156 skipped** (974.50s)
- `packages/kaizen-agents/tests/unit`: **3112 passed, 0 failed, 61 skipped**
  (653.11s)
- `pytest --collect-only`: kaizen 14323 collected / kaizen-agents 3447
  collected, both exit 0.
- `pre-commit run` (isort/ruff/black + repo hooks) clean on every touched file.

## Out-of-scope finding (filed, not fixed here)

Release verification also surfaced a **pre-existing, unrelated** bug —
confirmed reproducing against the currently-published PyPI `kaizen-agents==0.11.1`
in a clean venv, independent of this change: a bare `pip install kaizen-agents`
breaks on `from kaizen_agents.agents.specialized.<any> import ...` with
`ModuleNotFoundError: No module named 'numpy'` (an eager, undeclared
transitive import via `rag_research.py` → `kaizen.retrieval.vector_store`).
Filed as #1849 with full repro + root cause + fix recommendation; out of
scope for this PR (different bug class, real architectural fix needed, does
not regress or block the #1844/#1845 release).

## Related issues

Same-class follow-up to #1844, #1845 (merged 8fcaf3153 / PR #1847).