### PR TITLE
fix(trust): fail-closed non-ASCII guard on revocation delegation_id (+ drop key copies)

### DIFF
--- a/src/kailash/trust/revocation/head_commitment.py
+++ b/src/kailash/trust/revocation/head_commitment.py
@@ -195,7 +195,15 @@ class HeadCommitment:
             The 64-byte Ed25519 signature, lowercase hex-encoded.
         """
         b64_priv = base64.b64encode(private_key_seed).decode("ascii")
-        b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        try:
+            b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        finally:
+            # Drop the base64 secret-key copy immediately after use to minimize
+            # its in-memory lifetime (trust-plane-security.md MUST-NOT-3). Python
+            # cannot zeroize the immutable str's buffer, but dropping the reference
+            # lets it be reclaimed at the earliest GC (mirrors the SignedRevocationEvent
+            # signing site in signed_ledger.py).
+            del b64_priv
         return base64.b64decode(b64_sig).hex()
 
     def verify(self, signature_hex: str, public_key: bytes) -> bool:

--- a/src/kailash/trust/revocation/signed_ledger.py
+++ b/src/kailash/trust/revocation/signed_ledger.py
@@ -114,6 +114,24 @@ class SignedRevocationEvent:
             raise RevocationLedgerError(
                 f"delegation_id must be a non-empty str, got {self.delegation_id!r}"
             )
+        # Fail closed on a non-ASCII delegation_id. The event signing pre-image
+        # (canonical_json_dumps, raw-UTF-8 JCS) is byte-verified against the
+        # kailash-rs reference ONLY on the all-ASCII conformance vectors (see the
+        # module docstring). A non-ASCII delegation_id is the ONLY free-string
+        # field that reaches the pre-image, and it would emit un-pinned raw-UTF-8
+        # bytes single-SDK — the SAME fail-open the #1841 delegation-signing
+        # engine already closes (delegation_payload.py::_assert_signed_strings_ascii).
+        # Reject rather than sign un-verified bytes; a non-ASCII vector is a future
+        # cross-SDK lockstep item. Byte-NEUTRAL: every ASCII delegation_id (UUIDs
+        # in practice) is unchanged, so the pinned vectors stay green.
+        try:
+            self.delegation_id.encode("ascii")
+        except UnicodeEncodeError:
+            raise RevocationLedgerError(
+                "delegation_id must be ASCII-only (the cross-SDK event pre-image "
+                "has no pinned non-ASCII vector yet — future lockstep item), got "
+                f"{self.delegation_id!r}"
+            ) from None
         # bool is a subclass of int; reject it explicitly so it can never
         # serialize as a JSON boolean in the epoch slot.
         if not isinstance(self.epoch, int) or isinstance(self.epoch, bool):
@@ -169,7 +187,15 @@ class SignedRevocationEvent:
             The 64-byte Ed25519 signature, lowercase hex-encoded.
         """
         b64_priv = base64.b64encode(private_key_seed).decode("ascii")
-        b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        try:
+            b64_sig = crypto.sign(self.signing_preimage(), b64_priv)
+        finally:
+            # Drop the base64 secret-key copy immediately after use to minimize
+            # its in-memory lifetime (trust-plane-security.md MUST-NOT-3). Python
+            # cannot zeroize the immutable str's buffer, but dropping the reference
+            # lets it be reclaimed at the earliest GC (applied at both signing
+            # sites — head_commitment.SignedHeadCommitment.sign mirrors this).
+            del b64_priv
         return base64.b64decode(b64_sig).hex()
 
     def verify(self, signature_hex: str, public_key: bytes) -> bool:

--- a/tests/regression/test_signed_revocation_ledger_vectors.py
+++ b/tests/regression/test_signed_revocation_ledger_vectors.py
@@ -196,6 +196,29 @@ def test_malformed_event_fails_closed() -> None:
         SignedRevocationEvent("del-x", True, "2026-07-17T00:00:00.000000000Z")
 
 
