### PR TITLE
fix(pact): export MCP tenant-isolation types at pact top level (0.16.1)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,18 @@
 # PACT Changelog
 
+## [0.16.1] — 2026-07-20 — Export the tenant-isolation types at the `pact` top level
+
+### Fixed
+
+- **`pact.McpCallerIdentity`, `pact.McpTenantGrant`, and `pact.McpResourceContext`
+  now import at the top level.** The three tenant-isolation types added in 0.16.0
+  (#1843) were exported from `pact.mcp` but omitted from the top-level `pact`
+  package's re-export + `__all__`, unlike their sibling `McpActionContext` —
+  so `from pact import McpCallerIdentity` raised `ImportError` while
+  `from pact.mcp import McpCallerIdentity` worked. Added all three to
+  `pact/__init__.py`'s import block and `__all__` for API consistency. No
+  behavior change; the `pact.mcp` import path is unaffected.
+
 ## [0.16.0] — 2026-07-20 — First-class MCP tenant isolation (#1843)
 
 ### Added (Security)

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.16.0"
+version = "0.16.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (
@@ -155,10 +155,13 @@ from pact.mcp import (
     McpActionContext,
     McpAuditEntry,
     McpAuditTrail,
+    McpCallerIdentity,
     McpGovernanceConfig,
     McpGovernanceEnforcer,
     McpGovernanceMiddleware,
     McpInvocationResult,
+    McpResourceContext,
+    McpTenantGrant,
     McpToolPolicy,
 )
 
@@ -312,10 +315,13 @@ __all__ = [
     "McpActionContext",
     "McpAuditEntry",
     "McpAuditTrail",
+    "McpCallerIdentity",
     "McpGovernanceConfig",
     "McpGovernanceEnforcer",
     "McpGovernanceMiddleware",
     "McpInvocationResult",
+    "McpResourceContext",
+    "McpTenantGrant",
     "McpToolPolicy",
     # kailash-ml integration (W32.c)
     "AdmissionDecision",


### PR DESCRIPTION
## Summary
`McpCallerIdentity` / `McpTenantGrant` / `McpResourceContext` — the three tenant-isolation types added in kailash-pact 0.16.0 (#1843) — are exported from `pact.mcp` but were omitted from the top-level `pact` package's re-export + `__all__`, unlike their sibling `McpActionContext`. So `from pact import McpCallerIdentity` raised `ImportError` while `from pact.mcp import McpCallerIdentity` worked. This was caught by the 0.16.0 release-prep reviewer.

Adds all three to `pact/__init__.py`'s import block and `__all__`. **Additive, no behavior change**; the `pact.mcp` path is unaffected.

- kailash-pact 0.16.0 → **0.16.1** (patch), both `pyproject.toml` + `__init__.py::__version__`.
- CHANGELOG entry added.

## User-flow walk receipt
```
$ python -c "import pact; [pact.McpCallerIdentity, pact.McpTenantGrant, pact.McpResourceContext]; print(pact.__version__)"
0.16.1   # all 3 now import at top level
```
Disposition: `from pact import McpCallerIdentity` now works, consistent with `McpActionContext`.

## Related issues
Follow-up to #1843 (kailash-pact 0.16.0) — API-surface consistency.