### PR TITLE
fix(auth): PKCE + id_token nonce across the SSO provider-class suite (#1834)

### DIFF
--- a/packages/kailash-nexus/src/nexus/auth/sso/__init__.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/__init__.py
@@ -78,36 +78,58 @@ class SSOStateStore(Protocol):
     development only. For production multi-process or multi-server
     deployments, use a Redis-backed implementation.
 
+    The store persists — alongside the CSRF state token — the per-flow PKCE
+    ``code_verifier`` (RFC 7636) and OIDC ``nonce`` minted at authorization
+    time, so :func:`handle_sso_callback` can replay the verifier to the token
+    endpoint and enforce the nonce against the returned id_token.
+    ``validate_and_consume`` returns the stored data dict on a valid,
+    single-use consume and ``None`` when the state is unknown or expired.
+
     Example Redis implementation:
+        >>> import json
         >>> class RedisSSOStateStore:
         ...     def __init__(self, redis_client, ttl=600):
         ...         self._redis = redis_client
         ...         self._ttl = ttl
         ...
-        ...     def store(self, state: str) -> None:
-        ...         self._redis.setex(f"sso:state:{state}", self._ttl, "1")
+        ...     def store(self, state, *, code_verifier=None, nonce=None):
+        ...         payload = json.dumps(
+        ...             {"code_verifier": code_verifier, "nonce": nonce}
+        ...         )
+        ...         self._redis.setex(f"sso:state:{state}", self._ttl, payload)
         ...
-        ...     def validate_and_consume(self, state: str) -> bool:
+        ...     def validate_and_consume(self, state):
         ...         key = f"sso:state:{state}"
         ...         pipe = self._redis.pipeline()
         ...         pipe.get(key)
         ...         pipe.delete(key)
         ...         result = pipe.execute()
-        ...         return result[0] is not None
+        ...         if result[0] is None:
+        ...             return None
+        ...         return json.loads(result[0])
         ...
         ...     def cleanup(self) -> None:
         ...         pass  # Redis TTL handles expiration
     """
 
-    def store(self, state: str) -> None:
-        """Store a new CSRF state token."""
+    def store(
+        self,
+        state: str,
+        *,
+        code_verifier: Optional[str] = None,
+        nonce: Optional[str] = None,
+    ) -> None:
+        """Store a new CSRF state token with its PKCE verifier + OIDC nonce."""
         ...
 
-    def validate_and_consume(self, state: str) -> bool:
+    def validate_and_consume(self, state: str) -> Optional[Dict[str, Any]]:
         """Validate state token and remove it (single use).
 
         Returns:
-            True if state was valid and not expired, False otherwise
+            The stored ``{"code_verifier": ..., "nonce": ...}`` dict if the
+            state was valid and not expired, ``None`` otherwise. The dict is
+            truthy on success so ``if not store.validate_and_consume(state)``
+            remains a correct validity gate.
         """
         ...
 
@@ -125,27 +147,47 @@ class InMemorySSOStateStore:
     """
 
     def __init__(self, ttl_seconds: int = 600):
-        self._store: Dict[str, float] = {}
+        # state -> {"timestamp": float, "code_verifier": str|None, "nonce": str|None}
+        self._store: Dict[str, Dict[str, Any]] = {}
         self._ttl = ttl_seconds
 
-    def store(self, state: str) -> None:
-        """Store a new state token with current timestamp."""
+    def store(
+        self,
+        state: str,
+        *,
+        code_verifier: Optional[str] = None,
+        nonce: Optional[str] = None,
+    ) -> None:
+        """Store a new state token with its PKCE verifier + OIDC nonce."""
         self.cleanup()
-        self._store[state] = time.time()
+        self._store[state] = {
+            "timestamp": time.time(),
+            "code_verifier": code_verifier,
+            "nonce": nonce,
+        }
 
-    def validate_and_consume(self, state: str) -> bool:
-        """Validate and atomically consume state token."""
-        stored_time = self._store.pop(state, None)
-        if stored_time is None:
-            return False
-        if time.time() - stored_time > self._ttl:
-            return False
-        return True
+    def validate_and_consume(self, state: str) -> Optional[Dict[str, Any]]:
+        """Validate and atomically consume state token.
+
+        Returns the stored ``{"code_verifier", "nonce"}`` dict on success,
+        ``None`` when the state is unknown or expired.
+        """
+        entry = self._store.pop(state, None)
+        if entry is None:
+            return None
+        if time.time() - entry["timestamp"] > self._ttl:
+            return None
+        return {
+            "code_verifier": entry.get("code_verifier"),
+            "nonce": entry.get("nonce"),
+        }
 
     def cleanup(self) -> None:
         """Remove expired state entries."""
         now = time.time()
-        expired = [k for k, v in self._store.items() if now - v > self._ttl]
+        expired = [
+            k for k, v in self._store.items() if now - v["timestamp"] > self._ttl
+        ]
         for k in expired:
             del self._store[k]
 
@@ -206,14 +248,28 @@ async def initiate_sso_login(
 
     redirect_uri = f"{callback_base_url}/auth/sso/{provider.name}/callback"
 
+    # PKCE (RFC 7636) — a per-flow verifier/challenge pair bound to this state.
+    code_verifier, code_challenge = provider.generate_pkce_pair()
+
+    # OIDC nonce (id_token replay/injection defense) — minted ONLY for providers
+    # that issue an id_token (GitHub OAuth2 has none, so no nonce).
+    nonce = (
+        secrets.token_urlsafe(32)
+        if getattr(provider, "supports_id_token", False)
+        else None
+    )
+    if nonce is not None:
+        kwargs["nonce"] = nonce
+
     auth_url = provider.get_authorization_url(
         state=state,
         redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
         **kwargs,
     )
 
     store = _get_state_store()
-    store.store(state)
+    store.store(state, code_verifier=code_verifier, nonce=nonce)
 
     return RedirectResponse(url=auth_url)
 
@@ -242,15 +298,27 @@ async def handle_sso_callback(
         SSOAuthError: If SSO authentication fails
     """
     store = _get_state_store()
-    if not store.validate_and_consume(state):
+    state_result = store.validate_and_consume(state)
+    if not state_result:
         raise InvalidStateError("Invalid or expired SSO state - possible CSRF attack")
+
+    # A dict-returning store carries the per-flow PKCE verifier + nonce; a legacy
+    # bool-returning custom store carries neither (empty dict), so PKCE/nonce are
+    # simply absent — never a silent downgrade of a flow that DID mint them.
+    state_data = state_result if isinstance(state_result, dict) else {}
+    code_verifier = state_data.get("code_verifier")
+    nonce = state_data.get("nonce")
 
     redirect_uri = f"{callback_base_url or ''}/auth/sso/{provider.name}/callback"
 
-    tokens = await provider.exchange_code(code, redirect_uri)
+    tokens = await provider.exchange_code(
+        code, redirect_uri, code_verifier=code_verifier
+    )
 
     if tokens.id_token:
-        claims = provider.validate_id_token(tokens.id_token)
+        # nonce enforcement runs inside validate_id_token against the
+        # JWKS-verified claims (fail-closed on mismatch).
+        claims = provider.validate_id_token(tokens.id_token, nonce=nonce)
         user_id = claims.get("sub")
         email = claims.get("email")
         name = claims.get("name")

--- a/packages/kailash-nexus/src/nexus/auth/sso/apple.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/apple.py
@@ -21,6 +21,7 @@ from urllib.parse import urlencode
 
 import jwt
 from jwt import PyJWKClient
+
 from nexus.auth.sso.base import (
     BaseSSOProvider,
     SSOAuthError,
@@ -144,6 +145,7 @@ class AppleProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         response_mode: str = "form_post",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Apple authorization URL.
@@ -153,7 +155,10 @@ class AppleProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes
             response_mode: "query" or "form_post" (recommended)
-            **kwargs: Additional parameters
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (incl. ``nonce`` for OIDC id_token
+                replay defense)
 
         Returns:
             Authorization URL
@@ -169,6 +174,9 @@ class AppleProvider(BaseSSOProvider):
             "state": state,
             "response_mode": response_mode,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -177,12 +185,15 @@ class AppleProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response
@@ -199,6 +210,8 @@ class AppleProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(self.TOKEN_URL, data)
 
@@ -232,18 +245,22 @@ class AppleProvider(BaseSSOProvider):
         self,
         id_token: str,
         user_data: Optional[Dict[str, Any]] = None,
+        nonce: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Validate and decode Apple ID token.
 
         Args:
             id_token: JWT ID token
             user_data: User data from authorization (name, email on first auth)
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises — the id_token replay/injection defense.
 
         Returns:
             Decoded token claims with user data merged
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
 
         Note:
             Apple only sends user's name on FIRST authorization.
@@ -259,6 +276,10 @@ class AppleProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer="https://appleid.apple.com",
             )
+
+            # Nonce enforced ONLY against the verified payload above, before
+            # merging any non-token user_data.
+            self._enforce_nonce(payload, nonce)
 
             if user_data:
                 if "name" in user_data:

--- a/packages/kailash-nexus/src/nexus/auth/sso/azure.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/azure.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode
 
 import jwt
 from jwt import PyJWKClient
+
 from nexus.auth.sso.base import (
     BaseSSOProvider,
     SSOAuthError,
@@ -95,6 +96,7 @@ class AzureADProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         prompt: str = "select_account",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Azure AD authorization URL.
@@ -104,7 +106,10 @@ class AzureADProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes (space-separated)
             prompt: Login prompt behavior (none, login, consent, select_account)
-            **kwargs: Additional parameters (login_hint, domain_hint, etc.)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (login_hint, domain_hint, and
+                ``nonce`` for OIDC id_token replay defense)
 
         Returns:
             Authorization URL
@@ -118,6 +123,9 @@ class AzureADProvider(BaseSSOProvider):
             "response_mode": "query",
             "prompt": prompt,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         base_url = f"{self.AUTHORITY_BASE}/{self.tenant_id}/oauth2/v2.0/authorize"
@@ -127,12 +135,15 @@ class AzureADProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code from callback
             redirect_uri: Same redirect URI used in authorization
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response with access_token and id_token
@@ -149,6 +160,8 @@ class AzureADProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(token_url, data)
 
@@ -185,7 +198,11 @@ class AzureADProvider(BaseSSOProvider):
             raw_data=data,
         )
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode Azure AD ID token.
 
         Validates:
@@ -194,15 +211,19 @@ class AzureADProvider(BaseSSOProvider):
             - Audience (aud claim = client_id)
             - Issuer (iss claim = Azure AD)
             - Tenant ID (tid claim, for multi-tenant)
+            - Nonce (when provided; id_token replay/injection defense)
 
         Args:
             id_token: JWT ID token
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
         """
         try:
             signing_key = self._jwks_client.get_signing_key_from_jwt(id_token)
@@ -223,6 +244,9 @@ class AzureADProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer=issuer,
             )
+
+            # Nonce enforced ONLY against the verified payload above.
+            self._enforce_nonce(payload, nonce)
 
             return payload
 

--- a/packages/kailash-nexus/src/nexus/auth/sso/base.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/base.py
@@ -10,7 +10,10 @@ Evidence:
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
+import secrets
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
@@ -104,6 +107,8 @@ class SSOProvider(Protocol):
         state: str,
         redirect_uri: str,
         scope: Optional[str] = None,
+        code_challenge: Optional[str] = None,
+        nonce: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate authorization URL for OAuth2 flow.
@@ -112,6 +117,12 @@ class SSOProvider(Protocol):
             state: CSRF state parameter
             redirect_uri: Callback URL after authorization
             scope: OAuth2 scopes (optional, uses provider default)
+            code_challenge: PKCE (RFC 7636) S256 code_challenge. When present,
+                the provider MUST emit ``code_challenge`` +
+                ``code_challenge_method=S256`` on the authorization request.
+            nonce: OIDC nonce (id_token replay defense). When present, an
+                OIDC provider MUST emit ``nonce`` so the IdP echoes it into the
+                id_token for later verification in :meth:`validate_id_token`.
             **kwargs: Provider-specific parameters
 
         Returns:
@@ -123,12 +134,16 @@ class SSOProvider(Protocol):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code from callback
             redirect_uri: Same redirect_uri used in authorization
+            code_verifier: PKCE (RFC 7636) code_verifier retained from the
+                authorization request. When present, the provider MUST replay
+                it to the token endpoint so the IdP confirms proof-of-possession.
 
         Returns:
             Token response with access_token and optionally id_token
@@ -152,17 +167,25 @@ class SSOProvider(Protocol):
         """
         ...
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode ID token.
 
         Args:
             id_token: OIDC ID token (JWT)
+            nonce: The nonce minted at authorization time. When present, the
+                provider MUST enforce that the id_token's ``nonce`` claim
+                matches (constant-time), rejecting on mismatch — the id_token
+                replay/injection defense.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If token is invalid
+            SSOAuthError: If token is invalid or the nonce does not match
         """
         ...
 
@@ -174,7 +197,59 @@ class BaseSSOProvider:
         - HTTP client management
         - Common error handling
         - Token validation utilities
+        - PKCE (RFC 7636) pair generation + OIDC nonce enforcement
     """
+
+    #: Whether this provider issues an OIDC id_token (and therefore supports
+    #: nonce enforcement). GitHub OAuth2 has no id_token and overrides this to
+    #: False; callers use it to decide whether to mint + enforce a nonce.
+    supports_id_token: bool = True
+
+    @staticmethod
+    def generate_pkce_pair() -> tuple[str, str]:
+        """Generate a PKCE (RFC 7636) ``(code_verifier, code_challenge)`` pair.
+
+        The verifier is a high-entropy secret the caller retains and replays to
+        the token endpoint via :meth:`exchange_code`; the challenge is its S256
+        (SHA-256, base64url, no padding) transform sent on the authorization
+        request via :meth:`get_authorization_url`. Binding the two proves the
+        client that redeems the authorization code is the same one that
+        requested it, closing the auth-code interception attack on public
+        clients.
+
+        Returns:
+            ``(code_verifier, code_challenge)``
+        """
+        code_verifier = secrets.token_urlsafe(64)
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        return code_verifier, code_challenge
+
+    @staticmethod
+    def _enforce_nonce(claims: Dict[str, Any], nonce: Optional[str]) -> None:
+        """Enforce the OIDC nonce against VERIFIED id_token claims (fail-closed).
+
+        MUST be called only after the id_token signature/aud/iss/exp have been
+        verified — the claims passed here are trusted. When ``nonce`` is
+        provided, the id_token's ``nonce`` claim MUST be a string matching it
+        (compared in constant time); a missing, non-string, or mismatched
+        claim raises :class:`SSOAuthError`. When ``nonce`` is None the check is
+        skipped (no nonce was minted for this flow).
+        """
+        if nonce is None:
+            return
+        import hmac as _hmac
+
+        returned = claims.get("nonce")
+        if not isinstance(returned, str) or not _hmac.compare_digest(returned, nonce):
+            raise SSOAuthError(
+                "OIDC nonce mismatch — id_token nonce claim does not match the "
+                "value minted at authorization time; rejecting authentication "
+                "(possible id_token replay/injection)"
+            )
 
     def __init__(
         self,

--- a/packages/kailash-nexus/src/nexus/auth/sso/github.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/github.py
@@ -46,6 +46,10 @@ class GitHubProvider(BaseSSOProvider):
 
     name = "github"
 
+    # GitHub OAuth2 issues no OIDC id_token, so nonce enforcement does not
+    # apply; PKCE still applies to its authorization-code flow.
+    supports_id_token = False
+
     AUTHORIZATION_URL = "https://github.com/login/oauth/authorize"
     TOKEN_URL = "https://github.com/login/oauth/access_token"
     USERINFO_URL = "https://api.github.com/user"
@@ -77,6 +81,7 @@ class GitHubProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         allow_signup: bool = True,
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate GitHub authorization URL.
@@ -86,6 +91,8 @@ class GitHubProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes
             allow_signup: Allow new user signups (default: True)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
             **kwargs: Additional parameters (login hint)
 
         Returns:
@@ -98,6 +105,9 @@ class GitHubProvider(BaseSSOProvider):
             "state": state,
             "allow_signup": str(allow_signup).lower(),
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -106,12 +116,15 @@ class GitHubProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for access token.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response (no id_token for GitHub)
@@ -121,14 +134,18 @@ class GitHubProvider(BaseSSOProvider):
         """
         client = await self._get_http_client()
 
+        token_request_data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        if code_verifier:
+            token_request_data["code_verifier"] = code_verifier
+
         response = await client.post(
             self.TOKEN_URL,
-            data={
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "code": code,
-                "redirect_uri": redirect_uri,
-            },
+            data=token_request_data,
             headers={"Accept": "application/json"},
         )
 

--- a/packages/kailash-nexus/src/nexus/auth/sso/google.py
+++ b/packages/kailash-nexus/src/nexus/auth/sso/google.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode
 
 import jwt
 from jwt import PyJWKClient
+
 from nexus.auth.sso.base import (
     BaseSSOProvider,
     SSOAuthError,
@@ -82,6 +83,7 @@ class GoogleProvider(BaseSSOProvider):
         scope: Optional[str] = None,
         access_type: str = "offline",
         prompt: str = "consent",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Google authorization URL.
@@ -92,7 +94,10 @@ class GoogleProvider(BaseSSOProvider):
             scope: Override default scopes
             access_type: "online" or "offline" (for refresh token)
             prompt: "none", "consent", "select_account"
-            **kwargs: Additional parameters (login_hint, hd for G Suite)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (login_hint, hd for G Suite, and
+                ``nonce`` for OIDC id_token replay defense)
 
         Returns:
             Authorization URL
@@ -106,6 +111,9 @@ class GoogleProvider(BaseSSOProvider):
             "access_type": access_type,
             "prompt": prompt,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -114,12 +122,15 @@ class GoogleProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response
@@ -134,6 +145,8 @@ class GoogleProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(self.TOKEN_URL, data)
 
@@ -170,17 +183,24 @@ class GoogleProvider(BaseSSOProvider):
             raw_data=data,
         )
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode Google ID token.
 
         Args:
             id_token: JWT ID token
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises — the id_token replay/injection defense.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
         """
         try:
             signing_key = self._jwks_client.get_signing_key_from_jwt(id_token)
@@ -192,6 +212,9 @@ class GoogleProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer=["https://accounts.google.com", "accounts.google.com"],
             )
+
+            # Nonce enforced ONLY against the verified payload above.
+            self._enforce_nonce(payload, nonce)
 
             return payload
 

--- a/packages/kailash-nexus/tests/integration/auth/test_sso_integration.py
+++ b/packages/kailash-nexus/tests/integration/auth/test_sso_integration.py
@@ -8,6 +8,8 @@ import json
 import time
 
 import pytest
+from pytest_httpserver import HTTPServer
+
 from nexus.auth.sso import (
     InMemorySSOStateStore,
     InvalidStateError,
@@ -15,7 +17,6 @@ from nexus.auth.sso import (
     configure_state_store,
 )
 from nexus.auth.sso.base import SSOAuthError, SSOTokenResponse, SSOUserInfo
-from pytest_httpserver import HTTPServer
 
 # =============================================================================
 # Fixtures
@@ -399,11 +400,11 @@ class TestCsrfStateValidationIntegration:
         state = secrets.token_urlsafe(32)
         store.store(state)
 
-        # Validate (consume)
-        assert store.validate_and_consume(state) is True
+        # Validate (consume) — returns the stored data dict, not a bool
+        assert store.validate_and_consume(state) is not None
 
         # State consumed - cannot be used again
-        assert store.validate_and_consume(state) is False
+        assert store.validate_and_consume(state) is None
 
     def test_state_prevents_replay(self):
         """Same state cannot be used twice (one-time use)."""
@@ -415,7 +416,7 @@ class TestCsrfStateValidationIntegration:
         store.validate_and_consume(state)
 
         # Second use fails
-        assert store.validate_and_consume(state) is False
+        assert store.validate_and_consume(state) is None
 
     def test_expired_state_rejected(self):
         """Expired state is detected and rejected."""
@@ -424,16 +425,16 @@ class TestCsrfStateValidationIntegration:
         configure_state_store(short_ttl_store)
 
         state = "expired-state"
-        # Directly insert with past timestamp to simulate expiry
-        short_ttl_store._store[state] = time.time() - 100
+        # Directly insert with past timestamp to simulate expiry (dict entry)
+        short_ttl_store._store[state] = {"timestamp": time.time() - 100}
 
         # Expired state is rejected
-        assert short_ttl_store.validate_and_consume(state) is False
+        assert short_ttl_store.validate_and_consume(state) is None
 
     def test_unknown_state_rejected(self):
         """Unknown state (CSRF attack) is rejected."""
         store = _get_state_store()
-        assert store.validate_and_consume("unknown-state") is False
+        assert store.validate_and_consume("unknown-state") is None
 
     @pytest.mark.asyncio
     async def test_handle_callback_rejects_invalid_state(self):
@@ -466,7 +467,7 @@ class TestCsrfStateValidationIntegration:
         configure_state_store(short_ttl_store)
 
         state = "expired-callback-state"
-        short_ttl_store._store[state] = time.time() - 100
+        short_ttl_store._store[state] = {"timestamp": time.time() - 100}
 
         github = GitHubProvider(
             client_id="test-client",
@@ -520,7 +521,7 @@ class TestAuthorizationUrlIntegration:
             )
 
             assert "state=test-state" in url, f"{provider.name} missing state param"
-            assert f"client_id={provider.client_id}" in url, (
-                f"{provider.name} missing client_id param"
-            )
+            assert (
+                f"client_id={provider.client_id}" in url
+            ), f"{provider.name} missing client_id param"
             assert "redirect_uri=" in url, f"{provider.name} missing redirect_uri"

--- a/packages/kailash-nexus/tests/regression/test_issue_1834_sso_pkce_nonce_suite.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1834_sso_pkce_nonce_suite.py
@@ -1,0 +1,453 @@
+"""Regression suite for issue #1834 (Nexus mirror) — PKCE + id_token nonce
+across the ``nexus.auth.sso`` provider-class suite AND the SSO flow helpers.
+
+Mirror of the ``kailash.trust.auth.sso`` suite (the two are 1:1 mirrors). Covers:
+    - Provider ``get_authorization_url`` emits PKCE ``code_challenge`` + ``S256``.
+    - Provider ``exchange_code`` replays the ``code_verifier``.
+    - Provider ``validate_id_token(nonce=...)`` accepts a match / rejects a
+      mismatch on a REAL RSA/ES256-signed id_token verified via a real JWKS.
+    - ``initiate_sso_login`` mints + persists PKCE verifier + OIDC nonce, and
+      emits ``code_challenge`` (+ ``nonce`` for OIDC providers) on the auth URL.
+    - ``handle_sso_callback`` replays the verifier + enforces the nonce
+      (fail-closed on mismatch).
+
+Follow-up to #1815 / #1835.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytestmark = pytest.mark.regression
+
+
+class _JWKSHarness:
+    """Real in-process JWKS harness (RS256 or ES256) — nothing mocked."""
+
+    def __init__(self, alg: str):
+        import jwt
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+        self.alg = alg
+        self.kid = "test-key-1834n"
+        if alg == "RS256":
+            self._priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            from jwt.algorithms import RSAAlgorithm
+
+            jwk = json.loads(RSAAlgorithm.to_jwk(self._priv.public_key()))
+        else:
+            self._priv = ec.generate_private_key(ec.SECP256R1())
+            from jwt.algorithms import ECAlgorithm
+
+            jwk = json.loads(ECAlgorithm.to_jwk(self._priv.public_key()))
+        jwk.update({"kid": self.kid, "use": "sig", "alg": alg})
+        body = json.dumps({"keys": [jwk]}).encode()
+        self._jwt = jwt
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *a):
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        host, port = self._server.server_address
+        self.jwks_uri = f"http://{host}:{port}/jwks"
+        self.apple_client_secret_key = (
+            ec.generate_private_key(ec.SECP256R1())
+            .private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+            .decode()
+        )
+
+    def sign(self, claims: dict) -> str:
+        return self._jwt.encode(
+            claims, self._priv, algorithm=self.alg, headers={"kid": self.kid}
+        )
+
+    def base_claims(self, *, aud: str, iss: str, **overrides) -> dict:
+        now = int(time.time())
+        claims = {
+            "sub": "user-1834n",
+            "aud": aud,
+            "iss": iss,
+            "iat": now,
+            "exp": now + 3600,
+            "email": "u@example.com",
+            "name": "User",
+        }
+        claims.update(overrides)
+        return claims
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+@pytest.fixture
+def rs256_harness():
+    h = _JWKSHarness("RS256")
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+@pytest.fixture
+def es256_harness():
+    h = _JWKSHarness("ES256")
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+def _point_jwks(provider, harness):
+    from jwt import PyJWKClient
+
+    provider._jwks_client = PyJWKClient(harness.jwks_uri)
+
+
+# ===========================================================================
+# Provider classes — PKCE on the authorization URL
+# ===========================================================================
+
+
+def test_google_auth_url_emits_pkce_s256():
+    from nexus.auth.sso import GoogleProvider
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url and "code_challenge_method=S256" in url
+
+
+def test_azure_auth_url_emits_pkce_s256():
+    from nexus.auth.sso import AzureADProvider
+
+    p = AzureADProvider(tenant_id="t1", client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url and "code_challenge_method=S256" in url
+
+
+def test_apple_auth_url_emits_pkce_s256(es256_harness):
+    from nexus.auth.sso import AppleProvider
+
+    p = AppleProvider(
+        team_id="tm",
+        client_id="test-client",
+        key_id="k",
+        private_key=es256_harness.apple_client_secret_key,
+    )
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url and "code_challenge_method=S256" in url
+
+
+def test_github_auth_url_emits_pkce_and_no_id_token_support():
+    from nexus.auth.sso import GitHubProvider
+
+    p = GitHubProvider(client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url and "code_challenge_method=S256" in url
+    assert p.supports_id_token is False
+
+
+# ===========================================================================
+# Provider classes — exchange_code replays code_verifier
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_google_exchange_replays_code_verifier(monkeypatch):
+    from nexus.auth.sso import GoogleProvider
+
+    p = GoogleProvider(client_id="c", client_secret="s")
+    captured = {}
+
+    async def _fake_post_form(url, data):
+        captured["data"] = data
+        return {"access_token": "at", "token_type": "Bearer", "expires_in": 3600}
+
+    monkeypatch.setattr(p, "_post_form", _fake_post_form)
+    await p.exchange_code("code", "https://app/cb", code_verifier="V-1")
+    assert captured["data"]["code_verifier"] == "V-1"
+
+
+@pytest.mark.asyncio
+async def test_github_exchange_replays_code_verifier(monkeypatch):
+    from nexus.auth.sso import GitHubProvider
+
+    p = GitHubProvider(client_id="c", client_secret="s")
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at", "token_type": "Bearer", "scope": ""}
+
+    class _Client:
+        async def post(self, url, data=None, headers=None):
+            captured["data"] = data
+            return _Resp()
+
+    async def _get_client():
+        return _Client()
+
+    monkeypatch.setattr(p, "_get_http_client", _get_client)
+    await p.exchange_code("code", "https://app/cb", code_verifier="V-GH")
+    assert captured["data"]["code_verifier"] == "V-GH"
+
+
+# ===========================================================================
+# Provider classes — validate_id_token nonce accept/reject (real crypto)
+# ===========================================================================
+
+
+def test_google_validate_nonce_accept_and_reject(rs256_harness):
+    from nexus.auth.sso import GoogleProvider, SSOAuthError
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(
+            aud="test-client", iss="https://accounts.google.com", nonce="OK"
+        )
+    )
+    assert p.validate_id_token(token, nonce="OK")["nonce"] == "OK"
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+def test_azure_validate_nonce_accept_and_reject(rs256_harness):
+    from nexus.auth.sso import AzureADProvider, SSOAuthError
+
+    p = AzureADProvider(tenant_id="t1", client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(
+            aud="test-client",
+            iss="https://login.microsoftonline.com/t1/v2.0",
+            nonce="OK",
+        )
+    )
+    assert p.validate_id_token(token, nonce="OK")["nonce"] == "OK"
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+def test_apple_validate_nonce_accept_and_reject(es256_harness):
+    from nexus.auth.sso import AppleProvider, SSOAuthError
+
+    p = AppleProvider(
+        team_id="tm",
+        client_id="test-client",
+        key_id="k",
+        private_key=es256_harness.apple_client_secret_key,
+    )
+    _point_jwks(p, es256_harness)
+    token = es256_harness.sign(
+        es256_harness.base_claims(
+            aud="test-client", iss="https://appleid.apple.com", nonce="OK"
+        )
+    )
+    assert p.validate_id_token(token, nonce="OK")["nonce"] == "OK"
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+# ===========================================================================
+# State store — persists code_verifier + nonce
+# ===========================================================================
+
+
+def test_state_store_round_trips_pkce_and_nonce():
+    from nexus.auth.sso import InMemorySSOStateStore
+
+    store = InMemorySSOStateStore()
+    store.store("st", code_verifier="V", nonce="N")
+    data = store.validate_and_consume("st")
+    assert data == {"code_verifier": "V", "nonce": "N"}
+    # single-use
+    assert store.validate_and_consume("st") is None
+
+
+def test_state_store_without_data_is_valid_dict():
+    """A plain CSRF state (no PKCE/nonce) still validates as a truthy dict."""
+    from nexus.auth.sso import InMemorySSOStateStore
+
+    store = InMemorySSOStateStore()
+    store.store("st")
+    data = store.validate_and_consume("st")
+    assert data == {"code_verifier": None, "nonce": None}
+    assert data  # truthy → `if not validate_and_consume(...)` stays correct
+
+
+# ===========================================================================
+# initiate_sso_login — mints + persists PKCE + nonce, emits on the auth URL
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_initiate_oidc_provider_mints_pkce_and_nonce():
+    from nexus.auth.sso import (
+        GoogleProvider,
+        InMemorySSOStateStore,
+        _get_state_store,
+        configure_state_store,
+        initiate_sso_login,
+    )
+
+    configure_state_store(InMemorySSOStateStore())
+    p = GoogleProvider(client_id="c", client_secret="s")
+    resp = await initiate_sso_login(p, "https://app.example.com")
+
+    url = resp.headers["location"]
+    qs = parse_qs(urlparse(url).query)
+    assert qs["code_challenge_method"] == ["S256"]
+    assert qs["code_challenge"][0]
+    assert qs["nonce"][0]  # OIDC provider → nonce emitted
+
+    state = qs["state"][0]
+    data = _get_state_store().validate_and_consume(state)
+    assert data["code_verifier"] and data["nonce"] == qs["nonce"][0]
+
+
+@pytest.mark.asyncio
+async def test_initiate_github_mints_pkce_but_no_nonce():
+    from nexus.auth.sso import (
+        GitHubProvider,
+        InMemorySSOStateStore,
+        _get_state_store,
+        configure_state_store,
+        initiate_sso_login,
+    )
+
+    configure_state_store(InMemorySSOStateStore())
+    p = GitHubProvider(client_id="c", client_secret="s")
+    resp = await initiate_sso_login(p, "https://app.example.com")
+
+    url = resp.headers["location"]
+    qs = parse_qs(urlparse(url).query)
+    assert qs["code_challenge_method"] == ["S256"]
+    assert "nonce" not in qs  # GitHub is not OIDC → no nonce
+
+    state = qs["state"][0]
+    data = _get_state_store().validate_and_consume(state)
+    assert data["code_verifier"] and data["nonce"] is None
+
+
+# ===========================================================================
+# handle_sso_callback — replays verifier + enforces nonce end-to-end
+# ===========================================================================
+
+
+class _FakeJWTMiddleware:
+    def create_access_token(self, **kw):
+        return "access-token"
+
+    def create_refresh_token(self, **kw):
+        return "refresh-token"
+
+
+class _FakeAuthPlugin:
+    _jwt_middleware = _FakeJWTMiddleware()
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_rejects_mismatched_nonce(rs256_harness, monkeypatch):
+    from nexus.auth.sso import (
+        GoogleProvider,
+        InMemorySSOStateStore,
+        SSOAuthError,
+        configure_state_store,
+        handle_sso_callback,
+    )
+    from nexus.auth.sso.base import SSOTokenResponse
+
+    configure_state_store(InMemorySSOStateStore())
+    store = InMemorySSOStateStore()
+    configure_state_store(store)
+    store.store("st", code_verifier="V", nonce="EXPECTED-NONCE")
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    forged = rs256_harness.sign(
+        rs256_harness.base_claims(
+            aud="test-client",
+            iss="https://accounts.google.com",
+            nonce="ATTACKER-NONCE",
+        )
+    )
+    captured = {}
+
+    async def _fake_exchange(code, redirect_uri, code_verifier=None):
+        captured["code_verifier"] = code_verifier
+        return SSOTokenResponse(access_token="at", id_token=forged)
+
+    monkeypatch.setattr(p, "exchange_code", _fake_exchange)
+
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        await handle_sso_callback(p, "code", "st", _FakeAuthPlugin(), "https://app")
+
+    # The verifier was replayed to exchange_code before the nonce gate.
+    assert captured["code_verifier"] == "V"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_accepts_matching_nonce(rs256_harness, monkeypatch):
+    from nexus.auth.sso import (
+        GoogleProvider,
+        InMemorySSOStateStore,
+        configure_state_store,
+        handle_sso_callback,
+    )
+    from nexus.auth.sso.base import SSOTokenResponse
+
+    store = InMemorySSOStateStore()
+    configure_state_store(store)
+    store.store("st", code_verifier="V", nonce="GOOD-NONCE")
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    good = rs256_harness.sign(
+        rs256_harness.base_claims(
+            aud="test-client", iss="https://accounts.google.com", nonce="GOOD-NONCE"
+        )
+    )
+
+    async def _fake_exchange(code, redirect_uri, code_verifier=None):
+        return SSOTokenResponse(access_token="at", id_token=good)
+
+    monkeypatch.setattr(p, "exchange_code", _fake_exchange)
+
+    result = await handle_sso_callback(
+        p, "code", "st", _FakeAuthPlugin(), "https://app"
+    )
+    assert result["access_token"] == "access-token"
+    assert result["user"]["id"] == "user-1834n"

--- a/packages/kailash-nexus/tests/unit/auth/sso/test_sso_providers.py
+++ b/packages/kailash-nexus/tests/unit/auth/sso/test_sso_providers.py
@@ -8,6 +8,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from nexus.auth.sso.base import (
     BaseSSOProvider,
     SSOAuthError,
@@ -735,8 +736,8 @@ class TestStateManagement:
         state = secrets.token_urlsafe(32)
         store.store(state)
 
-        # State can be validated
-        assert store.validate_and_consume(state) is True
+        # State can be validated (returns the stored data dict, not a bool)
+        assert store.validate_and_consume(state) is not None
 
     def test_state_consumed_on_validate(self):
         """State is consumed (removed) after validation."""
@@ -746,9 +747,9 @@ class TestStateManagement:
         store.store("test-state")
 
         # First validation succeeds
-        assert store.validate_and_consume("test-state") is True
+        assert store.validate_and_consume("test-state") is not None
         # State is now consumed
-        assert store.validate_and_consume("test-state") is False
+        assert store.validate_and_consume("test-state") is None
 
     def test_state_one_time_use(self):
         """State cannot be used twice."""
@@ -761,7 +762,7 @@ class TestStateManagement:
         store.validate_and_consume("one-time-state")
 
         # Second use fails
-        assert store.validate_and_consume("one-time-state") is False
+        assert store.validate_and_consume("one-time-state") is None
 
     def test_expired_state_cleanup(self):
         """InMemorySSOStateStore.cleanup() removes expired entries."""
@@ -769,9 +770,9 @@ class TestStateManagement:
 
         store = InMemorySSOStateStore(ttl_seconds=1)
 
-        # Add an expired state (directly manipulate internal store)
-        store._store["expired"] = time.time() - 100
-        store._store["valid"] = time.time()
+        # Add an expired state (directly manipulate internal store; entries are dicts)
+        store._store["expired"] = {"timestamp": time.time() - 100}
+        store._store["valid"] = {"timestamp": time.time()}
 
         store.cleanup()
 

--- a/packages/kailash-nexus/tests/unit/auth/test_security_hardening.py
+++ b/packages/kailash-nexus/tests/unit/auth/test_security_hardening.py
@@ -18,6 +18,7 @@ import logging
 import time
 
 import pytest
+
 from nexus.auth.audit.config import AuditConfig
 from nexus.auth.audit.middleware import AuditMiddleware
 from nexus.auth.rate_limit.backends.memory import InMemoryBackend
@@ -95,33 +96,35 @@ class TestSSOStateStore:
         """Store a state and validate it once."""
         store = InMemorySSOStateStore()
         store.store("test-state-123")
-        assert store.validate_and_consume("test-state-123") is True
+        # validate_and_consume now returns the stored data dict (truthy) on a
+        # valid consume, None on an invalid/expired one.
+        assert store.validate_and_consume("test-state-123") is not None
 
     def test_single_use_consumption(self):
         """State tokens are consumed on first validation (single use)."""
         store = InMemorySSOStateStore()
         store.store("single-use-token")
-        assert store.validate_and_consume("single-use-token") is True
-        assert store.validate_and_consume("single-use-token") is False
+        assert store.validate_and_consume("single-use-token") is not None
+        assert store.validate_and_consume("single-use-token") is None
 
     def test_unknown_state_rejected(self):
         """Unknown state tokens are rejected."""
         store = InMemorySSOStateStore()
-        assert store.validate_and_consume("nonexistent") is False
+        assert store.validate_and_consume("nonexistent") is None
 
     def test_expired_state_rejected(self):
         """Expired state tokens are rejected."""
         store = InMemorySSOStateStore(ttl_seconds=1)
         store.store("will-expire")
-        # Manually backdate the entry
-        store._store["will-expire"] = time.time() - 10
-        assert store.validate_and_consume("will-expire") is False
+        # Manually backdate the entry's timestamp (entries are dicts).
+        store._store["will-expire"]["timestamp"] = time.time() - 10
+        assert store.validate_and_consume("will-expire") is None
 
     def test_cleanup_removes_expired(self):
         """cleanup() removes expired entries."""
         store = InMemorySSOStateStore(ttl_seconds=1)
-        store._store["old"] = time.time() - 10
-        store._store["fresh"] = time.time()
+        store._store["old"] = {"timestamp": time.time() - 10}
+        store._store["fresh"] = {"timestamp": time.time()}
         store.cleanup()
         assert "old" not in store._store
         assert "fresh" in store._store

--- a/packages/kailash-nexus/tests/unit/test_sso_jwt_security.py
+++ b/packages/kailash-nexus/tests/unit/test_sso_jwt_security.py
@@ -20,7 +20,6 @@ jwt_mod = pytest.importorskip("jwt", reason="pyjwt required for JWT security tes
 
 from kailash.trust.auth.jwt import JWTConfig, JWTValidator
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -139,10 +138,10 @@ class TestSSONonceReplay:
         nonce = "test-nonce-123"
         store.store(nonce)
 
-        # First consumption should succeed
-        assert store.validate_and_consume(nonce) is True
+        # First consumption should succeed (returns the stored data dict)
+        assert store.validate_and_consume(nonce) is not None
 
         # Second consumption should fail (replay attack)
         assert (
-            store.validate_and_consume(nonce) is False
-        ), "SSO nonce replay: second consumption should return False"
+            store.validate_and_consume(nonce) is None
+        ), "SSO nonce replay: second consumption should return None"

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -644,6 +644,12 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
         code_verifier, code_challenge = self._pkce_pair()
 
+        # OIDC nonce (id_token replay/injection defense). Azure AD is
+        # OIDC-capable, so mint + cache a nonce; the callback's
+        # ``expected_nonce`` then activates enforcement against the
+        # JWKS-verified id_token in ``_handle_oauth_callback``.
+        nonce = secrets.token_urlsafe(16)
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("azure_client_id"),
@@ -651,6 +657,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "scope": "openid profile email User.Read",
             "state": state,
             "response_mode": "query",
+            "nonce": nonce,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
@@ -663,6 +670,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
             "tenant_id": tenant_id,
+            "nonce": nonce,
             "code_verifier": code_verifier,
         }
 
@@ -681,6 +689,11 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
         code_verifier, code_challenge = self._pkce_pair()
 
+        # OIDC nonce (id_token replay/injection defense). Google is
+        # OIDC-capable; caching the nonce activates callback enforcement
+        # against the JWKS-verified id_token in ``_handle_oauth_callback``.
+        nonce = secrets.token_urlsafe(16)
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("google_client_id"),
@@ -688,6 +701,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "scope": "openid profile email",
             "state": state,
             "access_type": "offline",
+            "nonce": nonce,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
@@ -700,6 +714,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "provider": "google",
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
+            "nonce": nonce,
             "code_verifier": code_verifier,
         }
 
@@ -717,12 +732,18 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # PKCE (RFC 7636) — proof-of-possession binding for the auth-code flow
         code_verifier, code_challenge = self._pkce_pair()
 
+        # OIDC nonce (id_token replay/injection defense). Okta is OIDC-capable;
+        # caching the nonce activates callback enforcement against the
+        # JWKS-verified id_token in ``_handle_oauth_callback``.
+        nonce = secrets.token_urlsafe(16)
+
         auth_params = {
             "response_type": "code",
             "client_id": self.oauth_settings.get("okta_client_id"),
             "redirect_uri": redirect_uri,
             "scope": "openid profile email groups",
             "state": state,
+            "nonce": nonce,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
@@ -735,6 +756,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "timestamp": time.time(),
             "redirect_uri": redirect_uri,
             "okta_domain": okta_domain,
+            "nonce": nonce,
             "code_verifier": code_verifier,
         }
 

--- a/src/kailash/trust/auth/sso/apple.py
+++ b/src/kailash/trust/auth/sso/apple.py
@@ -155,6 +155,7 @@ class AppleProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         response_mode: str = "form_post",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Apple authorization URL.
@@ -164,7 +165,10 @@ class AppleProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes
             response_mode: "query" or "form_post" (recommended)
-            **kwargs: Additional parameters
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (incl. ``nonce`` for OIDC id_token
+                replay defense)
 
         Returns:
             Authorization URL
@@ -180,6 +184,9 @@ class AppleProvider(BaseSSOProvider):
             "state": state,
             "response_mode": response_mode,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -188,12 +195,15 @@ class AppleProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response
@@ -210,6 +220,8 @@ class AppleProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(self.TOKEN_URL, data)
 
@@ -243,18 +255,22 @@ class AppleProvider(BaseSSOProvider):
         self,
         id_token: str,
         user_data: Optional[Dict[str, Any]] = None,
+        nonce: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Validate and decode Apple ID token.
 
         Args:
             id_token: JWT ID token
             user_data: User data from authorization (name, email on first auth)
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises — the id_token replay/injection defense.
 
         Returns:
             Decoded token claims with user data merged
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
 
         Note:
             Apple only sends user's name on FIRST authorization.
@@ -270,6 +286,10 @@ class AppleProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer="https://appleid.apple.com",
             )
