### PR TITLE
fix(auth): verify SSO id_token via JWKS (sig/aud/iss/exp) before trusting nonce (#1835)

### DIFF
--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -535,6 +535,14 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             raise ValueError(
                 f"OIDC id_token verification failed: invalid token ({exc})"
             )
+        except Exception as exc:
+            # Fail-closed catch-all: some PyJWT versions surface a JWKS network
+            # fetch failure OUTSIDE the jwt exception hierarchy (e.g.
+            # urllib.error.URLError). It already REJECTS by propagating, but this
+            # normalizes it to the SAME typed ValueError so the fail-closed
+            # contract is uniform across PyJWT versions. It NEVER falls back to
+            # the unverified base64url read — it re-raises a rejection.
+            raise ValueError(f"OIDC id_token verification failed: {exc}") from exc
 
         if not isinstance(claims, dict):
             # jwt.decode returns a dict for a JWS; guard defensively so a later

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -451,15 +451,105 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         )
         return code_verifier, code_challenge
 
+    def _verify_id_token(self, provider: str, id_token: str) -> Dict[str, Any]:
+        """Cryptographically verify an OIDC id_token against the provider's JWKS.
+
+        Fail-closed. Any id_token whose claims (including ``nonce``) will be
+        trusted MUST first have its RS256/ES256 signature verified against the
+        provider's published JWKS AND its ``aud`` / ``iss`` / ``exp`` validated.
+        This reuses the same PyJWT ``PyJWKClient`` + ``jwt.decode`` pattern the
+        provider classes use (``kailash.trust.auth.sso.google`` et al.).
+
+        Configuration is read from ``oauth_settings``:
+
+        - ``jwks_uri`` — the provider's JWKS endpoint (required)
+        - ``issuer`` — the expected ``iss`` claim (required)
+        - ``{provider}_client_id`` or ``client_id`` — the expected ``aud``
+          claim (required)
+
+        If any of these are unconfigured, the JWKS is unreachable, or
+        verification fails (bad signature / audience / issuer / expiry), this
+        raises a typed :class:`ValueError` and REJECTS — it NEVER falls back to
+        the unverified base64url read for a trust decision.
+        """
+        try:
+            import jwt
+            from jwt import PyJWKClient
+        except ImportError as exc:  # pragma: no cover - optional-extra guard
+            raise ValueError(
+                "OIDC id_token signature verification requires PyJWT. Install "
+                "with: pip install 'kailash[server]' (or 'kailash[trust]')"
+            ) from exc
+
+        jwks_uri = self.oauth_settings.get("jwks_uri")
+        issuer = self.oauth_settings.get("issuer")
+        audience = self.oauth_settings.get(
+            f"{provider}_client_id"
+        ) or self.oauth_settings.get("client_id")
+
+        missing = [
+            name
+            for name, value in (
+                ("jwks_uri", jwks_uri),
+                ("issuer", issuer),
+                ("client_id", audience),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                "OIDC id_token signature verification is required for the nonce "
+                f"flow but oauth_settings is missing: {', '.join(missing)}. "
+                "Configure jwks_uri, issuer, and client_id; refusing to trust "
+                "an unverified id_token."
+            )
+
+        try:
+            jwks_client = PyJWKClient(jwks_uri)
+            signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+            claims = jwt.decode(
+                id_token,
+                signing_key.key,
+                algorithms=["RS256", "ES256"],
+                audience=audience,
+                issuer=issuer,
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise ValueError(
+                f"OIDC id_token verification failed: token expired ({exc})"
+            )
+        except jwt.InvalidAudienceError as exc:
+            raise ValueError(
+                f"OIDC id_token verification failed: audience mismatch ({exc})"
+            )
+        except jwt.InvalidIssuerError as exc:
+            raise ValueError(
+                f"OIDC id_token verification failed: issuer mismatch ({exc})"
+            )
+        except jwt.PyJWKClientError as exc:
+            raise ValueError(
+                "OIDC id_token verification failed: JWKS unreachable or signing "
+                f"key not found ({exc})"
+            )
+        except jwt.InvalidTokenError as exc:
+            raise ValueError(
+                f"OIDC id_token verification failed: invalid token ({exc})"
+            )
+
+        if not isinstance(claims, dict):
+            # jwt.decode returns a dict for a JWS; guard defensively so a later
+            # ``claims.get(...)`` cannot raise an opaque AttributeError.
+            raise ValueError("OIDC id_token verification produced a non-object payload")
+        return claims
+
     @staticmethod
     def _decode_id_token_claims(id_token: str) -> Dict[str, Any]:
         """Decode the (base64url) payload segment of a JWT id_token.
 
-        This reads the claims WITHOUT verifying the signature — it is used ONLY
-        to compare the ``nonce`` claim against the value minted at authorization
-        time (a replay/injection defense layered on the provider's own token
-        validation). It MUST NOT be relied on as authentication evidence beyond
-        the nonce match.
+        This reads the claims WITHOUT verifying the signature. It is a
+        DISPLAY-ONLY helper and MUST NOT be used for any trust decision — the
+        nonce comparison in ``_handle_oauth_callback`` uses the cryptographically
+        verified claims from :meth:`_verify_id_token` instead.
         """
         parts = id_token.split(".")
         if len(parts) < 2:
@@ -694,9 +784,12 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # OIDC nonce enforcement (id_token replay/injection defense).
         # When a nonce was minted at authorization time, the returned id_token
-        # MUST be present and its ``nonce`` claim MUST match the minted value.
-        # This is layered on the provider's own token validation; it does not
-        # weaken it — a mismatch fails closed with a typed error.
+        # MUST be present, cryptographically verified against the provider's
+        # JWKS (signature + aud + iss + exp), and its ``nonce`` claim MUST match
+        # the minted value. The nonce is compared ONLY against VERIFIED claims —
+        # a forged id_token whose signature fails JWKS verification is rejected
+        # before any claim is trusted. Fail-closed: any verification failure
+        # raises a typed error and rejects authentication.
         expected_nonce = cached_data.get("nonce")
         if expected_nonce is not None:
             id_token = token_result.get("id_token")
@@ -705,7 +798,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                     "OIDC nonce was minted but the token response carried no "
                     "id_token — cannot verify nonce; rejecting authentication"
                 )
-            claims = self._decode_id_token_claims(id_token)
+            claims = self._verify_id_token(provider, id_token)
             returned_nonce = claims.get("nonce")
             # Constant-time compare (defense-in-depth; the one-shot state pop
             # already bounds attempts). A missing/non-string claim fails closed.

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,122 @@
+"""Shared regression fixtures.
+
+``oidc_jwks_server`` — a REAL in-process OIDC JWKS test harness backing the
+issue #1835 (JWKS id_token verification) + #1815 (nonce/PKCE) regression suites.
+
+The harness mints a real RSA keypair, serves its public half as a JWKS over a
+loopback HTTP endpoint (so PyJWT's ``PyJWKClient`` performs a real network
+fetch), and signs real RS256 id_tokens with the private half. Signature
+verification exercised by the tests is the SDK's REAL ``jwt.decode`` against the
+served JWKS — nothing about the verifier is mocked (per ``rules/testing.md``
+Tier-2 NO-MOCKING contract for security-critical paths).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable, Dict, Optional
+
+import pytest
+
+
+@dataclass
+class OIDCJWKSHarness:
+    """Real RSA-signing OIDC harness (see module docstring)."""
+
+    jwks_uri: str
+    issuer: str
+    audience: str
+    kid: str
+    _sign: Callable[..., str]
+    _wrong_sign: Callable[..., str]
+
+    def sign(self, claims: Dict[str, Any]) -> str:
+        """Sign an id_token with the harness's real key (valid signature)."""
+        return self._sign(claims)
+
+    def sign_forged(self, claims: Dict[str, Any]) -> str:
+        """Sign with a DIFFERENT key but present the trusted ``kid``.
+
+        The JWKS returns the harness's real public key for that ``kid``, so the
+        signature check runs against the wrong key and fails — a genuine forged
+        signature, verified by real crypto, not a mock.
+        """
+        return self._wrong_sign(claims)
+
+    def base_claims(self, **overrides: Any) -> Dict[str, Any]:
+        """A valid claim set (correct aud/iss, future exp) for mutation."""
+        now = int(time.time())
+        claims: Dict[str, Any] = {
+            "sub": "user-1",
+            "aud": self.audience,
+            "iss": self.issuer,
+            "iat": now,
+            "exp": now + 3600,
+            "email": "user@example.com",
+            "name": "User One",
+        }
+        claims.update(overrides)
+        return claims
+
+
+@pytest.fixture
+def oidc_jwks_server():
+    """Yield a real RSA-signing JWKS harness on a loopback HTTP endpoint."""
+    import json
+
+    import jwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from jwt.algorithms import RSAAlgorithm
+
+    kid = "test-key-1"
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    # A SECOND, unrelated key — used to forge signatures the JWKS cannot verify.
+    wrong_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    jwk = json.loads(RSAAlgorithm.to_jwk(public_key))
+    jwk.update({"kid": kid, "use": "sig", "alg": "RS256"})
+    jwks_body = json.dumps({"keys": [jwk]}).encode()
+
+    class _JWKSHandler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(jwks_body)))
+            self.end_headers()
+            self.wfile.write(jwks_body)
+
+        def log_message(self, *args):  # silence per-request stderr noise
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _JWKSHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    jwks_uri = f"http://{host}:{port}/jwks"
+
+    def _sign(claims: Dict[str, Any]) -> str:
+        return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": kid})
+
+    def _wrong_sign(claims: Dict[str, Any]) -> str:
+        # Present the trusted kid so the JWKS returns the real public key; the
+        # signature (made with wrong_key) then fails verification.
+        return jwt.encode(claims, wrong_key, algorithm="RS256", headers={"kid": kid})
+
+    harness = OIDCJWKSHarness(
+        jwks_uri=jwks_uri,
+        issuer="https://idp.example.com",
+        audience="test-client",
+        kid=kid,
+        _sign=_sign,
+        _wrong_sign=_wrong_sign,
+    )
+    try:
+        yield harness
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/regression/test_issue_1815_oidc_nonce_pkce.py
+++ b/tests/regression/test_issue_1815_oidc_nonce_pkce.py
@@ -19,11 +19,18 @@ These tests pin the fixed behavior:
 - PKCE round-trip: ``_initiate_oauth`` emits ``code_challenge`` +
   ``code_challenge_method=S256``; the cached ``code_verifier`` flows into
   ``_exchange_oauth_code``; the verifier S256-hashes to the emitted challenge.
