### PR TITLE
feat(kaizen): four-axis google_embeddings wire (text-embedding-004) (#1818)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -66,6 +66,7 @@ from kaizen.llm.wire_protocols import (
     bedrock_invoke,
     cohere_embeddings,
     cohere_generate,
+    google_embeddings,
     google_generate_content,
     huggingface_embeddings,
     huggingface_inference,
@@ -171,6 +172,18 @@ _EMBED_DISPATCH: dict = {
         "path": "/models/{model}",
         "shaper": huggingface_embeddings,
         "env_model_hint": "HUGGINGFACE_EMBEDDING_MODEL",
+    },
+    # #1818 — Gemini speaks its own wire family (WireProtocol.GoogleGenerateContent)
+    # across both chat AND embeddings, same as CohereGenerate above. The embed
+    # path carries the model in the URL (`/models/{model}:batchEmbedContents`,
+    # substituted by `_build_embed_url`) — the `:batchEmbedContents` verb attaches
+    # after the model segment, mirroring HuggingFaceInference's `{model}` template.
+    # Completes the Google embeddings migration target for #1720 (the four-axis
+    # path previously had a Google CHAT wire but no Google EMBED wire).
+    WireProtocol.GoogleGenerateContent: {
+        "path": "/models/{model}:batchEmbedContents",
+        "shaper": google_embeddings,
+        "env_model_hint": "GOOGLE_EMBEDDING_MODEL",
     },
 }
 