+def test_non_ascii_delegation_id_fails_closed() -> None:
+    """A non-ASCII delegation_id is rejected at construction (fail-closed).
+
+    Regression for the DQ9 fail-open: ``delegation_id`` is the only free-string
+    field that reaches the event signing pre-image, which is byte-verified
+    against the kailash-rs reference ONLY on the all-ASCII conformance vectors.
+    A non-ASCII value would emit un-pinned raw-UTF-8 bytes single-SDK — the same
+    fail-open the #1841 delegation-signing engine already closes. Harmonizes the
+    revocation ledger with that fail-closed non-ASCII posture.
+    """
+    with pytest.raises(RevocationLedgerError, match="ASCII-only"):
+        SignedRevocationEvent("café-0001", 0, "2026-07-17T00:00:00.000000000Z")
+    with pytest.raises(RevocationLedgerError, match="ASCII-only"):
+        # an en-dash (U+2013) inside an otherwise-ASCII id is still rejected.
+        SignedRevocationEvent("del–0001", 0, "2026-07-17T00:00:00.000000000Z")
+    # Byte-NEUTRAL: an ASCII (UUID-shaped) delegation_id constructs unchanged and
+    # still reproduces the pinned pre-image (covered by the vector tests above).
+    ok = SignedRevocationEvent(
+        "00000000-0000-4000-8000-000000000001", 0, "2026-07-17T00:00:00.000000000Z"
+    )
+    assert ok.delegation_id == "00000000-0000-4000-8000-000000000001"
+
+
 # --- Crypto-review hardening -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes a cross-SDK **fail-open** in the signed revocation ledger and applies a defense-in-depth key-lifetime tweak at the two revocation signing sites.

- **DQ9 — non-ASCII guard.** `SignedRevocationEvent.delegation_id` is the *only* free-string field that reaches the cross-SDK revocation-event signing pre-image (`canonical_json_dumps`, raw-UTF-8 JCS), yet it had no ASCII guard — unlike the #1841 delegation-signing engine, which fail-closes on non-ASCII (`delegation_payload.py::_assert_signed_strings_ascii`). A non-ASCII `delegation_id` would emit un-pinned raw-UTF-8 bytes single-SDK, un-verifiable cross-SDK. This adds a fail-closed guard in `__post_init__` (raises `RevocationLedgerError`), harmonizing the ledger with the #1841 posture (same class as #1841-S1 FIX 2).
- **DQ10 — key-copy lifetime.** Drops the base64 secret-key copy immediately after use (`try/finally: del b64_priv`) at both revocation signing sites, per `trust-plane-security.md` MUST-NOT-3.

## Byte-neutrality (cross-SDK contract)

**Byte-NEUTRAL.** Every ASCII `delegation_id` (UUIDs in practice) is unchanged, so all pinned revocation / head-commitment / delegation vectors stay green (proven: 51 vector tests pass). No cross-SDK lockstep is required for the harmonize-down direction — the guard only *refuses* a previously-accepted, never-pinned input domain.

`head_commitment.py` needs no guard: its only str field (`signed_at`) is regex-ASCII-pinned; all other fields are ints/hex — verified adversarially.

## Verification

- 89 EATP signing/revocation regression tests pass (pinned vectors green); 214 passed in the broader revocation+signing surface.
- New behavioral regression: `test_non_ascii_delegation_id_fails_closed` (rejects `café`/en-dash ids; asserts ASCII UUID still constructs).
- Reviewed by both a correctness lens (CLEAN) and an adversarial security lens (CLEAN — guard holds against every construction path; frozen dataclass; `from_dict` routes through the constructor).

## Related issues

Follow-up hardening for the #1842 signed revocation ledger (revocation-event pre-image fail-open). A matching non-ASCII guard on the sibling SDK's revocation event is a tracked cross-SDK lockstep follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)