+
+            # Nonce enforced ONLY against the verified payload above, before
+            # merging any non-token user_data.
+            self._enforce_nonce(payload, nonce)
 
             if user_data:
                 if "name" in user_data:

--- a/src/kailash/trust/auth/sso/azure.py
+++ b/src/kailash/trust/auth/sso/azure.py
@@ -106,6 +106,7 @@ class AzureADProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         prompt: str = "select_account",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Azure AD authorization URL.
@@ -115,7 +116,10 @@ class AzureADProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes (space-separated)
             prompt: Login prompt behavior (none, login, consent, select_account)
-            **kwargs: Additional parameters (login_hint, domain_hint, etc.)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (login_hint, domain_hint, and
+                ``nonce`` for OIDC id_token replay defense)
 
         Returns:
             Authorization URL
@@ -129,6 +133,9 @@ class AzureADProvider(BaseSSOProvider):
             "response_mode": "query",
             "prompt": prompt,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         base_url = f"{self.AUTHORITY_BASE}/{self.tenant_id}/oauth2/v2.0/authorize"
@@ -138,12 +145,15 @@ class AzureADProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code from callback
             redirect_uri: Same redirect URI used in authorization
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response with access_token and id_token
@@ -160,6 +170,8 @@ class AzureADProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(token_url, data)
 
