### PR TITLE
feat(eatp): owner-signed HeadCommitment epoch anchor + anti-rollback (#1842 shard 2/N)

### DIFF
--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -649,7 +649,25 @@ epoch across persisted-head reads and REJECTS (`HeadCommitmentError`, fail-close
 a persisted `HeadCommitment` whose `epoch` is strictly LOWER than the retained
 high-water — a stale-head replay. An epoch EQUAL to the high-water (re-reading the
 current head) is accepted; a strictly-greater epoch advances the anchor. The
-high-water never decreases, including across a rejected replay.
+high-water never decreases within one instance lifetime, including across a
+rejected replay. Equal-epoch defense-in-depth: a same-epoch head whose `tip_hash`
+differs from the pinned one is REJECTED as an equivocation / same-epoch fork (under
+the strict-monotonic-epoch invariant one epoch has at most one head, so a differing
+same-epoch tip is a forgery signal).
+
+**Durability contract (`#1842-S3` REQUIREMENT).** The high-water is IN-MEMORY and
+monotonic only within ONE `HeadCommitmentAnchor` lifetime. A bare
+`HeadCommitmentAnchor()` (default `initial_epoch=0`) fails OPEN — it accepts any
+epoch ≥ 0, correct ONLY for genuine first-use with no head history. A caller
+persisting heads across process restarts MUST (a) persist `high_water_epoch` (and
+`high_water_tip_hash`, to carry the equivocation defense) after each `accept()`, and
+(b) RE-SEED `initial_epoch` (and `initial_tip_hash`) from that durable store when
+reconstructing the anchor on the persisted-head read path. Constructing a bare
+anchor on the persisted-head read path is a ROLLBACK VULNERABILITY (every restart
+resets the high-water to 0 and would accept a stale lower-epoch head silently). The
+durability WIRING (which store, when to persist) is #1842 shard 3's job; this shard
+ships the enforced-as-documented in-memory contract + the `initial_epoch` /
+`initial_tip_hash` re-seed handles.
 
 **Cross-SDK PROVISIONAL tripwires.** The event pre-image + signature (RE0-RE3,
 incl. the RE3 nanosecond-fidelity boundary), tip fold (LT0 all-zero empty, LT1,

--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -624,12 +624,42 @@ enforcement: `append()` fails closed (`RevocationLedgerError`) unless each
 event's `epoch` is strictly greater than the current tip's — no reorder, replay,
 or delete surface.
 
-**Cross-SDK PROVISIONAL tripwires.** The pre-image + signature (RE0-RE3, incl.
-the RE3 nanosecond-fidelity boundary) and tip fold (LT0 all-zero empty, LT1,
-LT2, LT3 reversed-differs) are pinned in
-`tests/regression/test_signed_revocation_ledger_vectors.py` against the
-rs-authored vectors vendored under `tests/test-vectors/`
-(`revocation-event-vectors.json`, `revocation-ledger-tip-vectors.json`) per
+**Owner-signed HeadCommitment epoch anchor.** An ADDITIVE persisted-head anchor
+lives in `kailash.trust.revocation.head_commitment`, BINDING the tip the fold
+above produces into a higher-level record the owner signs once per authenticated
+state change (it does NOT modify signed_ledger's byte contract).
+`HeadCommitment.signing_preimage()` builds canonical JSON (JCS: sorted keys,
+ASCII, no whitespace) of `{block_count, domain_sep, epoch,
+revocation_ledger_tip, signed_at, tip_hash}`, where `domain_sep` is the
+colon-LESS STRING-FIELD constant `HEAD_COMMITMENT_DOMAIN_SEP`
+(`"EATP-12/head-commitment/v1"`), both 32-byte hashes are lowercase-hex-encoded,
+and `signed_at` is RFC 3339 with EXACTLY 9 fractional (nanosecond) digits + `Z`,
+STRING-PRESERVED end-to-end. `revocation_ledger_tip` is the value
+`revocation_ledger_tip()` returns (`GENESIS_TIP` for an empty ledger). It uses
+the SAME shared `canonical_json_dumps` encoder (`kailash.trust._json`, raw-UTF-8
+JCS family — byte-identical to the pinned rs pre-image on the all-ASCII / hex
+conformance vectors). `HeadCommitment.sign()` / `.verify()` produce/check an
+Ed25519 hex signature over the pre-image bytes DIRECTLY (Ed25519 is
+deterministic) via the `kailash.trust.signing.crypto` primitives. `epoch` is the
+SAME unified `u64` counter the fold uses (spanning block-appends +
+revocation-appends), enforced fail-closed to `[0, 2**64)`.
+
+**Anti-rollback (replay defense).** `HeadCommitmentAnchor` retains a high-water
+epoch across persisted-head reads and REJECTS (`HeadCommitmentError`, fail-closed)
+a persisted `HeadCommitment` whose `epoch` is strictly LOWER than the retained
+high-water — a stale-head replay. An epoch EQUAL to the high-water (re-reading the
+current head) is accepted; a strictly-greater epoch advances the anchor. The
+high-water never decreases, including across a rejected replay.
+
+**Cross-SDK PROVISIONAL tripwires.** The event pre-image + signature (RE0-RE3,
+incl. the RE3 nanosecond-fidelity boundary), tip fold (LT0 all-zero empty, LT1,
+LT2, LT3 reversed-differs), and the head-commitment pre-image + owner signature
+(HC0 genesis-all-zero, HC1, HC2 post-revocation, HC3 nanosecond-fidelity
+boundary) plus the anti-rollback anchor are pinned in
+`tests/regression/test_signed_revocation_ledger_vectors.py` and
+`tests/regression/test_head_commitment_vectors.py` against the rs-authored vectors
+vendored under `tests/test-vectors/` (`revocation-event-vectors.json`,
+`revocation-ledger-tip-vectors.json`, `head-commitment-vectors.json`) per
 `rules/cross-sdk-inspection.md` Rule 4a. These are PROVISIONAL
 (rs#1849 / rs#1763 OPEN) — re-pin in lockstep if rs changes the reference bytes,
 per `rules/cross-sdk-inspection.md` Rule 4b.

--- a/src/kailash/trust/revocation/__init__.py
+++ b/src/kailash/trust/revocation/__init__.py
@@ -76,6 +76,12 @@ from kailash.trust.revocation.broadcaster import (
     TrustRevocationList,
 )
 from kailash.trust.revocation.cascade import RevocationResult, cascade_revoke
+from kailash.trust.revocation.head_commitment import (
+    HEAD_COMMITMENT_DOMAIN_SEP,
+    HeadCommitment,
+    HeadCommitmentAnchor,
+    HeadCommitmentError,
+)
 from kailash.trust.revocation.signed_ledger import (
     GENESIS_TIP,
     REVOCATION_EVENT_DOMAIN_SEP,
@@ -117,4 +123,9 @@ __all__ = [
     "REVOCATION_EVENT_DOMAIN_SEP",
     "REVOCATION_LEDGER_DOMAIN",
     "GENESIS_TIP",
+    # Owner-signed persisted-head commitment (EATP-12 D5)
+    "HeadCommitment",
+    "HeadCommitmentAnchor",
+    "HeadCommitmentError",
+    "HEAD_COMMITMENT_DOMAIN_SEP",
 ]

--- a/src/kailash/trust/revocation/head_commitment.py
+++ b/src/kailash/trust/revocation/head_commitment.py
@@ -270,39 +270,86 @@ class HeadCommitmentAnchor:
     :class:`HeadCommitment` whose ``epoch`` is LOWER than the retained high-water is
     a stale-head replay and is REJECTED fail-closed. An epoch EQUAL to the high-water
     is accepted (re-reading the current head is legitimate) and a strictly-greater
-    epoch advances the high-water.
+    epoch advances the high-water. Equal-epoch defense-in-depth: a same-epoch head
+    whose ``tip_hash`` differs from the retained one is REJECTED as an equivocation /
+    same-epoch fork (under the strict-monotonic-epoch invariant two legitimate heads
+    at one epoch cannot exist, so a differing same-epoch tip is a forgery signal).
 
-    The high-water is the anchor's ONLY mutable state; it never decreases.
+    **DURABILITY CONTRACT (MUST — this is IN-MEMORY, monotonic only within ONE
+    instance lifetime).** The high-water epoch (and pinned tip) live ONLY in this
+    object; a freshly-constructed ``HeadCommitmentAnchor()`` with the default
+    ``initial_epoch=0`` fails OPEN — it accepts ANY epoch ``>= 0`` (correct ONLY for
+    genuine first-use with no prior head history). A caller that persists heads
+    across process restarts MUST:
+
+    1. Persist :attr:`high_water_epoch` (and, to also carry the equivocation defense,
+       :attr:`high_water_tip_hash`) to a durable store after each :meth:`accept`.
+    2. RE-SEED ``initial_epoch`` (and ``initial_tip_hash``) from that durable store
+       when reconstructing the anchor on the persisted-head read path.
+
+    Constructing a BARE ``HeadCommitmentAnchor()`` on a persisted-head read path
+    (rather than re-seeding from the durable high-water store) is a ROLLBACK
+    VULNERABILITY: every restart resets the high-water to 0 and would ACCEPT a stale
+    lower-epoch head with no error, defeating the whole anti-rollback purpose. The
+    durability WIRING (which store, when to persist) is #1842-S3's job; THIS shard
+    ships the enforced-as-documented in-memory contract + the re-seed handles.
+
+    The high-water epoch is the anchor's ONLY monotonic state; it never decreases
+    within one lifetime, including across a rejected replay.
     """
 
-    def __init__(self, initial_epoch: int = 0) -> None:
-        """Initialize the anchor's retained high-water epoch.
+    def __init__(
+        self, initial_epoch: int = 0, initial_tip_hash: bytes | None = None
+    ) -> None:
+        """Initialize (or S3-re-seed) the anchor's retained high-water.
 
         Args:
             initial_epoch: The starting high-water epoch (default 0 — the genesis
                 head, epoch 0, is accepted since ``0 >= 0``). MUST be a non-negative
-                ``int`` in ``[0, 2**64)``.
+                ``int`` in ``[0, 2**64)``. On the persisted-head read path a caller
+                MUST re-seed this from the durable high-water store (see the class
+                DURABILITY CONTRACT), NOT rely on the default.
+            initial_tip_hash: The 32-byte ``tip_hash`` pinned at ``initial_epoch``
+                (for the equivocation defense across a restart), or ``None`` (default)
+                when there is no prior head — the first accept at ``initial_epoch``
+                then records its tip without an equivocation check (no baseline to
+                compare against).
 
         Raises:
-            HeadCommitmentError: If ``initial_epoch`` is malformed (fail-closed).
+            HeadCommitmentError: If ``initial_epoch`` or ``initial_tip_hash`` is
+                malformed (fail-closed).
         """
         _validate_u64(initial_epoch, "initial_epoch")
+        if initial_tip_hash is not None:
+            _validate_hash(initial_tip_hash, "initial_tip_hash")
+            initial_tip_hash = bytes(initial_tip_hash)
         self._high_water_epoch = initial_epoch
+        self._high_water_tip_hash = initial_tip_hash
 
     @property
     def high_water_epoch(self) -> int:
-        """The retained high-water epoch (never decreases)."""
+        """The retained high-water epoch (persist this for S3 durability re-seeding)."""
         return self._high_water_epoch
 
+    @property
+    def high_water_tip_hash(self) -> bytes | None:
+        """The ``tip_hash`` pinned at the high-water epoch, or ``None`` if no head has
+        been accepted yet (persist this alongside :attr:`high_water_epoch` to carry the
+        equivocation defense across an S3 durability re-seed)."""
+        return self._high_water_tip_hash
+
     def accept(self, commitment: HeadCommitment) -> None:
-        """Accept a persisted head, advancing the high-water; reject a rollback.
+        """Accept a persisted head, advancing the high-water; reject a rollback or
+        same-epoch equivocation.
 
         Args:
             commitment: The persisted :class:`HeadCommitment` being read back.
 
         Raises:
             HeadCommitmentError: If ``commitment.epoch`` is strictly LOWER than the
-                retained high-water epoch (fail-closed anti-rollback).
+                retained high-water epoch (fail-closed anti-rollback), OR if it EQUALS
+                the high-water but its ``tip_hash`` differs from the pinned one
+                (fail-closed equivocation / same-epoch fork detection).
         """
         if commitment.epoch < self._high_water_epoch:
             raise HeadCommitmentError(
@@ -310,7 +357,20 @@ class HeadCommitmentAnchor:
                 f"the retained high-water epoch {self._high_water_epoch} "
                 f"(a persisted head cannot roll back to an earlier epoch)"
             )
+        if (
+            commitment.epoch == self._high_water_epoch
+            and self._high_water_tip_hash is not None
+            and commitment.tip_hash != self._high_water_tip_hash
+        ):
+            raise HeadCommitmentError(
+                f"equivocation detected: two distinct heads at epoch "
+                f"{commitment.epoch} — retained tip_hash "
+                f"{self._high_water_tip_hash.hex()} vs presented "
+                f"{commitment.tip_hash.hex()} (under strict-monotonic epochs a single "
+                f"epoch has at most one head; a differing same-epoch tip is a fork)"
+            )
         self._high_water_epoch = commitment.epoch
+        self._high_water_tip_hash = commitment.tip_hash
 
 
 __all__ = [

--- a/src/kailash/trust/revocation/head_commitment.py
+++ b/src/kailash/trust/revocation/head_commitment.py
@@ -1,0 +1,321 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""EATP-12 D5 owner-signed ``HeadCommitment`` epoch anchor + anti-rollback.
+
+This module ADDS the persisted-head ``HeadCommitment`` on top of the signed
+RevocationEvent + append-only revocation-ledger tip fold in
+:mod:`kailash.trust.revocation.signed_ledger`. It does NOT modify signed_ledger's
+byte contract — it BINDS the tip that fold produces into a higher-level anchor
+the owner signs once per authenticated state change.
+
+Cross-SDK byte contract (kailash-rs LEADS; see ``specs/trust-eatp.md`` § 11.1
+"Signed Revocation Ledger (EATP-12 D5)"). A following SDK MUST reproduce the
+signing pre-image byte-for-byte or the owner signature will not re-verify.
+
+**Head-commitment signing pre-image.** :meth:`HeadCommitment.signing_preimage`
+builds canonical JSON (JCS: sorted keys, ASCII, no whitespace) of
+``{block_count, domain_sep, epoch, revocation_ledger_tip, signed_at, tip_hash}``,
+where ``domain_sep`` is the colon-LESS STRING-FIELD constant
+:data:`HEAD_COMMITMENT_DOMAIN_SEP` (``"EATP-12/head-commitment/v1"`` — the VALUE
+of a JSON field, never a byte prefix, exactly like signed_ledger's
+``REVOCATION_EVENT_DOMAIN_SEP``). Both 32-byte hashes are lowercase-hex-encoded in
+the pre-image; ``signed_at`` is RFC 3339 with EXACTLY 9 fractional (nanosecond)
+digits + ``Z`` and is STRING-PRESERVED end-to-end (never parsed to a ``datetime``
+and re-rendered, which would microsecond-truncate the nanosecond tail and diverge
+the pre-image from the rs bytes). It uses the SAME shared ``canonical_json_dumps``
+encoder signed_ledger matched (``kailash.trust._json``, the raw-UTF-8 JCS family —
+``ensure_ascii=False``, ``allow_nan=False``; RFC 8785 JCS emits raw UTF-8, and it
+is empirically byte-identical to the pinned rs pre-image on the all-ASCII
+conformance vectors, whose hashes are hex + ASCII).
+
+**Owner signature.** :meth:`HeadCommitment.sign` / :meth:`.verify` produce/check an
+Ed25519 hex signature over the pre-image bytes DIRECTLY (Ed25519 is deterministic)
+via the shared ``kailash.trust.signing.crypto`` primitives.
+
+**Unified epoch.** ``epoch`` is the SAME unified ``u64`` counter signed_ledger folds
+(monotonic; it spans block-appends AND revocation-appends). Its monotonicity is the
+anti-rollback signal: :class:`HeadCommitmentAnchor` retains a high-water epoch across
+persisted-head reads and REJECTS (fail-closed) a persisted ``HeadCommitment`` whose
+epoch is LOWER than the retained high-water — a replay/rollback of a stale head.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from kailash.trust._json import canonical_json_dumps
+from kailash.trust.exceptions import InvalidSignatureError
+from kailash.trust.signing import crypto
+
+# --- Domain constant (cross-SDK byte contract; kailash-rs LEADS) -------------
+
+#: JCS ``domain_sep`` STRING FIELD value inside the head-commitment pre-image.
+#: Colon-LESS (it is the VALUE of a JSON field, never a byte prefix) — the same
+#: shape as signed_ledger's ``REVOCATION_EVENT_DOMAIN_SEP``, contrasting the
+#: colon-suffixed raw-byte ``REVOCATION_LEDGER_DOMAIN`` hash-chain prefix.
+HEAD_COMMITMENT_DOMAIN_SEP = "EATP-12/head-commitment/v1"
+
+#: Number of bytes in each pinned hash slot (``tip_hash`` / ``revocation_ledger_tip``).
+_HASH_LEN = 32
+
+#: Upper bound of the unified ``u64`` epoch (exclusive). rs LEADS and parses the
+#: epoch into a ``u64``, so an out-of-range value serializes as a JSON number rs
+#: cannot ingest, making the signed pre-image unreproducible cross-SDK.
+_U64_EXCLUSIVE_MAX = 2**64
+
+# RFC 3339, EXACTLY 9 fractional (nanosecond) digits, UTC ``Z``. The pre-image pins
+# nanosecond fidelity (HC3 boundary vector), so a malformed / truncated timestamp
+# MUST fail closed rather than silently normalize.
+_SIGNED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z$")
+
+
+class HeadCommitmentError(ValueError):
+    """Raised on a malformed ``HeadCommitment`` or an anti-rollback violation."""
+
+
+def _validate_u64(value: Any, field_name: str) -> None:
+    """Reject a non-``int`` / ``bool`` / out-of-u64-range ``value`` (fail-closed).
+
+    ``bool`` is a subclass of ``int`` and would serialize as ``true``/``false`` in a
+    numeric slot, so it is rejected explicitly.
+    """
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise HeadCommitmentError(
+            f"{field_name} must be an int, got {type(value).__name__}"
+        )
+    if not (0 <= value < _U64_EXCLUSIVE_MAX):
+        raise HeadCommitmentError(
+            f"{field_name} must be in the u64 range [0, 2**64), got {value}"
+        )
+
+
+def _validate_hash(value: Any, field_name: str) -> None:
+    """Reject a non-``bytes`` / wrong-length 32-byte hash slot (fail-closed)."""
+    if not isinstance(value, (bytes, bytearray)):
+        raise HeadCommitmentError(
+            f"{field_name} must be 32 bytes, got {type(value).__name__}"
+        )
+    if len(value) != _HASH_LEN:
+        raise HeadCommitmentError(
+            f"{field_name} must be exactly {_HASH_LEN} bytes, got {len(value)}"
+        )
+
+
+@dataclass(frozen=True)
+class HeadCommitment:
+    """An owner-signed persisted-head epoch anchor (EATP-12 D5).
+
+    Frozen: the signing pre-image is a byte-for-byte cross-SDK contract, so an
+    instance MUST be immutable once constructed (mutation would silently invalidate
+    a produced owner signature).
+
+    Args:
+        epoch: The unified ``u64`` epoch — the SAME monotonic counter
+            :func:`kailash.trust.revocation.signed_ledger.revocation_ledger_tip`
+            folds (spanning block-appends + revocation-appends). MUST be a
+            non-negative ``int`` in ``[0, 2**64)`` (``bool`` is rejected).
+        block_count: The ``u64`` count of blocks in the chain at this head.
+        tip_hash: The 32-byte chain tip hash (the block hash chain's running tip).
+        revocation_ledger_tip: The 32-byte revocation-ledger tip — the value
+            :func:`revocation_ledger_tip` returns (``GENESIS_TIP`` for an empty
+            ledger).
+        signed_at: RFC 3339 timestamp with EXACTLY 9 fractional (nanosecond) digits
+            + ``Z`` (e.g. ``"2026-07-17T12:34:56.123456789Z"``). Stored and
+            serialized verbatim — never re-rendered from a ``datetime``.
+
+    Raises:
+        HeadCommitmentError: If any field is malformed (fail-closed).
+    """
+
+    epoch: int
+    block_count: int
+    tip_hash: bytes
+    revocation_ledger_tip: bytes
+    signed_at: str
+
+    def __post_init__(self) -> None:
+        _validate_u64(self.epoch, "epoch")
+        _validate_u64(self.block_count, "block_count")
+        _validate_hash(self.tip_hash, "tip_hash")
+        _validate_hash(self.revocation_ledger_tip, "revocation_ledger_tip")
+        if not isinstance(self.signed_at, str) or not _SIGNED_AT_RE.match(
+            self.signed_at
+        ):
+            raise HeadCommitmentError(
+                "signed_at must be RFC 3339 with 9 fractional (nanosecond) digits "
+                f"+ 'Z' (e.g. '2026-07-17T00:00:00.000000000Z'), "
+                f"got {self.signed_at!r}"
+            )
+        # Normalize bytearray inputs to immutable bytes so a frozen instance cannot
+        # be mutated through an aliased bytearray after construction.
+        if not isinstance(self.tip_hash, bytes):
+            object.__setattr__(self, "tip_hash", bytes(self.tip_hash))
+        if not isinstance(self.revocation_ledger_tip, bytes):
+            object.__setattr__(
+                self, "revocation_ledger_tip", bytes(self.revocation_ledger_tip)
+            )
+
+    def signing_preimage(self) -> str:
+        """Return the canonical-JSON signing pre-image string.
+
+        JCS: sorted keys, ASCII, no whitespace, of
+        ``{block_count, domain_sep, epoch, revocation_ledger_tip, signed_at,
+        tip_hash}`` with ``domain_sep`` = :data:`HEAD_COMMITMENT_DOMAIN_SEP` and both
+        hashes lowercase-hex-encoded. Uses the shared ``canonical_json_dumps`` encoder
+        (raw-UTF-8 JCS family, ``allow_nan`` already False).
+        """
+        return canonical_json_dumps(
+            {
+                "block_count": self.block_count,
+                "domain_sep": HEAD_COMMITMENT_DOMAIN_SEP,
+                "epoch": self.epoch,
+                "revocation_ledger_tip": self.revocation_ledger_tip.hex(),
+                "signed_at": self.signed_at,
+                "tip_hash": self.tip_hash.hex(),
+            }
+        )
+
+    def signing_preimage_bytes(self) -> bytes:
+        """Return the UTF-8 bytes of :meth:`signing_preimage` (the signed operand)."""
+        return self.signing_preimage().encode("utf-8")
+
+    def sign(self, private_key_seed: bytes) -> str:
+        """Ed25519-sign the pre-image; return the signature as lowercase hex.
+
+        The owner signs the pre-image bytes DIRECTLY (Ed25519 is deterministic).
+
+        Args:
+            private_key_seed: The 32-byte Ed25519 seed (RFC 8032 secret key).
+
+        Returns:
+            The 64-byte Ed25519 signature, lowercase hex-encoded.
+        """
+        b64_priv = base64.b64encode(private_key_seed).decode("ascii")
+        b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        return base64.b64decode(b64_sig).hex()
+
+    def verify(self, signature_hex: str, public_key: bytes) -> bool:
+        """Verify a hex Ed25519 signature over this head's pre-image.
+
+        Args:
+            signature_hex: Lowercase-hex 64-byte Ed25519 signature.
+            public_key: The 32-byte Ed25519 public key.
+
+        Returns:
+            True iff the signature is valid for this head's pre-image. Fail-closed: a
+            malformed / short / non-hex / wrong-length ``signature_hex`` returns False
+            (never raises an off-contract ``ValueError`` / ``InvalidSignatureError``).
+        """
+        try:
+            sig_bytes = bytes.fromhex(signature_hex)
+            b64_pub = base64.b64encode(public_key).decode("ascii")
+            b64_sig = base64.b64encode(sig_bytes).decode("ascii")
+            return crypto.verify_signature(self.signing_preimage(), b64_sig, b64_pub)
+        except (ValueError, TypeError, InvalidSignatureError):
+            # Malformed hex (ValueError/TypeError) OR a wrong-length signature the
+            # crypto layer rejects (InvalidSignatureError) → fail closed.
+            return False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-friendly dict (hashes as lowercase hex)."""
+        return {
+            "epoch": self.epoch,
+            "block_count": self.block_count,
+            "tip_hash": self.tip_hash.hex(),
+            "revocation_ledger_tip": self.revocation_ledger_tip.hex(),
+            "signed_at": self.signed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "HeadCommitment":
+        """Reconstruct from a dict (hashes are lowercase hex; validates via
+        ``__post_init__``).
+
+        Raises:
+            HeadCommitmentError: If a required field is missing (typed, names the
+                field) or a hex hash is malformed — not a bare ``KeyError`` /
+                ``ValueError``.
+        """
+        for field_name in (
+            "epoch",
+            "block_count",
+            "tip_hash",
+            "revocation_ledger_tip",
+            "signed_at",
+        ):
+            if field_name not in data:
+                raise HeadCommitmentError(f"missing required field {field_name!r}")
+        try:
+            tip_hash = bytes.fromhex(data["tip_hash"])
+            revocation_ledger_tip = bytes.fromhex(data["revocation_ledger_tip"])
+        except (ValueError, TypeError) as exc:
+            raise HeadCommitmentError(f"malformed hex hash field: {exc}") from exc
+        return cls(
+            epoch=data["epoch"],
+            block_count=data["block_count"],
+            tip_hash=tip_hash,
+            revocation_ledger_tip=revocation_ledger_tip,
+            signed_at=data["signed_at"],
+        )
+
+
+class HeadCommitmentAnchor:
+    """Retains a high-water epoch across persisted-head reads; rejects a rollback.
+
+    Anti-rollback (replay) defense on the PERSISTED read path: a persisted
+    :class:`HeadCommitment` whose ``epoch`` is LOWER than the retained high-water is
+    a stale-head replay and is REJECTED fail-closed. An epoch EQUAL to the high-water
+    is accepted (re-reading the current head is legitimate) and a strictly-greater
+    epoch advances the high-water.
+
+    The high-water is the anchor's ONLY mutable state; it never decreases.
+    """
+
+    def __init__(self, initial_epoch: int = 0) -> None:
+        """Initialize the anchor's retained high-water epoch.
+
+        Args:
+            initial_epoch: The starting high-water epoch (default 0 — the genesis
+                head, epoch 0, is accepted since ``0 >= 0``). MUST be a non-negative
+                ``int`` in ``[0, 2**64)``.
+
+        Raises:
+            HeadCommitmentError: If ``initial_epoch`` is malformed (fail-closed).
+        """
+        _validate_u64(initial_epoch, "initial_epoch")
+        self._high_water_epoch = initial_epoch
+
+    @property
+    def high_water_epoch(self) -> int:
+        """The retained high-water epoch (never decreases)."""
+        return self._high_water_epoch
+
+    def accept(self, commitment: HeadCommitment) -> None:
+        """Accept a persisted head, advancing the high-water; reject a rollback.
+
+        Args:
+            commitment: The persisted :class:`HeadCommitment` being read back.
+
+        Raises:
+            HeadCommitmentError: If ``commitment.epoch`` is strictly LOWER than the
+                retained high-water epoch (fail-closed anti-rollback).
+        """
+        if commitment.epoch < self._high_water_epoch:
+            raise HeadCommitmentError(
+                f"anti-rollback violation: epoch {commitment.epoch} is lower than "
+                f"the retained high-water epoch {self._high_water_epoch} "
+                f"(a persisted head cannot roll back to an earlier epoch)"
+            )
+        self._high_water_epoch = commitment.epoch
+
+
+__all__ = [
+    "HEAD_COMMITMENT_DOMAIN_SEP",
+    "HeadCommitmentError",
+    "HeadCommitment",
+    "HeadCommitmentAnchor",
+]

--- a/tests/regression/test_head_commitment_vectors.py
+++ b/tests/regression/test_head_commitment_vectors.py
@@ -156,6 +156,108 @@ def test_anti_rollback_equal_and_greater_epochs_accepted() -> None:
     assert anchor.high_water_epoch == 3
 
 
+def test_fresh_anchor_fails_open_documents_durability_requirement() -> None:
+    """The high-water is IN-MEMORY, monotonic only within ONE anchor lifetime. A
+    freshly-constructed ``HeadCommitmentAnchor()`` (default ``initial_epoch=0``) fails
+    OPEN — it accepts ANY epoch >= 0, INCLUDING a lower one a prior anchor instance had
+    already advanced past. This is the DOCUMENTED #1842-S3 durability requirement (a
+    caller MUST persist ``high_water_epoch`` and re-seed ``initial_epoch`` from it on
+    the persisted-head read path), NOT a silent bug: constructing a bare anchor on the
+    persisted read path is a rollback vulnerability the S3 wiring closes."""
+
+    def _head(epoch: int, block_count: int, tip_byte: int) -> HeadCommitment:
+        return HeadCommitment(
+            epoch=epoch,
+            block_count=block_count,
+            tip_hash=bytes([tip_byte]) * 32,
+            revocation_ledger_tip=bytes(32),
+            signed_at="2026-07-17T00:00:00.000000000Z",
+        )
+
+    anchor = HeadCommitmentAnchor()
+    anchor.accept(_head(100, 50, 0xAA))
+    assert anchor.high_water_epoch == 100
+    assert anchor.high_water_tip_hash == bytes([0xAA]) * 32
+
+    # A NEW bare anchor (the restart-without-re-seed path) has NO memory of epoch 100
+    # and fails OPEN — it accepts an epoch-5 head that the first anchor would reject.
+    fresh = HeadCommitmentAnchor()  # default initial_epoch=0 → fails open
+    fresh.accept(_head(5, 3, 0xBB))  # accepted: the S3 re-seed is what prevents this
+    assert fresh.high_water_epoch == 5
+
+    # Re-seeding from the persisted high-water (the S3 durability contract) restores the
+    # anti-rollback: the epoch-5 replay is now rejected.
+    reseeded = HeadCommitmentAnchor(
+        initial_epoch=100, initial_tip_hash=bytes([0xAA]) * 32
+    )
+    assert (
+        reseeded.high_water_epoch == 100
+        and reseeded.high_water_tip_hash == bytes([0xAA]) * 32
+    )
+    with pytest.raises(HeadCommitmentError, match="anti-rollback violation"):
+        reseeded.accept(_head(5, 3, 0xBB))
+
+
+def test_equivocation_same_epoch_differing_tip_rejected() -> None:
+    """Defense-in-depth: two DISTINCT heads at the SAME epoch (differing ``tip_hash``)
+    is an equivocation / same-epoch fork — the second is REJECTED fail-closed. Under the
+    strict-monotonic-epoch invariant a single epoch has at most one head, so a differing
+    same-epoch tip is a forgery signal. A same-epoch re-read of the IDENTICAL head is
+    still accepted (idempotent)."""
+
+    def _head(tip_byte: int) -> HeadCommitment:
+        return HeadCommitment(
+            epoch=7,
+            block_count=4,
+            tip_hash=bytes([tip_byte]) * 32,
+            revocation_ledger_tip=bytes(32),
+            signed_at="2026-07-17T00:00:00.000000000Z",
+        )
+
+    anchor = HeadCommitmentAnchor()
+    head_a = _head(0x11)
+    anchor.accept(head_a)  # pins (epoch 7, tip 0x11...)
+    assert anchor.high_water_tip_hash == bytes([0x11]) * 32
+
+    # Re-reading the IDENTICAL head at epoch 7 is idempotent — accepted, tip unchanged.
+    anchor.accept(head_a)
+    assert anchor.high_water_epoch == 7
+
+    # A DIFFERENT head at the SAME epoch 7 is a fork — rejected, pinned tip unchanged.
+    with pytest.raises(HeadCommitmentError, match="equivocation detected"):
+        anchor.accept(_head(0x22))
+    assert anchor.high_water_tip_hash == bytes([0x11]) * 32
+
+
+def test_equivocation_baseline_absent_first_same_seed_epoch_accepted() -> None:
+    """When an anchor is re-seeded with ``initial_epoch`` but NO ``initial_tip_hash``
+    (no prior tip to compare), the first accept at that seed epoch records its tip
+    WITHOUT an equivocation check — there is no baseline. The check engages only once a
+    tip is pinned."""
+    anchor = HeadCommitmentAnchor(initial_epoch=7)  # seed epoch, no pinned tip
+    assert anchor.high_water_tip_hash is None
+    first = HeadCommitment(
+        epoch=7,
+        block_count=4,
+        tip_hash=bytes([0x33]) * 32,
+        revocation_ledger_tip=bytes(32),
+        signed_at="2026-07-17T00:00:00.000000000Z",
+    )
+    anchor.accept(first)  # no baseline → accepted, tip now pinned
+    assert anchor.high_water_tip_hash == bytes([0x33]) * 32
+    # Now a differing same-epoch tip IS caught.
+    with pytest.raises(HeadCommitmentError, match="equivocation detected"):
+        anchor.accept(
+            HeadCommitment(
+                epoch=7,
+                block_count=4,
+                tip_hash=bytes([0x44]) * 32,
+                revocation_ledger_tip=bytes(32),
+                signed_at="2026-07-17T00:00:00.000000000Z",
+            )
+        )
+
+
 # --- Fail-closed construction + hardening ------------------------------------
 
 

--- a/tests/regression/test_head_commitment_vectors.py
+++ b/tests/regression/test_head_commitment_vectors.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-SDK PROVISIONAL tripwire vectors for the EATP-12 D5 owner-signed
+``HeadCommitment`` epoch anchor pre-image + Ed25519 signature, plus the
+anti-rollback high-water anchor.
+
+kailash-rs LEADS and authored the reference bytes (rs#1849 / rs#1763 OPEN — these
+vectors are PROVISIONAL; re-pin in lockstep if rs changes them, per
+``cross-sdk-inspection.md`` Rule 4b). These assert the Python production path
+reproduces the pinned rs bytes BYTE-FOR-BYTE:
+
+* ``HeadCommitment`` (HC0-HC3): the JCS pre-image string + Ed25519 signature hex,
+  incl. the HC3 nanosecond-fidelity boundary vector (a 9-digit fractional second
+  that MUST be string-preserved, not microsecond-truncated).
+* Anti-rollback: a persisted head whose epoch is LOWER than a retained high-water
+  is rejected fail-closed (replay defense); equal/greater epochs advance the anchor.
+
+The vectors are vendored (per ``cross-sdk-inspection.md`` Rule 4a) into
+``tests/test-vectors/head-commitment-vectors.json`` from the rs-authored reference
+set. Real crypto, no mocking (testing.md Tier 2/3).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kailash.trust.revocation.head_commitment import (
+    HeadCommitment,
+    HeadCommitmentAnchor,
+    HeadCommitmentError,
+)
+
+pytestmark = pytest.mark.regression
+
+_REF_DIR = Path(__file__).resolve().parents[1] / "test-vectors"
+_HC_VECTORS = json.loads(
+    (_REF_DIR / "head-commitment-vectors.json").read_text(encoding="utf-8")
+)
+
+# RFC 8032 §7.1 Test 1 keypair (cross-SDK byte-shape fixtures only; never live signing).
+_SECRET_SEED = bytes.fromhex(_HC_VECTORS["keypair"]["secret_key_hex"])
+_PUBLIC_KEY = bytes.fromhex(_HC_VECTORS["keypair"]["public_key_hex"])
+
+
+def _head_from_vector(vec: dict) -> HeadCommitment:
+    i = vec["input"]
+    return HeadCommitment(
+        epoch=i["epoch"],
+        block_count=i["block_count"],
+        tip_hash=bytes.fromhex(i["tip_hash"]),
+        revocation_ledger_tip=bytes.fromhex(i["revocation_ledger_tip"]),
+        signed_at=i["signed_at"],
+    )
+
+
+# --- HeadCommitment pre-image + signature (HC0-HC3) --------------------------
+
+
+@pytest.mark.parametrize(
+    "vec", _HC_VECTORS["vectors"], ids=[v["id"] for v in _HC_VECTORS["vectors"]]
+)
+def test_head_commitment_preimage_matches_pinned(vec: dict) -> None:
+    """The canonical JCS pre-image string EQUALS the pinned rs bytes."""
+    head = _head_from_vector(vec)
+    preimage = head.signing_preimage()
+    assert preimage == vec["expected_canonical_preimage"], (
+        f"{vec['id']}: pre-image diverged from pinned rs bytes\n"
+        f"  got:      {preimage!r}\n"
+        f"  expected: {vec['expected_canonical_preimage']!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "vec", _HC_VECTORS["vectors"], ids=[v["id"] for v in _HC_VECTORS["vectors"]]
+)
+def test_head_commitment_signature_matches_pinned(vec: dict) -> None:
+    """Owner Ed25519 signature (hex) over the pre-image EQUALS the pinned rs bytes."""
+    head = _head_from_vector(vec)
+    signature_hex = head.sign(_SECRET_SEED)
+    assert signature_hex == vec["expected_signature_hex"], (
+        f"{vec['id']}: signature diverged from pinned rs bytes\n"
+        f"  got:      {signature_hex}\n"
+        f"  expected: {vec['expected_signature_hex']}"
+    )
+    # Round-trip: the pinned signature verifies against the pinned public key.
+    assert head.verify(vec["expected_signature_hex"], _PUBLIC_KEY)
+
+
+def test_hc3_nanosecond_fidelity_preserved() -> None:
+    """HC3 pins that the 9-digit nanosecond tail is STRING-PRESERVED, not
+    microsecond-truncated — the pre-image + owner signature only match if the full
+    nanosecond timestamp survives verbatim."""
+    hc3 = next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC3"))
+    head = _head_from_vector(hc3)
+    # The nanosecond tail is carried verbatim (9 fractional digits).
+    assert head.signed_at == "2026-07-17T12:34:56.123456789Z"
+    assert "123456789" in head.signing_preimage()
+    assert head.sign(_SECRET_SEED) == hc3["expected_signature_hex"]
+
+
+def test_hc0_genesis_all_zero_tips() -> None:
+    """HC0: the genesis head (epoch 0, block_count 0) binds all-zero tips for BOTH
+    the chain tip and the (empty-ledger) revocation-ledger tip."""
+    hc0 = next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC0"))
+    head = _head_from_vector(hc0)
+    assert head.epoch == 0 and head.block_count == 0
+    assert head.tip_hash == bytes(32)
+    assert head.revocation_ledger_tip == bytes(32)
+    assert head.signing_preimage() == hc0["expected_canonical_preimage"]
+
+
+# --- Anti-rollback high-water anchor -----------------------------------------
+
+
+def test_anti_rollback_lower_epoch_replay_rejected() -> None:
+    """A persisted head whose epoch is LOWER than the retained high-water is
+    rejected fail-closed (replay/rollback defense) — the core anti-rollback test."""
+    anchor = HeadCommitmentAnchor()
+    hc2 = _head_from_vector(
+        next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC2"))
+    )  # epoch 2
+    hc1 = _head_from_vector(
+        next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC1"))
+    )  # epoch 1
+
+    anchor.accept(hc2)  # advance high-water to epoch 2
+    assert anchor.high_water_epoch == 2
+
+    # Replaying the earlier epoch-1 head against the retained high-water is a rollback.
+    with pytest.raises(HeadCommitmentError, match="anti-rollback violation"):
+        anchor.accept(hc1)
+    # The high-water is NOT rolled back by the rejected replay.
+    assert anchor.high_water_epoch == 2
+
+
+def test_anti_rollback_equal_and_greater_epochs_accepted() -> None:
+    """An epoch EQUAL to the high-water (re-reading the current head) is accepted;
+    a strictly-greater epoch advances the high-water. The high-water never decreases."""
+    heads = {v["id"][:3]: _head_from_vector(v) for v in _HC_VECTORS["vectors"]}
+    anchor = HeadCommitmentAnchor()
+
+    anchor.accept(heads["HC0"])  # epoch 0
+    assert anchor.high_water_epoch == 0
+    anchor.accept(heads["HC0"])  # equal epoch re-read → accepted, no rollback
+    assert anchor.high_water_epoch == 0
+    anchor.accept(heads["HC1"])  # epoch 1 → advance
+    anchor.accept(heads["HC2"])  # epoch 2 → advance
+    anchor.accept(heads["HC3"])  # epoch 3 → advance
+    assert anchor.high_water_epoch == 3
+    # Re-reading the current (highest) head is still accepted.
+    anchor.accept(heads["HC3"])
+    assert anchor.high_water_epoch == 3
+
+
+# --- Fail-closed construction + hardening ------------------------------------
+
+
+def test_malformed_head_fails_closed() -> None:
+    """Malformed fields are rejected at construction (fail-closed)."""
+    ok = {
+        "epoch": 1,
+        "block_count": 1,
+        "tip_hash": bytes(32),
+        "revocation_ledger_tip": bytes(32),
+        "signed_at": "2026-07-17T00:00:00.000000000Z",
+    }
+    # Wrong-length hash slot.
+    with pytest.raises(HeadCommitmentError, match="32 bytes"):
+        HeadCommitment(**{**ok, "tip_hash": bytes(31)})
+    with pytest.raises(HeadCommitmentError, match="32 bytes"):
+        HeadCommitment(**{**ok, "revocation_ledger_tip": bytes(33)})
+    # microsecond (6-digit) timestamp — would truncate nanosecond fidelity.
+    with pytest.raises(HeadCommitmentError, match="signed_at"):
+        HeadCommitment(**{**ok, "signed_at": "2026-07-17T00:00:00.000000Z"})
+    # bool epoch / block_count must not slip through the int check.
+    with pytest.raises(HeadCommitmentError, match="epoch must be an int"):
+        HeadCommitment(**{**ok, "epoch": True})
+    with pytest.raises(HeadCommitmentError, match="block_count must be an int"):
+        HeadCommitment(**{**ok, "block_count": False})
+
+
+def test_epoch_u64_range_enforced_fail_closed() -> None:
+    """A u64 epoch is fail-closed at both bounds: ``2**64`` (out of range) raises;
+    ``2**64 - 1`` (max u64) is accepted. An oversized epoch would serialize as a JSON
+    number rs cannot parse into a u64, making the signed pre-image unreproducible
+    cross-SDK."""
+    base = {
+        "block_count": 1,
+        "tip_hash": bytes(32),
+        "revocation_ledger_tip": bytes(32),
+        "signed_at": "2026-07-17T00:00:00.000000000Z",
+    }
+    with pytest.raises(HeadCommitmentError, match="u64 range"):
+        HeadCommitment(epoch=2**64, **base)
+    ok = HeadCommitment(epoch=2**64 - 1, **base)
+    assert ok.epoch == 2**64 - 1
+
+
+def test_verify_fails_closed_on_malformed_signature_hex() -> None:
+    """``verify()`` returns False (never raises) on malformed / short / non-hex
+    signature input — fail-closed, not an off-contract ValueError."""
+    head = HeadCommitment(
+        epoch=1,
+        block_count=1,
+        tip_hash=bytes(32),
+        revocation_ledger_tip=bytes(32),
+        signed_at="2026-07-17T00:00:00.000000000Z",
+    )
+    assert head.verify("not-hex-!!", _PUBLIC_KEY) is False
+    assert head.verify("dead", _PUBLIC_KEY) is False  # valid hex, wrong length
+    assert head.verify("", _PUBLIC_KEY) is False
+    assert head.verify("abc", _PUBLIC_KEY) is False  # odd-length hex
+
+
+def test_to_from_dict_round_trip() -> None:
+    """``from_dict(to_dict())`` round-trips; a missing field raises the typed error
+    naming the field, and a malformed hex hash raises the typed error (not a bare
+    ValueError)."""
+    head = _head_from_vector(
+        next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC2"))
+    )
+    data = head.to_dict()
+    assert HeadCommitment.from_dict(data) == head
+    # The signed head still verifies after a dict round-trip (bytes preserved).
+    hc2 = next(v for v in _HC_VECTORS["vectors"] if v["id"].startswith("HC2"))
+    assert HeadCommitment.from_dict(data).verify(
+        hc2["expected_signature_hex"], _PUBLIC_KEY
+    )
+    for missing in data:
+        partial = {k: v for k, v in data.items() if k != missing}
+        with pytest.raises(HeadCommitmentError, match=missing):
+            HeadCommitment.from_dict(partial)
+    with pytest.raises(HeadCommitmentError, match="malformed hex"):
+        HeadCommitment.from_dict({**data, "tip_hash": "zz"})

--- a/tests/test-vectors/head-commitment-vectors.json
+++ b/tests/test-vectors/head-commitment-vectors.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "contract": "head-commitment-v1",
+  "description": "Cross-SDK reference vectors for the EATP-12 D5 owner-signed HeadCommitment pre-image + Ed25519 signature (kailash-rs LEADS). The signing pre-image is canonical-JSON (JCS-sorted keys, ASCII-only, no whitespace) of {block_count, domain_sep, epoch, revocation_ledger_tip, signed_at, tip_hash} with 32-byte hashes hex-encoded and the timestamp as RFC 3339 with fixed 9-digit nanoseconds + Z. The owner signs those pre-image bytes directly (Ed25519 is deterministic). GENERATED from crates/eatp/src/vault/epoch_anchor.rs — do NOT hand-edit; regenerate via `cargo run -p eatp --example gen_epoch_anchor_vectors`. Pinned by tests/epoch_anchor_vectors.rs.",
+  "domain_sep": "EATP-12/head-commitment/v1",
+  "keypair": {
+    "comment": "RFC 8032 §7.1 Test 1 secret key. Cross-SDK byte-shape fixtures only; never live signing.",
+    "secret_key_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+    "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+  },
+  "vectors": [
+    {
+      "id": "HC0-genesis-epoch0",
+      "description": "Sentinel: genesis head, epoch=0, block_count=0, all-zero tips, empty revocation ledger.",
+      "input": {
+        "epoch": 0,
+        "block_count": 0,
+        "tip_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "revocation_ledger_tip": "0000000000000000000000000000000000000000000000000000000000000000",
+        "signed_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"block_count\":0,\"domain_sep\":\"EATP-12/head-commitment/v1\",\"epoch\":0,\"revocation_ledger_tip\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"signed_at\":\"2026-07-17T00:00:00.000000000Z\",\"tip_hash\":\"0000000000000000000000000000000000000000000000000000000000000000\"}",
+      "expected_signature_hex": "fc8c420ff50d85d413c670c02c168945aefc0a9c1c0641d5e376bd7f364c913eb3660d5cb3a5b59ae36f46fc823e5a88fbd4638f1c64199b8fdfbec261616d02"
+    },
+    {
+      "id": "HC1-single-append",
+      "description": "Single chain append: epoch=1, block_count=1, non-zero chain tip, empty revocation ledger.",
+      "input": {
+        "epoch": 1,
+        "block_count": 1,
+        "tip_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+        "revocation_ledger_tip": "0000000000000000000000000000000000000000000000000000000000000000",
+        "signed_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"block_count\":1,\"domain_sep\":\"EATP-12/head-commitment/v1\",\"epoch\":1,\"revocation_ledger_tip\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"signed_at\":\"2026-07-17T00:00:00.000000000Z\",\"tip_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\"}",
+      "expected_signature_hex": "2cfffff86e87b010e37fdb9d3e9e305b27abb819529672450ded5ab2f2103ece7065897f7b54b293e802b196ab8d87bf18eeaf6122b45ebe190b76a9f9a2930b"
+    },
+    {
+      "id": "HC2-post-revocation",
+      "description": "Post-revocation head: epoch=2, block_count=1, non-zero chain tip AND non-zero revocation-ledger tip.",
+      "input": {
+        "epoch": 2,
+        "block_count": 1,
+        "tip_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+        "revocation_ledger_tip": "abababababababababababababababababababababababababababababababab",
+        "signed_at": "2026-07-17T00:00:00.000000000Z"
+      },
+      "expected_canonical_preimage": "{\"block_count\":1,\"domain_sep\":\"EATP-12/head-commitment/v1\",\"epoch\":2,\"revocation_ledger_tip\":\"abababababababababababababababababababababababababababababababab\",\"signed_at\":\"2026-07-17T00:00:00.000000000Z\",\"tip_hash\":\"2222222222222222222222222222222222222222222222222222222222222222\"}",
+      "expected_signature_hex": "558f26d5c04f66b53606a22fe7c5bb39a75a6921eba0f6ce3c111c42aa53be17997fddf37d6e9911abe6b7aff89a05c8f97f28614b5889a9ac283083eeb96b0f"
+    },
+    {
+      "id": "HC3-fractional-second-boundary",
+      "description": "Boundary: non-zero 9-digit fractional second (2026-07-17T12:34:56.123456789Z) pins nanosecond fidelity — a following SDK MUST string-preserve the timestamp, not microsecond-truncate it.",
+      "input": {
+        "epoch": 3,
+        "block_count": 2,
+        "tip_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+        "revocation_ledger_tip": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "signed_at": "2026-07-17T12:34:56.123456789Z"
+      },
+      "expected_canonical_preimage": "{\"block_count\":2,\"domain_sep\":\"EATP-12/head-commitment/v1\",\"epoch\":3,\"revocation_ledger_tip\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\",\"signed_at\":\"2026-07-17T12:34:56.123456789Z\",\"tip_hash\":\"3333333333333333333333333333333333333333333333333333333333333333\"}",
+      "expected_signature_hex": "b65a7d3f30fa2e291945b912d0f6d12f555deb7a6811f86b921361050468e2c7fe71df41da1bc82b69e56997d398c34d88d8db0206539941317e42102bf95406"
+    }
+  ]
+}


### PR DESCRIPTION
Part of #1842. Shard 2/N — ADDITIVE on the S1 signed RevocationEvent + append-only revocation-ledger tip fold already on `main` (`kailash.trust.revocation.signed_ledger`). Does NOT modify signed_ledger's byte contract.

## What

Adds the owner-signed **HeadCommitment** persisted-head epoch anchor that BINDS the S1 revocation-ledger tip into a higher-level record the owner signs once per authenticated state change, plus a fail-closed **anti-rollback** high-water anchor.

- `kailash/trust/revocation/head_commitment.py`
  - `HeadCommitment` — frozen dataclass; JCS signing pre-image builder (shared `canonical_json_dumps`, the SAME raw-UTF-8 encoder S1 matched) over `{block_count, domain_sep, epoch, revocation_ledger_tip, signed_at, tip_hash}`; owner Ed25519 `sign()`/`verify()` over the pre-image bytes directly (via `kailash.trust.signing.crypto`). Both 32-byte hashes lowercase-hex-encoded; `signed_at` RFC 3339 9-nanosecond string, string-preserved.
  - `HEAD_COMMITMENT_DOMAIN_SEP = "EATP-12/head-commitment/v1"` — colon-LESS JCS field value (same shape as S1's event domain-sep).
  - `HeadCommitmentAnchor` — retains a high-water epoch; rejects (`HeadCommitmentError`, fail-closed) a persisted head whose epoch is LOWER than the retained high-water (replay defense). Equal epoch re-read accepted; greater advances; never decreases, incl. across a rejected replay.
  - Fail-closed: `epoch`/`block_count` enforced to the unified `u64` range `[0, 2**64)` (bool rejected); 32-byte hash-length checks; malformed timestamp/hex raise typed `HeadCommitmentError`; `verify()` returns False (never raises) on malformed signature hex.
- Exported through the `kailash.trust.revocation` package facade.

## Governance

- security.md / trust-crypto: byte-exact shared `canonical_json_dumps` (no hand-rolled JSON); Ed25519 via existing primitives; fail-closed on malformed + `u64` overflow + rollback; no secrets logged.
- testing.md Tier 2/3: real crypto, NO mocking; tripwires assert real bytes == pinned.
- zero-tolerance R2 (no stubs) / R3 (no silent except) / R6 (implement fully — HC + anti-rollback + all 4 vectors).

## Cross-SDK — PROVISIONAL (rs#1849 / rs#1763 OPEN)

kailash-rs LEADS the byte contract. HC0-HC3 pre-image + signature and the anti-rollback anchor are pinned byte-for-byte against the rs-authored vectors vendored at `tests/test-vectors/head-commitment-vectors.json` (per `cross-sdk-inspection.md` Rule 4a). Re-pin in lockstep if rs changes the reference bytes (Rule 4b). Encoder that matched: the shared `kailash.trust._json.canonical_json_dumps` (raw-UTF-8 JCS, `allow_nan=False`) — byte-identical to the pinned rs pre-image on the all-ASCII/hex vectors.

## AC progress

- [x] `HeadCommitment` JCS pre-image builder (shared encoder) + Ed25519 sign/verify
- [x] Unified-u64 epoch enforced fail-closed `[0, 2**64)`; 32-byte hash slots
- [x] Monotonic-epoch anti-rollback on the persisted read path (high-water, fail-closed)
- [x] Pinned-vector tripwires HC0-HC3 (incl. HC3 nanosecond fidelity) match byte-for-byte
- [x] Anti-rollback test: lower-epoch replay rejected against a retained high-water
- [x] Spec `specs/trust-eatp.md` §11.1 updated + PROVISIONAL note

## Verbatim tripwire output

```
tests/regression/test_head_commitment_vectors.py::test_head_commitment_preimage_matches_pinned[HC0-genesis-epoch0] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_preimage_matches_pinned[HC1-single-append] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_preimage_matches_pinned[HC2-post-revocation] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_preimage_matches_pinned[HC3-fractional-second-boundary] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_signature_matches_pinned[HC0-genesis-epoch0] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_signature_matches_pinned[HC1-single-append] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_signature_matches_pinned[HC2-post-revocation] PASSED
tests/regression/test_head_commitment_vectors.py::test_head_commitment_signature_matches_pinned[HC3-fractional-second-boundary] PASSED
tests/regression/test_head_commitment_vectors.py::test_hc3_nanosecond_fidelity_preserved PASSED
tests/regression/test_head_commitment_vectors.py::test_hc0_genesis_all_zero_tips PASSED
tests/regression/test_head_commitment_vectors.py::test_anti_rollback_lower_epoch_replay_rejected PASSED
tests/regression/test_head_commitment_vectors.py::test_anti_rollback_equal_and_greater_epochs_accepted PASSED
tests/regression/test_head_commitment_vectors.py::test_malformed_head_fails_closed PASSED
tests/regression/test_head_commitment_vectors.py::test_epoch_u64_range_enforced_fail_closed PASSED
tests/regression/test_head_commitment_vectors.py::test_verify_fails_closed_on_malformed_signature_hex PASSED
tests/regression/test_head_commitment_vectors.py::test_to_from_dict_round_trip PASSED
16 passed in 0.78s
```

S1 byte-contract unchanged: `test_signed_revocation_ledger_vectors.py` → 21 passed. `mypy --strict` on the new module → clean.

## User-flow walk receipt

Imported through the package facade exactly as a consumer would and composed with S1 end-to-end:

```
$ python -c "from kailash.trust.revocation import HeadCommitment, HeadCommitmentAnchor, ..."
facade exports OK; domain_sep = EATP-12/head-commitment/v1
compose-with-S1 fold + sign + verify + anchor OK (real 32B tip: e5dc20fdf01aa19c ...)
```

(fold a real S1 revocation-ledger tip → bind into a HeadCommitment → owner sign → verify True → anchor.accept advances high-water to epoch 2)

## Related issues

Part of #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)