### PR TITLE
fix(nexus): WebhookTransport.receive() fails closed on missing secret + allow_unsigned opt-in (#1836)

### DIFF
--- a/packages/kailash-nexus/src/nexus/transports/webhook.py
+++ b/packages/kailash-nexus/src/nexus/transports/webhook.py
@@ -311,8 +311,16 @@ class WebhookTransport(Transport):
     Args:
         secret: Shared secret for signature verification. When set, every
             inbound request must include a valid signature header. When
-            None, signature verification is skipped (not recommended for
-            production).
+            None, ``receive()`` fails closed (raises) unless
+            ``allow_unsigned=True`` is also set — an unsigned deployment
+            would otherwise silently accept forged webhook events (#1836).
+        allow_unsigned: Opt-in to accept unsigned inbound webhooks when no
+            ``secret`` is configured (default ``False``). Leaving this at the
+            secure default makes ``receive()`` raise when no secret is set,
+            so a missing-secret misconfiguration fails loudly instead of
+            accepting any forged payload. Set ``True`` ONLY for deployments
+            that genuinely front webhook verification elsewhere (e.g. an
+            edge proxy / gateway) or intentionally run unsigned.
         signature_header: Name of the HTTP header carrying the signature
             (default ``X-Webhook-Signature``). Twilio integrations should
             set this to ``X-Twilio-Signature``.
@@ -349,8 +357,10 @@ class WebhookTransport(Transport):
         max_idempotency_keys: int = 10000,
         max_deliveries: int = 10000,
         signer: Optional[WebhookSigner] = None,
+        allow_unsigned: bool = False,
     ):
         self._secret = secret
+        self._allow_unsigned = allow_unsigned
         self._signature_header = signature_header
         self._idempotency_header = idempotency_header
         self._max_retries = max_retries
@@ -653,8 +663,9 @@ class WebhookTransport(Transport):
             Dict with ``status``, ``handler``, and ``result`` keys.
 
         Raises:
-            ValueError: If signature verification fails or the handler
-                is not found.
+            ValueError: If signature verification fails, the handler is not
+                found, OR no signing secret is configured and
+                ``allow_unsigned`` was not set (fail-closed default, #1836).
             RuntimeError: If the transport is not running.
         """
         if not self._running:
@@ -671,6 +682,19 @@ class WebhookTransport(Transport):
                 raise ValueError("payload_bytes is required for signature verification")
             if not self.verify_signature(payload_bytes, signature):
                 raise ValueError("Invalid webhook signature")
+        elif not self._allow_unsigned:
+            # Fail closed (#1836): no signing secret configured means an
+            # inbound webhook cannot be authenticated, so a forged event is
+            # indistinguishable from a genuine one. Refuse rather than
+            # silently accept. Deployments that intentionally run unsigned
+            # (or verify at an edge proxy) MUST opt in explicitly.
+            raise ValueError(
+                "Refusing to process an unsigned webhook: no signing secret is "
+                "configured, so the payload's authenticity cannot be verified "
+                "and a forged event would be accepted. Configure a webhook "
+                "signing secret (WebhookTransport(secret=...)), or set "
+                "allow_unsigned=True to explicitly accept unsigned webhooks."
+            )
 
         # Idempotency deduplication. is_duplicate() returns False for None
         # keys; the explicit narrowing satisfies the str-only signature on

--- a/packages/kailash-nexus/tests/regression/test_issue_1814_webhook_fail_closed.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1814_webhook_fail_closed.py
@@ -23,11 +23,14 @@ This exercises the real ``WebhookTransport`` + the real
 - Secret configured + a forged signature → returns ``False`` (unchanged).
 - Secret configured + a valid signature → returns ``True`` (unchanged).
 
-Note ``receive()`` semantics are intentionally UNCHANGED and out of scope:
-it guards the verify call with ``if self._secret is not None`` and so
-never reaches the new raise on the unsigned-receive path. That path stays
-covered by the pre-existing unit test
-``test_receive_no_secret_skips_verification``.
+Note the ``receive()`` unsigned-receive path was subsequently hardened by
+issue #1836: ``receive()`` now also fails closed when no secret is
+configured unless ``allow_unsigned=True`` is set. That behaviour is covered
+by ``tests/regression/test_issue_1836_webhook_fail_closed.py`` and the unit
+tests ``test_receive_no_secret_fails_closed`` /
+``test_receive_no_secret_allow_unsigned_accepts``. This #1814 test remains
+scoped to the ``verify_signature`` / ``verify_signature_for_request`` entry
+points.
 """
 
 import hashlib

--- a/packages/kailash-nexus/tests/regression/test_issue_1836_webhook_fail_closed.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1836_webhook_fail_closed.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 regression test for issue #1836.
+
+``WebhookTransport.receive()`` MUST fail closed when no signing secret is
+configured. Before the fix, ``receive()`` guarded signature verification
+with ``if self._secret is not None`` and so SKIPPED verification entirely
+when no secret was set — a no-secret deployment silently accepted ANY
+forged inbound webhook event.
+
+#1814 already hardened ``verify_signature`` / ``verify_signature_for_request``
+to fail closed; #1836 (Option A) closes the remaining hole at ``receive()``
+itself: with no secret AND without the explicit ``allow_unsigned=True``
+opt-in, ``receive()`` now raises ``ValueError`` rather than dispatching the
+unsigned payload. Deployments that intentionally run unsigned (or verify at
+an edge proxy) opt in via ``WebhookTransport(allow_unsigned=True)``.
+
+This exercises the real ``WebhookTransport`` + the real ``HmacSha256Signer``
+with real HMAC signatures over real payloads (no mocking of the code under
+test, per ``rules/testing.md`` § Tier 2):
+
+1. No secret + ``allow_unsigned`` unset → REJECTED (raises ``ValueError``).
+2. No secret + ``allow_unsigned=True`` → ACCEPTED (unsigned mode preserved).
+3. Secret configured + VALID signature → ACCEPTED (unchanged).
+4. Secret configured + INVALID signature → REJECTED (unchanged from #1814).
+"""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from nexus.registry import HandlerRegistry
+from nexus.transports.webhook import WebhookTransport
+
+
+def _make_signature(secret: str, payload_bytes: bytes) -> str:
+    """Compute the canonical HMAC-SHA256 signature the signer expects."""
+    mac = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+async def _started_transport(transport: WebhookTransport) -> WebhookTransport:
+    """Register a real handler and start the transport."""
+    registry = HandlerRegistry()
+
+    async def process_event(event: str, amount: int) -> dict:
+        return {"processed": event, "amount": amount}
+
+    registry.register_handler("process_event", process_event)
+    await transport.start(registry)
+    return transport
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_receive_no_secret_no_optin_fails_closed():
+    """Case 1: no secret + allow_unsigned unset → raises (#1836)."""
+    transport = await _started_transport(WebhookTransport())  # secure default
+    forged_payload = {"event": "payment.completed", "amount": 1000000}
+    forged_bytes = json.dumps(forged_payload).encode("utf-8")
+
+    with pytest.raises(ValueError, match="unsigned webhook"):
+        await transport.receive(
+            "process_event",
+            forged_payload,
+            payload_bytes=forged_bytes,
+            signature="sha256=" + "0" * 64,
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_receive_no_secret_allow_unsigned_accepts():
+    """Case 2: no secret + allow_unsigned=True → accepted, unsigned mode preserved (#1836)."""
+    transport = await _started_transport(WebhookTransport(allow_unsigned=True))
+    payload = {"event": "payment.completed", "amount": 4200}
+
+    result = await transport.receive("process_event", payload)
+
+    assert result["status"] == "ok"
+    assert result["handler"] == "process_event"
+    assert result["result"] == {"processed": "payment.completed", "amount": 4200}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_receive_secret_valid_signature_accepts():
+    """Case 3: secret + valid HMAC signature → accepted (unchanged)."""
+    secret = "test-webhook-secret-key"
+    transport = await _started_transport(WebhookTransport(secret=secret))
+    payload = {"event": "user.created", "amount": 1}
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    valid_signature = _make_signature(secret, payload_bytes)
+
+    result = await transport.receive(
+        "process_event",
+        payload,
+        payload_bytes=payload_bytes,
+        signature=valid_signature,
+    )
+
+    assert result["status"] == "ok"
+    assert result["result"] == {"processed": "user.created", "amount": 1}
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_receive_secret_invalid_signature_rejects():
+    """Case 4: secret + forged signature → rejected (unchanged from #1814)."""
+    secret = "test-webhook-secret-key"
+    transport = await _started_transport(WebhookTransport(secret=secret))
+    payload = {"event": "user.created", "amount": 1}
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    # Signature computed with the WRONG secret → invalid.
+    forged_signature = _make_signature("attacker-secret", payload_bytes)
+
+    with pytest.raises(ValueError, match="Invalid webhook signature"):
+        await transport.receive(
+            "process_event",
+            payload,
+            payload_bytes=payload_bytes,
+            signature=forged_signature,
+        )

--- a/packages/kailash-nexus/tests/unit/transports/test_webhook.py
+++ b/packages/kailash-nexus/tests/unit/transports/test_webhook.py
@@ -46,6 +46,14 @@ def transport_no_secret():
 
 
 @pytest.fixture
+def transport_unsigned():
+    # Opt-in unsigned mode (#1836): no secret, but explicitly accepts
+    # unsigned inbound webhooks. Used by dispatch/idempotency tests that
+    # exercise receive() behaviour independent of signature verification.
+    return WebhookTransport(allow_unsigned=True)
+
+
+@pytest.fixture
 def registry():
     return HandlerRegistry()
 
@@ -315,10 +323,13 @@ class TestInboundReceive:
         assert result["result"]["message"] == "Hello, Alice!"
 
     @pytest.mark.asyncio
-    async def test_receive_no_secret_skips_verification(
-        self, transport_no_secret, registry
-    ):
-        """Without a secret, signature verification is skipped entirely."""
+    async def test_receive_no_secret_fails_closed(self, transport_no_secret, registry):
+        """Without a secret AND without allow_unsigned, receive() fails closed (#1836).
+
+        Previously this path silently accepted the unsigned payload
+        (``test_receive_no_secret_skips_verification``); a no-secret
+        deployment therefore accepted forged webhook events. It now raises.
+        """
 
         async def greet(name: str) -> dict:
             return {"message": f"Hello, {name}!"}
@@ -326,45 +337,60 @@ class TestInboundReceive:
         registry.register_handler("greet", greet)
         await transport_no_secret.start(registry)
 
-        result = await transport_no_secret.receive("greet", {"name": "Bob"})
+        with pytest.raises(ValueError, match="unsigned webhook"):
+            await transport_no_secret.receive("greet", {"name": "Bob"})
+
+    @pytest.mark.asyncio
+    async def test_receive_no_secret_allow_unsigned_accepts(
+        self, transport_unsigned, registry
+    ):
+        """With allow_unsigned=True and no secret, unsigned receive is accepted (#1836)."""
+
+        async def greet(name: str) -> dict:
+            return {"message": f"Hello, {name}!"}
+
+        registry.register_handler("greet", greet)
+        await transport_unsigned.start(registry)
+
+        result = await transport_unsigned.receive("greet", {"name": "Bob"})
         assert result["status"] == "ok"
         assert result["result"]["message"] == "Hello, Bob!"
 
     @pytest.mark.asyncio
-    async def test_receive_unknown_handler_raises(self, transport_no_secret, registry):
-        await transport_no_secret.start(registry)
+    async def test_receive_unknown_handler_raises(self, transport_unsigned, registry):
+        await transport_unsigned.start(registry)
         with pytest.raises(ValueError, match="not found"):
-            await transport_no_secret.receive("nonexistent", {"key": "val"})
+            await transport_unsigned.receive("nonexistent", {"key": "val"})
 
     @pytest.mark.asyncio
-    async def test_receive_handler_no_func_raises(self, transport_no_secret, registry):
+    async def test_receive_handler_no_func_raises(self, transport_unsigned, registry):
         """Handlers with func=None (workflow-only) cannot receive webhooks."""
-        await transport_no_secret.start(registry)
+        await transport_unsigned.start(registry)
         # Manually insert a handler without a function
-        transport_no_secret._handler_map["wf_only"] = HandlerDef(
+        transport_unsigned._handler_map["wf_only"] = HandlerDef(
             name="wf_only", func=None
         )
 
         with pytest.raises(ValueError, match="no callable function"):
-            await transport_no_secret.receive("wf_only", {"key": "val"})
+            await transport_unsigned.receive("wf_only", {"key": "val"})
 
     @pytest.mark.asyncio
-    async def test_receive_sync_handler(self, transport_no_secret, registry):
+    async def test_receive_sync_handler(self, transport_unsigned, registry):
         """Synchronous handler functions are executed in an executor."""
 
         def sync_greet(name: str) -> dict:
             return {"message": f"Sync Hello, {name}!"}
 
         registry.register_handler("sync_greet", sync_greet)
-        await transport_no_secret.start(registry)
+        await transport_unsigned.start(registry)
 
-        result = await transport_no_secret.receive("sync_greet", {"name": "Eve"})
+        result = await transport_unsigned.receive("sync_greet", {"name": "Eve"})
         assert result["status"] == "ok"
         assert result["result"]["message"] == "Sync Hello, Eve!"
 
     @pytest.mark.asyncio
     async def test_receive_idempotency_returns_cached(
-        self, transport_no_secret, registry
+        self, transport_unsigned, registry
     ):
         """Duplicate requests with the same idempotency key return cached responses."""
         call_count = 0
@@ -375,17 +401,17 @@ class TestInboundReceive:
             return {"count": call_count}
 
         registry.register_handler("counter", counter)
-        await transport_no_secret.start(registry)
+        await transport_unsigned.start(registry)
 
         # First call
-        r1 = await transport_no_secret.receive(
+        r1 = await transport_unsigned.receive(
             "counter", {"name": "A"}, idempotency_key="idem-1"
         )
         assert r1["result"]["count"] == 1
         assert call_count == 1
 
         # Second call with same key — should return cached, not call handler
-        r2 = await transport_no_secret.receive(
+        r2 = await transport_unsigned.receive(
             "counter", {"name": "A"}, idempotency_key="idem-1"
         )
         assert r2["result"]["count"] == 1
@@ -393,7 +419,7 @@ class TestInboundReceive:
 
     @pytest.mark.asyncio
     async def test_receive_different_idempotency_keys(
-        self, transport_no_secret, registry
+        self, transport_unsigned, registry
     ):
         """Different idempotency keys dispatch independently."""
         call_count = 0
@@ -404,14 +430,10 @@ class TestInboundReceive:
             return {"count": call_count}
 
         registry.register_handler("counter", counter)
-        await transport_no_secret.start(registry)
+        await transport_unsigned.start(registry)
 
-        await transport_no_secret.receive(
-            "counter", {"name": "A"}, idempotency_key="k1"
-        )
-        await transport_no_secret.receive(
-            "counter", {"name": "B"}, idempotency_key="k2"
-        )
+        await transport_unsigned.receive("counter", {"name": "A"}, idempotency_key="k1")
+        await transport_unsigned.receive("counter", {"name": "B"}, idempotency_key="k2")
         assert call_count == 2
 
 


### PR DESCRIPTION
## Summary

`WebhookTransport.receive()` guarded signature verification with `if self._secret is not None`, so a deployment with **no webhook signing secret** SKIPPED verification entirely and **silently accepted any forged inbound webhook event** — a genuine event was indistinguishable from a forgery. #1814 already hardened `verify_signature` / `verify_signature_for_request` to fail closed, but left `receive()` as an intentional unsigned-mode contract call. This closes that hole.

## Design (Option A — user-approved)

`receive()` now **fails closed by default** with an **explicit opt-in**:

- **No secret + `allow_unsigned` unset (secure default)** → raises `ValueError` with an actionable message naming the fix.
- **No secret + `allow_unsigned=True`** → proceeds in unsigned mode (prior behaviour preserved behind the explicit flag).
- **Secret set** → verifies as before (unchanged).

**Opt-in mechanism:** a constructor field `WebhookTransport(allow_unsigned: bool = False)` — the idiomatic spot alongside `secret`, and secure-by-default. **Error type:** `ValueError`, matching `verify_signature`'s #1814 fix and `receive()`'s existing signature-error convention. No silent fallback: the no-secret-without-opt-in path RAISES, it does not log-and-continue.

## Behaviour change / migration

This changes the default contract. **Deployments running unsigned webhooks with no secret must now pass `allow_unsigned=True`:**

```python
# before: silently accepted unsigned webhooks
app = WebhookTransport()
# after: explicit opt-in required for unsigned mode
app = WebhookTransport(allow_unsigned=True)
```

Deployments that already configure `secret=...` are unaffected.

### Stale-assertion sweep (orphan-detection Rule 4b)

Default change → swept every test asserting the old silent-accept in the same PR:
- `test_receive_no_secret_skips_verification` → rewritten as `test_receive_no_secret_fails_closed` (asserts the raise) + new `test_receive_no_secret_allow_unsigned_accepts` (asserts the opt-in accept).
- 5 dispatch/idempotency unit tests (`unknown_handler`, `handler_no_func`, `sync_handler`, 2× idempotency) repointed from the `transport_no_secret` fixture onto a new `transport_unsigned` (`allow_unsigned=True`) fixture — they intend unsigned-mode dispatch, not the fail-closed path.
- The now-stale `receive() semantics ... UNCHANGED` docstring note in the #1814 regression test.

## User-flow walk (receipt)

```
CASE1 (no secret, no opt-in) RAISED ValueError:
   Refusing to process an unsigned webhook: no signing secret is configured, so the payload's authenticity cannot be verified and a forged event would be accepted. Configure a webhook signing secret (WebhookTransport(secret=...)), or set allow_unsigned=True to explicitly accept unsigned webhooks.
CASE2 (no secret, allow_unsigned=True) ACCEPTED:
   {'status': 'ok', 'handler': 'h', 'result': {'ok': 'genuine-unsigned'}}
```

## Test evidence

New `tests/regression/test_issue_1836_webhook_fail_closed.py` (real payloads + real HMAC signatures, no mocking of the code under test):
1. no secret + no opt-in → raises;
2. no secret + `allow_unsigned=True` → accepts;
3. secret + valid signature → accepts;
4. secret + invalid signature → rejects (unchanged from #1814).

Full webhook suite (unit + signer + #1814 + #1836) green:
```
91 passed in 0.67s
```

## Related issues

Fixes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)