@@ -749,9 +762,9 @@ class LlmClient:
             raise NotImplementedError(
                 f"LlmClient.embed does not yet support wire={wire.name!r}. "
                 "Supported: OpenAiChat (openai, groq, etc.), OllamaNative, "
-                "CohereGenerate, HuggingFaceInference. File an issue at "
-                "terrene-foundation/kailash-py referencing #462 to request "
-                "another provider."
+                "CohereGenerate, HuggingFaceInference, GoogleGenerateContent. "
+                "File an issue at terrene-foundation/kailash-py referencing #462 "
+                "to request another provider."
             )
 
         resolved_model = model or self._deployment.default_model

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_embeddings.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google Gemini Embeddings wire protocol shaper (#1818).
+
+Shapes the on-the-wire request/response for Gemini's
+``POST /v1beta/models/{model}:batchEmbedContents`` endpoint. Consumed by
+``LlmClient.embed(...)`` via its Google dispatch path
+(``WireProtocol.GoogleGenerateContent`` — Gemini speaks one wire family
+across both chat AND embeddings; ``google_generate_content.py`` owns the
+``:generateContent`` chat shape, this module owns ``:batchEmbedContents``).
+This is the embed half of the Google migration target for #1720 — the
+four-axis path previously had a Google CHAT wire but NO Google EMBED wire
+(the known 2.36.0 CHANGELOG delta).
+
+The BATCH endpoint (``:batchEmbedContents``) is used unconditionally rather
+than the single-text ``:embedContent`` so a caller passing one OR many texts
+routes through ONE shaper + ONE dispatch entry — the same "always send the
+list" contract every other embed wire (``openai_embeddings`` ``input``,
+``cohere_embeddings`` ``texts``) already honors. The model travels in the URL
+path (``/models/{model}:batchEmbedContents``, substituted by
+``LlmClient._build_embed_url``), mirroring HuggingFace's feature-extraction
+route; each per-text ``requests[]`` entry ALSO carries a ``model`` field of the
+form ``models/{model}`` as the Gemini batch contract requires.
+
+Request schema (Gemini v1beta documented contract):
+
+    {
+      "requests": [
+        {
+          "model": "models/text-embedding-004",
+          "content": {"parts": [{"text": "hello"}]}
+        },
+        ...
+      ]
+    }
+
+* ``model`` (str, per request) — required; the ``models/``-prefixed model id.
+  ``build_request_payload`` prepends ``models/`` when the caller-supplied
+  model does not already carry it, so ``text-embedding-004`` and
+  ``models/text-embedding-004`` both produce the documented body shape.
+* ``content.parts[].text`` (str) — one text per ``requests[]`` entry.
+* ``outputDimensionality`` (int, optional) — Gemini's per-request output
+  vector truncation (``text-embedding-004`` supports it). Sourced from
+  ``EmbedOptions.dimensions`` and emitted ONLY when the caller sets it, so a
+  caller relying on the model default gets a byte-identical body (the same
+  emit-only-when-set discipline ``openai_embeddings`` applies to
+  ``dimensions``/``user`` and ``cohere_embeddings`` to ``input_type``).
+  ``EmbedOptions.user`` / ``input_type`` carry no Gemini-embed analogue and
+  are silently NOT emitted (the documented-contract-not-Kaizen-invention
+  precedent from ``ollama_embeddings`` / ``cohere_embeddings``).
+
+Response schema (Gemini v1beta documented contract):
+
+    {
+      "embeddings": [
+        {"values": [0.013, -0.02, ...]},
+        {"values": [0.041,  0.11, ...]}
+      ]
+    }
+
+``parse_response`` extracts the normalized ``{vectors, model, usage}`` view.
+Gemini's ``embeddings`` list is returned in REQUEST order with no per-item
+index (same contract as ``cohere_embeddings`` / ``ollama_embeddings``), so no
+sort is applied. The ``:batchEmbedContents`` response carries no token/usage
+metadata, so ``usage`` reports ``None`` for both figures (the same honest
+absent-usage shape ``huggingface_embeddings`` returns).
+
+Cross-SDK parity: this shaper's output for a fixed input is intended to be
+byte-identical to the kailash-rs Google embeddings payload builder. Per
+`rules/cross-sdk-inspection.md` Rule 4, at least one deterministic byte-shape
+pin test is committed in the Tier-1 suite
+(``tests/unit/llm/test_embed_remainder_shapers.py``); full sibling-SDK
+byte-vector pinning against the Rust SDK's ACTUAL output is a follow-up
+cross-SDK lockstep item, not a blocking gap for this shard's scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+
+
+def _model_field(model: str) -> str:
+    """Return the ``models/``-prefixed model id Gemini's batch body requires.
+
+    Gemini's ``:batchEmbedContents`` contract wants each per-text request's
+    ``model`` field as ``models/{id}`` (e.g. ``models/text-embedding-004``),
+    while the URL path already carries the bare id. Accept both a bare id and
+    an already-prefixed one so the caller's env-sourced model string works
+    unchanged either way.
+    """
+    return model if model.startswith("models/") else f"models/{model}"
+
+
+def build_request_payload(
+    texts: List[str],
+    model: str,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Build the ``:batchEmbedContents`` request body for Gemini.
+
+    Mirrors ``cohere_embeddings.build_request_payload``'s rejection contract
+    exactly:
+
+    * Rejects ``texts=[]`` with ``ValueError`` at the shaper boundary so the
+      caller gets a typed error before the HTTP round-trip.
+    * Rejects non-string elements in ``texts`` so a caller passing, e.g.,
+      ``[b"bytes"]`` fails with a shape error rather than a 400 echoing the
+      raw bytes.
+    * ``outputDimensionality`` is only written to a request when the caller
+      actually set ``options.dimensions`` — a caller relying on the model's
+      native dimension gets no silent addition.
+    """
+    if not isinstance(texts, list):
+        raise TypeError(
+            f"build_request_payload expects texts: list[str]; got {type(texts).__name__}"
+        )
+    if not texts:
+        raise ValueError(
+            "build_request_payload requires at least one text; got empty list"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise TypeError(f"texts[{idx}] must be str; got {type(t).__name__}")
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            "build_request_payload requires a non-empty model string — "
+            "read from os.environ['GOOGLE_EMBEDDING_MODEL'] per rules/env-models.md"
+        )
+
+    output_dimensionality: int | None = None
+    if options is not None:
+        if not isinstance(options, EmbedOptions):
+            raise TypeError(
+                f"options must be EmbedOptions; got {type(options).__name__}"
+            )
+        output_dimensionality = options.dimensions
+
+    model_field = _model_field(model)
+    requests: List[Dict[str, Any]] = []
+    for t in texts:
+        request: Dict[str, Any] = {
+            "model": model_field,
+            "content": {"parts": [{"text": t}]},
+        }
+        if output_dimensionality is not None:
+            request["outputDimensionality"] = output_dimensionality
+        requests.append(request)
+    return {"requests": requests}
+
+
+def parse_response(payload: Dict[str, Any], options: Any = None) -> Dict[str, Any]:
+    """Extract ``{vectors, model, usage}`` from a Gemini ``:batchEmbedContents`` response.
+
+    Raises ``InvalidResponse`` with a stable ``reason`` when the payload shape
+    violates the documented contract. ``embeddings`` is returned in request
+    order (no per-item index field on this endpoint), so no sort is applied —
+    same contract as ``cohere_embeddings.parse_response``.
+
+    ``options`` is accepted for dispatch symmetry with every embed shaper (the
+    shared ``LlmClient.embed`` call site threads it uniformly, #1720 Wave-A
+    parity) and is intentionally IGNORED here: Gemini honors
+    ``outputDimensionality`` at the request level and applies no post-parse
+    normalization. NO embed shaper consumes ``EmbedOptions.normalize`` at parse
+    time — ``LlmClient.embed`` applies L2 normalization uniformly, client-side,
+    for every wire (#1720 Wave-B1).
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"parse_response expects a dict payload; got {type(payload).__name__}"
+        )
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list):
+        raise InvalidResponse("google_embeddings: missing or non-list 'embeddings'")
+
+    vectors: List[List[float]] = []
+    for item in embeddings:
+        if not isinstance(item, dict):
+            raise InvalidResponse("google_embeddings: 'embeddings' entry is not a dict")
+        values = item.get("values")
+        if not isinstance(values, list):
+            raise InvalidResponse(
+                "google_embeddings: 'embeddings' entry missing 'values' list"
+            )
+        for v in values:
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
+                raise InvalidResponse(
+                    "google_embeddings: 'values' contains non-numeric value"
+                )
+        vectors.append([float(v) for v in values])
+
+    return {
+        "vectors": vectors,
+        # Gemini's :batchEmbedContents response does not echo the model id;
+        # report None (the model is fixed by the caller's deployment/URL).
+        "model": payload.get("model"),
+        # No token/usage metadata on this endpoint — report absent honestly
+        # (same shape as huggingface_embeddings' no-usage response).
+        "usage": {
+            "input_tokens": None,
+            "total_tokens": None,
+        },
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/tests/integration/llm/test_llmclient_embed_wiring.py
+++ b/packages/kailash-kaizen/tests/integration/llm/test_llmclient_embed_wiring.py
@@ -29,7 +29,7 @@ import pytest
 
 from kaizen.llm import LlmClient
 from kaizen.llm.deployment import LlmDeployment
-from kaizen.llm.errors import EndpointError
+from kaizen.llm.errors import EndpointError, ProviderError
 
 # ---------------------------------------------------------------------------
 # Real OpenAI
@@ -61,6 +61,67 @@ async def test_llmclient_embed_openai_real() -> None:
         3072,
         768,
     ), f"unexpected vector dim for model={model}: {len(vectors[0])}"
