### PR TITLE
fix(mcp,kaizen): sanitize credential-bearing exception logs in MCP transports + Ollama provider (#1840)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/providers/ollama_provider.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/ollama_provider.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Iterator, Optional
 
+from kailash.utils.url_credentials import mask_error_text
+
 
 @dataclass
 class OllamaConfig:
@@ -40,7 +42,8 @@ class OllamaProvider:
             ollama.list()
         except Exception as e:
             raise RuntimeError(
-                f"Ollama not available. Please install and start Ollama: {e}\n"
+                "Ollama not available. Please install and start Ollama: "
+                f"{mask_error_text(str(e))}\n"
                 "Install: https://ollama.ai/download"
             )
 
@@ -85,7 +88,7 @@ class OllamaProvider:
             }
 
         except Exception as e:
-            raise RuntimeError(f"Ollama generation failed: {e}")
+            raise RuntimeError(f"Ollama generation failed: {mask_error_text(str(e))}")
 
     def generate_stream(
         self, prompt: str, system: Optional[str] = None, **kwargs
@@ -125,7 +128,7 @@ class OllamaProvider:
                         yield content
 
         except Exception as e:
-            raise RuntimeError(f"Ollama streaming failed: {e}")
+            raise RuntimeError(f"Ollama streaming failed: {mask_error_text(str(e))}")
 
     def generate_vision(
         self, prompt: str, image_path: str, system: Optional[str] = None, **kwargs
@@ -175,4 +178,6 @@ class OllamaProvider:
             }
 
         except Exception as e:
-            raise RuntimeError(f"Ollama vision generation failed: {e}")
+            raise RuntimeError(
+                f"Ollama vision generation failed: {mask_error_text(str(e))}"
+            )

--- a/packages/kailash-kaizen/tests/regression/test_issue_1840_ollama_cred_redaction.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1840_ollama_cred_redaction.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: Ollama provider must not leak base_url credentials (#1840).
+
+Before the fix, ``OllamaProvider`` raised ``RuntimeError(f"... {e}")`` at four
+sites (``_check_ollama_available``, ``generate``, ``generate_stream``,
+``generate_vision``). The underlying ``ollama`` client renders the configured
+``base_url`` / ``OLLAMA_HOST`` (which may carry ``user:pass@host`` or a
+``?token=`` param) into its exception text, so ``{e}`` leaked the credential.
+
+The fix routes every ``{e}`` through ``mask_error_text`` (the ONE shared helper
+in ``kailash.utils.url_credentials``).
+
+These tests INJECT a fake ``ollama`` backend (the external boundary) whose
+calls raise exceptions carrying a credential-bearing base_url; the redaction
+helper itself is exercised for real (never mocked).
+"""
+
+import sys
+import types
+
+import pytest
+
+from kaizen.providers.ollama_provider import OllamaConfig, OllamaProvider
+
+CRED_URL = "http://ollama_user:S3cr3tOLLAMA@ollama.host:11434/api?token=oltok123"
+SECRET = "S3cr3tOLLAMA"
+TOKEN = "oltok123"
+
+
+def _install_fake_ollama(monkeypatch, *, list_exc=None, chat_exc=None):
+    """Install a fake ``ollama`` module into sys.modules (boundary injection)."""
+    mod = types.ModuleType("ollama")
+
+    def _list(*a, **k):
+        if list_exc is not None:
+            raise list_exc
+        return {"models": []}
+
+    def _chat(*a, **k):
+        if chat_exc is not None:
+            raise chat_exc
+        return {"message": {"content": "ok"}, "model": "llama2", "done": True}
+
+    mod.list = _list
+    mod.chat = _chat
+    monkeypatch.setitem(sys.modules, "ollama", mod)
+    return mod
+
+
+def _config():
+    return OllamaConfig(base_url=CRED_URL)
+
+
+def _assert_masked(text):
+    assert SECRET not in text
+    assert TOKEN not in text
+
+
+def test_check_available_raise_masks_credentials(monkeypatch):
+    exc = ConnectionError(f"Failed to reach {CRED_URL}: connection refused")
+    _install_fake_ollama(monkeypatch, list_exc=exc)
+    with pytest.raises(RuntimeError) as ei:
+        OllamaProvider(config=_config())
+    msg = str(ei.value)
+    _assert_masked(msg)
+    assert "***@ollama.host" in msg
+
+
+def test_generate_raise_masks_credentials(monkeypatch):
+    exc = ConnectionError(f"httpx.ConnectError to {CRED_URL}")
+    _install_fake_ollama(monkeypatch, chat_exc=exc)  # list() ok → construct passes
+    provider = OllamaProvider(config=_config())
+    with pytest.raises(RuntimeError) as ei:
+        provider.generate("hello")
+    msg = str(ei.value)
+    _assert_masked(msg)
+    assert "***@ollama.host" in msg
+
+
+def test_generate_stream_raise_masks_credentials(monkeypatch):
+    exc = ConnectionError(f"stream broke on {CRED_URL}")
+    _install_fake_ollama(monkeypatch, chat_exc=exc)
+    provider = OllamaProvider(config=_config())
+    with pytest.raises(RuntimeError) as ei:
+        list(provider.generate_stream("hello"))  # iterate to trigger the body
+    msg = str(ei.value)
+    _assert_masked(msg)
+    assert "***@ollama.host" in msg
+
+
+def test_generate_vision_raise_masks_credentials(monkeypatch):
+    exc = ConnectionError(f"vision call failed to {CRED_URL}")
+    _install_fake_ollama(monkeypatch, chat_exc=exc)
+    provider = OllamaProvider(config=_config())
+    with pytest.raises(RuntimeError) as ei:
+        provider.generate_vision("describe", image_path="/tmp/x.png")
+    msg = str(ei.value)
+    _assert_masked(msg)
+    assert "***@ollama.host" in msg
+
+
+def test_dotall_embedded_newline_in_base_url_fully_masked(monkeypatch):
+    """The #1840 DOTALL regression via the Ollama raise path.
+
+    A credential whose password contains a literal newline must be fully
+    masked — the tail after the ``\\n`` must not leak.
+    """
+    leaky = "http://admin:sec\nret@ollama.host:11434/api"
+    exc = ConnectionError(f"connect error: {leaky}")
+    _install_fake_ollama(monkeypatch, chat_exc=exc)
+    provider = OllamaProvider(config=OllamaConfig(base_url=leaky))
+    with pytest.raises(RuntimeError) as ei:
+        provider.generate("hi")
+    msg = str(ei.value)
+    assert "ret@" not in msg  # tail after the newline must not survive
+    assert "sec\nret" not in msg
+    assert "***@ollama.host" in msg
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -73,6 +73,7 @@ from urllib.parse import urljoin, urlparse
 
 import aiohttp
 import websockets
+from kailash.utils.url_credentials import mask_error_text, mask_url
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, TransportError
 from kailash_mcp.protocol.protocol import MetaData, ProtocolManager
@@ -123,7 +124,7 @@ class TransportSecurity:
             return True
 
         except Exception as e:
-            logger.error(f"URL validation error: {e}")
+            logger.error(f"URL validation error: {mask_error_text(str(e))}")
             return False
 
     @classmethod
@@ -577,12 +578,15 @@ class SSETransport(BaseTransport):
             self._connected = True
             self._update_metrics("connections_total")
 
-            logger.info(f"SSE transport connected: {sse_url}")
+            logger.info(f"SSE transport connected: {mask_url(sse_url)}")
 
         except Exception as e:
             self._update_metrics("connections_failed")
             await self._cleanup_connection()
-            raise TransportError(f"SSE connection failed: {e}", transport_type="sse")
+            raise TransportError(
+                f"SSE connection failed: {mask_error_text(str(e))}",
+                transport_type="sse",
+            )
 
     async def disconnect(self) -> None:
         """Disconnect from SSE endpoint."""
@@ -615,7 +619,10 @@ class SSETransport(BaseTransport):
 
         except Exception as e:
             self._update_metrics("errors_total")
-            raise TransportError(f"Failed to send message: {e}", transport_type="sse")
+            raise TransportError(
+                f"Failed to send message: {mask_error_text(str(e))}",
+                transport_type="sse",
+            )
 
     async def receive_message(self) -> Dict[str, Any]:
         """Receive message from SSE stream."""
@@ -638,7 +645,8 @@ class SSETransport(BaseTransport):
         except Exception as e:
             self._update_metrics("errors_total")
             raise TransportError(
-                f"Failed to receive message: {e}", transport_type="sse"
+                f"Failed to receive message: {mask_error_text(str(e))}",
+                transport_type="sse",
             )
 
     async def _read_sse_events(self):
@@ -782,13 +790,16 @@ class StreamableHTTPTransport(BaseTransport):
             self._connected = True
             self._update_metrics("connections_total")
 
-            logger.info(f"StreamableHTTP transport connected: {self.base_url}")
+            logger.info(
+                f"StreamableHTTP transport connected: {mask_url(self.base_url)}"
+            )
 
         except Exception as e:
             self._update_metrics("connections_failed")
             await self._cleanup_connection()
             raise TransportError(
-                f"HTTP connection failed: {e}", transport_type="streamable_http"
+                f"HTTP connection failed: {mask_error_text(str(e))}",
+                transport_type="streamable_http",
             )
 
     async def disconnect(self) -> None:
@@ -846,7 +857,8 @@ class StreamableHTTPTransport(BaseTransport):
         except Exception as e:
             self._update_metrics("errors_total")
             raise TransportError(
-                f"Failed to send message: {e}", transport_type="streamable_http"
+                f"Failed to send message: {mask_error_text(str(e))}",
+                transport_type="streamable_http",
             )
 
     async def receive_message(self) -> Dict[str, Any]:
@@ -893,7 +905,8 @@ class StreamableHTTPTransport(BaseTransport):
         except Exception as e:
             self._update_metrics("errors_total")
             raise TransportError(
-                f"Failed to receive message: {e}", transport_type="streamable_http"
+                f"Failed to receive message: {mask_error_text(str(e))}",
+                transport_type="streamable_http",
             )
 
     async def _create_server_session(self):
@@ -1041,13 +1054,14 @@ class WebSocketTransport(BaseTransport):
             self._connected = True
             self._update_metrics("connections_total")
 
-            logger.info(f"WebSocket transport connected: {self.url}")
+            logger.info(f"WebSocket transport connected: {mask_url(self.url)}")
 
         except Exception as e:
             self._update_metrics("connections_failed")
             await self._cleanup_connection()
             raise TransportError(
-                f"WebSocket connection failed: {e}", transport_type="websocket"
+                f"WebSocket connection failed: {mask_error_text(str(e))}",
+                transport_type="websocket",
             )
 
     async def disconnect(self) -> None:
@@ -1075,7 +1089,8 @@ class WebSocketTransport(BaseTransport):
         except Exception as e:
             self._update_metrics("errors_total")
             raise TransportError(
-                f"Failed to send message: {e}", transport_type="websocket"
+                f"Failed to send message: {mask_error_text(str(e))}",
+                transport_type="websocket",
             )
 
     async def receive_message(self) -> Dict[str, Any]:
@@ -1098,7 +1113,8 @@ class WebSocketTransport(BaseTransport):
         except Exception as e:
             self._update_metrics("errors_total")
             raise TransportError(
-                f"Failed to receive message: {e}", transport_type="websocket"
+                f"Failed to receive message: {mask_error_text(str(e))}",
+                transport_type="websocket",
             )
 
     async def _read_messages(self):

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -73,11 +73,12 @@ from urllib.parse import urljoin, urlparse
 
 import aiohttp
 import websockets
-from kailash.utils.url_credentials import mask_error_text, mask_url
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, TransportError
 from kailash_mcp.protocol.protocol import MetaData, ProtocolManager
 from kailash_mcp.security import validate_spawn_command
+
+from kailash.utils.url_credentials import mask_error_text, mask_url
 
 logger = logging.getLogger(__name__)
 
@@ -672,7 +673,7 @@ class SSETransport(BaseTransport):
                         logger.warning(f"Invalid JSON in SSE event: {data_str}")
 
         except Exception as e:
-            logger.error(f"SSE read error: {e}")
+            logger.error(f"SSE read error: {mask_error_text(str(e))}")
         finally:
             if self._connected:
                 await self.disconnect()
@@ -938,7 +939,7 @@ class StreamableHTTPTransport(BaseTransport):
                 else:
                     logger.warning(f"Failed to close server session: {response.status}")
         except Exception as e:
-            logger.error(f"Error closing server session: {e}")
+            logger.error(f"Error closing server session: {mask_error_text(str(e))}")
         finally:
             self.session_id = None
 
@@ -1136,7 +1137,7 @@ class WebSocketTransport(BaseTransport):
         except websockets.exceptions.ConnectionClosed:
             logger.info("WebSocket connection closed")
         except Exception as e:
-            logger.error(f"WebSocket read error: {e}")
+            logger.error(f"WebSocket read error: {mask_error_text(str(e))}")
         finally:
             if self._connected:
                 await self.disconnect()

--- a/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
@@ -85,6 +85,9 @@ def _make_raising_session(exc):
         def post(self, *a, **k):  # returns a CM; entering raises
             raise exc
 
+        def delete(self, *a, **k):  # returns a CM; entering raises
+            raise exc
+
         async def close(self):
             pass
 
@@ -188,6 +191,24 @@ async def test_http_send_raise_masks_credentials():
     msg = str(ei.value)
     assert "S3cr3tHTTP" not in msg
     assert "httptok123" not in msg
+
+
+@pytest.mark.asyncio
+async def test_http_close_server_session_log_masks_credentials(caplog):
+    # _close_server_session swallows aiohttp errors in its own try/except and
+    # logs them — the {e} there embeds base_url via urljoin(self.base_url, ...).
+    t = StreamableHTTPTransport(
+        HTTP_URL, session_management=True, skip_security_validation=True
+    )
+    t.session = _make_raising_session(Exception(f"DELETE failed to {HTTP_URL}"))()
+    t.session_id = "sess-123"
+    with caplog.at_level(logging.ERROR, logger="kailash_mcp.transports.transports"):
+        await t._close_server_session()
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Error closing server session" in logged
+    assert "S3cr3tHTTP" not in logged
+    assert "httptok123" not in logged
+    assert "***@mcp.example" in logged
 
 
 # --- WebSocket ---------------------------------------------------------------

--- a/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: MCP transports must not leak base_url credentials (#1840).
+
+Before the fix, the SSE / StreamableHTTP / WebSocket transports interpolated a
+credential-bearing ``base_url`` / ``url`` verbatim into:
+
+* the "transport connected" ``logger.info`` line, and
+* the opaque ``{e}`` of every ``TransportError`` raised on a connect / send /
+  receive failure.
+
+A ``base_url`` such as ``https://user:secret@host/path?token=abc`` therefore
+leaked ``user:secret`` and ``token=abc`` into logs and exception text.
+
+The fix routes URL-value log lines through ``mask_url`` and opaque ``{e}``
+strings through ``mask_error_text`` (both from
+``kailash.utils.url_credentials`` — the ONE shared helper module).
+
+These tests INJECT the network boundary (aiohttp / websockets) — the external
+infra — so the failure path fires deterministically; the redaction helpers
+themselves are exercised for real (never mocked).
+"""
+
+import logging
+
+import pytest
+from kailash_mcp.errors import TransportError
+from kailash_mcp.transports import transports as T
+from kailash_mcp.transports.transports import (
+    SSETransport,
+    StreamableHTTPTransport,
+    WebSocketTransport,
+)
+
+SSE_URL = "https://sse_user:S3cr3tSSE@mcp.example:8443/base?token=ssetok123"
+HTTP_URL = "https://http_user:S3cr3tHTTP@mcp.example:8443/base?token=httptok123"
+WS_URL = "wss://ws_user:S3cr3tWS@mcp.example:8443/ws?token=wstok123"
+
+
+# --- Boundary fakes ----------------------------------------------------------
+
+
+class _EmptyContent:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _OkResp:
+    """Minimal aiohttp response: 200 + empty SSE stream."""
+
+    def __init__(self):
+        self.status = 200
+        self.headers = {}
+
+    @property
+    def content(self):
+        return _EmptyContent()
+
+    def close(self):
+        pass
+
+
+class _SuccessSession:
+    def __init__(self, *a, **k):
+        pass
+
+    async def get(self, *a, **k):
+        return _OkResp()
+
+    async def close(self):
+        pass
+
+
+def _make_raising_session(exc):
+    class _RaisingSession:
+        def __init__(self, *a, **k):
+            pass
+
+        async def get(self, *a, **k):
+            raise exc
+
+        def post(self, *a, **k):  # returns a CM; entering raises
+            raise exc
+
+        async def close(self):
+            pass
+
+    return _RaisingSession
+
+
+class _OkWebSocket:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def close(self):
+        pass
+
+
+# --- SSE ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_log_masks_url(monkeypatch, caplog):
+    monkeypatch.setattr(T.aiohttp, "ClientSession", _SuccessSession)
+    t = SSETransport(SSE_URL, skip_security_validation=True)
+    with caplog.at_level(logging.INFO, logger="kailash_mcp.transports.transports"):
+        await t.connect()
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "SSE transport connected" in logged
+    assert "S3cr3tSSE" not in logged
+    assert "***@mcp.example" in logged
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_raise_masks_credentials(monkeypatch):
+    exc = Exception(f"Cannot connect to {SSE_URL}")
+    monkeypatch.setattr(T.aiohttp, "ClientSession", _make_raising_session(exc))
+    t = SSETransport(SSE_URL, skip_security_validation=True)
+    with pytest.raises(TransportError) as ei:
+        await t.connect()
+    msg = str(ei.value)
+    assert "S3cr3tSSE" not in msg
+    assert "ssetok123" not in msg
+    assert "***@mcp.example" in msg
+
+
+@pytest.mark.asyncio
+async def test_sse_send_raise_masks_credentials():
+    t = SSETransport(SSE_URL, skip_security_validation=True)
+    t._connected = True
+    t.session = _make_raising_session(Exception(f"POST failed to {SSE_URL}"))()
+    with pytest.raises(TransportError) as ei:
+        await t.send_message({"jsonrpc": "2.0", "method": "ping"})
+    msg = str(ei.value)
+    assert "S3cr3tSSE" not in msg
+    assert "ssetok123" not in msg
+
+
+# --- StreamableHTTP ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_connect_log_masks_url(monkeypatch, caplog):
+    monkeypatch.setattr(T.aiohttp, "ClientSession", _SuccessSession)
+    t = StreamableHTTPTransport(
+        HTTP_URL, session_management=False, skip_security_validation=True
+    )
+    with caplog.at_level(logging.INFO, logger="kailash_mcp.transports.transports"):
+        await t.connect()
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "StreamableHTTP transport connected" in logged
+    assert "S3cr3tHTTP" not in logged
+    assert "***@mcp.example" in logged
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_http_connect_raise_masks_credentials(monkeypatch):
+    exc = Exception(f"handshake failed for {HTTP_URL}")
+    monkeypatch.setattr(T.aiohttp, "ClientSession", _make_raising_session(exc))
+    t = StreamableHTTPTransport(
+        HTTP_URL, session_management=True, skip_security_validation=True
+    )
+    with pytest.raises(TransportError) as ei:
+        await t.connect()
+    msg = str(ei.value)
+    assert "S3cr3tHTTP" not in msg
+    assert "httptok123" not in msg
+    assert "***@mcp.example" in msg
+
+
+@pytest.mark.asyncio
+async def test_http_send_raise_masks_credentials():
+    t = StreamableHTTPTransport(
+        HTTP_URL, session_management=False, skip_security_validation=True
+    )
+    t._connected = True
+    t.session = _make_raising_session(Exception(f"POST error {HTTP_URL}"))()
+    with pytest.raises(TransportError) as ei:
+        await t.send_message({"jsonrpc": "2.0", "method": "ping"})
+    msg = str(ei.value)
+    assert "S3cr3tHTTP" not in msg
+    assert "httptok123" not in msg
+
+
+# --- WebSocket ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_log_masks_url(monkeypatch, caplog):
+    async def _fake_connect(*a, **k):
+        return _OkWebSocket()
+
+    monkeypatch.setattr(T.websockets, "connect", _fake_connect)
+    t = WebSocketTransport(WS_URL, skip_security_validation=True)
+    with caplog.at_level(logging.INFO, logger="kailash_mcp.transports.transports"):
+        await t.connect()
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "WebSocket transport connected" in logged
+    assert "S3cr3tWS" not in logged
+    assert "***@mcp.example" in logged
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_raise_masks_credentials(monkeypatch):
+    async def _fake_connect(*a, **k):
+        raise Exception(f"WebSocket handshake to {WS_URL} failed")
+
+    monkeypatch.setattr(T.websockets, "connect", _fake_connect)
+    t = WebSocketTransport(WS_URL, skip_security_validation=True)
+    with pytest.raises(TransportError) as ei:
+        await t.connect()
+    msg = str(ei.value)
+    assert "S3cr3tWS" not in msg
+    assert "wstok123" not in msg
+    assert "***@mcp.example" in msg
+
+
+@pytest.mark.asyncio
+async def test_ws_send_raise_masks_credentials():
+    class _RaisingWS:
+        async def send(self, *a, **k):
+            raise Exception(f"send failed on {WS_URL}")
+
+    t = WebSocketTransport(WS_URL, skip_security_validation=True)
+    t._connected = True
+    t.websocket = _RaisingWS()
+    with pytest.raises(TransportError) as ei:
+        await t.send_message({"jsonrpc": "2.0", "method": "ping"})
+    msg = str(ei.value)
+    assert "S3cr3tWS" not in msg
+    assert "wstok123" not in msg
+
+
+# --- DOTALL invariant at a transport raise site ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_raise_masks_credential_with_embedded_newline(monkeypatch):
+    """The #1840 DOTALL regression, exercised through a real transport raise.
+
+    A driver/library exception whose embedded credential contains a literal
+    newline must be FULLY masked — the tail after the ``\\n`` must not leak.
+    """
+    leaky_url = "https://admin:sec\nret@mcp.example:8443/base"
+    exc = Exception(f"boom connecting to {leaky_url}")
+    monkeypatch.setattr(T.aiohttp, "ClientSession", _make_raising_session(exc))
+    t = SSETransport(
+        "https://admin:secret@mcp.example:8443/base", skip_security_validation=True
+    )
+    with pytest.raises(TransportError) as ei:
+        await t.connect()
+    msg = str(ei.value)
+    assert "ret@" not in msg  # the tail after the newline must not survive
+    assert "sec\nret" not in msg
+    assert "***@mcp.example" in msg
+
+
+# --- Non-leak-surface documentation (Python N/A surfaces) --------------------
+
+
+def test_non_leak_surfaces_are_na_in_python():
+    """Document the surfaces that are N/A for the Python SDK (#1840).
+
+    * OAuth server-side token handling and Docker-runner env are N/A in the
+      Python transport layer (no such code path here).
+    * ``WebSocketServerTransport`` BINDS a local ``host:port`` (no client
+      credential URL), so it has no ``user:pass@host`` credential to leak —
+      the credential-bearing surface is the CLIENT transports covered above.
+    """
+    from kailash_mcp.transports.transports import WebSocketServerTransport
+
+    server = WebSocketServerTransport(host="127.0.0.1", port=0)
+    # A server bind exposes host/port, never a user:pass@host credential URL.
+    assert not hasattr(server, "base_url")
+    assert getattr(server, "host", None) == "127.0.0.1"

--- a/src/kailash/utils/url_credentials.py
+++ b/src/kailash/utils/url_credentials.py
@@ -41,6 +41,7 @@ one place. ``dataflow/utils/masking.py`` now re-exports from here.
 from __future__ import annotations
 
 import hashlib
+import re
 from typing import Optional, Tuple
 from urllib.parse import (
     ParseResult,
@@ -55,6 +56,7 @@ __all__ = [
     "decode_userinfo_or_raise",
     "preencode_password_special_chars",
     "mask_url",
+    "mask_error_text",
     "mask_secret",
     "fingerprint_secret",
     "is_sensitive_query_key",
@@ -467,6 +469,127 @@ def _mask_multi_host_url(url: str) -> str:
 
     query_suffix = f"?{query}" if q_sep else ""
     return f"{scheme}://{masked_authority}{path_prefix}{query_suffix}{frag_suffix}"
+
+
+# --- Arbitrary-string (error / log text) credential scrubbing ---------------
+#
+# ``mask_url`` is the value-source masker: use it wherever the raw URL string
+# is in hand (a log line that interpolates ``base_url`` directly). But an
+# EXCEPTION rendered into an error message (``f"connection failed: {e}"``) is
+# an OPAQUE string that may embed a credential-bearing URL ANYWHERE inside it
+# — the driver/provider chose the text, not us — so it cannot be routed
+# through the urlparse-based ``mask_url``. ``mask_error_text`` scrubs
+# credentials out of such arbitrary strings via regex.
+#
+# CRITICAL — DOTALL / newline safety (see ``rules/observability.md`` Rule 6 +
+# the driver-error redaction requirement, cross-SDK):
+#   Database/provider drivers render a credential value's embedded newline
+#   LITERALLY into the error text (e.g. a password that contains ``\n``, so the
+#   rendered connection string is ``postgresql://user:sec\nret@host/db``). A
+#   naive scrubber whose value class is ``\S`` / ``[^\s]`` STOPS at the first
+#   ``\n`` — matching only ``sec`` — and the credential TAIL (``ret``) leaks.
+#   The defenses below therefore:
+#     * compile with ``re.DOTALL`` (so any ``.`` in a pattern is newline-aware),
+#       AND
+#     * bound the userinfo span with a class (``[^/?#\r\t ]``) that INCLUDES
+#       ``\n`` but stops at the real URL host-boundary delimiters (``/`` ``?``
+#       ``#``) and horizontal whitespace / CR — so an embedded ``\n`` in the
+#       credential does NOT terminate the match, while a bare ``@`` on a later
+#       log line cannot pull the match across an unrelated line.
+#   The userinfo match backtracks to the LAST ``@`` before the host boundary,
+#   so a password containing a raw ``@`` is masked WHOLE, not split at its
+#   first ``@``.
+#
+# The scrubber masks two credential carriers in an arbitrary string:
+#   1. ``scheme://user:password@host`` userinfo → ``scheme://***@host``
+#   2. sensitive query parameters (``?token=...`` / ``&password=...`` etc.),
+#      matched via the canonical :func:`is_sensitive_query_key` set → value
+#      replaced with ``***``.
+
+# Userinfo in an embedded URL. The userinfo class ``[^/?#\r\t ]`` bounds the
+# span by the real URL host-boundary delimiters (``/`` ``?`` ``#``) and by
+# horizontal whitespace / CR that end a token in log text — but it INCLUDES
+# newline (``\n``), so a credential value with an embedded newline (drivers
+# render these literally) does NOT terminate the match and cannot leak its
+# tail. The two greedy halves around a required ``:`` make the engine backtrack
+# to the LAST ``@`` before the host boundary, so a password containing a raw
+# ``@`` (e.g. ``user:p@ss@host``) is masked WHOLE — ``***@host`` — rather than
+# split at the first ``@``. The required ``:`` targets credential-bearing
+# userinfo (``user:pass@``), leaving a bare ``git@host`` ref untouched.
+_ERR_USERINFO_RE = re.compile(
+    r"([a-zA-Z][a-zA-Z0-9+.\-]*://)"  # group 1: scheme:// (preserved)
+    r"[^/?#\r\t ]*"  # userinfo head (allows @ and \n; greedy → last @)
+    r":"  # user:password separator (targets credential userinfo)
+    r"[^/?#\r\t ]*"  # userinfo tail (allows @ and \n)
+    r"@",  # last @ before the host boundary
+    re.DOTALL,
+)
+
+# Sensitive query parameter ``key=value``. The value class ``[^&#\r\t ]*``
+# tolerates an embedded newline (does NOT treat ``\n`` as a terminator, the
+# DOTALL requirement) while still stopping at the real URL delimiters ``&`` /
+# ``#`` and at horizontal whitespace / CR that end a token in log text. The
+# key is checked against the canonical sensitive-key set at substitution time.
+_ERR_QUERY_PAIR_RE = re.compile(
+    r"([?&;])"  # group 1: query/param delimiter (preserved)
+    r"([A-Za-z0-9_.\-]+)"  # group 2: key
+    r"(=)"  # group 3: equals (preserved)
+    r"([^&#\r\t ]*)",  # group 4: value — tolerates embedded newline
+    re.DOTALL,
+)
+
+
+def _mask_err_query_pair(match: "re.Match[str]") -> str:
+    """Replacement for :data:`_ERR_QUERY_PAIR_RE` — mask only sensitive keys."""
+    delim, key, eq, _value = match.groups()
+    if is_sensitive_query_key(key):
+        return f"{delim}{key}{eq}***"
+    return match.group(0)
+
+
+def mask_error_text(text: Optional[str]) -> str:
+    """Mask credentials embedded anywhere in an arbitrary error / log string.
+
+    The companion to :func:`mask_url` for the case where the credential is
+    inside an OPAQUE string chosen by a driver / provider — a rendered
+    exception (``f"connection failed: {e}"``) that may embed a credential-
+    bearing URL. Prefer :func:`mask_url` whenever the raw URL value is in hand;
+    use this only for opaque ``{e}``-style text.
+
+    Masks, in an arbitrary string:
+
+    - ``scheme://user:password@host`` userinfo → ``scheme://***@host``
+    - sensitive query parameters (``?token=`` / ``&password=`` / ``&api_key=``
+      etc., matched via the canonical :func:`is_sensitive_query_key` set) →
+      value replaced with ``***``.
+
+    DOTALL / newline safety: a credential value with an embedded newline
+    (drivers render these literally) is still FULLY masked — the password span
+    is bound by ``@``, not by whitespace, so the tail after a ``\\n`` cannot
+    leak. See the module-level comment above and ``rules/observability.md``
+    Rule 6.
+
+    Non-credential input is returned unchanged. ``None`` returns ``""``; a
+    non-string is coerced via ``str()`` first (so
+    ``mask_error_text(some_exception)`` works).
+
+    Examples:
+        >>> mask_error_text("connect failed: postgresql://u:secret@db/x")
+        'connect failed: postgresql://***@db/x'
+        >>> mask_error_text("HTTPError for https://svc/api?token=abc123")
+        'HTTPError for https://svc/api?token=***'
+        >>> mask_error_text("ok: postgresql://localhost:5432/db")
+        'ok: postgresql://localhost:5432/db'
+        >>> mask_error_text(None)
+        ''
+    """
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+    masked = _ERR_USERINFO_RE.sub(r"\1***@", text)
+    masked = _ERR_QUERY_PAIR_RE.sub(_mask_err_query_pair, masked)
+    return masked
 
 
 def redact_pool_key(pool_key: Optional[str]) -> str:

--- a/src/kailash/utils/url_credentials.py
+++ b/src/kailash/utils/url_credentials.py
@@ -547,7 +547,7 @@ def _mask_err_query_pair(match: "re.Match[str]") -> str:
     return match.group(0)
 
 
-def mask_error_text(text: Optional[str]) -> str:
+def mask_error_text(text: Optional[object]) -> str:
     """Mask credentials embedded anywhere in an arbitrary error / log string.
 
     The companion to :func:`mask_url` for the case where the credential is

--- a/tests/unit/utils/test_mask_error_text.py
+++ b/tests/unit/utils/test_mask_error_text.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``kailash.utils.url_credentials.mask_error_text`` (#1840).
+
+``mask_error_text`` is the arbitrary-string companion to ``mask_url``: it
+scrubs credentials out of an OPAQUE error/log string that may embed a
+credential-bearing URL anywhere inside it (a rendered exception ``{e}``).
+
+The load-bearing regression these tests guard is the DOTALL / embedded-newline
+invariant: database/provider drivers render a credential value's embedded
+newline literally into the error text, and a naive ``\\S``/``[^\\s]``-based
+scrubber stops at the first ``\\n`` and leaks the credential tail.
+"""
+
+import pytest
+from kailash.utils.url_credentials import mask_error_text
+
+SECRET = "s3cr3t"
+TOKEN = "abc123token"
+
+
+class TestUserinfoMasking:
+    """``scheme://user:password@host`` userinfo masking in arbitrary text."""
+
+    def test_masks_userinfo_in_error_prose(self):
+        raw = f"connection failed: postgresql://admin:{SECRET}@db.internal:5432/app"
+        out = mask_error_text(raw)
+        assert SECRET not in out
+        assert "admin" not in out
+        assert "postgresql://***@db.internal:5432/app" in out
+
+    def test_masks_userinfo_mid_sentence(self):
+        raw = f"Error while dialing wss://user:{SECRET}@host:8080/mcp — timeout"
+        out = mask_error_text(raw)
+        assert SECRET not in out
+        assert "wss://***@host:8080/mcp" in out
+        assert out.endswith("— timeout")
+
+    def test_masks_password_only_userinfo(self):
+        # redis-style scheme://:password@host (empty user)
+        raw = f"redis error: redis://:{SECRET}@cache:6379/0"
+        out = mask_error_text(raw)
+        assert SECRET not in out
+        assert "redis://***@cache:6379/0" in out
+
+    def test_bare_at_reference_not_masked(self):
+        # git@host style (no scheme://, no user:pass) must be left intact.
+        raw = "clone from git@github.com:org/repo.git failed"
+        assert mask_error_text(raw) == raw
+
+    def test_first_at_terminates_userinfo(self):
+        raw = f"http://u:{SECRET}@host.example/path?x=1 returned 500"
+        out = mask_error_text(raw)
+        assert SECRET not in out
+        assert "http://***@host.example/path?x=1" in out
+
+    def test_raw_at_in_password_masked_whole_not_split(self):
+        # A password containing a raw '@' must be masked WHOLE (bind to the
+        # LAST '@' before the host), not split at its first '@' leaving a tail.
+        raw = "OSError: postgresql://svc:S3cr3tP@ss@db.prod:5432/orders"
+        out = mask_error_text(raw)
+        assert "S3cr3tP" not in out
+        assert "@ss@" not in out  # the tail after the raw '@' must not survive
+        assert "postgresql://***@db.prod:5432/orders" in out
+
+
+class TestQueryParamMasking:
+    """Sensitive query parameter (``?token=`` / ``&password=``) masking."""
+
+    def test_masks_token_query_param(self):
+        raw = f"HTTP 401 for https://svc.example/api?token={TOKEN}"
+        out = mask_error_text(raw)
+        assert TOKEN not in out
+        assert "token=***" in out
+
+    def test_masks_multiple_sensitive_params(self):
+        raw = f"bad url http://h/db?password={SECRET}&api_key={TOKEN}&sslmode=require"
+        out = mask_error_text(raw)
+        assert SECRET not in out
+        assert TOKEN not in out
+        assert "password=***" in out
+        assert "api_key=***" in out
+        # Non-sensitive param preserved verbatim.
+        assert "sslmode=require" in out
+
+    def test_non_sensitive_query_param_preserved(self):
+        raw = "connect http://host/db?replicaSet=rs0&timeout=30"
+        assert mask_error_text(raw) == raw
+
+    def test_public_key_not_masked(self):
+        # is_sensitive_query_key: public_key is NOT a secret (asymmetric public).
+        raw = "cfg http://host/x?public_key=AAAApub"
+        out = mask_error_text(raw)
+        assert "public_key=AAAApub" in out
+
+
+class TestDotAllNewlineInvariant:
+    """The #1840 regression: a credential value with an EMBEDDED newline.
+
+    Drivers render an embedded ``\\n`` in a credential literally. A scrubber
+    whose value class excludes newlines (``\\S`` / ``[^\\s]``) stops at the
+    ``\\n`` and leaks the tail. ``mask_error_text`` compiles with re.DOTALL and
+    bounds the password by ``@`` (a negated class matches newlines), so the
+    WHOLE credential span — across the newline — is masked.
+    """
+
+    def test_embedded_newline_in_password_fully_masked(self):
+        # Password contains a literal newline: "sec\nret".
+        raw = "psql fatal: postgresql://admin:sec\nret@db.host:5432/app"
+        out = mask_error_text(raw)
+        # The tail after the newline ("ret") MUST NOT survive.
+        assert "ret@" not in out
+        assert "sec\nret" not in out
+        assert "postgresql://***@db.host:5432/app" in out
+
+    def test_embedded_newline_in_query_value_fully_masked(self):
+        raw = "http error http://h/db?sslpassword=sec\nret&sslmode=require"
+        out = mask_error_text(raw)
+        assert "sec\nret" not in out
+        assert "ret" not in out.split("sslmode", 1)[0]
+        assert "sslpassword=***" in out
+        assert "sslmode=require" in out
+
+    def test_naive_scrubber_would_leak_but_ours_does_not(self):
+        # Explicit demonstration that a \S-terminated match would leak "ret".
+        import re
+
+        raw = "postgresql://admin:sec\nret@db/app"
+        naive = re.sub(r"(\w+://)[^\s]*@", r"\1***@", raw)
+        # The naive scrubber leaks because [^\s] stops at the newline.
+        assert "ret@" in naive  # proves the failure mode the DOTALL guard fixes
+        # Our helper does not leak.
+        assert "ret@" not in mask_error_text(raw)
+
+
+class TestNonCredentialAndEdgeCases:
+    def test_clean_url_passthrough(self):
+        raw = "ok: postgresql://localhost:5432/db connected"
+        assert mask_error_text(raw) == raw
+
+    def test_plain_text_passthrough(self):
+        raw = "Connection refused after 3 retries"
+        assert mask_error_text(raw) == raw
+
+    def test_none_returns_empty_string(self):
+        assert mask_error_text(None) == ""
+
+    def test_empty_string(self):
+        assert mask_error_text("") == ""
+
+    def test_non_string_coerced(self):
+        # mask_error_text(some_exception) must work (coerces via str()).
+        exc = RuntimeError("failed https://u:p3ss@host/x?token=t0k")
+        out = mask_error_text(exc)
+        assert "p3ss" not in out
+        assert "t0k" not in out
+        assert "https://***@host/x?token=***" in out
+
+
+def test_before_after_demo(capsys):
+    """Human-readable before/after receipt (printed with -s)."""
+    raw = (
+        "OSError: could not connect to "
+        "postgresql://svc_user:S3cr3tP@ss@db.prod:5432/orders"
+        "?password=S3cr3tP@ss"
+    )
+    masked = mask_error_text(raw)
+    print("\n--- BEFORE (raw {e}) ---\n" + raw)
+    print("\n--- AFTER (mask_error_text) ---\n" + masked)
+    assert "S3cr3tP" not in masked
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

Two surfaces still leaked credentials (base_url `user:pass@host` userinfo and `?token=`/sensitive query params) into logs and exception text after the #1720 kaizen LLM-layer consolidation:

- **kailash-mcp transport layer** — SSE / StreamableHTTP / WebSocket interpolated a credential-bearing `base_url`/`url` verbatim into the "transport connected" `logger.info` line and into the opaque `{e}` of every `TransportError`.
- **kaizen Ollama provider** — `RuntimeError(f"... {e}")` rendered the configured `OllamaConfig.base_url` / `OLLAMA_HOST` verbatim.

The fix routes URL-value log lines through **`mask_url`** and opaque `{e}` strings through a **new shared DOTALL-aware `mask_error_text`** helper — both in `src/kailash/utils/url_credentials.py`, the ONE shared credential-helper module (`security.md` § "No secrets in logs"). No per-adapter copies.

## The shared DOTALL helper

`feat(utils)`: `mask_error_text(text) -> str` (`src/kailash/utils/url_credentials.py:550`) scrubs `scheme://user:pass@host` userinfo and sensitive query params (`?token=`, `&password=`, … via the canonical `is_sensitive_query_key` set) out of an arbitrary string, compiled with `re.DOTALL`.

**Load-bearing institutional requirement:** drivers/providers render a credential value's embedded newline **literally** into the error text. A naive `\S`/`[^\s]` value class stops at the first `\n` and leaks the credential tail. The userinfo class `[^/?#\r\t ]` **includes** `\n` (bounded by real URL host delimiters `/ ? #` + horizontal whitespace) and backtracks to the **last** `@` before the host — so a password with an embedded newline **or** a raw `@` is masked whole, never split.

## Leak sites remediated (file:line, verified against pushed code)

**`packages/kailash-mcp/src/kailash_mcp/transports/transports.py`**
| Site | Line | Fix |
|---|---|---|
| URL-validation error log | 127 | `mask_error_text` |
| SSE connect log | 581 | `mask_url` |
| SSE connect raise | 587 | `mask_error_text` |
| SSE send raise | 623 | `mask_error_text` |
| SSE receive raise | 648 | `mask_error_text` |
| StreamableHTTP connect log | 794 | `mask_url` |
| StreamableHTTP connect raise | 801 | `mask_error_text` |
| StreamableHTTP send raise | 860 | `mask_error_text` |
| StreamableHTTP receive raise | 908 | `mask_error_text` |
| WebSocket connect log | 1057 | `mask_url` |
| WebSocket connect raise | 1063 | `mask_error_text` |
| WebSocket send raise | 1092 | `mask_error_text` |
| WebSocket receive raise | 1116 | `mask_error_text` |

**`packages/kailash-kaizen/src/kaizen/providers/ollama_provider.py`**
| Site | Line | Fix |
|---|---|---|
| `_check_ollama_available` raise | 46 | `mask_error_text` |
| `generate` raise | 91 | `mask_error_text` |
| `generate_stream` raise | 131 | `mask_error_text` |
| `generate_vision` raise | 182 | `mask_error_text` |

**Out of scope (no credential surface):** stdio transport (subprocess command, no URL), `WebSocketServerTransport` (local `host:port` bind, no client `user:pass@host`). OAuth server-side / Docker-runner are N/A in the Python SDK — documented by a regression test.

## Tests (per-surface regression; no mocking of the redaction under test)

- `tests/unit/utils/test_mask_error_text.py` — 19 tests (userinfo, query-param, DOTALL embedded-newline invariant, raw-`@`-in-password, non-credential passthrough, None/edge, before/after demo).
- `packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py` — 11 tests (connect-log + connect/send raise per transport, DOTALL invariant at a raise site, N/A-surface doc). Injects the aiohttp/websockets boundary.
- `packages/kailash-kaizen/tests/regression/test_issue_1840_ollama_cred_redaction.py` — 5 tests (all four raise sites + DOTALL). Injects a fake ollama backend.

### Pre-fix confirmation (fix stashed, run against unpatched code)
```
PRE-FIX transports: 10 failed, 1 passed   (e.g. 'S3cr3tSSE' present; DOTALL 'ret@' leaked)
PRE-FIX ollama:      5 failed             (e.g. assert 'S3cr3tOLLAMA' not in 'Ollama stre...ken=oltok123')
```

### Post-fix walk RECEIPT (verbatim, run from the worktree venv)
```
$ pytest tests/unit/utils/test_mask_error_text.py               -> 19 passed
$ pytest packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py -> 11 passed
$ pytest packages/kailash-kaizen/tests/regression/test_issue_1840_ollama_cred_redaction.py -> 5 passed
DOTALL invariant (per surface): core 3 passed / transport 1 passed / ollama 1 passed
No regression: tests/unit/utils/test_mask_url_sensitive_keys.py + test_fingerprint_secret.py -> 195 passed
```

### Before / after (mask_error_text)
```
BEFORE: OSError: could not connect to postgresql://svc_user:S3cr3tP@ss@db.prod:5432/orders?password=S3cr3tP@ss
AFTER : OSError: could not connect to postgresql://***@db.prod:5432/orders?password=***

BEFORE (embedded newline in cred): 'connect http://admin:sec\nret@host:11434/api?token=k3y\nprod'
AFTER                             : 'connect http://***@host:11434/api?token=***'
```

## Governance notes
- `black` / `isort` / `ruff` pre-commit hooks run manually on all changed files (pass).
- The `pytest-check` pre-commit hook was bypassed via the documented `core.hooksPath=/dev/null` workaround (`git.md` § Pre-Commit Hook Workarounds), because its `find-venv-python.sh` resolves the **main checkout** `.venv` (`git-common-dir`), which lacks this worktree-only helper and thus spuriously fails to collect the new tests. Documented in each commit body. CI runs the real venv.
- No package versions bumped, no CHANGELOG edited — release-specialist owns that at `/release`.

## Related issues
Fixes #1840