### PR TITLE
Release v2.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.58.1] - 2026-07-20
+
+### Fixed (Trust Plane — Revocation)
+
+- **Fail-closed non-ASCII guard on the signed revocation event
+  `delegation_id` (#1842).** `SignedRevocationEvent.__post_init__`
+  (`kailash.trust.revocation.signed_ledger`) now rejects a non-ASCII
+  `delegation_id` with a `RevocationLedgerError` before signing. The event
+  signing pre-image (canonical JCS over raw UTF-8) is byte-verified against
+  the Rust SDK reference ONLY on the all-ASCII conformance vectors, and
+  `delegation_id` is the sole free-string field that reaches the pre-image —
+  a non-ASCII value would emit un-pinned raw-UTF-8 bytes single-SDK (the same
+  fail-open the #1841 delegation-signing engine already closes). This closure
+  is **byte-neutral**: every ASCII `delegation_id` (UUIDs in practice) signs
+  and verifies byte-identically to 2.58.0, so all pinned vectors stay green; a
+  non-ASCII vector is a future cross-SDK lockstep item.
+
+### Security (Trust Plane — Revocation)
+
+- **Drop the base64 secret-key copy at both revocation signing sites.**
+  `SignedRevocationEvent.sign` (`signed_ledger.py`) and
+  `HeadCommitment.sign` (`head_commitment.py`) now `del` the base64-encoded
+  private-key-seed copy in a `finally` block immediately after use, minimizing
+  its in-memory lifetime. Python cannot zeroize the immutable `str` buffer, but
+  dropping the reference lets it be reclaimed at the earliest GC. No behavioral
+  change to signature output.
+
 ## [2.58.0] - 2026-07-20
 
 ### Added (EATP Trust Plane)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.58.0"
+version = "2.58.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.58.0"
+__version__ = "2.58.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep for **kailash core 2.58.0 → 2.58.1** (patch). Metadata-only diff — cuts the already-merged #1880 trust-plane revocation fix to PyPI. No source changes; this PR only bumps the version anchors and adds the CHANGELOG entry.

## What ships in 2.58.1

The only src change since 2.58.0 (merged PR #1880):

- **Fail-closed non-ASCII guard** on `SignedRevocationEvent.delegation_id` — closes a cross-SDK fail-open where a non-ASCII `delegation_id` would emit un-pinned raw-UTF-8 signing bytes (the same fail-open the #1841 delegation-signing engine already closes). Byte-neutral for all-ASCII inputs; every pinned conformance vector stays green.
- **Key-copy-lifetime drop** (`del b64_priv` in a `finally`) at both revocation signing sites (`signed_ledger.py::SignedRevocationEvent.sign` + `head_commitment.py::HeadCommitment.sign`).

## Version bump (atomic — zero-tolerance Rule 5)

| File | Old → New |
| --- | --- |
| `pyproject.toml` | `2.58.0` → `2.58.1` |
| `src/kailash/__init__.py` `__version__` | `2.58.0` → `2.58.1` |

## Dep-pin finding

No sub-package re-pin required. This change adds **no new public core symbol** (internal validation guard + memory hygiene only). Verified no sub-package (dataflow/nexus/kaizen/pact/ml/align) imports the changed symbols (`SignedRevocationEvent`, `signed_ledger`, `head_commitment`, `HeadCommitment`) from `src/` — the only sub-package hits were unrelated `trust.signing.crypto` example imports and a stale `build/lib/` artifact.

## Verification

- `.venv/bin/python -c "import kailash; print(kailash.__version__)"` → `2.58.1`
- DQ9 revocation regression suite: `22 passed`

## Related issues

Cuts #1842 (revocation ledger fail-closed guard, merged in #1880) to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)