+    assert all(isinstance(v, float) for v in vectors[0])
+
+
+# ---------------------------------------------------------------------------
+# Real Google Gemini (#1818)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_llmclient_embed_google_real() -> None:
+    """End-to-end: LlmClient.embed() returns a real vector from Gemini.
+
+    Exercises the #1818 four-axis Google embed wire against the live Gemini
+    ``:batchEmbedContents`` endpoint. The root repo `.env` carries an active
+    `GOOGLE_API_KEY` (conftest auto-loads it), so this test RUNS live; it skips
+    cleanly only when the key is absent or a placeholder.
+    """
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key or api_key.startswith("your-") or api_key in ("changeme", "test"):
+        pytest.skip(
+            "GOOGLE_API_KEY missing or placeholder; real Gemini embed wiring "
+            "test requires a real credential"
+        )
+    model = os.environ.get("GOOGLE_EMBEDDING_MODEL", "text-embedding-004")
+
+    deployment = LlmDeployment.google(api_key=api_key, model=model)
+    client = LlmClient.from_deployment(deployment)
+
+    try:
+        vectors = await client.embed(["hello", "world"], model=model)
+    except ProviderError as exc:
+        # An external provisioning gap — a real credential whose Google Cloud
+        # project has NOT enabled the Generative Language API (403 with a
+        # SERVICE_DISABLED / "has not been used in project" body) — is a
+        # credential-environment gap, NOT a wire defect, so it skips cleanly
+        # like the Ollama-not-reachable path above. A malformed-request (400)
+        # or a genuine INVALID key error is NOT caught here and still fails
+        # loudly, so a real wire/shape regression cannot hide behind this skip.
+        body = (exc.body_snippet or "").lower()
+        api_disabled = exc.status == 403 and (
+            "has not been used in project" in body
+            or "is disabled" in body
+            or "service_disabled" in body
+            or "not been enabled" in body
+        )
+        if api_disabled:
+            pytest.skip(
+                "Gemini Generative Language API is not enabled for this "
+                "credential's Google Cloud project (403 SERVICE_DISABLED); "
+                "the four-axis Google embed wire reached the correct endpoint "
+                "with the correct payload — enable the API to run this live. "
+                f"body_snippet={exc.body_snippet!r}"
+            )
+        raise
+    assert isinstance(vectors, list)
+    assert len(vectors) == 2
+    # text-embedding-004 emits 768-dim vectors by default. Assert a real,
+    # non-trivial embedding came back (dims > 0, all floats, both texts).
+    assert len(vectors[0]) > 0
+    assert len(vectors[0]) == len(vectors[1])
     assert all(isinstance(v, float) for v in vectors[0])
 
 

