### PR TITLE
codify: default/behavior change must sweep stale-assertion tests (orphan-detection Rule 4b)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1141,3 +1141,22 @@ changes:
       verdict FINDINGS -> the one MED (stale "5-step" descriptor) fixed same-shard; all cross-refs resolve,
       both incidents corroborate against commits 2d2f57f3c / c66b7ceab / 5408381ad. Landed locally on
       kailash-py main (PR #1715). Journal: workspaces/observability-1708/journal/0001-DECISION + 0002-DISCOVERY.'
+  - type: rule_update
+    artifact: orphan-detection
+    files:
+      - .claude/rules/orphan-detection.md
+    classification_suggestion: global
+    context: >
+      Rule 4b (Default/Behavior Change MUST Sweep Stale-Assertion Tests In Same PR — Including
+      Out-Of-CI-Matrix Tests) — sibling of Rule 4a, generalizing "sweep tests in the same commit"
+      from stub-implementation (4a) to ANY default/behavior change, PLUS the "CI-green is NOT
+      full-suite-green" insight: CI matrices exclude example / optional-dep-gated / ambient-.env
+      tests, so a default change can be fully CI-green while N full-suite tests still assert the old
+      value. Evidence: kailash-py PR #1847 (#1844/#1845 cost fix) changed model defaults
+      (gpt-3.5-turbo->gpt-4o-mini in examples; gpt-4->env-resolved in specialized agents); CI fully
+      green, yet 18 test files (example + sentence-transformers-gated + ambient-.env-dependent) still
+      asserted the old defaults, caught only at release prep (PR #1850), not by #1847's own CI. Ships
+      canonical-8-field Trust Posture Wiring (clause-scoped; orphan-detection.md is a grandfathered
+      priority:10 path-scoped rule; added a length rationale in the same edit). NOT on the
+      self-referential-codify allowlist -> no mandatory multi-agent gate. CLASSIFICATION global: any
+      SDK / downstream consumer that changes a default inherits the failure mode (language-agnostic).

--- a/.claude/rules/orphan-detection.md
+++ b/.claude/rules/orphan-detection.md
@@ -125,6 +125,45 @@ Mirror of Rule 4. Any PR that _implements_ a previously-deferred stub — replac
 
 Origin: Session 2026-04-20 kailash-ml 0.13.0 release (PR #552). See `skills/16-validation-patterns/orphan-audit-playbook.md` § 4a for the full 5-matrix-job CI failure.
 
+### 4b. Default / Behavior Change MUST Sweep Stale-Assertion Tests In The Same PR — Including Out-Of-CI-Matrix Tests
+
+Sibling of Rule 4a for VALUE changes. Any PR that changes a default value or observable behavior — a default parameter, a fallback constant, a resolution order, an env-derived default — MUST update or delete EVERY test asserting the OLD value in the SAME PR. The sweep MUST cover tests OUTSIDE the standard CI matrix — example tests, optional-dependency-gated tests (silently skipped when the dep is absent), and ambient-`.env`/environment-dependent tests — which pass **stale-green** (CI never runs them) and fail only in a full local suite. **CI-green is NOT full-suite-green.**
+
+```bash
+# DO — grep the old value across ALL test trees; update each in the SAME PR;
+#      run the FULL suite with every optional dep installed, not just the CI subset
+grep -rn '"gpt-3.5-turbo"' packages/*/tests   # every stale assertion of the old default
+uv pip install -e "packages/<pkg>[all]" && pytest packages/<pkg>/tests   # full suite, deps present
+
+# DO NOT — change the default, see CI green, ship
+#   (example / optional-dep / ambient-env tests keep asserting the old value,
+#    stale-green until a full suite at release prep surfaces them)
+```
+
+**BLOCKED rationalizations:**
+
+- "CI is green, the change is covered"
+- "Example / integration tests aren't in the matrix, they don't count"
+- "The skipped test will be fixed when someone installs the dep"
+- "The fix's own targeted regression run passed" (it ran the new tests, not the stale ones)
+
+**Why:** CI matrices deliberately exclude example, optional-heavy-dependency, and env-coupled tests for speed and hermeticity — so a default change can be fully CI-green while N full-suite tests still assert the old value, surfacing only at release prep or for a downstream user. Grepping the old value + running the full suite in the SAME PR closes it.
+
+Origin: kailash-py PR #1847/#1850 (2026-07-19). The #1844/#1845 cost fix changed model defaults (`gpt-3.5-turbo`→`gpt-4o-mini` in examples; `gpt-4`→env-resolved in specialized agents); CI was fully green, yet 18 test files (example + `sentence-transformers`-gated + ambient-`.env`-dependent) still asserted the old defaults — caught only at release prep (PR #1850), not by #1847's own CI.
+
+#### Trust Posture Wiring (Rule 4b — clause-scoped)
+
+Rule 4b lands post-`trust-posture.md`-MUST-8-cutoff → ships canonical-8-field-compliant; Rules 1–4/4a/5–6a stay grandfathered until each is itself `/codify`-touched (clause-scoped precedent: `security.md`/`git.md`).
+
+- **Severity:** `halt-and-report` at gate-review (reviewer at `/implement` + release-specialist at `/release` confirm any default/behavior-changing diff swept every stale-assertion test, incl. out-of-CI-matrix ones); `advisory` at the hook layer (a default-change→stale-test property is judgment-bearing over the diff, no structural tool-call signal — `hook-output-discipline.md` MUST-2).
+- **Grace period:** 7 days from clause landing (2026-07-19 → 2026-07-26).
+- **Cumulative posture impact:** same-class violations (a default/behavior change shipped without sweeping out-of-CI-matrix stale-assertion tests) contribute to `trust-posture.md` MUST-4 cumulative-window math (3× same-rule in 30d → drop 1 posture; 5× total in 30d → drop 1 posture).
+- **Regression-within-grace:** routes through the GENERIC `regression_within_grace` emergency trigger per `trust-posture.md` MUST-4 (1× = drop 1 posture) — NO dedicated per-clause key (a stale-test-sweep property is review-layer judgment; the universal trigger covers it). Named deviation from key-per-clause per `trust-posture.md` Rule 8 — the same no-dedicated-key disposition `security.md` § Enforcement-Surface Parity took.
+- **Receipt requirement:** SessionStart soft-gate `[ack: orphan-detection]` IFF `posture.json::pending_verification` includes the `orphan-detection` rule_id.
+- **Detection mechanism:** Phase 1 (manual, gate-review) — reviewer at `/implement` + release-specialist at `/release` inspect any diff changing a default/fallback/resolution-order and confirm (a) a grep of the old value across `packages/*/tests` returns no stale assertions, (b) the full suite (all optional deps installed) was run, not just the CI subset. Phase 2 (deferred per `trust-posture.md` § Two-Phase Rollout) — no hook detector; audit fixtures land with it at `.claude/audit-fixtures/default-change-test-sweep/` per `cc-artifacts.md` Rule 9.
+- **Violation scope:** Rule 4b (default/behavior-change stale-test sweep) ONLY; the grandfathered Rules 1–4/4a/5–6a stay exempt until each is itself `/codify`-touched.
+- **Origin:** See Rule 4b Origin (kailash-py PR #1847/#1850).
+
 ### 5. Collect-Only Is A Merge Gate
 
 `pytest --collect-only` across every test directory MUST return exit 0 before any PR merges. A collection error is a blocker in the same class as a test failure.
@@ -271,3 +310,5 @@ Origin: kailash-ml-audit session 2026-04-23 — W31/W33 parallel-shard `__all__`
 ## Detection Protocol
 
 The 6-step `/redteam` audit procedure (six detection steps + disposition) lives in `skills/16-validation-patterns/orphan-audit-playbook.md` § "Detection Protocol". Runs as part of `/redteam` and `/codify`.
+
+**Length rationale (per `rules/rule-authoring.md` MUST NOT § "Rules longer than 200 lines").** Rule body exceeds the 200-line guidance. Named rationale: **orphan-family scope** — the rule codifies the complete orphan/facade + test-sweep contract (Rules 1–6b: production-call-site, Tier-2 wiring, delete-not-deprecate, API-removal + stub-implementation + default-change test sweeps, collect-only gate, `__all__` reconciliation), each carrying the DO/DO-NOT + `**Why:**` the meta-rule mandates. `priority: 10` + `scope: path-scoped` — loaded only in sessions matching `packages/**` / `src/**` / `**/tests/**`, so it pays NO baseline-emission cost and Rule 10's proximity-band gate does NOT fire. Sibling precedent: `dependencies.md` + `cc-artifacts.md` length rationales.

--- a/workspaces/issue-1720-llm-consolidation/journal/0006-DECISION-codify-default-change-test-sweep.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0006-DECISION-codify-default-change-test-sweep.md
@@ -1,0 +1,44 @@
+# DECISION — /codify: default/behavior-change stale-test sweep (orphan-detection Rule 4b)
+
+Date: 2026-07-19. Repo class: BUILD (`name = "kailash"`). Coordination OFF
+(un-enrolled public repo) → no codify lease needed.
+
+## What was codified
+
+**`.claude/rules/orphan-detection.md` — new Rule 4b** "Default / Behavior Change MUST
+Sweep Stale-Assertion Tests In The Same PR — Including Out-Of-CI-Matrix Tests."
+
+- **Generalizes Rule 4a** (implement-stub → sweep-deferral-tests) to ANY default/behavior
+  change: a changed default parameter / fallback constant / resolution order / env-derived
+  default MUST update or delete every test asserting the OLD value in the same PR.
+- **Adds the load-bearing insight "CI-green is NOT full-suite-green":** the sweep MUST
+  cover tests OUTSIDE the standard CI matrix — example tests, optional-dependency-gated
+  tests (silently skipped when the dep is absent), and ambient-`.env`/environment-dependent
+  tests — which pass **stale-green** because CI never runs them, surfacing only in a full
+  local suite.
+- Ships canonical-8-field Trust Posture Wiring (clause-scoped; orphan-detection.md is a
+  grandfathered `priority:10` path-scoped rule). Added a length rationale in the same edit
+  (the rule was already >200 lines; my clause pushed it further).
+
+## Evidence (DISCOVERY)
+
+This session's #1844/#1845 cost fix (**PR #1847**) changed model defaults
+(`gpt-3.5-turbo`→`gpt-4o-mini` in examples; `gpt-4`→env-resolved in specialized agents).
+**#1847 CI was fully green** (28 checks) — yet **18 test files** still asserted the old
+defaults: kailash-kaizen example tests (not in the matrix), a `sentence-transformers`-gated
+test (silently skipped — never ran), and kaizen-agents specialized-agent tests that resolved
+against the ambient `.env` rather than a stable literal. They were caught only at **release
+prep (PR #1850)** running the full suite with all optional deps installed — NOT by #1847's
+own CI or its targeted regression run. Root cause: a default change's blast radius includes
+tests the fast CI matrix deliberately excludes.
+
+## Process notes
+
+- `orphan-detection.md` is NOT on the `self-referential-codify.md` Rule 2 allowlist → no
+  mandatory multi-agent redteam gate; structural self-check confirmed the 8 wiring fields +
+  DO/DO-NOT + Why + BLOCKED present.
+- `priority:10 path-scoped` → `rule-authoring.md` Rule 10 proximity-band gate does NOT fire
+  (no baseline-emission cost).
+- Proposal appended to `.claude/.proposals/latest.yaml` (`origin: build`, `pending_review`,
+  classification GLOBAL — language-agnostic: any SDK/consumer changing a default inherits
+  the failure mode). Anchor `learning-codified.json::last_codified` advanced.


### PR DESCRIPTION
Codifies the lesson from this session's #1844/#1845 cost fix: **PR #1847 changed model defaults and passed full CI (28 checks green), yet 18 test files still asserted the old defaults** — example tests, a `sentence-transformers`-gated test (silently skipped), and ambient-`.env`-dependent tests, none in the standard CI matrix. Caught only at release prep (PR #1850).

Adds **orphan-detection.md Rule 4b** (sibling of Rule 4a): any default/behavior change MUST sweep every test asserting the OLD value in the same PR, **including out-of-CI-matrix tests — CI-green is NOT full-suite-green.** Canonical-8-field Trust Posture Wiring (clause-scoped, grandfathered path-scoped rule). Proposal appended (`origin: build`, GLOBAL — language-agnostic). Journal 0006.

Rule/doc only — auto-skips the test matrix.