### PR TITLE
release: EATP trust-plane + MCP tenant isolation — kailash 2.58.0, kailash-pact 0.16.0, kailash-kaizen 2.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.58.0] - 2026-07-20
+
+### Added (EATP Trust Plane)
+
+- **Cross-SDK canonical delegation-signing pre-image engine (#1841).** New
+  `kailash.trust.signing.delegation_payload` module: `SigningPayloadVersion`
+  enum (`v1-legacy` / `v2-complete` / `v3-complete` — wire tokens matching the
+  Rust SDK's `delegation.rs::SigningPayloadVersion`) plus
+  `delegation_signing_payload()`, the version-gated canonical pre-image
+  builder shared across the V1 (legacy), V2 (complete-constraint), and V3
+  (multi-sig) signing shapes. `kailash.trust.signing.delegation_record_signing`
+  adds the dispatch layer (`delegation_record_signing_payload()`,
+  `build_delegation_signing_input()`) that resolves a `DelegationRecord`'s
+  `signing_payload_version` field to the matching pre-image builder.
+  `DelegationRecord` gains a new `signing_payload_version: str` field
+  (default `"legacy-python-v0"`) — existing records with no explicit version
+  sign and verify byte-identically to before this release; only a record
+  explicitly opted into `v2-complete` / `v3-complete` uses the new pre-image
+  shapes. Sign callers still emit the legacy shape by default; the v2/v3
+  engine is wired end-to-end and fails closed on an unsupported/un-pinned
+  `signing_payload_version`.
+
+- **Signed revocation ledger + owner-signed anti-rollback anchor (#1842).**
+  Three new modules under `kailash.trust.revocation`: `signed_ledger.py`
+  (`SignedRevocationEvent`, `RevocationLedger`, `revocation_ledger_tip()` —
+  a signed, append-only revocation event log with a foldable tip hash),
+  `head_commitment.py` (`HeadCommitment`, `HeadCommitmentAnchor` — an
+  owner-signed epoch anchor giving the ledger durable anti-rollback /
+  same-epoch equivocation protection), and `verify.py`
+  (`SignedRevocationVerifier`, `SignedRevocationStore`,
+  `DurableHighWaterStore` — the authoritative verify path that now consults
+  the signed ledger instead of trusting an unsigned revocation list).
+  `TrustOperations` gains an optional `revocation_verifier:
+SignedRevocationVerifier | None = None` constructor parameter; the default
+  `None` preserves the pre-existing (unsigned) revocation-check behavior
+  exactly, with a one-time `WARN`-level log noting the authoritative
+  signed-ledger path is available but not configured. Passing a configured
+  `SignedRevocationVerifier` makes ledger consultation authoritative and
+  fail-closed.
+
+### Changed
+
+- **`kailash.trust.pact.governance_posture` coverage docstring extended
+  (#1803).** Documentation-only change describing the additional kaizen
+  provider/backend egress chokepoints (Azure AI Foundry, document-extraction
+  vision providers, multi-modal adapters, the legacy standalone Ollama
+  provider) now gated by `enforce_governance_posture` — see the
+  `kailash-kaizen` 2.38.0 CHANGELOG entry for the actual enforcement change.
+  No functional or public-API change to `kailash` itself.
+
 ## [2.57.0] - 2026-07-20
 
 ### Added (Security)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Rust SDK's `delegation.rs::SigningPayloadVersion`) plus
   `delegation_signing_payload()`, the version-gated canonical pre-image
   builder shared across the V1 (legacy), V2 (complete-constraint), and V3
-  (multi-sig) signing shapes. `kailash.trust.signing.delegation_record_signing`
-  adds the dispatch layer (`delegation_record_signing_payload()`,
-  `build_delegation_signing_input()`) that resolves a `DelegationRecord`'s
-  `signing_payload_version` field to the matching pre-image builder.
-  `DelegationRecord` gains a new `signing_payload_version: str` field
-  (default `"legacy-python-v0"`) — existing records with no explicit version
-  sign and verify byte-identically to before this release; only a record
-  explicitly opted into `v2-complete` / `v3-complete` uses the new pre-image
-  shapes. Sign callers still emit the legacy shape by default; the v2/v3
-  engine is wired end-to-end and fails closed on an unsupported/un-pinned
-  `signing_payload_version`.
+  (multi-sig) signing shapes. `DelegationRecord` gains a new
+  `signing_payload_version: str` field (default `"legacy-python-v0"`,
+  excluded from the signing pre-image itself) — every existing record signs
+  and verifies byte-identically to before this release.
+  `kailash.trust.signing.delegation_record_signing` adds the SINGLE shared
+  sign/verify dispatch (`delegation_canonical_payload_str()`) every
+  delegation call site routes through: it returns the legacy pre-image for a
+  `legacy-python-v0` record and fails closed
+  (`UnsupportedSigningPayloadVersionError`) for any other declared version —
+  **the record-persisted `v2-complete`/`v3-complete` sign/verify path is NOT
+  wired yet** (a later shard, S2b, once the structured constraint /
+  resource-limit / scope data those pre-images need is persisted on the
+  record). The v2/v3 engine itself IS usable today via the additive bridge
+  `build_delegation_signing_input()` / `delegation_record_signing_payload()`,
+  which maps a record's existing fields plus caller-supplied structured data
+  onto the engine pre-image directly — exercised now for cross-SDK
+  conformance, not yet reachable by setting a record's
+  `signing_payload_version` field.
 
 - **Signed revocation ledger + owner-signed anti-rollback anchor (#1842).**
   Three new modules under `kailash.trust.revocation`: `signed_ledger.py`

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,85 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.38.0] — 2026-07-20 — Governance gate extended to the provider/backend layer (#1803)
+
+### Added (Security)
+
+- **`governance_required` posture now gates the remaining
+  `kaizen.providers.*` direct-egress construction sites (#1803).** Extends
+  the prior `governance_required` gate (four-axis `LlmClient` +
+  `Delegate`/`AgentLoop`/adapter registry) to every non-retired
+  direct-egress chokepoint that constructs a provider client
+  (`openai`/`anthropic`/`genai`/`aiohttp`/`ollama`) OUTSIDE that surface:
+  - `kaizen.providers.llm.azure.AzureAIFoundryProvider` — gated at each
+    real-egress method (`chat`/`chat_async`/`stream_chat`/`embed`/
+    `embed_async`); construction and metadata-only methods are unaffected.
+  - The document-extraction vision providers
+    (`kaizen.providers.document.{landing_ai_provider,openai_vision_provider,
+ollama_vision_provider}`) — gated at the top of `extract()`.
+  - `kaizen.providers.multi_modal_adapter` — both `OpenAIMultiModalAdapter`
+    and `OllamaMultiModalAdapter` gated before any real egress or
+    availability check.
+  - `kaizen.providers.ollama_provider.OllamaProvider` (re-exported as
+    `kaizen.providers.LegacyOllamaProvider`) — gated at `__init__`, before
+    its unconditional `ollama.list()` availability probe.
+  - `kaizen.nodes.ai.semantic_memory.SimpleEmbeddingProvider` — gated at
+    the top of `embed_text()` (real `aiohttp` egress to an embedding
+    host), a HIGH gap the mechanical parity sweep's original regex missed
+    (no aiohttp/requests pattern) and a security-review follow-up caught
+    same session. The provider is now constructed instance-level (not
+    class-cached) on every consumer node, matching
+    `SemanticHybridSearchNode`'s existing pattern — the class-cache had a
+    sticky-default bug where the FIRST construction's `ungoverned` value
+    silently applied to every later instance of that class.
+
+  An `ungoverned=False` constructor opt-out is threaded end-to-end for
+  every site above (e.g. `ProviderManager` → its sub-providers;
+  `OllamaMultiModalAdapter` → `OllamaVisionConfig`;
+  `kaizen.providers.registry.get_provider(..., ungoverned=...)` → the
+  constructed instance). OFF-posture (the default) is byte-identical to
+  pre-#1803 behavior. A new mechanical parity test greps `kaizen/` (and,
+  as of a same-session follow-up, `kaizen_agents/` too) for
+  openai/anthropic/genai/httpx/aiohttp/ollama/Azure client-construction
+  patterns and asserts every containing file also calls
+  `enforce_governance_posture`, or is explicitly allowlisted with a
+  documented reason.
+
+  `BYOKClientCache` (`kaizen.nodes.ai.client_cache`) was audited and found
+  orphaned (zero production call sites) — documented, not gated.
+  `kaizen.nodes.ai.azure_backends` / `unified_azure_provider` were
+  confirmed already retired by #1820 — nothing to gate.
+
+### Fixed
+
+- **`SemanticMemoryStoreNode` was unconstructible.** A pre-existing bug
+  (unrelated to this release's gating change, caught while wiring the
+  `ungoverned` threading above): `self.metadata = None` ran before
+  `super().__init__()`, and `Node.metadata`'s setter requires
+  `self.config` to already exist — every construction of this registered,
+  exported node raised `AttributeError`. Fixed via
+  `self.config.setdefault("metadata", None)` after `super().__init__()`.
+
+- **`OllamaMultiModalAdapter` gate ran after, not before, its availability
+  check**, so an infra-free environment (no real `ollama` package
+  importable — the case in CI) raised `RuntimeError("Ollama not
+available")` before `enforce_governance_posture` ever ran, masking the
+  gate under posture ON. Reordered to match the sibling
+  `OpenAIMultiModalAdapter` pattern (gate first, availability check
+  second).
+
+- **`BaseAgentConfig.from_domain_config()`'s dict-input branch silently
+  downgraded `structured_output_mode` to the deprecated `"auto"` when the
+  key was absent**, contradicting the dataclass field's own `"explicit"`
+  default two lines above. Every `Agent()` construction routes through
+  this dict branch (`Agent._convert_to_base_agent_config()`'s 5-key dict
+  never sets this key), so every signature-based `Agent` run silently used
+  the deprecated mode and fired `workflow_generator`'s `FutureWarning` on
+  every call. Fixed the stale dict-branch default to match the dataclass
+  default (`"explicit"`); verified against the full
+  `packages/kailash-kaizen/tests/unit/{core,llm}/` suite (2092 tests, 0
+  failures, 0 unexpected warnings) with every optional extra installed.
+
 ## [2.37.3] — 2026-07-19 — Dependency pin fix: require kailash>=2.56.0
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.37.3"
+version = "2.38.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.37.3"
+__version__ = "2.38.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,54 @@
 # PACT Changelog
 
+## [0.16.0] — 2026-07-20 — First-class MCP tenant isolation (#1843)
+
+### Added (Security)
+
+- **`pact.mcp` gains first-class tenant isolation for `tools/call` and
+  `resources/read` (#1843).** Prior to this release, MCP governance had no
+  tenant isolation at all — a tenant-A caller could reach tenant-B's tools,
+  and `resources/read` had no governance layer whatsoever (not even
+  default-deny). `McpGovernanceConfig` gains an additive, optional
+  `tenant_grants: dict[str, McpTenantGrant]` field (new `McpTenantGrant`
+  dataclass: `tenant`, `tools: frozenset[str]`, `resources: frozenset[str]`).
+  Two new types round out the surface: `McpCallerIdentity` (a trusted,
+  non-serialized identity — resolved by the transport/auth layer before
+  governance evaluation — whose `tenant` OVERWRITES any self-asserted
+  `metadata["tenant_id"]`, defeating impersonation) and `McpResourceContext`
+  (the `resources/read` sibling of `McpActionContext`, consumed by the new
+  `McpGovernanceEnforcer.check_resource_read()` /
+  `McpGovernanceMiddleware.invoke_resource_read()` entry points). A single
+  shared restrictiveness function scopes both `tools/call` (keyed on tool
+  name) and `resources/read` (keyed on URI), evaluated at Step 0 — before
+  tool registration — so isolation applies even under
+  `DefaultPolicy.ALLOW`. Tenant rides the existing free-form
+  `metadata["tenant_id"]` channel; no new field was added to the
+  wire-serialized `McpActionContext` envelope, so the fix is byte-neutral
+  when `tenant_grants` is empty (the default — isolation OFF, both surfaces
+  behave exactly as before this release).
+  All four new types (`McpCallerIdentity`, `McpTenantGrant`,
+  `McpResourceContext`, `McpGovernanceConfig.tenant_grants`) are exported
+  from `pact.mcp`.
+
+- **`McpGovernanceConfig.require_caller_identity` defaults to `True`
+  (secure-by-default fix, redteam round 1 on #1843).** Ships in the SAME
+  release as `tenant_grants` — there was no prior release where the weaker
+  default was live, so this is not a behavior change for any existing
+  deployment. When `True` (the default), the tenant resolver never
+  consults the self-asserted `metadata["tenant_id"]` fallback; a deployment
+  that sets `tenant_grants` but never wires `caller_identity` through its
+  transport layer fails closed instead of silently trusting the request
+  body. Pass `require_caller_identity=False` explicitly to opt into the
+  weaker metadata-fallback channel (appropriate only for deployments with
+  no transport-level identity resolution).
+
+### Fixed
+
+- **`McpInvocationResult` was missing from `pact.mcp.middleware.__all__`**
+  (orphan-detection.md Rule 6 gap, caught by the #1843 redteam) —
+  `from pact.mcp.middleware import *` now includes it, matching the
+  existing top-level `pact` re-export.
+
 ## [0.15.0] — 2026-07-15 — SOC 2 evidence-collection primitives at the governance layer (#1711)
 
 ### Added

--- a/packages/kailash-pact/README.md
+++ b/packages/kailash-pact/README.md
@@ -25,6 +25,7 @@ pip install kailash-pact
 ```
 
 With Kaizen agent integration:
+
 ```bash
 pip install kailash-pact[kaizen]
 ```
@@ -40,6 +41,46 @@ pip install kailash-pact[kaizen]
 - **SQLite/PostgreSQL Stores** — Persistent governance state
 - **REST API** — 9 governance endpoints with auth and rate limiting
 - **CLI** — `kailash-pact validate org.yaml`
+
+## MCP Governance — Tenant Isolation (Pre-Pledge v0)
+
+`pact.mcp` adds deterministic governance to MCP (Model Context Protocol) tool
+calls and resource reads, including first-class multi-tenant isolation
+(issue #1843, shipped in 0.16.0). Because `kailash-pact` is still pre-1.0,
+this section is an explicit pledge of what the tenant-isolation surface
+enforces **today** versus what remains open — read it before relying on
+`McpGovernanceConfig.tenant_grants` in a multi-tenant deployment.
+
+- **Enforced today:** `McpGovernanceConfig.tenant_grants` (a
+  `dict[str, McpTenantGrant]`) scopes both `tools/call` and `resources/read`
+  to the caller's tenant through one shared, fail-closed restrictiveness
+  function, evaluated before tool registration (so it applies even under
+  `DefaultPolicy.ALLOW`). `McpCallerIdentity.tenant` — resolved by your
+  transport/auth layer and passed to `check_tool_call`/`check_resource_read`
+  — always overwrites a self-asserted `metadata["tenant_id"]`, defeating
+  impersonation. `require_caller_identity` defaults to `True`: with no
+  trusted identity wired, the self-asserted body value is never trusted and
+  the call fails closed rather than silently falling back to it.
+- **Deferred:** `resources/read` has ONLY the tenant-isolation check today —
+  no cost, argument, clearance, or rate-limit governance layer exists yet
+  for that surface (that richer contract exists only for `tools/call` via
+  `McpToolPolicy`). No first-class serialized `tenant_id` field exists on
+  the wire envelope; tenant rides the existing free-form
+  `metadata["tenant_id"]` channel by design (byte-neutral with the Rust
+  SDK's frozen envelope) and may change if the ecosystems converge on a
+  first-class field later.
+- **Non-promises:** `tenant_grants` being empty is NOT "tenant isolation
+  enabled with an empty allowlist" — it is isolation OFF entirely (every
+  call auto-approved on that axis, byte-identical to pre-0.16.0 behavior).
+  Passing `require_caller_identity=False` is NOT a recommended production
+  setting — it exists only for deployments with no transport-level identity
+  resolution, and re-enables the weaker, spoofable metadata fallback.
+- **Verify:** `pytest packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py -v`
+  exercises the fail-closed defaults, the impersonation-defeat contract, and
+  the `resources/read` isolation-only surface end-to-end.
+- **Status:** v0 within a pre-1.0 package (`kailash-pact` 0.16.0) — the
+  isolation contract above is stable for this release; the deferred items
+  may change shape (not just grow) before a 1.0 cut.
 
 ## Documentation
 

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.15.0"
+version = "0.16.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (
@@ -118,6 +118,16 @@ from kailash.trust.pact.config import (
 
 # --- Gradient engine (re-exported from kailash.trust.pact.gradient) ---
 from kailash.trust.pact.gradient import EvaluationResult, GradientEngine
+
+# --- SOC 2 compliance-evidence tooling (issue #1711) ---
+from pact.compliance import (
+    ControlEvidence,
+    CriterionEvidence,
+    EvidenceCollectionError,
+    EvidenceCollector,
+    EvidenceItem,
+    EvidencePackage,
+)
 from pact.costs import CostTracker
 
 # --- Enforcement modes ---
@@ -167,16 +177,6 @@ from pact.ml import (
     check_trial_admission,
 )
 from pact.work import WorkResult, WorkSubmission
-
-# --- SOC 2 compliance-evidence tooling (issue #1711) ---
-from pact.compliance import (
-    ControlEvidence,
-    CriterionEvidence,
-    EvidenceCollectionError,
-    EvidenceCollector,
-    EvidenceItem,
-    EvidencePackage,
-)
 
 __all__ = [
     # Error hierarchy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.57.0"
+version = "2.58.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.57.0"
+__version__ = "2.58.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Version bumps + CHANGELOG for the work merged into `main` since `v2.57.0` (all additive, non-breaking; MINOR bumps per semver). **This PR does NOT tag or publish to PyPI** — it prepares the release; the actual PyPI push is a separate, explicitly human-authorized step.

| Package | Old | New | Why |
|---|---|---|---|
| `kailash` | 2.57.0 | 2.58.0 | EATP cross-SDK delegation-signing pre-image engine (#1841) + signed revocation ledger w/ owner-signed anti-rollback anchor (#1842) |
| `kailash-pact` | 0.15.0 | 0.16.0 | First-class MCP tenant isolation for `tools/call` + `resources/read` (#1843), secure-by-default `require_caller_identity` |
| `kailash-kaizen` | 2.37.3 | 2.38.0 | `governance_required` posture extended to the remaining `kaizen.providers.*` egress sites (#1803) + a `structured_output_mode` default bugfix |

`kailash-nexus` and `kailash-mcp` had zero commits since their last tags (`nexus-v2.14.0`, `mcp-v0.4.2`) — not included.

### Dep-pin check (verified, not assumed)

Grepped `kailash-pact` and `kailash-kaizen` source for every NEW core symbol this release adds (`HeadCommitment`, `SignedRevocationLedger`, `revocation_verifier`, `delegation_payload`, `SigningPayloadVersion`, `delegation_record_signing`) — zero references in either sub-package. Both packages' existing `kailash>=` floors (`kailash-pact`: `>=2.41.0`; `kailash-kaizen`: `>=2.56.0`) remain valid; no dep-pin bump needed this release.

### Docs

Added a "Pre-Pledge v0" disclosure section to `packages/kailash-pact/README.md` for the new MCP tenant-isolation surface (`kailash-pact` is pre-1.0; `deployment.md` requires this disclosure for any new public API shipped at a v0 version anchor). Verified against the actual `check_tool_call`/`check_resource_read`/`McpCallerIdentity` source and the `test_issue_1843_mcp_tenant_isolation.py` regression suite (49/49 passing).

### Verification performed this session

- All three `pyproject.toml` + `__init__.py::__version__` pairs bumped atomically and parse-checked.
- Clean editable-env import check: `kailash 2.58.0`, `pact 0.16.0`, `kaizen 2.38.0` all import correctly; `McpCallerIdentity`/`McpTenantGrant`/`McpResourceContext` import from `pact.mcp`; `McpGovernanceConfig().require_caller_identity == True` (secure default confirmed).
- `pytest packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py` — 49 passed.
- `pytest --collect-only` clean across `kailash-pact` (1761 tests) and the touched `kailash-kaizen` unit suites (2647 tests) — no collection errors.
- `pre-commit run` on all 10 touched files — clean (isort also fixed a pre-existing, unrelated import-ordering drift in `pact/__init__.py` from the prior #1711 SOC-2 PR; cosmetic only, `__all__` unaffected).

### Note for reviewers

`kailash`'s `trust/pact/governance_posture.py` picked up a docstring-only update from #1803 (documents which kaizen provider sites are now gated) — no functional or public-API change to `kailash` itself; called out in its own CHANGELOG bullet under "Changed" rather than "Added" for that reason.

## Related issues

Relates to #1841, #1842, #1843, #1803.

## Test plan

- [x] Version bumps atomic across `pyproject.toml` + `__init__.py::__version__` (all 3 packages)
- [x] CHANGELOG entries verified against actual merged source (module paths, class names, field defaults all grep/import-confirmed, not carried from summary)
- [x] Dep-pin floors re-verified against new-symbol usage (grep, zero hits)
- [x] `pact` MCP tenant-isolation regression suite green (49/49)
- [x] Collection-only sweep clean (no orphaned/broken tests)
- [x] `pre-commit run` clean on all touched files
- [ ] security-reviewer + reviewer parallel gate (dispatched, pending)
- [ ] Human go-ahead for TestPyPI + production PyPI publish (NOT part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)