### PR TITLE
feat(trust): fold multi-sig policy into V3Complete signing pre-image — quorum integrity (#1841 S2b-2)

### DIFF
--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -35,6 +35,7 @@ from kailash.trust.signing.crypto import (
 from kailash.trust.signing.delegation_payload import (
     ConstraintDimensions,
     DelegationScope,
+    MultiSigSigningPolicy,
     ResourceLimits,
 )
 
@@ -330,6 +331,19 @@ class DelegationRecord:
     resource_limits: Optional[ResourceLimits] = None
     scope: Optional[DelegationScope] = None
 
+    # Multi-sig fold fields (#1841 S2b-2). Backward-compat defaults (False/None)
+    # so a pre-S2b-2 record is byte-identical. When multi_sig is True AND
+    # multi_sig_policy is set (with all three structured fields present AND an
+    # unscoped dimension_scope), the record signs the cross-SDK V3Complete
+    # pre-image, folding the quorum policy (threshold + canonically-sorted
+    # authorized_signers) into the Ed25519-signed bytes so a store-write actor
+    # cannot weaken quorum (lower the threshold, swap/remove a signer) without
+    # invalidating the signature. These fold into the ENGINE pre-image only —
+    # never into the legacy to_signing_payload() below (whose bytes stay
+    # unchanged) nor the v2 pre-image (a non-multi-sig record is byte-neutral).
+    multi_sig: bool = False
+    multi_sig_policy: Optional[MultiSigSigningPolicy] = None
+
     def __post_init__(self) -> None:
         """Validate dimension_scope values are from the canonical set."""
         if not isinstance(self.dimension_scope, frozenset):
@@ -423,6 +437,14 @@ class DelegationRecord:
             d["resource_limits"] = self.resource_limits.to_dict()
         if self.scope is not None:
             d["scope"] = self.scope.to_dict()
+        # Multi-sig fold fields (#1841 S2b-2) — emitted ONLY when set, so a
+        # non-multi-sig record's persisted dict carries NO multi_sig keys and is
+        # byte-identical to a pre-S2b-2 record (prune-when-unset, matching the
+        # structured-field pattern above and cross-sdk-inspection 4d).
+        if self.multi_sig:
+            d["multi_sig"] = True
+        if self.multi_sig_policy is not None:
+            d["multi_sig_policy"] = self.multi_sig_policy.to_dict()
         return d
 
     @classmethod
@@ -480,6 +502,18 @@ class DelegationRecord:
             else None
         )
 
+        # Multi-sig fold fields (#1841 S2b-2): backward-compatible -- a pre-S2b-2
+        # record has no key, so multi_sig defaults False and multi_sig_policy is
+        # None. MultiSigSigningPolicy.from_dict decodes hex->bytes AND re-runs
+        # __post_init__, so distinct-signer / 32-byte / threshold<=N validation
+        # fires on reconstruction (a tampered persisted policy fails closed).
+        raw_multi_sig_policy = data.get("multi_sig_policy")
+        multi_sig_policy = (
+            MultiSigSigningPolicy.from_dict(raw_multi_sig_policy)
+            if raw_multi_sig_policy is not None
+            else None
+        )
+
         return cls(
             id=data["id"],
             delegator_id=data["delegator_id"],
@@ -516,6 +550,9 @@ class DelegationRecord:
             constraints=constraints,
             resource_limits=resource_limits,
             scope=scope,
+            # Multi-sig fold fields (#1841 S2b-2): defaults when absent.
+            multi_sig=data.get("multi_sig", False),
+            multi_sig_policy=multi_sig_policy,
         )
 
 

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -73,6 +73,7 @@ from kailash.trust.signing.crypto import (
 from kailash.trust.signing.delegation_payload import (
     ConstraintDimensions,
     DelegationScope,
+    MultiSigSigningPolicy,
     ResourceLimits,
 )
 from kailash.trust.signing.delegation_record_signing import (
@@ -1704,6 +1705,7 @@ class TrustOperations:
         constraints: Optional[ConstraintDimensions] = None,  # #1841 S2b-1: V2 fold
         resource_limits: Optional[ResourceLimits] = None,  # #1841 S2b-1: V2 fold
         scope: Optional[DelegationScope] = None,  # #1841 S2b-1: V2 fold
+        multi_sig_policy: Optional[MultiSigSigningPolicy] = None,  # #1841 S2b-2: V3
     ) -> DelegationRecord:
         """
         DELEGATE: Transfer trust from one agent to another.
@@ -1737,6 +1739,15 @@ class TrustOperations:
             scope: Optional structured DelegationScope (see constraints). When
                 constraints + resource_limits + scope are ALL supplied AND the
                 record is unscoped + non-multi-sig, the record signs V2Complete.
+            multi_sig_policy: Optional M-of-N MultiSigSigningPolicy (#1841 S2b-2).
+                When supplied, the record is MULTI-SIG and signs the cross-SDK
+                V3Complete pre-image, folding the quorum policy (threshold +
+                canonically-sorted authorized_signers) into the Ed25519 signature
+                so a store-write actor cannot weaken quorum undetected. A
+                multi-sig delegation REQUIRES constraints + resource_limits +
+                scope ALL supplied AND an unscoped dimension_scope; a policy
+                supplied without the full structured fold fails closed (a
+                ValueError) before signing/persisting.
 
         Returns:
             DelegationRecord: Signed delegation record with human_origin
@@ -1877,23 +1888,27 @@ class TrustOperations:
                 expires_at = min(expires_at, delegator_chain.genesis.expires_at)
 
         # 7. Create DelegationRecord with EATP fields.
-        # A v2-bound record (all structured fields supplied) signs the cross-SDK
-        # V2Complete engine pre-image, which pins a WHOLE-SECOND timestamp (§5.3;
-        # the engine fails closed on sub-second precision). datetime.now() carries
-        # microseconds, so truncate to whole-second for a v2-bound record — else
-        # the v2 sign path would raise on every real call. Legacy records keep
-        # full microsecond precision (Python-only pre-image, no cross-SDK pin).
-        _v2_bound = (
+        # An ENGINE-bound record (all three structured fields supplied) signs the
+        # cross-SDK V2Complete (non-multi-sig) or V3Complete (multi-sig) engine
+        # pre-image, which pins a WHOLE-SECOND timestamp (§5.3; the engine fails
+        # closed on sub-second precision). datetime.now() carries microseconds,
+        # so truncate to whole-second for an engine-bound record — else the v2/v3
+        # sign path would raise on every real call. TRUNCATE (floor), never round
+        # (rounding could EXTEND an expiry — a security regression). Legacy
+        # records keep full microsecond precision (Python-only pre-image, no
+        # cross-SDK pin). A multi-sig record is always engine-bound (v3 requires
+        # the full structured fold), so this covers the v3 creation path too.
+        _engine_bound = (
             constraints is not None
             and resource_limits is not None
             and scope is not None
         )
         _delegated_at = datetime.now(timezone.utc)
-        if _v2_bound:
+        if _engine_bound:
             _delegated_at = _delegated_at.replace(microsecond=0)
-            # expires_at is also folded into the v2 pre-image via the same
+            # expires_at is also folded into the v2/v3 pre-image via the same
             # whole-second-only guard; truncate it too so a sub-second expiry
-            # (e.g. inherited from the genesis) does not fail the v2 sign path.
+            # (e.g. inherited from the genesis) does not fail the engine sign path.
             if expires_at is not None and expires_at.microsecond != 0:
                 expires_at = expires_at.replace(microsecond=0)
         delegation = DelegationRecord(
@@ -1917,6 +1932,14 @@ class TrustOperations:
             constraints=constraints,
             resource_limits=resource_limits,
             scope=scope,
+            # Multi-sig fold fields (#1841 S2b-2). When multi_sig_policy is
+            # supplied, the record is multi-sig and (with the full structured
+            # fold + unscoped dimension_scope) signs the V3Complete pre-image,
+            # binding the quorum policy into the signature. A policy supplied
+            # without the full structured fold fails closed at
+            # select_signing_version below (before signing/persisting).
+            multi_sig=multi_sig_policy is not None,
+            multi_sig_policy=multi_sig_policy,
         )
 
         # Select the signing pre-image version from the structured fields

--- a/src/kailash/trust/signing/delegation_payload.py
+++ b/src/kailash/trust/signing/delegation_payload.py
@@ -368,6 +368,38 @@ class MultiSigSigningPolicy:
         """Return the signer keys as canonically-ordered lowercase-hex strings."""
         return sorted(bytes(signer).hex() for signer in self.authorized_signers)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for DelegationRecord persistence (#1841 S2b-2).
+
+        The 32-byte signer keys are hex-encoded (lowercase) in their STORED
+        order (NOT the sorted pre-image order — persistence round-trips the exact
+        policy; the signing pre-image sorts independently via
+        :meth:`authorized_signers_hex`). ``threshold`` is emitted verbatim.
+        """
+        return {
+            "threshold": self.threshold,
+            "authorized_signers": [
+                bytes(signer).hex() for signer in self.authorized_signers
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MultiSigSigningPolicy":
+        """Reconstruct from a :meth:`to_dict` mapping (hex → 32-byte keys).
+
+        Decodes each hex signer back to raw bytes and re-runs ``__post_init__``,
+        so the distinct-signer / ≥32-byte / ``threshold ≤ N`` validation fires on
+        reconstruction — a tampered persisted policy (duplicate/short signer,
+        over-large threshold) fails closed at deserialization rather than
+        silently reconstructing a weakened quorum.
+        """
+        return cls(
+            threshold=data["threshold"],
+            authorized_signers=tuple(
+                bytes.fromhex(signer) for signer in data["authorized_signers"]
+            ),
+        )
+
 
 @dataclass(frozen=True)
 class DelegationSigningInput:

--- a/src/kailash/trust/signing/delegation_payload.py
+++ b/src/kailash/trust/signing/delegation_payload.py
@@ -329,6 +329,19 @@ class MultiSigSigningPolicy:
     authorized_signers: tuple[bytes, ...]
 
     def __post_init__(self) -> None:
+        # Threshold MUST be a true int — folded verbatim into the V3 JCS
+        # pre-image (delegation_signing_payload). A float (2.0 → "2.0") or bool
+        # (True → "true") serializes to bytes that DIVERGE from the kailash-rs
+        # integer contract this pre-image is byte-locked to (rs emits "2"),
+        # breaking cross-SDK verification. bool is a subclass of int in Python,
+        # so it must be rejected EXPLICITLY. Fail closed at construction,
+        # matching the rest of the policy's validation posture
+        # (cross-sdk-inspection.md — number-typing byte parity).
+        if not isinstance(self.threshold, int) or isinstance(self.threshold, bool):
+            raise ValueError(
+                "multi_sig threshold must be an int, got "
+                f"{type(self.threshold).__name__}"
+            )
         if not self.authorized_signers:
             raise ValueError("multi-sig policy requires at least one signer")
         if self.threshold < 1:

--- a/src/kailash/trust/signing/delegation_record_signing.py
+++ b/src/kailash/trust/signing/delegation_record_signing.py
@@ -19,13 +19,16 @@ Two surfaces, one dispatch (#1841 shard 2):
 1. :func:`delegation_canonical_payload_str` is the SINGLE shared entry point that
    EVERY delegation sign/verify call site routes through. It returns the legacy
    canonical string for a ``legacy-python-v0`` record (byte-identical to the
-   pre-migration behaviour), and FAILS CLOSED
+   pre-migration behaviour), the cross-SDK V2Complete engine pre-image for a
+   ``v2-complete`` record (folding the record-persisted structured constraint /
+   resource-limit / scope — #1841 S2b-1), and the cross-SDK V3Complete engine
+   pre-image for a ``v3-complete`` (multi-sig) record (the V2Complete fold PLUS
+   the record-persisted ``multi_sig_policy`` — #1841 S2b-2). It FAILS CLOSED
    (:class:`~kailash.trust.exceptions.UnsupportedSigningPayloadVersionError`) for
-   any other version — because the engine (v2/v3) pre-image requires structured
-   constraint / resource-limit / scope / multi-sig data a ``DelegationRecord``
-   does not yet persist, so a non-legacy record MUST NOT fall through to the
-   legacy verifier (which would sign/verify the WRONG pre-image). Wiring the
-   record-persisted v2/v3 path is a later shard (S2b).
+   any UNRECOGNISED version, and (via a ``ValueError`` from the engine bridge)
+   for a v2/v3-labelled record missing the structured fold data — a non-legacy
+   record MUST NOT fall through to the legacy verifier (which would sign/verify
+   the WRONG pre-image).
 
 2. :func:`build_delegation_signing_input` / :func:`delegation_record_signing_payload`
    are the ADDITIVE engine bridge: they MAP a ``DelegationRecord``'s carried
@@ -66,27 +69,39 @@ __all__ = [
 
 
 def select_signing_version(record: "DelegationRecord") -> str:
-    """Select which canonical pre-image a delegation record signs (#1841 S2b-1).
+    """Select which canonical pre-image a delegation record signs (#1841 S2b-1/S2b-2).
 
     The structured engine-fold fields (``constraints`` / ``resource_limits`` /
-    ``scope``) are ALL-OR-NOTHING: supply all three (→ v2) or none (→ legacy).
+    ``scope``) are ALL-OR-NOTHING: supply all three (→ v2, or v3 when multi-sig)
+    or none (→ legacy).
 
     Returns:
         * ``legacy-python-v0`` (the DEFAULT) when NONE of the structured fields
-          is supplied, OR (all three supplied but) the record carries a NARROWED
-          ``dimension_scope`` (whose cross-SDK v2/v3 fold is not yet pinned —
-          rs#1795), OR is multi-sig (V3 is a later shard).
+          is supplied on a NON-multi-sig record, OR (all three supplied but) a
+          non-multi-sig record carries a NARROWED ``dimension_scope`` (whose
+          cross-SDK v2/v3 fold is not yet pinned — rs#1795).
         * ``v2-complete`` when ALL structured fields are present AND the record
-          is non-multi-sig AND ``dimension_scope`` is the full (unscoped) CARE
+          is NON-multi-sig AND ``dimension_scope`` is the full (unscoped) CARE
           set — so it signs the cross-SDK V2Complete engine pre-image.
+        * ``v3-complete`` when the record is MULTI-SIG (``multi_sig=True`` with a
+          ``multi_sig_policy``) AND all three structured fields are present AND
+          ``dimension_scope`` is the full (unscoped) CARE set — so it signs the
+          cross-SDK V3Complete pre-image, folding the quorum policy into the
+          signature (#1841 S2b-2, the quorum-integrity headline).
 
     Raises:
-        ValueError: If SOME but not ALL of the three structured fields are
-            supplied (partial supply). A partial-supply record would silently
-            downgrade to legacy (which does NOT bind the supplied fields into
-            the signature) while ``to_dict`` still persists them UNSIGNED — a
-            fail-open secure-default (``rules/security.md`` § "Secure-Default …
-            Never A Silent No-Op"). Fail closed + loud instead.
+        ValueError: (a) If SOME but not ALL of the three structured fields are
+            supplied on a non-multi-sig record (partial supply) — a partial
+            record would silently downgrade to legacy (dropping the supplied
+            fields from the signature) while ``to_dict`` still persists them
+            UNSIGNED, a fail-open secure-default (``rules/security.md`` §
+            "Secure-Default … Never A Silent No-Op"). (b) If the multi-sig flags
+            are INCONSISTENT (``multi_sig=True`` without a policy, OR a policy
+            with ``multi_sig=False``) — a mis-constructed record. (c) If a
+            MULTI-SIG record lacks the structured fold fields OR carries a
+            narrowed ``dimension_scope`` — a multi-sig record MUST sign v3 (never
+            legacy/v2, which drop the quorum binding); when v3 bytes are not
+            producible it fails closed rather than silently downgrading.
 
     The record's ``signing_payload_version`` is set from this at ``delegate()``
     sign time; :func:`delegation_canonical_payload_str` then dispatches on that
@@ -97,7 +112,26 @@ def select_signing_version(record: "DelegationRecord") -> str:
         ALL_DIMENSIONS,
         DELEGATION_SIGNING_VERSION_LEGACY,
         DELEGATION_SIGNING_VERSION_V2,
+        DELEGATION_SIGNING_VERSION_V3,
     )
+
+    multi_sig = getattr(record, "multi_sig", False)
+    multi_sig_policy = getattr(record, "multi_sig_policy", None)
+
+    # Multi-sig flag/policy consistency (fail-closed on a mis-constructed record).
+    # A record with ONE of the two set is inconsistent: silently downgrading it
+    # would drop the quorum binding the v3 fold exists to provide.
+    if multi_sig and multi_sig_policy is None:
+        raise ValueError(
+            "multi_sig=True requires a multi_sig_policy; a multi-sig record with "
+            "no policy cannot bind its quorum (threshold + authorized_signers) "
+            "into the signature (fail-closed)"
+        )
+    if multi_sig_policy is not None and not multi_sig:
+        raise ValueError(
+            "multi_sig_policy is set but multi_sig=False; a policy with no "
+            "multi-sig flag is a mis-constructed record (fail-closed)"
+        )
 
     structured = {
         "constraints": getattr(record, "constraints", None),
@@ -105,6 +139,34 @@ def select_signing_version(record: "DelegationRecord") -> str:
         "scope": getattr(record, "scope", None),
     }
     supplied = [name for name, val in structured.items() if val is not None]
+    record_scope = getattr(record, "dimension_scope", ALL_DIMENSIONS)
+    unscoped = frozenset(record_scope) == frozenset(ALL_DIMENSIONS)
+
+    if multi_sig:
+        # A multi-sig record MUST sign V3Complete — NEVER legacy/v2 (which do not
+        # fold the quorum policy, so a store-write actor could weaken quorum
+        # undetected). It REQUIRES all three structured fields AND the full
+        # (unscoped) CARE set; anything else is not producible as v3 bytes and
+        # fails closed rather than silently downgrading.
+        if len(supplied) != len(structured):
+            missing = sorted(name for name, val in structured.items() if val is None)
+            raise ValueError(
+                "multi-sig record requires constraints, resource_limits, and "
+                f"scope for the V3Complete fold; missing {missing} (fail-closed — "
+                "a multi-sig record must sign v3, never legacy/v2 which drop the "
+                "quorum binding)"
+            )
+        if not unscoped:
+            raise ValueError(
+                "multi-sig record carries a narrowed dimension_scope "
+                f"({sorted(record_scope)}); its cross-SDK V3 fold is not yet "
+                "pinned (rs#1795) and the engine byte-verifies only the unscoped "
+                "form — fail closed rather than downgrade a multi-sig record to "
+                "legacy/v2 (which would drop the quorum binding)"
+            )
+        return DELEGATION_SIGNING_VERSION_V3
+
+    # --- Non-multi-sig (S2b-1 logic, byte-identical) -------------------------
     if not supplied:
         # None supplied → legacy (byte-identical to pre-S2b).
         return DELEGATION_SIGNING_VERSION_LEGACY
@@ -118,17 +180,10 @@ def select_signing_version(record: "DelegationRecord") -> str:
             f"{sorted(supplied)} without {missing}"
         )
 
-    # V3 (multi-sig) is a later shard (S2b-2); no multi-sig field exists on the
-    # record yet, but guard defensively so a future multi-sig field cannot slip
-    # a multi-sig record onto the v2 path.
-    if getattr(record, "multi_sig", False):
-        return DELEGATION_SIGNING_VERSION_LEGACY
-
     # The engine byte-verifies only the all-dimensions form; a narrowed
     # dimension_scope stays legacy (its scope-widening defence lives in the
     # legacy payload, chain.py:to_signing_payload). See build_delegation_signing_input.
-    record_scope = getattr(record, "dimension_scope", ALL_DIMENSIONS)
-    if frozenset(record_scope) != frozenset(ALL_DIMENSIONS):
+    if not unscoped:
         return DELEGATION_SIGNING_VERSION_LEGACY
 
     return DELEGATION_SIGNING_VERSION_V2
@@ -150,13 +205,21 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
         pre-migration behaviour). For a ``v2-complete`` record, the canonical
         cross-SDK V2Complete engine pre-image (folding the record-persisted
         ``constraints`` / ``resource_limits`` / ``scope``) as a UTF-8 string
-        (#1841 S2b-1).
+        (#1841 S2b-1). For a ``v3-complete`` (multi-sig) record, the canonical
+        cross-SDK V3Complete engine pre-image (the V2Complete fold PLUS the
+        record-persisted ``multi_sig_policy`` — threshold + canonically-sorted
+        authorized_signers) as a UTF-8 string (#1841 S2b-2).
 
     Raises:
-        UnsupportedSigningPayloadVersionError: If the record declares
-            ``v3-complete`` (multi-sig — a later shard, S2b-2) or any
-            unrecognised version. Falling through to the legacy verifier would
-            sign/verify the WRONG pre-image, so this fails closed.
+        UnsupportedSigningPayloadVersionError: If the record declares an
+            UNRECOGNISED version (not legacy / v2 / v3). Falling through to the
+            legacy verifier would sign/verify the WRONG pre-image, so this fails
+            closed.
+        ValueError: If a ``v2``/``v3``-labelled record is missing the structured
+            fold fields (or a ``v3`` record lacks a valid multi_sig policy) — the
+            engine bridge fails closed rather than emitting guessed bytes. The
+            verify path catches this and returns ``valid=False`` (never lets it
+            escape as a DoS-via-exception).
     """
     # Import lazily to avoid a chain <-> signing import cycle: chain.py imports
     # kailash.trust.signing.crypto at module load, which initialises the signing
@@ -165,6 +228,7 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
     from kailash.trust.chain import (
         DELEGATION_SIGNING_VERSION_LEGACY,
         DELEGATION_SIGNING_VERSION_V2,
+        DELEGATION_SIGNING_VERSION_V3,
     )
 
     version = getattr(
@@ -187,9 +251,28 @@ def delegation_canonical_payload_str(record: "DelegationRecord") -> str:
         )
         return payload_bytes.decode("utf-8")
 
-    # v3-complete (multi-sig) and any unrecognised version fail closed — their
-    # record-persisted verify path is a later shard (S2b-2). Falling through to
-    # the legacy verifier would check the WRONG pre-image.
+    if version == DELEGATION_SIGNING_VERSION_V3:
+        # v3-complete: the V2Complete fold PLUS the record-persisted multi-sig
+        # policy (threshold + canonically-sorted authorized_signers) folded into
+        # the signed pre-image (#1841 S2b-2 — the quorum-integrity headline). The
+        # record's own multi_sig / multi_sig_policy are passed faithfully: a
+        # record LABELLED v3 that is not a genuine multi-sig record (multi_sig
+        # False or policy None) fails closed at the engine (which requires a
+        # multi-sig record with a policy for V3_COMPLETE) rather than emitting
+        # guessed bytes.
+        payload_bytes = delegation_record_signing_payload(
+            record,
+            SigningPayloadVersion.V3_COMPLETE,
+            constraints=record.constraints,
+            resource_limits=record.resource_limits,
+            scope=record.scope,
+            multi_sig=getattr(record, "multi_sig", False),
+            multi_sig_policy=getattr(record, "multi_sig_policy", None),
+        )
+        return payload_bytes.decode("utf-8")
+
+    # Any UNRECOGNISED version (not legacy / v2 / v3) fails closed — falling
+    # through to the legacy verifier would check the WRONG pre-image.
     raise UnsupportedSigningPayloadVersionError(
         version, record_id=getattr(record, "id", None)
     )

--- a/tests/regression/test_issue_1841_delegation_signing_migration.py
+++ b/tests/regression/test_issue_1841_delegation_signing_migration.py
@@ -168,11 +168,12 @@ def test_record_deserialized_without_version_key_still_verifies():
 
 
 @pytest.mark.parametrize(
-    # v2-complete is WIRED as of #1841 S2b-1 (see the v2 tests below); v3-complete
-    # (multi-sig) remains a later shard (S2b-2), and any unrecognised version
-    # still fails closed with UnsupportedSigningPayloadVersionError.
+    # v2-complete (S2b-1) and v3-complete (S2b-2, multi-sig) are BOTH WIRED (see
+    # the v2/v3 tests below + tests/regression/test_issue_1841_s2b2_v3_*.py). Only
+    # a genuinely UNRECOGNISED version still fails closed with
+    # UnsupportedSigningPayloadVersionError at dispatch.
     "version",
-    [DELEGATION_SIGNING_VERSION_V3, "future-vX"],
+    ["future-vX", "v9-bogus"],
 )
 def test_non_legacy_version_fails_closed_at_dispatch(version):
     record = _record(signing_payload_version=version)
@@ -192,6 +193,21 @@ def test_v2_labeled_record_without_structured_fields_fails_closed():
     legacy.
     """
     record = _record(signing_payload_version=DELEGATION_SIGNING_VERSION_V2)
+    with pytest.raises(ValueError, match="constraints"):
+        delegation_canonical_payload_str(record)
+
+
+def test_v3_labeled_record_without_structured_fields_fails_closed():
+    """A v3-labeled record lacking the structured fold fields fails closed.
+
+    #1841 S2b-2 wires v3, but the engine bridge REQUIRES the structured
+    constraints / resource_limits / scope (AND a multi_sig policy). A record
+    stamped v3 without them is an inconsistent state (select_signing_version
+    never produces it) and MUST fail closed at the bridge (ValueError) rather
+    than emit guessed bytes — never fall through to legacy. Swept from the former
+    v3-unwired deferral assertion per orphan-detection.md Rule 4a.
+    """
+    record = _record(signing_payload_version=DELEGATION_SIGNING_VERSION_V3)
     with pytest.raises(ValueError, match="constraints"):
         delegation_canonical_payload_str(record)
 

--- a/tests/regression/test_issue_1841_s2b1_v2_enrich.py
+++ b/tests/regression/test_issue_1841_s2b1_v2_enrich.py
@@ -38,7 +38,6 @@ from kailash.trust.chain import (
     DELEGATION_SIGNING_VERSION_V2,
     DelegationRecord,
 )
-from kailash.trust.exceptions import UnsupportedSigningPayloadVersionError
 from kailash.trust.signing.crypto import (
     generate_keypair,
     serialize_for_signing,
@@ -186,12 +185,25 @@ def test_narrowed_scope_direct_bridge_call_raises() -> None:
         )
 
 
-def test_v3_version_fails_closed() -> None:
-    """A record declaring v3-complete fails closed (multi-sig is a later shard)."""
+def test_v3_labeled_record_without_policy_fails_closed() -> None:
+    """A record LABELLED v3 but lacking a multi_sig policy fails closed.
+
+    #1841 S2b-2 WIRES v3 (see tests/regression/test_issue_1841_s2b2_v3_*.py for
+    the full multi-sig coverage). This test formerly asserted v3 was UNwired
+    (raising ``UnsupportedSigningPayloadVersionError``); with v3 implemented, a
+    v3-LABELLED record that is NOT a genuine multi-sig record (no policy) now
+    fails closed at the engine bridge with a ``ValueError`` — it MUST NOT fall
+    through to the legacy verifier and MUST NOT emit guessed bytes. The verify
+    path catches this ValueError and returns valid=False (never a DoS-escape).
+    Swept per orphan-detection.md Rule 4a (implementing a deferred stub sweeps
+    its deferral assertion in the same commit).
+    """
     from kailash.trust.chain import DELEGATION_SIGNING_VERSION_V3
 
+    # _v2_record has the structured fold fields but NO multi_sig policy; forcing
+    # the v3 label makes it an inconsistent (mislabeled) record.
     record = _v2_record(signing_payload_version=DELEGATION_SIGNING_VERSION_V3)
-    with pytest.raises(UnsupportedSigningPayloadVersionError):
+    with pytest.raises(ValueError, match="multi_sig_policy"):
         delegation_canonical_payload_str(record)
 
 

--- a/tests/regression/test_issue_1841_s2b2_v3_multisig.py
+++ b/tests/regression/test_issue_1841_s2b2_v3_multisig.py
@@ -266,6 +266,49 @@ def test_multi_sig_record_narrowed_scope_fails_closed() -> None:
         select_signing_version(record)
 
 
+# --- Threshold integer-type guard (cross-SDK byte-parity) --------------------
+
+
+def test_float_threshold_rejected_at_construction() -> None:
+    """A float threshold (2.0 → JCS "2.0") diverges from the rs int contract.
+
+    threshold is folded verbatim into the V3 JCS pre-image; ``json.dumps(2.0)``
+    → ``"2.0"`` while rs (integer type) emits ``"2"`` — a cross-SDK byte-parity
+    hole. Fail closed at construction.
+    """
+    with pytest.raises(ValueError, match="threshold must be an int"):
+        MultiSigSigningPolicy.new(2.0, [_key(1), _key(2), _key(3)])
+
+
+def test_bool_threshold_rejected_at_construction() -> None:
+    """A bool threshold (True → JCS "true") diverges from the rs int contract.
+
+    bool is a subclass of int in Python, so it passes a naive isinstance(int)
+    check yet serializes to ``"true"`` — it MUST be rejected explicitly.
+    """
+    with pytest.raises(ValueError, match="threshold must be an int"):
+        MultiSigSigningPolicy.new(True, [_key(1)])
+
+
+def test_int_threshold_still_constructs() -> None:
+    """A normal int threshold constructs unchanged (the guard rejects non-int only)."""
+    policy = MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)])
+    assert policy.threshold == 2
+    assert isinstance(policy.threshold, int) and not isinstance(policy.threshold, bool)
+
+
+def test_from_dict_float_threshold_rejected() -> None:
+    """from_dict of a persisted policy carrying a float threshold fails closed.
+
+    from_dict re-runs __post_init__, so a store-tampered float threshold is
+    rejected at deserialization (never reconstructs a byte-diverging policy).
+    """
+    d = _v1_policy().to_dict()
+    d["threshold"] = 2.0
+    with pytest.raises(ValueError, match="threshold must be an int"):
+        MultiSigSigningPolicy.from_dict(d)
+
+
 # --- Signer canonical-order invariance ---------------------------------------
 
 

--- a/tests/regression/test_issue_1841_s2b2_v3_multisig.py
+++ b/tests/regression/test_issue_1841_s2b2_v3_multisig.py
@@ -1,0 +1,473 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1841 S2b-2: DelegationRecord signs the cross-SDK V3Complete pre-image.
+
+The FINAL shard of #1841 — the QUORUM-INTEGRITY headline. A MULTI-SIG
+``DelegationRecord`` (``multi_sig=True`` + a ``multi_sig_policy``) carrying the
+full structured fold (``constraints`` / ``resource_limits`` / ``scope``, unscoped
+``dimension_scope``) signs the ``v3-complete`` engine pre-image instead of
+``v2-complete`` — folding the multi-sig policy (threshold + canonically-sorted
+authorized_signers) into the Ed25519-SIGNED bytes so a store-write actor cannot
+weaken quorum (lower the threshold, swap/remove a signer) undetected.
+
+This is a SECURITY-CRITICAL, BYTE-CHANGING, cross-SDK-lockstep migration. Pins:
+
+* the 4 V3 byte vectors (V1_2_OF_3 / V3_3_OF_5 / S2_ZERO_ONE / S3_ONE_BYTE_DIFF)
+  reproduced byte-for-byte at the RECORD dispatch level (the same kailash-rs
+  cross-SDK anchor the engine-level test pins — vendored, not re-authored);
+* V2 anchor byte-neutrality (V2C_NON_MULTI_SIG unchanged) + legacy unchanged —
+  adding the multi_sig fields changes ZERO bytes for a non-multi-sig record;
+* QUORUM INTEGRITY: a store-mutated threshold / swapped / removed signer breaks
+  the v3 signature (the #1841 headline);
+* downgrade v3→v2 / v3→legacy → verify fails;
+* can't-force-v3 (a non-multi-sig record never signs v3) + fail-closed on the
+  inconsistent multi-sig flag/policy combos;
+* signer canonical-order invariance (shuffle the stored order → same bytes);
+* real Ed25519 multi-sig sign→verify round-trip through the store;
+* to_dict/from_dict of a v3 record reconstructs the policy (hex→bytes, validation
+  re-runs) + reproduces the signature;
+* the multi-sig delegate() path produces a signable+verifiable v3 record (the
+  whole-second-timestamp end-to-end check).
+
+The pinned V3 hex vectors are the kailash-rs canonical bytes, VENDORED (imported)
+from ``test_delegation_signing_payload_vectors.py`` so the record-level dispatch
+is byte-checked against the SAME cross-SDK anchor as the engine-level test and
+cannot drift from it (cross-sdk-inspection.md Rule 4a).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.chain import (
+    DELEGATION_SIGNING_VERSION_LEGACY,
+    DELEGATION_SIGNING_VERSION_V2,
+    DELEGATION_SIGNING_VERSION_V3,
+    DelegationRecord,
+)
+from kailash.trust.signing.crypto import (
+    generate_keypair,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    MultiSigSigningPolicy,
+    ResourceLimits,
+    TrustLevel,
+)
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
+    select_signing_version,
+)
+
+# Vendored kailash-rs V3Complete byte vectors — the SAME cross-SDK anchor the
+# engine-level test pins (re-pin ONLY in a cross-SDK lockstep event, rs#1795).
+from tests.regression.test_delegation_signing_payload_vectors import (
+    S2_ZERO_ONE,
+    S3_ONE_BYTE_DIFF,
+    V1_2_OF_3,
+    V2C_NON_MULTI_SIG,
+    V3_3_OF_5,
+)
+
+# Reuse the S2b-1 real-ops fixture builder (real crypto + real store, NO mocking).
+from tests.regression.test_issue_1841_s2b1_v2_enrich import _real_ops_with_delegator
+
+pytestmark = pytest.mark.regression
+
+
+# --- Fixed inputs (mirror the rs fixed_inputs() / key(n)=[n;32]) -------------
+
+
+def _key(n: int) -> bytes:
+    return bytes([n]) * 32
+
+
+def _supervised_constraints() -> ConstraintDimensions:
+    return ConstraintDimensions.for_level(TrustLevel.SUPERVISED)
+
+
+def _supervised_limits() -> ResourceLimits:
+    return ResourceLimits.for_level(TrustLevel.SUPERVISED)
+
+
+def _engineering_read_scope() -> DelegationScope:
+    return DelegationScope.new("engineering").with_operation("read")
+
+
+def _v1_policy() -> MultiSigSigningPolicy:
+    return MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)])
+
+
+def _v3_policy() -> MultiSigSigningPolicy:
+    return MultiSigSigningPolicy.new(3, [_key(1), _key(2), _key(3), _key(4), _key(5)])
+
+
+def _s2_policy() -> MultiSigSigningPolicy:
+    return MultiSigSigningPolicy.new(1, [_key(0), _key(1)])
+
+
+def _s3_policy() -> MultiSigSigningPolicy:
+    last = bytearray(32)
+    last[31] = 1
+    return MultiSigSigningPolicy.new(2, [_key(0), bytes(last)])
+
+
+def _base_kwargs() -> dict:
+    """The rs ``fixed_inputs()`` mapped onto a DelegationRecord's fields."""
+    return dict(
+        id="00000000-0000-4000-8000-000000000001",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-fixed",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+    )
+
+
+def _v3_record(policy: MultiSigSigningPolicy, **overrides) -> DelegationRecord:
+    kwargs = _base_kwargs()
+    kwargs.update(
+        multi_sig=True,
+        multi_sig_policy=policy,
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V3,
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _v2_record(**overrides) -> DelegationRecord:
+    kwargs = _base_kwargs()
+    kwargs.update(signing_payload_version=DELEGATION_SIGNING_VERSION_V2)
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _v3_hex(policy: MultiSigSigningPolicy) -> str:
+    return delegation_canonical_payload_str(_v3_record(policy)).encode("utf-8").hex()
+
+
+# --- 4 V3 byte-pins (record dispatch reproduces the kailash-rs bytes) --------
+
+
+def test_v3_record_dispatch_reproduces_pinned_vectors() -> None:
+    """The record-level v3 dispatch reproduces the pinned kailash-rs V3 bytes."""
+    assert _v3_hex(_v1_policy()) == V1_2_OF_3, "V1 (2-of-3) record dispatch drifted"
+    assert _v3_hex(_v3_policy()) == V3_3_OF_5, "V3 (3-of-5) record dispatch drifted"
+    assert _v3_hex(_s2_policy()) == S2_ZERO_ONE, "S2 (zero/one) record dispatch drifted"
+    assert (
+        _v3_hex(_s3_policy()) == S3_ONE_BYTE_DIFF
+    ), "S3 (1-byte-diff) record dispatch drifted"
+
+
+def test_v3_bytes_carry_folded_policy_and_v3_token() -> None:
+    """The v3 pre-image self-describes (v3 token) + folds the policy; no bundle."""
+    payload = delegation_canonical_payload_str(_v3_record(_v1_policy()))
+    assert '"signing_payload_version":"v3-complete"' in payload
+    assert '"multi_sig_threshold":2' in payload
+    assert '"multi_sig_authorized_signers":[' in payload
+    assert '"multi_sig":true' in payload
+    assert "multi_sig_bundle" not in payload  # signatures are NOT folded
+
+
+# --- Byte-neutrality: v2 anchor + legacy UNCHANGED ---------------------------
+
+
+def test_v2_anchor_byte_neutral_alongside_v3() -> None:
+    """A NON-multi-sig record still reproduces the pinned V2 bytes (byte-neutral).
+
+    Adding multi_sig / multi_sig_policy fields MUST NOT change the v2 pre-image.
+    """
+    payload = delegation_canonical_payload_str(_v2_record())
+    assert payload.encode("utf-8").hex() == V2C_NON_MULTI_SIG, "V2 anchor drifted"
+    assert "multi_sig" not in payload, "non-multi-sig v2 record leaked a multi_sig key"
+    assert '"signing_payload_version":"v2-complete"' in payload
+
+
+def test_legacy_record_bytes_unchanged() -> None:
+    """A legacy (no structured / no multi-sig) record signs byte-identically."""
+    record = DelegationRecord(
+        id="del-legacy-s2b2",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="t",
+        capabilities_delegated=["LlmCall", "FileRead"],
+        constraint_subset=["read_only"],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+    )
+    assert record.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    dispatched = delegation_canonical_payload_str(record)
+    assert dispatched == serialize_for_signing(record.to_signing_payload())
+    assert "multi_sig" not in dispatched
+
+
+# --- select_signing_version → v3 selection logic -----------------------------
+
+
+def test_select_version_multisig_is_v3() -> None:
+    """A full multi-sig record selects v3-complete."""
+    assert select_signing_version(_v3_record(_v1_policy())) == (
+        DELEGATION_SIGNING_VERSION_V3
+    )
+
+
+def test_non_multi_sig_record_cannot_be_forced_v3() -> None:
+    """A non-multi-sig record (multi_sig=False) NEVER selects v3."""
+    record = _v2_record(multi_sig=False, multi_sig_policy=None)
+    assert select_signing_version(record) == DELEGATION_SIGNING_VERSION_V2
+    # Even a full-structured non-multi-sig record cannot be forced to v3.
+    assert select_signing_version(record) != DELEGATION_SIGNING_VERSION_V3
+
+
+def test_multi_sig_true_without_policy_raises() -> None:
+    """multi_sig=True with NO policy is a mis-constructed record — fail closed."""
+    record = _v3_record(_v1_policy())
+    record.multi_sig_policy = None  # flag on, policy stripped → inconsistent
+    with pytest.raises(ValueError, match="requires a multi_sig_policy"):
+        select_signing_version(record)
+
+
+def test_policy_without_multi_sig_flag_raises() -> None:
+    """A policy set with multi_sig=False is a mis-constructed record — fail closed."""
+    record = _v3_record(_v1_policy())
+    record.multi_sig = False  # policy set, flag off → inconsistent
+    with pytest.raises(ValueError, match="multi_sig=False"):
+        select_signing_version(record)
+
+
+def test_multi_sig_record_missing_structured_fold_fails_closed() -> None:
+    """A multi-sig record MUST have the full structured fold — else fail closed.
+
+    A multi-sig record MUST sign v3 (never legacy/v2, which drop the quorum
+    binding); when the v3 bytes are not producible it fails closed rather than
+    silently downgrading.
+    """
+    record = _v3_record(_v1_policy(), scope=None)
+    with pytest.raises(ValueError, match="multi-sig record requires"):
+        select_signing_version(record)
+
+
+def test_multi_sig_record_narrowed_scope_fails_closed() -> None:
+    """A multi-sig record with a narrowed dimension_scope fails closed (un-pinned)."""
+    record = _v3_record(_v1_policy(), dimension_scope=frozenset({"financial"}))
+    with pytest.raises(ValueError, match="narrowed dimension_scope"):
+        select_signing_version(record)
+
+
+# --- Signer canonical-order invariance ---------------------------------------
+
+
+def test_signer_order_invariance() -> None:
+    """The pre-image sorts signers by hex → invariant to stored insertion order."""
+    forward = MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)])
+    reverse = MultiSigSigningPolicy.new(2, [_key(3), _key(2), _key(1)])
+    shuffled = MultiSigSigningPolicy.new(2, [_key(2), _key(1), _key(3)])
+    assert _v3_hex(forward) == _v3_hex(reverse) == _v3_hex(shuffled) == V1_2_OF_3
+
+
+# --- QUORUM INTEGRITY (the #1841 headline) -----------------------------------
+
+
+def test_quorum_integrity_threshold_mutation_fails_verify() -> None:
+    """A store-write actor lowering the threshold 2→1 breaks the v3 signature."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)]))
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    # The signed record verifies before tampering.
+    assert verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    )
+
+    # A store-writer weakens quorum: threshold 2 → 1, same signers.
+    record.multi_sig_policy = MultiSigSigningPolicy.new(1, [_key(1), _key(2), _key(3)])
+    assert not verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    ), "threshold mutation MUST break the v3 signature (quorum integrity)"
+
+
+def test_quorum_integrity_signer_swap_fails_verify() -> None:
+    """A store-write actor swapping an authorized signer breaks the v3 signature."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)]))
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    # Swap key(3) → key(4) (an attacker's key).
+    record.multi_sig_policy = MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(4)])
+    assert not verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    ), "signer swap MUST break the v3 signature (quorum integrity)"
+
+
+def test_quorum_integrity_signer_removal_fails_verify() -> None:
+    """A store-write actor removing an authorized signer breaks the v3 signature."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)]))
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    # Remove key(3) → a 2-of-2 the original signer never authorized.
+    record.multi_sig_policy = MultiSigSigningPolicy.new(2, [_key(1), _key(2)])
+    assert not verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    ), "signer removal MUST break the v3 signature (quorum integrity)"
+
+
+# --- Downgrade attacks -------------------------------------------------------
+
+
+def test_downgrade_v3_to_v2_fails_verify() -> None:
+    """A v3→v2 version flip drops the policy fold → verify fails."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(_v1_policy())
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    record.signing_payload_version = DELEGATION_SIGNING_VERSION_V2
+    assert not verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    ), "v3→v2 downgrade MUST fail verification"
+
+
+def test_downgrade_v3_to_legacy_fails_verify() -> None:
+    """A v3→legacy version flip drops the whole fold → verify fails."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(_v1_policy())
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    record.signing_payload_version = DELEGATION_SIGNING_VERSION_LEGACY
+    assert not verify_signature(
+        delegation_canonical_payload_str(record), record.signature, public_key
+    ), "v3→legacy downgrade MUST fail verification"
+
+
+# --- Real Ed25519 multi-sig round-trip ---------------------------------------
+
+
+def test_v3_real_ed25519_round_trip() -> None:
+    """Sign a v3 record with a real Ed25519 key; verify over the SAME pre-image."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(_v1_policy())
+
+    payload = delegation_canonical_payload_str(record)
+    record.signature = sign(payload, private_key)
+
+    verify_payload = delegation_canonical_payload_str(record)
+    assert verify_signature(verify_payload, record.signature, public_key)
+
+
+# --- Persistence round-trip (to_dict / from_dict) ----------------------------
+
+
+def test_v3_to_dict_from_dict_reconstructs_and_reproduces_bytes() -> None:
+    """to_dict → from_dict reconstructs the policy + reproduces the pre-image + sig."""
+    private_key, public_key = generate_keypair()
+    record = _v3_record(_v1_policy())
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+
+    d = record.to_dict()
+    assert d["multi_sig"] is True
+    assert d["multi_sig_policy"]["threshold"] == 2
+    assert len(d["multi_sig_policy"]["authorized_signers"]) == 3
+
+    restored = DelegationRecord.from_dict(d)
+    assert restored.multi_sig is True
+    assert restored.multi_sig_policy == record.multi_sig_policy
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+
+    # Byte-identical pre-image after the round-trip + the signature still verifies.
+    assert delegation_canonical_payload_str(restored).encode("utf-8").hex() == V1_2_OF_3
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    )
+
+
+def test_from_dict_tampered_policy_fails_closed() -> None:
+    """A persisted policy tampered to a duplicate signer fails closed on from_dict.
+
+    from_dict re-runs MultiSigSigningPolicy.__post_init__, so a store-write actor
+    who duplicates a signer (weakening the quorum) is rejected at deserialization.
+    """
+    d = _v3_record(_v1_policy()).to_dict()
+    signers = d["multi_sig_policy"]["authorized_signers"]
+    signers[1] = signers[0]  # duplicate → weakened quorum
+    with pytest.raises(ValueError, match="distinct"):
+        DelegationRecord.from_dict(d)
+
+
+def test_non_multi_sig_record_persists_without_multi_sig_keys() -> None:
+    """A non-multi-sig record round-trips with NO multi_sig keys (prune-when-unset)."""
+    record = _v2_record()
+    d = record.to_dict()
+    assert "multi_sig" not in d
+    assert "multi_sig_policy" not in d
+
+    restored = DelegationRecord.from_dict(d)
+    assert restored.multi_sig is False
+    assert restored.multi_sig_policy is None
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+
+
+# --- Multi-sig delegate() creation path (real ops, through the store) --------
+
+
+async def test_delegate_multi_sig_produces_verifiable_v3_record() -> None:
+    """delegate(..., multi_sig_policy=...) mints a signable + verifiable v3 record.
+
+    The whole-second-timestamp end-to-end check: the v3 engine pre-image fails
+    closed on sub-second precision, so the creation path MUST truncate
+    delegated_at (and any inherited expires_at) to whole-second — else the v3
+    sign path raises for every real caller (the S2b-1 latent-stub failure mode).
+    """
+    ops, _ = await _real_ops_with_delegator()
+    policy = MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)])
+
+    deleg = await ops.delegate(
+        delegator_id="agent-delegator",
+        delegatee_id="agent-multisig",
+        task_id="task-ms",
+        capabilities=["LlmCall"],
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+        multi_sig_policy=policy,
+    )
+
+    assert deleg.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+    assert deleg.multi_sig is True
+    assert deleg.multi_sig_policy == policy
+    # Whole-second truncation applied (v3 engine fails closed on sub-second).
+    assert deleg.delegated_at.microsecond == 0
+    # Verifiable through the store (real Ed25519 round-trip).
+    assert (await ops.verify_delegation_chain("agent-multisig")).valid is True
+
+
+async def test_delegate_multi_sig_without_structured_fold_fails_closed() -> None:
+    """delegate() with a policy but NO structured fold fails closed before signing."""
+    ops, _ = await _real_ops_with_delegator()
+    policy = MultiSigSigningPolicy.new(1, [_key(9)])
+
+    with pytest.raises(ValueError, match="multi-sig record requires"):
+        await ops.delegate(
+            delegator_id="agent-delegator",
+            delegatee_id="agent-nofold",
+            task_id="task-nofold",
+            capabilities=["LlmCall"],
+            multi_sig_policy=policy,  # no constraints/resource_limits/scope
+        )
+
+    # The failed multi-sig delegation MUST NOT have been persisted.
+    from kailash.trust.exceptions import TrustChainNotFoundError
+
+    with pytest.raises(TrustChainNotFoundError):
+        await ops.trust_store.get_chain("agent-nofold")