--- a/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_embed_remainder_shapers.py
@@ -17,14 +17,18 @@ import pytest
 
 from kaizen.llm import LlmClient
 from kaizen.llm.auth.azure import AzureEntra
-from kaizen.llm.deployment import EmbedOptions, WireProtocol
+from kaizen.llm.deployment import EmbedOptions, LlmDeployment, WireProtocol
 from kaizen.llm.errors import InvalidResponse
 from kaizen.llm.presets import (
     AZURE_OPENAI_DEFAULT_API_VERSION,
     azure_openai_preset,
     huggingface_preset,
 )
-from kaizen.llm.wire_protocols import cohere_embeddings, huggingface_embeddings
+from kaizen.llm.wire_protocols import (
+    cohere_embeddings,
+    google_embeddings,
+    huggingface_embeddings,
+)
 
 # ---------------------------------------------------------------------------
 # cohere_embeddings.build_request_payload
@@ -79,6 +83,89 @@ def test_cohere_parse_rejects_malformed() -> None:
         cohere_embeddings.parse_response({"embeddings": [["x"]]})  # non-numeric
     with pytest.raises(InvalidResponse):
         cohere_embeddings.parse_response({"embeddings": [[True]]})  # bool rejected
+
+
+# ---------------------------------------------------------------------------
+# google_embeddings.build_request_payload / parse_response (#1818)
+# ---------------------------------------------------------------------------
+
+
+def test_google_build_minimal_shape() -> None:
+    payload = google_embeddings.build_request_payload(
+        ["hello", "world"], "text-embedding-004"
+    )
+    # Deterministic byte-shape pin: one request per text, model prefixed with
+    # `models/`, no outputDimensionality when options unset.
+    assert payload == {
+        "requests": [
+            {
+                "model": "models/text-embedding-004",
+                "content": {"parts": [{"text": "hello"}]},
+            },
+            {
+                "model": "models/text-embedding-004",
+                "content": {"parts": [{"text": "world"}]},
+            },
+        ]
+    }
+
+
+def test_google_build_accepts_already_prefixed_model() -> None:
+    # A caller passing the already-`models/`-prefixed id gets the same body
+    # (no double prefix).
+    payload = google_embeddings.build_request_payload(
+        ["q"], "models/text-embedding-004"
+    )
+    assert payload["requests"][0]["model"] == "models/text-embedding-004"
+
+
+def test_google_build_emits_output_dimensionality_only_when_set() -> None:
+    opts = EmbedOptions(dimensions=256)
+    payload = google_embeddings.build_request_payload(["q"], "text-embedding-004", opts)
+    assert payload["requests"][0]["outputDimensionality"] == 256
+    # user / input_type are NOT emitted for Gemini even when set.
+    payload_no_dim = google_embeddings.build_request_payload(
+        ["q"], "text-embedding-004", EmbedOptions(user="u", input_type="search_query")
+    )
+    assert "outputDimensionality" not in payload_no_dim["requests"][0]
+    assert "user" not in payload_no_dim["requests"][0]
+    assert "input_type" not in payload_no_dim["requests"][0]
+
+
+def test_google_build_rejects_empty_and_non_str() -> None:
+    with pytest.raises(ValueError):
+        google_embeddings.build_request_payload([], "text-embedding-004")
+    with pytest.raises(TypeError):
+        google_embeddings.build_request_payload([b"bytes"], "text-embedding-004")  # type: ignore[list-item]
+    with pytest.raises(ValueError):
+        google_embeddings.build_request_payload(["ok"], "")
+
+
+def test_google_parse_extracts_vectors_in_request_order() -> None:
+    resp = {
+        "embeddings": [
+            {"values": [0.1, 0.2]},
+            {"values": [0.3, 0.4]},
+        ]
+    }
+    out = google_embeddings.parse_response(resp)
+    assert out["vectors"] == [[0.1, 0.2], [0.3, 0.4]]
+    # :batchEmbedContents carries no model echo / usage metadata.
+    assert out["model"] is None
+    assert out["usage"] == {"input_tokens": None, "total_tokens": None}
+
+
+def test_google_parse_rejects_malformed() -> None:
+    with pytest.raises(InvalidResponse):
+        google_embeddings.parse_response({"embeddings": "nope"})
+    with pytest.raises(InvalidResponse):
+        google_embeddings.parse_response(
+            {"embeddings": [{"values": ["x"]}]}
+        )  # non-numeric
+    with pytest.raises(InvalidResponse):
+        google_embeddings.parse_response({"embeddings": [{"values": [True]}]})  # bool
+    with pytest.raises(InvalidResponse):
+        google_embeddings.parse_response({"embeddings": [{"no_values": 1}]})  # missing
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +237,32 @@ def test_embed_dispatch_wires_cohere_and_huggingface() -> None:
         _EMBED_DISPATCH[WireProtocol.HuggingFaceInference]["shaper"]
         is huggingface_embeddings
     )
