### PR TITLE
feat(eatp): verify consults signed revocation ledger + durable anti-rollback re-seed (#1842 shard 3/N)

### DIFF
--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -738,30 +738,40 @@ resets the high-water to 0 and would accept a stale lower-epoch head silently).
 
 **Authoritative verify + durable anti-rollback wiring (`#1842` shard 3).** The
 durability WIRING and the verify consult live in
-`kailash.trust.revocation.verify`. `DurableHighWaterStore` persists the
-`high_water_epoch` + `high_water_tip_hash` to `revocation_highwater.json` after
-each `accept()` (via `persist_anchor`) and RE-SEEDS a `HeadCommitmentAnchor` from
-it on every read (via `load_anchor` — never a bare anchor, so a process-restart
-replay of a lower-epoch head is REJECTED). `SignedRevocationStore` persists the
-ledger event set ALONGSIDE the owner-signed `HeadCommitment` +
-signature to `revocation_head.json`, so a verifier RECOMPUTES the ledger tip and
-detects a store-writer who added / deleted / reordered an event (the tip changes
-→ the owner-head signature no longer binds it). `SignedRevocationVerifier` is the
-AUTHORITATIVE revocation decision (`verified_revoked_set` / `is_revoked`): it (1)
-verifies the owner's Ed25519 signature over the head, (2) recomputes the ledger
-tip and confirms it equals the signed head tip, (3) re-seeds the durable anchor
-and `accept`s the head (anti-rollback + equivocation), then persists the advanced
-high-water. Any unverifiable condition RAISES `RevocationVerificationError` —
+`kailash.trust.revocation.verify`. `SignedRevocationStore` persists the ledger
+event set ALONGSIDE the owner-signed `HeadCommitment` + signature to
+`revocation_head.json`, so a verifier RECOMPUTES the ledger tip and detects a
+store-writer who added / deleted / reordered an event (the tip changes → the
+owner-head signature no longer binds it). `DurableHighWaterStore` persists the
+accepted head as an **owner-SIGNED** high-water record (`{head, head_signature}`)
+to `revocation_highwater.json` and RE-SEEDS a `HeadCommitmentAnchor` from it on
+every read — never a bare anchor, so a process-restart replay of a lower-epoch
+head is REJECTED. The high-water record's owner signature is verified on every
+load (a store-writer cannot forge an arbitrary lower epoch; the documented
+RESIDUAL is replay of a previously-valid owner-signed head — complete defense
+against a full-local-write adversary needs an EXTERNAL append-only anchor, out of
+scope for local persistence). The re-seed → `accept` → persist sequence runs as
+ONE atomic compare-and-swap under a single `file_lock`, so a concurrent verifier
+cannot interleave a stale read and regress the high-water (monotonic-non-
+decreasing by construction). `SignedRevocationVerifier` is the AUTHORITATIVE
+revocation decision (`verified_revoked_set` / `is_revoked`): it (1) loads the
+signed-head store — an ABSENT store consults the durable high-water FIRST and
+RAISES if a head was ever accepted (`high_water_epoch > 0` = a deleted-head
+resurrection attempt), only genesis (high-water at 0) yields the empty set; (2)
+verifies the owner Ed25519 signature over the head; (3) recomputes the ledger tip
+and confirms it equals the signed head tip; (4) runs the atomic anti-rollback
+CAS. Any unverifiable condition RAISES `RevocationVerificationError` —
 fail-closed: the caller DENIES, NEVER falling open to the mutable unsigned
-`revoked` flag / the in-memory cascade. An ABSENT store is the legitimate
-genesis / empty-ledger case (empty revoked set), distinct from a
-PRESENT-but-unverifiable store (deny). The delegation verify path consults this
-verifier authoritatively: `TrustOperations.verify` (`operations/__init__.py`,
-the `_check_signed_revocation` helper) DENIES at EVERY level (including QUICK)
-when the agent's chain (its `agent_id` or any delegation id) is in the verified
-signed ledger, or when the ledger/head is unverifiable. The in-memory cascade
-(`TrustRevocationList`) and the CRL (`CertificateRevocationList`) MAY remain a
-fast-path cache, but the AUTHORITATIVE decision derives from the signed ledger.
+`revoked` flag / the in-memory cascade. The delegation verify path consults this
+verifier authoritatively: `TrustOperations.verify` (`operations/__init__.py`, the
+`_check_signed_revocation` helper) DENIES at EVERY level (including QUICK) when
+the agent's chain (its `agent_id` or any delegation id) is in the verified signed
+ledger, or when the ledger/head is unverifiable. When NO verifier is wired,
+`verify` emits a one-time WARN that the authoritative layer is OFF (a deployment
+handling untrusted store writers MUST wire a `SignedRevocationVerifier`); it does
+not hard-fail (backward-compatible). The in-memory cascade (`TrustRevocationList`)
+and the CRL (`CertificateRevocationList`) MAY remain a fast-path cache, but the
+AUTHORITATIVE decision derives from the signed ledger.
 
 **Cross-SDK PROVISIONAL tripwires.** The event pre-image + signature (RE0-RE3,
 incl. the RE3 nanosecond-fidelity boundary), tip fold (LT0 all-zero empty, LT1,

--- a/specs/trust-eatp.md
+++ b/specs/trust-eatp.md
@@ -725,7 +725,7 @@ differs from the pinned one is REJECTED as an equivocation / same-epoch fork (un
 the strict-monotonic-epoch invariant one epoch has at most one head, so a differing
 same-epoch tip is a forgery signal).
 
-**Durability contract (`#1842-S3` REQUIREMENT).** The high-water is IN-MEMORY and
+**Durability contract.** The high-water is IN-MEMORY and
 monotonic only within ONE `HeadCommitmentAnchor` lifetime. A bare
 `HeadCommitmentAnchor()` (default `initial_epoch=0`) fails OPEN — it accepts any
 epoch ≥ 0, correct ONLY for genuine first-use with no head history. A caller
@@ -734,10 +734,34 @@ persisting heads across process restarts MUST (a) persist `high_water_epoch` (an
 (b) RE-SEED `initial_epoch` (and `initial_tip_hash`) from that durable store when
 reconstructing the anchor on the persisted-head read path. Constructing a bare
 anchor on the persisted-head read path is a ROLLBACK VULNERABILITY (every restart
-resets the high-water to 0 and would accept a stale lower-epoch head silently). The
-durability WIRING (which store, when to persist) is #1842 shard 3's job; this shard
-ships the enforced-as-documented in-memory contract + the `initial_epoch` /
-`initial_tip_hash` re-seed handles.
+resets the high-water to 0 and would accept a stale lower-epoch head silently).
+
+**Authoritative verify + durable anti-rollback wiring (`#1842` shard 3).** The
+durability WIRING and the verify consult live in
+`kailash.trust.revocation.verify`. `DurableHighWaterStore` persists the
+`high_water_epoch` + `high_water_tip_hash` to `revocation_highwater.json` after
+each `accept()` (via `persist_anchor`) and RE-SEEDS a `HeadCommitmentAnchor` from
+it on every read (via `load_anchor` — never a bare anchor, so a process-restart
+replay of a lower-epoch head is REJECTED). `SignedRevocationStore` persists the
+ledger event set ALONGSIDE the owner-signed `HeadCommitment` +
+signature to `revocation_head.json`, so a verifier RECOMPUTES the ledger tip and
+detects a store-writer who added / deleted / reordered an event (the tip changes
+→ the owner-head signature no longer binds it). `SignedRevocationVerifier` is the
+AUTHORITATIVE revocation decision (`verified_revoked_set` / `is_revoked`): it (1)
+verifies the owner's Ed25519 signature over the head, (2) recomputes the ledger
+tip and confirms it equals the signed head tip, (3) re-seeds the durable anchor
+and `accept`s the head (anti-rollback + equivocation), then persists the advanced
+high-water. Any unverifiable condition RAISES `RevocationVerificationError` —
+fail-closed: the caller DENIES, NEVER falling open to the mutable unsigned
+`revoked` flag / the in-memory cascade. An ABSENT store is the legitimate
+genesis / empty-ledger case (empty revoked set), distinct from a
+PRESENT-but-unverifiable store (deny). The delegation verify path consults this
+verifier authoritatively: `TrustOperations.verify` (`operations/__init__.py`,
+the `_check_signed_revocation` helper) DENIES at EVERY level (including QUICK)
+when the agent's chain (its `agent_id` or any delegation id) is in the verified
+signed ledger, or when the ledger/head is unverifiable. The in-memory cascade
+(`TrustRevocationList`) and the CRL (`CertificateRevocationList`) MAY remain a
+fast-path cache, but the AUTHORITATIVE decision derives from the signed ledger.
 
 **Cross-SDK PROVISIONAL tripwires.** The event pre-image + signature (RE0-RE3,
 incl. the RE3 nanosecond-fidelity boundary), tip fold (LT0 all-zero empty, LT1,

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -74,6 +74,9 @@ from kailash.trust.signing.delegation_record_signing import (
     delegation_canonical_payload_str,
 )
 
+if TYPE_CHECKING:
+    from kailash.trust.revocation.verify import SignedRevocationVerifier
+
 # Logger for trust operations
 logger = logging.getLogger(__name__)
 
@@ -244,6 +247,7 @@ class TrustOperations:
         key_manager: TrustKeyManager,
         trust_store: TrustStore,
         max_delegation_depth: int = MAX_DELEGATION_DEPTH,
+        revocation_verifier: "SignedRevocationVerifier | None" = None,
     ):
         """
         Initialize TrustOperations.
@@ -254,11 +258,19 @@ class TrustOperations:
             trust_store: Storage for trust chains
             max_delegation_depth: Maximum allowed delegation depth from human origin
                                   (CARE-004). Defaults to MAX_DELEGATION_DEPTH (10).
+            revocation_verifier: Optional AUTHORITATIVE signed-ledger revocation
+                verifier (#1842). When set, :meth:`verify` consults the
+                owner-signed revocation ledger as the authoritative revocation
+                source and DENIES a revoked delegation — fail-closed on an
+                unverifiable ledger/head, never falling open to the unsigned
+                ``revoked`` flag. When ``None`` (default), verify behaviour is
+                unchanged (the in-memory cascade remains the only surface).
         """
         self.authority_registry = authority_registry
         self.key_manager = key_manager
         self.trust_store = trust_store
         self.max_delegation_depth = max_delegation_depth
+        self.revocation_verifier = revocation_verifier
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -565,6 +577,18 @@ class TrustOperations:
                 level=level,
             )
 