### PR DESCRIPTION
## Summary
Final shard of #1841 (S2b-2 of 2). Multi-sig `DelegationRecord`s now sign the cross-SDK **V3Complete** pre-image — folding the multi-sig policy (`threshold` + canonically-ordered `authorized_signers`) into the Ed25519 signature. **A store-write actor can no longer weaken quorum undetected** — the quorum-integrity headline of #1841. Builds on S2b-1 (V2 non-multi-sig, merged).

## What
- `chain.py` — `DelegationRecord` gains `multi_sig` + `multi_sig_policy` (backward-compat defaults); `to_dict`/`from_dict` **prune-when-unset** (a non-multi-sig record persists with NO `multi_sig` keys, byte-identical to pre-S2b-2 — cross-sdk-inspection 4d).
- `delegation_payload.py` — `MultiSigSigningPolicy.to_dict`/`from_dict` (hex-encode signers; `from_dict` re-runs `__post_init__` so a tampered persisted policy — duplicate/short signer, over-large threshold — fails closed on deserialization).
- `delegation_record_signing.py` — `select_signing_version` routes a full multi-sig record → `v3-complete`, fail-closed on inconsistent combos (multi_sig without policy, policy without flag, multi-sig record missing structured fold / narrowed scope → a multi-sig record MUST sign v3, never legacy/v2 which drop the quorum binding); dispatch emits the V3 engine pre-image.
- `operations/__init__.py` — `delegate(..., multi_sig_policy=...)` mints a v3 record; extended the S2b-1 whole-second timestamp **truncation** (floor, never round) to the v3-bound path.