+
+Note (issue #1835): the nonce is now compared ONLY against cryptographically
+verified id_token claims — ``_handle_oauth_callback`` verifies the id_token
+signature against the provider's JWKS (RS256/ES256 + aud + iss + exp) before
+reading any claim. The nonce tests below therefore sign REAL tokens via the
+``oidc_jwks_server`` fixture (an unsigned-shape token would now be rejected at
+the signature gate, never reaching the nonce comparison). The full JWKS-verify
+matrix lives in ``test_issue_1835_sso_id_token_verify.py``.
 """
 
 import base64
 import hashlib
-import json
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -39,33 +46,23 @@ def _s256(verifier: str) -> str:
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 
 
-def _make_id_token(claims: dict) -> str:
-    """Build an unsigned-shape JWT (header.payload.signature) for tests.
-
-    Only the base64url payload segment is load-bearing here — the nonce check
-    reads the ``nonce`` claim; it does not (and must not) treat this token as
-    signature-validated evidence beyond the nonce match.
-    """
-
-    def _seg(obj: dict) -> str:
-        raw = json.dumps(obj).encode()
-        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
-
-    header = _seg({"alg": "RS256", "typ": "JWT"})
-    payload = _seg(claims)
-    return f"{header}.{payload}.sig"
-
-
-def _make_node() -> SSOAuthenticationNode:
+def _make_node(harness=None) -> SSOAuthenticationNode:
+    """Build the node. When ``harness`` is given, wire the JWKS-verify config
+    (jwks_uri / issuer) so the nonce path can verify real signed id_tokens; the
+    harness audience matches ``client_id`` ("test-client")."""
+    oauth_settings = {
+        "client_id": "test-client",
+        "auth_endpoint": "https://idp.example.com/oauth2/authorize",
+        "token_endpoint": "https://idp.example.com/oauth2/token",
+        "userinfo_endpoint": "https://idp.example.com/oauth2/userinfo",
+    }
+    if harness is not None:
+        oauth_settings["jwks_uri"] = harness.jwks_uri
+        oauth_settings["issuer"] = harness.issuer
     return SSOAuthenticationNode(
         name="sso_test",
         enable_jit_provisioning=False,  # skip audit-logger path; isolate the nonce gate
-        oauth_settings={
-            "client_id": "test-client",
-            "auth_endpoint": "https://idp.example.com/oauth2/authorize",
-            "token_endpoint": "https://idp.example.com/oauth2/token",
-            "userinfo_endpoint": "https://idp.example.com/oauth2/userinfo",
-        },
+        oauth_settings=oauth_settings,
     )
 
 
@@ -75,9 +72,12 @@ def _make_node() -> SSOAuthenticationNode:
 
 
 @pytest.mark.asyncio
-async def test_callback_rejects_nonce_mismatch():
-    """Callback MUST reject when id_token nonce != minted nonce."""
-    node = _make_node()
+async def test_callback_rejects_nonce_mismatch(oidc_jwks_server):
+    """Callback MUST reject when a VALIDLY-SIGNED id_token's nonce != minted.
+
+    The token passes JWKS signature + aud/iss/exp verification (issue #1835);
+    it is rejected on the nonce gate, not the signature gate."""
+    node = _make_node(oidc_jwks_server)
     init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
     state = init["state"]
 
@@ -85,7 +85,9 @@ async def test_callback_rejects_nonce_mismatch():
         return {
             "access_token": "test_access_token",
             "token_type": "Bearer",
-            "id_token": _make_id_token({"sub": "u1", "nonce": "ATTACKER-INJECTED"}),
+            "id_token": oidc_jwks_server.sign(
+                oidc_jwks_server.base_claims(sub="u1", nonce="ATTACKER-INJECTED")
+            ),
         }
 
     node._exchange_oauth_code = fake_exchange
@@ -97,9 +99,9 @@ async def test_callback_rejects_nonce_mismatch():
 
 
 @pytest.mark.asyncio
-async def test_callback_rejects_missing_id_token_when_nonce_minted():
+async def test_callback_rejects_missing_id_token_when_nonce_minted(oidc_jwks_server):
     """When a nonce was minted, an id_token MUST be present; absence rejects."""
-    node = _make_node()
+    node = _make_node(oidc_jwks_server)
     init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
     state = init["state"]
 
@@ -116,9 +118,10 @@ async def test_callback_rejects_missing_id_token_when_nonce_minted():
 
 
 @pytest.mark.asyncio
-async def test_callback_accepts_matching_nonce():
-    """Callback MUST succeed when the id_token nonce matches the minted nonce."""
-    node = _make_node()
+async def test_callback_accepts_matching_nonce(oidc_jwks_server):
+    """Callback MUST succeed when a VALIDLY-SIGNED id_token's nonce matches the
+    minted nonce (signature + aud/iss/exp verified, then nonce matched)."""
+    node = _make_node(oidc_jwks_server)
     init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
     state = init["state"]
     minted_nonce = node.provider_cache[state]["nonce"]
@@ -128,7 +131,9 @@ async def test_callback_accepts_matching_nonce():
         return {
             "access_token": "test_access_token",
             "token_type": "Bearer",
-            "id_token": _make_id_token({"sub": "u1", "nonce": minted_nonce}),
+            "id_token": oidc_jwks_server.sign(
+                oidc_jwks_server.base_claims(sub="u1", nonce=minted_nonce)
+            ),
         }
 
     async def fake_userinfo(provider, access_token):

--- a/tests/regression/test_issue_1835_sso_id_token_verify.py
+++ b/tests/regression/test_issue_1835_sso_id_token_verify.py
@@ -198,6 +198,35 @@ async def test_fail_closed_when_jwks_unreachable(oidc_jwks_server):
         await _callback(node, state, token)
 
 
+@pytest.mark.asyncio
+async def test_fail_closed_normalizes_non_jwt_error_to_typed_valueerror(
+    oidc_jwks_server, monkeypatch
+):
+    """A JWKS/network failure OUTSIDE the jwt exception hierarchy MUST still be
+    normalized to the typed fail-closed ValueError (uniform across PyJWT
+    versions). This injects a non-jwt failure at the JWKS-client boundary — a
+    forced REJECT, never a mocked verification pass — to exercise the catch-all
+    that a version-specific specific-handler would otherwise miss."""
+    import jwt
+
+    class _Boom:
+        def __init__(self, *a, **kw):
+            raise OSError("simulated non-jwt JWKS fetch failure")
+
+    # Patch the JWKS client so construction raises an error OUTSIDE jwt.*;
+    # `_verify_id_token` does `from jwt import PyJWKClient` at call time, so this
+    # attribute patch is picked up. The verifier itself is not mocked — the
+    # boundary is forced to FAIL, and the node MUST reject with a typed error.
+    monkeypatch.setattr(jwt, "PyJWKClient", _Boom)
+
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    token = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce=minted))
+
+    with pytest.raises(ValueError, match="verification failed"):
+        await _callback(node, state, token)
+
+
 # --------------------------------------------------------------------------- #
 # structural: the base64url display helper is NOT used for the trust decision
 # --------------------------------------------------------------------------- #

--- a/tests/regression/test_issue_1835_sso_id_token_verify.py
+++ b/tests/regression/test_issue_1835_sso_id_token_verify.py
@@ -1,0 +1,213 @@
+"""Regression tests for issue #1835 — SSO id_token JWKS verification.
+
+Before the fix, ``SSOAuthenticationNode._handle_oauth_callback`` read the OIDC
+``nonce`` claim from an UNVERIFIED id_token: ``_decode_id_token_claims`` was a
+base64url-only decode (no signature, no aud, no iss, no exp validation), so a
+forged id_token carrying the expected nonce was trusted — an authentication
+bypass surface.
+
+The fix adds ``_verify_id_token`` — a JWKS-backed ``jwt.decode`` (RS256/ES256,
+audience + issuer + expiry enforced) reusing the provider-class pattern
+(``kailash.trust.auth.sso.google``). The nonce is now compared ONLY against
+cryptographically verified claims, and the path fails closed when verification
+config is missing, the JWKS is unreachable, or verification fails.
+
+These tests use REAL RSA signing + a REAL in-process JWKS endpoint (the
+``oidc_jwks_server`` fixture); nothing about the verifier is mocked.
+
+Assertions pinned here:
+1. valid token (right key, correct aud/iss/exp, matching nonce) -> ACCEPTED
+2. forged signature (signed by a different key)               -> REJECTED
+3. wrong audience                                             -> REJECTED
+4. wrong issuer                                               -> REJECTED
+5. expired (exp in the past)                                  -> REJECTED
+6. fail-closed: jwks_uri unconfigured / JWKS unreachable      -> REJECTED
+"""
+
+import time
+
+import pytest
+
+from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+pytestmark = pytest.mark.regression
+
+
+def _make_node(oauth_settings) -> SSOAuthenticationNode:
+    return SSOAuthenticationNode(
+        name="sso_1835",
+        enable_jit_provisioning=False,  # isolate the verify+nonce gate
+        oauth_settings=oauth_settings,
+    )
+
+
+def _oauth_settings(harness, *, jwks_uri=..., issuer=..., client_id=...):
+    return {
+        "client_id": harness.audience if client_id is ... else client_id,
+        "auth_endpoint": "https://idp.example.com/oauth2/authorize",
+        "token_endpoint": "https://idp.example.com/oauth2/token",
+        "userinfo_endpoint": "https://idp.example.com/oauth2/userinfo",
+        "jwks_uri": harness.jwks_uri if jwks_uri is ... else jwks_uri,
+        "issuer": harness.issuer if issuer is ... else issuer,
+    }
+
+
+async def _seed(node) -> tuple[str, str]:
+    """Run the authorize step; return (state, minted_nonce)."""
+    init = await node._initiate_oauth("oidc", "https://app.example.com/cb")
+    state = init["state"]
+    minted = node.provider_cache[state]["nonce"]
+    assert minted  # sanity: a nonce was minted
+    return state, minted
+
+
+async def _callback(node, state, id_token):
+    """Drive _handle_oauth_callback with a fixed token response."""
+
+    async def fake_exchange(provider, auth_code, cached_data):
+        resp = {"access_token": "at", "token_type": "Bearer"}
+        if id_token is not None:
+            resp["id_token"] = id_token
+        return resp
+
+    async def fake_userinfo(provider, access_token):
+        return {"sub": "user-1", "email": "user@example.com", "name": "User One"}
+
+    node._exchange_oauth_code = fake_exchange
+    node._get_oauth_user_info = fake_userinfo
+    return await node._handle_oauth_callback(
+        "oidc", {"state": state, "code": "auth-code-1"}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# (1) valid token accepted
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_valid_signed_token_with_matching_nonce_accepted(oidc_jwks_server):
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    token = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce=minted))
+
+    result = await _callback(node, state, token)
+
+    assert result["authenticated"] is True
+
+
+# --------------------------------------------------------------------------- #
+# (2) forged signature rejected
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_forged_signature_rejected(oidc_jwks_server):
+    """A token signed by a DIFFERENT key (presenting the trusted kid) fails the
+    real signature check and is rejected before its nonce is trusted."""
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    forged = oidc_jwks_server.sign_forged(oidc_jwks_server.base_claims(nonce=minted))
+
+    with pytest.raises(ValueError, match="verification failed"):
+        await _callback(node, state, forged)
+
+
+# --------------------------------------------------------------------------- #
+# (3) wrong audience rejected
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_wrong_audience_rejected(oidc_jwks_server):
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    token = oidc_jwks_server.sign(
+        oidc_jwks_server.base_claims(nonce=minted, aud="some-other-client")
+    )
+
+    with pytest.raises(ValueError, match="audience"):
+        await _callback(node, state, token)
+
+
+# --------------------------------------------------------------------------- #
+# (4) wrong issuer rejected
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_rejected(oidc_jwks_server):
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    token = oidc_jwks_server.sign(
+        oidc_jwks_server.base_claims(nonce=minted, iss="https://evil.example.com")
+    )
+
+    with pytest.raises(ValueError, match="issuer"):
+        await _callback(node, state, token)
+
+
+# --------------------------------------------------------------------------- #
+# (5) expired token rejected
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_expired_token_rejected(oidc_jwks_server):
+    node = _make_node(_oauth_settings(oidc_jwks_server))
+    state, minted = await _seed(node)
+    past = int(time.time()) - 3600
+    token = oidc_jwks_server.sign(
+        oidc_jwks_server.base_claims(nonce=minted, iat=past - 60, exp=past)
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        await _callback(node, state, token)
+
+
+# --------------------------------------------------------------------------- #
+# (6) fail-closed: unconfigured jwks_uri / unreachable JWKS
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_when_jwks_uri_unconfigured(oidc_jwks_server):
+    """A nonce flow with NO jwks_uri configured MUST reject — never fall back
+    to trusting an unverified id_token."""
+    node = _make_node(_oauth_settings(oidc_jwks_server, jwks_uri=None))
+    state, minted = await _seed(node)
+    # Even a correctly-signed token cannot be trusted with no JWKS configured.
+    token = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce=minted))
+
+    with pytest.raises(ValueError, match="jwks_uri"):
+        await _callback(node, state, token)
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_when_jwks_unreachable(oidc_jwks_server):
+    """A configured-but-unreachable JWKS endpoint MUST reject, not accept."""
+    node = _make_node(
+        _oauth_settings(
+            oidc_jwks_server, jwks_uri="http://127.0.0.1:1/jwks"  # dead port
+        )
+    )
+    state, minted = await _seed(node)
+    token = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce=minted))
+
+    with pytest.raises(ValueError, match="verification failed"):
+        await _callback(node, state, token)
+
+
+# --------------------------------------------------------------------------- #
+# structural: the base64url display helper is NOT used for the trust decision
+# --------------------------------------------------------------------------- #
+
+
+def test_nonce_trust_path_uses_verified_claims_not_base64url_decode():
+    """The callback trust path must call _verify_id_token, not the unverified
+    base64url _decode_id_token_claims helper."""
+    import inspect
+
+    src = inspect.getsource(SSOAuthenticationNode._handle_oauth_callback)
+    assert "_verify_id_token" in src
+    assert "_decode_id_token_claims" not in src


### PR DESCRIPTION
## Summary

`SSOAuthenticationNode` read the OIDC `nonce` claim from an **unverified** id_token. `_decode_id_token_claims` (`src/kailash/nodes/auth/sso.py`) was base64url-only — it split on `.`, base64url-decoded the payload, and `json.loads`'d it with **no signature, no `aud`, no `iss`, no `exp`** validation. `_handle_oauth_callback` then trusted that token's `nonce` claim. #1815 added nonce enforcement + PKCE, but the nonce was compared against claims that were never cryptographically verified — so a **forged id_token carrying the expected nonce was accepted**: an authentication-bypass surface.

## The fix (fail-closed)

Adds `_verify_id_token(provider, id_token)` — a JWKS-backed `jwt.decode` (RS256/ES256, `audience` + `issuer` + expiry enforced) reusing the exact provider-class pattern already in `kailash.trust.auth.sso.google` (`PyJWKClient(jwks_uri)` → `get_signing_key_from_jwt` → `jwt.decode(...)`). No new dependency — `PyJWT>=2.8` + `cryptography>=41` are already declared in `pyproject.toml`; the import is lazy (does not burden slim-core module import).

`_handle_oauth_callback` (nonce path) now compares the nonce **only against cryptographically verified claims**. Any failure — missing config, unreachable JWKS, bad signature/aud/iss/exp — raises a typed `ValueError` and **rejects**. There is **no fallback** to the unverified base64url read for a trust decision. The base64url decode is retained as a **display-only** helper, no longer on the trust path.

### Config keys read from `oauth_settings`
| Key | Meaning | Required |
| --- | --- | --- |
| `jwks_uri` | provider JWKS endpoint | yes |
| `issuer` | expected `iss` claim | yes |
| `{provider}_client_id` → falls back to `client_id` | expected `aud` claim | yes |

## Behavior change / migration

This is a fail-closed security tightening. **Existing configs that use the id_token nonce flow must now provide `jwks_uri` + `issuer` + `client_id` in `oauth_settings`.** Without them, the callback **rejects** (typed `ValueError`) rather than trusting an unverified id_token. Configs that do not mint an OIDC nonce are unaffected.

## Tests — REAL crypto, verifier NOT mocked

`tests/regression/conftest.py::oidc_jwks_server` mints a real RSA keypair, serves its public half as a JWKS over a loopback HTTP endpoint (real `PyJWKClient` fetch), and signs real RS256 id_tokens. The signature verification exercised is the SDK's real `jwt.decode` — nothing about the verifier is mocked (Tier-2 no-mocking for a security-critical path).

`tests/regression/test_issue_1835_sso_id_token_verify.py` pins:
1. valid token (right key, correct aud/iss/exp, matching nonce) → **ACCEPTED**
2. forged signature (signed by a different key) → **REJECTED**
3. wrong audience → **REJECTED**
4. wrong issuer → **REJECTED**
5. expired (exp in the past) → **REJECTED**
6. fail-closed: jwks_uri unconfigured / JWKS unreachable → **REJECTED**

Orphan-detection Rule 4b: the #1815 nonce tests asserted the node "must not treat this token as signature-validated" using unsigned tokens — an assumption this fix overturns. They are swept to sign **real** tokens via the shared harness (an unsigned token would now be rejected at the signature gate, never reaching the nonce comparison); legitimate coverage retained.

### Walk receipt (verbatim)

```
$ PYTHONPATH=$WT/src pytest tests/regression/test_issue_1835_sso_id_token_verify.py tests/regression/test_issue_1815_oidc_nonce_pkce.py -v
collected 14 items

test_issue_1835_sso_id_token_verify.py::test_valid_signed_token_with_matching_nonce_accepted PASSED
test_issue_1835_sso_id_token_verify.py::test_forged_signature_rejected PASSED
test_issue_1835_sso_id_token_verify.py::test_wrong_audience_rejected PASSED
test_issue_1835_sso_id_token_verify.py::test_wrong_issuer_rejected PASSED
test_issue_1835_sso_id_token_verify.py::test_expired_token_rejected PASSED
test_issue_1835_sso_id_token_verify.py::test_fail_closed_when_jwks_uri_unconfigured PASSED
test_issue_1835_sso_id_token_verify.py::test_fail_closed_when_jwks_unreachable PASSED
test_issue_1835_sso_id_token_verify.py::test_nonce_trust_path_uses_verified_claims_not_base64url_decode PASSED
test_issue_1815_oidc_nonce_pkce.py::test_callback_rejects_nonce_mismatch PASSED
test_issue_1815_oidc_nonce_pkce.py::test_callback_rejects_missing_id_token_when_nonce_minted PASSED
test_issue_1815_oidc_nonce_pkce.py::test_callback_accepts_matching_nonce PASSED
test_issue_1815_oidc_nonce_pkce.py::test_initiate_oauth_emits_pkce_challenge PASSED
test_issue_1815_oidc_nonce_pkce.py::test_exchange_sends_cached_code_verifier PASSED
test_issue_1815_oidc_nonce_pkce.py::test_decode_id_token_rejects_non_object_payload PASSED

============================== 14 passed in 7.14s ==============================
```

Forged-signature rejection, shown explicitly (real wrong-key signature vs the served JWKS):

```
FORGED-SIG REJECTED (fail-closed): OIDC id_token verification failed: invalid token (Signature verification failed)
```

## Related issues

Fixes #1835

🤖 Generated with [Claude Code](https://claude.com/claude-code)