### PR TITLE
feat(trust): enrich DelegationRecord to sign V2Complete for non-multi-sig records (#1841 S2b-1)

### DIFF
--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from kailash.trust.signing.crypto import (
     hash_trust_chain_state,
     hash_trust_chain_state_salted,
-    serialize_for_signing,
 )
 
 # Structured engine-fold dataclasses (#1841 S2b-1). A DelegationRecord carrying

--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -27,6 +27,18 @@ from kailash.trust.signing.crypto import (
     serialize_for_signing,
 )
 
+# Structured engine-fold dataclasses (#1841 S2b-1). A DelegationRecord carrying
+# all three signs the cross-SDK V2Complete pre-image instead of legacy-python-v0
+# (see kailash.trust.signing.delegation_record_signing.select_signing_version).
+# Safe at module scope: this file already imports kailash.trust.signing.crypto
+# above (initialising the signing package), and delegation_payload depends only
+# on kailash.trust._json — no cycle back to chain.
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    ResourceLimits,
+)
+
 # Canonical CARE constraint dimension names for dimension_scope validation.
 # Matches kailash.trust.plane.delegation.VALID_DIMENSIONS and
 # kailash.trust.pact.config.ConstraintDimension enum values.
@@ -308,6 +320,17 @@ class DelegationRecord:
     # legacy payload would change every existing record's signed bytes.
     signing_payload_version: str = DELEGATION_SIGNING_VERSION_LEGACY
 
+    # Structured engine-fold fields (#1841 S2b-1). All Optional/default-None so a
+    # pre-S2b record is byte-identical (from_dict of an old record leaves these
+    # None → version legacy → legacy pre-image). When ALL THREE are present AND
+    # dimension_scope is unscoped AND the record is non-multi-sig, the record
+    # signs the cross-SDK V2Complete pre-image (select_signing_version). These
+    # fold into the ENGINE pre-image only — never into the legacy
+    # to_signing_payload() below, whose bytes MUST stay unchanged.
+    constraints: Optional[ConstraintDimensions] = None
+    resource_limits: Optional[ResourceLimits] = None
+    scope: Optional[DelegationScope] = None
+
     def __post_init__(self) -> None:
         """Validate dimension_scope values are from the canonical set."""
         if not isinstance(self.dimension_scope, frozenset):
@@ -364,7 +387,7 @@ class DelegationRecord:
         Returns:
             Dictionary representation with all fields
         """
-        d = {
+        d: Dict[str, Any] = {
             "id": self.id,
             "delegator_id": self.delegator_id,
             "delegatee_id": self.delegatee_id,
@@ -391,6 +414,16 @@ class DelegationRecord:
         d["reasoning_signature"] = self.reasoning_signature
         if self.reasoning_trace:
             d["reasoning_trace"] = self.reasoning_trace.to_dict()
+        # Structured engine-fold fields (#1841 S2b-1) — emitted only when present
+        # so a legacy record round-trips without new keys (missing key -> None on
+        # from_dict, mirroring the dimension_scope / signing_payload_version
+        # backward-compat pattern above).
+        if self.constraints is not None:
+            d["constraints"] = self.constraints.to_dict()
+        if self.resource_limits is not None:
+            d["resource_limits"] = self.resource_limits.to_dict()
+        if self.scope is not None:
+            d["scope"] = self.scope.to_dict()
         return d
 
     @classmethod
@@ -426,6 +459,28 @@ class DelegationRecord:
         else:
             dimension_scope = ALL_DIMENSIONS
 
+        # Structured engine-fold fields (#1841 S2b-1): backward-compatible --
+        # a pre-S2b record has no key, so each deserializes to None → the record
+        # resolves to the legacy schema and verifies byte-identically.
+        raw_constraints = data.get("constraints")
+        constraints = (
+            ConstraintDimensions.from_dict(raw_constraints)
+            if raw_constraints is not None
+            else None
+        )
+        raw_resource_limits = data.get("resource_limits")
+        resource_limits = (
+            ResourceLimits.from_dict(raw_resource_limits)
+            if raw_resource_limits is not None
+            else None
+        )
+        raw_delegation_scope = data.get("scope")
+        scope = (
+            DelegationScope.from_dict(raw_delegation_scope)
+            if raw_delegation_scope is not None
+            else None
+        )
+
         return cls(
             id=data["id"],
             delegator_id=data["delegator_id"],
@@ -458,6 +513,10 @@ class DelegationRecord:
             signing_payload_version=data.get(
                 "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
             ),
+            # Structured engine-fold fields (#1841 S2b-1): None when absent.
+            constraints=constraints,
+            resource_limits=resource_limits,
+            scope=scope,
         )
 
 

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -18,7 +18,7 @@ import asyncio
 import hmac
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -70,8 +70,14 @@ from kailash.trust.signing.crypto import (
     sign,
     verify_signature,
 )
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    ResourceLimits,
+)
 from kailash.trust.signing.delegation_record_signing import (
     delegation_canonical_payload_str,
+    select_signing_version,
 )
 
 if TYPE_CHECKING:
@@ -1665,6 +1671,9 @@ class TrustOperations:
         metadata: Optional[Dict[str, Any]] = None,
         context: Optional[ExecutionContext] = None,  # EATP: ExecutionContext parameter
         reasoning_trace: Optional[Any] = None,  # EATP: ReasoningTrace for WHY
+        constraints: Optional[ConstraintDimensions] = None,  # #1841 S2b-1: V2 fold
+        resource_limits: Optional[ResourceLimits] = None,  # #1841 S2b-1: V2 fold
+        scope: Optional[DelegationScope] = None,  # #1841 S2b-1: V2 fold
     ) -> DelegationRecord:
         """
         DELEGATE: Transfer trust from one agent to another.
@@ -1691,6 +1700,13 @@ class TrustOperations:
             expires_at: When delegation expires
             metadata: Additional context
             context: EATP ExecutionContext with human_origin (REQUIRED for new delegations)
+            constraints: Optional structured ConstraintDimensions to fold into
+                the cross-SDK V2Complete pre-image (#1841 S2b-1). Additive: omit
+                (with resource_limits/scope) → the record signs legacy-python-v0.
+            resource_limits: Optional structured ResourceLimits (see constraints).
+            scope: Optional structured DelegationScope (see constraints). When
+                constraints + resource_limits + scope are ALL supplied AND the
+                record is unscoped + non-multi-sig, the record signs V2Complete.
 
         Returns:
             DelegationRecord: Signed delegation record with human_origin
@@ -1847,7 +1863,17 @@ class TrustOperations:
             delegation_depth=delegation_depth,
             # Reasoning trace extension (optional)
             reasoning_trace=reasoning_trace,
+            # Structured engine-fold fields (#1841 S2b-1). When all three are
+            # supplied, the record signs the cross-SDK V2Complete pre-image.
+            constraints=constraints,
+            resource_limits=resource_limits,
+            scope=scope,
         )
