### PR TITLE
chore(authz): commit cross-repo READ authorization receipt for kailash-rs

### DIFF
--- a/.claude/cross-repo-authz/2026-07-19-esperie-enterprise-kailash-rs-read-eatp-dataflow.md
+++ b/.claude/cross-repo-authz/2026-07-19-esperie-enterprise-kailash-rs-read-eatp-dataflow.md
@@ -1,0 +1,41 @@
+---
+type: cross-repo-authorization-receipt
+date: 2026-07-19
+timestamp: 2026-07-19T18:01:04.533Z
+requester: jack-hong
+target: esperie-enterprise/kailash-rs
+action: READ: EATP + DataFlow byte-contract mint specs and pinned cross-SDK reference vectors for rs#1795 (V3Complete multi-sig signing pre-image), rs#1849/#1763 (RevocationEvent ledger + HeadCommitment), rs#1770/#1990 (DataFlow Vector DDL/value form) — Python-side byte-lockstep for #1841/#1842/#1846. No writes.
+mode: read
+---
+
+# Cross-Repo Authorization Receipt
+
+cross-repo-authorized: esperie-enterprise/kailash-rs read
+
+## Bounded action
+
+- **Target repo:** esperie-enterprise/kailash-rs
+- **Action (read):** READ: EATP + DataFlow byte-contract mint specs and pinned cross-SDK reference vectors for rs#1795 (V3Complete multi-sig signing pre-image), rs#1849/#1763 (RevocationEvent ledger + HeadCommitment), rs#1770/#1990 (DataFlow Vector DDL/value form) — Python-side byte-lockstep for #1841/#1842/#1846. No writes.
+- **Requester (display_id):** jack-hong
+- **Authorized at:** 2026-07-19T18:01:04.533Z
+
+## Verbatim user instruction
+
+> continue from last session, /autonomize with as many parallelized workflows as possible and /redteam to convergence. [Wave B cross-repo READ approved: user replied 'approved' to the restate for esperie-enterprise/kailash-rs read tier]
+
+## Five-condition attestation (repo-scope-discipline.md § User-Authorized Exception)
+
+- condition_1_user_initiated: REQUIRED — a genuine user turn
+- condition_2_explicit_specific: REQUIRED — names the target repo AND the exact bounded READ
+- condition_3_confirmed: REQUIRED — the ceremony restated action+target and the user confirmed yes/no BEFORE this write
+- condition_4_receipt_before_acting: DOWNGRADED (READ tier) — one-line affordance receipt; a read leaves no durable trace in the target
+- condition_5_scoped_exactly: REQUIRED — only the named read against only the named repo
+
+<!--
+  This receipt is the ONLY distinguisher between an authorized and an
+  unauthorized cross-repo action. It is written by
+  .claude/bin/cross-repo-authorize.mjs AFTER the user confirmed the restated
+  action+target in chat, and BEFORE the action runs. The hook
+  (violation-patterns.js::hasCrossRepoAuthorizationReceipt) greps this file's
+  marker line within its mtime window; commit it for durable team audit.
+-->


### PR DESCRIPTION
Commits the durable cross-repo authorization receipt for the `esperie-enterprise/kailash-rs` READ performed this session to obtain the EATP + DataFlow byte-contract reference vectors (#1841/#1842 byte-lockstep).

Per `repo-scope-discipline.md` § User-Authorized Exception, the receipt is the durable audit witness distinguishing an authorized cross-repo action from an unauthorized one; it must live on origin for team audit. The READ was user-authorized in-session (restate + confirm via `/cross-repo-authorize`, read tier).

Receipt-only (one file under `.claude/cross-repo-authz/`); no code.

## Related issues
Supports the #1841 / #1842 EATP cross-SDK byte-lockstep work.