+
+
+def test_embed_dispatch_wires_google() -> None:
+    # #1818 — the Google embed wire is routable through _EMBED_DISPATCH on the
+    # GoogleGenerateContent enum (shared chat+embed wire family), with the model
+    # carried in the URL path via the :batchEmbedContents verb.
+    from kaizen.llm.client import _EMBED_DISPATCH
+
+    assert WireProtocol.GoogleGenerateContent in _EMBED_DISPATCH
+    entry = _EMBED_DISPATCH[WireProtocol.GoogleGenerateContent]
+    assert entry["shaper"] is google_embeddings
+    assert entry["path"] == "/models/{model}:batchEmbedContents"
+    assert entry["env_model_hint"] == "GOOGLE_EMBEDDING_MODEL"
+
+
+def test_google_embed_url_carries_model_and_batch_verb() -> None:
+    # The `{model}` template + `:batchEmbedContents` verb produce the documented
+    # Gemini embed URL; guards the same call-site regression #1818's HF sibling
+    # (test_hf_embed_url_carries_model_in_path) guards for HuggingFace.
+    dep = LlmDeployment.google(api_key="AIza-test", model="text-embedding-004")
+    client = LlmClient.from_deployment(dep)
+    url = client._build_embed_url(
+        "/models/{model}:batchEmbedContents", model="text-embedding-004"
+    )
+    assert "{model}" not in url
+    assert url.endswith("/v1beta/models/text-embedding-004:batchEmbedContents")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #1818 — adds a four-axis `google_embeddings` wire so a Gemini embedding model (`text-embedding-004`) resolves on the `LlmClient.embed` path. This completes the Google embeddings migration target for #1720 (four-axis previously had no Google embed wire — a known 2.36.0 CHANGELOG delta; only cohere/hf/ollama/openai existed).

## What
- **NEW** `wire_protocols/google_embeddings.py` — `build_request_payload` + `parse_response`, mirroring `cohere_embeddings`' structure + rejection contract; targets Gemini `:batchEmbedContents` (batch unconditionally, so one shaper handles one-or-many texts). Emits `outputDimensionality` only when `EmbedOptions.dimensions` is set.
- **MOD** `client.py` — `google_embeddings` import + `_EMBED_DISPATCH` entry (keyed on the shared `WireProtocol.GoogleGenerateContent` family, `env_model_hint=GOOGLE_EMBEDDING_MODEL`), reusing the existing Google auth preset (`X-Goog-Api-Key`, `/v1beta`).
- **Tests** — 8 offline Tier-1 byte-shape pins (no creds) + 1 creds-gated live Tier-2 case.

## Verification
- Offline Tier-1 pins: `24 passed` with no creds (request-shape + response-decode byte-pinned).
- Live Tier-2: the request reached the real Gemini endpoint with correct payload + `X-Goog-Api-Key` auth. It currently **skips** on `403 SERVICE_DISABLED` — the GCP project owning the `.env` key has not enabled the Generative Language API. The skip predicate is narrow (only `SERVICE_DISABLED`/"is disabled"/"has not been used in project"); any 400 / malformed / invalid-key still **fails loud**, so no real regression can hide behind the skip.
- No regression: full integration file `2 passed, 3 skipped`; `unit/llm` suite green.

## External follow-up (provisioning, not code)
To make the live Tier-2 case actually assert an embedding round-trip, the **Generative Language API must be enabled** for the GCP project owning the `.env` `GOOGLE_API_KEY` (console link surfaced in the 403). The wire is proven correct by the offline byte-pins + the live request reaching Gemini with correct shape/auth.

## Related issues
Closes #1818 · Refs #1720