### PR TITLE
release: SSO PKCE+nonce — kailash 2.57.0 + kailash-nexus 2.14.0 (#1834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.57.0] - 2026-07-20
+
+### Added (Security)
+
+- **PKCE (S256) + `id_token` nonce enforcement primitives land on
+  `BaseSSOProvider`; the SSO provider suite adopts them (#1834).**
+  `generate_pkce_pair()` (RFC 7636 `code_verifier`/`code_challenge` pair) and
+  a `supports_id_token` flag are now available on every SSO provider in
+  `kailash.trust.auth.sso`. The google/azure/apple providers enforce the OIDC
+  `nonce` claim against JWKS-verified id_token claims (`_enforce_nonce`,
+  built on the JWKS-backed verifier from #1835); GitHub — which issues no
+  OIDC id_token — sets `supports_id_token = False` and adopts PKCE only.
+  `SSOAuthenticationNode`'s azure/google/okta initiators now mint and cache a
+  nonce per authorization request, activating #1835's callback-side nonce
+  enforcement for the node-based SSO flow.
+
 ## [2.56.0] - 2026-07-19
 
 ### Security

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Nexus Changelog
 
+## [2.14.0] — 2026-07-20 — PKCE + id_token nonce across the SSO provider suite (#1834)
+
+### Added (Security)
+
+- **PKCE + id_token nonce enforcement across the SSO provider suite, with
+  state-store persistence of `code_verifier`/`nonce` (#1834).**
+  `initiate_sso_login` now stores the per-flow PKCE `code_verifier` and OIDC
+  `nonce` alongside the CSRF state token; `complete_sso_login` reads them back
+  from the state store to complete the token exchange (`code_verifier`) and
+  verify the returned `id_token`'s `nonce` claim against JWKS-verified claims
+  (fail-closed on mismatch).
+  **Migration (BREAKING for custom `SSOStateStore` implementers):**
+  `SSOStateStore.store()` gained keyword-only parameters `code_verifier` and
+  `nonce`; `initiate_sso_login` now calls
+  `store.store(state, code_verifier=..., nonce=...)`. A custom store
+  implementing the old `def store(self, state)` signature will raise
+  `TypeError` at login — add `*, code_verifier=None, nonce=None` to your
+  `store()` signature. The `validate_and_consume` return-shape change is
+  backward-tolerant: a legacy store still returning a bare `bool` is treated
+  as carrying no PKCE verifier/nonce (never a silent downgrade of a flow that
+  did mint them), while a dict-returning store's stored values are used.
+
 ## [2.13.0] — 2026-07-19 — `WebhookTransport.receive()` fails closed on missing secret (#1836)
 
 ### Fixed (Security)

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.13.0"
+version = "2.14.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -117,7 +117,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.13.0"
+__version__ = "2.14.0"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.56.0"
+version = "2.57.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.56.0"
+__version__ = "2.57.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep for the #1834 SSO PKCE/nonce work (merged to main via #1863). Version bumps + CHANGELOG only — **no source changes**. Publishing is tag-triggered OIDC per `deploy/deployment-config.md`; this PR does not merge or tag.

| Package | Old | New | Bump |
|---|---|---|---|
| `kailash` (core) | 2.56.0 | **2.57.0** | MINOR |
| `kailash-nexus` | 2.13.0 | **2.14.0** | MINOR |

### kailash 2.57.0
New public API surface: `BaseSSOProvider.generate_pkce_pair()` + `supports_id_token` flag; google/azure/apple SSO providers enforce the OIDC `nonce` claim against JWKS-verified id_token claims; GitHub adopts PKCE only (no id_token). `SSOAuthenticationNode`'s azure/google/okta initiators now mint+cache a nonce, activating #1835's callback-side enforcement for the node path.

### kailash-nexus 2.14.0
PKCE + id_token nonce across the SSO provider suite, with state-store persistence of `code_verifier`/`nonce`.

**BREAKING for custom `SSOStateStore` implementers:** `SSOStateStore.store()` gained keyword-only params `code_verifier` and `nonce`; `initiate_sso_login` now calls `store.store(state, code_verifier=..., nonce=...)`. A custom store implementing the old `def store(self, state)` signature will raise `TypeError` at login — add `*, code_verifier=None, nonce=None` to your `store()` signature. The `validate_and_consume` return-shape change is backward-tolerant (a legacy bool-returning store is treated as carrying no PKCE verifier/nonce, never a silent downgrade).

**Cross-pin check:** `kailash-nexus`'s `kailash>=2.50.0` pin is **unchanged**. Verified `packages/kailash-nexus/src/nexus/auth/sso/` imports nothing new from core kailash for #1834 — `grep -rn "from kailash|import kailash"` over that directory returns zero matches; PKCE generation uses stdlib `secrets`/`base64`/`hashlib` and nonce enforcement (`_enforce_nonce`) operates on already-JWKS-verified claims passed in by the caller.

## Test plan

- [x] Both packages' `pyproject.toml` + `__init__.py::__version__` bumped atomically and grep-verified consistent
- [x] Cross-pin check performed (no pin change needed — evidence above)
- [x] CHANGELOG.md (core) + packages/kailash-nexus/CHANGELOG.md updated, including the breaking-change migration note
- [x] pre-commit hooks passed on commit
- [ ] CI green on this PR (release/* branch — CI-gate auto-skip per repo convention for metadata-only diffs)
- Not merged, not tagged — awaiting human release authorization

Related: #1834