+        # 1a. AUTHORITATIVE revocation gate (#1842). When a signed-ledger
+        # verifier is configured it is the AUTHORITATIVE revocation source —
+        # consulted at EVERY level (including QUICK) so no verification path
+        # authorizes a revoked delegation. Fail-closed: an unverifiable
+        # ledger/head (bad owner signature, a store-tampered event set, an
+        # anti-rollback violation) DENIES; it NEVER falls open to the mutable
+        # unsigned ``revoked`` flag / the in-memory cascade.
+        if self.revocation_verifier is not None:
+            revoked = self._check_signed_revocation(chain, level)
+            if revoked is not None:
+                return revoked
+
         # QUICK level: Just check hash and expiration
         if level == VerificationLevel.QUICK:
             return await self._verify_quick(chain, level)
@@ -697,6 +721,70 @@ class TrustOperations:
             reasoning_present=reasoning_present,
             reasoning_verified=reasoning_verified,
         )
+
+    def _check_signed_revocation(
+        self,
+        chain: TrustLineageChain,
+        level: VerificationLevel,
+    ) -> Optional[VerificationResult]:
+        """Consult the AUTHORITATIVE signed revocation ledger (#1842).
+
+        Returns a DENY :class:`VerificationResult` when the agent's chain (its
+        ``agent_id`` or any delegation id in the chain) is present in the
+        owner-signed revocation ledger, OR when the ledger/head cannot be verified
+        (fail-closed). Returns ``None`` when the signed ledger authoritatively
+        shows the chain is NOT revoked, so verification proceeds.
+
+        The signed ledger is the AUTHORITATIVE source: a store-writer who flips a
+        persisted unsigned ``revoked`` flag changes nothing here, and one who
+        deletes a signed revocation event changes the recomputed tip → the
+        owner-head signature no longer binds it → detected and denied.
+        """
+        from kailash.trust.revocation.verify import RevocationVerificationError
+
+        assert self.revocation_verifier is not None  # gated by caller
+        try:
+            revoked_set = self.revocation_verifier.verified_revoked_set()
+        except RevocationVerificationError as exc:
+            # Fail-closed: an unverifiable signed ledger/head DENIES. We do NOT
+            # fall open to the unsigned ``revoked`` flag / in-memory cascade.
+            logger.warning(
+                "signed revocation ledger unverifiable — denying verify "
+                "(fail-closed, #1842)",
+                extra={"agent_id": chain.genesis.agent_id, "error": str(exc)},
+            )
+            return VerificationResult(
+                valid=False,
+                reason=(
+                    "Revocation ledger unverifiable — fail-closed deny "
+                    f"(signed ledger is authoritative): {exc}"
+                ),
+                level=level,
+            )
+
+        # Match the chain's identifiers against the signed revoked set. The
+        # ledger's unit is the delegation id; we also match the agent id so a
+        # revocation recorded against the agent denies too.
+        candidate_ids = {chain.genesis.agent_id}
+        candidate_ids.update(d.id for d in chain.delegations)
+        hit = candidate_ids & revoked_set
+        if hit:
+            logger.info(
+                "signed revocation ledger authoritative DENY (#1842)",
+                extra={
+                    "agent_id": chain.genesis.agent_id,
+                    "revoked_ids": sorted(hit),
+                },
+            )
+            return VerificationResult(
+                valid=False,
+                reason=(
+                    "Delegation revoked per the owner-signed revocation ledger "
+                    f"(authoritative): {sorted(hit)}"
+                ),
+                level=level,
+            )
+        return None
 
     async def _verify_quick(
         self,

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -271,6 +271,10 @@ class TrustOperations:
         self.trust_store = trust_store
         self.max_delegation_depth = max_delegation_depth
         self.revocation_verifier = revocation_verifier
+        # FIX 4 (#1842) — one-time WARN latch. When no signed-ledger verifier is
+        # wired, the authoritative resurrection/rollback defenses are OFF; verify()
+        # emits ONE WARN the first time it runs unprotected (observability Rule 4).
+        self._revocation_verifier_absent_warned = False
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -588,6 +592,20 @@ class TrustOperations:
             revoked = self._check_signed_revocation(chain, level)
             if revoked is not None:
                 return revoked
+        elif not self._revocation_verifier_absent_warned:
+            # FIX 4 (#1842) — opt-in fail-open is a real gap: with no signed-ledger
+            # verifier, verify() offers ZERO protection against a store-writer who
+            # flips a persisted `revoked` flag or replays a stale head. Emit ONE
+            # WARN so the missing authoritative layer is observable rather than
+            # silent (observability Rule 4). Deployments handling untrusted store
+            # writers MUST wire a SignedRevocationVerifier.
+            self._revocation_verifier_absent_warned = True
+            logger.warning(
+                "trust verify running WITHOUT the authoritative signed-revocation "
+                "layer (#1842): resurrection/rollback defenses are OFF — wire a "
+                "SignedRevocationVerifier via TrustOperations(revocation_verifier=...) "
+                "for store-tamper protection"
+            )
 
         # QUICK level: Just check hash and expiration
         if level == VerificationLevel.QUICK:

--- a/src/kailash/trust/revocation/__init__.py
+++ b/src/kailash/trust/revocation/__init__.py
@@ -91,6 +91,12 @@ from kailash.trust.revocation.signed_ledger import (
     SignedRevocationEvent,
     revocation_ledger_tip,
 )
+from kailash.trust.revocation.verify import (
+    DurableHighWaterStore,
+    RevocationVerificationError,
+    SignedRevocationStore,
+    SignedRevocationVerifier,
+)
 
 __all__ = [
     # Enums
@@ -128,4 +134,9 @@ __all__ = [
     "HeadCommitmentAnchor",
     "HeadCommitmentError",
     "HEAD_COMMITMENT_DOMAIN_SEP",
+    # Authoritative signed-ledger verify + durable anti-rollback (EATP-12 D5, #1842)
+    "SignedRevocationVerifier",
+    "SignedRevocationStore",
+    "DurableHighWaterStore",
+    "RevocationVerificationError",
 ]

--- a/src/kailash/trust/revocation/verify.py
+++ b/src/kailash/trust/revocation/verify.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""EATP-12 D5 signed-ledger revocation verify + durable anti-rollback re-seed.
+
+This module wires the append-only signed revocation ledger
+(:mod:`kailash.trust.revocation.signed_ledger`) and the owner-signed persisted
+head (:mod:`kailash.trust.revocation.head_commitment`) into the AUTHORITATIVE
+revocation decision on the delegation verify path (#1842 shard 3).
+
+Two durable artifacts persist under a store directory:
+
+* ``revocation_head.json`` — the full ledger event set + the current
+  owner-signed :class:`HeadCommitment` + its Ed25519 signature (hex). The event
+  set is what lets a verifier RECOMPUTE the ledger tip and detect a store-writer
+  who added / deleted / reordered an event (the tip changes → head signature no
+  longer binds it → detected).
+* ``revocation_highwater.json`` — the durable anti-rollback high-water
+  (``epoch`` + pinned ``tip_hash``). The persisted-head READ path RE-SEEDS a
+  :class:`HeadCommitmentAnchor` from this file (NOT a bare anchor), so a
+  process-restart replay of a lower-epoch head is REJECTED — the rollback
+  vulnerability :class:`HeadCommitmentAnchor`'s DURABILITY CONTRACT calls out.
+
+**Fail-closed (``rules/eatp.md`` / ``rules/security.md``).** The signed ledger is
+the AUTHORITATIVE revocation source. If the persisted head cannot be verified —
+missing/malformed store, bad owner signature, a recomputed ledger tip that does
+not match the signed head's tip, or an anti-rollback / equivocation violation —
+the verifier RAISES :class:`RevocationVerificationError` and the caller MUST deny
+(treat as revoked). It NEVER falls open to the unsigned ``revoked`` flag / the
+in-memory cascade. An ABSENT store (no revocation ever persisted) is the
+legitimate genesis / empty-ledger case and yields an EMPTY revoked set (not a
+deny) — distinct from a PRESENT-but-unverifiable store, which denies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+
+from kailash.trust._locking import atomic_write, file_lock, safe_read_json
+from kailash.trust.exceptions import TrustError
+from kailash.trust.revocation.head_commitment import (
+    HeadCommitment,
+    HeadCommitmentAnchor,
+    HeadCommitmentError,
+)
+from kailash.trust.revocation.signed_ledger import (
+    RevocationLedgerError,
+    SignedRevocationEvent,
+    revocation_ledger_tip,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Filename of the persisted signed head + ledger event set.
+HEAD_FILENAME = "revocation_head.json"
+
+#: Filename of the durable anti-rollback high-water.
+HIGHWATER_FILENAME = "revocation_highwater.json"
+
+
+class RevocationVerificationError(TrustError):
+    """Raised (fail-closed) when the signed revocation ledger/head cannot be
+    verified — a missing owner signature, a store-tamper tip mismatch, or an
+    anti-rollback / equivocation violation. The caller MUST deny (treat as
+    revoked); it MUST NOT fall open to the unsigned ``revoked`` flag.
+    """
+
+
+class DurableHighWaterStore:
+    """Durable anti-rollback high-water store (a single JSON record).
+
+    Persists :attr:`HeadCommitmentAnchor.high_water_epoch` + the pinned
+    :attr:`HeadCommitmentAnchor.high_water_tip_hash` after each accepted head, and
+    RE-SEEDS a fresh :class:`HeadCommitmentAnchor` from that record on the
+    persisted-head read path. Reconstructing a BARE ``HeadCommitmentAnchor()``
+    instead is the rollback vulnerability the head-commitment DURABILITY CONTRACT
+    documents; :meth:`load_anchor` closes it.
+
+    Uses the trust-plane single-record persistence idiom
+    (``_locking.atomic_write`` + ``safe_read_json`` + ``file_lock`` — the same
+    crash-safe temp-file-rename + O_NOFOLLOW symlink guard the delegation WAL
+    uses), NOT a bespoke store.
+    """
+
+    def __init__(self, store_dir: Path) -> None:
+        self._store_dir = Path(store_dir)
+        self._path = self._store_dir / HIGHWATER_FILENAME
+        self._lock_path = self._store_dir / f".{HIGHWATER_FILENAME}.lock"
+
+    def load_anchor(self) -> HeadCommitmentAnchor:
+        """Reconstruct the anchor, re-seeding the high-water from durable state.
+
+        A missing file yields a genesis anchor (``initial_epoch=0``) — the
+        legitimate first-use case with no prior head. A present record re-seeds
+        ``initial_epoch`` (+ ``initial_tip_hash``) so a lower-epoch replay after a
+        restart is rejected.
+
+        Raises:
+            RevocationVerificationError: If the persisted high-water record is
+                present but malformed (fail-closed — never silently reset to 0,
+                which would defeat the anti-rollback purpose).
+        """
+        if not self._path.exists():
+            return HeadCommitmentAnchor()
+        try:
+            data = safe_read_json(self._path)
+            epoch = data["epoch"]
+            tip_hex = data.get("tip_hash")
+            tip_hash = bytes.fromhex(tip_hex) if tip_hex is not None else None
+            return HeadCommitmentAnchor(initial_epoch=epoch, initial_tip_hash=tip_hash)
+        except (
+            OSError,
+            json.JSONDecodeError,
+            KeyError,
+            ValueError,
+            TypeError,
+            HeadCommitmentError,
+        ) as exc:
+            raise RevocationVerificationError(
+                "durable high-water store is present but unreadable/malformed "
+                "(fail-closed — refusing to reset the anti-rollback high-water "
+                f"to 0): {exc}"
+            ) from exc
+
+    def persist_anchor(self, anchor: HeadCommitmentAnchor) -> None:
+        """Persist the anchor's current high-water (epoch + pinned tip) durably.
+
+        Called after each successful :meth:`HeadCommitmentAnchor.accept` so the
+        advanced high-water survives a process restart.
+        """
+        tip = anchor.high_water_tip_hash
+        record: Dict[str, Any] = {
+            "epoch": anchor.high_water_epoch,
+            "tip_hash": tip.hex() if tip is not None else None,
+        }
+        with file_lock(self._lock_path):
+            atomic_write(self._path, record)
+
+
+class SignedRevocationStore:
+    """Persists the ledger event set + the owner-signed :class:`HeadCommitment`.
+
+    The event set is persisted ALONGSIDE the head so a verifier can RECOMPUTE the
+    ledger tip and confirm it matches the tip the owner signed — the store-tamper
+    (revocation-resurrection / deletion) detection. Same crash-safe atomic-write +
+    O_NOFOLLOW idiom as :class:`DurableHighWaterStore`.
+    """
+
+    def __init__(self, store_dir: Path) -> None:
+        self._store_dir = Path(store_dir)
+        self._path = self._store_dir / HEAD_FILENAME
+        self._lock_path = self._store_dir / f".{HEAD_FILENAME}.lock"
+
+    def persist_head(
+        self,
+        events: Sequence[SignedRevocationEvent],
+        head: HeadCommitment,
+        head_signature_hex: str,
+    ) -> None:
+        """Persist the ledger events + the owner-signed head + its signature.
+
+        Args:
+            events: The signed revocation events, in epoch-ascending fold order —
+                the exact sequence whose fold produced ``head.revocation_ledger_tip``.
+            head: The owner-signed :class:`HeadCommitment` binding that tip.
+            head_signature_hex: The owner's Ed25519 signature over ``head`` (hex).
+        """
+        record: Dict[str, Any] = {
+            "events": [e.to_dict() for e in events],
+            "head": head.to_dict(),
+            "head_signature": head_signature_hex,
+        }
+        with file_lock(self._lock_path):
+            atomic_write(self._path, record)
+
+    def load_head(
+        self,
+    ) -> Tuple[List[SignedRevocationEvent], HeadCommitment, str] | None:
+        """Load the persisted events + head + signature.
+
+        Returns:
+            ``(events, head, signature_hex)`` if a head is persisted, or ``None``
+            when the store is ABSENT (the legitimate empty-ledger / genesis case —
+            NOT a fail-closed condition).
+
+        Raises:
+            RevocationVerificationError: If the store is PRESENT but malformed
+                (fail-closed — a corrupt store is a tamper signal, not an empty
+                ledger).
+        """
+        if not self._path.exists():
+            return None
+        try:
+            data = safe_read_json(self._path)
+            events = [SignedRevocationEvent.from_dict(e) for e in data["events"]]
+            head = HeadCommitment.from_dict(data["head"])
+            signature_hex = data["head_signature"]
+            if not isinstance(signature_hex, str):
+                raise ValueError("head_signature must be a hex string")
+            return events, head, signature_hex
+        except (
+            OSError,
+            json.JSONDecodeError,
+            KeyError,
+            ValueError,
+            TypeError,
+            RevocationLedgerError,
+            HeadCommitmentError,
+        ) as exc:
+            raise RevocationVerificationError(
+                "signed revocation head store is present but "
+                f"unreadable/malformed (fail-closed deny): {exc}"
+            ) from exc
+
+
+class SignedRevocationVerifier:
+    """AUTHORITATIVE revocation decision, derived from the signed ledger.
+
+    The in-memory cascade (:class:`~kailash.trust.revocation.broadcaster.TrustRevocationList`)
+    and the CRL may remain a fast-path cache, but the AUTHORITATIVE revocation
+    decision on the verify path MUST derive from THIS verifier — the signed
+    ledger verified against the owner-signed head, with a durable anti-rollback
+    anchor. It NEVER trusts the mutable unsigned ``revoked`` flag.
+
+    A store-writer who flips a persisted ``revoked`` flag at rest changes NOTHING
+    here: the signed ledger + head are the source of truth. Conversely, a
+    store-writer who DELETES a revocation event from the ledger changes the
+    recomputed tip → the owner's head signature no longer binds it → detected and
+    denied.
+    """
+
+    def __init__(
+        self,
+        owner_public_key: bytes,
+        signed_store: SignedRevocationStore,
+        highwater_store: DurableHighWaterStore,
+    ) -> None:
+        """Initialize the verifier.
+
+        Args:
+            owner_public_key: The 32-byte Ed25519 public key the persisted head is
+                signed under.
+            signed_store: The durable signed-head + event-set store.
+            highwater_store: The durable anti-rollback high-water store (re-seeds
+                the :class:`HeadCommitmentAnchor` on every read).
+        """
+        self._owner_public_key = owner_public_key
+        self._signed_store = signed_store
+        self._highwater_store = highwater_store
+
+    def verified_revoked_set(self) -> set[str]:
+        """Return the set of revoked delegation ids, verified fail-closed.
+
+        Performs, in order (any failure RAISES — fail-closed, the caller denies):
+
+        1. Load the persisted head + event set. ABSENT store → empty set (genesis).
+        2. Verify the owner's Ed25519 signature over the head.
+        3. Recompute the ledger tip from the persisted events and confirm it
+           matches ``head.revocation_ledger_tip`` (store-tamper / resurrection
+           detection).
+        4. Re-seed the :class:`HeadCommitmentAnchor` from the durable high-water
+           and ``accept`` the head (anti-rollback + equivocation). Persist the
+           advanced high-water on success.
+
+        Returns:
+            The set of ``delegation_id`` present in the verified signed ledger
+            (empty when the store is absent).
+
+        Raises:
+            RevocationVerificationError: On any unverifiable condition
+                (fail-closed). The caller MUST deny.
+        """
+        loaded = self._signed_store.load_head()
+        if loaded is None:
+            # Genesis / empty ledger — nothing revoked. NOT a fail-closed deny.
+            return set()
+        events, head, signature_hex = loaded
+
+        # (2) Owner signature over the head — fail-closed if it does not verify.
+        if not head.verify(signature_hex, self._owner_public_key):
+            raise RevocationVerificationError(
+                "persisted revocation head owner signature did not verify "
+                "(fail-closed deny — refusing to fall open to the unsigned "
+                "revoked flag)"
+            )
+
+        # (3) Recompute the ledger tip from the persisted events and confirm the
+        # owner-signed head binds THIS event set. A store-writer who added,
+        # deleted, or reordered an event changes the recomputed tip; the head
+        # signature (verified above) binds the ORIGINAL tip, so a mismatch is a
+        # tamper signal → deny.
+        recomputed_tip = revocation_ledger_tip(events)
+        if recomputed_tip != head.revocation_ledger_tip:
+            raise RevocationVerificationError(
+                "recomputed revocation-ledger tip does not match the "
+                "owner-signed head tip — the persisted event set was tampered "
+                "(added/deleted/reordered); fail-closed deny"
+            )
+
+        # (4) Anti-rollback: re-seed the anchor from the DURABLE high-water (never
+        # a bare anchor) and accept the head. A restart replay of a lower-epoch
+        # head — or a same-epoch equivocating fork — raises here.
+        anchor = self._highwater_store.load_anchor()
+        try:
+            anchor.accept(head)
+        except HeadCommitmentError as exc:
+            raise RevocationVerificationError(
+                f"anti-rollback check rejected the persisted head: {exc}"
+            ) from exc
+        self._highwater_store.persist_anchor(anchor)
+
+        return {e.delegation_id for e in events}
+
+    def is_revoked(self, delegation_id: str) -> bool:
+        """Return True iff ``delegation_id`` is revoked per the signed ledger.
+
+        Raises:
+            RevocationVerificationError: On any unverifiable condition
+                (fail-closed). The caller MUST deny rather than treat the raise as
+                "not revoked".
+        """
+        return delegation_id in self.verified_revoked_set()
+
+
+__all__ = [
+    "HEAD_FILENAME",
+    "HIGHWATER_FILENAME",
+    "RevocationVerificationError",
+    "DurableHighWaterStore",
+    "SignedRevocationStore",
+    "SignedRevocationVerifier",
+]

--- a/src/kailash/trust/revocation/verify.py
+++ b/src/kailash/trust/revocation/verify.py
@@ -85,32 +85,39 @@ class DurableHighWaterStore:
     uses), NOT a bespoke store.
     """
 
-    def __init__(self, store_dir: Path) -> None:
+    def __init__(self, store_dir: Path, owner_public_key: bytes) -> None:
+        """Initialize the durable high-water store.
+
+        Args:
+            store_dir: Directory holding ``revocation_highwater.json``.
+            owner_public_key: The 32-byte Ed25519 owner public key. The persisted
+                high-water is itself an owner-SIGNED head (see the class
+                docstring's FIX-3 note); the signature is verified on every read so
+                a store-writer cannot forge an arbitrary lower epoch — only replay
+                a PREVIOUSLY-VALID owner-signed head (the documented residual).
+        """
         self._store_dir = Path(store_dir)
         self._path = self._store_dir / HIGHWATER_FILENAME
         self._lock_path = self._store_dir / f".{HIGHWATER_FILENAME}.lock"
+        self._owner_public_key = owner_public_key
 
-    def load_anchor(self) -> HeadCommitmentAnchor:
-        """Reconstruct the anchor, re-seeding the high-water from durable state.
+    def _load_anchor_unlocked(self) -> HeadCommitmentAnchor:
+        """Re-seed the anchor from the durable (owner-signed) high-water record.
 
-        A missing file yields a genesis anchor (``initial_epoch=0``) — the
-        legitimate first-use case with no prior head. A present record re-seeds
-        ``initial_epoch`` (+ ``initial_tip_hash``) so a lower-epoch replay after a
-        restart is rejected.
-
-        Raises:
-            RevocationVerificationError: If the persisted high-water record is
-                present but malformed (fail-closed — never silently reset to 0,
-                which would defeat the anti-rollback purpose).
+        Caller MUST hold ``self._lock_path``. A missing file yields a genesis
+        anchor (``initial_epoch=0``) — the legitimate first-use case. A present
+        record is an owner-signed head; its signature is verified before the epoch
+        is trusted (FIX 3). Fail-closed on absent-signature / malformed / bad-sig —
+        NEVER silently reset to 0 (which would defeat anti-rollback).
         """
         if not self._path.exists():
             return HeadCommitmentAnchor()
         try:
             data = safe_read_json(self._path)
-            epoch = data["epoch"]
-            tip_hex = data.get("tip_hash")
-            tip_hash = bytes.fromhex(tip_hex) if tip_hex is not None else None
-            return HeadCommitmentAnchor(initial_epoch=epoch, initial_tip_hash=tip_hash)
+            head = HeadCommitment.from_dict(data["head"])
+            signature_hex = data["head_signature"]
+            if not isinstance(signature_hex, str):
+                raise ValueError("head_signature must be a hex string")
         except (
             OSError,
             json.JSONDecodeError,
@@ -124,19 +131,73 @@ class DurableHighWaterStore:
                 "(fail-closed — refusing to reset the anti-rollback high-water "
                 f"to 0): {exc}"
             ) from exc
+        # FIX 3 — bind the durable high-water to the owner signature. A store-writer
+        # who lowers the persisted epoch must present a validly-owner-signed head at
+        # that epoch, not forge an arbitrary number; an unsigned/forged high-water
+        # fails closed here. RESIDUAL (documented): a full-local-write adversary can
+        # still REPLAY a previously-valid owner-signed head at an earlier epoch —
+        # complete defense against a local store-writer requires an EXTERNAL
+        # monotonic/append-only anchor outside the store's write scope, out of scope
+        # for local persistence.
+        if not head.verify(signature_hex, self._owner_public_key):
+            raise RevocationVerificationError(
+                "durable high-water head signature did not verify (fail-closed — "
+                "the persisted anti-rollback high-water was tampered)"
+            )
+        return HeadCommitmentAnchor(
+            initial_epoch=head.epoch, initial_tip_hash=head.tip_hash
+        )
 
-    def persist_anchor(self, anchor: HeadCommitmentAnchor) -> None:
-        """Persist the anchor's current high-water (epoch + pinned tip) durably.
+    def load_anchor(self) -> HeadCommitmentAnchor:
+        """Re-seed the anchor from durable state (read-only, off the CAS path).
 
-        Called after each successful :meth:`HeadCommitmentAnchor.accept` so the
-        advanced high-water survives a process restart.
+        Used by the head-absent tamper check (a persisted high-water at epoch ≥ 1
+        with the signed-head store deleted is a resurrection signal). Held under the
+        file lock for a consistent read.
+
+        Raises:
+            RevocationVerificationError: If the persisted high-water record is
+                present but malformed or its owner signature does not verify
+                (fail-closed).
         """
-        tip = anchor.high_water_tip_hash
-        record: Dict[str, Any] = {
-            "epoch": anchor.high_water_epoch,
-            "tip_hash": tip.hex() if tip is not None else None,
-        }
         with file_lock(self._lock_path):
+            return self._load_anchor_unlocked()
+
+    def accept_and_persist(
+        self, commitment: HeadCommitment, head_signature_hex: str
+    ) -> None:
+        """Atomic anti-rollback compare-and-swap under ONE file lock (FIX 2).
+
+        Reads the current durable high-water, re-seeds an anchor from it, and
+        ``accept``s ``commitment`` — all inside a SINGLE ``file_lock`` so no
+        concurrent verifier can interleave a stale read between another's
+        accept and persist (the non-monotonic-regression race). ``accept`` enforces
+        ``commitment.epoch >= current`` (rollback → raise) and equal-epoch tip
+        equality (equivocation → raise), so the persisted high-water is
+        monotonic-non-decreasing by construction. Persists the accepted head as the
+        new owner-signed high-water record (FIX 3).
+
+        Args:
+            commitment: The verified :class:`HeadCommitment` being accepted.
+            head_signature_hex: The owner's Ed25519 signature over ``commitment``
+                (already verified by the caller; re-verified on the next load).
+
+        Raises:
+            RevocationVerificationError: On rollback / equivocation (fail-closed),
+                or if the current durable record is unverifiable.
+        """
+        with file_lock(self._lock_path):
+            anchor = self._load_anchor_unlocked()
+            try:
+                anchor.accept(commitment)
+            except HeadCommitmentError as exc:
+                raise RevocationVerificationError(
+                    f"anti-rollback check rejected the persisted head: {exc}"
+                ) from exc
+            record: Dict[str, Any] = {
+                "head": commitment.to_dict(),
+                "head_signature": head_signature_hex,
+            }
             atomic_write(self._path, record)
 
 
@@ -275,6 +336,22 @@ class SignedRevocationVerifier:
         """
         loaded = self._signed_store.load_head()
         if loaded is None:
+            # FIX 1 (CRITICAL) — a MISSING signed-head store is NOT unconditionally
+            # "nothing revoked". A store-writer who deletes ONLY
+            # revocation_head.json (leaving the durable high-water at epoch ≥ 1)
+            # would silently un-revoke EVERY delegation. Consult the durable
+            # high-water FIRST: if a head was ever accepted (high_water_epoch > 0),
+            # an absent signed-head store is a resurrection/tamper signal → deny.
+            # ONLY head-absent AND high-water-at-genesis(0) is the legitimate
+            # empty-ledger case.
+            anchor = self._highwater_store.load_anchor()
+            if anchor.high_water_epoch > 0:
+                raise RevocationVerificationError(
+                    "signed revocation head store is absent but the durable "
+                    f"high-water is at epoch {anchor.high_water_epoch} — the "
+                    "persisted head was deleted (resurrection attempt); "
+                    "fail-closed deny"
+                )
             # Genesis / empty ledger — nothing revoked. NOT a fail-closed deny.
             return set()
         events, head, signature_hex = loaded
@@ -301,16 +378,12 @@ class SignedRevocationVerifier:
             )
 
         # (4) Anti-rollback: re-seed the anchor from the DURABLE high-water (never
-        # a bare anchor) and accept the head. A restart replay of a lower-epoch
-        # head — or a same-epoch equivocating fork — raises here.
-        anchor = self._highwater_store.load_anchor()
-        try:
-            anchor.accept(head)
-        except HeadCommitmentError as exc:
-            raise RevocationVerificationError(
-                f"anti-rollback check rejected the persisted head: {exc}"
-            ) from exc
-        self._highwater_store.persist_anchor(anchor)
+        # a bare anchor) and accept the head — as ONE atomic compare-and-swap under
+        # a single file lock (FIX 2), so a concurrent verifier cannot interleave a
+        # stale read and regress the high-water. A restart replay of a lower-epoch
+        # head — or a same-epoch equivocating fork — raises here. The accepted head
+        # is persisted as the new owner-signed high-water (FIX 3).
+        self._highwater_store.accept_and_persist(head, signature_hex)
 
         return {e.delegation_id for e in events}
 

--- a/src/kailash/trust/revocation/verify.py
+++ b/src/kailash/trust/revocation/verify.py
@@ -101,6 +101,17 @@ class DurableHighWaterStore:
         self._lock_path = self._store_dir / f".{HIGHWATER_FILENAME}.lock"
         self._owner_public_key = owner_public_key
 
+    @property
+    def owner_public_key(self) -> bytes:
+        """The owner public key the persisted high-water head is verified under.
+
+        Exposed so :class:`SignedRevocationVerifier` can assert at construction
+        that its own owner key and this store's key are the SAME — a mis-wired
+        factory passing two different owner keys would otherwise verify the
+        high-water head against the WRONG key (a latent key-confusion footgun).
+        """
+        return self._owner_public_key
+
     def _load_anchor_unlocked(self) -> HeadCommitmentAnchor:
         """Re-seed the anchor from the durable (owner-signed) high-water record.
 
@@ -306,8 +317,23 @@ class SignedRevocationVerifier:
                 signed under.
             signed_store: The durable signed-head + event-set store.
             highwater_store: The durable anti-rollback high-water store (re-seeds
-                the :class:`HeadCommitmentAnchor` on every read).
+                the :class:`HeadCommitmentAnchor` on every read). Its
+                ``owner_public_key`` MUST equal ``owner_public_key`` — the verifier
+                and the store verify the SAME owner signatures, so a mismatch is a
+                mis-wiring.
+
+        Raises:
+            RevocationVerificationError: If ``highwater_store.owner_public_key``
+                differs from ``owner_public_key`` — a key-confusion mis-wiring that
+                would verify the persisted high-water head against the WRONG key
+                (fail-closed at construction; a mismatch is unconstructable).
         """
+        if highwater_store.owner_public_key != owner_public_key:
+            raise RevocationVerificationError(
+                "owner-public-key mismatch: the SignedRevocationVerifier and its "
+                "DurableHighWaterStore were wired with DIFFERENT owner keys — both "
+                "MUST verify the same owner signatures (key-confusion mis-wiring)"
+            )
         self._owner_public_key = owner_public_key
         self._signed_store = signed_store
         self._highwater_store = highwater_store

--- a/tests/trust/integration/test_signed_revocation_verify.py
+++ b/tests/trust/integration/test_signed_revocation_verify.py
@@ -99,7 +99,7 @@ def _make_verifier(
     store_dir: Path, pubkey: bytes
 ) -> Tuple[SignedRevocationVerifier, SignedRevocationStore, DurableHighWaterStore]:
     signed_store = SignedRevocationStore(store_dir)
-    highwater_store = DurableHighWaterStore(store_dir)
+    highwater_store = DurableHighWaterStore(store_dir, pubkey)
     verifier = SignedRevocationVerifier(pubkey, signed_store, highwater_store)
     return verifier, signed_store, highwater_store
 
@@ -270,10 +270,128 @@ def test_malformed_high_water_store_fails_closed(tmp_path, owner_keys):
     resets the anti-rollback high-water to 0)."""
     from kailash.trust.revocation.verify import HIGHWATER_FILENAME
 
+    _, pubkey = owner_keys
     (tmp_path / HIGHWATER_FILENAME).write_text('{"epoch": "not-an-int"}')
-    hw_store = DurableHighWaterStore(tmp_path)
+    hw_store = DurableHighWaterStore(tmp_path, pubkey)
     with pytest.raises(RevocationVerificationError):
         hw_store.load_anchor()
+
+
+# ---------------------------------------------------------------------------
+# Security-redteam regression cases (FIX 1 CRITICAL, FIX 2 HIGH, FIX 3 HIGH)
+# ---------------------------------------------------------------------------
+
+
+def test_R1_head_delete_with_high_water_is_detected(tmp_path, owner_keys):
+    """FIX 1 (CRITICAL): deleting ONLY the signed-head store, leaving the durable
+    high-water at epoch ≥ 1, is a resurrection attempt — verify RAISES, does NOT
+    return an empty (nothing-revoked) set.
+    """
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("del-01", epoch=5, revoked_at=_rfc3339_ns())]
+    head, sig = _build_signed_head(seed, events, epoch=5)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+    assert verifier.is_revoked("del-01") is True  # advances + persists high-water
+
+    # Store-writer deletes ONLY revocation_head.json (high-water file remains).
+    (tmp_path / HEAD_FILENAME).unlink()
+
+    # A fresh verifier (restart) MUST NOT read "nothing revoked" — the retained
+    # high-water at epoch 5 proves a head existed → fail-closed.
+    verifier2, _, _ = _make_verifier(tmp_path, pubkey)
+    with pytest.raises(RevocationVerificationError) as exc:
+        verifier2.verified_revoked_set()
+    assert (
+        "resurrection" in str(exc.value).lower() or "deleted" in str(exc.value).lower()
+    )
+
+
+def test_R2_lower_epoch_persist_does_not_regress_high_water(tmp_path, owner_keys):
+    """FIX 2 (HIGH): a lower-epoch accept after a higher one is rejected and does
+    NOT lower the durable high-water.
+    """
+    seed, pubkey = owner_keys
+    _, _, hw_store = _make_verifier(tmp_path, pubkey)
+
+    head_hi, sig_hi = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=10, revoked_at=_rfc3339_ns())], epoch=10
+    )
+    hw_store.accept_and_persist(head_hi, sig_hi)
+    assert hw_store.load_anchor().high_water_epoch == 10
+
+    head_lo, sig_lo = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=7, revoked_at=_rfc3339_ns())], epoch=7
+    )
+    with pytest.raises(RevocationVerificationError):
+        hw_store.accept_and_persist(head_lo, sig_lo)
+    # High-water is UNCHANGED at 10 — no regression.
+    assert hw_store.load_anchor().high_water_epoch == 10
+
+
+def test_R2_concurrent_accepts_never_regress_high_water(tmp_path, owner_keys):
+    """FIX 2 (HIGH): under concurrency, the compare-and-swap under a single file
+    lock guarantees the durable high-water is monotonic — a racing lower-epoch
+    accept can never lower it below a higher accepted epoch.
+    """
+    import threading
+
+    seed, pubkey = owner_keys
+    _, _, hw_store = _make_verifier(tmp_path, pubkey)
+    head_hi, sig_hi = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=10, revoked_at=_rfc3339_ns())], epoch=10
+    )
+    head_lo, sig_lo = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=7, revoked_at=_rfc3339_ns())], epoch=7
+    )
+    barrier = threading.Barrier(2)
+
+    def worker(commitment, signature):
+        barrier.wait()
+        try:
+            hw_store.accept_and_persist(commitment, signature)
+        except RevocationVerificationError:
+            pass  # a lost race for the lower epoch legitimately raises
+
+    threads = [
+        threading.Thread(target=worker, args=(head_hi, sig_hi)),
+        threading.Thread(target=worker, args=(head_lo, sig_lo)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Whatever the interleaving, the durable high-water settles at the MAX
+    # accepted epoch (10) and never regresses to 7.
+    assert hw_store.load_anchor().high_water_epoch == 10
+
+
+def test_R3_forged_unsigned_high_water_fails_closed(tmp_path, owner_keys):
+    """FIX 3 (HIGH): the durable high-water is owner-signed; a store-writer who
+    forges a low-epoch high-water with a BOGUS signature cannot pass the
+    signature check — load fails closed. (The documented RESIDUAL is replay of a
+    previously-valid owner-signed head, which this signature binding does not
+    claim to prevent.)
+    """
+    seed, pubkey = owner_keys
+    _, _, hw_store = _make_verifier(tmp_path, pubkey)
+    head_hi, sig_hi = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=10, revoked_at=_rfc3339_ns())], epoch=10
+    )
+    hw_store.accept_and_persist(head_hi, sig_hi)
+
+    # Attacker rewrites the high-water to a forged low-epoch head with a bad sig.
+    forged_head, _ = _build_signed_head(
+        seed, [SignedRevocationEvent("d", epoch=1, revoked_at=_rfc3339_ns())], epoch=1
+    )
+    path = tmp_path / "revocation_highwater.json"
+    path.write_text(
+        json.dumps({"head": forged_head.to_dict(), "head_signature": "00" * 64})
+    )
+    with pytest.raises(RevocationVerificationError) as exc:
+        hw_store.load_anchor()
+    assert "signature" in str(exc.value).lower() or "tamper" in str(exc.value).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -409,6 +527,26 @@ async def test_operations_verify_fails_closed_on_unverifiable_ledger(
         "unverifiable" in result.reason.lower()
         or "fail-closed" in result.reason.lower()
     )
+
+
+async def test_operations_verify_warns_once_when_verifier_absent(ops_factory, caplog):
+    """FIX 4 (Check-2): with NO signed-ledger verifier wired, verify() emits ONE
+    WARN that the authoritative resurrection/rollback layer is OFF (observability),
+    and does NOT hard-fail (backward-compatible default).
+    """
+    import logging
+
+    ops = await ops_factory(verifier=None)
+    with caplog.at_level(logging.WARNING):
+        r1 = await ops.verify(agent_id="agent-001", action="analyze_data")
+        r2 = await ops.verify(agent_id="agent-001", action="analyze_data")
+    assert r1.valid is True and r2.valid is True  # not hard-failed
+    warns = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and "signed-revocation" in rec.getMessage()
+    ]
+    assert len(warns) == 1  # emitted exactly ONCE, not per-verify
 
 
 def test_ledger_append_only_ordering_matches_persisted_events(tmp_path, owner_keys):

--- a/tests/trust/integration/test_signed_revocation_verify.py
+++ b/tests/trust/integration/test_signed_revocation_verify.py
@@ -394,6 +394,29 @@ def test_R3_forged_unsigned_high_water_fails_closed(tmp_path, owner_keys):
     assert "signature" in str(exc.value).lower() or "tamper" in str(exc.value).lower()
 
 
+def test_R4_mismatched_owner_keys_unconstructable(tmp_path, owner_keys):
+    """Round-2 nit (key-wiring footgun): a verifier and its durable high-water
+    store wired with DIFFERENT owner keys is unconstructable — the equality
+    assertion fails closed at construction, so a mis-wired factory cannot verify
+    the high-water head against the wrong key.
+    """
+    _, pubkey = owner_keys
+    _, other_pubkey = (
+        base64.b64decode(generate_keypair()[0]),
+        base64.b64decode(generate_keypair()[1]),
+    )
+    signed_store = SignedRevocationStore(tmp_path)
+    # Store wired with a DIFFERENT owner key than the verifier.
+    highwater_store = DurableHighWaterStore(tmp_path, other_pubkey)
+    with pytest.raises(RevocationVerificationError) as exc:
+        SignedRevocationVerifier(pubkey, signed_store, highwater_store)
+    assert "mismatch" in str(exc.value).lower()
+
+    # Matched keys construct cleanly (the single-key threading path).
+    matched = DurableHighWaterStore(tmp_path, pubkey)
+    SignedRevocationVerifier(pubkey, signed_store, matched)  # no raise
+
+
 # ---------------------------------------------------------------------------
 # TrustOperations.verify consults the signed ledger authoritatively
 # ---------------------------------------------------------------------------

--- a/tests/trust/integration/test_signed_revocation_verify.py
+++ b/tests/trust/integration/test_signed_revocation_verify.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 2/3 integration tests for the AUTHORITATIVE signed-ledger revocation
+verify + durable anti-rollback re-seed (#1842 shard 3).
+
+Real crypto (Ed25519 via the shared signing primitives) + real persistence
+(temp-dir JSON stores). NO mocking. Exercises:
+
+* Store-tamper / revocation-resurrection is DETECTED — a persisted event set
+  altered at rest changes the recomputed ledger tip → the owner-head signature
+  no longer binds it → fail-closed DENY.
+* A replayed lower-epoch head is REJECTED via the DURABLE anchor re-seed
+  (contrast: a bare ``HeadCommitmentAnchor()`` with no re-seed would wrongly
+  accept it — asserted).
+* Fail-closed on an unverifiable ledger/head — never falling open to the
+  unsigned ``revoked`` flag.
+* The ``TrustOperations.verify`` path consults the signed ledger as the
+  authoritative revocation source and DENIES a revoked delegation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import AuthorityType, CapabilityType, VerificationLevel
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.operations import CapabilityRequest, TrustKeyManager, TrustOperations
+from kailash.trust.revocation.head_commitment import (
+    HeadCommitment,
+    HeadCommitmentAnchor,
+)
+from kailash.trust.revocation.signed_ledger import (
+    RevocationLedger,
+    SignedRevocationEvent,
+    revocation_ledger_tip,
+)
+from kailash.trust.revocation.verify import (
+    HEAD_FILENAME,
+    DurableHighWaterStore,
+    RevocationVerificationError,
+    SignedRevocationStore,
+    SignedRevocationVerifier,
+)
+from kailash.trust.signing.crypto import generate_keypair
+
+# ---------------------------------------------------------------------------
+# Real Ed25519 keypair (raw seed + pubkey bytes for head signing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owner_keys() -> Tuple[bytes, bytes]:
+    """A fresh Ed25519 keypair as raw (32-byte seed, 32-byte public key)."""
+    priv_b64, pub_b64 = generate_keypair()
+    return base64.b64decode(priv_b64), base64.b64decode(pub_b64)
+
+
+def _rfc3339_ns() -> str:
+    """An RFC-3339 timestamp with exactly 9 fractional (nanosecond) digits + Z."""
+    now = datetime.now(timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond * 1000:09d}Z"
+
+
+def _build_signed_head(
+    seed: bytes,
+    events: List[SignedRevocationEvent],
+    *,
+    epoch: int,
+    block_count: int = 0,
+    tip_hash: bytes | None = None,
+) -> Tuple[HeadCommitment, str]:
+    """Fold ``events`` into a ledger tip, wrap it in an owner-signed head.
+
+    Returns ``(head, owner_signature_hex)``. ``tip_hash`` defaults to a
+    deterministic 32-byte block-chain tip derived from ``epoch``.
+    """
+    ledger_tip = revocation_ledger_tip(events)
+    if tip_hash is None:
+        tip_hash = bytes([epoch & 0xFF]) * 32
+    head = HeadCommitment(
+        epoch=epoch,
+        block_count=block_count,
+        tip_hash=tip_hash,
+        revocation_ledger_tip=ledger_tip,
+        signed_at=_rfc3339_ns(),
+    )
+    return head, head.sign(seed)
+
+
+def _make_verifier(
+    store_dir: Path, pubkey: bytes
+) -> Tuple[SignedRevocationVerifier, SignedRevocationStore, DurableHighWaterStore]:
+    signed_store = SignedRevocationStore(store_dir)
+    highwater_store = DurableHighWaterStore(store_dir)
+    verifier = SignedRevocationVerifier(pubkey, signed_store, highwater_store)
+    return verifier, signed_store, highwater_store
+
+
+# ---------------------------------------------------------------------------
+# Core verifier — authoritative decision + store-tamper detection
+# ---------------------------------------------------------------------------
+
+
+def test_absent_store_is_genesis_not_revoked(tmp_path, owner_keys):
+    """An ABSENT store is the legitimate empty-ledger case: nothing revoked."""
+    _, pubkey = owner_keys
+    verifier, _, _ = _make_verifier(tmp_path, pubkey)
+    assert verifier.verified_revoked_set() == set()
+    assert verifier.is_revoked("del-anything") is False
+
+
+def test_signed_ledger_is_authoritative_revocation_source(tmp_path, owner_keys):
+    """A delegation present in the owner-signed ledger reads as revoked."""
+    seed, pubkey = owner_keys
+    events = [
+        SignedRevocationEvent("del-001", epoch=1, revoked_at=_rfc3339_ns()),
+        SignedRevocationEvent("del-002", epoch=2, revoked_at=_rfc3339_ns()),
+    ]
+    head, sig = _build_signed_head(seed, events, epoch=2)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    assert verifier.is_revoked("del-001") is True
+    assert verifier.is_revoked("del-002") is True
+    assert verifier.is_revoked("del-003") is False
+
+
+def test_resurrection_via_flipped_unsigned_flag_has_no_effect(tmp_path, owner_keys):
+    """The verifier ignores any mutable unsigned ``revoked`` field: the signed
+    ledger still shows the delegation revoked → verify DENIES.
+
+    Simulates a store-writer adding an unsigned ``revoked: false`` alongside the
+    signed record (a resurrection attempt). The signed event set is authoritative
+    and its owner signature is untouched, so the delegation stays revoked.
+    """
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("del-001", epoch=1, revoked_at=_rfc3339_ns())]
+    head, sig = _build_signed_head(seed, events, epoch=1)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    # Attacker injects an unsigned resurrection flag into the persisted file.
+    path = tmp_path / HEAD_FILENAME
+    data = json.loads(path.read_text())
+    data["revoked"] = False  # unsigned, not part of the signing pre-image
+    data["events"][0]["revoked"] = False
+    path.write_text(json.dumps(data))
+
+    # The signed ledger remains authoritative — del-001 is STILL revoked.
+    assert verifier.is_revoked("del-001") is True
+
+
+def test_deleted_signed_event_is_detected_via_tip_mismatch(tmp_path, owner_keys):
+    """A store-writer who DELETES a signed revocation event changes the
+    recomputed tip → the owner-head signature no longer binds it → fail-closed.
+    """
+    seed, pubkey = owner_keys
+    events = [
+        SignedRevocationEvent("del-001", epoch=1, revoked_at=_rfc3339_ns()),
+        SignedRevocationEvent("del-002", epoch=2, revoked_at=_rfc3339_ns()),
+    ]
+    head, sig = _build_signed_head(seed, events, epoch=2)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    # Attacker deletes del-001's event to "resurrect" it, leaving the (now stale)
+    # owner-signed head in place.
+    path = tmp_path / HEAD_FILENAME
+    data = json.loads(path.read_text())
+    data["events"] = [e for e in data["events"] if e["delegation_id"] != "del-001"]
+    path.write_text(json.dumps(data))
+
+    with pytest.raises(RevocationVerificationError) as exc:
+        verifier.verified_revoked_set()
+    assert "tamper" in str(exc.value).lower() or "tip" in str(exc.value).lower()
+
+
+def test_bad_owner_signature_fails_closed(tmp_path, owner_keys):
+    """An unverifiable owner signature DENIES (never falls open)."""
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("del-001", epoch=1, revoked_at=_rfc3339_ns())]
+    head, _sig = _build_signed_head(seed, events, epoch=1)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    # Persist a bogus signature.
+    signed_store.persist_head(events, head, "00" * 64)
+
+    with pytest.raises(RevocationVerificationError) as exc:
+        verifier.verified_revoked_set()
+    assert "signature" in str(exc.value).lower()
+
+
+def test_malformed_store_fails_closed(tmp_path, owner_keys):
+    """A PRESENT but corrupt store is a tamper signal → fail-closed, not empty."""
+    _, pubkey = owner_keys
+    (tmp_path / HEAD_FILENAME).write_text("{ not valid json ")
+    verifier, _, _ = _make_verifier(tmp_path, pubkey)
+    with pytest.raises(RevocationVerificationError):
+        verifier.verified_revoked_set()
+
+
+# ---------------------------------------------------------------------------
+# Durable anti-rollback re-seed
+# ---------------------------------------------------------------------------
+
+
+def test_durable_anchor_persists_and_reseeds_high_water(tmp_path, owner_keys):
+    """After accepting an epoch-N head, the durable high-water survives a
+    'process restart' (fresh store instances re-seed from disk)."""
+    seed, pubkey = owner_keys
+    events = [
+        SignedRevocationEvent("del-001", epoch=5, revoked_at=_rfc3339_ns()),
+    ]
+    head, sig = _build_signed_head(seed, events, epoch=5, tip_hash=bytes([0xAA]) * 32)
+    verifier, signed_store, hw_store = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    # First verify accepts the head and persists the high-water durably.
+    assert verifier.is_revoked("del-001") is True
+    reseeded = hw_store.load_anchor()
+    assert reseeded.high_water_epoch == 5
+    assert reseeded.high_water_tip_hash == bytes([0xAA]) * 32
+
+
+def test_replayed_lower_epoch_head_is_rejected_via_durable_anchor(tmp_path, owner_keys):
+    """Persist high-water at epoch N; simulate a restart by reconstructing the
+    verifier FROM the durable store; feed an epoch < N head → REJECTED.
+
+    Contrast: a bare ``HeadCommitmentAnchor()`` (no re-seed) would WRONGLY accept
+    the lower epoch — asserted, proving the durable path is what closes it.
+    """
+    seed, pubkey = owner_keys
+
+    # Phase 1: accept a high head at epoch 100, persisting the durable high-water.
+    events_hi = [SignedRevocationEvent("del-hi", epoch=100, revoked_at=_rfc3339_ns())]
+    head_hi, sig_hi = _build_signed_head(seed, events_hi, epoch=100)
+    verifier1, signed_store1, _ = _make_verifier(tmp_path, pubkey)
+    signed_store1.persist_head(events_hi, head_hi, sig_hi)
+    assert verifier1.is_revoked("del-hi") is True  # advances + persists high-water
+
+    # Phase 2: "process restart" — a store-writer replaces the persisted head with
+    # a validly-owner-signed but STALE lower-epoch head (epoch 5).
+    events_lo = [SignedRevocationEvent("del-lo", epoch=5, revoked_at=_rfc3339_ns())]
+    head_lo, sig_lo = _build_signed_head(seed, events_lo, epoch=5)
+    signed_store2 = SignedRevocationStore(tmp_path)
+    signed_store2.persist_head(events_lo, head_lo, sig_lo)
+
+    # Fresh verifier instances (the restart) RE-SEED the anchor from the durable
+    # high-water (epoch 100) and REJECT the epoch-5 replay.
+    verifier2, _, _ = _make_verifier(tmp_path, pubkey)
+    with pytest.raises(RevocationVerificationError) as exc:
+        verifier2.verified_revoked_set()
+    assert "rollback" in str(exc.value).lower()
+
+    # Contrast: a BARE anchor (the restart-WITHOUT-re-seed bug) would accept it.
+    bare = HeadCommitmentAnchor()
+    bare.accept(head_lo)  # no raise — this is exactly the vulnerability we close
+    assert bare.high_water_epoch == 5
+
+
+def test_malformed_high_water_store_fails_closed(tmp_path, owner_keys):
+    """A present-but-corrupt durable high-water file DENIES (never silently
+    resets the anti-rollback high-water to 0)."""
+    from kailash.trust.revocation.verify import HIGHWATER_FILENAME
+
+    (tmp_path / HIGHWATER_FILENAME).write_text('{"epoch": "not-an-int"}')
+    hw_store = DurableHighWaterStore(tmp_path)
+    with pytest.raises(RevocationVerificationError):
+        hw_store.load_anchor()
+
+
+# ---------------------------------------------------------------------------
+# TrustOperations.verify consults the signed ledger authoritatively
+# ---------------------------------------------------------------------------
+
+
+class SimpleAuthorityRegistry:
+    """Real in-memory authority registry (NOT a mock)."""
+
+    def __init__(self) -> None:
+        self._authorities: Dict[str, OrganizationalAuthority] = {}
+
+    async def initialize(self) -> None:
+        pass
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            from kailash.trust.exceptions import AuthorityNotFoundError
+
+            raise AuthorityNotFoundError(authority_id)
+        return authority
+
+    async def update_authority(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+
+@pytest.fixture
+async def ops_factory(owner_keys):
+    """Factory building an initialized TrustOperations with an optional signed
+    revocation verifier, plus the established agent."""
+
+    async def _build(verifier=None):
+        chain_priv_b64, chain_pub_b64 = generate_keypair()
+        authority = OrganizationalAuthority(
+            id="org-acme",
+            name="ACME",
+            authority_type=AuthorityType.ORGANIZATION,
+            public_key=chain_pub_b64,
+            signing_key_id="acme-key-001",
+            permissions=[
+                AuthorityPermission.CREATE_AGENTS,
+                AuthorityPermission.GRANT_CAPABILITIES,
+            ],
+        )
+        registry = SimpleAuthorityRegistry()
+        registry.register(authority)
+        km = TrustKeyManager()
+        km.register_key("acme-key-001", chain_priv_b64)
+        store = InMemoryTrustStore()
+        await store.initialize()
+        ops = TrustOperations(
+            authority_registry=registry,
+            key_manager=km,
+            trust_store=store,
+            revocation_verifier=verifier,
+        )
+        await ops.initialize()
+        await ops.establish(
+            agent_id="agent-001",
+            authority_id="org-acme",
+            capabilities=[
+                CapabilityRequest(
+                    capability="analyze_data",
+                    capability_type=CapabilityType.ACTION,
+                )
+            ],
+        )
+        return ops
+
+    return _build
+
+
+async def test_operations_verify_denies_revoked_agent_via_signed_ledger(
+    tmp_path, owner_keys, ops_factory
+):
+    """TrustOperations.verify consults the signed ledger and DENIES when the
+    agent is revoked there (authoritative), at STANDARD level."""
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("agent-001", epoch=1, revoked_at=_rfc3339_ns())]
+    head, sig = _build_signed_head(seed, events, epoch=1)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    ops = await ops_factory(verifier=verifier)
+    result = await ops.verify(
+        agent_id="agent-001", action="analyze_data", level=VerificationLevel.STANDARD
+    )
+    assert result.valid is False
+    assert "revoked" in result.reason.lower()
+
+
+async def test_operations_verify_allows_when_not_in_signed_ledger(
+    tmp_path, owner_keys, ops_factory
+):
+    """A signed ledger that does NOT list the agent lets verify proceed."""
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("other-agent", epoch=1, revoked_at=_rfc3339_ns())]
+    head, sig = _build_signed_head(seed, events, epoch=1)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+
+    ops = await ops_factory(verifier=verifier)
+    result = await ops.verify(
+        agent_id="agent-001", action="analyze_data", level=VerificationLevel.STANDARD
+    )
+    assert result.valid is True
+
+
+async def test_operations_verify_fails_closed_on_unverifiable_ledger(
+    tmp_path, owner_keys, ops_factory
+):
+    """An unverifiable signed ledger (bad owner signature) DENIES the whole
+    verify — never falling open to the unsigned flag."""
+    seed, pubkey = owner_keys
+    events = [SignedRevocationEvent("agent-001", epoch=1, revoked_at=_rfc3339_ns())]
+    head, _sig = _build_signed_head(seed, events, epoch=1)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, "11" * 64)  # bad signature
+
+    ops = await ops_factory(verifier=verifier)
+    result = await ops.verify(
+        agent_id="agent-001", action="analyze_data", level=VerificationLevel.STANDARD
+    )
+    assert result.valid is False
+    assert (
+        "unverifiable" in result.reason.lower()
+        or "fail-closed" in result.reason.lower()
+    )
+
+
+def test_ledger_append_only_ordering_matches_persisted_events(tmp_path, owner_keys):
+    """Sanity: the RevocationLedger append-only fold equals the persisted event
+    fold, so a verifier recomputing the tip agrees with the ledger."""
+    seed, pubkey = owner_keys
+    ledger = RevocationLedger()
+    events = []
+    for i in range(1, 4):
+        ev = SignedRevocationEvent(f"del-{i:03d}", epoch=i, revoked_at=_rfc3339_ns())
+        ledger.append(ev)
+        events.append(ev)
+    assert ledger.tip() == revocation_ledger_tip(events)
+
+    head, sig = _build_signed_head(seed, events, epoch=3)
+    verifier, signed_store, _ = _make_verifier(tmp_path, pubkey)
+    signed_store.persist_head(events, head, sig)
+    assert verifier.verified_revoked_set() == {"del-001", "del-002", "del-003"}


### PR DESCRIPTION
Final shard of #1842. S1 (signed ledger) + S2 (owner-signed head + in-memory anchor) are merged to main; this shard delivers the two value ACs still open: **delegation verify derives its AUTHORITATIVE revocation decision from the signed ledger** (not the mutable unsigned `revoked` field), and the **anti-rollback anchor is re-seeded from a DURABLE high-water store** on the persisted read path (closing the RT-headcommit-sec rollback hole).

## What changed
- `src/kailash/trust/revocation/verify.py` (new):
  - `SignedRevocationVerifier` — AUTHORITATIVE revocation decision (`verified_revoked_set` / `is_revoked`): verifies the owner Ed25519 signature over the head → recomputes the ledger tip and confirms it binds the signed head (add/delete/reorder → tip mismatch → detected) → re-seeds the durable anchor and `accept`s the head (anti-rollback + equivocation) → persists the advanced high-water. Any unverifiable condition raises `RevocationVerificationError` — **fail-closed, never falling open to the unsigned flag**. Absent store = genesis (empty set); present-but-unverifiable = deny.
  - `DurableHighWaterStore` — persists `high_water_epoch` + `high_water_tip_hash` after each accept and re-seeds a `HeadCommitmentAnchor` on the read path (never a bare anchor).
  - `SignedRevocationStore` — persists the ledger event set alongside the owner-signed head + signature, so the tip is recomputable for tamper detection.
  - Persistence uses the existing trust-plane `atomic_write`/`safe_read_json`/`file_lock` idiom (crash-safe temp-rename + O_NOFOLLOW), not a bespoke store.
- `src/kailash/trust/operations/__init__.py` — `TrustOperations.verify` gains an optional `revocation_verifier`; the `_check_signed_revocation` helper consults it authoritatively at EVERY level (incl. QUICK) and denies a revoked chain (by `agent_id` or delegation id) or an unverifiable ledger. In-memory cascade / CRL remain a fast-path cache only.
- `src/kailash/trust/revocation/__init__.py` — exports the new surface.
- `specs/trust-eatp.md` §11.1 — records the verify-consults-signed-ledger contract + the durable re-seed, resolving the S2 "#1842-S3 REQUIREMENT" note.

## Acceptance criteria (#1842)
- [x] `RevocationEvent` + ledger-tip byte contract pinned (≥3 vectors + empty-ledger sentinel) — **S1, merged** (`test_signed_revocation_ledger_vectors.py`, 21 tests still green).
- [x] `HeadCommitment` epoch/tip byte contract pinned (**S2, merged**); monotonic-epoch anti-rollback enforced on the **persisted read path** — **this shard** (`DurableHighWaterStore` re-seed; `test_head_commitment_vectors.py` 19 tests still green).
- [x] Delegation verify consults the signed ledger, not the unsigned `revoked` field — **this shard** (`SignedRevocationVerifier` + `TrustOperations.verify`).

→ **Closes all #1842 ACs.**

## Tests — Tier 2/3, real Ed25519 + real temp-dir persistence, NO mocking (verbatim)
```
tests/trust/integration/test_signed_revocation_verify.py::test_absent_store_is_genesis_not_revoked PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_signed_ledger_is_authoritative_revocation_source PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_resurrection_via_flipped_unsigned_flag_has_no_effect PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_deleted_signed_event_is_detected_via_tip_mismatch PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_bad_owner_signature_fails_closed PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_malformed_store_fails_closed PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_durable_anchor_persists_and_reseeds_high_water PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_replayed_lower_epoch_head_is_rejected_via_durable_anchor PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_malformed_high_water_store_fails_closed PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_operations_verify_denies_revoked_agent_via_signed_ledger PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_operations_verify_allows_when_not_in_signed_ledger PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_operations_verify_fails_closed_on_unverifiable_ledger PASSED
tests/trust/integration/test_signed_revocation_verify.py::test_ledger_append_only_ordering_matches_persisted_events PASSED
============================== 13 passed in 0.56s ==============================
```
S1/S2 tripwires still green: `40 passed` (21 ledger + 19 head-commitment). No-regression: `tests/trust -k "revocation or delegation or verify or operations or crl or lifecycle or cascade"` → `707 passed, 7 skipped`. mypy + ruff + pre-commit (Black/isort/Ruff/type-annotations/Tier-1) green on the diff.

## User-flow walk (receipt)
Real public-API path exercised end-to-end (`from kailash.trust.revocation import SignedRevocationVerifier, ...`):
```
1. authoritative revoked check   -> True
2. resurrection (event delete)   -> DENIED: recomputed revocation-ledger tip does not match ...
3. rollback replay (restart)     -> REJECTED: anti-rollback check rejected the persisted h ...
Disposition: authoritative deny + resurrection + rollback all fail-closed.
```

## Related issues
Fixes #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)