### PR TITLE
feat(eatp): signed RevocationEvent + append-only ledger tip fold (#1842 shard 1/N)

### DIFF
--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -530,6 +530,50 @@ Project Owner (Genesis Record)
 
 **Cascade revocation**: Revoking a delegate revokes all sub-delegates. Uses a WAL (Write-Ahead Log) for crash recovery during cascade operations. WAL hashes are verified with `hmac.compare_digest()`.
 
+### 11.1 Signed Revocation Ledger (EATP-12 D5)
+
+An ADDITIVE signed store lives in `kailash.trust.revocation.signed_ledger`,
+ALONGSIDE the in-memory cascade above (it does NOT replace or rewire it). The
+cascade's own pub/sub `RevocationEvent` is a DIFFERENT type from the signed,
+epoch-keyed `SignedRevocationEvent` here. kailash-rs LEADS the byte contract
+(mint spec is the cross-SDK arbiter, never a sibling issue comment).
+
+**Event signing pre-image.** `SignedRevocationEvent.signing_preimage()` builds
+canonical JSON (JCS: sorted keys, ASCII, no whitespace) of
+`{delegation_id, domain_sep, epoch, revoked_at}`, where `domain_sep` is the
+colon-LESS STRING-FIELD constant `REVOCATION_EVENT_DOMAIN_SEP`
+(`"EATP-12/revocation-event/v1"`). It uses the shared `canonical_json_dumps`
+encoder (`kailash.trust._json`, the raw-UTF-8 JCS family — `ensure_ascii=False`,
+`allow_nan=False`; RFC 8785 JCS emits raw UTF-8, and it is empirically
+byte-identical to the pinned rs pre-image on the all-ASCII conformance vectors).
+`SignedRevocationEvent.sign()` / `.verify()` produce/check an Ed25519 hex
+signature via the `kailash.trust.signing.crypto` primitives. `revoked_at` is
+RFC 3339 with EXACTLY 9 fractional (nanosecond) digits + `Z` and is
+STRING-PRESERVED end-to-end — never parsed to a `datetime` and re-rendered
+(which would microsecond-truncate the nanosecond tail).
+
+**Ledger tip fold.** `revocation_ledger_tip(events)` folds a SHA-256 hash chain:
+`tip_0 = GENESIS_TIP` (32 zero bytes); `tip_i = SHA-256(REVOCATION_LEDGER_DOMAIN
+|| tip_{i-1} || signing_preimage(e_i))`. The domain `REVOCATION_LEDGER_DOMAIN` is
+the RAW-BYTE prefix `b"EATP-12/revocation-ledger/v1:"` — WITH a trailing colon
+(a load-bearing byte separator, contrasting the colon-less event `domain_sep`
+string field). The fold is signature-INDEPENDENT (binds each event's pre-image,
+not its signature) and ORDER-DEPENDENT (reordering or deleting any event changes
+every subsequent tip). `RevocationLedger` wraps the fold with append-only
+enforcement: `append()` fails closed (`RevocationLedgerError`) unless each
+event's `epoch` is strictly greater than the current tip's — no reorder, replay,
+or delete surface.
+
+**Cross-SDK PROVISIONAL tripwires.** The pre-image + signature (RE0-RE3, incl.
+the RE3 nanosecond-fidelity boundary) and tip fold (LT0 all-zero empty, LT1,
+LT2, LT3 reversed-differs) are pinned in
+`tests/regression/test_signed_revocation_ledger_vectors.py` against the
+rs-authored vectors vendored under `tests/test-vectors/`
+(`revocation-event-vectors.json`, `revocation-ledger-tip-vectors.json`) per
+`rules/cross-sdk-inspection.md` Rule 4a. These are PROVISIONAL
+(rs#1849 / rs#1763 OPEN) — re-pin in lockstep if rs changes the reference bytes,
+per `rules/cross-sdk-inspection.md` Rule 4b.
+
 **Valid dimensions**: `{"operational", "data_access", "financial", "temporal", "communication"}`.
 
 ---

--- a/src/kailash/trust/revocation/__init__.py
+++ b/src/kailash/trust/revocation/__init__.py
@@ -76,6 +76,15 @@ from kailash.trust.revocation.broadcaster import (
     TrustRevocationList,
 )
 from kailash.trust.revocation.cascade import RevocationResult, cascade_revoke
+from kailash.trust.revocation.signed_ledger import (
+    GENESIS_TIP,
+    REVOCATION_EVENT_DOMAIN_SEP,
+    REVOCATION_LEDGER_DOMAIN,
+    RevocationLedger,
+    RevocationLedgerError,
+    SignedRevocationEvent,
+    revocation_ledger_tip,
+)
 
 __all__ = [
     # Enums
@@ -100,4 +109,12 @@ __all__ = [
     "cascade_revoke",
     # Trust Revocation List
     "TrustRevocationList",
+    # Signed revocation ledger (EATP-12 D5)
+    "SignedRevocationEvent",
+    "RevocationLedger",
+    "RevocationLedgerError",
+    "revocation_ledger_tip",
+    "REVOCATION_EVENT_DOMAIN_SEP",
+    "REVOCATION_LEDGER_DOMAIN",
+    "GENESIS_TIP",
 ]

--- a/src/kailash/trust/revocation/signed_ledger.py
+++ b/src/kailash/trust/revocation/signed_ledger.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Sequence
 
 from kailash.trust._json import canonical_json_dumps
+from kailash.trust.exceptions import InvalidSignatureError
 from kailash.trust.signing import crypto
 
 logger = logging.getLogger(__name__)
@@ -119,8 +120,14 @@ class SignedRevocationEvent:
             raise RevocationLedgerError(
                 f"epoch must be an int, got {type(self.epoch).__name__}"
             )
-        if self.epoch < 0:
-            raise RevocationLedgerError(f"epoch must be >= 0, got {self.epoch}")
+        # Unified u64 epoch: rs LEADS and parses it into a u64, so an
+        # out-of-u64-range value serializes as a JSON number rs cannot ingest,
+        # making the folded tip unreproducible cross-SDK. Fail closed on both
+        # bounds.
+        if not (0 <= self.epoch < 2**64):
+            raise RevocationLedgerError(
+                f"epoch must be in the u64 range [0, 2**64), got {self.epoch}"
+            )
         if not isinstance(self.revoked_at, str) or not _REVOKED_AT_RE.match(
             self.revoked_at
         ):
@@ -174,10 +181,19 @@ class SignedRevocationEvent:
 
         Returns:
             True iff the signature is valid for this event's pre-image.
+            Fail-closed: a malformed / short / non-hex / wrong-length
+            ``signature_hex`` returns False (never raises an off-contract
+            ``ValueError`` / ``InvalidSignatureError``).
         """
-        b64_pub = base64.b64encode(public_key).decode("ascii")
-        b64_sig = base64.b64encode(bytes.fromhex(signature_hex)).decode("ascii")
-        return crypto.verify_signature(self.signing_preimage(), b64_sig, b64_pub)
+        try:
+            sig_bytes = bytes.fromhex(signature_hex)
+            b64_pub = base64.b64encode(public_key).decode("ascii")
+            b64_sig = base64.b64encode(sig_bytes).decode("ascii")
+            return crypto.verify_signature(self.signing_preimage(), b64_sig, b64_pub)
+        except (ValueError, TypeError, InvalidSignatureError):
+            # Malformed hex (ValueError/TypeError) OR a wrong-length signature
+            # the crypto layer rejects (InvalidSignatureError) → fail closed.
+            return False
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a JSON-friendly dict."""
@@ -189,7 +205,15 @@ class SignedRevocationEvent:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SignedRevocationEvent":
-        """Reconstruct from a dict (validates via ``__post_init__``)."""
+        """Reconstruct from a dict (validates via ``__post_init__``).
+
+        Raises:
+            RevocationLedgerError: If a required field is missing (typed, names
+                the field) — not a bare ``KeyError``.
+        """
+        for field_name in ("delegation_id", "epoch", "revoked_at"):
+            if field_name not in data:
+                raise RevocationLedgerError(f"missing required field {field_name!r}")
         return cls(
             delegation_id=data["delegation_id"],
             epoch=data["epoch"],

--- a/src/kailash/trust/revocation/signed_ledger.py
+++ b/src/kailash/trust/revocation/signed_ledger.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""EATP-12 D5 signed RevocationEvent + append-only revocation-ledger tip fold.
+
+This module implements the cross-SDK byte contract for the persisted-head
+``revocation_ledger_tip`` (kailash-rs LEADS; see ``specs/trust-eatp.md``
+§ "Revocation Ledger — Signed Store (S1)"). It is an ADDITIVE standalone store
+that lives ALONGSIDE the in-memory pub/sub cascade in
+``kailash.trust.revocation.broadcaster`` / ``.cascade`` — it does NOT replace or
+rewire them. The runtime cascade's own ``RevocationEvent`` (pub/sub notification
+record) is a DIFFERENT type from :class:`SignedRevocationEvent` here (the signed,
+epoch-keyed ledger entry).
+
+Two byte contracts, DISTINCT by design:
+
+* **Event signing pre-image** — canonical JSON (JCS: sorted keys, no whitespace)
+  of ``{delegation_id, domain_sep, epoch, revoked_at}`` where ``domain_sep`` is
+  the colon-LESS STRING FIELD :data:`REVOCATION_EVENT_DOMAIN_SEP`
+  (``"EATP-12/revocation-event/v1"``). Produced via
+  ``kailash.trust._json.canonical_json_dumps`` (the DELEGATE / raw-UTF-8 JCS
+  family — RFC 8785 emits raw UTF-8, not ``\\uXXXX`` escapes; empirically
+  byte-identical to the pinned rs pre-image on the all-ASCII conformance
+  vectors). Signed with Ed25519 via the shared
+  ``kailash.trust.signing.crypto`` primitives.
+
+* **Ledger tip fold** — a SHA-256 hash chain domain-separated by the RAW-BYTE
+  prefix :data:`REVOCATION_LEDGER_DOMAIN` (``b"EATP-12/revocation-ledger/v1:"``
+  — WITH a trailing colon, contrasting the colon-less event ``domain_sep``
+  string field). ``tip_0 = 32 zero bytes``; ``tip_i = SHA-256(DOMAIN ||
+  tip_{i-1} || signing_preimage(e_i))``. Signature-INDEPENDENT: the fold binds
+  each event's signing pre-image, NOT its Ed25519 signature, so a following SDK
+  reproduces the tip from ``{delegation_id, epoch, revoked_at}`` inputs alone.
+  The fold is ORDER-DEPENDENT — reordering or deleting any event changes every
+  subsequent tip (the revocation-deletion / reorder detection the persisted-head
+  signature relies on).
+
+The timestamp ``revoked_at`` is RFC 3339 with EXACTLY 9 fractional (nanosecond)
+digits + ``Z``, and is STRING-PRESERVED end-to-end — never parsed to a
+``datetime`` and re-rendered (that would microsecond-truncate the nanosecond
+tail and diverge the pre-image from the rs bytes).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence
+
+from kailash.trust._json import canonical_json_dumps
+from kailash.trust.signing import crypto
+
+logger = logging.getLogger(__name__)
+
+# --- Domain constants (cross-SDK byte contract; kailash-rs LEADS) ------------
+
+#: JCS ``domain_sep`` STRING FIELD value inside the event pre-image. Colon-LESS
+#: (it is the VALUE of a JSON field, never a byte prefix). Contrast
+#: :data:`REVOCATION_LEDGER_DOMAIN`.
+REVOCATION_EVENT_DOMAIN_SEP = "EATP-12/revocation-event/v1"
+
+#: RAW-BYTE domain prefix for the ledger tip hash chain. WITH a trailing colon
+#: (``:``) — a deliberate, load-bearing byte separator, UNLIKE the colon-less
+#: JCS ``domain_sep`` string field above. Distinct from every per-record domain
+#: so the ledger tip can never collide with a single record's signing pre-image.
+REVOCATION_LEDGER_DOMAIN = b"EATP-12/revocation-ledger/v1:"
+
+#: Genesis / empty-ledger tip: 32 zero bytes (matches the epoch-0 genesis
+#: ``HeadCommitment``).
+GENESIS_TIP = bytes(32)
+
+# RFC 3339, EXACTLY 9 fractional (nanosecond) digits, UTC ``Z``. The fold pins
+# nanosecond fidelity (RE3 / boundary vectors), so a malformed or truncated
+# timestamp MUST fail closed rather than silently normalize.
+_REVOKED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z$")
+
+
+class RevocationLedgerError(ValueError):
+    """Raised on a malformed signed revocation event or an append-only violation."""
+
+
+@dataclass(frozen=True)
+class SignedRevocationEvent:
+    """A signed, epoch-keyed revocation-ledger entry (EATP-12 D5).
+
+    Frozen: the signing pre-image is a byte-for-byte cross-SDK contract, so an
+    instance MUST be immutable once constructed (mutation would silently
+    invalidate a produced signature / folded tip).
+
+    Args:
+        delegation_id: The revoked delegation's identifier.
+        epoch: The unified ``u64`` epoch at which the revocation was recorded
+            (the SAME counter the head commitment folds). MUST be a non-negative
+            ``int`` (``bool`` is rejected — it is an ``int`` subclass that would
+            serialize as ``true``/``false``).
+        revoked_at: RFC 3339 timestamp with EXACTLY 9 fractional (nanosecond)
+            digits + ``Z`` (e.g. ``"2026-07-17T12:34:56.123456789Z"``). Stored
+            and serialized verbatim — never re-rendered from a ``datetime``.
+
+    Raises:
+        RevocationLedgerError: If any field is malformed (fail-closed).
+    """
+
+    delegation_id: str
+    epoch: int
+    revoked_at: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.delegation_id, str) or not self.delegation_id:
+            raise RevocationLedgerError(
+                f"delegation_id must be a non-empty str, got {self.delegation_id!r}"
+            )
+        # bool is a subclass of int; reject it explicitly so it can never
+        # serialize as a JSON boolean in the epoch slot.
+        if not isinstance(self.epoch, int) or isinstance(self.epoch, bool):
+            raise RevocationLedgerError(
+                f"epoch must be an int, got {type(self.epoch).__name__}"
+            )
+        if self.epoch < 0:
+            raise RevocationLedgerError(f"epoch must be >= 0, got {self.epoch}")
+        if not isinstance(self.revoked_at, str) or not _REVOKED_AT_RE.match(
+            self.revoked_at
+        ):
+            raise RevocationLedgerError(
+                "revoked_at must be RFC 3339 with 9 fractional (nanosecond) "
+                f"digits + 'Z' (e.g. '2026-07-17T00:00:00.000000000Z'), "
+                f"got {self.revoked_at!r}"
+            )
+
+    def signing_preimage(self) -> str:
+        """Return the canonical-JSON signing pre-image string.
+
+        JCS: sorted keys, ASCII, no whitespace, of
+        ``{delegation_id, domain_sep, epoch, revoked_at}`` with ``domain_sep`` =
+        :data:`REVOCATION_EVENT_DOMAIN_SEP`. Uses the shared
+        ``canonical_json_dumps`` encoder (raw-UTF-8 JCS family, ``allow_nan``
+        already False).
+        """
+        return canonical_json_dumps(
+            {
+                "delegation_id": self.delegation_id,
+                "domain_sep": REVOCATION_EVENT_DOMAIN_SEP,
+                "epoch": self.epoch,
+                "revoked_at": self.revoked_at,
+            }
+        )
+
+    def signing_preimage_bytes(self) -> bytes:
+        """Return the UTF-8 bytes of :meth:`signing_preimage` (the folded operand)."""
+        return self.signing_preimage().encode("utf-8")
+
+    def sign(self, private_key_seed: bytes) -> str:
+        """Ed25519-sign the pre-image; return the signature as lowercase hex.
+
+        Args:
+            private_key_seed: The 32-byte Ed25519 seed (RFC 8032 secret key).
+
+        Returns:
+            The 64-byte Ed25519 signature, lowercase hex-encoded.
+        """
+        b64_priv = base64.b64encode(private_key_seed).decode("ascii")
+        b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        return base64.b64decode(b64_sig).hex()
+
+    def verify(self, signature_hex: str, public_key: bytes) -> bool:
+        """Verify a hex Ed25519 signature over this event's pre-image.
+
+        Args:
+            signature_hex: Lowercase-hex 64-byte Ed25519 signature.
+            public_key: The 32-byte Ed25519 public key.
+
+        Returns:
+            True iff the signature is valid for this event's pre-image.
+        """
+        b64_pub = base64.b64encode(public_key).decode("ascii")
+        b64_sig = base64.b64encode(bytes.fromhex(signature_hex)).decode("ascii")
+        return crypto.verify_signature(self.signing_preimage(), b64_sig, b64_pub)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "delegation_id": self.delegation_id,
+            "epoch": self.epoch,
+            "revoked_at": self.revoked_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SignedRevocationEvent":
+        """Reconstruct from a dict (validates via ``__post_init__``)."""
+        return cls(
+            delegation_id=data["delegation_id"],
+            epoch=data["epoch"],
+            revoked_at=data["revoked_at"],
+        )
+
+
+def revocation_ledger_tip(events: Sequence[SignedRevocationEvent]) -> bytes:
+    """Fold a sequence of signed revocation events into the 32-byte ledger tip.
+
+    The fold is the SHA-256 hash chain (cross-SDK byte contract, kailash-rs
+    LEADS)::
+
+        tip_0 = GENESIS_TIP                                         (empty ledger)
+        tip_i = SHA-256( REVOCATION_LEDGER_DOMAIN
+                         || tip_{i-1}
+                         || e_i.signing_preimage_bytes() )   for i = 1..=n
+
+    Folds events in the ORDER GIVEN — it is signature-INDEPENDENT (binds each
+    event's signing pre-image, not its signature) and ORDER-DEPENDENT (reordering
+    or removing any event changes every subsequent tip). In canonical operation
+    the events are in epoch-ascending order (see :class:`RevocationLedger`, which
+    enforces that on append); this pure function folds whatever order it is
+    handed so callers can verify order-dependence.
+
+    Args:
+        events: The revocation events, in fold order.
+
+    Returns:
+        The 32-byte running tip (``GENESIS_TIP`` for an empty sequence).
+    """
+    tip = GENESIS_TIP
+    for event in events:
+        tip = hashlib.sha256(
+            REVOCATION_LEDGER_DOMAIN + tip + event.signing_preimage_bytes()
+        ).digest()
+    return tip
+
+
+class RevocationLedger:
+    """Append-only revocation ledger with an epoch-ascending tip fold.
+
+    Enforces the canonical append-only invariant: each appended event MUST carry
+    a strictly-greater ``epoch`` than the previous one (a distinct unified epoch
+    per authenticated state change), so events can never be reordered or
+    re-inserted out of order, and there is NO delete/mutate surface. The tip is
+    :func:`revocation_ledger_tip` over the internal ascending sequence.
+    """
+
+    def __init__(self) -> None:
+        self._events: List[SignedRevocationEvent] = []
+
+    def append(self, event: SignedRevocationEvent) -> None:
+        """Append an event, enforcing strictly-ascending epoch (append-only).
+
+        Raises:
+            RevocationLedgerError: If ``event.epoch`` is not strictly greater than
+                the last appended event's epoch (fail-closed on reorder / replay).
+        """
+        if self._events and event.epoch <= self._events[-1].epoch:
+            raise RevocationLedgerError(
+                f"append-only violation: epoch {event.epoch} is not strictly "
+                f"greater than the current tip epoch {self._events[-1].epoch}"
+            )
+        self._events.append(event)
+
+    @property
+    def events(self) -> tuple[SignedRevocationEvent, ...]:
+        """The appended events, in epoch-ascending order (immutable view)."""
+        return tuple(self._events)
+
+    def tip(self) -> bytes:
+        """Return the current 32-byte ledger tip over the ascending sequence."""
+        return revocation_ledger_tip(self._events)
+
+    def tip_hex(self) -> str:
+        """Return :meth:`tip` as lowercase hex."""
+        return self.tip().hex()
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+
+__all__ = [
+    "REVOCATION_EVENT_DOMAIN_SEP",
+    "REVOCATION_LEDGER_DOMAIN",
+    "GENESIS_TIP",
+    "RevocationLedgerError",
+    "SignedRevocationEvent",
+    "revocation_ledger_tip",
+    "RevocationLedger",
+]

--- a/tests/regression/test_signed_revocation_ledger_vectors.py
+++ b/tests/regression/test_signed_revocation_ledger_vectors.py
@@ -194,3 +194,58 @@ def test_malformed_event_fails_closed() -> None:
     with pytest.raises(RevocationLedgerError):
         # bool epoch must not slip through the int check.
         SignedRevocationEvent("del-x", True, "2026-07-17T00:00:00.000000000Z")
+
+
+# --- Crypto-review hardening -------------------------------------------------
+
+
+def test_epoch_u64_range_enforced_fail_closed() -> None:
+    """A u64 epoch is fail-closed at both bounds: ``2**64`` (out of range)
+    raises; ``2**64 - 1`` (max u64) is accepted. An oversized epoch would
+    serialize as a JSON number rs cannot parse into a u64, making the folded
+    tip unreproducible cross-SDK."""
+    with pytest.raises(RevocationLedgerError, match="u64 range"):
+        SignedRevocationEvent("del-x", 2**64, "2026-07-17T00:00:00.000000000Z")
+    ok = SignedRevocationEvent("del-x", 2**64 - 1, "2026-07-17T00:00:00.000000000Z")
+    assert ok.epoch == 2**64 - 1
+
+
+def test_verify_fails_closed_on_malformed_signature_hex() -> None:
+    """``verify()`` returns False (never raises) on malformed / short / non-hex
+    signature input — fail-closed, not an off-contract ValueError."""
+    event = SignedRevocationEvent("del-0001", 2, "2026-07-17T00:00:00.000000000Z")
+    assert event.verify("not-hex-!!", _PUBLIC_KEY) is False
+    assert event.verify("dead", _PUBLIC_KEY) is False  # valid hex, wrong length
+    assert event.verify("", _PUBLIC_KEY) is False
+    assert event.verify("abc", _PUBLIC_KEY) is False  # odd-length hex
+
+
+def test_from_dict_missing_field_raises_typed_error() -> None:
+    """``from_dict`` raises the typed ``RevocationLedgerError`` naming the
+    missing field, not a bare ``KeyError``."""
+    base = {
+        "delegation_id": "del-0001",
+        "epoch": 2,
+        "revoked_at": "2026-07-17T00:00:00.000000000Z",
+    }
+    # Round-trip sanity.
+    assert SignedRevocationEvent.from_dict(base).to_dict() == base
+    for missing in ("delegation_id", "epoch", "revoked_at"):
+        partial = {k: v for k, v in base.items() if k != missing}
+        with pytest.raises(RevocationLedgerError, match=missing):
+            SignedRevocationEvent.from_dict(partial)
+
+
+def test_duplicate_delegation_id_across_epochs_accepted() -> None:
+    """A re-revocation event for an already-revoked delegation_id at a later
+    epoch is a legitimate append (duplicate delegation_id across epochs is
+    intended, not blocked)."""
+    ledger = RevocationLedger()
+    ledger.append(
+        SignedRevocationEvent("del-0001", 2, "2026-07-17T00:00:00.000000000Z")
+    )
+    ledger.append(
+        SignedRevocationEvent("del-0001", 5, "2026-07-17T00:00:00.000000000Z")
+    )
+    assert len(ledger) == 2
+    assert [e.delegation_id for e in ledger.events] == ["del-0001", "del-0001"]

--- a/tests/regression/test_signed_revocation_ledger_vectors.py
+++ b/tests/regression/test_signed_revocation_ledger_vectors.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-SDK PROVISIONAL tripwire vectors for the EATP-12 D5 signed
+RevocationEvent pre-image + Ed25519 signature AND the append-only
+revocation-ledger tip fold.
+
+kailash-rs LEADS and authored the reference bytes (rs#1849 / rs#1763 OPEN — these
+vectors are PROVISIONAL; re-pin in lockstep if rs changes them, per
+``cross-sdk-inspection.md`` Rule 4b). These assert the Python production path
+reproduces the pinned rs bytes BYTE-FOR-BYTE:
+
+* ``RevocationEvent`` (RE0-RE3): pre-image string + Ed25519 signature hex, incl.
+  the RE3 nanosecond-fidelity boundary vector.
+* Ledger tip fold (LT0-LT3): LT0 all-zero empty tip, LT1 single, LT2 two ascending,
+  LT3 two reversed (a DIFFERENT tip — pins order-dependence).
+
+The vectors are vendored (per ``cross-sdk-inspection.md`` Rule 4a) into
+``tests/test-vectors/`` from the rs-authored reference set. Real crypto, no
+mocking (testing.md Tier 2/3).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kailash.trust.revocation.signed_ledger import (
+    GENESIS_TIP,
+    RevocationLedger,
+    RevocationLedgerError,
+    SignedRevocationEvent,
+    revocation_ledger_tip,
+)
+
+pytestmark = pytest.mark.regression
+
+_REF_DIR = Path(__file__).resolve().parents[1] / "test-vectors"
+_EVENT_VECTORS = json.loads(
+    (_REF_DIR / "revocation-event-vectors.json").read_text(encoding="utf-8")
+)
+_TIP_VECTORS = json.loads(
+    (_REF_DIR / "revocation-ledger-tip-vectors.json").read_text(encoding="utf-8")
+)
+
+# RFC 8032 §7.1 Test 1 keypair (cross-SDK byte-shape fixtures only; never live signing).
+_SECRET_SEED = bytes.fromhex(_EVENT_VECTORS["keypair"]["secret_key_hex"])
+_PUBLIC_KEY = bytes.fromhex(_EVENT_VECTORS["keypair"]["public_key_hex"])
+
+
+def _event_from_vector(vec: dict) -> SignedRevocationEvent:
+    return SignedRevocationEvent(
+        delegation_id=vec["input"]["delegation_id"],
+        epoch=vec["input"]["epoch"],
+        revoked_at=vec["input"]["revoked_at"],
+    )
+
+
+# --- RevocationEvent pre-image + signature (RE0-RE3) -------------------------
+
+
+@pytest.mark.parametrize(
+    "vec", _EVENT_VECTORS["vectors"], ids=[v["id"] for v in _EVENT_VECTORS["vectors"]]
+)
+def test_revocation_event_preimage_matches_pinned(vec: dict) -> None:
+    """The canonical JCS pre-image string EQUALS the pinned rs bytes."""
+    event = _event_from_vector(vec)
+    preimage = event.signing_preimage()
+    assert preimage == vec["expected_canonical_preimage"], (
+        f"{vec['id']}: pre-image diverged from pinned rs bytes\n"
+        f"  got:      {preimage!r}\n"
+        f"  expected: {vec['expected_canonical_preimage']!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "vec", _EVENT_VECTORS["vectors"], ids=[v["id"] for v in _EVENT_VECTORS["vectors"]]
+)
+def test_revocation_event_signature_matches_pinned(vec: dict) -> None:
+    """Ed25519 signature (hex) over the pre-image EQUALS the pinned rs bytes."""
+    event = _event_from_vector(vec)
+    signature_hex = event.sign(_SECRET_SEED)
+    assert signature_hex == vec["expected_signature_hex"], (
+        f"{vec['id']}: signature diverged from pinned rs bytes\n"
+        f"  got:      {signature_hex}\n"
+        f"  expected: {vec['expected_signature_hex']}"
+    )
+    # Round-trip: the pinned signature verifies against the pinned public key.
+    assert event.verify(vec["expected_signature_hex"], _PUBLIC_KEY)
+
+
+def test_re3_nanosecond_fidelity_preserved() -> None:
+    """RE3 pins that the 9-digit nanosecond tail is STRING-PRESERVED, not
+    microsecond-truncated — the pre-image + signature only match if the full
+    nanosecond timestamp survives verbatim."""
+    re3 = next(v for v in _EVENT_VECTORS["vectors"] if v["id"].startswith("RE3"))
+    event = _event_from_vector(re3)
+    # The nanosecond tail is carried verbatim (9 fractional digits).
+    assert event.revoked_at == "2026-07-17T12:34:56.123456789Z"
+    assert "123456789" in event.signing_preimage()
+    assert event.sign(_SECRET_SEED) == re3["expected_signature_hex"]
+
+
+# --- Ledger tip fold (LT0-LT3) ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "vec", _TIP_VECTORS["vectors"], ids=[v["id"] for v in _TIP_VECTORS["vectors"]]
+)
+def test_revocation_ledger_tip_matches_pinned(vec: dict) -> None:
+    """The folded tip EQUALS the pinned rs tip hex (LT0 empty all-zero,
+    LT1 single, LT2 two ascending, LT3 two reversed)."""
+    events = [
+        SignedRevocationEvent(
+            delegation_id=e["delegation_id"],
+            epoch=e["epoch"],
+            revoked_at=e["revoked_at"],
+        )
+        for e in vec["events"]
+    ]
+    tip_hex = revocation_ledger_tip(events).hex()
+    assert tip_hex == vec["expected_tip_hex"], (
+        f"{vec['id']}: ledger tip diverged from pinned rs bytes\n"
+        f"  got:      {tip_hex}\n"
+        f"  expected: {vec['expected_tip_hex']}"
+    )
+
+
+def test_lt0_empty_ledger_is_all_zero_tip() -> None:
+    """LT0: an empty ledger folds to the 32-zero-byte genesis tip."""
+    lt0 = next(v for v in _TIP_VECTORS["vectors"] if v["id"].startswith("LT0"))
+    assert revocation_ledger_tip([]) == GENESIS_TIP
+    assert GENESIS_TIP.hex() == lt0["expected_tip_hex"]
+    assert RevocationLedger().tip() == GENESIS_TIP
+
+
+def test_lt3_order_dependence_reversed_differs_from_ascending() -> None:
+    """LT3 vs LT2: the SAME two events in reversed order fold to a DIFFERENT
+    tip — the fold is order-dependent (reorder/delete detection)."""
+    lt2 = next(v for v in _TIP_VECTORS["vectors"] if v["id"].startswith("LT2"))
+    lt3 = next(v for v in _TIP_VECTORS["vectors"] if v["id"].startswith("LT3"))
+
+    def _fold(vec: dict) -> str:
+        events = [
+            SignedRevocationEvent(
+                delegation_id=e["delegation_id"],
+                epoch=e["epoch"],
+                revoked_at=e["revoked_at"],
+            )
+            for e in vec["events"]
+        ]
+        return revocation_ledger_tip(events).hex()
+
+    ascending = _fold(lt2)
+    reversed_ = _fold(lt3)
+    assert ascending != reversed_, "fold MUST be order-dependent (LT2 != LT3)"
+    assert ascending == lt2["expected_tip_hex"]
+    assert reversed_ == lt3["expected_tip_hex"]
+
+
+# --- Append-only enforcement -------------------------------------------------
+
+
+def test_ledger_append_enforces_strictly_ascending_epoch() -> None:
+    """The ledger rejects a non-ascending epoch on append (no reorder/replay);
+    the canonical ascending path reproduces the LT2 tip."""
+    ledger = RevocationLedger()
+    ledger.append(
+        SignedRevocationEvent("del-0001", 2, "2026-07-17T00:00:00.000000000Z")
+    )
+    # Replaying / reordering a lower-or-equal epoch is a fail-closed violation.
+    with pytest.raises(RevocationLedgerError, match="append-only violation"):
+        ledger.append(
+            SignedRevocationEvent("del-0001", 2, "2026-07-17T00:00:00.000000000Z")
+        )
+    ledger.append(
+        SignedRevocationEvent("del-0002", 3, "2026-07-17T00:00:00.000000000Z")
+    )
+    lt2 = next(v for v in _TIP_VECTORS["vectors"] if v["id"].startswith("LT2"))
+    assert ledger.tip_hex() == lt2["expected_tip_hex"]
+
+
+def test_malformed_event_fails_closed() -> None:
+    """Malformed events are rejected at construction (fail-closed)."""
+    with pytest.raises(RevocationLedgerError):
+        SignedRevocationEvent("", 0, "2026-07-17T00:00:00.000000000Z")
+    with pytest.raises(RevocationLedgerError):
+        SignedRevocationEvent("del-x", -1, "2026-07-17T00:00:00.000000000Z")
+    with pytest.raises(RevocationLedgerError):
+        # microsecond (6-digit) timestamp — would truncate nanosecond fidelity.
+        SignedRevocationEvent("del-x", 0, "2026-07-17T00:00:00.000000Z")
+    with pytest.raises(RevocationLedgerError):
+        # bool epoch must not slip through the int check.
+        SignedRevocationEvent("del-x", True, "2026-07-17T00:00:00.000000000Z")

--- a/tests/test-vectors/revocation-event-vectors.json
+++ b/tests/test-vectors/revocation-event-vectors.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "contract": "revocation-event-v1",
+  "description": "Cross-SDK reference vectors for the EATP-12 D5 signed RevocationEvent pre-image + Ed25519 signature (kailash-rs LEADS). The signing pre-image is canonical-JSON (JCS-sorted keys, ASCII-only, no whitespace) of {delegation_id, domain_sep, epoch, revoked_at} with the timestamp as RFC 3339 fixed 9-digit nanoseconds + Z. The record is keyed by delegation_id and carries the unified u64 epoch (the SAME counter the head commitment folds). GENERATED from crates/eatp/src/vault/epoch_anchor.rs — do NOT hand-edit; regenerate via `cargo run -p eatp --example gen_epoch_anchor_vectors`. Pinned by tests/epoch_anchor_vectors.rs.",
+  "domain_sep": "EATP-12/revocation-event/v1",
+  "keypair": {
+    "comment": "RFC 8032 §7.1 Test 1 secret key. Cross-SDK byte-shape fixtures only; never live signing.",
+    "secret_key_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+    "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+  },
+  "vectors": [
+    {
+      "id": "RE0-epoch0-sentinel",
+      "description": "Sentinel: revocation recorded at genesis epoch=0 (edge — a delegation revoked before any advance).",
+      "input": {
+        "delegation_id": "del-0000",
+        "epoch": 0,
+        "revoked_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"delegation_id\":\"del-0000\",\"domain_sep\":\"EATP-12/revocation-event/v1\",\"epoch\":0,\"revoked_at\":\"2026-07-17T00:00:00.000000000Z\"}",
+      "expected_signature_hex": "60d412513ca1c063b874fc344e12560979b76df292fcfe8f3ee8e3de14ff6909eab1b099d7e3a2dc790a205f93aa853304b9d44478e8ddda5c52bc7ffda6750b"
+    },
+    {
+      "id": "RE1-single-append",
+      "description": "First revocation append: delegation 'del-0001' at epoch=2.",
+      "input": {
+        "delegation_id": "del-0001",
+        "epoch": 2,
+        "revoked_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"delegation_id\":\"del-0001\",\"domain_sep\":\"EATP-12/revocation-event/v1\",\"epoch\":2,\"revoked_at\":\"2026-07-17T00:00:00.000000000Z\"}",
+      "expected_signature_hex": "8cd0be89613dfa16e83bae6b6bd5d0a57d0d5f908dc28520c36f651f4af79c8bb002665560c154962f7ba5763214690649b8ed1ed722a9aae59f519cee217d03"
+    },
+    {
+      "id": "RE2-post-revocation-second",
+      "description": "Second revocation append: delegation 'del-0002' at epoch=3.",
+      "input": {
+        "delegation_id": "del-0002",
+        "epoch": 3,
+        "revoked_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"delegation_id\":\"del-0002\",\"domain_sep\":\"EATP-12/revocation-event/v1\",\"epoch\":3,\"revoked_at\":\"2026-07-17T00:00:00.000000000Z\"}",
+      "expected_signature_hex": "0a7b74db397711b150ea27af720c4a3c7507289a319dc82b1ac57d96bac6fb4918953da728fb860c20122e8f3e1c6ff4b6675eb62c3c5410e31bd1762be73f07"
+    },
+    {
+      "id": "RE3-fractional-second-boundary",
+      "description": "Boundary: non-zero 9-digit fractional second (2026-07-17T12:34:56.123456789Z) pins nanosecond fidelity — a following SDK MUST string-preserve the timestamp, not microsecond-truncate it.",
+      "input": {
+        "delegation_id": "del-0003",
+        "epoch": 4,
+        "revoked_at": "2026-07-17T12:34:56.123456789Z"
+      },
+      "expected_canonical_preimage": "{\"delegation_id\":\"del-0003\",\"domain_sep\":\"EATP-12/revocation-event/v1\",\"epoch\":4,\"revoked_at\":\"2026-07-17T12:34:56.123456789Z\"}",
+      "expected_signature_hex": "29c40a124fb792d324a202a975de029d945afb3a2b19de2aa3ddc27eb27d85a030d9f0092e4b3a67907000ec6677180ce64c3dd11f46d034091dd9ffd09e0a04"
+    }
+  ]
+}

--- a/tests/test-vectors/revocation-ledger-tip-vectors.json
+++ b/tests/test-vectors/revocation-ledger-tip-vectors.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "contract": "revocation-ledger-tip-v1",
+  "description": "Cross-SDK reference vectors for the EATP-12 D5 (S4b) append-only revocation-ledger tip fold (kailash-rs LEADS). The tip is a SHA-256 hash chain: tip_0 = 32 zero bytes; tip_i = SHA-256(REVOCATION_LEDGER_DOMAIN || tip_{i-1} || RevocationEvent::signing_preimage(delegation_id, epoch, revoked_at)) over the events in epoch-ascending order. The domain is the RAW-BYTE prefix 'EATP-12/revocation-ledger/v1:' (WITH a trailing colon — a byte-prefix, contrasted with the colon-less JCS domain_sep string-field domains). The fold is signature-INDEPENDENT: it binds each event's signing pre-image, not its signature, so a following SDK reproduces expected_tip_hex from the {delegation_id, epoch, revoked_at} inputs alone. GENERATED from crates/eatp/src/vault/persisted_head.rs — do NOT hand-edit; regenerate via `cargo run -p eatp --example gen_epoch_anchor_vectors`. Pinned by tests/epoch_anchor_vectors.rs.",
+  "domain_sep": "EATP-12/revocation-ledger/v1:",
+  "keypair": {
+    "comment": "RFC 8032 §7.1 Test 1 secret key. Used only to build RevocationEvent values for the fold; the tip is signature-independent.",
+    "secret_key_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+    "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+  },
+  "vectors": [
+    {
+      "id": "LT0-empty-ledger",
+      "description": "Empty / genesis ledger: no events fold to the all-zero tip [0u8;32] (matches the epoch-0 genesis HeadCommitment).",
+      "events": [],
+      "expected_tip_hex": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "id": "LT1-single-event",
+      "description": "Single revocation event ('del-0001' @ epoch 2): tip_1 = SHA-256(DOMAIN || [0u8;32] || preimage(e1)).",
+      "events": [
+        { "delegation_id": "del-0001", "epoch": 2, "revoked_at": "2026-07-17T00:00:00.000000000Z" }
+      ],
+      "expected_tip_hex": "e5dc20fdf01aa19c5bb39dbe005dd6b66adc84596a2457bb6fec767d7a3aa6a5"
+    },
+    {
+      "id": "LT2-two-events-ascending",
+      "description": "Two events in canonical epoch-ascending order ('del-0001'@2, then 'del-0002'@3): the folded two-event tip.",
+      "events": [
+        { "delegation_id": "del-0001", "epoch": 2, "revoked_at": "2026-07-17T00:00:00.000000000Z" },
+        { "delegation_id": "del-0002", "epoch": 3, "revoked_at": "2026-07-17T00:00:00.000000000Z" }
+      ],
+      "expected_tip_hex": "bb9d05a0fa2c03851343205fb0b93900548cd428b259a26470c90cee3bb5572a"
+    },
+    {
+      "id": "LT3-two-events-reversed",
+      "description": "The SAME two events in REVERSED order ('del-0002'@3, then 'del-0001'@2): a DIFFERENT tip than LT2 — pins that the fold is order-dependent.",
+      "events": [
+        { "delegation_id": "del-0002", "epoch": 3, "revoked_at": "2026-07-17T00:00:00.000000000Z" },
+        { "delegation_id": "del-0001", "epoch": 2, "revoked_at": "2026-07-17T00:00:00.000000000Z" }
+      ],
+      "expected_tip_hex": "27c9eaccf6f7e7c57dee3b8ff036d995c582c05d655a95ef8ea2c23e8e9497d9"
+    }
+  ]
+}


### PR DESCRIPTION
Part of #1842 (multi-shard). **Shard 1/N** — the signed `RevocationEvent` + append-only revocation-ledger tip fold, as a standalone module ALONGSIDE the existing in-memory pub/sub cascade. **Additive**: the runtime cascade (`broadcaster.py` / `cascade.py`) is untouched; delegation verify is NOT rewired this shard.

## What landed
- `src/kailash/trust/revocation/signed_ledger.py`
  - `SignedRevocationEvent` — frozen dataclass; `signing_preimage()` builds the JCS pre-image `{delegation_id, domain_sep, epoch, revoked_at}` (colon-LESS `domain_sep` string field `EATP-12/revocation-event/v1`) via the shared `canonical_json_dumps` (raw-UTF-8 JCS family, `allow_nan=False`); Ed25519 `sign()`/`verify()` via `kailash.trust.signing.crypto`. `revoked_at` is string-preserved (9 nanosecond digits) — never `datetime`-reparsed / microsecond-truncated.
  - `revocation_ledger_tip(events)` — SHA-256 hash chain: `tip_0 = 32 zero bytes`; `tip_i = SHA-256(REVOCATION_LEDGER_DOMAIN || tip_{i-1} || preimage(e_i))`. Domain is the RAW-BYTE prefix `b"EATP-12/revocation-ledger/v1:"` (WITH trailing colon — distinct from the colon-less event `domain_sep`). Signature-independent, order-dependent.
  - `RevocationLedger` — append-only enforcement (strictly-ascending epoch; no reorder/replay/delete surface; fail-closed).
- Re-exported additively from `kailash.trust.revocation.__init__`.
- Vectors vendored to `tests/test-vectors/` per `cross-sdk-inspection.md` Rule 4a.
- `specs/trust-eatp.md` §11.1 documents the contract + PROVISIONAL-tripwire note.

## Canonical encoder
`canonical_json_dumps` (`kailash/trust/_json.py`, Family A — `ensure_ascii=False` raw-UTF-8 JCS, matching RFC 8785). Empirically byte-identical to the pinned rs pre-image on the all-ASCII vectors (`serialize_for_signing` also matches, being ASCII-input-equivalent; the JCS raw-UTF-8 family is the semantically-correct cross-SDK choice).

## AC progress — pinned-vector tripwires PASS (verbatim)
```
tests/regression/test_signed_revocation_ledger_vectors.py .................  [100%]
17 passed in 0.61s
```
Covers: RE0-RE3 pre-image string + Ed25519 signature hex (incl. RE3 nanosecond-fidelity boundary + a `123456789` tail assertion); LT0 all-zero empty tip, LT1 single, LT2 two-ascending, LT3 two-reversed (asserts LT2 ≠ LT3 order-dependence); append-only epoch enforcement + fail-closed malformed-event rejection. RFC 8032 §7.1 Test-1 keypair; real crypto, no mocking.

## Provisional-tripwire note
kailash-rs LEADS and authored the reference bytes. These are **PROVISIONAL** cross-SDK tripwires — rs#1849 / rs#1763 OPEN; re-pin in lockstep if rs changes the reference bytes, per `rules/cross-sdk-inspection.md` Rule 4b.

## User-flow walk (receipt)
```
$ from kailash.trust.revocation import SignedRevocationEvent, RevocationLedger, revocation_ledger_tip
preimage : {"delegation_id":"del-0001","domain_sep":"EATP-12/revocation-event/v1","epoch":2,"revoked_at":"2026-07-17T00:00:00.000000000Z"}
verify   : True   (sig 8cd0be89... == RE1 pinned)
tip_hex  : bb9d05a0fa2c03851343205fb0b93900548cd428b259a26470c90cee3bb5572a   (== LT2 pinned)
empty tip: 000...000   (== LT0)
```
Disposition: facade import + fold + verify reproduce the pinned rs bytes; next-step clear.

No version bumps / CHANGELOG (shard, not a release).

## Related issues
Part of #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)