+
+        # Select the signing pre-image version from the structured fields
+        # (#1841 S2b-1). Defaults to legacy-python-v0 when the caller omits the
+        # structured fields, so existing callers are byte-identical.
+        delegation.signing_payload_version = select_signing_version(delegation)
 
         logger.info(
             f"Delegation created: {delegator_id} -> {delegatee_id} "

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -1333,6 +1333,16 @@ class TrustOperations:
                     reason=f"Delegator chain not found: {delegation.delegator_id}",
                     level=VerificationLevel.FULL,
                 )
+            except ValueError as exc:
+                # Fail closed on a pre-image build error (#1841 S2b-1 redteam) —
+                # a v2-labelled record with missing / narrowed structured fields
+                # MUST NOT let the exception escape to the caller. (Mirrors the
+                # ValueError handling in _verify_delegation_signature.)
+                return VerificationResult(
+                    valid=False,
+                    reason=(f"Delegation {delegation.id} could not be verified: {exc}"),
+                    level=VerificationLevel.FULL,
+                )
 
         return VerificationResult(
             valid=True,
@@ -1497,6 +1507,16 @@ class TrustOperations:
                 reason=f"Unsupported delegation signing_payload_version: {exc.version}",
                 level=VerificationLevel.FULL,
             )
+        except ValueError as exc:
+            # A v2-labelled record with missing / narrowed structured fields
+            # fails closed at the engine bridge with a ValueError (#1841 S2b-1
+            # redteam). Catch it here so verify returns valid=False rather than
+            # letting the exception escape to the caller (DoS-via-exception).
+            return VerificationResult(
+                valid=False,
+                reason=f"Delegation signing pre-image could not be built: {exc}",
+                level=VerificationLevel.FULL,
+            )
 
         # Verify signature using authority's key
         if not verify_signature(
@@ -1561,6 +1581,16 @@ class TrustOperations:
                 return VerificationResult(
                     valid=False,
                     reason=f"Delegator chain not found: {delegation.delegator_id}",
+                    level=VerificationLevel.FULL,
+                )
+            except ValueError as exc:
+                # Fail closed on a pre-image build error (#1841 S2b-1 redteam) —
+                # a v2-labelled record with missing / narrowed structured fields
+                # MUST NOT let the exception escape to the caller. (Mirrors the
+                # ValueError handling in _verify_delegation_signature.)
+                return VerificationResult(
+                    valid=False,
+                    reason=(f"Delegation {delegation.id} could not be verified: {exc}"),
                     level=VerificationLevel.FULL,
                 )
 
@@ -1846,7 +1876,26 @@ class TrustOperations:
             else:
                 expires_at = min(expires_at, delegator_chain.genesis.expires_at)
 
-        # 7. Create DelegationRecord with EATP fields
+        # 7. Create DelegationRecord with EATP fields.
+        # A v2-bound record (all structured fields supplied) signs the cross-SDK
+        # V2Complete engine pre-image, which pins a WHOLE-SECOND timestamp (§5.3;
+        # the engine fails closed on sub-second precision). datetime.now() carries
+        # microseconds, so truncate to whole-second for a v2-bound record — else
+        # the v2 sign path would raise on every real call. Legacy records keep
+        # full microsecond precision (Python-only pre-image, no cross-SDK pin).
+        _v2_bound = (
+            constraints is not None
+            and resource_limits is not None
+            and scope is not None
+        )
+        _delegated_at = datetime.now(timezone.utc)
+        if _v2_bound:
+            _delegated_at = _delegated_at.replace(microsecond=0)
+            # expires_at is also folded into the v2 pre-image via the same
+            # whole-second-only guard; truncate it too so a sub-second expiry
+            # (e.g. inherited from the genesis) does not fail the v2 sign path.
+            if expires_at is not None and expires_at.microsecond != 0:
+                expires_at = expires_at.replace(microsecond=0)
         delegation = DelegationRecord(
             id=f"del-{uuid4()}",
             delegator_id=delegator_id,
@@ -1854,7 +1903,7 @@ class TrustOperations:
             task_id=task_id,
             capabilities_delegated=capabilities,
             constraint_subset=constraint_subset,
-            delegated_at=datetime.now(timezone.utc),
+            delegated_at=_delegated_at,
             expires_at=expires_at,
             signature="",  # Will be signed below
             # EATP fields

--- a/src/kailash/trust/signing/delegation_payload.py
+++ b/src/kailash/trust/signing/delegation_payload.py
@@ -183,6 +183,26 @@ class ConstraintDimensions:
             "reasoning_required": self.reasoning_required,
         }
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for DelegationRecord persistence (identical shape to the
+        signing sub-object; #1841 S2b-1 EATP § Dataclasses to_dict/from_dict)."""
+        return self.to_signing_dict()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConstraintDimensions":
+        """Reconstruct from a :meth:`to_dict` mapping (``allowed_tools`` re-tupled)."""
+        tools = data.get("allowed_tools")
+        return cls(
+            allow_code_execution=data["allow_code_execution"],
+            allow_delegation=data["allow_delegation"],
+            allow_filesystem=data["allow_filesystem"],
+            allow_network=data["allow_network"],
+            allow_state_mutation=data["allow_state_mutation"],
+            allowed_tools=tuple(tools) if tools is not None else None,
+            max_context_tokens=data["max_context_tokens"],
+            reasoning_required=data["reasoning_required"],
+        )
+
 
 @dataclass(frozen=True)
 class ResourceLimits:
@@ -225,6 +245,20 @@ class ResourceLimits:
             "max_total_tokens": self.max_total_tokens,
         }
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for DelegationRecord persistence (#1841 S2b-1)."""
+        return self.to_signing_dict()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ResourceLimits":
+        """Reconstruct from a :meth:`to_dict` mapping."""
+        return cls(
+            max_execution_secs=data["max_execution_secs"],
+            max_llm_calls=data["max_llm_calls"],
+            max_tool_calls=data["max_tool_calls"],
+            max_total_tokens=data["max_total_tokens"],
+        )
+
 
 @dataclass(frozen=True)
 class DelegationScope:
@@ -259,6 +293,21 @@ class DelegationScope:
             "max_financial_cents": self.max_financial_cents,
             "operations": list(self.operations),
         }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for DelegationRecord persistence (#1841 S2b-1)."""
+        return self.to_signing_dict()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DelegationScope":
+        """Reconstruct from a :meth:`to_dict` mapping (``operations`` re-tupled,
+        insertion order preserved)."""
+        operations = data.get("operations") or ()
+        return cls(
+            domain=data["domain"],
+            max_financial_cents=data.get("max_financial_cents"),
+            operations=tuple(operations),
+        )
 
 
 @dataclass(frozen=True)

--- a/src/kailash/trust/signing/delegation_record_signing.py
+++ b/src/kailash/trust/signing/delegation_record_signing.py
@@ -59,9 +59,56 @@ if TYPE_CHECKING:
 
 __all__ = [
     "delegation_canonical_payload_str",
+    "select_signing_version",
     "build_delegation_signing_input",
     "delegation_record_signing_payload",
 ]
+
+
+def select_signing_version(record: "DelegationRecord") -> str:
+    """Select which canonical pre-image a delegation record signs (#1841 S2b-1).
+
+    Returns:
+        * ``legacy-python-v0`` (the DEFAULT) when the record lacks any of the
+          structured engine-fold fields (``constraints`` / ``resource_limits`` /
+          ``scope`` — any ``None``), OR carries a NARROWED ``dimension_scope``
+          (whose cross-SDK v2/v3 fold is not yet pinned — rs#1795), OR is
+          multi-sig (V3 is a later shard).
+        * ``v2-complete`` when ALL structured fields are present AND the record
+          is non-multi-sig AND ``dimension_scope`` is the full (unscoped) CARE
+          set — so it signs the cross-SDK V2Complete engine pre-image.
+
+    The record's ``signing_payload_version`` is set from this at ``delegate()``
+    sign time; :func:`delegation_canonical_payload_str` then dispatches on that
+    persisted field. Kept a pure function of the record so it is safe to call
+    from both the sign path and any pre-persistence classification.
+    """
+    from kailash.trust.chain import (
+        ALL_DIMENSIONS,
+        DELEGATION_SIGNING_VERSION_LEGACY,
+        DELEGATION_SIGNING_VERSION_V2,
+    )
+
+    constraints = getattr(record, "constraints", None)
+    resource_limits = getattr(record, "resource_limits", None)
+    scope = getattr(record, "scope", None)
+    if constraints is None or resource_limits is None or scope is None:
+        return DELEGATION_SIGNING_VERSION_LEGACY
+
+    # V3 (multi-sig) is a later shard (S2b-2); no multi-sig field exists on the
+    # record yet, but guard defensively so a future multi-sig field cannot slip
+    # a multi-sig record onto the v2 path.
+    if getattr(record, "multi_sig", False):
+        return DELEGATION_SIGNING_VERSION_LEGACY
+
+    # The engine byte-verifies only the all-dimensions form; a narrowed
+    # dimension_scope stays legacy (its scope-widening defence lives in the
+    # legacy payload, chain.py:to_signing_payload). See build_delegation_signing_input.
+    record_scope = getattr(record, "dimension_scope", ALL_DIMENSIONS)
+    if frozenset(record_scope) != frozenset(ALL_DIMENSIONS):
+        return DELEGATION_SIGNING_VERSION_LEGACY
+
+    return DELEGATION_SIGNING_VERSION_V2
 
 
 def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
@@ -75,21 +122,27 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
         record: The delegation record whose canonical pre-image is requested.
 
     Returns:
-        The ``serialize_for_signing`` string of the legacy
-        ``to_signing_payload()`` pre-image (for a ``legacy-python-v0`` record).
+        For a ``legacy-python-v0`` record, the ``serialize_for_signing`` string
+        of the legacy ``to_signing_payload()`` pre-image (byte-identical to the
+        pre-migration behaviour). For a ``v2-complete`` record, the canonical
+        cross-SDK V2Complete engine pre-image (folding the record-persisted
+        ``constraints`` / ``resource_limits`` / ``scope``) as a UTF-8 string
+        (#1841 S2b-1).
 
     Raises:
-        UnsupportedSigningPayloadVersionError: If the record declares any version
-            other than ``legacy-python-v0``. The engine-backed v2/v3 pre-images
-            require record-persisted structured data this build does not yet
-            carry (#1841 shard 2b); falling through to the legacy verifier would
+        UnsupportedSigningPayloadVersionError: If the record declares
+            ``v3-complete`` (multi-sig — a later shard, S2b-2) or any
+            unrecognised version. Falling through to the legacy verifier would
             sign/verify the WRONG pre-image, so this fails closed.
     """
     # Import lazily to avoid a chain <-> signing import cycle: chain.py imports
     # kailash.trust.signing.crypto at module load, which initialises the signing
     # package; a top-level `from kailash.trust.chain import ...` here would run
     # before chain's module-level constants are defined.
-    from kailash.trust.chain import DELEGATION_SIGNING_VERSION_LEGACY
+    from kailash.trust.chain import (
+        DELEGATION_SIGNING_VERSION_LEGACY,
+        DELEGATION_SIGNING_VERSION_V2,
+    )
 
     version = getattr(
         record, "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
@@ -97,6 +150,23 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
     if version == DELEGATION_SIGNING_VERSION_LEGACY:
         return serialize_for_signing(record.to_signing_payload())
 
+    if version == DELEGATION_SIGNING_VERSION_V2:
+        # v2-complete: fold the record-persisted structured constraints /
+        # resource_limits / scope into the cross-SDK V2Complete engine pre-image
+        # (#1841 S2b-1). The engine emits ASCII-only canonical JCS bytes for the
+        # §5.3 inputs; decode to str for the signer (byte-identical on re-encode).
+        payload_bytes = delegation_record_signing_payload(
+            record,
+            SigningPayloadVersion.V2_COMPLETE,
+            constraints=record.constraints,
+            resource_limits=record.resource_limits,
+            scope=record.scope,
+        )
+        return payload_bytes.decode("utf-8")
+
+    # v3-complete (multi-sig) and any unrecognised version fail closed — their
+    # record-persisted verify path is a later shard (S2b-2). Falling through to
+    # the legacy verifier would check the WRONG pre-image.
     raise UnsupportedSigningPayloadVersionError(
         version, record_id=getattr(record, "id", None)
     )
@@ -105,9 +175,9 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
 def build_delegation_signing_input(
     record: "DelegationRecord",
     *,
-    constraints: ConstraintDimensions,
-    resource_limits: ResourceLimits,
-    scope: DelegationScope,
+    constraints: Optional[ConstraintDimensions],
+    resource_limits: Optional[ResourceLimits],
+    scope: Optional[DelegationScope],
     multi_sig: bool = False,
     multi_sig_policy: Optional[MultiSigSigningPolicy] = None,
 ) -> DelegationSigningInput:
@@ -224,9 +294,9 @@ def delegation_record_signing_payload(
     record: "DelegationRecord",
     version: SigningPayloadVersion,
     *,
-    constraints: ConstraintDimensions,
-    resource_limits: ResourceLimits,
-    scope: DelegationScope,
+    constraints: Optional[ConstraintDimensions],
+    resource_limits: Optional[ResourceLimits],
+    scope: Optional[DelegationScope],
     multi_sig: bool = False,
     multi_sig_policy: Optional[MultiSigSigningPolicy] = None,
 ) -> bytes:

--- a/src/kailash/trust/signing/delegation_record_signing.py
+++ b/src/kailash/trust/signing/delegation_record_signing.py
@@ -68,15 +68,25 @@ __all__ = [
 def select_signing_version(record: "DelegationRecord") -> str:
     """Select which canonical pre-image a delegation record signs (#1841 S2b-1).
 
+    The structured engine-fold fields (``constraints`` / ``resource_limits`` /
+    ``scope``) are ALL-OR-NOTHING: supply all three (→ v2) or none (→ legacy).
+
     Returns:
-        * ``legacy-python-v0`` (the DEFAULT) when the record lacks any of the
-          structured engine-fold fields (``constraints`` / ``resource_limits`` /
-          ``scope`` — any ``None``), OR carries a NARROWED ``dimension_scope``
-          (whose cross-SDK v2/v3 fold is not yet pinned — rs#1795), OR is
-          multi-sig (V3 is a later shard).
+        * ``legacy-python-v0`` (the DEFAULT) when NONE of the structured fields
+          is supplied, OR (all three supplied but) the record carries a NARROWED
+          ``dimension_scope`` (whose cross-SDK v2/v3 fold is not yet pinned —
+          rs#1795), OR is multi-sig (V3 is a later shard).
         * ``v2-complete`` when ALL structured fields are present AND the record
           is non-multi-sig AND ``dimension_scope`` is the full (unscoped) CARE
           set — so it signs the cross-SDK V2Complete engine pre-image.
+
+    Raises:
+        ValueError: If SOME but not ALL of the three structured fields are
+            supplied (partial supply). A partial-supply record would silently
+            downgrade to legacy (which does NOT bind the supplied fields into
+            the signature) while ``to_dict`` still persists them UNSIGNED — a
+            fail-open secure-default (``rules/security.md`` § "Secure-Default …
+            Never A Silent No-Op"). Fail closed + loud instead.
 
     The record's ``signing_payload_version`` is set from this at ``delegate()``
     sign time; :func:`delegation_canonical_payload_str` then dispatches on that
@@ -89,11 +99,24 @@ def select_signing_version(record: "DelegationRecord") -> str:
         DELEGATION_SIGNING_VERSION_V2,
     )
 
-    constraints = getattr(record, "constraints", None)
-    resource_limits = getattr(record, "resource_limits", None)
-    scope = getattr(record, "scope", None)
-    if constraints is None or resource_limits is None or scope is None:
+    structured = {
+        "constraints": getattr(record, "constraints", None),
+        "resource_limits": getattr(record, "resource_limits", None),
+        "scope": getattr(record, "scope", None),
+    }
+    supplied = [name for name, val in structured.items() if val is not None]
+    if not supplied:
+        # None supplied → legacy (byte-identical to pre-S2b).
         return DELEGATION_SIGNING_VERSION_LEGACY
+    if len(supplied) != len(structured):
+        # Partial supply is fail-open: it would sign legacy bytes (dropping the
+        # supplied fields from the signature) yet persist them unsigned. Refuse.
+        missing = sorted(name for name, val in structured.items() if val is None)
+        raise ValueError(
+            "structured signing fields (constraints, resource_limits, scope) "
+            "must be supplied together or all omitted; got "
+            f"{sorted(supplied)} without {missing}"
+        )
 
     # V3 (multi-sig) is a later shard (S2b-2); no multi-sig field exists on the
     # record yet, but guard defensively so a future multi-sig field cannot slip

--- a/tests/regression/test_issue_1841_delegation_signing_migration.py
+++ b/tests/regression/test_issue_1841_delegation_signing_migration.py
@@ -168,8 +168,11 @@ def test_record_deserialized_without_version_key_still_verifies():
 
 
 @pytest.mark.parametrize(
+    # v2-complete is WIRED as of #1841 S2b-1 (see the v2 tests below); v3-complete
+    # (multi-sig) remains a later shard (S2b-2), and any unrecognised version
+    # still fails closed with UnsupportedSigningPayloadVersionError.
     "version",
-    [DELEGATION_SIGNING_VERSION_V2, DELEGATION_SIGNING_VERSION_V3, "future-vX"],
+    [DELEGATION_SIGNING_VERSION_V3, "future-vX"],
 )
 def test_non_legacy_version_fails_closed_at_dispatch(version):
     record = _record(signing_payload_version=version)
@@ -179,24 +182,44 @@ def test_non_legacy_version_fails_closed_at_dispatch(version):
     assert exc.value.record_id == "del-1841"
 
 
-def test_non_legacy_record_does_not_verify_under_legacy_bytes():
-    """A v2-declared record signed over legacy bytes MUST fail closed, not pass.
+def test_v2_labeled_record_without_structured_fields_fails_closed():
+    """A v2-labeled record lacking the structured fold fields fails closed.
 
-    This is the core security property: the version gate stops a record whose
-    declared shape (v2) differs from the bytes a naive legacy verifier would
-    check, so a mismatched record can never be accepted.
+    #1841 S2b-1 wires v2, but the engine bridge REQUIRES the structured
+    constraints / resource_limits / scope. A record stamped v2 without them is an
+    inconsistent state (select_signing_version never produces it) and MUST fail
+    closed at the bridge rather than emit guessed bytes — never fall through to
+    legacy.
     """
-    private_key, _ = generate_keypair()
-    record = _record()
-    # Attacker/legacy signs over the legacy bytes but stamps a v2 version.
+    record = _record(signing_payload_version=DELEGATION_SIGNING_VERSION_V2)
+    with pytest.raises(ValueError, match="constraints"):
+        delegation_canonical_payload_str(record)
+
+
+def test_non_legacy_record_does_not_verify_under_legacy_bytes():
+    """A v2 record signed over LEGACY bytes MUST fail verification.
+
+    Core security property (now testable with v2 wired, #1841 S2b-1): a record
+    whose declared shape (v2, carrying structured fields) differs from the bytes
+    a naive legacy signer produced can never verify — the version gate emits the
+    v2 pre-image, which does not match a legacy-bytes signature.
+    """
+    private_key, public_key = generate_keypair()
+    constraints, limits, scope = _supervised_structured()
+    record = _record(
+        constraints=constraints,
+        resource_limits=limits,
+        scope=scope,
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V2,
+    )
+    # Attacker/legacy signs over the LEGACY bytes but the record is a v2 record.
     record.signature = sign(
         serialize_for_signing(record.to_signing_payload()), private_key
     )
-    record.signing_payload_version = DELEGATION_SIGNING_VERSION_V2
 
-    # The dispatch refuses to produce a verify pre-image → fail closed.
-    with pytest.raises(UnsupportedSigningPayloadVersionError):
-        delegation_canonical_payload_str(record)
+    # The dispatch emits the v2 pre-image (≠ the signed legacy bytes) → verify fails.
+    v2_payload = delegation_canonical_payload_str(record)
+    assert verify_signature(v2_payload, record.signature, public_key) is False
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/regression/test_issue_1841_s2b1_v2_enrich.py
+++ b/tests/regression/test_issue_1841_s2b1_v2_enrich.py
@@ -198,23 +198,42 @@ def test_v3_version_fails_closed() -> None:
 # --- select_signing_version selection logic ----------------------------------
 
 
-def test_select_version_requires_all_three_structured_fields() -> None:
-    """Missing ANY structured field falls back to legacy."""
-    full = _v2_record()
-    assert select_signing_version(full) == DELEGATION_SIGNING_VERSION_V2
+def test_select_version_all_three_present_is_v2_none_is_legacy() -> None:
+    """All three structured fields → v2; none → legacy."""
+    assert select_signing_version(_v2_record()) == DELEGATION_SIGNING_VERSION_V2
 
-    assert (
-        select_signing_version(_v2_record(constraints=None))
-        == DELEGATION_SIGNING_VERSION_LEGACY
+    none_record = _v2_record(
+        constraints=None,
+        resource_limits=None,
+        scope=None,
+        signing_payload_version=DELEGATION_SIGNING_VERSION_LEGACY,
     )
-    assert (
-        select_signing_version(_v2_record(resource_limits=None))
-        == DELEGATION_SIGNING_VERSION_LEGACY
-    )
-    assert (
-        select_signing_version(_v2_record(scope=None))
-        == DELEGATION_SIGNING_VERSION_LEGACY
-    )
+    assert select_signing_version(none_record) == DELEGATION_SIGNING_VERSION_LEGACY
+
+
+@pytest.mark.parametrize(
+    "kwargs,missing",
+    [
+        ({"scope": None}, "scope"),
+        ({"constraints": None}, "constraints"),
+        ({"resource_limits": None}, "resource_limits"),
+        ({"constraints": None, "resource_limits": None}, "constraints"),
+        ({"resource_limits": None, "scope": None}, "resource_limits"),
+    ],
+)
+def test_select_version_partial_supply_raises(kwargs, missing) -> None:
+    """PARTIAL structured-field supply fails closed (all-or-nothing) — #1841 S2b-1 FIX 1.
+
+    A partial-supply record would silently downgrade to legacy (dropping the
+    supplied fields from the signature) while to_dict persists them UNSIGNED —
+    a fail-open secure-default. select_signing_version MUST raise instead.
+    """
+    record = _v2_record(**kwargs)
+    with pytest.raises(ValueError, match="must be supplied together or all omitted"):
+        select_signing_version(record)
+    # The raised message names the missing field(s).
+    with pytest.raises(ValueError, match=missing):
+        select_signing_version(record)
 
 
 # --- Real Ed25519 round-trip (Tier-2 crypto, NO mocking) ---------------------
@@ -313,3 +332,177 @@ def test_dimension_scope_default_unset_yields_v2_after_roundtrip() -> None:
     assert frozenset(record.dimension_scope) == frozenset(ALL_DIMENSIONS)
     restored = DelegationRecord.from_dict(record.to_dict())
     assert select_signing_version(restored) == DELEGATION_SIGNING_VERSION_V2
+
+
+# --- FIX 2: verify FAILS CLOSED (returns valid=False), never raises -----------
+
+
+class _SimpleRegistry:
+    """Real in-memory authority registry (NOT a mock) — mirrors the lifecycle test."""
+
+    def __init__(self):
+        self._authorities = {}
+
+    async def initialize(self):  # noqa: D401 - protocol no-op
+        pass
+
+    def register(self, authority):
+        self._authorities[authority.id] = authority
+
+    async def get_authority(self, authority_id, include_inactive=False):
+        from kailash.trust.exceptions import AuthorityNotFoundError
+
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            raise AuthorityNotFoundError(authority_id)
+        return authority
+
+    async def update_authority(self, authority):
+        self._authorities[authority.id] = authority
+
+
+async def _real_ops_with_delegator():
+    """Build a real TrustOperations (real crypto + real store, NO mocking) and a
+    delegator trust chain rooted at ``org-acme``."""
+    from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+    from kailash.trust.chain import AuthorityType, CapabilityType
+    from kailash.trust.chain_store.memory import InMemoryTrustStore
+    from kailash.trust.operations import (
+        CapabilityRequest,
+        TrustKeyManager,
+        TrustOperations,
+    )
+
+    private_key, public_key = generate_keypair()
+    authority = OrganizationalAuthority(
+        id="org-acme",
+        name="ACME Corporation",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="acme-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.DELEGATE_TRUST,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+    registry = _SimpleRegistry()
+    registry.register(authority)
+    key_manager = TrustKeyManager()
+    key_manager.register_key("acme-key-001", private_key)
+    store = InMemoryTrustStore()
+    await store.initialize()
+    ops = TrustOperations(
+        authority_registry=registry, key_manager=key_manager, trust_store=store
+    )
+    await ops.initialize()
+    delegator_chain = await ops.establish(
+        agent_id="agent-delegator",
+        authority_id="org-acme",
+        capabilities=[
+            CapabilityRequest(
+                capability="LlmCall", capability_type=CapabilityType.ACTION
+            )
+        ],
+    )
+    return ops, delegator_chain
+
+
+async def test_verify_returns_false_on_v2_record_missing_structured_fields() -> None:
+    """A v2-labelled record with NO structured fields → verify returns valid=False.
+
+    #1841 S2b-1 FIX 2: the engine bridge fails closed with a ValueError; the verify
+    path MUST catch it and return valid=False, NOT let the exception escape
+    (DoS-via-exception).
+    """
+    ops, delegator_chain = await _real_ops_with_delegator()
+
+    bad = DelegationRecord(
+        id="del-bad-v2",
+        delegator_id="agent-delegator",
+        delegatee_id="agent-x",
+        task_id="t",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="not-a-real-sig",
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V2,
+        # constraints / resource_limits / scope deliberately absent → bridge raises.
+    )
+
+    result = await ops._verify_delegation_signature(bad, delegator_chain)
+    assert result.valid is False
+    assert result.reason and "could not be built" in result.reason
+
+
+async def test_verify_chain_returns_false_on_v2_record_missing_fields() -> None:
+    """verify_delegation_chain also fails closed (does NOT raise) on the bad record."""
+    ops, delegator_chain = await _real_ops_with_delegator()
+
+    bad = DelegationRecord(
+        id="del-bad-v2-chain",
+        delegator_id="agent-delegator",
+        delegatee_id="agent-y",
+        task_id="t",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="not-a-real-sig",
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V2,
+    )
+    # Attach the bad delegation to agent-y's chain and verify the chain.
+    delegatee_chain = await ops.trust_store.get_chain("agent-delegator")
+    delegatee_chain.delegations.append(bad)
+    await ops.trust_store.update_chain("agent-delegator", delegatee_chain)
+
+    result = await ops.verify_delegation_chain("agent-delegator")
+    assert result.valid is False  # fails closed, no exception escaped
+
+
+async def test_delegate_partial_structured_supply_raises() -> None:
+    """delegate() with PARTIAL structured params fails closed — #1841 S2b-1 FIX 1."""
+    ops, _ = await _real_ops_with_delegator()
+
+    with pytest.raises(ValueError, match="must be supplied together or all omitted"):
+        await ops.delegate(
+            delegator_id="agent-delegator",
+            delegatee_id="agent-z",
+            task_id="task-partial",
+            capabilities=["LlmCall"],
+            constraints=_supervised_constraints(),
+            resource_limits=_supervised_limits(),
+            scope=None,  # partial supply → raise before signing/persisting
+        )
+    # The partial-supply delegation MUST NOT have been persisted.
+    from kailash.trust.exceptions import TrustChainNotFoundError
+
+    with pytest.raises(TrustChainNotFoundError):
+        await ops.trust_store.get_chain("agent-z")
+
+
+async def test_delegate_all_three_v2_none_legacy_unchanged() -> None:
+    """delegate() all-3 → v2 record; none → legacy record (behavior UNCHANGED)."""
+    ops, _ = await _real_ops_with_delegator()
+
+    v2_deleg = await ops.delegate(
+        delegator_id="agent-delegator",
+        delegatee_id="agent-v2",
+        task_id="task-v2",
+        capabilities=["LlmCall"],
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+    )
+    assert v2_deleg.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+
+    legacy_deleg = await ops.delegate(
+        delegator_id="agent-delegator",
+        delegatee_id="agent-legacy",
+        task_id="task-legacy",
+        capabilities=["LlmCall"],
+    )
+    assert legacy_deleg.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+
+    # Both records verify (real Ed25519 round-trip through the store).
+    assert (await ops.verify_delegation_chain("agent-v2")).valid is True
+    assert (await ops.verify_delegation_chain("agent-legacy")).valid is True

--- a/tests/regression/test_issue_1841_s2b1_v2_enrich.py
+++ b/tests/regression/test_issue_1841_s2b1_v2_enrich.py
@@ -1,0 +1,315 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1841 S2b-1: DelegationRecord signs the cross-SDK V2Complete pre-image.
+
+A NON-multi-sig ``DelegationRecord`` carrying structured
+``constraints`` / ``resource_limits`` / ``scope`` (and an unscoped
+``dimension_scope``) signs the ``v2-complete`` engine pre-image instead of the
+pre-migration ``legacy-python-v0`` schema. This is a SECURITY-CRITICAL,
+BYTE-CHANGING, cross-SDK-lockstep migration; the tests here pin:
+
+* the ``V2C_NON_MULTI_SIG`` byte vector (byte-for-byte cross-SDK contract);
+* legacy bytes UNCHANGED for a pre-S2b record (backward-compat, byte-identical);
+* the ``dimension_scope`` gate (a narrowed record stays legacy; a direct bridge
+  call on narrowed scope raises);
+* real Ed25519 round-trip sign -> verify over the V2 pre-image (Tier-2 crypto,
+  NO mocking);
+* to_dict -> from_dict persistence reconstructs the structured fields and
+  reproduces the signature;
+* capability INSERTION ORDER is preserved on the V2 path (the engine matches
+  kailash-rs; the legacy path SORTS).
+
+The pinned ``V2C_NON_MULTI_SIG`` hex is the kailash-rs canonical byte vector
+(vendored in ``test_delegation_signing_payload_vectors.py``); it is re-used here
+so the record-level dispatch is byte-checked against the SAME cross-SDK anchor
+as the engine-level test.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.chain import (
+    ALL_DIMENSIONS,
+    DELEGATION_SIGNING_VERSION_LEGACY,
+    DELEGATION_SIGNING_VERSION_V2,
+    DelegationRecord,
+)
+from kailash.trust.exceptions import UnsupportedSigningPayloadVersionError
+from kailash.trust.signing.crypto import (
+    generate_keypair,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    ResourceLimits,
+    SigningPayloadVersion,
+    TrustLevel,
+)
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
+    delegation_record_signing_payload,
+    select_signing_version,
+)
+
+# The pinned kailash-rs V2Complete byte vector for the NON-multi-sig fixed
+# record (identical hex to test_delegation_signing_payload_vectors.py :: V2C).
+V2C_NON_MULTI_SIG = "7b226361706162696c6974696573223a5b224c6c6d43616c6c225d2c22636f6e73747261696e7473223a7b22616c6c6f775f636f64655f657865637574696f6e223a66616c73652c22616c6c6f775f64656c65676174696f6e223a66616c73652c22616c6c6f775f66696c6573797374656d223a66616c73652c22616c6c6f775f6e6574776f726b223a747275652c22616c6c6f775f73746174655f6d75746174696f6e223a747275652c22616c6c6f7765645f746f6f6c73223a6e756c6c2c226d61785f636f6e746578745f746f6b656e73223a31363338342c22726561736f6e696e675f7265717569726564223a66616c73657d2c22637265617465645f6174223a22323032362d30312d30325430333a30343a30352b30303a3030222c2264656c6567617465223a22626f62222c2264656c65676174696f6e5f6964223a2230303030303030302d303030302d343030302d383030302d303030303030303030303031222c2264656c656761746f72223a22616c696365222c22657870697265735f6174223a6e756c6c2c22706172656e745f64656c65676174696f6e5f6964223a6e756c6c2c22726561736f6e696e675f74726163655f68617368223a6e756c6c2c227265736f757263655f6c696d697473223a7b226d61785f657865637574696f6e5f73656373223a3330302c226d61785f6c6c6d5f63616c6c73223a35302c226d61785f746f6f6c5f63616c6c73223a32302c226d61785f746f74616c5f746f6b656e73223a3130303030307d2c2273636f7065223a7b22646f6d61696e223a22656e67696e656572696e67222c226d61785f66696e616e6369616c5f63656e7473223a6e756c6c2c226f7065726174696f6e73223a5b2272656164225d7d2c227369676e696e675f7061796c6f61645f76657273696f6e223a2276322d636f6d706c657465227d"
+
+pytestmark = pytest.mark.regression
+
+
+def _supervised_constraints() -> ConstraintDimensions:
+    return ConstraintDimensions.for_level(TrustLevel.SUPERVISED)
+
+
+def _supervised_limits() -> ResourceLimits:
+    return ResourceLimits.for_level(TrustLevel.SUPERVISED)
+
+
+def _engineering_read_scope() -> DelegationScope:
+    return DelegationScope.new("engineering").with_operation("read")
+
+
+def _v2_record(**overrides) -> DelegationRecord:
+    """Build the fixed-input V2 record (matches the rs ``fixed_inputs()``)."""
+    kwargs = dict(
+        id="00000000-0000-4000-8000-000000000001",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-fixed",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V2,
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _legacy_record(**overrides) -> DelegationRecord:
+    """A pre-S2b record: no structured fields, default legacy version."""
+    kwargs = dict(
+        id="del-legacy-1",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-legacy",
+        capabilities_delegated=["LlmCall", "FileRead"],
+        constraint_subset=["read_only"],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+# --- Byte-pin (TDD anchor) ---------------------------------------------------
+
+
+def test_v2c_non_multi_sig_byte_pin() -> None:
+    """A V2 record's canonical dispatch string == the pinned rs V2Complete bytes."""
+    record = _v2_record()
+    payload_str = delegation_canonical_payload_str(record)
+    assert (
+        payload_str.encode("utf-8").hex() == V2C_NON_MULTI_SIG
+    ), "V2Complete record-dispatch bytes drifted from the kailash-rs pin"
+    # Structural spot-checks the byte-pin also encodes.
+    assert '"signing_payload_version":"v2-complete"' in payload_str
+    assert "multi_sig" not in payload_str
+
+
+# --- Backward-compat: legacy bytes UNCHANGED ---------------------------------
+
+
+def test_legacy_record_dispatch_is_byte_identical_to_pre_migration() -> None:
+    """A default (no structured fields) record signs the legacy pre-image unchanged."""
+    record = _legacy_record()
+    assert record.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    assert select_signing_version(record) == DELEGATION_SIGNING_VERSION_LEGACY
+
+    dispatched = delegation_canonical_payload_str(record)
+    expected = serialize_for_signing(record.to_signing_payload())
+    assert (
+        dispatched == expected
+    ), "legacy dispatch bytes drifted from to_signing_payload"
+
+
+def test_legacy_to_signing_payload_has_no_v2_fields() -> None:
+    """The legacy pre-image MUST NOT carry the new structured / version keys."""
+    record = (
+        _v2_record()
+    )  # structured fields present, but legacy pre-image ignores them
+    legacy_payload = record.to_signing_payload()
+    for absent in (
+        "constraints",
+        "resource_limits",
+        "scope",
+        "signing_payload_version",
+    ):
+        assert (
+            absent not in legacy_payload
+        ), f"legacy to_signing_payload leaked {absent!r} — legacy bytes changed"
+
+
+# --- dimension_scope gate ----------------------------------------------------
+
+
+def test_narrowed_dimension_scope_stays_legacy() -> None:
+    """A narrowed-dimension_scope record with structured fields stays legacy-python-v0."""
+    record = _v2_record(
+        dimension_scope=frozenset({"financial", "operational"}),
+        signing_payload_version=DELEGATION_SIGNING_VERSION_LEGACY,
+    )
+    assert select_signing_version(record) == DELEGATION_SIGNING_VERSION_LEGACY
+
+
+def test_narrowed_scope_direct_bridge_call_raises() -> None:
+    """A direct engine-bridge call on a narrowed-scope record fails closed."""
+    record = _v2_record(dimension_scope=frozenset({"financial"}))
+    with pytest.raises(ValueError, match="dimension_scope is narrowed"):
+        delegation_record_signing_payload(
+            record,
+            SigningPayloadVersion.V2_COMPLETE,
+            constraints=record.constraints,
+            resource_limits=record.resource_limits,
+            scope=record.scope,
+        )
+
+
+def test_v3_version_fails_closed() -> None:
+    """A record declaring v3-complete fails closed (multi-sig is a later shard)."""
+    from kailash.trust.chain import DELEGATION_SIGNING_VERSION_V3
+
+    record = _v2_record(signing_payload_version=DELEGATION_SIGNING_VERSION_V3)
+    with pytest.raises(UnsupportedSigningPayloadVersionError):
+        delegation_canonical_payload_str(record)
+
+
+# --- select_signing_version selection logic ----------------------------------
+
+
+def test_select_version_requires_all_three_structured_fields() -> None:
+    """Missing ANY structured field falls back to legacy."""
+    full = _v2_record()
+    assert select_signing_version(full) == DELEGATION_SIGNING_VERSION_V2
+
+    assert (
+        select_signing_version(_v2_record(constraints=None))
+        == DELEGATION_SIGNING_VERSION_LEGACY
+    )
+    assert (
+        select_signing_version(_v2_record(resource_limits=None))
+        == DELEGATION_SIGNING_VERSION_LEGACY
+    )
+    assert (
+        select_signing_version(_v2_record(scope=None))
+        == DELEGATION_SIGNING_VERSION_LEGACY
+    )
+
+
+# --- Real Ed25519 round-trip (Tier-2 crypto, NO mocking) ---------------------
+
+
+def test_v2_record_real_ed25519_round_trip() -> None:
+    """Sign a V2 record with a real Ed25519 key; verify over the SAME pre-image."""
+    private_key, public_key = generate_keypair()
+    record = _v2_record()
+
+    payload = delegation_canonical_payload_str(record)
+    signature = sign(payload, private_key)
+    record.signature = signature
+
+    # Re-derive the pre-image and verify (mirrors _verify_delegation_signature).
+    verify_payload = delegation_canonical_payload_str(record)
+    assert verify_signature(verify_payload, record.signature, public_key)
+
+    # A tampered scope changes the pre-image → verification MUST fail.
+    tampered = _v2_record(scope=DelegationScope.new("finance").with_operation("read"))
+    tampered.signature = record.signature
+    assert not verify_signature(
+        delegation_canonical_payload_str(tampered), tampered.signature, public_key
+    )
+
+
+def test_legacy_record_real_ed25519_round_trip_survives_persistence() -> None:
+    """A legacy record signs, persists via to_dict/from_dict, and re-verifies."""
+    private_key, public_key = generate_keypair()
+    record = _legacy_record()
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    restored = DelegationRecord.from_dict(record.to_dict())
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    )
+
+
+# --- Persistence round-trip (V2) ---------------------------------------------
+
+
+def test_v2_to_dict_from_dict_reconstructs_and_reproduces_bytes() -> None:
+    """to_dict -> from_dict reconstructs the structured fields + reproduces the pre-image."""
+    record = _v2_record()
+    restored = DelegationRecord.from_dict(record.to_dict())
+
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+
+    # Byte-identical pre-image after the round-trip.
+    assert (
+        delegation_canonical_payload_str(restored).encode("utf-8").hex()
+        == V2C_NON_MULTI_SIG
+    )
+
+
+def test_pre_s2b_record_from_dict_all_none_and_legacy() -> None:
+    """from_dict of a persisted pre-S2b record (no structured keys) → all None, legacy."""
+    legacy_dict = _legacy_record().to_dict()
+    # Simulate an on-wire pre-S2b record: strip the structured keys entirely.
+    for k in ("constraints", "resource_limits", "scope"):
+        legacy_dict.pop(k, None)
+    restored = DelegationRecord.from_dict(legacy_dict)
+    assert restored.constraints is None
+    assert restored.resource_limits is None
+    assert restored.scope is None
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+
+
+# --- Capability insertion-order preservation (V2 path) -----------------------
+
+
+def test_v2_preserves_capability_insertion_order() -> None:
+    """The V2 engine path PRESERVES capability insertion order (legacy SORTS)."""
+    unsorted_caps = ["Zeta", "Alpha", "Mid"]
+    record = _v2_record(capabilities_delegated=unsorted_caps)
+    payload = delegation_canonical_payload_str(record)
+    assert (
+        '"capabilities":["Zeta","Alpha","Mid"]' in payload
+    ), "V2 path MUST preserve capability insertion order (must NOT sort)"
+
+    # Contrast: the legacy pre-image SORTS the same capabilities.
+    legacy_payload = record.to_signing_payload()
+    assert legacy_payload["capabilities_delegated"] == ["Alpha", "Mid", "Zeta"]
+
+
+# --- dimension_scope binding survives to_dict/from_dict ----------------------
+
+
+def test_dimension_scope_default_unset_yields_v2_after_roundtrip() -> None:
+    """A default (all-dimensions) V2 record round-trips to V2, not legacy."""
+    record = _v2_record()
+    assert frozenset(record.dimension_scope) == frozenset(ALL_DIMENSIONS)
+    restored = DelegationRecord.from_dict(record.to_dict())
+    assert select_signing_version(restored) == DELEGATION_SIGNING_VERSION_V2


### PR DESCRIPTION
## Summary
Part of #1841 (S2b-1 of 2). Non-multi-sig `DelegationRecord`s now sign the cross-SDK **V2Complete** pre-image (folding `constraints`/`resource_limits`/`scope` into the signature) instead of `legacy-python-v0`. S1 (engine) + S2 (version-gated dispatch) already merged; this wires real records to the verified engine for the non-multi-sig case. Multi-sig **V3Complete** (the quorum-integrity headline) is the next shard (S2b-2).

## What
- `chain.py` — `DelegationRecord` gains `constraints`/`resource_limits`/`scope` (all Optional/None); `to_dict`/`from_dict` wire them (emit-only-when-present → legacy records round-trip with **no new keys**). `to_signing_payload()` (legacy pre-image) is **unchanged**.
- `delegation_payload.py` — `to_dict`/`from_dict` on `ConstraintDimensions`/`ResourceLimits`/`DelegationScope`.
- `delegation_record_signing.py` — new `select_signing_version(record)`; `delegation_canonical_payload_str` dispatches v2-complete → engine pre-image; legacy unchanged; v3/unknown fail closed.
- `operations/__init__.py` — `delegate()` gains optional `constraints`/`resource_limits`/`scope` (additive; omit → legacy).

## Key invariants (verified)
- **V2C_NON_MULTI_SIG byte-pin matches byte-for-byte** (1372/1372; pinned rs vector NOT edited).
- **Legacy bytes unchanged** — pre-S2b records verify byte-identically (2 tests).
- **dimension_scope gate** — a narrowed-scope record stays `legacy-python-v0` (its scope-widening defence lives in the legacy payload); v2 only when `dimension_scope == ALL_DIMENSIONS`.
- **Capability ordering** — v2 preserves insertion order (matches rs engine); legacy sorts. Deliberate contract difference, tested.
- Real Ed25519 sign→verify round-trip (Tier-2, no mocking); tampered scope → verify fails.

## Test / regression
13 new tests + updated 2 S1/S2 migration tests (v2 is now wired — the fail-closed *security* property preserved: a v2-labelled record without structured fields still fails closed; a v2 record over legacy bytes fails verification). `40 passed` (new+migration+vectors); `3040 passed` trust unit suite.

## Notes for review
- 2 migration tests changed — scrutinize the fail-closed property was preserved, not force-fit.
- Pre-existing mypy in `chain.py`: base HEAD 12 errors → 5 here (0 introduced, count reduced); remaining 5 in untouched `get_delegation_chain`/`TrustLineageChain.to_dict`.
- CLI `delegate()` left constructing legacy records (no structured-constraint input surface yet; routes legacy via the shared dispatch — backward-compat).

## Related issues
Refs #1841 (S2b-1 of 2; S2b-2 = V3 multi-sig quorum integrity)