### PR TITLE
fix(testing): uniform package-root cost-guard placement + durable per-rootdir regression tests (#1848)

### DIFF
--- a/packages/kailash-align/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-align/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-align pytest rootdir withholds provider secrets.
+
+kailash-align declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-align`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_align_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-align pytest session — the rootdir "
+            f"cost-guard (packages/kailash-align/conftest.py) is not firing"
+        )

--- a/packages/kailash-kaizen/conftest.py
+++ b/packages/kailash-kaizen/conftest.py
@@ -1,0 +1,30 @@
+"""
+Pytest configuration for Kaizen tests.
+
+Ensures that the src directory is in sys.path for proper imports, and installs
+the repo LLM cost-guard at the PACKAGE ROOT so an explicit
+`pytest packages/kailash-kaizen/examples/...` invocation is covered too (the
+tests/-subtree conftest guard only covers `packages/kailash-kaizen/tests`).
+kailash-kaizen declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-kaizen` — and a bare run MUST make ZERO
+billed LLM calls, so this rootdir MUST withhold/scrub provider secrets.
+"""
+
+import sys
+from pathlib import Path
+
+from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
+
+# Add src directory to sys.path
+src_dir = Path(__file__).parent / "src"
+if src_dir.exists() and str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+# LLM cost-guard: a bare `pytest packages/kailash-kaizen` must make ZERO billed
+# LLM calls even with a provider key in .env or exported in the shell.
+install_cost_guard(Path(__file__).resolve().parents[2] / ".env")
+
+
+def pytest_collection_finish(session):
+    """Backstop: remove any provider secret re-injected during collection."""
+    scrub_provider_secrets()

--- a/packages/kailash-kaizen/tests/conftest.py
+++ b/packages/kailash-kaizen/tests/conftest.py
@@ -14,21 +14,9 @@ import os
 import sys
 from pathlib import Path
 
-from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
-
-# LLM cost-guard: a bare `pytest` (no KAIZEN_ALLOW_REAL_LLM=1) must make ZERO
-# billed LLM calls. kailash-kaizen declares its own pytest rootdir, so the
-# repo-root conftest guard never fires here. install_cost_guard loads .env with
-# provider secret keys withheld, monkeypatches dotenv.load_dotenv so any
-# module-scope / nested-conftest load_dotenv self-scrubs, and actively removes
-# any secret already present. Model names + non-secret vars still load.
-install_cost_guard(Path(__file__).resolve().parents[3] / ".env")
-
-
-def pytest_collection_finish(session):
-    """Backstop: after every module (and its module-scope load_dotenv) is
-    imported, remove any provider secret re-injected during collection."""
-    scrub_provider_secrets()
+# Cost-guard moved to the package-root conftest (packages/kailash-kaizen/conftest.py)
+# so an explicit `pytest packages/kailash-kaizen/examples/...` invocation is
+# covered too (#1848). The package-root guard fires for this tests/ subtree as well.
 
 
 # Check if we should use real providers (for E2E/integration tests)

--- a/packages/kailash-kaizen/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-kaizen/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-kaizen pytest rootdir withholds provider secrets.
+
+kailash-kaizen declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-kaizen`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_kaizen_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-kaizen pytest session — the rootdir "
+            f"cost-guard (packages/kailash-kaizen/conftest.py) is not firing"
+        )

--- a/packages/kailash-mcp/conftest.py
+++ b/packages/kailash-mcp/conftest.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pytest configuration for kailash-mcp tests.
+
+Ensures that the src directory is in sys.path for proper imports, and installs
+the repo LLM cost-guard at the PACKAGE ROOT so an explicit
+`pytest packages/kailash-mcp/examples/...` invocation is covered too (the
+tests/-subtree conftest guard only covers `packages/kailash-mcp/tests`).
+kailash-mcp declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-mcp` — and a bare run MUST make ZERO
+billed LLM calls, so this rootdir MUST withhold/scrub provider secrets.
+"""
+
+import sys
+from pathlib import Path
+
+from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
+
+# Add src directory to sys.path
+src_dir = Path(__file__).parent / "src"
+if src_dir.exists() and str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+# LLM cost-guard: a bare `pytest packages/kailash-mcp` must make ZERO billed
+# LLM calls even with a provider key in .env or exported in the shell.
+# (package-root is one level shallower than tests/, so parents[3] -> parents[2].)
+install_cost_guard(Path(__file__).resolve().parents[2] / ".env")
+
+
+def pytest_collection_finish(session):
+    """Backstop: remove any provider secret re-injected during collection."""
+    scrub_provider_secrets()

--- a/packages/kailash-mcp/tests/conftest.py
+++ b/packages/kailash-mcp/tests/conftest.py
@@ -1,23 +1,10 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared test fixtures for kailash-mcp."""
+"""Shared test fixtures for kailash-mcp.
 
-from pathlib import Path
-
-from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
-
-# Load .env from the project root with the repo's LLM cost-guard applied.
-# kailash-mcp declares its own pytest rootdir, so the repo-root conftest's
-# cost-guard does NOT fire here. install_cost_guard withholds provider secret
-# keys on a bare `pytest packages/kailash-mcp/tests`, monkeypatches
-# dotenv.load_dotenv so any module-scope load_dotenv self-scrubs, and actively
-# removes any secret already present — provider secrets load only with
-# KAIZEN_ALLOW_REAL_LLM=1.
-_project_root = Path(__file__).resolve().parents[3]
-install_cost_guard(_project_root / ".env")
-
-
-def pytest_collection_finish(session):
-    """Backstop: remove any provider secret re-injected during collection."""
-    scrub_provider_secrets()
+The LLM cost-guard moved to the package-root conftest
+(packages/kailash-mcp/conftest.py) so an explicit
+`pytest packages/kailash-mcp/examples/...` invocation is covered too (#1848).
+The package-root guard fires for this tests/ subtree as well.
+"""

--- a/packages/kailash-mcp/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-mcp/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-mcp pytest rootdir withholds provider secrets.
+
+kailash-mcp declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-mcp`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_mcp_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-mcp pytest session — the rootdir "
+            f"cost-guard (packages/kailash-mcp/conftest.py) is not firing"
+        )

--- a/packages/kailash-ml/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-ml/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-ml pytest rootdir withholds provider secrets.
+
+kailash-ml declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-ml`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_ml_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-ml pytest session — the rootdir "
+            f"cost-guard (packages/kailash-ml/conftest.py) is not firing"
+        )

--- a/packages/kailash-nexus/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-nexus/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-nexus pytest rootdir withholds provider secrets.
+
+kailash-nexus declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-nexus`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_nexus_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-nexus pytest session — the rootdir "
+            f"cost-guard (packages/kailash-nexus/conftest.py) is not firing"
+        )

--- a/packages/kailash-pact/tests/test_cost_guard_rootdir.py
+++ b/packages/kailash-pact/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kailash-pact pytest rootdir withholds provider secrets.
+
+kailash-pact declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kailash-pact`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_pact_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kailash-pact pytest session — the rootdir "
+            f"cost-guard (packages/kailash-pact/conftest.py) is not firing"
+        )

--- a/packages/kaizen-agents/conftest.py
+++ b/packages/kaizen-agents/conftest.py
@@ -1,0 +1,30 @@
+"""
+Pytest configuration for kaizen-agents tests.
+
+Ensures that the src directory is in sys.path for proper imports, and installs
+the repo LLM cost-guard at the PACKAGE ROOT so an explicit
+`pytest packages/kaizen-agents/examples/...` invocation is covered too (the
+tests/-subtree conftest guard only covers `packages/kaizen-agents/tests`).
+kaizen-agents declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kaizen-agents` — and a bare run MUST make ZERO
+billed LLM calls, so this rootdir MUST withhold/scrub provider secrets.
+"""
+
+import sys
+from pathlib import Path
+
+from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
+
+# Add src directory to sys.path
+src_dir = Path(__file__).parent / "src"
+if src_dir.exists() and str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+# LLM cost-guard: a bare `pytest packages/kaizen-agents` must make ZERO billed
+# LLM calls even with a provider key in .env or exported in the shell.
+install_cost_guard(Path(__file__).resolve().parents[2] / ".env")
+
+
+def pytest_collection_finish(session):
+    """Backstop: remove any provider secret re-injected during collection."""
+    scrub_provider_secrets()

--- a/packages/kaizen-agents/tests/conftest.py
+++ b/packages/kaizen-agents/tests/conftest.py
@@ -5,23 +5,10 @@ Provides shared fixtures for the agent engine tests migrated from kailash-kaizen
 """
 
 import os
-from pathlib import Path
 
-from kailash.testing.env_cost_guard import install_cost_guard, scrub_provider_secrets
-
-# LLM cost-guard: a bare `pytest` (no KAIZEN_ALLOW_REAL_LLM=1) must make ZERO
-# billed LLM calls. kaizen-agents declares its own pytest rootdir, so the
-# repo-root conftest guard never fires here. install_cost_guard loads .env with
-# provider secret keys withheld, monkeypatches dotenv.load_dotenv so any
-# module-scope / nested-conftest load_dotenv self-scrubs, and actively removes
-# any secret already present. Model names + non-secret vars still load.
-install_cost_guard(Path(__file__).resolve().parents[3] / ".env")
-
-
-def pytest_collection_finish(session):
-    """Backstop: after every module (and its module-scope load_dotenv) is
-    imported, remove any provider secret re-injected during collection."""
-    scrub_provider_secrets()
+# Cost-guard moved to the package-root conftest (packages/kaizen-agents/conftest.py)
+# so an explicit `pytest packages/kaizen-agents/examples/...` invocation is
+# covered too (#1848). The package-root guard fires for this tests/ subtree as well.
 
 
 # Unit-tier deterministic model default (issue-822 pattern): supervisor /

--- a/packages/kaizen-agents/tests/test_cost_guard_rootdir.py
+++ b/packages/kaizen-agents/tests/test_cost_guard_rootdir.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the kaizen-agents pytest rootdir withholds provider secrets.
+
+kaizen-agents declares its own pytest rootdir, so the repo-root conftest guard
+never fires for `pytest packages/kaizen-agents`. This durable test pins the
+package-root conftest cost-guard so a future regression (guard removed / rootdir
+moved) fails loudly instead of silently carrying a provider credential into the
+session (issue #1845/#1848).
+"""
+
+import os
+
+
+def test_kaizen_agents_rootdir_scrubs_provider_secrets():
+    if os.environ.get("KAIZEN_ALLOW_REAL_LLM") == "1":
+        return  # opt-in on: real-LLM tests intentionally carry credentials
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "DEEPSEEK_API_KEY",
+    ):
+        assert os.environ.get(name) is None, (
+            f"{name} leaked into the kaizen-agents pytest session — the rootdir "
+            f"cost-guard (packages/kaizen-agents/conftest.py) is not firing"
+        )


### PR DESCRIPTION
## Summary
Closes #1848 — two non-blocking cost-guard durability-hardening follow-ups from the #1845 convergence review. No open billing path today; this makes the "a bare \`pytest\` never spends" invariant robust as the test tree evolves.

**Part 1 — uniform package-root guard placement.** kaizen / kaizen-agents / mcp installed the cost guard only in \`tests/conftest.py\` (covers the \`tests/\` subtree only). Moved each to a package-root \`conftest.py\` (matching the 5 sibling packages), so an explicit \`pytest packages/<pkg>/examples/...\` invocation is also covered. This closes a real (narrow) gap: kaizen + kaizen-agents carry collectable \`examples/\` test files the \`tests/\`-only guard missed. \`.env\` path resolved via \`parents[2]\` (package-root is one level shallower than \`tests/\`); verified == repo root for all three.

**Part 2 — 7 durable per-rootdir regression tests.** Only root + dataflow had a per-rootdir tripwire. Added the same tiny Tier-1 assertion (verbatim from dataflow's template — same 5-secret list, no marker, no infra, no mocking) under nexus / pact / align / ml / kaizen / kaizen-agents / mcp, so the throwaway convergence probes become durable regression guards (verify-resource-existence MUST-4).

## Verification
All 7 new guards pass (exported 5 fake provider secrets, each guard scrubbed them → `1 passed`). Moved packages' \`tests/\` subtrees + \`examples/\` collect cleanly. Full receipts in the commit body.

## Pre-existing (not introduced, not fixed here)
\`pytest packages/kailash-align/tests/\` fails at collection in the shared dev \`.venv\` because align's own \`tests/conftest.py\` imports \`kailash_align\` at module scope (commit \`002acbc5c\`, 2026-04-01) and the package isn't editable-installed locally. Reproduces identically on main; independent of this change (the new align test imports only \`os\`). In CI, align's \`[dev]\` extras install the package, so the align guard runs+passes there like the other 6. Installing torch-heavy deps into a venv shared by concurrent agents would be high-blast-radius and out of scope.

## Related issues
Closes #1848