### PR TITLE
Release v2.37.1-kaizen + v0.11.2-kaizen-agents

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.37.1] — 2026-07-19 — Cost fix: obsolete-model call-defaults now resolve from .env (#1844, #1845)
+
+### Fixed
+
+- **Hardcoded `gpt-4` / `gpt-3.5-turbo` call-defaults across core agent/framework/node/provider
+  paths now resolve from the environment (#1844).** `.env` sets `OPENAI_PROD_MODEL` /
+  `DEFAULT_LLM_MODEL` (current, non-deprecated models) but several LLM call sites still fell
+  back to a hardcoded, deprecated, billed literal whenever no explicit `model=` was supplied —
+  silently spending against `gpt-4` / `gpt-3.5-turbo-0125` (root cause of a ~$208 obsolete-model
+  spend across the shared dev environment). Fixed at five call sites: `core/agents.py`'s CoT and
+  ReAct param builders and the multi-cycle-pattern base params (`self.config.get("model",
+"gpt-4")` / an unconditional `model="gpt-4"` → `self.config.get("model") or` env-first
+  resolution via a new `_resolve_default_model()` helper — `OPENAI_PROD_MODEL` →
+  `DEFAULT_LLM_MODEL` → the provider-intrinsic `DEFAULT_OPENAI_MODEL` constant, `gpt-4o-mini`);
+  `core/framework.py`'s `create_team` (`model="gpt-3.5-turbo"` → the same env-first resolution);
+  `nodes/ai/iterative_llm_agent.py`'s action and synthesis LLM calls (`kwargs.get("model",
+"gpt-4")` → a new `_resolve_action_model(kwargs)` helper — caller-supplied `kwargs["model"]`
+  still wins); `nodes/ai/llm_agent.py`'s `LLMAgentNode` `model` `NodeParameter` default
+  (hardcoded `"gpt-4"` → the same env-first resolution). `providers/multi_modal_adapter.py`'s
+  text-only OpenAI path switched its hardcoded literal from `gpt-4` to `gpt-4o` (matching the
+  adapter's own vision call site, which already used `gpt-4o`). No public signature changes —
+  every fix is a default-_value_ change; explicit `model=` / `config["model"]` callers are
+  unaffected.
+- **Removed the stray `nodes/ai/monitored_llm.py.backup`** — a 407-line dead backup file with
+  no import references anywhere in the tree (orphan cleanup, no behavior change).
+
+Companion release: `kaizen-agents` `0.11.2` (released alongside) extends the equivalent
+`resolve_default_model()` env-first pattern to its specialized agents, pattern factories, and
+workflow templates. `kailash` core also gained a `kailash.testing.env_cost_guard` test-infra
+module in the same source range (#1845 — a bare `pytest` now makes zero real LLM calls even
+when a provider key is present); it ships in the next core release and is not part of this
+kaizen bump.
+
 ## [2.37.0] — 2026-07-19 — Multimodal normalizer + Gemini structured-output guard + legacy-provider retirement (#1817, #1819, #1820)
 
 ### Added

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.37.0"
+version = "2.37.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.37.0"
+__version__ = "2.37.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] — 2026-07-19 — Cost fix: KAIZEN_MODEL fallbacks now resolve via the shared env helper (#1844, #1845)
+
+### Fixed
+
+- **Specialized agents, pattern factories, and workflow templates now resolve their
+  `KAIZEN_MODEL`-unset fallback through the shared `kaizen_agents._model_env.resolve_default_model()`
+  helper instead of a hardcoded `gpt-4` / `gpt-3.5-turbo` literal (#1844).** 0.11.1 introduced
+  `resolve_default_model()` (`OPENAI_PROD_MODEL` → `DEFAULT_LLM_MODEL` → the provider-intrinsic
+  `gpt-4o` fallback) for the `api` config layer only; every other consumer still had its own
+  `os.getenv("KAIZEN_MODEL", "gpt-4")` (or `"gpt-3.5-turbo"`) pattern, so an unconfigured agent
+  silently spent against a deprecated, billed model whenever `KAIZEN_MODEL` was unset (root
+  cause of a ~$208 obsolete-model spend across the shared dev environment — the specialized
+  agents, pattern factories, and coordination examples were the primary source, run on their
+  obsolete defaults). `KAIZEN_MODEL`, when explicitly set, still wins at every call site — only
+  the _unset_ fallback changed. Touched: the 14 specialized agents (`batch_processing`,
+  `chain_of_thought`, `code_generation`, `human_approval`, `memory_agent`, `pev`, `planning`,
+  `rag_research`, `react`, `resilient`, `self_reflection`, `simple_qa`, `streaming_chat`,
+  `tree_of_thoughts`), the 4 pattern factories (`consensus`, `debate`, `handoff`,
+  `supervisor_worker`), and `workflows/enterprise_templates.py` +
+  `workflows/supervisor_worker.py`. No public signature changes — every fix is a default-_value_
+  change; explicit `model=` / `KAIZEN_MODEL=` are unaffected.
+
+Companion release: `kailash-kaizen` `2.37.1` (released alongside) closes the equivalent gap at
+the Core-SDK-agent layer (`core/agents.py`, `core/framework.py`,
+`nodes/ai/{llm_agent,iterative_llm_agent}.py`, `providers/multi_modal_adapter.py`). Dependency
+floor stays `kailash-kaizen>=2.36.0` — this release does not depend on any new kaizen surface.
+
 ## [0.11.1] — 2026-07-19 — env-models: model defaults resolve from .env (#1825)
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.1"
+version = "0.11.2"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

Patch-release prep for the #1844/#1845 cost fix (merged `8fcaf3153`, PR #1847
— "Hardcoded gpt-4 / gpt-3.5-turbo defaults were spending real money on
obsolete billed models"). Version bump + CHANGELOG only, per the
`release/v*` branch convention (auto-skips the PR-gate test matrix; only
the Version Consistency check runs).

| Package | Old | New | Why |
|---|---|---|---|
| `kailash-kaizen` | 2.37.0 | **2.37.1** | patch — obsolete-model call-defaults now resolve from `.env` |
| `kaizen-agents` | 0.11.1 | **0.11.2** | patch — `KAIZEN_MODEL` fallbacks now resolve via the shared env helper |

`kailash` core is **NOT** released this cycle. Its only unreleased src change
since `v2.55.0` is a new test-infra module
(`src/kailash/testing/env_cost_guard.py`) with no runtime coupling into
either package above (`grep -rn env_cost_guard` across both packages' `src/`
returns only the module's own definition/self-test — confirmed at
release-prep time) — it rides the next core release.

## Scope confirmation

Per-package `src/` diff vs each package's last tag confirms this is the
correct and complete set of packages needing release:

- `kaizen-v2.37.0..HEAD -- packages/kailash-kaizen/src/` → `core/agents.py`,
  `core/framework.py`, `nodes/ai/{llm_agent,iterative_llm_agent}.py`,
  `providers/multi_modal_adapter.py` (+ removed `nodes/ai/monitored_llm.py.backup`)
- `kaizen-agents-v0.11.1..HEAD -- packages/kaizen-agents/src/` → 14
  specialized agents + 4 pattern factories + 2 workflow templates
- `v2.55.0..HEAD -- src/kailash/` → only `src/kailash/testing/env_cost_guard.py`

## CHANGELOG entries

Both packages' `CHANGELOG.md` document the actual shipped diff (verified
against `git diff` on each touched file, not carried forward from memory —
see the commit body / file diff for full text).

## Companion PR

#1850 (test-only, already opened) fixes 17 test files that broke as a
same-class side effect of #1844/#1845 that its own targeted regression runs
didn't cover. It does not touch `src/` or these version/CHANGELOG files, so
it can merge before or after this PR with no conflict — but merging it
**before** cutting the release tags keeps `main`'s test suite green at
release time.

## Verification (this session, release-prep)

- `uv build` both packages → wheel + sdist; `twine check` PASSED on all 4
  artifacts.
- Clean venv (`uv venv --python 3.12`, wheels installed from the local
  build): `kaizen.__version__ == "2.37.1"`, `kaizen_agents.__version__ ==
  "0.11.2"`; behavioral check of the env-first model resolution on both
  packages (no-env → provider-intrinsic fallback; `OPENAI_PROD_MODEL` set →
  that value wins) confirmed live against the built wheels, not asserted.
- Full local test suites (post companion-PR fixes): kailash-kaizen
  `tests/unit` + `tests/regression` 11702 passed / 0 failed / 156 skipped;
  kaizen-agents `tests/unit` 3112 passed / 0 failed / 61 skipped.

## Not done in this PR / session (by design)

Per this session's explicit scope: **no PyPI publish, no tag push**. This PR
stops at the release-prep stage — the actual `git tag` + push (which
triggers `publish-pypi.yml` and is irreversible on PyPI) is left for
explicit human authorization.

## Related issues

Closes the release-prep half of #1844, #1845 (src fix merged in PR #1847).