@@ -196,7 +208,11 @@ class AzureADProvider(BaseSSOProvider):
             raw_data=data,
         )
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode Azure AD ID token.
 
         Validates:
@@ -205,15 +221,19 @@ class AzureADProvider(BaseSSOProvider):
             - Audience (aud claim = client_id)
             - Issuer (iss claim = Azure AD)
             - Tenant ID (tid claim, for multi-tenant)
+            - Nonce (when provided; id_token replay/injection defense)
 
         Args:
             id_token: JWT ID token
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
         """
         try:
             signing_key = self._jwks_client.get_signing_key_from_jwt(id_token)
@@ -234,6 +254,9 @@ class AzureADProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer=issuer,
             )
+
+            # Nonce enforced ONLY against the verified payload above.
+            self._enforce_nonce(payload, nonce)
 
             return payload
 

--- a/src/kailash/trust/auth/sso/base.py
+++ b/src/kailash/trust/auth/sso/base.py
@@ -10,7 +10,10 @@ Evidence:
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
+import secrets
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
@@ -104,6 +107,8 @@ class SSOProvider(Protocol):
         state: str,
         redirect_uri: str,
         scope: Optional[str] = None,
+        code_challenge: Optional[str] = None,
+        nonce: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate authorization URL for OAuth2 flow.
@@ -112,6 +117,12 @@ class SSOProvider(Protocol):
             state: CSRF state parameter
             redirect_uri: Callback URL after authorization
             scope: OAuth2 scopes (optional, uses provider default)
+            code_challenge: PKCE (RFC 7636) S256 code_challenge. When present,
+                the provider MUST emit ``code_challenge`` +
+                ``code_challenge_method=S256`` on the authorization request.
+            nonce: OIDC nonce (id_token replay defense). When present, an
+                OIDC provider MUST emit ``nonce`` so the IdP echoes it into the
+                id_token for later verification in :meth:`validate_id_token`.
             **kwargs: Provider-specific parameters
 
         Returns:
@@ -123,12 +134,16 @@ class SSOProvider(Protocol):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code from callback
             redirect_uri: Same redirect_uri used in authorization
+            code_verifier: PKCE (RFC 7636) code_verifier retained from the
+                authorization request. When present, the provider MUST replay
+                it to the token endpoint so the IdP confirms proof-of-possession.
 
         Returns:
             Token response with access_token and optionally id_token
@@ -152,17 +167,25 @@ class SSOProvider(Protocol):
         """
         ...
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode ID token.
 
         Args:
             id_token: OIDC ID token (JWT)