## Verification (verbatim receipts in the commit)
- **4 V3 byte-pins** reproduce byte-for-byte: `V1_2_OF_3` / `V3_3_OF_5` / `S2_ZERO_ONE` / `S3_ONE_BYTE_DIFF` (vendored rs vectors, imported not re-authored — the cross-SDK lockstep tripwire, unedited).
- **Quorum integrity (the headline):** threshold-mutation / signer-swap / signer-removal → verify **FALSE** (all 3 pass).
- **V2 + legacy byte-neutrality:** V2C_NON_MULTI_SIG unchanged (1372/1372); legacy dispatch unchanged.
- Downgrade v3→v2 / v3→legacy → verify FALSE; signer-order-invariance (shuffle → same bytes) passes.
- Full: 22 S2b-2 tests + 232 `-k "1841 or delegation or signing or vectors"` + 1263 blast-radius, all green.

## Notes for review
- 2 deferral assertions swept v3-UNWIRED → v3-WIRED fail-closed (orphan-detection 4a — implementing a deferred stub sweeps its deferral test same-commit). No byte-neutrality test touched.
- Pre-existing `verify_integrity() deprecated` warnings from `LinkedHashChain` deprecation-shim self-tests (HEAD `70653845e`, predates this session) — outside the multi-sig scope; those self-tests intentionally exercise the deprecated path.

## Related issues
Refs #1841 (S2b-2 of 2 — completes the S1→S2→S2b arc; delivers the quorum-integrity value)