### PR TITLE
fix(kaizen): Azure reasoning-model detection keys off model family, not deployment name (#1859)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -1077,8 +1077,14 @@ class LlmClient:
         # path for the {model}-template wires; reject traversal / URL-control
         # injection before the request is built (security-reviewer #1717 MEDIUM).
         _validate_completion_model(resolved_model)
+        # #1859: thread the deployment's canonical model FAMILY onto the request
+        # so the wire shaper's reasoning-model detection + token-limit field
+        # selection key off the family rather than a routing alias. `None` for
+        # every direct provider (deployment carries no canonical_model) =>
+        # detection falls back to `resolved_model`, byte-identical to pre-#1859.
         return CompletionRequest(
             model=resolved_model,
+            canonical_model=self._deployment.canonical_model,
             messages=redacted,
             temperature=temperature,
             top_p=top_p,

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -1068,6 +1068,20 @@ class LlmClient:
         # (rules/observability.md §8 / §6.5). No-op when no policy installed.
         redacted = self.redact_request_messages(messages)
         resolved_model = model or self._deployment.default_model
+        # #1859: an ALIAS deployment carries a canonical model FAMILY distinct
+        # from its wire identity — Azure OpenAI's `default_model` is the
+        # caller-chosen DEPLOYMENT NAME that Azure requires in BOTH the URL path
+        # (`/openai/deployments/{deployment}`) AND the wire body `model` field,
+        # while the family lives on `canonical_model` (detection only). The live
+        # node path calls `complete(model=<family>)` (e.g. "gpt-5"), so a bare
+        # `model or default_model` would put the FAMILY on the wire body/URL,
+        # mismatching the Azure deployment. When the deployment declares a
+        # `canonical_model`, the wire model MUST be the deployment name
+        # (`default_model`) regardless of the family passed for detection. For
+        # every non-Azure deployment `canonical_model` is None => this is a no-op
+        # (wire model = the passed model, byte-identical to pre-#1859).
+        if self._deployment.canonical_model is not None:
+            resolved_model = self._deployment.default_model or resolved_model
         if not resolved_model:
             raise ValueError(
                 "complete() requires a model — pass model=..., or construct "
@@ -1079,9 +1093,10 @@ class LlmClient:
         _validate_completion_model(resolved_model)
         # #1859: thread the deployment's canonical model FAMILY onto the request
         # so the wire shaper's reasoning-model detection + token-limit field
-        # selection key off the family rather than a routing alias. `None` for
-        # every direct provider (deployment carries no canonical_model) =>
-        # detection falls back to `resolved_model`, byte-identical to pre-#1859.
+        # selection key off the family, while `model` (above) is the wire
+        # identity (deployment name for Azure). `canonical_model` is `None` for
+        # every direct provider => detection falls back to `model`,
+        # byte-identical to pre-#1859.
         return CompletionRequest(
             model=resolved_model,
             canonical_model=self._deployment.canonical_model,

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -276,6 +276,19 @@ class CompletionRequest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     model: str
+    # #1859 provider-API param-compatibility hint. The CANONICAL model FAMILY
+    # this request targets — used ONLY for provider-side parameter compatibility
+    # (reasoning-model sampling-param filtering + the
+    # ``max_tokens``/``max_completion_tokens`` field selection), NEVER emitted on
+    # the wire. Set when ``model`` is a routing ALIAS that does not name the
+    # model family: the canonical case is an Azure OpenAI deployment whose name
+    # is caller-chosen (e.g. ``"my-gpt5-deploy"`` for a gpt-5 deployment). Azure
+    # requires the deployment NAME in the URL / wire ``model`` field, but
+    # reasoning-model detection must key off the FAMILY (``"gpt-5"``) or the
+    # reasoning-param strip is skipped and Azure returns 400 ``unsupported_value``.
+    # ``None`` (the default) => detection falls back to ``model``, byte-identical
+    # to pre-#1859 for every direct provider whose ``model`` already IS the family.
+    canonical_model: Optional[str] = None
     messages: list[dict[str, Any]]
     temperature: Optional[float] = None
     top_p: Optional[float] = None
@@ -408,6 +421,21 @@ class LlmDeployment(BaseModel):
     endpoint: Endpoint
     auth: Any  # AuthStrategy Protocol; validated at preset construction
     default_model: Optional[str] = None
+    canonical_model: Optional[str] = None
+    """#1859 canonical model FAMILY for provider-API param compatibility.
+
+    ``default_model`` is the value sent on the wire / interpolated into the URL;
+    for Azure OpenAI that is the caller-chosen DEPLOYMENT NAME (a routing alias),
+    NOT the model family. ``canonical_model`` carries the family
+    (``"gpt-5"`` / ``"o1"`` / …) so the reasoning-model sampling-param filter and
+    the ``max_tokens``/``max_completion_tokens`` field selection key off the
+    family — a gpt-5 deployment named ``"my-gpt5-deploy"`` still gets its
+    reasoning params stripped instead of taking a 400 ``unsupported_value``.
+    ``None`` (the default, every direct provider whose ``default_model`` already
+    IS the family) => detection falls back to ``default_model``/``request.model``,
+    byte-identical to pre-#1859. Threaded onto the request as
+    ``CompletionRequest.canonical_model`` by ``LlmClient._prepare_completion``.
+    """
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)
     completion_routing: Optional[CompletionRouting] = None

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -283,11 +283,16 @@ class CompletionRequest(BaseModel):
     # the wire. Set when ``model`` is a routing ALIAS that does not name the
     # model family: the canonical case is an Azure OpenAI deployment whose name
     # is caller-chosen (e.g. ``"my-gpt5-deploy"`` for a gpt-5 deployment). Azure
-    # requires the deployment NAME in the URL / wire ``model`` field, but
-    # reasoning-model detection must key off the FAMILY (``"gpt-5"``) or the
-    # reasoning-param strip is skipped and Azure returns 400 ``unsupported_value``.
-    # ``None`` (the default) => detection falls back to ``model``, byte-identical
-    # to pre-#1859 for every direct provider whose ``model`` already IS the family.
+    # requires the deployment NAME in the URL path AND the wire body ``model``
+    # field, so ``model`` here IS the deployment name — ``LlmClient`` resolves the
+    # wire ``model`` to the deployment's ``default_model`` (the deployment name)
+    # for any deployment that declares a ``canonical_model``, even when the caller
+    # passes the family as ``complete(model=...)`` (the live node path). Meanwhile
+    # reasoning-model detection keys off THIS field (the FAMILY, ``"gpt-5"``) or
+    # the reasoning-param strip is skipped and Azure returns 400
+    # ``unsupported_value``. ``None`` (the default) => detection falls back to
+    # ``model``, byte-identical to pre-#1859 for every direct provider whose
+    # ``model`` already IS the family.
     canonical_model: Optional[str] = None
     messages: list[dict[str, Any]]
     temperature: Optional[float] = None
@@ -431,10 +436,17 @@ class LlmDeployment(BaseModel):
     the ``max_tokens``/``max_completion_tokens`` field selection key off the
     family — a gpt-5 deployment named ``"my-gpt5-deploy"`` still gets its
     reasoning params stripped instead of taking a 400 ``unsupported_value``.
-    ``None`` (the default, every direct provider whose ``default_model`` already
-    IS the family) => detection falls back to ``default_model``/``request.model``,
-    byte-identical to pre-#1859. Threaded onto the request as
-    ``CompletionRequest.canonical_model`` by ``LlmClient._prepare_completion``.
+
+    When this field is set, ``LlmClient._build_completion_request`` resolves the
+    wire ``CompletionRequest.model`` to ``default_model`` (the deployment name)
+    even if the caller passes the family as ``complete(model=...)`` — the live
+    node path calls ``complete(model=<family>)`` — so the Azure URL AND the wire
+    body ``model`` field both carry the deployment name while ``canonical_model``
+    drives detection. ``None`` (the default, every direct provider whose
+    ``default_model`` already IS the family) => the wire model is the passed
+    ``model`` and detection falls back to it, byte-identical to pre-#1859.
+    Threaded onto the request as ``CompletionRequest.canonical_model`` by
+    ``LlmClient._build_completion_request``.
     """
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment_resolver.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment_resolver.py
@@ -169,7 +169,12 @@ _UNSUPPORTED_PROVIDERS = frozenset({"azure_ai_foundry"})
 
 
 def _resolve_azure_deployment(
-    model: str, api_key: Optional[str], base_url: Optional[str]
+    model: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    *,
+    deployment: Optional[str] = None,
+    api_version: Optional[str] = None,
 ):
     """Build an ``OpenAiChat``-wire Azure-OpenAI deployment (#1720 Wave-A #3).
 
@@ -177,17 +182,32 @@ def _resolve_azure_deployment(
     (``/openai/deployments/{deployment}/...?api-version=``) and the auth
     header (``api-key: <KEY>`` via ``AzureEntra`` api-key variant) differ —
     mirrors ``kaizen.llm.presets.azure_openai_preset``'s endpoint shape,
-    sourcing the resource host from ``base_url`` and the deployment name from
-    ``model`` instead of separate ``resource_name`` / ``deployment_name``
-    args (the shadow/live callers only carry ``provider, model, api_key,
-    base_url``).
+    sourcing the resource host from ``base_url``.
+
+    #1859 deployment-name vs model-family split. Azure's deployment name is
+    caller-chosen and is what Azure requires in the URL / wire ``model`` field;
+    the model FAMILY (``gpt-5`` / ``o1`` / …) is what reasoning-model detection
+    must key off. Two caller shapes:
+
+    * ``deployment`` given (``BaseAgentConfig(model="gpt-5",
+      provider_config={"deployment": "my-gpt5-deploy"})``): ``deployment`` is the
+      URL / wire deployment name, ``model`` is the canonical family. The built
+      deployment carries ``default_model=<deployment name>`` (URL + wire) AND
+      ``canonical_model=<family>`` so the reasoning-param strip fires off the
+      family regardless of the deployment name.
+    * ``deployment`` absent (legacy shape, ``model`` IS the deployment name):
+      ``default_model`` and ``canonical_model`` both resolve to ``model`` —
+      byte-identical to pre-#1859. (No family is available in this shape, so the
+      strip still keys off the deployment name; callers with a non-canonical
+      deployment name must pass ``model``=family + ``provider_config.deployment``.)
 
     Credentials mirror the canonical Azure env resolution
     (``kaizen.llm.azure_env.resolve_azure_env``): the per-request
     override wins, else the canonical ``AZURE_*`` env vars (legacy
     ``AZURE_OPENAI_*`` names still resolve with a DeprecationWarning). A
     missing endpoint or api-key returns ``None`` (skip), matching the
-    base-url family's missing-credential contract.
+    base-url family's missing-credential contract. ``api_version`` from
+    ``provider_config`` wins over the ``AZURE_*`` env vars when supplied.
     """
     from kaizen.llm.auth.azure import AzureEntra
     from kaizen.llm.azure_env import resolve_azure_env
@@ -211,29 +231,36 @@ def _resolve_azure_deployment(
             extra={"provider": "azure", "reason": "missing_api_key"},
         )
         return None
-    api_version = (
-        resolve_azure_env("AZURE_API_VERSION", "AZURE_OPENAI_API_VERSION")
+    resolved_api_version = (
+        api_version
+        or resolve_azure_env("AZURE_API_VERSION", "AZURE_OPENAI_API_VERSION")
         or AZURE_OPENAI_DEFAULT_API_VERSION
     )
 
-    # The deployment name is interpolated into the URL path; validate it
+    # #1859: the DEPLOYMENT NAME (from provider_config, else `model` for the
+    # legacy single-arg shape) is interpolated into the URL path; validate it
     # through the canonical Azure grammar (fail-closed on path-control chars)
     # BEFORE the f-string interpolation below — the same validator
-    # azure_openai_preset uses.
-    resolved_deployment = AzureOpenAIGrammar().resolve(model)
+    # azure_openai_preset uses. `model` remains the canonical FAMILY.
+    deployment_name = deployment or model
+    resolved_deployment = AzureOpenAIGrammar().resolve(deployment_name)
 
     endpoint = Endpoint(
         base_url=resolved_endpoint,
         path_prefix=f"/openai/deployments/{resolved_deployment}",
         # Azure REQUIRES ?api-version= on EVERY request URL; both
         # _build_completion_url and _build_embed_url append query_params.
-        query_params={"api-version": api_version},
+        query_params={"api-version": resolved_api_version},
     )
     return LlmDeployment(
         wire=WireProtocol.OpenAiChat,
         endpoint=endpoint,
         auth=AzureEntra(api_key=resolved_key),
         default_model=resolved_deployment,
+        # #1859: reasoning-model detection keys off the canonical family, not the
+        # deployment name. When no separate deployment was supplied `model` IS the
+        # deployment name, so family == deployment name (byte-neutral).
+        canonical_model=model,
         preset_name="azure_openai",
     )
 
@@ -279,6 +306,8 @@ def resolve_deployment_for(
     *,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
+    deployment: Optional[str] = None,
+    api_version: Optional[str] = None,
 ):
     """Resolve a four-axis ``LlmDeployment`` for a legacy ``provider`` name.
 
@@ -294,6 +323,13 @@ def resolve_deployment_for(
     did not pass a per-request override, the same ``<PROVIDER>_API_KEY`` env
     var the legacy provider itself reads (``rules/env-models.md``) is tried
     before giving up.
+
+    ``deployment`` / ``api_version`` are Azure-only (#1859): they come from the
+    caller's ``provider_config`` (``{"deployment": ..., "api_version": ...}``).
+    When ``deployment`` is given, ``model`` is the canonical model FAMILY and
+    ``deployment`` is the Azure deployment NAME (URL / wire ``model`` field), so
+    reasoning-model detection keys off the family regardless of the deployment
+    name. Both are ignored by every non-Azure provider.
     """
     provider_key = (provider or "").strip().lower()
 
@@ -321,7 +357,13 @@ def resolve_deployment_for(
         raise UnsupportedDeploymentProvider(provider_key)
 
     if provider_key in _AZURE_PROVIDERS:
-        return _resolve_azure_deployment(model, api_key, base_url)
+        return _resolve_azure_deployment(
+            model,
+            api_key,
+            base_url,
+            deployment=deployment,
+            api_version=api_version,
+        )
 
     api_key_map = _api_key_preset_map()
     if provider_key in api_key_map:

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -1755,6 +1755,7 @@ def azure_openai_preset(
     auth: AzureEntra,
     *,
     api_version: Optional[str] = None,
+    canonical_model: Optional[str] = None,
 ) -> LlmDeployment:
     """Azure OpenAI deployment -- composed with an AzureEntra auth strategy.
 
@@ -1778,6 +1779,13 @@ def azure_openai_preset(
     Optional:
 
     * `api_version` -- defaults to `AZURE_OPENAI_DEFAULT_API_VERSION`.
+    * `canonical_model` (#1859) -- the canonical model FAMILY (`"gpt-5"` /
+      `"o1"` / …) this deployment serves, when the caller-chosen
+      `deployment_name` is NOT itself the family. Reasoning-model detection +
+      the `max_tokens`/`max_completion_tokens` field selection key off this so a
+      gpt-5 deployment named e.g. `"my-gpt5-deploy"` gets its reasoning params
+      stripped instead of taking a 400 `unsupported_value`. `None` (default) =>
+      detection falls back to the deployment name (byte-identical to pre-#1859).
 
     Cross-SDK parity: preset name `azure_openai` + default api-version +
     endpoint path template are byte-identical to the Rust SDK.
@@ -1815,6 +1823,9 @@ def azure_openai_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_deployment,
+        # #1859: family for reasoning/token detection; None keeps pre-#1859
+        # behavior (detection keys off the deployment name).
+        canonical_model=canonical_model,
         preset_name="azure_openai",
     )
     logger.info(
@@ -1852,12 +1863,14 @@ def _register_and_attach_session_6_presets() -> None:
         auth: AzureEntra,
         *,
         api_version: Optional[str] = None,
+        canonical_model: Optional[str] = None,
     ) -> LlmDeployment:
         return azure_openai_preset(
             resource_name,
             deployment_name,
             auth,
             api_version=api_version,
+            canonical_model=canonical_model,
         )
 
     @classmethod  # type: ignore[misc]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py
@@ -88,6 +88,17 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         "messages": list(request.messages),
     }
 
+    # #1859: reasoning-model detection + the token-limit field NAME key off the
+    # canonical model FAMILY, NOT `request.model`. For a direct provider
+    # `request.model` already IS the family, so `canonical_model` is None and
+    # this is `request.model` — byte-identical to pre-#1859. For Azure OpenAI
+    # `request.model` is the caller-chosen DEPLOYMENT NAME (a routing alias that
+    # Azure requires in the URL / wire `model` field); the family arrives on
+    # `request.canonical_model`. Keying detection off the deployment name skips
+    # the reasoning-param strip whenever the deployment name != the canonical
+    # model id (the common case) and Azure returns 400 `unsupported_value`.
+    detection_model = request.canonical_model or request.model
+
     # Collect the caller-set sampling fields, THEN filter by model family —
     # insertion into `payload` still happens at each field's ORIGINAL
     # position below, so key order (and therefore JSON byte output) is
@@ -101,7 +112,7 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
         sampling["frequency_penalty"] = request.frequency_penalty
     if request.presence_penalty is not None:
         sampling["presence_penalty"] = request.presence_penalty
-    filtered_sampling = filter_reasoning_model_params(request.model, sampling)
+    filtered_sampling = filter_reasoning_model_params(detection_model, sampling)
     if filtered_sampling != sampling:
         logger.debug(
             "openai_chat.reasoning_model_params_filtered",
@@ -116,7 +127,11 @@ def build_request_payload(request: CompletionRequest) -> Dict[str, Any]:
     if "top_p" in filtered_sampling:
         payload["top_p"] = filtered_sampling["top_p"]
     if request.max_tokens is not None:
-        payload[_token_limit_field(request.model)] = request.max_tokens
+        # #1859: the token-limit field NAME is model-family-aware, so it keys off
+        # `detection_model` (the canonical family) — an Azure gpt-5/o-series
+        # deployment with a non-canonical name still emits `max_completion_tokens`
+        # instead of `max_tokens` (which those families 400 on).
+        payload[_token_limit_field(detection_model)] = request.max_tokens
     if request.stop:
         payload["stop"] = list(request.stop)
     if request.stream:

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -915,6 +915,15 @@ class LLMAgentNode(Node):
         model = kwargs["model"]
         messages = kwargs["messages"]
         system_prompt = kwargs.get("system_prompt")
+        # #1859: provider-specific settings (Azure deployment name + api-version).
+        # Node config wins over connection inputs (same precedence as the other
+        # config params below). For Azure this carries {"deployment": ...,
+        # "api_version": ...}; the four-axis path uses `deployment` as the wire /
+        # URL deployment name so `model` stays the canonical family reasoning-model
+        # detection keys off.
+        provider_config = self.config.get(
+            "provider_config", kwargs.get("provider_config")
+        )
         # Extract config parameters from self.config first (node configuration),
         # then fall back to kwargs (connection inputs) for backward compatibility
         tools = self.config.get("tools", kwargs.get("tools", []))
@@ -1043,6 +1052,7 @@ class LLMAgentNode(Node):
                     generation_config,
                     api_key=per_request_api_key,
                     base_url=per_request_base_url,
+                    provider_config=provider_config,
                 )
 
             # Handle tool execution if enabled and tools were called
@@ -1094,6 +1104,7 @@ class LLMAgentNode(Node):
                             generation_config,
                             api_key=per_request_api_key,
                             base_url=per_request_base_url,
+                            provider_config=provider_config,
                         )
 
                 # Update final response metadata
@@ -2365,12 +2376,20 @@ Final Answer: 6 hours"""
         generation_config: dict,
         api_key: str = None,
         base_url: str = None,
+        provider_config: dict | None = None,
     ) -> dict[str, Any]:
         """Generate LLM response using provider architecture.
 
         Args:
             api_key: Optional per-request API key override for BYOK scenarios.
             base_url: Optional per-request base URL override.
+            provider_config: Provider-specific settings. #1859: for Azure
+                (`azure` / `azure_openai`) this carries `{"deployment": ...,
+                "api_version": ...}` — the Azure DEPLOYMENT NAME (URL / wire
+                `model` field) and api-version. When `deployment` is present,
+                `model` is the canonical model FAMILY, so reasoning-model
+                detection keys off the family regardless of the deployment name.
+                Ignored by every non-Azure provider.
 
         #1720 Wave-B1a — LIVE CUTOVER. This method now returns the four-axis
         ``kaizen.llm.client.LlmClient`` result (mapped onto the legacy shape via
@@ -2402,9 +2421,20 @@ Final Answer: 6 hours"""
             # the legacy get_provider(...).chat(...) path until a wire lands.
             # BYOK overrides are validated inside resolve_deployment_for (the
             # sibling enforcement surface to LlmClient.complete's api_key guard).
+            # #1859: for Azure, thread the deployment NAME + api-version from
+            # provider_config so `model` stays the canonical family that
+            # reasoning-model detection keys off. Non-Azure providers ignore both.
+            _pc = provider_config or {}
+            azure_deployment = _pc.get("deployment")
+            azure_api_version = _pc.get("api_version")
             try:
                 deployment = resolve_deployment_for(
-                    provider, model, api_key=api_key, base_url=base_url
+                    provider,
+                    model,
+                    api_key=api_key,
+                    base_url=base_url,
+                    deployment=azure_deployment,
+                    api_version=azure_api_version,
                 )
             except UnsupportedDeploymentProvider:
                 return self._legacy_provider_chat(

--- a/packages/kailash-kaizen/tests/regression/test_issue_1859_azure_reasoning_deployment_name.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1859_azure_reasoning_deployment_name.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: Azure reasoning-model detection keys off the model FAMILY, not
+the deployment name (#1859).
+
+Bug: the four-axis Azure path built the deployment with
+``default_model = <deployment name>`` (Azure's caller-chosen deployment name is
+the URL / wire ``model`` field). The OpenAI-chat wire shaper then ran
+``filter_reasoning_model_params`` + the ``max_tokens``/``max_completion_tokens``
+selection against that deployment name. When the deployment name is not the
+canonical model id (the common case — Azure deployment names are user-chosen),
+the anchored patterns (``^gpt-?5`` / ``^o1`` / …) miss, the reasoning-param strip
+is skipped, and Azure returns ``400 unsupported_value`` on the default
+``temperature: 0.7`` (or on ``max_tokens``).
+
+Fix: the deployment carries a separate ``canonical_model`` (the family), threaded
+onto ``CompletionRequest.canonical_model`` and consumed by the wire shaper for
+DETECTION only — the wire ``model`` field + URL keep the deployment name.
+
+These tests exercise the param-filtering / request-construction logic directly
+and OFFLINE (no Azure call): they build the Azure deployment via the shared
+resolver, construct the wire request through ``LlmClient``, and inspect the
+shaped payload / URL bytes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.client import LlmClient
+from kaizen.llm.deployment import CompletionRequest
+from kaizen.llm.deployment_resolver import resolve_deployment_for
+from kaizen.llm.wire_protocols import openai_chat
+
+_RESOURCE_BASE_URL = "https://my-openai-resource.openai.azure.com"
+_API_KEY = "test-key-not-a-real-secret"
+
+
+def _azure_deployment(model: str, deployment: str):
+    """Build the four-axis Azure deployment the live path builds (#1859 shape:
+    ``model`` = canonical family, ``deployment`` = caller-chosen deployment name).
+    """
+    dep = resolve_deployment_for(
+        "azure_openai",
+        model,
+        api_key=_API_KEY,
+        base_url=_RESOURCE_BASE_URL,
+        deployment=deployment,
+    )
+    assert dep is not None, "resolver returned None (credential resolution failed)"
+    return dep
+
+
+def _payload_and_url(
+    deployment,
+    *,
+    temperature=0.7,
+    max_tokens=500,
+    top_p=0.9,
+    frequency_penalty=0.1,
+    presence_penalty=0.1,
+):
+    """Build the wire payload + URL through the real client + shaper (offline)."""
+    client = LlmClient.from_deployment(deployment, ungoverned=True)
+    request = client._build_completion_request(
+        [{"role": "user", "content": "hello"}],
+        model=None,  # falls back to deployment.default_model (the deployment name)
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        stop=None,
+        user=None,
+        stream=False,
+        frequency_penalty=frequency_penalty,
+        presence_penalty=presence_penalty,
+    )
+    payload, url = client._build_completion_payload_and_url(request, stream=False)
+    return request, payload, url
+
+
+# ---------------------------------------------------------------------------
+# (1) gpt-5 family, NON-canonical deployment name -> reasoning strip fires
+# ---------------------------------------------------------------------------
+
+
+def test_gpt5_deployment_noncanonical_name_strips_reasoning_params():
+    """model='gpt-5' + deployment='my-gpt5-deploy': the strip fires off the
+    FAMILY. gpt-5 forces temperature=1.0 and drops top_p/frequency/presence;
+    max_tokens becomes max_completion_tokens.
+    """
+    dep = _azure_deployment("gpt-5", "my-gpt5-deploy")
+    request, payload, url = _payload_and_url(dep)
+
+    # canonical family threaded onto the request (detection input)
+    assert request.canonical_model == "gpt-5"
+    # gpt-5 REQUIRES temperature=1.0 (the 0.7 default is what caused the 400)
+    assert payload.get("temperature") == 1.0
+    # the other sampling params gpt-5 rejects are dropped
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+    # token-limit field is family-aware: max_completion_tokens, NOT max_tokens
+    assert payload.get("max_completion_tokens") == 500
+    assert "max_tokens" not in payload
+
+
+def test_o1_deployment_noncanonical_name_strips_temperature():
+    """o1-family with a non-canonical deployment name: temperature is dropped
+    entirely (o1/o3/o4 reject it outright).
+    """
+    dep = _azure_deployment("o1", "prod-reasoner")
+    request, payload, _url = _payload_and_url(dep)
+
+    assert request.canonical_model == "o1"
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+    assert payload.get("max_completion_tokens") == 500
+    assert "max_tokens" not in payload
+
+
+# ---------------------------------------------------------------------------
+# (2) the wire request STILL targets the deployment name (Azure URL/model field)
+# ---------------------------------------------------------------------------
+
+
+def test_wire_still_targets_deployment_name():
+    """The reasoning-detection input changed to the family, but the wire
+    ``model`` field AND the URL path MUST still carry the Azure deployment name.
+    """
+    dep = _azure_deployment("gpt-5", "my-gpt5-deploy")
+    _request, payload, url = _payload_and_url(dep)
+
+    # wire body model field = deployment name (NOT the family)
+    assert payload["model"] == "my-gpt5-deploy"
+    # URL path targets the deployment
+    assert "/openai/deployments/my-gpt5-deploy/chat/completions" in url
+    assert "api-version=" in url
+    # the family never leaks into the URL
+    assert "/deployments/gpt-5/" not in url
+
+
+# ---------------------------------------------------------------------------
+# (3) non-reasoning model KEEPS temperature (no false-positive strip)
+# ---------------------------------------------------------------------------
+
+
+def test_non_reasoning_model_keeps_temperature_and_max_tokens():
+    """gpt-4o (non-reasoning) with any deployment name: temperature stays,
+    max_tokens stays max_tokens — the fix does not over-strip.
+    """
+    dep = _azure_deployment("gpt-4o", "my-gpt4o-deploy")
+    request, payload, _url = _payload_and_url(dep)
+
+    assert request.canonical_model == "gpt-4o"
+    assert payload.get("temperature") == 0.7
+    assert payload.get("top_p") == 0.9
+    assert payload.get("frequency_penalty") == 0.1
+    assert payload.get("presence_penalty") == 0.1
+    assert payload.get("max_tokens") == 500
+    assert "max_completion_tokens" not in payload
+    assert payload["model"] == "my-gpt4o-deploy"
+
+
+# ---------------------------------------------------------------------------
+# (4) the resolver carries family vs deployment name distinctly
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_separates_family_from_deployment_name():
+    dep = _azure_deployment("gpt-5", "my-gpt5-deploy")
+    # wire / URL identifier = deployment name
+    assert dep.default_model == "my-gpt5-deploy"
+    # reasoning-detection identifier = canonical family
+    assert dep.canonical_model == "gpt-5"
+
+
+def test_resolver_backward_compat_single_arg_shape():
+    """Legacy shape (no separate deployment): ``model`` IS the deployment name,
+    so family == deployment name (byte-neutral, pre-#1859 behavior)."""
+    dep = resolve_deployment_for(
+        "azure_openai",
+        "gpt-4o",
+        api_key=_API_KEY,
+        base_url=_RESOURCE_BASE_URL,
+    )
+    assert dep is not None
+    assert dep.default_model == "gpt-4o"
+    assert dep.canonical_model == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Guard: the OLD behavior (detection off the deployment name) IS the bug.
+# This documents what the fix corrects — a request whose canonical_model is the
+# deployment name (the pre-#1859 shape) skips the strip and would 400.
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fix_shape_would_not_strip_reasoning_params():
+    """A CompletionRequest whose canonical_model is the non-canonical deployment
+    name (== the pre-#1859 behavior) does NOT get its reasoning params stripped —
+    demonstrating the bug the fix closes.
+    """
+    request = CompletionRequest(
+        model="my-gpt5-deploy",
+        canonical_model="my-gpt5-deploy",  # pre-fix: detection off deployment name
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.7,
+        max_tokens=500,
+    )
+    payload = openai_chat.build_request_payload(request)
+    # the bug: temperature 0.7 survives (Azure would 400 on this) and max_tokens
+    # is NOT converted — exactly what keying detection off the deployment name does
+    assert payload.get("temperature") == 0.7
+    assert payload.get("max_tokens") == 500
+    assert "max_completion_tokens" not in payload
+
+    # ...whereas keying off the FAMILY (the fix) strips it:
+    fixed = CompletionRequest(
+        model="my-gpt5-deploy",
+        canonical_model="gpt-5",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.7,
+        max_tokens=500,
+    )
+    fixed_payload = openai_chat.build_request_payload(fixed)
+    assert fixed_payload.get("temperature") == 1.0
+    assert fixed_payload.get("max_completion_tokens") == 500
+    assert "max_tokens" not in fixed_payload
+    assert fixed_payload["model"] == "my-gpt5-deploy"  # wire still the deployment
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/kailash-kaizen/tests/regression/test_issue_1859_azure_reasoning_deployment_name.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1859_azure_reasoning_deployment_name.py
@@ -55,17 +55,24 @@ def _azure_deployment(model: str, deployment: str):
 def _payload_and_url(
     deployment,
     *,
+    model=None,
     temperature=0.7,
     max_tokens=500,
     top_p=0.9,
     frequency_penalty=0.1,
     presence_penalty=0.1,
 ):
-    """Build the wire payload + URL through the real client + shaper (offline)."""
+    """Build the wire payload + URL through the real client + shaper (offline).
+
+    ``model`` mirrors what the caller passes to ``complete(model=...)``:
+    ``None`` = the strategy/TEST fallback (wire model <- deployment.default_model);
+    a family string (e.g. ``"gpt-5"``) = the LIVE node path
+    (``llm_agent._provider_llm_response`` -> ``complete(model=<family>)``).
+    """
     client = LlmClient.from_deployment(deployment, ungoverned=True)
     request = client._build_completion_request(
         [{"role": "user", "content": "hello"}],
-        model=None,  # falls back to deployment.default_model (the deployment name)
+        model=model,
         temperature=temperature,
         top_p=top_p,
         max_tokens=max_tokens,
@@ -142,6 +149,40 @@ def test_wire_still_targets_deployment_name():
     assert "/deployments/gpt-5/" not in url
 
 
+def test_live_node_path_model_is_family_wire_body_is_deployment_name():
+    """LIVE node path shape: `llm_agent._provider_llm_response` calls
+    `client.complete(messages, model=<FAMILY>)` (the value of `kwargs["model"]`,
+    which is the canonical family, e.g. "gpt-5") against the Azure deployment
+    built with deployment_name="my-gpt5-deploy".
+
+    Regression for the round-3 gap: a bare `model or default_model` would put the
+    FAMILY on the wire body `model` field, mismatching the Azure deployment the
+    URL targets. The fix forces the wire body/URL model to the deployment name
+    (`default_model`) for any deployment declaring a `canonical_model`, while
+    detection still keys off the family.
+
+    FAILS pre-fix (wire body would be "gpt-5"); PASSES after.
+    """
+    dep = _azure_deployment("gpt-5", "my-gpt5-deploy")
+    request, payload, url = _payload_and_url(dep, model="gpt-5")
+
+    # wire body model = deployment name, NOT the family the caller passed
+    assert payload["model"] == "my-gpt5-deploy"
+    assert request.model == "my-gpt5-deploy"
+    # detection still keyed off the family
+    assert request.canonical_model == "gpt-5"
+    # URL targets the deployment (never the family)
+    assert "/openai/deployments/my-gpt5-deploy/chat/completions" in url
+    assert "/deployments/gpt-5/" not in url
+    # reasoning strip fired off the family
+    assert payload.get("temperature") == 1.0
+    assert "top_p" not in payload
+    assert "frequency_penalty" not in payload
+    assert "presence_penalty" not in payload
+    assert payload.get("max_completion_tokens") == 500
+    assert "max_tokens" not in payload
+
+
 # ---------------------------------------------------------------------------
 # (3) non-reasoning model KEEPS temperature (no false-positive strip)
 # ---------------------------------------------------------------------------
@@ -167,6 +208,30 @@ def test_non_reasoning_model_keeps_temperature_and_max_tokens():
 # ---------------------------------------------------------------------------
 # (4) the resolver carries family vs deployment name distinctly
 # ---------------------------------------------------------------------------
+
+
+def test_non_azure_direct_provider_is_byte_neutral():
+    """Guard the client fix does NOT regress non-Azure providers: a direct
+    OpenAI deployment has no canonical_model, so `complete(model="o1")` puts the
+    passed model on the wire body AND uses it for detection (canonical is None).
+    """
+    from kaizen.llm.presets import openai_preset
+
+    dep = openai_preset("test-key-not-a-real-secret", "gpt-4o")
+    assert dep.canonical_model is None  # direct providers carry no alias family
+    # caller passes a reasoning model per-call; wire body = the passed model
+    _request, payload, _url = _payload_and_url(dep, model="o1")
+    assert payload["model"] == "o1"
+    # detection keyed off the passed model (canonical is None) -> temperature dropped
+    assert "temperature" not in payload
+    assert payload.get("max_completion_tokens") == 500
+
+    # and a plain non-reasoning direct call is fully unchanged
+    _r2, p2, _u2 = _payload_and_url(dep, model="gpt-4o")
+    assert p2["model"] == "gpt-4o"
+    assert p2.get("temperature") == 0.7
+    assert p2.get("max_tokens") == 500
+    assert "max_completion_tokens" not in p2
 
 
 def test_resolver_separates_family_from_deployment_name():


### PR DESCRIPTION
## Problem

Azure OpenAI uses the caller-chosen **deployment name** as the wire `model` field / URL path (`/openai/deployments/{deployment}/chat/completions`). The four-axis Azure path built the deployment with `default_model = <deployment name>`, and the OpenAI-chat wire shaper ran reasoning-model detection + the `max_tokens`/`max_completion_tokens` selection against that name.

The reasoning patterns are anchored (`^gpt-?5` / `^o1` / `^o3` / `^o4`), so a gpt-5 deployment named e.g. `my-gpt5-deploy` (the common case — Azure deployment names are user-chosen) fails the match, the reasoning-param strip is skipped, and Azure returns `400 unsupported_value` on the default `temperature: 0.7` (and on `max_tokens`). gpt-5 / o-series were unusable on `azure_openai` whenever the deployment name differed from the canonical model id.

## Reconciliation (issue filed against 2.28.0 `azure_backends.py`; tree is now 2.37.x)

The legacy `azure_backends.py::_is_reasoning_model` and the `azure`/`azure_openai` legacy providers were **retired** (`packages/kailash-kaizen/src/kaizen/providers/registry.py:35`). The only reachable reasoning path in the current tree is the four-axis wire filter, and `azure_openai` now resolves exclusively through it. The bug reproduces on the **live four-axis path**:

- `LLMAgentNode.run` → `_provider_llm_response` (`packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py:2406`) → `resolve_deployment_for("azure_openai", model, ...)` → `_resolve_azure_deployment` (`packages/kailash-kaizen/src/kaizen/llm/deployment_resolver.py`) set `default_model = <deployment name>`.
- `LlmClient._build_completion_request` (`client.py`) → `CompletionRequest(model=<deployment name>)`.
- `openai_chat.build_request_payload` (`wire_protocols/openai_chat.py:104`) → `filter_reasoning_model_params(request.model, ...)` = the deployment name → strip skipped.
- `_token_limit_field(request.model)` (`openai_chat.py:119`) = the deployment name → sends `max_tokens` instead of `max_completion_tokens`.

`request.model` for Azure is the **deployment name** (URL path via `endpoint.path_prefix`; also the wire body `model` field, which Azure ignores in favor of the URL). The canonical model family was not carried anywhere on the four-axis Azure path, and `provider_config["deployment"]` was declared as a NodeParameter but never consumed.

## Fix (detection off the model FAMILY; wire still targets the deployment name — AC1)

- `LlmDeployment` + `CompletionRequest` gain an optional `canonical_model` (the family). `None` (every direct provider whose `model` already IS the family) => detection falls back to `model` — byte-identical to pre-#1859.
- The Azure resolver / preset carry the **deployment name** as `default_model` (wire/URL) and the **family** as `canonical_model`. `provider_config.deployment` (+ `api_version`) is now consumed (threaded `LLMAgentNode.run` → `_provider_llm_response` → `resolve_deployment_for` → `_resolve_azure_deployment`) so `model="gpt-5"` stays the family and `provider_config={"deployment": "my-gpt5-deploy"}` supplies the wire deployment name.
- `LlmClient._build_completion_request` threads `deployment.canonical_model` onto the request.
- The `openai_chat` shaper computes `request.canonical_model or request.model` as the DETECTION input for both the reasoning-param filter and the token-limit field; `payload["model"]` and the URL keep the deployment name.
- Anchored patterns confirmed to cover `gpt-5` / `o1` / `o3` / `o4` (`reasoning_filter.py`).
- Backward-compat: legacy single-arg shape (`model` IS the deployment name, no `provider_config.deployment`) sets `canonical_model == default_model` — byte-neutral.

## Files changed

- `packages/kailash-kaizen/src/kaizen/llm/deployment.py` — `canonical_model` on `LlmDeployment` + `CompletionRequest`
- `packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_chat.py` — detection + token-field key off `canonical_model or model`
- `packages/kailash-kaizen/src/kaizen/llm/client.py` — thread `canonical_model` onto the request
- `packages/kailash-kaizen/src/kaizen/llm/deployment_resolver.py` — `_resolve_azure_deployment`/`resolve_deployment_for` accept `deployment` + `api_version`; set `canonical_model`
- `packages/kailash-kaizen/src/kaizen/llm/presets.py` — `azure_openai_preset` optional `canonical_model`
- `packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py` — `run()` reads `provider_config`; `_provider_llm_response` threads `deployment`/`api_version`
- `packages/kailash-kaizen/tests/regression/test_issue_1859_azure_reasoning_deployment_name.py` — new offline regression suite

## User-flow walk (verbatim, offline — no Azure call)

`resolve_deployment_for("azure_openai", "gpt-5", deployment="my-gpt5-deploy", ...)` → `LlmClient` → shaped payload:

```
deployment.default_model (wire/URL) = my-gpt5-deploy
deployment.canonical_model (detection) = gpt-5

--- SHAPED WIRE PAYLOAD (gpt-5 deployment named 'my-gpt5-deploy') ---
  model = 'my-gpt5-deploy'
  temperature = 1.0
  max_completion_tokens = 500
URL = https://my-openai-resource.openai.azure.com/openai/deployments/my-gpt5-deploy/chat/completions?api-version=2024-06-01
```

`temperature` forced to `1.0` (pre-fix sent `0.7` → the 400), `top_p`/`frequency_penalty`/`presence_penalty` stripped, `max_completion_tokens` used, and the wire `model` field + URL still carry the deployment name.

## Test evidence

New regression suite — 7 passed (offline, no network):

```
test_gpt5_deployment_noncanonical_name_strips_reasoning_params PASSED
test_o1_deployment_noncanonical_name_strips_temperature PASSED
test_wire_still_targets_deployment_name PASSED
test_non_reasoning_model_keeps_temperature_and_max_tokens PASSED
test_resolver_separates_family_from_deployment_name PASSED
test_resolver_backward_compat_single_arg_shape PASSED
test_pre_fix_shape_would_not_strip_reasoning_params PASSED
```

`test_pre_fix_shape_would_not_strip_reasoning_params` demonstrates the fix's necessity: a request whose `canonical_model` is the deployment name (the pre-#1859 behavior) keeps `temperature: 0.7` / `max_tokens` (would 400), while keying off `gpt-5` forces `temperature: 1.0` + `max_completion_tokens`.

Regression sweep on the touched surfaces (offline, worktree src): azure preset/resolver/grammar/env (50 passed), openai_chat + reasoning-filter + completion + deployment + byok + multimodal (379 passed), llm_agent dual-run/shadow + tool-execution + provider_config + azure-docker + b1b cutover (110 passed), azure-provider node (18 passed).

## Cross-SDK note

Plausibly cross-SDK relevant: the Rust SDK's `azure.rs` deployment builder / OpenAI-chat wire likely keys reasoning-model detection off the same deployment-name-as-`model` value (the Python resolver comments reference `kailash-rs/.../deployment/azure.rs::DEFAULT_API_VERSION` for parity). A `canonical_model`/family field would need the equivalent addition there. Flagged for a possible cross-SDK issue (not filed from this session).

Fixes #1859