+            nonce: The nonce minted at authorization time. When present, the
+                provider MUST enforce that the id_token's ``nonce`` claim
+                matches (constant-time), rejecting on mismatch — the id_token
+                replay/injection defense.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If token is invalid
+            SSOAuthError: If token is invalid or the nonce does not match
         """
         ...
 
@@ -174,7 +197,59 @@ class BaseSSOProvider:
         - HTTP client management
         - Common error handling
         - Token validation utilities
+        - PKCE (RFC 7636) pair generation + OIDC nonce enforcement
     """
+
+    #: Whether this provider issues an OIDC id_token (and therefore supports
+    #: nonce enforcement). GitHub OAuth2 has no id_token and overrides this to
+    #: False; callers use it to decide whether to mint + enforce a nonce.
+    supports_id_token: bool = True
+
+    @staticmethod
+    def generate_pkce_pair() -> tuple[str, str]:
+        """Generate a PKCE (RFC 7636) ``(code_verifier, code_challenge)`` pair.
+
+        The verifier is a high-entropy secret the caller retains and replays to
+        the token endpoint via :meth:`exchange_code`; the challenge is its S256
+        (SHA-256, base64url, no padding) transform sent on the authorization
+        request via :meth:`get_authorization_url`. Binding the two proves the
+        client that redeems the authorization code is the same one that
+        requested it, closing the auth-code interception attack on public
+        clients.
+
+        Returns:
+            ``(code_verifier, code_challenge)``
+        """
+        code_verifier = secrets.token_urlsafe(64)
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        return code_verifier, code_challenge
+
+    @staticmethod
+    def _enforce_nonce(claims: Dict[str, Any], nonce: Optional[str]) -> None:
+        """Enforce the OIDC nonce against VERIFIED id_token claims (fail-closed).
+
+        MUST be called only after the id_token signature/aud/iss/exp have been
+        verified — the claims passed here are trusted. When ``nonce`` is
+        provided, the id_token's ``nonce`` claim MUST be a string matching it
+        (compared in constant time); a missing, non-string, or mismatched
+        claim raises :class:`SSOAuthError`. When ``nonce`` is None the check is
+        skipped (no nonce was minted for this flow).
+        """
+        if nonce is None:
+            return
+        import hmac as _hmac
+
+        returned = claims.get("nonce")
+        if not isinstance(returned, str) or not _hmac.compare_digest(returned, nonce):
+            raise SSOAuthError(
+                "OIDC nonce mismatch — id_token nonce claim does not match the "
+                "value minted at authorization time; rejecting authentication "
+                "(possible id_token replay/injection)"
+            )
 
     def __init__(
         self,

--- a/src/kailash/trust/auth/sso/github.py
+++ b/src/kailash/trust/auth/sso/github.py
@@ -46,6 +46,10 @@ class GitHubProvider(BaseSSOProvider):
 
     name = "github"
 
+    # GitHub OAuth2 issues no OIDC id_token, so nonce enforcement does not
+    # apply; PKCE still applies to its authorization-code flow.
+    supports_id_token = False
+
     AUTHORIZATION_URL = "https://github.com/login/oauth/authorize"
     TOKEN_URL = "https://github.com/login/oauth/access_token"
     USERINFO_URL = "https://api.github.com/user"
@@ -77,6 +81,7 @@ class GitHubProvider(BaseSSOProvider):
         redirect_uri: str,
         scope: Optional[str] = None,
         allow_signup: bool = True,
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate GitHub authorization URL.
@@ -86,6 +91,8 @@ class GitHubProvider(BaseSSOProvider):
             redirect_uri: Callback URL
             scope: Override default scopes
             allow_signup: Allow new user signups (default: True)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
             **kwargs: Additional parameters (login hint)
 
         Returns:
@@ -98,6 +105,9 @@ class GitHubProvider(BaseSSOProvider):
             "state": state,
             "allow_signup": str(allow_signup).lower(),
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -106,12 +116,15 @@ class GitHubProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for access token.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response (no id_token for GitHub)
@@ -121,14 +134,18 @@ class GitHubProvider(BaseSSOProvider):
         """
         client = await self._get_http_client()
 
+        token_request_data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        if code_verifier:
+            token_request_data["code_verifier"] = code_verifier
+
         response = await client.post(
             self.TOKEN_URL,
-            data={
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "code": code,
-                "redirect_uri": redirect_uri,
-            },
+            data=token_request_data,
             headers={"Accept": "application/json"},
         )
 

--- a/src/kailash/trust/auth/sso/google.py
+++ b/src/kailash/trust/auth/sso/google.py
@@ -93,6 +93,7 @@ class GoogleProvider(BaseSSOProvider):
         scope: Optional[str] = None,
         access_type: str = "offline",
         prompt: str = "consent",
+        code_challenge: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Generate Google authorization URL.
@@ -103,7 +104,10 @@ class GoogleProvider(BaseSSOProvider):
             scope: Override default scopes
             access_type: "online" or "offline" (for refresh token)
             prompt: "none", "consent", "select_account"
-            **kwargs: Additional parameters (login_hint, hd for G Suite)
+            code_challenge: PKCE (RFC 7636) S256 challenge. When present, emits
+                ``code_challenge`` + ``code_challenge_method=S256``.
+            **kwargs: Additional parameters (login_hint, hd for G Suite, and
+                ``nonce`` for OIDC id_token replay defense)
 
         Returns:
             Authorization URL
@@ -117,6 +121,9 @@ class GoogleProvider(BaseSSOProvider):
             "access_type": access_type,
             "prompt": prompt,
         }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
         params.update(kwargs)
 
         return f"{self.AUTHORIZATION_URL}?{urlencode(params)}"
@@ -125,12 +132,15 @@ class GoogleProvider(BaseSSOProvider):
         self,
         code: str,
         redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> SSOTokenResponse:
         """Exchange authorization code for tokens.
 
         Args:
             code: Authorization code
             redirect_uri: Callback URL
+            code_verifier: PKCE (RFC 7636) verifier replayed to the token
+                endpoint to prove proof-of-possession.
 
         Returns:
             Token response
@@ -145,6 +155,8 @@ class GoogleProvider(BaseSSOProvider):
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
         }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
 
         response = await self._post_form(self.TOKEN_URL, data)
 
