### PR TITLE
fix(kaizen-agents): lazy-load RAGResearchAgent so bare install imports without numpy (#1849)

### DIFF
--- a/packages/kaizen-agents/src/kaizen_agents/agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/__init__.py
@@ -29,6 +29,8 @@ Creating Custom Agents:
     - Implementing custom strategies
 """
 
+from typing import TYPE_CHECKING, Any
+
 # IMPORTANT: Auto-register all builtin agents with the registry
 # This enables Agent(agent_type="simple"), Agent(agent_type="react"), etc.
 from kaizen_agents.agents import register_builtin  # noqa: F401
@@ -45,7 +47,7 @@ from kaizen_agents.agents.multi_modal.transcription_agent import (
 from kaizen_agents.agents.multi_modal.vision_agent import VisionAgent, VisionAgentConfig
 
 # Registry functions for agent type registration and discovery
-from kaizen_agents.agents.registry import (
+from kaizen_agents.agents.registry import (  # Backward compatibility alias
     create_agent_from_type,
     get_agent_type_registration,
     get_agent_types_by_category,
@@ -57,13 +59,12 @@ from kaizen_agents.agents.registry import (
     register_agent,
     register_agent_type,
     unregister_agent_type,
-)  # Backward compatibility alias
+)
 from kaizen_agents.agents.specialized.batch_processing import BatchProcessingAgent
 from kaizen_agents.agents.specialized.chain_of_thought import ChainOfThoughtAgent
 from kaizen_agents.agents.specialized.code_generation import CodeGenerationAgent
 from kaizen_agents.agents.specialized.human_approval import HumanApprovalAgent
 from kaizen_agents.agents.specialized.memory_agent import MemoryAgent
-from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 from kaizen_agents.agents.specialized.react import ReActAgent
 from kaizen_agents.agents.specialized.resilient import ResilientAgent
 from kaizen_agents.agents.specialized.self_reflection import SelfReflectionAgent
@@ -71,6 +72,12 @@ from kaizen_agents.agents.specialized.self_reflection import SelfReflectionAgent
 # Specialized agents (single-purpose, ready-to-use)
 from kaizen_agents.agents.specialized.simple_qa import SimpleQAAgent
 from kaizen_agents.agents.specialized.streaming_chat import StreamingChatAgent
+
+if TYPE_CHECKING:
+    # Static-analysis-only import so pyright / mypy / Sphinx resolve the symbol
+    # without dragging RAGResearchAgent's optional numpy dependency into the
+    # eager import path (see __getattr__ below).
+    from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 
 __all__ = [
     # Specialized (11 production agents)
@@ -105,3 +112,20 @@ __all__ = [
     "get_registry_info",
     "create_agent_from_type",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional-dependency agents (PEP 562).
+
+    ``RAGResearchAgent`` pulls in ``kaizen.retrieval.vector_store`` -> numpy, an
+    OPTIONAL dependency shipped only under ``kailash-kaizen[rag]``. Importing
+    this package (and thus every other agent) must NOT require numpy, so
+    ``RAGResearchAgent`` resolves lazily here instead of at module scope. When
+    numpy is absent the underlying ``ImportError`` propagates with its original
+    actionable message.
+    """
+    if name == "RAGResearchAgent":
+        from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+
+        return RAGResearchAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/kaizen-agents/src/kaizen_agents/agents/nodes.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/nodes.py
@@ -34,6 +34,7 @@ Registered Agents:
     2. MemoryAgent - Conversational agent with multi-turn memory
     3. ChainOfThoughtAgent - Step-by-step reasoning with verification
     4. RAGResearchAgent - Retrieval-Augmented Generation with vector search
+       (optional — registered only when numpy is present via kailash-kaizen[rag])
     5. CodeGenerationAgent - Multi-language code generation with tests
     6. ReActAgent - Reasoning + Acting agent with tool use
     7. BatchProcessingAgent - Concurrent high-throughput batch processing
@@ -53,6 +54,9 @@ See Also:
     - KAIZEN_MEMORY_ARCHITECTURE.md - Memory management
 """
 
+import logging
+from typing import TYPE_CHECKING, Any
+
 from kaizen_agents.agents.multi_modal.multi_modal_agent import MultiModalAgent
 from kaizen_agents.agents.multi_modal.transcription_agent import TranscriptionAgent
 
@@ -63,7 +67,6 @@ from kaizen_agents.agents.specialized.chain_of_thought import ChainOfThoughtAgen
 from kaizen_agents.agents.specialized.code_generation import CodeGenerationAgent
 from kaizen_agents.agents.specialized.human_approval import HumanApprovalAgent
 from kaizen_agents.agents.specialized.memory_agent import MemoryAgent
-from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 from kaizen_agents.agents.specialized.react import ReActAgent
 from kaizen_agents.agents.specialized.resilient import ResilientAgent
 from kaizen_agents.agents.specialized.self_reflection import SelfReflectionAgent
@@ -71,6 +74,14 @@ from kaizen_agents.agents.specialized.self_reflection import SelfReflectionAgent
 # Specialized agents
 from kaizen_agents.agents.specialized.simple_qa import SimpleQAAgent
 from kaizen_agents.agents.specialized.streaming_chat import StreamingChatAgent
+
+if TYPE_CHECKING:
+    # Static-analysis-only import — RAGResearchAgent's numpy dependency is
+    # optional (kailash-kaizen[rag]); it is registered into KAIZEN_AGENTS
+    # conditionally below and exposed via __getattr__.
+    from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+
+logger = logging.getLogger(__name__)
 
 # Agent metadata for Studio integration
 KAIZEN_AGENTS = {
@@ -116,23 +127,6 @@ KAIZEN_AGENTS = {
         ],
         "icon": "git-branch",
         "color": "#DC2626",  # Red
-    },
-    "RAGResearchAgent": {
-        "class": RAGResearchAgent,
-        "category": "AI Agents",
-        "description": "Retrieval-Augmented Generation agent with semantic vector search and source attribution",
-        "version": "1.0.0",
-        "tags": [
-            "ai",
-            "kaizen",
-            "rag",
-            "research",
-            "retrieval",
-            "vector-search",
-            "semantic",
-        ],
-        "icon": "search",
-        "color": "#059669",  # Green
     },
     "CodeGenerationAgent": {
         "class": CodeGenerationAgent,
@@ -255,6 +249,41 @@ KAIZEN_AGENTS = {
 }
 
 
+# RAGResearchAgent is optional — it pulls in numpy via
+# kaizen.retrieval.vector_store, which ships only under kailash-kaizen[rag].
+# Register its Studio metadata only when the import succeeds so a bare install
+# without numpy can still import this module and use every other agent node.
+try:
+    from kaizen_agents.agents.specialized.rag_research import (
+        RAGResearchAgent as _RAGResearchAgent,
+    )
+except ImportError as _rag_exc:  # numpy (kailash-kaizen[rag]) not installed
+    logger.warning(
+        "RAGResearchAgent Studio node not registered — its optional "
+        "dependencies are missing: %s. Install with: pip install "
+        "'kailash-kaizen[rag]' (provides numpy).",
+        _rag_exc,
+    )
+else:
+    KAIZEN_AGENTS["RAGResearchAgent"] = {
+        "class": _RAGResearchAgent,
+        "category": "AI Agents",
+        "description": "Retrieval-Augmented Generation agent with semantic vector search and source attribution",
+        "version": "1.0.0",
+        "tags": [
+            "ai",
+            "kaizen",
+            "rag",
+            "research",
+            "retrieval",
+            "vector-search",
+            "semantic",
+        ],
+        "icon": "search",
+        "color": "#059669",  # Green
+    }
+
+
 # Export all agents for convenience
 __all__ = [
     "SimpleQAAgent",
@@ -273,6 +302,21 @@ __all__ = [
     "MultiModalAgent",
     "KAIZEN_AGENTS",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional-dependency agents (PEP 562).
+
+    ``RAGResearchAgent`` pulls in numpy via ``kaizen.retrieval.vector_store``
+    (the optional ``kailash-kaizen[rag]`` extra). Importing this node module
+    must NOT require numpy, so the symbol resolves lazily here; when numpy is
+    absent the underlying ``ImportError`` propagates with its original message.
+    """
+    if name == "RAGResearchAgent":
+        from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+
+        return RAGResearchAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_agent_class(agent_name: str):

--- a/packages/kaizen-agents/src/kaizen_agents/agents/register_builtin.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/register_builtin.py
@@ -10,6 +10,8 @@ are registered on import.
 Part of ADR-020: Unified Agent API Architecture
 """
 
+import logging
+
 # Import autonomous agents
 from kaizen_agents.agents.autonomous.base import BaseAutonomousAgent
 from kaizen_agents.agents.autonomous.claude_code import ClaudeCodeAgent
@@ -30,7 +32,6 @@ from kaizen_agents.agents.specialized.chain_of_thought import ChainOfThoughtAgen
 from kaizen_agents.agents.specialized.code_generation import CodeGenerationAgent
 from kaizen_agents.agents.specialized.human_approval import HumanApprovalAgent
 from kaizen_agents.agents.specialized.memory_agent import MemoryAgent
-from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 from kaizen_agents.agents.specialized.react import ReActAgent
 from kaizen_agents.agents.specialized.resilient import ResilientAgent
 from kaizen_agents.agents.specialized.self_reflection import SelfReflectionAgent
@@ -42,6 +43,8 @@ from kaizen_agents.agents.specialized.streaming_chat import StreamingChatAgent
 # =============================================================================
 # Register Specialized Agents
 # =============================================================================
+
+logger = logging.getLogger(__name__)
 
 
 def register_builtin_agents():
@@ -83,14 +86,30 @@ def register_builtin_agents():
         tags=["reasoning", "step-by-step", "analysis"],
     )
 
-    # RAG Research Agent
-    register_agent(
-        name="rag",
-        agent_class=RAGResearchAgent,
-        description="Retrieval-Augmented Generation with document retrieval",
-        category="specialized",
-        tags=["rag", "retrieval", "research", "knowledge"],
-    )
+    # RAG Research Agent (optional — requires numpy via kailash-kaizen[rag])
+    # RAGResearchAgent pulls in kaizen.retrieval.vector_store -> numpy, which
+    # ships only under the kailash-kaizen[rag] extra. On a bare kaizen-agents
+    # install numpy is absent, so importing it raises ImportError. Guard the
+    # import + registration so every non-RAG agent stays available and the
+    # skip reason is actionable rather than a silent swallow.
+    try:
+        from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+    except ImportError as exc:
+        logger.warning(
+            "RAGResearchAgent not registered (agent_type='rag') — its optional "
+            "dependencies are missing: %s. Install with: pip install "
+            "'kailash-kaizen[rag]' (provides numpy). All other builtin agents "
+            "remain available.",
+            exc,
+        )
+    else:
+        register_agent(
+            name="rag",
+            agent_class=RAGResearchAgent,
+            description="Retrieval-Augmented Generation with document retrieval",
+            category="specialized",
+            tags=["rag", "retrieval", "research", "knowledge"],
+        )
 
     # Memory Agent
     register_agent(

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/__init__.py
@@ -1,12 +1,19 @@
 """Specialized single-purpose agents ready for production use."""
 
+from typing import TYPE_CHECKING, Any
+
 from kaizen_agents.agents.specialized.chain_of_thought import ChainOfThoughtAgent
 from kaizen_agents.agents.specialized.code_generation import CodeGenerationAgent
 from kaizen_agents.agents.specialized.memory_agent import MemoryAgent
 from kaizen_agents.agents.specialized.planning import PlanningAgent, PlanningConfig
-from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 from kaizen_agents.agents.specialized.react import ReActAgent
 from kaizen_agents.agents.specialized.simple_qa import SimpleQAAgent
+
+if TYPE_CHECKING:
+    # Static-analysis-only import so pyright / mypy / Sphinx resolve the symbol
+    # without dragging RAGResearchAgent's optional numpy dependency into the
+    # eager import path (see __getattr__ below).
+    from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
 
 __all__ = [
     "SimpleQAAgent",
@@ -18,3 +25,20 @@ __all__ = [
     "CodeGenerationAgent",
     "MemoryAgent",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import optional-dependency agents (PEP 562).
+
+    ``RAGResearchAgent`` pulls in ``kaizen.retrieval.vector_store``, which
+    imports numpy — an OPTIONAL dependency that ships only under
+    ``kailash-kaizen[rag]``. Importing any other specialized agent (or this
+    package) must NOT require numpy, so RAGResearchAgent resolves lazily here
+    instead of at module scope. When numpy is absent the underlying
+    ``ImportError`` propagates with its original actionable message.
+    """
+    if name == "RAGResearchAgent":
+        from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent
+
+        return RAGResearchAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/kaizen-agents/src/kaizen_agents/agents/specialized/rag_research.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/specialized/rag_research.py
@@ -37,7 +37,19 @@ from typing import Any
 from kailash.nodes.base import NodeMetadata
 from kaizen.core.base_agent import BaseAgent
 from kaizen.memory.vector import VectorMemory
-from kaizen.retrieval.vector_store import SimpleVectorStore
+
+try:
+    # SimpleVectorStore pulls in numpy, which ships only under the optional
+    # kailash-kaizen[rag] extra. Re-raise with an actionable message so a direct
+    # `from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent`
+    # on a bare install fails with guidance, not a raw ModuleNotFoundError.
+    from kaizen.retrieval.vector_store import SimpleVectorStore
+except ImportError as exc:
+    raise ImportError(
+        "RAGResearchAgent requires numpy — install it with: "
+        "pip install 'kailash-kaizen[rag]'"
+    ) from exc
+
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.strategies.multi_cycle import MultiCycleStrategy
 from kaizen_agents._model_env import resolve_default_model

--- a/packages/kaizen-agents/tests/regression/test_issue_1849_bare_import.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_1849_bare_import.py
@@ -1,0 +1,128 @@
+"""Regression test for issue #1849 — bare kaizen-agents install unimportable.
+
+Bug: ``import kaizen_agents.agents`` (and any ``kaizen_agents.agents.specialized.*``
+agent) raised ``ImportError`` on a bare ``pip install kailash-kaizen-agents`` because
+an unguarded module-scope import chain eager-loaded numpy:
+
+    agents/__init__.py       -> from kaizen_agents.agents import register_builtin
+    register_builtin.py      -> from ...specialized.rag_research import RAGResearchAgent
+    specialized/__init__.py  -> from ...rag_research import RAGResearchAgent
+    rag_research.py          -> from kaizen.retrieval.vector_store import SimpleVectorStore
+    vector_store.py          -> import numpy as np
+
+numpy is declared by NO manifest on a bare kaizen-agents install — it ships only
+under ``kailash-kaizen[rag]``. So every non-RAG specialized agent (chain_of_thought,
+etc.) was collateral-damaged by RAGResearchAgent's optional dependency.
+
+The fix lazy-loads RAGResearchAgent (PEP 562 ``__getattr__``) and guards its
+registration behind ``try/except ImportError`` so importing any other agent — or
+the registry — never requires numpy. RAGResearchAgent itself keeps working when
+numpy IS present.
+
+These tests exercise the REAL import with numpy GENUINELY ABSENT: each runs in a
+fresh subprocess whose ``sys.meta_path`` blocks numpy (and every ``numpy.*``
+submodule) before the target import, and drops any preloaded numpy from
+``sys.modules``. numpy is not mocked — it is made unavailable, exactly as a bare
+install would leave it. They FAIL on pre-fix main (eager numpy import) and PASS
+with the fix.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Prelude installed in every child interpreter: block numpy for real.
+_BLOCK_NUMPY = """
+import sys
+
+class _NumpyBlocker:
+    def find_spec(self, name, path=None, target=None):
+        if name == "numpy" or name.startswith("numpy."):
+            raise ImportError(
+                "numpy blocked (issue #1849 regression: simulating a bare "
+                "kaizen-agents install without kailash-kaizen[rag])"
+            )
+        return None
+
+sys.meta_path.insert(0, _NumpyBlocker())
+for _m in [m for m in sys.modules if m == "numpy" or m.startswith("numpy.")]:
+    del sys.modules[_m]
+
+# Sanity: numpy must genuinely be unavailable in this interpreter.
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    pass
+else:  # pragma: no cover - defensive
+    raise AssertionError("numpy blocker failed; test would be vacuous")
+"""
+
+
+def _run_without_numpy(body: str) -> subprocess.CompletedProcess:
+    """Run ``body`` in a fresh interpreter with numpy blocked for real."""
+    script = _BLOCK_NUMPY + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.regression
+def test_specialized_agent_imports_without_numpy():
+    """A non-RAG specialized agent imports with numpy absent (the core defect)."""
+    result = _run_without_numpy(
+        """
+        import kaizen_agents.agents.specialized.chain_of_thought as cot
+        assert hasattr(cot, "ChainOfThoughtAgent")
+        print("OK: specialized import without numpy")
+        """
+    )
+    assert result.returncode == 0, (
+        "importing a non-RAG specialized agent must not require numpy\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "OK: specialized import without numpy" in result.stdout
+
+
+@pytest.mark.regression
+def test_agents_registry_imports_without_numpy():
+    """``import kaizen_agents.agents`` (the registry) succeeds with numpy absent."""
+    result = _run_without_numpy(
+        """
+        import kaizen_agents.agents as agents
+        from kaizen_agents.agents import is_agent_type_registered
+
+        # The registry loads and non-RAG agents register without numpy.
+        assert is_agent_type_registered("simple")
+        assert is_agent_type_registered("cot")
+        # "rag" is skipped (guarded) when numpy is unavailable.
+        assert not is_agent_type_registered("rag")
+        print("OK: registry import without numpy")
+        """
+    )
+    assert result.returncode == 0, (
+        "importing kaizen_agents.agents must not require numpy\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "OK: registry import without numpy" in result.stdout
+
+
+@pytest.mark.regression
+def test_top_level_kaizen_agents_imports_without_numpy():
+    """``import kaizen_agents`` (top-level package) succeeds with numpy absent."""
+    result = _run_without_numpy(
+        """
+        import kaizen_agents  # noqa: F401
+        print("OK: top-level import without numpy")
+        """
+    )
+    assert result.returncode == 0, (
+        "importing kaizen_agents must not require numpy\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "OK: top-level import without numpy" in result.stdout

--- a/packages/kaizen-agents/tests/regression/test_issue_1849_bare_import.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_1849_bare_import.py
@@ -113,6 +113,41 @@ def test_agents_registry_imports_without_numpy():
 
 
 @pytest.mark.regression
+def test_direct_rag_import_raises_actionable_error_without_numpy():
+    """The AC-named direct import raises an ACTIONABLE ImportError (issue #1849 AC2).
+
+    ``from kaizen_agents.agents.specialized.rag_research import RAGResearchAgent``
+    on a bare install (no numpy) must fail with guidance naming
+    ``kailash-kaizen[rag]`` — NOT a raw ``ModuleNotFoundError: No module named
+    'numpy'``. The original cause stays chained (``raise ... from exc``), so this
+    is an actionable re-raise, not a silent swallow.
+    """
+    result = _run_without_numpy(
+        """
+        try:
+            from kaizen_agents.agents.specialized.rag_research import (
+                RAGResearchAgent,  # noqa: F401
+            )
+        except ImportError as exc:
+            msg = str(exc)
+            assert "kailash-kaizen[rag]" in msg, f"not actionable: {msg!r}"
+            assert msg != "No module named 'numpy'", "still a bare ModuleNotFoundError"
+            assert exc.__cause__ is not None, "original cause not chained"
+            print("OK: actionable ImportError on direct RAGResearchAgent import")
+        else:
+            raise AssertionError("expected ImportError with numpy absent")
+        """
+    )
+    assert result.returncode == 0, (
+        "direct RAGResearchAgent import must raise an actionable ImportError\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert (
+        "OK: actionable ImportError on direct RAGResearchAgent import" in result.stdout
+    )
+
+
+@pytest.mark.regression
 def test_top_level_kaizen_agents_imports_without_numpy():
     """``import kaizen_agents`` (top-level package) succeeds with numpy absent."""
     result = _run_without_numpy(

--- a/packages/kaizen-agents/tests/unit/agents/test_registry.py
+++ b/packages/kaizen-agents/tests/unit/agents/test_registry.py
@@ -23,6 +23,24 @@ def _sentence_transformers_available() -> bool:
         return False
 
 
+def _rag_available() -> bool:
+    """Check if RAGResearchAgent is importable.
+
+    RAGResearchAgent pulls in numpy via kaizen.retrieval.vector_store — an
+    optional dependency shipped only under kailash-kaizen[rag]. The "rag" agent
+    type registers if and only if this import succeeds (see register_builtin.py),
+    so registry assertions about "rag" are gated on the same condition.
+    """
+    try:
+        from kaizen_agents.agents.specialized.rag_research import (  # noqa: F401
+            RAGResearchAgent,
+        )
+
+        return True
+    except ImportError:
+        return False
+
+
 class TestAgentRegistryBasics:
     """Test basic agent registry operations."""
 
@@ -79,10 +97,17 @@ class TestAgentTypeRegistration:
         assert is_agent_type_registered("vision")
 
     def test_rag_research_agent_registered(self):
-        """Test that RAGResearchAgent is registered."""
+        """RAGResearchAgent registers only when its optional deps (numpy) are present.
+
+        On a bare install without numpy, "rag" is skipped (not eagerly imported),
+        so the registration is gated on RAGResearchAgent being importable.
+        """
         from kaizen.agents import is_agent_type_registered
 
-        assert is_agent_type_registered("rag")
+        if _rag_available():
+            assert is_agent_type_registered("rag")
+        else:
+            assert not is_agent_type_registered("rag")
 
     def test_code_generation_agent_registered(self):
         """Test that CodeGenerationAgent is registered."""
@@ -218,13 +243,13 @@ class TestListAgentTypes:
 
         names = list_agent_type_names()
 
-        # All 18 agent types should be present
+        # All builtin agent types should be present. "rag" is optional — it
+        # registers only when numpy (via kailash-kaizen[rag]) is installed.
         expected_agents = [
             "simple",
             "react",
             "cot",
             "vision",
-            "rag",
             "code",
             "reflection",
             "memory",
@@ -239,18 +264,26 @@ class TestListAgentTypes:
             "claude_code",
             "autonomous",
         ]
+        if _rag_available():
+            expected_agents.append("rag")
 
         for agent_type in expected_agents:
             assert agent_type in names, f"{agent_type} not found in registry"
 
     def test_list_agent_type_names_count(self):
-        """Test that exactly 18 agent types are registered."""
+        """Test that all builtin agent types are registered.
+
+        The base count is 17; "rag" is optional (numpy-gated) and adds one when
+        its dependencies are installed.
+        """
         from kaizen.agents import list_agent_type_names
 
         names = list_agent_type_names()
 
-        # Should have exactly 18 agent types
-        assert len(names) >= 18, f"Expected at least 18 agents, found {len(names)}"
+        expected_min = 18 if _rag_available() else 17
+        assert (
+            len(names) >= expected_min
+        ), f"Expected at least {expected_min} agents, found {len(names)}"
 
 
 class TestCoreSKDIntegration:


### PR DESCRIPTION
## Summary

A bare `pip install kailash-kaizen-agents` left `import kaizen_agents.agents` — and every non-RAG `kaizen_agents.agents.specialized.*` agent — **unimportable**. An unguarded module-scope chain eager-loaded `RAGResearchAgent`, which pulls in numpy. numpy is declared by **no** kaizen-agents manifest (it ships only under `kailash-kaizen[rag]`), so its absence collateral-damaged agents that have nothing to do with RAG (chain_of_thought, etc.).

numpy stays **optional** — this PR adds no hard numpy dependency.

## Import chain fixed

```
agents/__init__.py       -> from kaizen_agents.agents import register_builtin
register_builtin.py      -> from ...specialized.rag_research import RAGResearchAgent
specialized/__init__.py  -> from ...rag_research import RAGResearchAgent
rag_research.py          -> from kaizen.retrieval.vector_store import SimpleVectorStore
kaizen vector_store.py   -> import numpy as np   # <- absent on a bare install
```

## Changes

- **`specialized/__init__.py`** + **`agents/__init__.py`**: `RAGResearchAgent` now resolves via PEP 562 `__getattr__` (with a `TYPE_CHECKING` block preserving static analysis + `__all__`) instead of an eager module-scope import.
- **`register_builtin.py`** + **`nodes.py`**: the `RAGResearchAgent` import + its registration are guarded by `try/except ImportError`, emitting an actionable WARN (`install kailash-kaizen[rag]`) rather than a silent swallow. `nodes.py` turned out to be **on the import path** (its Studio-node registration ran during a plain specialized import — see the walk receipt below), so its guard is load-bearing, not defensive.
- RAGResearchAgent stays fully functional when numpy IS present; `"rag"` registers exactly as before.

## User-flow walk (verbatim)

All commands run against the worktree code (`PYTHONPATH` -> worktree `kaizen-agents/src`), Python 3.13, main `.venv`.

**Bare-install break — specialized import with numpy blocked for real (meta_path finder):**
```
$ python -c "<block numpy via sys.meta_path> ; import kaizen_agents.agents.specialized.chain_of_thought"
RAGResearchAgent not registered (agent_type='rag') — its optional dependencies are missing: numpy blocked (#1849 walk). Install with: pip install 'kailash-kaizen[rag]' (provides numpy). All other builtin agents remain available.
RAGResearchAgent Studio node not registered — its optional dependencies are missing: numpy blocked (#1849 walk). Install with: pip install 'kailash-kaizen[rag]' (provides numpy).
OK: specialized import without numpy
```

**Registry import with numpy blocked:**
```
$ python -c "<block numpy> ; import kaizen_agents.agents ; ..."
simple registered: True
cot registered: True
rag registered: False
OK: registry import without numpy
```

**Pre-fix proof — same blocked import against current `main`'s code (no fix):**
```
EXPECTED FAILURE on main: ImportError numpy blocked
```

**Happy path — RAGResearchAgent still works WITH numpy present:**
```
numpy present: 2.2.6
RAGResearchAgent lazy-resolved: RAGResearchAgent / RAGResearchAgent
rag registered (numpy present): True
```

## Test evidence

New `tests/regression/test_issue_1849_bare_import.py` exercises the **real** import with numpy **genuinely absent** — a `sys.meta_path` finder blocks numpy (and every `numpy.*` submodule) in a fresh subprocess; numpy is made unavailable, not mocked. It fails on pre-fix `main` and passes with the fix.

```
tests/regression/test_issue_1849_bare_import.py::test_specialized_agent_imports_without_numpy PASSED
tests/regression/test_issue_1849_bare_import.py::test_agents_registry_imports_without_numpy PASSED
tests/regression/test_issue_1849_bare_import.py::test_top_level_kaizen_agents_imports_without_numpy PASSED
tests/unit/agents/test_registry.py ... 40 passed
============================= 43 passed in 13.89s ==============================
```

`test_registry.py` rag-registration assertions were swept to be numpy-availability-aware (orphan-detection Rule 4b — the registration path is now conditional). `pytest --collect-only` over the whole kaizen-agents tree: 3450 tests collected, 0 collection errors. `pre-commit run` on all changed files: all non-skip hooks pass.

## Related issues

Fixes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)