### PR TITLE
release: dep-pin fix — kailash-mcp 0.4.2 + kailash-kaizen 2.37.3 require kailash>=2.56.0

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.37.3] — 2026-07-19 — Dependency pin fix: require kailash>=2.56.0
+
+### Fixed
+
+- **`kailash>=2.54.0` pin was too low for the 2.37.2 `mask_error_text` import.**
+  2.37.2 (below) made `ollama_provider.py` import `mask_error_text` from
+  `kailash.utils.url_credentials` — a helper new in `kailash` 2.56.0. A user
+  on core `>=2.54.0,<2.56.0` satisfied the declared pin but hit
+  `ImportError` at `import kaizen`. The pin now reads `kailash>=2.56.0`.
+
 ## [2.37.2] — 2026-07-19 — Ollama credential-log sanitization + Azure reasoning-model detection fix (#1840, #1859)
 
 ### Security

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.37.2"
+version = "2.37.3"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -31,7 +31,7 @@ dependencies = [
     # SDKs, observability, PostgreSQL, RAG numerics) remain lazy-loaded or
     # scoped to optional subsystems behind extras.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.54.0",  # governance_gate imports kailash.is_governance_required (new in 2.54.0)
+    "kailash>=2.56.0",  # mask_error_text (ollama_provider.py) is new in core 2.56.0
     "kailash-mcp>=0.2.4",       # core/base_agent.py:32 module-scope MCPClient
     "pydantic>=2.0.0",          # llm/deployment.py + auth modules
     "typing-extensions>=4.5.0", # core/schema_factory.py

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.37.2"
+__version__ = "2.37.3"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.4.2] — 2026-07-19 — Dependency pin fix: require kailash>=2.56.0
+
+### Fixed
+
+- **`kailash>=2.50.0` pin was too low for the 0.4.1 `mask_error_text` import.**
+  0.4.1 (below) made `transports.py` import `mask_error_text` from
+  `kailash.utils.url_credentials` — a helper new in `kailash` 2.56.0. A user
+  on core `>=2.50.0,<2.56.0` satisfied the declared pin but hit
+  `ImportError` at `import kailash_mcp`. The pin now reads
+  `kailash>=2.56.0`.
+
 ## [0.4.1] — 2026-07-19 — Credential-bearing exception logs sanitized (#1840)
 
 ### Security

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -40,7 +40,7 @@ dependencies = [
     #   `[websocket]` extras retain their declarations as harmless
     #   redundancy (already-installed entries are no-ops).
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.50.0",
+    "kailash>=2.56.0",  # mask_error_text (transports.py) is new in core 2.56.0
     "mcp[cli]>=1.23.0",
     "aiohttp>=3.12.4",
     "websockets>=12.0",

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (


### PR DESCRIPTION
## Summary

Two packages published earlier today already ship code importing `mask_error_text` from `kailash.utils.url_credentials` — a helper new in kailash core 2.56.0 — but their `kailash>=` dependency pins were left below that floor:

| Package | Version | File importing `mask_error_text` | Pin was | Pin now |
|---|---|---|---|---|
| kailash-mcp | 0.4.1 → **0.4.2** | `src/kailash_mcp/transports/transports.py` | `kailash>=2.50.0` | `kailash>=2.56.0` |
| kailash-kaizen | 2.37.2 → **2.37.3** | `src/kaizen/providers/ollama_provider.py` | `kailash>=2.54.0` | `kailash>=2.56.0` |

A user installing either package who has an older core version that still satisfies the (too-low) declared pin hits `ImportError` at `import kailash_mcp` / `import kaizen`. PyPI is immutable, so this ships as a patch republish rather than an edit to the already-published wheels.

- Bumped `pyproject.toml::version` + `__init__.py::__version__` for both packages (atomic per `zero-tolerance.md` Rule 5).
- Corrected only the `kailash>=` pin line in each package's `dependencies` list — no other pins touched.
- Added a `### Fixed` CHANGELOG entry for each package documenting the gap and the fix.
- `kaizen-agents`' `kailash-kaizen>=2.36.0` pin is unaffected (it does not import `mask_error_text`; 2.37.3 satisfies its floor) and was left untouched.

No source code changed — this is a metadata-only (pins + version + CHANGELOG) diff.

## Test plan

- [x] `grep` verified `pyproject.toml` + `__init__.py::__version__` agree per package (0.4.2 / 2.37.3)
- [x] `grep` verified both new pin lines read `kailash>=2.56.0`
- [x] Confirmed `mask_error_text` is actually imported in both flagged files (the reason for the pin bump)
- [x] `pre-commit run --files <the 6 changed files>` — all hooks pass, including the "First-party dependency-pin drift gate (#1183)"
- [ ] Not merging / not tagging from this PR — orchestrator controls those per this session's instructions

## Related issues

Follow-up to the same-day #1840 security fix (credential masking via `mask_error_text`) that introduced the dependency this PR pins correctly.