### PR TITLE
release: CF-blocking security+bug bundle — kailash 2.56.0, mcp 0.4.1, nexus 2.13.0, kaizen 2.37.2, kaizen-agents 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.56.0] - 2026-07-19
+
+### Security
+
+- **SSO `id_token` is now cryptographically verified via JWKS before its
+  `nonce` claim is trusted (#1835).** `SSOAuthenticationNode` previously read
+  the OIDC `nonce` claim from an id_token decoded with base64url only — no
+  signature, audience, issuer, or expiry check — so a forged id_token
+  carrying the expected nonce was trusted at the callback (#1815 added nonce
+  enforcement + PKCE but compared the nonce against claims that were never
+  cryptographically verified). A new JWKS-backed verifier (RS256/ES256 +
+  `aud`/`iss`/expiry) now runs before the nonce comparison; the base64url
+  decode is retained only as a display-only helper and is no longer on the
+  trust path. Fail-closed: a missing JWKS/issuer/client_id config, an
+  unreachable JWKS endpoint, or any verification failure (including
+  network/library errors outside PyJWT's own exception hierarchy) raises a
+  typed `ValueError` and rejects the login — there is no fallback to the
+  unverified read.
+  **Migration:** deployments using the id_token-nonce SSO flow MUST now
+  provide `jwks_uri` + `issuer` + `client_id` in `oauth_settings`; without
+  them the callback fails closed (rejects) rather than trusting an
+  unverified token.
+
+### Added
+
+- **`kailash.utils.url_credentials.mask_error_text` — a DOTALL-aware
+  credential scrubber for opaque exception text (#1840).** `mask_url` masks
+  a URL value in hand; an exception rendered into `f"...{e}"` is an opaque
+  string that may embed a credential-bearing URL anywhere inside it, so it
+  cannot route through `mask_url`'s `urlparse`-based path. The new helper
+  scrubs `user:pass@host` userinfo and sensitive query params
+  (`?token=`/`&password=`/...) out of arbitrary strings via a `re.DOTALL`
+  regex — drivers/providers render an embedded newline in a credential value
+  literally into error text, and a naive `\S`/`[^\s]` value class stops at
+  the first `\n` and leaks the credential tail; the userinfo class used here
+  includes `\n` (bounded by real URL host delimiters) and backtracks to the
+  last `@` before the host, so a password with an embedded newline or a raw
+  `@` is masked whole, never split. This is the one shared credential-helper
+  module (`security.md` § "No secrets in logs") — no per-adapter copies.
+  Companion fixes routing through this helper: `kailash-mcp` 0.4.1
+  (SSE/StreamableHTTP/WebSocket transport connect/send/receive logs +
+  server-session close / read-loop error logs) and `kailash-kaizen` 2.37.2
+  (Ollama provider exception logs).
+
 ## [2.55.0] - 2026-07-19
 
 ### Added (Security)

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.37.2] — 2026-07-19 — Ollama credential-log sanitization + Azure reasoning-model detection fix (#1840, #1859)
+
+### Security
+
+- **Ollama provider exception logs no longer leak `base_url` credentials
+  (#1840).** `OllamaProvider` raised `RuntimeError(f"... {e}")` at four sites
+  (`_check_ollama_available`, `generate`, `generate_stream`,
+  `generate_vision`); the `ollama` client renders the configured
+  `base_url` / `OLLAMA_HOST` (which may carry `user:pass@host` or
+  `?token=...`) into its exception text, so every raised error leaked the
+  credential. All four sites now route through the shared
+  `kailash.utils.url_credentials.mask_error_text` helper (companion fix:
+  `kailash` 2.56.0, `kailash-mcp` 0.4.1).
+
+### Fixed
+
+- **Azure reasoning-model detection now keys off the configured model
+  family, not the deployment name (#1859).** Azure OpenAI uses a
+  caller-chosen deployment name as the wire `model` field / URL path, so
+  the four-axis path built the deployment with `default_model = <deployment
+name>`. Reasoning-model detection (`filter_reasoning_model_params` +
+  `max_tokens`/`max_completion_tokens` selection) ran against that
+  deployment name; whenever the deployment name was not the canonical model
+  id (the common case — Azure deployment names are user-chosen), the
+  anchored patterns (`^gpt-?5`/`^o1`/`^o3`/`^o4`) missed, the reasoning-param
+  strip was skipped, and Azure returned a 400 `unsupported_value` on the
+  default `temperature` (and on `max_tokens`) — gpt-5/o-series deployments
+  with non-canonical names were unusable on `azure_openai`. Detection and
+  the token-limit field name now key off a new optional `canonical_model`
+  threaded end-to-end (`LlmDeployment`/`CompletionRequest`; `None` falls
+  back to `model`, byte-identical for every direct provider whose `model`
+  already IS the family) while the wire `model` field and URL keep the
+  deployment name — so the live path now sends the deployment name on the
+  wire (not the family) while detection stays correct on the family.
+  Non-Azure providers carry no `canonical_model` and are unaffected.
+
 ## [2.37.1] — 2026-07-19 — Cost fix: obsolete-model call-defaults now resolve from .env (#1844, #1845)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.37.1"
+version = "2.37.2"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.37.1"
+__version__ = "2.37.2"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.4.1] — 2026-07-19 — Credential-bearing exception logs sanitized (#1840)
+
+### Security
+
+- **SSE / StreamableHTTP / WebSocket transports no longer leak `base_url`
+  credentials into logs or exception text (#1840).** A credential-bearing
+  `base_url`/`url` (e.g. `https://user:secret@host?token=abc`) was
+  interpolated verbatim into the "transport connected" `logger.info` line
+  and into the opaque `{e}` of every `TransportError` raised on
+  connect/send/receive — readable by anyone with log access. URL-value log
+  lines now route through `mask_url`; opaque `{e}` strings route through the
+  new `mask_error_text` helper (both from the shared
+  `kailash.utils.url_credentials` module — no per-transport copies). A
+  round-1 sweep also closed the same class in `_close_server_session`'s
+  swallowed-exception log and the SSE / WebSocket read-loop error logs.
+  `stdio` (subprocess command, no URL) and `WebSocketServerTransport` (local
+  bind, no client credential) carry no credential surface and are
+  unaffected.
+
 ## [0.4.0] — 2026-07-16 — Server-initiated request/response lifecycle hardening (#1712)
 
 Completes the #1712 MCP 2025-11-25 work. The 2025-11-25 wire surface

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Nexus Changelog
 
+## [2.13.0] — 2026-07-19 — `WebhookTransport.receive()` fails closed on missing secret (#1836)
+
+### Fixed (Security)
+
+- **`WebhookTransport.receive()` now fails closed when no signing secret is
+  configured (#1836).** `receive()` guarded signature verification with
+  `if self._secret is not None`, so a deployment with no webhook signing
+  secret SKIPPED verification entirely and silently accepted any forged
+  inbound webhook event. #1814 (2.12.1) hardened `verify_signature` /
+  `verify_signature_for_request` to fail closed but left this `receive()`
+  path as an intentional unsigned-mode contract; this closes it.
+  **Behavior change:** with no secret configured, `receive()` now raises a
+  typed `ValueError` by default. Deployments that intentionally run
+  unsigned webhooks (or verify signatures at an edge proxy/gateway) must
+  pass `allow_unsigned=True` to `WebhookTransport(...)` to opt back into the
+  prior unsigned-accept behavior.
+
 ## [2.12.1] — 2026-07-19 — Webhook signature verification fails closed (#1814)
 
 ### Fixed (Security)

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.12.1"
+version = "2.13.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -117,7 +117,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.12.1"
+__version__ = "2.13.0"
 __all__ = [
     # Core
     "Nexus",

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] — 2026-07-19 — RAGResearchAgent lazy-loads so bare install imports without numpy (#1849)
+
+### Fixed
+
+- **A bare install no longer fails to import `kaizen_agents.agents` (or any
+  `specialized.*` agent) when `numpy` is absent (#1849).** An unguarded
+  module-scope import chain eagerly loaded `RAGResearchAgent`, which pulls
+  `kaizen.retrieval.vector_store` → `import numpy`. `numpy` is declared by
+  no `kaizen-agents` manifest — it ships only under `kailash-kaizen[rag]` —
+  so its absence collateral-damaged every non-RAG agent (`chain_of_thought`,
+  etc.) even though they have nothing to do with RAG. `RAGResearchAgent` now
+  resolves via a PEP 562 `__getattr__` (static analysis / `__all__`
+  preserved via a `TYPE_CHECKING` block) instead of an eager module-scope
+  import; the registration path (`register_builtin.py` / `nodes.py`) guards
+  the import with `try/except ImportError`, emitting an actionable WARN
+  ("install kailash-kaizen[rag]") instead of a silent swallow. A **direct**
+  submodule import
+  (`from kaizen_agents.agents.specialized.rag_research import
+RAGResearchAgent`) without numpy now raises an actionable `ImportError`
+  naming `kailash-kaizen[rag]` (chained via `from exc`, not swallowed)
+  instead of a bare `ModuleNotFoundError: No module named 'numpy'`.
+  `RAGResearchAgent` remains fully functional when numpy IS present — no new
+  hard dependency, no behavior change on the RAG path.
+
 ## [0.11.2] — 2026-07-19 — Cost fix: KAIZEN_MODEL fallbacks now resolve via the shared env helper (#1844, #1845)
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.2"
+version = "0.11.3"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.55.0"
+version = "2.56.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.55.0"
+__version__ = "2.56.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep only — version bumps + CHANGELOG entries for a coordinated 5-package release. All underlying fixes are already merged to `main` (PRs #1855–#1860). This PR does **not** touch source; publishing is tag-triggered via Trusted Publisher OIDC per `deploy/deployment-config.md` and is a separate, later step.

## Versions

| Package | Old | New |
|---|---|---|
| kailash (core) | 2.55.0 | **2.56.0** |
| kailash-mcp | 0.4.0 | **0.4.1** |
| kailash-nexus | 2.12.1 | **2.13.0** |
| kailash-kaizen | 2.37.1 | **2.37.2** |
| kaizen-agents | 0.11.2 | **0.11.3** |

## Issues fixed

- **kailash 2.56.0**
  - fix(auth): SSO `id_token` JWKS signature/`aud`/`iss`/expiry verification before trusting the OIDC `nonce` (#1835)
  - feat(utils): new `mask_error_text` DOTALL-aware credential-redaction helper (#1840)
- **kailash-mcp 0.4.1**
  - fix(mcp): sanitize credential-bearing exception logs in SSE/StreamableHTTP/WebSocket transports (#1840)
- **kailash-nexus 2.13.0**
  - fix(nexus): `WebhookTransport.receive()` now fails closed when no signing secret is configured (#1836)
- **kailash-kaizen 2.37.2**
  - fix(kaizen): sanitize Ollama provider exception logs (#1840)
  - fix(kaizen): Azure reasoning-model detection keys off the configured model family (not the deployment name), so gpt-5/o-series deployments with non-canonical names strip reasoning params correctly and send the deployment name on the wire (#1859)
- **kaizen-agents 0.11.3**
  - fix(kaizen-agents): lazy-load `RAGResearchAgent` so a bare install imports without numpy; actionable `ImportError` when numpy is absent (#1849)

## Migration notes (behavior changes)

- **kailash 2.56.0 (SSO):** id_token-nonce SSO flows now REQUIRE `jwks_uri` + `issuer` + `client_id` in `oauth_settings`; without them the callback fails closed (rejects) rather than trusting an unverified token.
- **kailash-nexus 2.13.0 (webhooks):** deployments intentionally running UNSIGNED webhooks must now pass `allow_unsigned=True` to `WebhookTransport(...)`; otherwise `receive()` raises a typed `ValueError`.

## Verification

- Every package's `pyproject.toml::version` and `__init__.py::__version__` bumped atomically and grepped for consistency (see below).
- `pre-commit run --files <all 15 changed files>` — all hooks passed (black, isort, ruff, trailing-whitespace, TOML syntax, Tier 1 unit tests, doc-style, dependency-pin-drift gate).
- No source files touched — diff is `pyproject.toml` + `__init__.py::__version__` + `CHANGELOG.md` per package only.

## Related issues

Related: #1835 #1836 #1840 #1849 #1859