@@ -181,17 +193,24 @@ class GoogleProvider(BaseSSOProvider):
             raw_data=data,
         )
 
-    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+    def validate_id_token(
+        self,
+        id_token: str,
+        nonce: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Validate and decode Google ID token.
 
         Args:
             id_token: JWT ID token
+            nonce: The nonce minted at authorization time. When present, the
+                id_token's ``nonce`` claim MUST match (constant-time) or this
+                raises — the id_token replay/injection defense.
 
         Returns:
             Decoded token claims
 
         Raises:
-            SSOAuthError: If validation fails
+            SSOAuthError: If validation fails or the nonce does not match
         """
         try:
             signing_key = self._jwks_client.get_signing_key_from_jwt(id_token)
@@ -203,6 +222,9 @@ class GoogleProvider(BaseSSOProvider):
                 audience=self.client_id,
                 issuer=["https://accounts.google.com", "accounts.google.com"],
             )
+
+            # Nonce enforced ONLY against the verified payload above.
+            self._enforce_nonce(payload, nonce)
 
             return payload
 

--- a/tests/regression/test_issue_1834_sso_pkce_nonce_suite.py
+++ b/tests/regression/test_issue_1834_sso_pkce_nonce_suite.py
@@ -1,0 +1,486 @@
+"""Regression suite for issue #1834 — PKCE + id_token nonce across the SSO
+provider-class suite AND the SSOAuthenticationNode initiators.
+
+Part A: ``kailash.trust.auth.sso`` provider classes (Google/Azure/Apple/GitHub)
+    - ``get_authorization_url`` emits PKCE ``code_challenge`` + ``S256``.
+    - ``exchange_code`` replays the ``code_verifier`` to the token endpoint.
+    - ``validate_id_token(nonce=...)`` ACCEPTS a matching nonce and REJECTS a
+      mismatch, against a REAL RSA/ES256-signed id_token verified via a real
+      in-process JWKS (nothing about the verifier is mocked).
+
+Part B: ``kailash.nodes.auth.sso.SSOAuthenticationNode``
+    - ``_initiate_azure_ad`` / ``_initiate_google`` / ``_initiate_okta`` mint +
+      cache a nonce (previously only ``provider=="oidc"`` did).
+    - ``_handle_oauth_callback`` REJECTS a mismatched nonce for those providers
+      against a real JWKS-verified id_token (the #1835 verified path), and
+      ACCEPTS a matching one.
+
+Follow-up to #1815 (node PKCE+nonce) and #1835 (node JWKS id_token verify).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# Real in-process JWKS harness (RS256 for Google/Azure, ES256 for Apple).
+# Mints a real keypair, serves the public half as a JWKS over loopback so
+# PyJWT's PyJWKClient performs a real fetch, and signs real id_tokens.
+# ---------------------------------------------------------------------------
+
+
+class _JWKSHarness:
+    def __init__(self, alg: str):
+        import jwt
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+        self.alg = alg
+        self.kid = "test-key-1834"
+        if alg == "RS256":
+            self._priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            from jwt.algorithms import RSAAlgorithm
+
+            jwk = json.loads(RSAAlgorithm.to_jwk(self._priv.public_key()))
+        elif alg == "ES256":
+            self._priv = ec.generate_private_key(ec.SECP256R1())
+            from jwt.algorithms import ECAlgorithm
+
+            jwk = json.loads(ECAlgorithm.to_jwk(self._priv.public_key()))
+        else:  # pragma: no cover - test misconfiguration
+            raise ValueError(alg)
+        jwk.update({"kid": self.kid, "use": "sig", "alg": alg})
+        body = json.dumps({"keys": [jwk]}).encode()
+        self._jwt = jwt
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *a):
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        host, port = self._server.server_address
+        self.jwks_uri = f"http://{host}:{port}/jwks"
+        # An EC private key PEM for AppleProvider's client-secret generation.
+        self.apple_client_secret_key = (
+            ec.generate_private_key(ec.SECP256R1())
+            .private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+            .decode()
+        )
+
+    def sign(self, claims: dict) -> str:
+        return self._jwt.encode(
+            claims, self._priv, algorithm=self.alg, headers={"kid": self.kid}
+        )
+
+    def base_claims(self, *, aud: str, iss: str, **overrides) -> dict:
+        now = int(time.time())
+        claims = {
+            "sub": "user-1834",
+            "aud": aud,
+            "iss": iss,
+            "iat": now,
+            "exp": now + 3600,
+            "email": "u@example.com",
+            "name": "User 1834",
+        }
+        claims.update(overrides)
+        return claims
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+@pytest.fixture
+def rs256_harness():
+    h = _JWKSHarness("RS256")
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+@pytest.fixture
+def es256_harness():
+    h = _JWKSHarness("ES256")
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+def _point_jwks(provider, harness):
+    from jwt import PyJWKClient
+
+    provider._jwks_client = PyJWKClient(harness.jwks_uri)
+
+
+# ===========================================================================
+# Part A — provider classes: PKCE on the authorization URL
+# ===========================================================================
+
+
+def test_google_auth_url_emits_pkce_s256():
+    from kailash.trust.auth.sso import GoogleProvider
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url
+    assert "code_challenge_method=S256" in url
+
+
+def test_azure_auth_url_emits_pkce_s256():
+    from kailash.trust.auth.sso import AzureADProvider
+
+    p = AzureADProvider(tenant_id="t1", client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url
+    assert "code_challenge_method=S256" in url
+
+
+def test_apple_auth_url_emits_pkce_s256(es256_harness):
+    from kailash.trust.auth.sso import AppleProvider
+
+    p = AppleProvider(
+        team_id="tm",
+        client_id="test-client",
+        key_id="k",
+        private_key=es256_harness.apple_client_secret_key,
+    )
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url
+    assert "code_challenge_method=S256" in url
+
+
+def test_github_auth_url_emits_pkce_s256():
+    from kailash.trust.auth.sso import GitHubProvider
+
+    p = GitHubProvider(client_id="test-client", client_secret="s")
+    url = p.get_authorization_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="CHAL"
+    )
+    assert "code_challenge=CHAL" in url
+    assert "code_challenge_method=S256" in url
+    # GitHub is not OIDC — nonce enforcement does not apply.
+    assert p.supports_id_token is False
+
+
+def test_pkce_pair_challenge_is_s256_of_verifier():
+    """generate_pkce_pair() produces a valid RFC 7636 S256 challenge."""
+    import base64
+    import hashlib
+
+    from kailash.trust.auth.sso import GoogleProvider
+
+    verifier, challenge = GoogleProvider.generate_pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert challenge == expected
+    assert "=" not in challenge  # no base64 padding
+
+
+# ===========================================================================
+# Part A — provider classes: exchange_code replays code_verifier
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_google_exchange_replays_code_verifier(monkeypatch):
+    from kailash.trust.auth.sso import GoogleProvider
+
+    p = GoogleProvider(client_id="c", client_secret="s")
+    captured = {}
+
+    async def _fake_post_form(url, data):
+        captured["data"] = data
+        return {"access_token": "at", "token_type": "Bearer", "expires_in": 3600}
+
+    monkeypatch.setattr(p, "_post_form", _fake_post_form)
+    await p.exchange_code("code", "https://app/cb", code_verifier="VERIFIER-123")
+    assert captured["data"]["code_verifier"] == "VERIFIER-123"
+
+
+@pytest.mark.asyncio
+async def test_azure_exchange_replays_code_verifier(monkeypatch):
+    from kailash.trust.auth.sso import AzureADProvider
+
+    p = AzureADProvider(tenant_id="t1", client_id="c", client_secret="s")
+    captured = {}
+
+    async def _fake_post_form(url, data):
+        captured["data"] = data
+        return {"access_token": "at", "token_type": "Bearer", "expires_in": 3600}
+
+    monkeypatch.setattr(p, "_post_form", _fake_post_form)
+    await p.exchange_code("code", "https://app/cb", code_verifier="VERIFIER-AZ")
+    assert captured["data"]["code_verifier"] == "VERIFIER-AZ"
+
+
+@pytest.mark.asyncio
+async def test_apple_exchange_replays_code_verifier(monkeypatch, es256_harness):
+    from kailash.trust.auth.sso import AppleProvider
+
+    p = AppleProvider(
+        team_id="tm",
+        client_id="c",
+        key_id="k",
+        private_key=es256_harness.apple_client_secret_key,
+    )
+    captured = {}
+
+    async def _fake_post_form(url, data):
+        captured["data"] = data
+        return {"access_token": "at", "token_type": "Bearer", "expires_in": 3600}
+
+    monkeypatch.setattr(p, "_post_form", _fake_post_form)
+    await p.exchange_code("code", "https://app/cb", code_verifier="VERIFIER-AP")
+    assert captured["data"]["code_verifier"] == "VERIFIER-AP"
+
+
+@pytest.mark.asyncio
+async def test_github_exchange_replays_code_verifier(monkeypatch):
+    from kailash.trust.auth.sso import GitHubProvider
+
+    p = GitHubProvider(client_id="c", client_secret="s")
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "at", "token_type": "Bearer", "scope": ""}
+
+    class _Client:
+        async def post(self, url, data=None, headers=None):
+            captured["data"] = data
+            return _Resp()
+
+    async def _get_client():
+        return _Client()
+
+    monkeypatch.setattr(p, "_get_http_client", _get_client)
+    await p.exchange_code("code", "https://app/cb", code_verifier="VERIFIER-GH")
+    assert captured["data"]["code_verifier"] == "VERIFIER-GH"
+
+
+# ===========================================================================
+# Part A — provider classes: validate_id_token nonce accept/reject
+# (real-signed tokens, real JWKS verification)
+# ===========================================================================
+
+
+def test_google_validate_id_token_nonce_accept_and_reject(rs256_harness):
+    from kailash.trust.auth.sso import GoogleProvider, SSOAuthError
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(
+            aud="test-client", iss="https://accounts.google.com", nonce="NONCE-OK"
+        )
+    )
+    # Accept: matching nonce returns claims.
+    claims = p.validate_id_token(token, nonce="NONCE-OK")
+    assert claims["nonce"] == "NONCE-OK"
+    assert claims["sub"] == "user-1834"
+    # Reject: mismatched nonce raises.
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+def test_google_validate_id_token_missing_nonce_claim_rejected(rs256_harness):
+    """A minted-nonce flow whose id_token carries NO nonce claim fails closed."""
+    from kailash.trust.auth.sso import GoogleProvider, SSOAuthError
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(aud="test-client", iss="https://accounts.google.com")
+    )
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="EXPECTED")
+
+
+def test_google_validate_id_token_no_nonce_when_not_requested(rs256_harness):
+    """nonce=None skips enforcement (no nonce was minted for this flow)."""
+    from kailash.trust.auth.sso import GoogleProvider
+
+    p = GoogleProvider(client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(aud="test-client", iss="https://accounts.google.com")
+    )
+    claims = p.validate_id_token(token)  # nonce defaults to None
+    assert claims["sub"] == "user-1834"
+
+
+def test_azure_validate_id_token_nonce_accept_and_reject(rs256_harness):
+    from kailash.trust.auth.sso import AzureADProvider, SSOAuthError
+
+    p = AzureADProvider(tenant_id="t1", client_id="test-client", client_secret="s")
+    _point_jwks(p, rs256_harness)
+    iss = "https://login.microsoftonline.com/t1/v2.0"
+    token = rs256_harness.sign(
+        rs256_harness.base_claims(aud="test-client", iss=iss, nonce="AZ-NONCE")
+    )
+    claims = p.validate_id_token(token, nonce="AZ-NONCE")
+    assert claims["nonce"] == "AZ-NONCE"
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+def test_apple_validate_id_token_nonce_accept_and_reject(es256_harness):
+    from kailash.trust.auth.sso import AppleProvider, SSOAuthError
+
+    p = AppleProvider(
+        team_id="tm",
+        client_id="test-client",
+        key_id="k",
+        private_key=es256_harness.apple_client_secret_key,
+    )
+    _point_jwks(p, es256_harness)
+    token = es256_harness.sign(
+        es256_harness.base_claims(
+            aud="test-client", iss="https://appleid.apple.com", nonce="AP-NONCE"
+        )
+    )
+    claims = p.validate_id_token(token, nonce="AP-NONCE")
+    assert claims["nonce"] == "AP-NONCE"
+    with pytest.raises(SSOAuthError, match="nonce mismatch"):
+        p.validate_id_token(token, nonce="WRONG")
+
+
+# ===========================================================================
+# Part B — SSOAuthenticationNode: nonce minting + callback enforcement
+# ===========================================================================
+
+
+def _make_node(*, enable_jit_provisioning: bool = True):
+    from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+    # enable_jit_provisioning=False isolates the nonce gate from the unrelated
+    # audit-logger provisioning path (the #1815/#1835 test convention).
+    return SSOAuthenticationNode(
+        name="sso_1834", enable_jit_provisioning=enable_jit_provisioning
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initiator,provider",
+    [
+        ("_initiate_azure_ad", "azure"),
+        ("_initiate_google", "google"),
+        ("_initiate_okta", "okta"),
+    ],
+)
+async def test_node_initiators_mint_and_cache_nonce(initiator, provider):
+    node = _make_node()
+    result = await getattr(node, initiator)("https://app/cb")
+    state = result["state"]
+    # The auth URL carries the nonce, and it is cached for callback enforcement.
+    assert "nonce=" in result["auth_url"]
+    cached = node.provider_cache[state]
+    assert cached["nonce"], f"{provider} initiator must cache a nonce"
+    assert cached["provider"] == provider
+    # PKCE verifier is also cached (from #1815).
+    assert cached["code_verifier"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initiator,provider",
+    [
+        ("_initiate_azure_ad", "azure"),
+        ("_initiate_google", "google"),
+        ("_initiate_okta", "okta"),
+    ],
+)
+async def test_node_callback_rejects_mismatched_nonce(
+    initiator, provider, oidc_jwks_server, monkeypatch
+):
+    node = _make_node()
+    node.oauth_settings.update(
+        {
+            "jwks_uri": oidc_jwks_server.jwks_uri,
+            "issuer": oidc_jwks_server.issuer,
+            f"{provider}_client_id": oidc_jwks_server.audience,
+        }
+    )
+    result = await getattr(node, initiator)("https://app/cb")
+    state = result["state"]
+    expected_nonce = node.provider_cache[state]["nonce"]
+
+    # A real-signed id_token whose nonce does NOT match the minted value.
+    forged = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce="ATTACKER-NONCE"))
+    assert expected_nonce != "ATTACKER-NONCE"
+
+    async def _fake_exchange(prov, code, cached):
+        return {"access_token": "at", "id_token": forged}
+
+    monkeypatch.setattr(node, "_exchange_oauth_code", _fake_exchange)
+
+    with pytest.raises(ValueError, match="nonce"):
+        await node._handle_oauth_callback(
+            provider, {"state": state, "code": "authcode"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_node_callback_accepts_matching_nonce(oidc_jwks_server, monkeypatch):
+    node = _make_node(enable_jit_provisioning=False)
+    node.oauth_settings.update(
+        {
+            "jwks_uri": oidc_jwks_server.jwks_uri,
+            "issuer": oidc_jwks_server.issuer,
+            "google_client_id": oidc_jwks_server.audience,
+        }
+    )
+    result = await node._initiate_google("https://app/cb")
+    state = result["state"]
+    expected_nonce = node.provider_cache[state]["nonce"]
+
+    good = oidc_jwks_server.sign(oidc_jwks_server.base_claims(nonce=expected_nonce))
+
+    async def _fake_exchange(prov, code, cached):
+        return {"access_token": "at", "id_token": good}
+
+    async def _fake_userinfo(prov, access_token):
+        return {"sub": "s", "email": "u@example.com", "name": "U"}
+
+    monkeypatch.setattr(node, "_exchange_oauth_code", _fake_exchange)
+    monkeypatch.setattr(node, "_get_oauth_user_info", _fake_userinfo)
+
+    out = await node._handle_oauth_callback("google", {"state": state, "code": "ac"})
+    assert out["authenticated"] is True


### PR DESCRIPTION
## Summary

Follow-up to #1815 (node PKCE+nonce) and #1835 (node JWKS id_token verify). Two adjacent SSO surfaces were deliberately left out of #1815's literal "minted-but-not-enforced" framing and are brought to parity here.

### Part A — provider classes (`kailash.trust.auth.sso`, mirrored 1:1 in `packages/kailash-nexus/src/nexus/auth/sso`)

- **`BaseSSOProvider`** gains `generate_pkce_pair()` (RFC 7636 S256), a `supports_id_token` class flag, and a shared `_enforce_nonce()` — constant-time (`hmac.compare_digest`), fail-closed.
- **`get_authorization_url()`** emits `code_challenge` + `code_challenge_method=S256` (all providers, incl. GitHub).
- **`exchange_code()`** replays the `code_verifier` to the token endpoint.
- **`validate_id_token(nonce=...)`** enforces the nonce against the **JWKS-verified** claims (google / azure / apple); `GitHubProvider` keeps PKCE but has no nonce (no id_token).
- **nexus `SSOStateStore`** now persists `code_verifier` + `nonce` alongside the CSRF state; `initiate_sso_login` mints + stores them (nonce only for OIDC providers) and `handle_sso_callback` replays the verifier + enforces the nonce.

### Part B — `SSOAuthenticationNode` initiators (`src/kailash/nodes/auth/sso.py`)

- `_initiate_azure_ad` / `_initiate_google` / `_initiate_okta` now mint + cache a nonce, **activating** the existing (#1835 JWKS-verified) callback enforcement that was inert because `expected_nonce` was `None` for those providers. #1835's verified-nonce path is unchanged.

## Files changed

Both **trust** and **nexus** mirrors (provider logic diff between them ≈ zero — verified):

- `src/kailash/trust/auth/sso/{base,google,azure,apple,github}.py`
- `packages/kailash-nexus/src/nexus/auth/sso/{base,google,azure,apple,github,__init__}.py`
- `src/kailash/nodes/auth/sso.py` (Part B)
- Tests: `tests/regression/test_issue_1834_sso_pkce_nonce_suite.py` (trust + node, 21 tests), `packages/kailash-nexus/tests/regression/test_issue_1834_sso_pkce_nonce_suite.py` (nexus mirror + flow, 15 tests)
- Swept `validate_and_consume` return-shape callers (orphan-detection Rule 4b): `packages/kailash-nexus/tests/{unit/auth/test_security_hardening.py, unit/auth/sso/test_sso_providers.py, unit/test_sso_jwt_security.py, integration/auth/test_sso_integration.py}`

## Per-provider status after this change

| Provider | PKCE (S256) | id_token nonce |
| --- | --- | --- |
| Google | ✅ | ✅ enforced |
| Azure AD | ✅ | ✅ enforced |
| Apple | ✅ | ✅ enforced (ES256) |
| GitHub | ✅ | N/A (no id_token) |
| Node azure/google/okta initiators | (already PKCE) | ✅ nonce now minted → enforced |

## User-flow walk (receipt)

WALK 1 — PKCE `code_challenge` + `S256` present on the auth URL (real generated pair):
```
google auth URL: https://accounts.google.com/o/oauth2/v2/auth?...&code_challenge=VNPrIKk_D7IZ5pt4Jszf03V9SQmmgilxKndYpiY6CqM&code_challenge_method=S256&nonce=NONCE123
github auth URL: https://github.com/login/oauth/authorize?...&code_challenge=VNPrIKk_D7IZ5pt4Jszf03V9SQmmgilxKndYpiY6CqM&code_challenge_method=S256
github supports_id_token: False
```

WALK 2 — nonce-mismatch rejection on a REAL RSA/ES256-signed id_token (verifier not mocked):
```
tests/regression/test_issue_1834_sso_pkce_nonce_suite.py -k "nonce_accept_and_reject or callback_rejects"
......                                                                   [100%]
6 passed, 15 deselected in 4.69s
```

## Test evidence

- Root suite (trust providers + node): `21 passed`
- Nexus mirror suite (providers + `initiate`/`handle_sso_callback` flow): `15 passed`
- Existing swept suites: node #1815/#1835 `26 passed`; nexus unit sso `116 passed`; nexus sso integration `16 passed`
- `pre-commit run` on all changed files: Black / isort / Ruff / type-annotations / Tier-1 all **Passed**

## Related issues

Fixes #1834
Refs #1815, #1835