### PR TITLE
feat(eatp): migrate delegation signing onto canonical engine + version-gate backward-compat (#1841 shard 2/N)

### DIFF
--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -265,9 +265,14 @@ class DelegationRecord:
 
     # Dimension Scope Extension (#170)
     dimension_scope: frozenset[str] = ALL_DIMENSIONS
+
+    # Signing-Payload Version Discriminator (#1841 shard 2)
+    signing_payload_version: str = "legacy-python-v0"
 ```
 
 **Signing contract**: `to_signing_payload()` includes `reasoning_trace_hash` (binding the reasoning to the delegation signature) and `dimension_scope` (sorted list, preventing post-hoc scope widening). The full reasoning trace and its separate signature are excluded from the parent payload -- they have their own verification path.
+
+**Signing-payload version discriminator (#1841 shard 2)**: `signing_payload_version` records WHICH canonical pre-image shape the signature was produced over, so a verifier can dispatch to the matching builder. It defaults to `legacy-python-v0` (the pre-migration Python schema) and a record deserialized from a wire form with NO version key also resolves to `legacy-python-v0` (`from_dict` backward-compat), so every existing signed record keeps verifying byte-identically. The discriminator is NOT folded into the legacy `to_signing_payload()` pre-image -- adding it there would change every existing record's signed bytes; the engine (v2/v3) owns its own `signing_payload_version` key inside its pre-image. See §3.3.1 § "Version-gated migration" for the dual-path contract.
 
 **Dimension scope validation**: `__post_init__` validates that all scope values are from `VALID_DIMENSION_NAMES = {"financial", "operational", "temporal", "data_access", "communication"}`. At least one dimension is required.
 
@@ -330,6 +335,71 @@ multi-sig signers (a multiset weakens the M-of-N quorum — the threshold is
 validated against the DISTINCT signer count); and the inconsistent
 `V2_COMPLETE` + `multi_sig=True` combo (a multi-sig record MUST sign
 `V3_COMPLETE`).
+
+**Version-gated migration (#1841 shard 2 -- the ratified byte-CHANGING migration, least-breaking form).**
+The engine above is the byte-exact pre-image builder; `DelegationRecord`'s
+sign/verify path is put behind a per-record `signing_payload_version`
+discriminator so the engine can be adopted WITHOUT invalidating existing
+Python-signed records. Three discriminator values are defined
+(`DELEGATION_SIGNING_VERSION_LEGACY` / `_V2` / `_V3` in `chain.py`):
+
+- **`legacy-python-v0`** (the DEFAULT) -- the pre-migration Python schema emitted
+  by `DelegationRecord.to_signing_payload()` (`id` / `delegator_id` /
+  `delegatee_id` / `task_id` / `capabilities_delegated` / `constraint_subset` /
+  `delegated_at` / `dimension_scope` / `expires_at` / `parent_delegation_id` /
+  `reasoning_trace_hash`). This is DISTINCT from the engine's rs-canonical
+  `v1-legacy` shape (`delegation_id` / `delegator` / ...): the Python legacy
+  schema pre-dates the cross-SDK engine and never used the rs-canonical base.
+  A record deserialized from a wire form with NO `signing_payload_version` key
+  resolves to this value (`from_dict` / chain `_deserialize_delegation`
+  backward-compat), so every existing signed record verifies byte-identically.
+- **`v2-complete` / `v3-complete`** -- the engine pre-images. New non-multi-sig
+  records sign v2; new multi-sig records sign v3 (folding the multi-sig policy
+  per the quorum-integrity goal).
+
+**Single dispatch, fail-closed.** Every delegation sign/verify call site routes
+through ONE shared function `delegation_canonical_payload_str()` in
+`kailash.trust.signing.delegation_record_signing` (call sites:
+`operations/__init__.py` `_verify_delegation_signature` + the delegate mint;
+`cli/commands.py` delegate + verify; `signing/rotation.py` key-rotation
+re-sign). It returns the byte-identical legacy pre-image for a
+`legacy-python-v0` record and RAISES
+`UnsupportedSigningPayloadVersionError` (fail-closed) for any other version --
+a non-legacy record MUST NOT fall through to the legacy verifier (which would
+check the WRONG pre-image). The verify sites map that raise to a verification
+failure; the sign/rotation sites propagate it.
+
+**Engine-mapping bridge.** `build_delegation_signing_input()` /
+`delegation_record_signing_payload()` (same module) MAP a `DelegationRecord`'s
+carried fields (`id`->`delegation_id`, `delegator_id`->`delegator`,
+`delegatee_id`->`delegate`, `capabilities_delegated`->`capabilities`,
+`delegated_at`->`created_at`, `expires_at`/`parent_delegation_id`/
+`reasoning_trace_hash` verbatim) onto the engine's `DelegationSigningInput` and
+emit the byte-exact v2/v3 pre-image. `DelegationRecord` does NOT persist the
+structured `constraints` / `resource_limits` / `scope` (nor a multi-sig policy)
+the engine folds, so the caller supplies them; the bridge fails closed when a
+required structured field is missing AND when a record carries a narrowed
+`dimension_scope` (its v2/v3 fold is un-pinned cross-SDK, rs#1795, and the
+engine byte-verifies only the unscoped form -- signing a scoped record under
+v2/v3 would silently drop its widening-attack scope binding).
+
+**What breaks + backward-compat.** This is a byte-CHANGING migration: a record
+signed under `v2-complete` / `v3-complete` produces DIFFERENT bytes from the
+legacy schema and cannot verify under it (and vice versa) -- which is why the
+discriminator is mandatory. Existing (`legacy-python-v0`) records are
+byte-preserved: the shared dispatch reproduces the exact pre-migration
+`serialize_for_signing(to_signing_payload())` bytes, and the discriminator is
+never folded into the legacy pre-image.
+
+**Shard scope.** Shard 2 lands the additive + version-gate half: the
+discriminator field + serde-default backward-compat, the shared fail-closed
+dispatch (all sign/verify/rotation callers migrated), and the additive
+engine-mapping bridge. Sign callers still emit `legacy-python-v0` (byte-identical
+to today); making new records SIGN `v2`/`v3` via the engine requires persisting
+the structured `constraints`/`resource_limits`/`scope`/multi-sig fields on
+`DelegationRecord` (so verify can reconstruct the pre-image) and is a follow-on
+shard (S2b). Verify already fails closed on any non-legacy record until S2b
+wires the record-persisted v2/v3 path.
 
 ### 3.4 AuditAnchor
 

--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -37,6 +37,31 @@ VALID_DIMENSION_NAMES: frozenset[str] = frozenset(
 # Default dimension scope: all five dimensions (no scoping restriction).
 ALL_DIMENSIONS: frozenset[str] = VALID_DIMENSION_NAMES
 
+# Delegation signing-payload version discriminator (#1841 shard 2).
+#
+# A DelegationRecord records WHICH canonical pre-image shape its Ed25519
+# signature was produced over, so a verifier can dispatch to the matching
+# builder. Three values are defined:
+#
+# * ``legacy-python-v0`` (the DEFAULT) — the pre-migration Python schema emitted
+#   by ``DelegationRecord.to_signing_payload()`` (id / delegator_id / ... ).
+#   This is DISTINCT from the engine's rs-canonical ``v1-legacy`` shape
+#   (delegation_id / delegator / ... in ``delegation_payload.py``); the Python
+#   legacy schema pre-dates the cross-SDK engine and never used the rs-canonical
+#   base. Records with NO version field on the wire deserialize to this value
+#   (``from_dict`` backward-compat), so every existing signed record keeps
+#   verifying byte-identically.
+# * ``v2-complete`` / ``v3-complete`` — the engine pre-images
+#   (``kailash.trust.signing.delegation_payload``). New non-multi-sig records
+#   sign v2; new multi-sig records sign v3. Wiring these into the persisted
+#   DelegationRecord sign/verify path (which requires persisting the structured
+#   constraints / resource_limits / scope / multi-sig policy the engine folds)
+#   is a later shard (S2b); this shard lands the discriminator + the additive
+#   engine-mapping bridge + a fail-closed verify dispatch.
+DELEGATION_SIGNING_VERSION_LEGACY: str = "legacy-python-v0"
+DELEGATION_SIGNING_VERSION_V2: str = "v2-complete"
+DELEGATION_SIGNING_VERSION_V3: str = "v3-complete"
+
 if TYPE_CHECKING:
     from kailash.trust.execution_context import HumanOrigin
     from kailash.trust.reasoning.traces import ReasoningTrace
@@ -273,6 +298,16 @@ class DelegationRecord:
     # envelope computation; unscoped dimensions inherit from the parent unchanged.
     dimension_scope: frozenset[str] = field(default_factory=lambda: ALL_DIMENSIONS)
 
+    # Signing-payload version discriminator (#1841 shard 2).
+    # Records which canonical pre-image shape the signature was produced over.
+    # Defaults to the pre-migration Python schema (``legacy-python-v0``); a
+    # record deserialized with NO version field also resolves to this value
+    # (from_dict backward-compat), so existing signed records verify unchanged.
+    # NOT folded into the legacy ``to_signing_payload()`` pre-image — the engine
+    # (v2/v3) owns its own ``signing_payload_version`` key; adding it to the
+    # legacy payload would change every existing record's signed bytes.
+    signing_payload_version: str = DELEGATION_SIGNING_VERSION_LEGACY
+
     def __post_init__(self) -> None:
         """Validate dimension_scope values are from the canonical set."""
         if not isinstance(self.dimension_scope, frozenset):
@@ -341,6 +376,9 @@ class DelegationRecord:
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
             "signature": self.signature,
             "parent_delegation_id": self.parent_delegation_id,
+            # Signing-payload version discriminator (#1841 shard 2). Always
+            # emitted; from_dict defaults a missing key to legacy-python-v0.
+            "signing_payload_version": self.signing_payload_version,
             # EATP fields
             "delegation_chain": self.delegation_chain,
             "delegation_depth": self.delegation_depth,
@@ -413,6 +451,13 @@ class DelegationRecord:
             reasoning_signature=data.get("reasoning_signature"),
             # Dimension scope extension (#170)
             dimension_scope=dimension_scope,
+            # Signing-payload version (#1841 shard 2): backward-compatible --
+            # a record serialized before this field existed has no key, so it
+            # deserializes to the pre-migration legacy schema and verifies
+            # byte-identically to how it was signed.
+            signing_payload_version=data.get(
+                "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+            ),
         )
 
 
@@ -954,6 +999,8 @@ class TrustLineageChain:
             "delegated_at": d.delegated_at.isoformat(),
             "expires_at": d.expires_at.isoformat() if d.expires_at else None,
             "parent_delegation_id": d.parent_delegation_id,
+            # Signing-payload version discriminator (#1841 shard 2).
+            "signing_payload_version": d.signing_payload_version,
         }
         # Reasoning trace extension fields (only if present)
         if d.reasoning_trace:
@@ -992,6 +1039,10 @@ class TrustLineageChain:
             reasoning_trace=reasoning_trace,
             reasoning_trace_hash=d.get("reasoning_trace_hash"),
             reasoning_signature=d.get("reasoning_signature"),
+            # Signing-payload version (#1841 shard 2): absent key = legacy.
+            signing_payload_version=d.get(
+                "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+            ),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1420,6 +1471,9 @@ __all__ = [
     # Constants
     "ALL_DIMENSIONS",
     "VALID_DIMENSION_NAMES",
+    "DELEGATION_SIGNING_VERSION_LEGACY",
+    "DELEGATION_SIGNING_VERSION_V2",
+    "DELEGATION_SIGNING_VERSION_V3",
     # Enums
     "AuthorityType",
     "CapabilityType",

--- a/src/kailash/trust/cli/commands.py
+++ b/src/kailash/trust/cli/commands.py
@@ -32,8 +32,20 @@ from kailash.trust.chain import (
     TrustLineageChain,
     VerificationLevel,
 )
-from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign, verify_signature
-from kailash.trust.exceptions import TrustChainNotFoundError, TrustError
+from kailash.trust.exceptions import (
+    TrustChainNotFoundError,
+    TrustError,
+    UnsupportedSigningPayloadVersionError,
+)
+from kailash.trust.signing.crypto import (
+    generate_keypair,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +151,9 @@ def _format_chain_summary(chain: TrustLineageChain) -> str:
         lines.append("  Capability List:")
         for cap in chain.capabilities:
             expired_tag = " [EXPIRED]" if cap.is_expired() else ""
-            lines.append(f"    - {cap.capability} ({cap.capability_type.value}){expired_tag}")
+            lines.append(
+                f"    - {cap.capability} ({cap.capability_type.value}){expired_tag}"
+            )
     if chain.delegations:
         lines.append("  Delegation List:")
         for d in chain.delegations:
@@ -208,7 +222,9 @@ def _load_private_key(store_dir: str, key_id: str) -> str:
         if data["key_id"] == key_id:
             return data["private_key"]
 
-    raise click.ClickException(f"Key not found: '{key_id}'. Run 'eatp init' to generate keys.")
+    raise click.ClickException(
+        f"Key not found: '{key_id}'. Run 'eatp init' to generate keys."
+    )
 
 
 def _find_delegation_in_store(store_dir: str, delegation_id: str) -> tuple:
@@ -341,7 +357,7 @@ def init_cmd(
             )
         )
     else:
-        click.echo(f"Authority initialized successfully.")
+        click.echo("Authority initialized successfully.")
         click.echo(f"  Authority ID:   {authority_id}")
         click.echo(f"  Name:           {name}")
         click.echo(f"  Type:           {authority_type}")
@@ -472,7 +488,7 @@ def establish_cmd(
             )
         )
     else:
-        click.echo(f"Agent established successfully.")
+        click.echo("Agent established successfully.")
         click.echo(f"  Agent ID:    {agent_name}")
         click.echo(f"  Authority:   {auth.id}")
         click.echo(f"  Capabilities: {', '.join(cap_names)}")
@@ -596,8 +612,9 @@ def delegate_cmd(
         reasoning_trace=reasoning_trace,
     )
 
-    # Sign delegation
-    del_payload = serialize_for_signing(delegation.to_signing_payload())
+    # Sign delegation over the version-gated canonical pre-image (#1841 shard 2).
+    # New records default to legacy-python-v0 (byte-identical to pre-migration).
+    del_payload = delegation_canonical_payload_str(delegation)
     delegation.signature = sign(del_payload, private_key)
 
     # Get or create delegatee's chain
@@ -631,7 +648,9 @@ def delegate_cmd(
                 (c for c in delegator_chain.capabilities if c.capability == cap_name),
                 None,
             )
-            cap_type = source_cap.capability_type if source_cap else CapabilityType.ACTION
+            cap_type = (
+                source_cap.capability_type if source_cap else CapabilityType.ACTION
+            )
             cap_scope = source_cap.scope if source_cap else None
 
             derived_cap = CapabilityAttestation(
@@ -720,7 +739,9 @@ def verify_cmd(
     try:
         chain = _run_async(store.get_chain(agent_id))
     except TrustChainNotFoundError:
-        raise click.ClickException(f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents.")
+        raise click.ClickException(
+            f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents."
+        )
 
     # Check expiration
     if chain.is_expired():
@@ -772,7 +793,9 @@ def verify_cmd(
     if level == "full" and valid:
         auth = _load_authority(store_dir, chain.genesis.authority_id)
         genesis_payload = serialize_for_signing(chain.genesis.to_signing_payload())
-        sig_valid = verify_signature(genesis_payload, chain.genesis.signature, auth.public_key)
+        sig_valid = verify_signature(
+            genesis_payload, chain.genesis.signature, auth.public_key
+        )
         if not sig_valid:
             valid = False
             reason = "Invalid genesis signature"
@@ -864,11 +887,11 @@ def revoke_cmd(
             )
         )
     else:
-        click.echo(f"Delegation revoked successfully.")
+        click.echo("Delegation revoked successfully.")
         click.echo(f"  Delegation ID: {delegation_id}")
         click.echo(f"  Agent:         {agent_id}")
         if cascade:
-            click.echo(f"  Cascade:       Yes (downstream delegations also revoked)")
+            click.echo("  Cascade:       Yes (downstream delegations also revoked)")
 
 
 @click.command("status")
@@ -894,7 +917,9 @@ def status_cmd(
         try:
             chain = _run_async(store.get_chain(agent_id))
         except TrustChainNotFoundError:
-            raise click.ClickException(f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents.")
+            raise click.ClickException(
+                f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents."
+            )
 
         if json_output:
             result = {
@@ -902,7 +927,11 @@ def status_cmd(
                 "authority_id": chain.genesis.authority_id,
                 "authority_type": chain.genesis.authority_type.value,
                 "created_at": chain.genesis.created_at.isoformat(),
-                "expires_at": (chain.genesis.expires_at.isoformat() if chain.genesis.expires_at else None),
+                "expires_at": (
+                    chain.genesis.expires_at.isoformat()
+                    if chain.genesis.expires_at
+                    else None
+                ),
                 "expired": chain.is_expired(),
                 "capabilities": [
                     {
@@ -989,7 +1018,9 @@ def audit_cmd(
     try:
         chain = _run_async(store.get_chain(agent_id))
     except TrustChainNotFoundError:
-        raise click.ClickException(f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents.")
+        raise click.ClickException(
+            f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents."
+        )
 
     # Filter audit anchors
     anchors = list(chain.audit_anchors)
@@ -1036,7 +1067,9 @@ def audit_cmd(
             click.echo("-" * 60)
             for a in anchors:
                 resource_str = f" on {a.resource}" if a.resource else ""
-                click.echo(f"  [{_format_datetime(a.timestamp)}] {a.action}{resource_str} -> {a.result.value}")
+                click.echo(
+                    f"  [{_format_datetime(a.timestamp)}] {a.action}{resource_str} -> {a.result.value}"
+                )
 
 
 @click.command("export")
@@ -1056,7 +1089,9 @@ def export_cmd(ctx: click.Context, agent_id: str) -> None:
     try:
         chain = _run_async(store.get_chain(agent_id))
     except TrustChainNotFoundError:
-        raise click.ClickException(f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents.")
+        raise click.ClickException(
+            f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents."
+        )
 
     chain_dict = chain.to_dict()
 
@@ -1134,7 +1169,9 @@ def scan_cmd(
         else:
             click.echo(f"Scanned: {scan_dir}")
             click.echo("No EATP configuration found.")
-            click.echo("  Expected 'chains/' or 'authorities/' subdirectories, or a '.eatp/' directory.")
+            click.echo(
+                "  Expected 'chains/' or 'authorities/' subdirectories, or a '.eatp/' directory."
+            )
         return
 
     # Aggregate results across all candidate directories
@@ -1213,7 +1250,11 @@ def scan_cmd(
                     "authority_type": chain.genesis.authority_type.value,
                     "chain_status": "expired" if expired else "active",
                     "created_at": chain.genesis.created_at.isoformat(),
-                    "expires_at": (chain.genesis.expires_at.isoformat() if chain.genesis.expires_at else None),
+                    "expires_at": (
+                        chain.genesis.expires_at.isoformat()
+                        if chain.genesis.expires_at
+                        else None
+                    ),
                     "capabilities": capabilities,
                     "active_capabilities": active_caps,
                     "total_capabilities": len(chain.capabilities),
@@ -1237,8 +1278,12 @@ def scan_cmd(
                     "summary": {
                         "total_authorities": len(all_authorities),
                         "total_agents": len(all_agents),
-                        "active_agents": sum(1 for a in all_agents if a["chain_status"] == "active"),
-                        "expired_agents": sum(1 for a in all_agents if a["chain_status"] == "expired"),
+                        "active_agents": sum(
+                            1 for a in all_agents if a["chain_status"] == "active"
+                        ),
+                        "expired_agents": sum(
+                            1 for a in all_agents if a["chain_status"] == "expired"
+                        ),
                     },
                 },
                 indent=2,
@@ -1255,7 +1300,9 @@ def scan_cmd(
             click.echo(f"Authorities ({len(all_authorities)}):")
             click.echo("-" * 60)
             for auth in all_authorities:
-                click.echo(f"  {auth['authority_id']}  |  name={auth['name']}  |  type={auth['type']}")
+                click.echo(
+                    f"  {auth['authority_id']}  |  name={auth['name']}  |  type={auth['type']}"
+                )
         else:
             click.echo("No authorities found.")
         click.echo()
@@ -1263,11 +1310,15 @@ def scan_cmd(
         if all_agents:
             active_count = sum(1 for a in all_agents if a["chain_status"] == "active")
             expired_count = sum(1 for a in all_agents if a["chain_status"] == "expired")
-            click.echo(f"Agents ({len(all_agents)} total, {active_count} active, {expired_count} expired):")
+            click.echo(
+                f"Agents ({len(all_agents)} total, {active_count} active, {expired_count} expired):"
+            )
             click.echo("-" * 60)
             for agent in all_agents:
                 status_tag = " [EXPIRED]" if agent["chain_status"] == "expired" else ""
-                caps_str = ", ".join(c["name"] for c in agent["capabilities"] if not c["expired"])
+                caps_str = ", ".join(
+                    c["name"] for c in agent["capabilities"] if not c["expired"]
+                )
                 click.echo(
                     f"  {agent['agent_id']}{status_tag}"
                     f"  |  auth={agent['authority_id']}"
@@ -1300,7 +1351,9 @@ def verify_chain_cmd(
     try:
         chain = _run_async(store.get_chain(agent_id))
     except TrustChainNotFoundError:
-        raise click.ClickException(f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents.")
+        raise click.ClickException(
+            f"Agent not found: '{agent_id}'. Use 'eatp status' to list known agents."
+        )
 
     # Load authority
     authority_id = chain.genesis.authority_id
@@ -1318,9 +1371,18 @@ def verify_chain_cmd(
         if not verify_signature(cap_payload, cap.signature, auth.public_key):
             issues.append(f"Invalid capability signature (cap_id={cap.id})")
 
-    # Verify delegation signatures
+    # Verify delegation signatures via the version-gated dispatch (#1841 shard 2).
+    # A non-legacy record fails closed (its record-persisted v2/v3 verify path is
+    # not wired in this build) rather than verifying the WRONG legacy pre-image.
     for d in chain.delegations:
-        del_payload = serialize_for_signing(d.to_signing_payload())
+        try:
+            del_payload = delegation_canonical_payload_str(d)
+        except UnsupportedSigningPayloadVersionError as exc:
+            issues.append(
+                f"Unsupported delegation signing_payload_version "
+                f"(del_id={d.id}, version={exc.version})"
+            )
+            continue
         if not verify_signature(del_payload, d.signature, auth.public_key):
             issues.append(f"Invalid delegation signature (del_id={d.id})")
 
@@ -1332,8 +1394,12 @@ def verify_chain_cmd(
             "agent_id": agent_id,
             "chain_hash": chain.hash(),
             "genesis_verified": "Invalid genesis signature" not in " ".join(issues),
-            "capabilities_verified": not any("capability signature" in i for i in issues),
-            "delegations_verified": not any("delegation signature" in i for i in issues),
+            "capabilities_verified": not any(
+                "capability signature" in i for i in issues
+            ),
+            "delegations_verified": not any(
+                "delegation signature" in i for i in issues
+            ),
         }
         if issues:
             result["issues"] = issues
@@ -1341,7 +1407,7 @@ def verify_chain_cmd(
     else:
         if valid:
             click.echo(f"Chain integrity VERIFIED for agent '{agent_id}'.")
-            click.echo(f"  Genesis:      OK")
+            click.echo("  Genesis:      OK")
             click.echo(f"  Capabilities: {len(chain.capabilities)} verified")
             click.echo(f"  Delegations:  {len(chain.delegations)} verified")
             click.echo(f"  Chain Hash:   {chain.hash()[:16]}...")

--- a/src/kailash/trust/exceptions.py
+++ b/src/kailash/trust/exceptions.py
@@ -172,6 +172,32 @@ class InvalidSignatureError(TrustError):
         self.record_id = record_id
 
 
+class UnsupportedSigningPayloadVersionError(TrustError):
+    """Raised when a delegation record declares a signing-payload version whose
+    sign/verify path is not wired for the record in this build.
+
+    Fail-closed discriminator (#1841 shard 2): the shared canonical-payload
+    dispatch produces the legacy (``legacy-python-v0``) pre-image for records
+    on the pre-migration schema. The engine-backed ``v2-complete`` /
+    ``v3-complete`` pre-images require structured constraint / resource-limit /
+    scope (and, for v3, multi-sig policy) data that a :class:`DelegationRecord`
+    does not yet persist, so a record carrying a non-legacy version MUST NOT
+    fall through to the legacy verifier (which would sign/verify the WRONG
+    pre-image). Wiring the record-persisted v2/v3 path is a later shard (S2b).
+    """
+
+    def __init__(self, version: str, record_id: Optional[str] = None):
+        super().__init__(
+            f"Unsupported delegation signing_payload_version {version!r} "
+            f"(record_id={record_id!r}): only 'legacy-python-v0' is wired for "
+            f"DelegationRecord sign/verify in this build; v2/v3-complete require "
+            f"record-persisted structured pre-image data (#1841 shard 2b)",
+            details={"version": version, "record_id": record_id},
+        )
+        self.version = version
+        self.record_id = record_id
+
+
 class VerificationFailedError(TrustError):
     """Raised when trust verification fails for an action."""
 
@@ -332,6 +358,7 @@ __all__ = [
     "DelegationCycleError",
     "DelegationExpiredError",
     "InvalidSignatureError",
+    "UnsupportedSigningPayloadVersionError",
     "VerificationFailedError",
     "AgentAlreadyEstablishedError",
     "TrustStoreError",

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -56,6 +56,7 @@ from kailash.trust.exceptions import (
     InvalidTrustChainError,
     TrustChainNotFoundError,
     TrustError,
+    UnsupportedSigningPayloadVersionError,
     VerificationFailedError,
 )
 from kailash.trust.execution_context import (
@@ -68,6 +69,9 @@ from kailash.trust.signing.crypto import (
     serialize_for_signing,
     sign,
     verify_signature,
+)
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
 )
 
 # Logger for trust operations
@@ -1368,8 +1372,19 @@ class TrustOperations:
             include_inactive=True,  # Allow inactive for historical verification
         )
 
-        # Build signing payload from delegation
-        del_payload = serialize_for_signing(delegation.to_signing_payload())
+        # Build the canonical signing payload via the version-gated dispatch
+        # (#1841 shard 2). A ``legacy-python-v0`` record yields the byte-identical
+        # legacy pre-image; a non-legacy record fails closed (its record-persisted
+        # v2/v3 verify path is not wired in this build) rather than falling through
+        # to the legacy verifier (which would check the WRONG pre-image).
+        try:
+            del_payload = delegation_canonical_payload_str(delegation)
+        except UnsupportedSigningPayloadVersionError as exc:
+            return VerificationResult(
+                valid=False,
+                reason=f"Unsupported delegation signing_payload_version: {exc.version}",
+                level=VerificationLevel.FULL,
+            )
 
         # Verify signature using authority's key
         if not verify_signature(
@@ -1745,7 +1760,11 @@ class TrustOperations:
         authority_id = delegator_chain.genesis.authority_id
         authority = await self.authority_registry.get_authority(authority_id)
 
-        delegation_payload = serialize_for_signing(delegation.to_signing_payload())
+        # Sign over the version-gated canonical pre-image (#1841 shard 2). New
+        # records default to ``legacy-python-v0``, so this is byte-identical to
+        # the pre-migration signing behaviour; the shared dispatch is the single
+        # site S2b extends to sign the engine (v2/v3) pre-image.
+        delegation_payload = delegation_canonical_payload_str(delegation)
         delegation.signature = await self.key_manager.sign(
             delegation_payload,
             authority.signing_key_id,

--- a/src/kailash/trust/signing/__init__.py
+++ b/src/kailash/trust/signing/__init__.py
@@ -76,6 +76,11 @@ from kailash.trust.signing.delegation_payload import (
     TrustLevel,
     delegation_signing_payload,
 )
+from kailash.trust.signing.delegation_record_signing import (
+    build_delegation_signing_input,
+    delegation_canonical_payload_str,
+    delegation_record_signing_payload,
+)
 from kailash.trust.signing.derivation import derive_trace_token
 
 __all__ = [
@@ -115,6 +120,10 @@ __all__ = [
     "MultiSigSigningPolicy",
     "DelegationSigningInput",
     "delegation_signing_payload",
+    # Version-gated DelegationRecord signing/verify bridge (#1841 shard 2)
+    "delegation_canonical_payload_str",
+    "build_delegation_signing_input",
+    "delegation_record_signing_payload",
     # EATP-08 v1.1 algorithm-identifier surface (canonical namespace)
     "ADOPTION_DATE",
     "ADOPTION_DATE_PARSED",

--- a/src/kailash/trust/signing/delegation_record_signing.py
+++ b/src/kailash/trust/signing/delegation_record_signing.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Version-gated delegation signing/verify bridge for ``DelegationRecord``.
+
+This module is the version-discriminated boundary between a
+:class:`kailash.trust.chain.DelegationRecord` and the two pre-image families a
+delegation signature can be produced over:
+
+* the pre-migration **legacy** Python schema (``legacy-python-v0``), emitted by
+  ``DelegationRecord.to_signing_payload()`` and encoded with the trust-plane
+  signing encoder ``serialize_for_signing`` (issue #959); and
+* the cross-SDK **engine** pre-images (``v2-complete`` / ``v3-complete``) built
+  by :func:`kailash.trust.signing.delegation_payload.delegation_signing_payload`,
+  which mirror the kailash-rs byte contract (EATP §5.3).
+
+Two surfaces, one dispatch (#1841 shard 2):
+
+1. :func:`delegation_canonical_payload_str` is the SINGLE shared entry point that
+   EVERY delegation sign/verify call site routes through. It returns the legacy
+   canonical string for a ``legacy-python-v0`` record (byte-identical to the
+   pre-migration behaviour), and FAILS CLOSED
+   (:class:`~kailash.trust.exceptions.UnsupportedSigningPayloadVersionError`) for
+   any other version — because the engine (v2/v3) pre-image requires structured
+   constraint / resource-limit / scope / multi-sig data a ``DelegationRecord``
+   does not yet persist, so a non-legacy record MUST NOT fall through to the
+   legacy verifier (which would sign/verify the WRONG pre-image). Wiring the
+   record-persisted v2/v3 path is a later shard (S2b).
+
+2. :func:`build_delegation_signing_input` / :func:`delegation_record_signing_payload`
+   are the ADDITIVE engine bridge: they MAP a ``DelegationRecord``'s carried
+   fields onto the engine's :class:`DelegationSigningInput` and emit the byte-exact
+   v2/v3 engine pre-image. They are exercised directly (with the caller supplying
+   the structured constraints / resource_limits / scope the record lacks) and are
+   the mapping S2b will call from the sign/verify path once the structured fields
+   are persisted on the record. They fail closed on missing structured data and
+   on a scoped record whose ``dimension_scope`` binding is not yet cross-SDK-pinned
+   (see :func:`build_delegation_signing_input`), never emitting guessed bytes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from kailash.trust.exceptions import UnsupportedSigningPayloadVersionError
+from kailash.trust.signing.crypto import serialize_for_signing
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    DelegationSigningInput,
+    MultiSigSigningPolicy,
+    ResourceLimits,
+    SigningPayloadVersion,
+    delegation_signing_payload,
+)
+
+if TYPE_CHECKING:
+    from kailash.trust.chain import DelegationRecord
+
+__all__ = [
+    "delegation_canonical_payload_str",
+    "build_delegation_signing_input",
+    "delegation_record_signing_payload",
+]
+
+
+def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
+    """Return the canonical signing string a delegation record is signed/verified over.
+
+    The SINGLE shared dispatch every delegation sign/verify call site routes
+    through, so the version gate has ONE source of truth (``rules/security.md``
+    § Multi-Site Kwarg Plumbing).
+
+    Args:
+        record: The delegation record whose canonical pre-image is requested.
+
+    Returns:
+        The ``serialize_for_signing`` string of the legacy
+        ``to_signing_payload()`` pre-image (for a ``legacy-python-v0`` record).
+
+    Raises:
+        UnsupportedSigningPayloadVersionError: If the record declares any version
+            other than ``legacy-python-v0``. The engine-backed v2/v3 pre-images
+            require record-persisted structured data this build does not yet
+            carry (#1841 shard 2b); falling through to the legacy verifier would
+            sign/verify the WRONG pre-image, so this fails closed.
+    """
+    # Import lazily to avoid a chain <-> signing import cycle: chain.py imports
+    # kailash.trust.signing.crypto at module load, which initialises the signing
+    # package; a top-level `from kailash.trust.chain import ...` here would run
+    # before chain's module-level constants are defined.
+    from kailash.trust.chain import DELEGATION_SIGNING_VERSION_LEGACY
+
+    version = getattr(
+        record, "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+    )
+    if version == DELEGATION_SIGNING_VERSION_LEGACY:
+        return serialize_for_signing(record.to_signing_payload())
+
+    raise UnsupportedSigningPayloadVersionError(
+        version, record_id=getattr(record, "id", None)
+    )
+
+
+def build_delegation_signing_input(
+    record: "DelegationRecord",
+    *,
+    constraints: ConstraintDimensions,
+    resource_limits: ResourceLimits,
+    scope: DelegationScope,
+    multi_sig: bool = False,
+    multi_sig_policy: Optional[MultiSigSigningPolicy] = None,
+) -> DelegationSigningInput:
+    """Map a ``DelegationRecord`` onto the engine's ``DelegationSigningInput``.
+
+    ``DelegationRecord`` carries the identity / capability / timestamp fields the
+    engine base needs, but NOT the structured constraint / resource-limit / scope
+    (and multi-sig policy) the v2/v3 fold requires — those are supplied by the
+    caller. This is the mapping table (record field -> engine field):
+
+    ======================  ===============================
+    DelegationRecord         DelegationSigningInput
+    ======================  ===============================
+    ``id``                   ``delegation_id``
+    ``delegator_id``         ``delegator``
+    ``delegatee_id``         ``delegate``
+    ``capabilities_delegated`` ``capabilities`` (order preserved)
+    ``delegated_at``         ``created_at``
+    ``expires_at``           ``expires_at``
+    ``parent_delegation_id`` ``parent_delegation_id``
+    ``reasoning_trace_hash`` ``reasoning_trace_hash``
+    (caller-supplied)        ``constraints`` / ``resource_limits`` / ``scope``
+    (caller-supplied)        ``multi_sig`` / ``multi_sig_policy``
+    ======================  ===============================
+
+    Fail-closed guards (matching the engine's own posture — never emit guessed
+    bytes):
+
+    * ``constraints`` / ``resource_limits`` / ``scope`` are REQUIRED (the engine
+      folds them into every v2/v3 pre-image); a ``None`` raises rather than
+      fabricating a default.
+    * A record whose ``dimension_scope`` is narrower than the full CARE set is
+      REFUSED for the engine pre-image: the Python ``dimension_scope`` is a
+      security-relevant scoping the legacy ``to_signing_payload`` binds, but its
+      fold into the cross-SDK v2/v3 pre-image is not yet pinned (rs#1795), and
+      the engine byte-verifies only ``dimension_scope=None``. Signing such a
+      record under v2/v3 without binding its scope would silently drop a
+      widening-attack defence, so it fails closed here.
+
+    Args:
+        record: The delegation record to map.
+        constraints: The structured constraint dimensions to fold (required).
+        resource_limits: The structured resource-limit ceilings to fold (required).
+        scope: The delegation scope to fold (required).
+        multi_sig: Whether the record is multi-sig (v3).
+        multi_sig_policy: The M-of-N policy to fold (required when ``multi_sig``).
+
+    Returns:
+        A :class:`DelegationSigningInput` ready for
+        :func:`delegation_signing_payload`.
+
+    Raises:
+        ValueError: If a required structured field is missing, or the record
+            carries a narrowed ``dimension_scope`` whose v2/v3 binding is not
+            cross-SDK-pinned.
+    """
+    from kailash.trust.chain import ALL_DIMENSIONS
+
+    if constraints is None:
+        raise ValueError(
+            "build_delegation_signing_input: 'constraints' is required for the "
+            "engine (v2/v3) pre-image; DelegationRecord does not persist "
+            "structured ConstraintDimensions, so the caller MUST supply it "
+            "(fail-closed — no guessed defaults)"
+        )
+    if resource_limits is None:
+        raise ValueError(
+            "build_delegation_signing_input: 'resource_limits' is required for "
+            "the engine (v2/v3) pre-image; DelegationRecord does not persist "
+            "structured ResourceLimits, so the caller MUST supply it "
+            "(fail-closed — no guessed defaults)"
+        )
+    if scope is None:
+        raise ValueError(
+            "build_delegation_signing_input: 'scope' is required for the engine "
+            "(v2/v3) pre-image; DelegationRecord does not persist a structured "
+            "DelegationScope, so the caller MUST supply it (fail-closed — no "
+            "guessed defaults)"
+        )
+
+    # A narrowed dimension_scope is a security-relevant scoping the legacy
+    # pre-image binds; its cross-SDK v2/v3 fold is un-pinned (rs#1795) and the
+    # engine byte-verifies only dimension_scope=None. Refuse rather than sign a
+    # scoped record whose scope the engine pre-image would silently drop.
+    record_scope = getattr(record, "dimension_scope", ALL_DIMENSIONS)
+    if frozenset(record_scope) != frozenset(ALL_DIMENSIONS):
+        raise ValueError(
+            "build_delegation_signing_input: record.dimension_scope is narrowed "
+            f"({sorted(record_scope)}); its fold into the cross-SDK v2/v3 "
+            "pre-image is not yet pinned (rs#1795), and the engine byte-verifies "
+            "only the unscoped (all-dimensions) form. Signing a scoped record "
+            "under v2/v3 would drop its scope binding (a widening-attack defence) "
+            "— fail closed until a scoped vector is pinned in lockstep"
+        )
+
+    return DelegationSigningInput(
+        delegation_id=record.id,
+        delegator=record.delegator_id,
+        delegate=record.delegatee_id,
+        capabilities=tuple(record.capabilities_delegated),
+        created_at=record.delegated_at,
+        constraints=constraints,
+        resource_limits=resource_limits,
+        scope=scope,
+        expires_at=record.expires_at,
+        parent_delegation_id=record.parent_delegation_id,
+        multi_sig=multi_sig,
+        multi_sig_policy=multi_sig_policy,
+        reasoning_trace_hash=record.reasoning_trace_hash,
+    )
+
+
+def delegation_record_signing_payload(
+    record: "DelegationRecord",
+    version: SigningPayloadVersion,
+    *,
+    constraints: ConstraintDimensions,
+    resource_limits: ResourceLimits,
+    scope: DelegationScope,
+    multi_sig: bool = False,
+    multi_sig_policy: Optional[MultiSigSigningPolicy] = None,
+) -> bytes:
+    """Build the byte-exact engine (v2/v3) signing pre-image for a delegation record.
+
+    Maps the record via :func:`build_delegation_signing_input`, then delegates to
+    the cross-SDK engine :func:`delegation_signing_payload` for the byte contract.
+    The engine enforces its own fail-closed posture (non-ASCII content, sub-second
+    timestamps, ``V2_COMPLETE`` + ``multi_sig=True``, ``V3_COMPLETE`` without a
+    policy, populated ``dimension_scope``); this function adds the
+    DelegationRecord-side guards (missing structured data, narrowed scope).
+
+    Args:
+        record: The delegation record.
+        version: ``SigningPayloadVersion.V2_COMPLETE`` or ``.V3_COMPLETE``.
+        constraints: Structured constraint dimensions to fold (required).
+        resource_limits: Structured resource-limit ceilings to fold (required).
+        scope: Delegation scope to fold (required).
+        multi_sig: Whether the record is multi-sig (v3).
+        multi_sig_policy: The M-of-N policy to fold (required when ``multi_sig``).
+
+    Returns:
+        The canonical JCS engine pre-image as UTF-8 bytes.
+
+    Raises:
+        ValueError: On any DelegationRecord-side or engine fail-closed guard.
+    """
+    signing_input = build_delegation_signing_input(
+        record,
+        constraints=constraints,
+        resource_limits=resource_limits,
+        scope=scope,
+        multi_sig=multi_sig,
+        multi_sig_policy=multi_sig_policy,
+    )
+    return delegation_signing_payload(signing_input, version)

--- a/src/kailash/trust/signing/rotation.py
+++ b/src/kailash/trust/signing/rotation.py
@@ -35,6 +35,9 @@ from kailash.trust.exceptions import (
 )
 from kailash.trust.operations import TrustKeyManager
 from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
+)
 
 
 class RotationStatus(str, Enum):
@@ -533,12 +536,14 @@ class CredentialRotationManager:
                         )
                         capability.signature = new_signature
 
-                # Re-sign delegations
+                # Re-sign delegations over the version-gated canonical pre-image
+                # (#1841 shard 2). A legacy-python-v0 delegation re-signs over the
+                # byte-identical legacy pre-image; a non-legacy record fails closed
+                # (its record-persisted v2/v3 re-sign path is wired in S2b) rather
+                # than re-signing the WRONG pre-image with the rotated key.
                 for delegation in updated_chain.delegations:
                     if delegation.delegator_id == authority_id:
-                        del_payload = serialize_for_signing(
-                            delegation.to_signing_payload()
-                        )
+                        del_payload = delegation_canonical_payload_str(delegation)
                         new_signature = await self.key_manager.sign(
                             del_payload, new_key_id
                         )

--- a/tests/regression/test_issue_1841_delegation_signing_migration.py
+++ b/tests/regression/test_issue_1841_delegation_signing_migration.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1841 shard 2 — DelegationRecord signing version gate.
+
+Covers the additive + version-gate migration that puts the delegation
+sign/verify path behind a ``signing_payload_version`` discriminator while
+keeping every existing (pre-migration) record verifying byte-identically:
+
+* backward-compat — a delegation signed the pre-migration way still verifies
+  through the migrated dispatch, AND a record deserialized from a wire form with
+  NO ``signing_payload_version`` key verifies unchanged;
+* byte-identity — the shared dispatch emits the SAME bytes the pre-migration
+  ``serialize_for_signing(to_signing_payload())`` did for a legacy record (the
+  migration changes zero legacy signing bytes);
+* fail-closed — a record declaring a non-legacy version fails closed at verify
+  rather than falling through to the legacy verifier;
+* the engine-mapping bridge — byte-exact v2/v3 engine pre-images + its
+  fail-closed guards (missing structured data, narrowed dimension_scope).
+
+Real Ed25519 crypto throughout (Tier 2 — no mocking).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.chain import (
+    DELEGATION_SIGNING_VERSION_LEGACY,
+    DELEGATION_SIGNING_VERSION_V2,
+    DELEGATION_SIGNING_VERSION_V3,
+    DelegationRecord,
+)
+from kailash.trust.exceptions import UnsupportedSigningPayloadVersionError
+from kailash.trust.signing import (
+    ConstraintDimensions,
+    DelegationScope,
+    DelegationSigningInput,
+    MultiSigSigningPolicy,
+    ResourceLimits,
+    SigningPayloadVersion,
+    TrustLevel,
+    build_delegation_signing_input,
+    delegation_canonical_payload_str,
+    delegation_record_signing_payload,
+    delegation_signing_payload,
+)
+from kailash.trust.signing.crypto import (
+    generate_keypair,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
+
+pytestmark = pytest.mark.regression
+
+
+def _record(**overrides) -> DelegationRecord:
+    base = dict(
+        id="del-1841",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-1",
+        capabilities_delegated=["read"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        signature="",
+    )
+    base.update(overrides)
+    return DelegationRecord(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Field default + serde backward-compat                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_new_record_defaults_to_legacy_version():
+    """A freshly-constructed record signs under the pre-migration schema."""
+    assert _record().signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+
+
+def test_from_dict_missing_version_key_defaults_legacy():
+    """A pre-migration wire form (no version key) deserializes to legacy."""
+    d = _record().to_dict()
+    assert d["signing_payload_version"] == DELEGATION_SIGNING_VERSION_LEGACY
+    # Simulate a record serialized BEFORE the field existed.
+    del d["signing_payload_version"]
+    restored = DelegationRecord.from_dict(d)
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+
+
+def test_to_dict_from_dict_roundtrips_version():
+    d = _record(signing_payload_version=DELEGATION_SIGNING_VERSION_V2).to_dict()
+    assert DelegationRecord.from_dict(d).signing_payload_version == (
+        DELEGATION_SIGNING_VERSION_V2
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identity: the migration changes zero legacy signing bytes              #
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_dispatch_byte_identical_to_pre_migration():
+    """The shared dispatch emits exactly the pre-migration legacy pre-image."""
+    record = _record()
+    # The pre-migration signing site did precisely this.
+    pre_migration = serialize_for_signing(record.to_signing_payload())
+    assert delegation_canonical_payload_str(record) == pre_migration
+
+
+def test_signing_payload_version_not_in_legacy_preimage():
+    """The discriminator MUST NOT enter the legacy signed bytes (byte-compat)."""
+    record = _record()
+    assert "signing_payload_version" not in record.to_signing_payload()
+    assert "signing_payload_version" not in delegation_canonical_payload_str(record)
+
+
+# --------------------------------------------------------------------------- #
+# Backward-compat: existing legacy record still verifies (real crypto)        #
+# --------------------------------------------------------------------------- #
+
+
+def test_existing_legacy_record_still_verifies():
+    """A delegation signed the pre-migration way verifies via the migrated path."""
+    private_key, public_key = generate_keypair()
+    record = _record()
+
+    # Sign the pre-migration way (what a record already on disk carries).
+    legacy_payload = serialize_for_signing(record.to_signing_payload())
+    record.signature = sign(legacy_payload, private_key)
+
+    # Verify through the migrated dispatch — MUST succeed byte-identically.
+    verify_payload = delegation_canonical_payload_str(record)
+    assert verify_signature(verify_payload, record.signature, public_key) is True
+
+
+def test_record_deserialized_without_version_key_still_verifies():
+    """A record persisted before the field existed round-trips + verifies."""
+    private_key, public_key = generate_keypair()
+    record = _record()
+    record.signature = sign(
+        serialize_for_signing(record.to_signing_payload()), private_key
+    )
+
+    # Round-trip through a wire form that predates the version field.
+    wire = record.to_dict()
+    del wire["signing_payload_version"]
+    restored = DelegationRecord.from_dict(wire)
+
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    assert (
+        verify_signature(
+            delegation_canonical_payload_str(restored),
+            restored.signature,
+            public_key,
+        )
+        is True
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed: a non-legacy version does NOT fall through to the legacy path  #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "version",
+    [DELEGATION_SIGNING_VERSION_V2, DELEGATION_SIGNING_VERSION_V3, "future-vX"],
+)
+def test_non_legacy_version_fails_closed_at_dispatch(version):
+    record = _record(signing_payload_version=version)
+    with pytest.raises(UnsupportedSigningPayloadVersionError) as exc:
+        delegation_canonical_payload_str(record)
+    assert exc.value.version == version
+    assert exc.value.record_id == "del-1841"
+
+
+def test_non_legacy_record_does_not_verify_under_legacy_bytes():
+    """A v2-declared record signed over legacy bytes MUST fail closed, not pass.
+
+    This is the core security property: the version gate stops a record whose
+    declared shape (v2) differs from the bytes a naive legacy verifier would
+    check, so a mismatched record can never be accepted.
+    """
+    private_key, _ = generate_keypair()
+    record = _record()
+    # Attacker/legacy signs over the legacy bytes but stamps a v2 version.
+    record.signature = sign(
+        serialize_for_signing(record.to_signing_payload()), private_key
+    )
+    record.signing_payload_version = DELEGATION_SIGNING_VERSION_V2
+
+    # The dispatch refuses to produce a verify pre-image → fail closed.
+    with pytest.raises(UnsupportedSigningPayloadVersionError):
+        delegation_canonical_payload_str(record)
+
+
+# --------------------------------------------------------------------------- #
+# Engine-mapping bridge — byte-exact v2/v3 + fail-closed guards               #
+# --------------------------------------------------------------------------- #
+
+
+def _supervised_structured():
+    return (
+        ConstraintDimensions.for_level(TrustLevel.SUPERVISED),
+        ResourceLimits.for_level(TrustLevel.SUPERVISED),
+        DelegationScope.new("engineering").with_operation("read"),
+    )
+
+
+def test_bridge_v2_byte_exact_against_direct_engine():
+    """The bridge's v2 pre-image equals the direct engine pre-image."""
+    record = _record()
+    constraints, limits, scope = _supervised_structured()
+
+    via_bridge = delegation_record_signing_payload(
+        record,
+        SigningPayloadVersion.V2_COMPLETE,
+        constraints=constraints,
+        resource_limits=limits,
+        scope=scope,
+    )
+    via_engine = delegation_signing_payload(
+        DelegationSigningInput(
+            delegation_id=record.id,
+            delegator=record.delegator_id,
+            delegate=record.delegatee_id,
+            capabilities=tuple(record.capabilities_delegated),
+            created_at=record.delegated_at,
+            constraints=constraints,
+            resource_limits=limits,
+            scope=scope,
+            expires_at=record.expires_at,
+            parent_delegation_id=record.parent_delegation_id,
+        ),
+        SigningPayloadVersion.V2_COMPLETE,
+    )
+    assert via_bridge == via_engine
+
+
+def test_bridge_v3_folds_multisig_policy():
+    record = _record()
+    constraints, limits, scope = _supervised_structured()
+    policy = MultiSigSigningPolicy.new(2, [b"\x01" * 32, b"\x02" * 32])
+
+    payload = delegation_record_signing_payload(
+        record,
+        SigningPayloadVersion.V3_COMPLETE,
+        constraints=constraints,
+        resource_limits=limits,
+        scope=scope,
+        multi_sig=True,
+        multi_sig_policy=policy,
+    )
+    assert b"multi_sig_threshold" in payload
+    assert b"multi_sig_authorized_signers" in payload
+
+
+@pytest.mark.parametrize("missing", ["constraints", "resource_limits", "scope"])
+def test_bridge_fails_closed_on_missing_structured_field(missing):
+    record = _record()
+    constraints, limits, scope = _supervised_structured()
+    kwargs = {"constraints": constraints, "resource_limits": limits, "scope": scope}
+    kwargs[missing] = None
+    with pytest.raises(ValueError, match=missing):
+        build_delegation_signing_input(record, **kwargs)
+
+
+def test_bridge_fails_closed_on_narrowed_dimension_scope():
+    """A scoped record MUST NOT sign under v2/v3 (its scope binding is un-pinned)."""
+    record = _record(dimension_scope=frozenset({"financial"}))
+    constraints, limits, scope = _supervised_structured()
+    with pytest.raises(ValueError, match="dimension_scope"):
+        delegation_record_signing_payload(
+            record,
+            SigningPayloadVersion.V2_COMPLETE,
+            constraints=constraints,
+            resource_limits=limits,
+            scope=scope,
+        )

--- a/tests/trust/unit/test_reasoning_backward_compat.py
+++ b/tests/trust/unit/test_reasoning_backward_compat.py
@@ -18,30 +18,30 @@ backward compatibility guarantee:
 """
 
 import json
-import pytest
 from datetime import datetime, timezone
 
+import pytest
+
 from kailash.trust.chain import (
-    GenesisRecord,
-    CapabilityAttestation,
-    DelegationRecord,
-    ConstraintEnvelope,
-    Constraint,
-    AuditAnchor,
-    TrustLineageChain,
-    AuthorityType,
-    CapabilityType,
     ActionResult,
+    AuditAnchor,
+    AuthorityType,
+    CapabilityAttestation,
+    CapabilityType,
+    Constraint,
+    ConstraintEnvelope,
     ConstraintType,
+    DelegationRecord,
+    GenesisRecord,
+    TrustLineageChain,
 )
 from kailash.trust.signing.crypto import (
     generate_keypair,
+    hash_trust_chain_state,
+    serialize_for_signing,
     sign,
     verify_signature,
-    serialize_for_signing,
-    hash_trust_chain_state,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures: canonical test objects representing the "v1" wire format
@@ -600,6 +600,10 @@ class TestChainInlineSerialization:
             "delegated_at",
             "expires_at",
             "parent_delegation_id",
+            # Signing-payload version discriminator (#1841 shard 2). Serialized
+            # so a verifier can dispatch to the matching pre-image builder; a
+            # record deserialized without the key defaults to legacy-python-v0.
+            "signing_payload_version",
         }
         assert set(delegation_dict.keys()) == expected_keys
 


### PR DESCRIPTION
Part of #1841. Migrates the delegation signing path onto the canonical cross-SDK pre-image **engine** (merged in shard 1) behind a **dual-path version gate** so the engine can be adopted WITHOUT invalidating existing Python-signed delegation records. This is the additive + version-gate half of the ratified byte-CHANGING migration, in its least-breaking form.

## The problem
`DelegationRecord.to_signing_payload()` uses a legacy Python schema (`id`/`delegator_id`/`delegatee_id`/`task_id`/`capabilities_delegated`/`constraint_subset`/`delegated_at`/`dimension_scope`/`expires_at`/`parent_delegation_id`/`reasoning_trace_hash`) that does NOT match the engine's rs-canonical schema (`delegation_id`/`delegator`/`delegate`/`capabilities`/`created_at`/`expires_at`/`parent_delegation_id` + folds). Existing Python-signed records were signed over the legacy schema; adopting the engine outright means they can never verify again. So this is a byte-CHANGING migration that MUST preserve existing records via a version discriminator.

## Dual-path design (as implemented)
1. **`signing_payload_version` field** on `DelegationRecord` (`str`, default `legacy-python-v0`). Serialized in `to_dict` / `_serialize_delegation`; `from_dict` / `_deserialize_delegation` default a MISSING key to `legacy-python-v0` (serde-default backward-compat). NOT folded into the legacy `to_signing_payload()` pre-image — adding it there would change every existing record's signed bytes.
2. **`legacy-python-v0`** (default) — verify/sign via the existing `to_signing_payload()` path, byte-identical to pre-migration.
3. **`v2-complete` / `v3-complete`** — the engine pre-images (available via the bridge; not yet emitted by sign callers — see S2b).
4. **Single shared fail-closed dispatch** `delegation_canonical_payload_str()` (new module `kailash.trust.signing.delegation_record_signing`) that EVERY sign/verify/rotation caller routes through: legacy → byte-identical legacy pre-image; any non-legacy version → raises `UnsupportedSigningPayloadVersionError` (fail closed) rather than falling through to the legacy verifier (which would check the WRONG bytes).
5. **Engine-mapping bridge** `build_delegation_signing_input()` / `delegation_record_signing_payload()` — maps `DelegationRecord` fields onto the engine's `DelegationSigningInput` and emits byte-exact v2/v3 pre-images, failing closed on missing structured data + narrowed `dimension_scope` (un-pinned v2/v3 fold, rs#1795).

### Field-mapping table (DelegationRecord → engine)
| DelegationRecord | DelegationSigningInput |
|---|---|
| `id` | `delegation_id` |
| `delegator_id` | `delegator` |
| `delegatee_id` | `delegate` |
| `capabilities_delegated` | `capabilities` (order preserved) |
| `delegated_at` | `created_at` |
| `expires_at` | `expires_at` |
| `parent_delegation_id` | `parent_delegation_id` |
| `reasoning_trace_hash` | `reasoning_trace_hash` |
| (caller-supplied) | `constraints` / `resource_limits` / `scope` |
| (caller-supplied) | `multi_sig` / `multi_sig_policy` |

`DelegationRecord` does NOT persist structured `constraints`/`resource_limits`/`scope`/multi-sig; the bridge requires them from the caller (fail-closed, no guessed defaults).

## Callers migrated (grep-verified — all sign/verify/rotation sites)
- verify: `operations/__init__.py::_verify_delegation_signature`, `cli/commands.py` `verify-chain`
- sign: `operations/__init__.py` delegate mint, `cli/commands.py` `delegate`
- re-sign: `signing/rotation.py` key-rotation

## What breaks + backward-compat proof
Byte-CHANGING: a v2/v3 record's bytes differ from the legacy schema and cannot cross-verify — which is why the discriminator is mandatory. Existing (`legacy-python-v0`) records are **byte-preserved**. Proof (verbatim):

```
tests/regression/test_issue_1841_delegation_signing_migration.py ... 17 passed
- test_legacy_dispatch_byte_identical_to_pre_migration PASSED   # dispatch == serialize_for_signing(to_signing_payload())
- test_existing_legacy_record_still_verifies PASSED             # real Ed25519 sign(legacy) -> verify via migrated path
- test_record_deserialized_without_version_key_still_verifies PASSED
- test_non_legacy_version_fails_closed_at_dispatch[v2/v3/future] PASSED
- test_non_legacy_record_does_not_verify_under_legacy_bytes PASSED
- test_bridge_v2_byte_exact_against_direct_engine PASSED
- test_bridge_v3_folds_multisig_policy PASSED
- test_bridge_fails_closed_on_missing_structured_field[constraints/resource_limits/scope] PASSED
- test_bridge_fails_closed_on_narrowed_dimension_scope PASSED
```

Full trust tree + engine tripwire (verbatim):
```
tests/trust/ + regression: 6373 passed, 28 skipped   (52 "errors" = pytest-benchmark fixture missing under -p no:benchmark; pass with plugin on)
tests/regression/test_delegation_signing_payload_vectors.py: 10 passed   # engine byte contract UNTOUCHED
```

The pre-existing frozen test `test_delegation_signing_payload_matches_frozen` (asserting the exact legacy `to_signing_payload()` dict) still passes — independent confirmation the legacy pre-image is unchanged.

## User-flow walk receipt (real `eatp` CLI, scrubbed)
```
$ eatp init --name "Acme Corp" --json           -> authority created
$ eatp establish alice --authority <id> --capabilities "read_data,write_data"  -> Agent established
$ eatp delegate --from alice --to bob --capabilities "read_data"               -> Delegation created (signed via migrated sign site)
$ eatp verify-chain bob
  Chain integrity VERIFIED for agent 'bob'.
  Delegations:  1 verified
  exit 0
```
Disposition: a new delegation is signed (migrated sign site -> legacy-python-v0, byte-identical) and verified (migrated dispatch), end-to-end, exit 0.

## AC progress
- [x] Version discriminator + serde-default backward-compat (existing records byte-identical)
- [x] Engine-mapping bridge + byte-exact v2/v3 pre-images, fail-closed guards
- [x] Verify dispatch fails closed on unknown/non-legacy version
- [x] All sign/verify/rotation callers migrated to one shared dispatch
- [x] Specs updated (`specs/trust-eatp.md` §3.3 + §3.3.1 § Version-gated migration)
- [ ] **S2b (follow-on):** persist structured `constraints`/`resource_limits`/`scope`/multi-sig on `DelegationRecord` so new records SIGN v2/v3 via the engine (verify already fails closed until then); version-aware key-rotation re-sign; policy-bearing-non-v3 rejection once multi-sig fields exist.

## Scope note (S2 vs S2b)
Sign callers still emit `legacy-python-v0` (byte-identical to today). Making new records SIGN v2/v3 requires `DelegationRecord` to persist the structured fields the engine folds (so verify can reconstruct the pre-image) — a data-model enrichment + cross-SDK-lockstep change that is a clean separate shard. This PR is complete and mergeable on its own: existing records verify unchanged, the engine bridge is available + tested, and verify is fail-closed on any non-legacy record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
