### PR TITLE
fix(trust): carry S2b signing fold-fields through chain/store/interop serializers (#1841)

### DIFF
--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -32,6 +32,10 @@ from kailash.trust.signing.crypto import (
 # Safe at module scope: this file already imports kailash.trust.signing.crypto
 # above (initialising the signing package), and delegation_payload depends only
 # on kailash.trust._json — no cycle back to chain.
+from kailash.trust.signing.delegation_fold_serde import (
+    deserialize_fold_fields,
+    serialize_fold_fields,
+)
 from kailash.trust.signing.delegation_payload import (
     ConstraintDimensions,
     DelegationScope,
@@ -427,24 +431,12 @@ class DelegationRecord:
         d["reasoning_signature"] = self.reasoning_signature
         if self.reasoning_trace:
             d["reasoning_trace"] = self.reasoning_trace.to_dict()
-        # Structured engine-fold fields (#1841 S2b-1) — emitted only when present
-        # so a legacy record round-trips without new keys (missing key -> None on
-        # from_dict, mirroring the dimension_scope / signing_payload_version
-        # backward-compat pattern above).
-        if self.constraints is not None:
-            d["constraints"] = self.constraints.to_dict()
-        if self.resource_limits is not None:
-            d["resource_limits"] = self.resource_limits.to_dict()
-        if self.scope is not None:
-            d["scope"] = self.scope.to_dict()
-        # Multi-sig fold fields (#1841 S2b-2) — emitted ONLY when set, so a
-        # non-multi-sig record's persisted dict carries NO multi_sig keys and is
-        # byte-identical to a pre-S2b-2 record (prune-when-unset, matching the
-        # structured-field pattern above and cross-sdk-inspection 4d).
-        if self.multi_sig:
-            d["multi_sig"] = True
-        if self.multi_sig_policy is not None:
-            d["multi_sig_policy"] = self.multi_sig_policy.to_dict()
+        # #1841 S2b signing fold-fields (constraints / resource_limits / scope /
+        # multi_sig / multi_sig_policy) — emitted prune-when-unset via the SHARED
+        # serializer so this path and the sibling chain / interop serializers
+        # cannot drift (security.md § Multi-Site Kwarg Plumbing). A legacy record
+        # emits NO fold keys (byte-identical to a pre-S2b dict).
+        d.update(serialize_fold_fields(self))
         return d
 
     @classmethod
@@ -480,38 +472,21 @@ class DelegationRecord:
         else:
             dimension_scope = ALL_DIMENSIONS
 
-        # Structured engine-fold fields (#1841 S2b-1): backward-compatible --
-        # a pre-S2b record has no key, so each deserializes to None → the record
-        # resolves to the legacy schema and verifies byte-identically.
-        raw_constraints = data.get("constraints")
-        constraints = (
-            ConstraintDimensions.from_dict(raw_constraints)
-            if raw_constraints is not None
-            else None
+        # Signing-payload version (#1841 shard 2): backward-compatible -- a record
+        # serialized before this field existed has no key, so it deserializes to
+        # the pre-migration legacy schema and verifies byte-identically.
+        signing_payload_version = data.get(
+            "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
         )
-        raw_resource_limits = data.get("resource_limits")
-        resource_limits = (
-            ResourceLimits.from_dict(raw_resource_limits)
-            if raw_resource_limits is not None
-            else None
-        )
-        raw_delegation_scope = data.get("scope")
-        scope = (
-            DelegationScope.from_dict(raw_delegation_scope)
-            if raw_delegation_scope is not None
-            else None
-        )
-
-        # Multi-sig fold fields (#1841 S2b-2): backward-compatible -- a pre-S2b-2
-        # record has no key, so multi_sig defaults False and multi_sig_policy is
-        # None. MultiSigSigningPolicy.from_dict decodes hex->bytes AND re-runs
-        # __post_init__, so distinct-signer / 32-byte / threshold<=N validation
-        # fires on reconstruction (a tampered persisted policy fails closed).
-        raw_multi_sig_policy = data.get("multi_sig_policy")
-        multi_sig_policy = (
-            MultiSigSigningPolicy.from_dict(raw_multi_sig_policy)
-            if raw_multi_sig_policy is not None
-            else None
+        # #1841 S2b signing fold-fields (constraints / resource_limits / scope /
+        # multi_sig / multi_sig_policy) via the SHARED deserializer: backward-
+        # compatible (absent keys = legacy defaults), MultiSigSigningPolicy
+        # validation re-runs on reconstruction, AND an inconsistent multi-sig
+        # record fails closed (defense in depth against a store-tampered record).
+        fold = deserialize_fold_fields(
+            data,
+            signing_payload_version=signing_payload_version,
+            record_id=data.get("id"),
         )
 
         return cls(
@@ -539,20 +514,12 @@ class DelegationRecord:
             reasoning_signature=data.get("reasoning_signature"),
             # Dimension scope extension (#170)
             dimension_scope=dimension_scope,
-            # Signing-payload version (#1841 shard 2): backward-compatible --
-            # a record serialized before this field existed has no key, so it
-            # deserializes to the pre-migration legacy schema and verifies
-            # byte-identically to how it was signed.
-            signing_payload_version=data.get(
-                "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
-            ),
-            # Structured engine-fold fields (#1841 S2b-1): None when absent.
-            constraints=constraints,
-            resource_limits=resource_limits,
-            scope=scope,
-            # Multi-sig fold fields (#1841 S2b-2): defaults when absent.
-            multi_sig=data.get("multi_sig", False),
-            multi_sig_policy=multi_sig_policy,
+            # Signing-payload version (#1841 shard 2).
+            signing_payload_version=signing_payload_version,
+            # #1841 S2b signing fold-fields (constraints / resource_limits / scope
+            # / multi_sig / multi_sig_policy) — shared deserializer, legacy
+            # defaults when absent.
+            **fold,
         )
 
 
@@ -1083,7 +1050,19 @@ class TrustLineageChain:
 
     @staticmethod
     def _serialize_delegation(d: DelegationRecord) -> Dict[str, Any]:
-        """Serialize a delegation record for chain-level serialization."""
+        """Serialize a delegation record for chain-level serialization.
+
+        Carries the #1841 S2b signing fold-fields (``constraints`` /
+        ``resource_limits`` / ``scope`` / ``multi_sig`` / ``multi_sig_policy``)
+        prune-when-unset so a v2/v3 delegation reconstructed by a persistent store
+        (this is the chain-level serialization every store uses) recomputes the
+        SAME signing pre-image and its signature verifies. A legacy record emits
+        NO fold-field keys (byte-identical to a pre-S2b dict). ``dimension_scope``
+        is emitted only when narrowed (a default/all-dimensions record round-trips
+        via from_dict's ALL_DIMENSIONS default) — it is bound into the legacy
+        signing pre-image (``to_signing_payload``), so a narrowed record must
+        carry it through or its signature would not re-verify.
+        """
         result = {
             "id": d.id,
             "delegator_id": d.delegator_id,
@@ -1097,6 +1076,13 @@ class TrustLineageChain:
             # Signing-payload version discriminator (#1841 shard 2).
             "signing_payload_version": d.signing_payload_version,
         }
+        # dimension_scope binds into the legacy pre-image; emit only when narrowed
+        # so a default (all-dimensions) record stays byte-neutral (from_dict
+        # defaults a missing key to ALL_DIMENSIONS).
+        if frozenset(d.dimension_scope) != frozenset(ALL_DIMENSIONS):
+            result["dimension_scope"] = sorted(d.dimension_scope)
+        # #1841 S2b signing fold-fields (shared serializer — prune-when-unset).
+        result.update(serialize_fold_fields(d))
         # Reasoning trace extension fields (only if present)
         if d.reasoning_trace:
             result["reasoning_trace"] = d.reasoning_trace.to_dict()
@@ -1118,6 +1104,25 @@ class TrustLineageChain:
         if d.get("reasoning_trace"):
             reasoning_trace = ReasoningTrace.from_dict(d["reasoning_trace"])
 
+        # Signing-payload version (#1841 shard 2): absent key = legacy.
+        signing_payload_version = d.get(
+            "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+        )
+        # dimension_scope: absent key = all dimensions (matches DelegationRecord).
+        raw_dimension_scope = d.get("dimension_scope")
+        dimension_scope = (
+            frozenset(raw_dimension_scope)
+            if raw_dimension_scope is not None
+            else ALL_DIMENSIONS
+        )
+        # #1841 S2b signing fold-fields (shared deserializer — fail-closed on an
+        # inconsistent multi-sig record; absent keys = legacy defaults).
+        fold = deserialize_fold_fields(
+            d,
+            signing_payload_version=signing_payload_version,
+            record_id=d.get("id"),
+        )
+
         return DelegationRecord(
             id=d["id"],
             delegator_id=d["delegator_id"],
@@ -1134,10 +1139,9 @@ class TrustLineageChain:
             reasoning_trace=reasoning_trace,
             reasoning_trace_hash=d.get("reasoning_trace_hash"),
             reasoning_signature=d.get("reasoning_signature"),
-            # Signing-payload version (#1841 shard 2): absent key = legacy.
-            signing_payload_version=d.get(
-                "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
-            ),
+            dimension_scope=dimension_scope,
+            signing_payload_version=signing_payload_version,
+            **fold,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/kailash/trust/interop/jwt.py
+++ b/src/kailash/trust/interop/jwt.py
@@ -26,8 +26,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict
 
-logger = logging.getLogger(__name__)
-
 # ---------------------------------------------------------------------------
 # Guarded import of PyJWT
 # ---------------------------------------------------------------------------
@@ -39,18 +37,9 @@ except ImportError as _import_err:
         "Install it with: pip install 'pyjwt[crypto]'"
     ) from _import_err
 
-# ---------------------------------------------------------------------------
-# Module-level constants
-# ---------------------------------------------------------------------------
-
-EATP_VERSION: str = "0.2.0"
-"""EATP protocol version embedded in every JWT payload."""
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
 from kailash.trust.chain import (
+    ALL_DIMENSIONS,
+    DELEGATION_SIGNING_VERSION_LEGACY,
     AuthorityType,
     CapabilityAttestation,
     CapabilityType,
@@ -62,6 +51,23 @@ from kailash.trust.chain import (
     TrustLineageChain,
 )
 from kailash.trust.reasoning.traces import ConfidentialityLevel
+from kailash.trust.signing.delegation_fold_serde import (
+    deserialize_fold_fields,
+    serialize_fold_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+EATP_VERSION: str = "0.2.0"
+"""EATP protocol version embedded in every JWT payload."""
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 
 def _validate_signing_key(signing_key: str) -> None:
@@ -147,6 +153,14 @@ def _serialize_delegation(delegation: DelegationRecord) -> Dict[str, Any]:
         d["reasoning_trace_hash"] = delegation.reasoning_trace_hash
     if delegation.reasoning_signature is not None:
         d["reasoning_signature"] = delegation.reasoning_signature
+    # #1841 S2b signing fields — a v2/v3 delegation's signature verifies only if
+    # these survive the JWT round-trip (security.md § Multi-Site Kwarg Plumbing).
+    # Prune-when-unset: a legacy record adds NO new claims (byte-neutral JWT).
+    if delegation.signing_payload_version != DELEGATION_SIGNING_VERSION_LEGACY:
+        d["signing_payload_version"] = delegation.signing_payload_version
+    if frozenset(delegation.dimension_scope) != frozenset(ALL_DIMENSIONS):
+        d["dimension_scope"] = sorted(delegation.dimension_scope)
+    d.update(serialize_fold_fields(delegation))
     return d
 
 
@@ -278,6 +292,22 @@ def _deserialize_delegation(data: Dict[str, Any]) -> DelegationRecord:
 
         reasoning_trace = ReasoningTrace.from_dict(data["reasoning_trace"])
 
+    # #1841 S2b signing fields (backward compatible — absent = legacy defaults).
+    signing_payload_version = data.get(
+        "signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+    )
+    raw_dimension_scope = data.get("dimension_scope")
+    dimension_scope = (
+        frozenset(raw_dimension_scope)
+        if raw_dimension_scope is not None
+        else ALL_DIMENSIONS
+    )
+    fold = deserialize_fold_fields(
+        data,
+        signing_payload_version=signing_payload_version,
+        record_id=data.get("id"),
+    )
+
     return DelegationRecord(
         id=data["id"],
         delegator_id=data["delegator_id"],
@@ -299,6 +329,9 @@ def _deserialize_delegation(data: Dict[str, Any]) -> DelegationRecord:
         reasoning_trace=reasoning_trace,
         reasoning_trace_hash=data.get("reasoning_trace_hash"),
         reasoning_signature=data.get("reasoning_signature"),
+        dimension_scope=dimension_scope,
+        signing_payload_version=signing_payload_version,
+        **fold,
     )
 
 

--- a/src/kailash/trust/interop/ucan.py
+++ b/src/kailash/trust/interop/ucan.py
@@ -437,8 +437,6 @@ def to_ucan(
         private_key, public_key = generate_keypair()
         token = to_ucan(delegation, private_key)
     """
-    from kailash.trust.chain import DelegationRecord as _DelegationRecord
-
     _validate_signing_key(signing_key)
 
     # Resolve DIDs

--- a/src/kailash/trust/interop/ucan.py
+++ b/src/kailash/trust/interop/ucan.py
@@ -52,6 +52,10 @@ if TYPE_CHECKING:
     from kailash.trust.chain import DelegationRecord
 
 from kailash.trust.reasoning.traces import ConfidentialityLevel
+from kailash.trust.signing.delegation_fold_serde import (
+    deserialize_fold_fields,
+    serialize_fold_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -326,6 +330,14 @@ def _build_facts(
     Returns:
         Dict of EATP fact claims for the fct field.
     """
+    from kailash.trust.chain import ALL_DIMENSIONS, DELEGATION_SIGNING_VERSION_LEGACY
+
+    # #1841 S2b signing fold-fields — nested under a distinct key (the flat
+    # ``eatp_constraints`` fact already carries constraint_subset). A v2/v3
+    # delegation's ``eatp_original_signature`` re-verifies only if these survive
+    # the UCAN round-trip (security.md § Multi-Site Kwarg Plumbing). Prune-when-
+    # unset: a legacy record adds NO new facts (byte-neutral token).
+    fold = serialize_fold_fields(delegation)
     return {
         "eatp_delegation_id": delegation.id,
         "eatp_delegator_id": delegation.delegator_id,
@@ -340,6 +352,18 @@ def _build_facts(
         ),
         "eatp_parent_delegation_id": delegation.parent_delegation_id,
         "eatp_original_signature": delegation.signature,
+        # #1841 S2b fold-fields + version + narrowed dimension_scope (prune-when-unset)
+        **({"eatp_signing_fold": fold} if fold else {}),
+        **(
+            {"eatp_signing_payload_version": delegation.signing_payload_version}
+            if delegation.signing_payload_version != DELEGATION_SIGNING_VERSION_LEGACY
+            else {}
+        ),
+        **(
+            {"eatp_dimension_scope": sorted(delegation.dimension_scope)}
+            if frozenset(delegation.dimension_scope) != frozenset(ALL_DIMENSIONS)
+            else {}
+        ),
         # Reasoning trace extension (confidentiality-filtered)
         **(
             {"eatp_reasoning_trace": delegation.reasoning_trace.to_dict()}
@@ -615,6 +639,25 @@ def from_ucan(
 
         reasoning_trace = ReasoningTrace.from_dict(fct["eatp_reasoning_trace"])
 
+    # #1841 S2b signing fold-fields (absent facts = legacy defaults; a v2/v3
+    # delegation's eatp_original_signature re-verifies only with these).
+    from kailash.trust.chain import ALL_DIMENSIONS, DELEGATION_SIGNING_VERSION_LEGACY
+
+    signing_payload_version = fct.get(
+        "eatp_signing_payload_version", DELEGATION_SIGNING_VERSION_LEGACY
+    )
+    raw_dimension_scope = fct.get("eatp_dimension_scope")
+    dimension_scope = (
+        frozenset(raw_dimension_scope)
+        if raw_dimension_scope is not None
+        else ALL_DIMENSIONS
+    )
+    fold = deserialize_fold_fields(
+        fct.get("eatp_signing_fold", {}),
+        signing_payload_version=signing_payload_version,
+        record_id=fct["eatp_delegation_id"],
+    )
+
     delegation = _DelegationRecord(
         id=fct["eatp_delegation_id"],
         delegator_id=fct["eatp_delegator_id"],
@@ -631,6 +674,9 @@ def from_ucan(
         reasoning_trace=reasoning_trace,
         reasoning_trace_hash=fct.get("eatp_reasoning_trace_hash"),
         reasoning_signature=fct.get("eatp_reasoning_signature"),
+        dimension_scope=dimension_scope,
+        signing_payload_version=signing_payload_version,
+        **fold,
     )
 
     logger.debug(

--- a/src/kailash/trust/interop/w3c_vc.py
+++ b/src/kailash/trust/interop/w3c_vc.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from kailash.trust.chain import (
+    ALL_DIMENSIONS,
+    DELEGATION_SIGNING_VERSION_LEGACY,
     AuthorityType,
     CapabilityAttestation,
     CapabilityType,
@@ -31,8 +33,12 @@ from kailash.trust.chain import (
     GenesisRecord,
     TrustLineageChain,
 )
-from kailash.trust.signing.crypto import serialize_for_signing, sign, verify_signature
 from kailash.trust.reasoning.traces import ConfidentialityLevel, ReasoningTrace
+from kailash.trust.signing.crypto import serialize_for_signing, sign, verify_signature
+from kailash.trust.signing.delegation_fold_serde import (
+    deserialize_fold_fields,
+    serialize_fold_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +190,16 @@ def _serialize_delegation(d: DelegationRecord) -> Dict[str, Any]:
     if d.reasoning_signature is not None:
         result["reasoningSignature"] = d.reasoning_signature
 
+    # #1841 S2b signing fields (camelCase, W3C VC convention) — a v2/v3
+    # delegation's signature verifies only if these survive the VC round-trip
+    # (security.md § Multi-Site Kwarg Plumbing). Prune-when-unset: a legacy record
+    # adds NO new keys (byte-neutral VC).
+    if d.signing_payload_version != DELEGATION_SIGNING_VERSION_LEGACY:
+        result["signingPayloadVersion"] = d.signing_payload_version
+    if frozenset(d.dimension_scope) != frozenset(ALL_DIMENSIONS):
+        result["dimensionScope"] = sorted(d.dimension_scope)
+    result.update(serialize_fold_fields(d, camel=True))
+
     return result
 
 
@@ -260,7 +276,9 @@ def _create_proof(
     try:
         signature_b64 = sign(payload, signing_key)
     except ValueError as exc:
-        raise ValueError(f"Failed to sign credential: invalid signing_key — {exc}") from exc
+        raise ValueError(
+            f"Failed to sign credential: invalid signing_key — {exc}"
+        ) from exc
 
     return {
         "type": _PROOF_TYPE,
@@ -301,7 +319,9 @@ def export_as_verifiable_credential(
     if not issuer_did or not issuer_did.strip():
         raise ValueError("issuer_did must be a non-empty DID string, got empty value")
     if not signing_key or not signing_key.strip():
-        raise ValueError("signing_key must be a non-empty base64-encoded Ed25519 private key")
+        raise ValueError(
+            "signing_key must be a non-empty base64-encoded Ed25519 private key"
+        )
 
     credential_subject: Dict[str, Any] = {
         "genesis": _serialize_genesis(chain.genesis),
@@ -357,7 +377,9 @@ def export_capability_as_vc(
     if not issuer_did or not issuer_did.strip():
         raise ValueError("issuer_did must be a non-empty DID string, got empty value")
     if not signing_key or not signing_key.strip():
-        raise ValueError("signing_key must be a non-empty base64-encoded Ed25519 private key")
+        raise ValueError(
+            "signing_key must be a non-empty base64-encoded Ed25519 private key"
+        )
 
     credential_subject = _serialize_capability(attestation)
 
@@ -403,14 +425,20 @@ def verify_credential(credential: Dict[str, Any], public_key: str) -> bool:
         ValueError: If public_key is empty or invalid.
     """
     if not public_key or not public_key.strip():
-        raise ValueError("public_key must be a non-empty base64-encoded Ed25519 public key")
+        raise ValueError(
+            "public_key must be a non-empty base64-encoded Ed25519 public key"
+        )
 
     if "proof" not in credential:
-        raise ValueError("Credential is missing 'proof' field — cannot verify an unsigned credential")
+        raise ValueError(
+            "Credential is missing 'proof' field — cannot verify an unsigned credential"
+        )
 
     proof = credential["proof"]
     if "proofValue" not in proof:
-        raise ValueError("Credential proof is missing 'proofValue' — the signature is required for verification")
+        raise ValueError(
+            "Credential proof is missing 'proofValue' — the signature is required for verification"
+        )
 
     signature_b64 = proof["proofValue"]
 
@@ -423,7 +451,9 @@ def verify_credential(credential: Dict[str, Any], public_key: str) -> bool:
     except Exception as exc:
         # InvalidSignatureError or other crypto errors from verify_signature
         # are raised for structural problems (bad key format, etc.)
-        raise ValueError(f"public_key is invalid or signature verification encountered an error: {exc}") from exc
+        raise ValueError(
+            f"public_key is invalid or signature verification encountered an error: {exc}"
+        ) from exc
 
 
 def import_from_verifiable_credential(
@@ -453,7 +483,9 @@ def import_from_verifiable_credential(
     """
     if public_key is not None:
         if not verify_credential(credential, public_key):
-            raise ValueError("W3C VC proof verification failed — credential may be forged")
+            raise ValueError(
+                "W3C VC proof verification failed — credential may be forged"
+            )
     else:
         logger.warning(
             "[W3C-VC] Importing credential WITHOUT proof verification. "
@@ -464,7 +496,9 @@ def import_from_verifiable_credential(
     # --- Validate @context ---
     context = credential.get("@context", [])
     if W3C_CREDENTIALS_V2_CONTEXT not in context:
-        raise ValueError(f"Invalid credential @context: must include '{W3C_CREDENTIALS_V2_CONTEXT}', got {context!r}")
+        raise ValueError(
+            f"Invalid credential @context: must include '{W3C_CREDENTIALS_V2_CONTEXT}', got {context!r}"
+        )
     if EATP_CONTEXT_URL not in context:
         raise ValueError(
             f"Invalid credential @context: must include EATP context '{EATP_CONTEXT_URL}', got {context!r}"
@@ -473,7 +507,9 @@ def import_from_verifiable_credential(
     # --- Validate type ---
     vc_type = credential.get("type", [])
     if "EATPTrustChain" not in vc_type:
-        raise ValueError(f"Invalid credential type: must include 'EATPTrustChain', got {vc_type!r}")
+        raise ValueError(
+            f"Invalid credential type: must include 'EATPTrustChain', got {vc_type!r}"
+        )
 
     # --- Validate credentialSubject ---
     if "credentialSubject" not in credential:
@@ -496,7 +532,9 @@ def import_from_verifiable_credential(
         authority_id=g["authorityId"],
         authority_type=AuthorityType(g["authorityType"]),
         created_at=datetime.fromisoformat(g["createdAt"]),
-        expires_at=(datetime.fromisoformat(g["expiresAt"]) if g.get("expiresAt") else None),
+        expires_at=(
+            datetime.fromisoformat(g["expiresAt"]) if g.get("expiresAt") else None
+        ),
         signature=g.get("signature", ""),
         signature_algorithm=g.get("signatureAlgorithm", "Ed25519"),
         metadata=g.get("metadata", {}),
@@ -513,7 +551,11 @@ def import_from_verifiable_credential(
                 constraints=c.get("constraints", []),
                 attester_id=c["attesterId"],
                 attested_at=datetime.fromisoformat(c["attestedAt"]),
-                expires_at=(datetime.fromisoformat(c["expiresAt"]) if c.get("expiresAt") else None),
+                expires_at=(
+                    datetime.fromisoformat(c["expiresAt"])
+                    if c.get("expiresAt")
+                    else None
+                ),
                 signature=c.get("signature", ""),
                 scope=c.get("scope"),
             )
@@ -533,12 +575,31 @@ def import_from_verifiable_credential(
                     "rationale": reasoning_data["rationale"],
                     "confidentiality": reasoning_data["confidentiality"],
                     "timestamp": reasoning_data["timestamp"],
-                    "alternatives_considered": reasoning_data.get("alternativesConsidered", []),
+                    "alternatives_considered": reasoning_data.get(
+                        "alternativesConsidered", []
+                    ),
                     "evidence": reasoning_data.get("evidence", []),
                     "methodology": reasoning_data.get("methodology"),
                     "confidence": reasoning_data.get("confidence"),
                 }
             )
+
+        # #1841 S2b signing fields (camelCase; absent = legacy defaults).
+        deleg_version = d.get(
+            "signingPayloadVersion", DELEGATION_SIGNING_VERSION_LEGACY
+        )
+        raw_dimension_scope = d.get("dimensionScope")
+        deleg_dimension_scope = (
+            frozenset(raw_dimension_scope)
+            if raw_dimension_scope is not None
+            else ALL_DIMENSIONS
+        )
+        deleg_fold = deserialize_fold_fields(
+            d,
+            signing_payload_version=deleg_version,
+            camel=True,
+            record_id=d.get("id"),
+        )
 
         delegations.append(
             DelegationRecord(
@@ -549,12 +610,19 @@ def import_from_verifiable_credential(
                 capabilities_delegated=d.get("capabilitiesDelegated", []),
                 constraint_subset=d.get("constraintSubset", []),
                 delegated_at=datetime.fromisoformat(d["delegatedAt"]),
-                expires_at=(datetime.fromisoformat(d["expiresAt"]) if d.get("expiresAt") else None),
+                expires_at=(
+                    datetime.fromisoformat(d["expiresAt"])
+                    if d.get("expiresAt")
+                    else None
+                ),
                 signature=d.get("signature", ""),
                 parent_delegation_id=d.get("parentDelegationId"),
                 reasoning_trace=reasoning_trace,
                 reasoning_trace_hash=d.get("reasoningTraceHash"),
                 reasoning_signature=d.get("reasoningSignature"),
+                dimension_scope=deleg_dimension_scope,
+                signing_payload_version=deleg_version,
+                **deleg_fold,
             )
         )
 

--- a/src/kailash/trust/interop/w3c_vc.py
+++ b/src/kailash/trust/interop/w3c_vc.py
@@ -77,13 +77,6 @@ def _iso(dt: datetime) -> str:
     return dt.isoformat()
 
 
-def _iso_optional(dt: Optional[datetime]) -> Optional[str]:
-    """Format an optional datetime; returns None when input is None."""
-    if dt is None:
-        return None
-    return _iso(dt)
-
-
 def _make_vc_id(record_id: str) -> str:
     """Generate a URN-format VC identifier from an EATP record ID."""
     return f"urn:eatp:vc:{record_id}"

--- a/src/kailash/trust/signing/delegation_fold_serde.py
+++ b/src/kailash/trust/signing/delegation_fold_serde.py
@@ -34,22 +34,38 @@ faithfully round-trips the five fields. The snake_case shape matches
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Dict, Optional, Protocol
 
 from kailash.trust.signing.delegation_payload import (
     ConstraintDimensions,
     DelegationScope,
     MultiSigSigningPolicy,
     ResourceLimits,
+    SigningPayloadVersion,
 )
-
-if TYPE_CHECKING:  # pragma: no cover - typing only (avoids a chain <-> signing cycle)
-    from kailash.trust.chain import DelegationRecord
 
 __all__ = [
     "serialize_fold_fields",
     "deserialize_fold_fields",
 ]
+
+
+class _FoldSourceRecord(Protocol):
+    """Structural type for the record fields ``serialize_fold_fields`` reads.
+
+    A LOCAL Protocol (not an import of ``kailash.trust.chain.DelegationRecord``)
+    so this low-level serializer never imports the high-level ``chain`` module —
+    not even under ``TYPE_CHECKING``. That one-way dependency (chain → this
+    module, never back) is what keeps CodeQL's ``py/unsafe-cyclic-import`` clear;
+    ``DelegationRecord`` satisfies this Protocol structurally.
+    """
+
+    constraints: "Optional[ConstraintDimensions]"
+    resource_limits: "Optional[ResourceLimits]"
+    scope: "Optional[DelegationScope]"
+    multi_sig: bool
+    multi_sig_policy: "Optional[MultiSigSigningPolicy]"
+
 
 # Attribute name -> serialized key, per case convention. ``constraints`` and
 # ``scope`` are identical in both; ``resource_limits`` / ``multi_sig`` /
@@ -76,7 +92,7 @@ def _keys(camel: bool) -> Dict[str, str]:
 
 
 def serialize_fold_fields(
-    record: "DelegationRecord", *, camel: bool = False
+    record: _FoldSourceRecord, *, camel: bool = False
 ) -> Dict[str, Any]:
     """Serialize the five S2b fold-fields prune-when-unset.
 
@@ -143,9 +159,12 @@ def deserialize_fold_fields(
     Raises:
         ValueError: On an inconsistent multi-sig record (fail-closed).
     """
-    # Import the version constant lazily to avoid a chain <-> signing import
-    # cycle (chain.py imports this module's package at load time).
-    from kailash.trust.chain import DELEGATION_SIGNING_VERSION_V3
+    # The v3 wire token is sourced from the LOW-LEVEL delegation_payload enum
+    # (``SigningPayloadVersion.V3_COMPLETE.value == "v3-complete"``), the same
+    # string as ``chain.DELEGATION_SIGNING_VERSION_V3`` — so this module never
+    # imports the high-level ``chain`` module (not even lazily), keeping the
+    # dependency one-way (chain → this module) and CodeQL's cyclic-import clear.
+    v3_version = SigningPayloadVersion.V3_COMPLETE.value
 
     k = _keys(camel)
 
@@ -176,7 +195,7 @@ def deserialize_fold_fields(
         multi_sig=multi_sig,
         multi_sig_policy=multi_sig_policy,
         signing_payload_version=signing_payload_version,
-        v3_version=DELEGATION_SIGNING_VERSION_V3,
+        v3_version=v3_version,
         record_id=record_id,
     )
 

--- a/src/kailash/trust/signing/delegation_fold_serde.py
+++ b/src/kailash/trust/signing/delegation_fold_serde.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared serialization for the #1841 S2b signing fold-fields.
+
+#1841 S2b-1/S2b-2 added five structured signing fields to ``DelegationRecord`` —
+``constraints`` / ``resource_limits`` / ``scope`` (S2b-1) and ``multi_sig`` /
+``multi_sig_policy`` (S2b-2) — which fold into the cross-SDK V2Complete /
+V3Complete signing pre-image (:func:`delegation_canonical_payload_str`). A v2/v3
+record's signature verifies ONLY if these fields survive persistence: the
+reconstructed record MUST recompute the SAME pre-image the signature was made
+over.
+
+Every delegation serializer — ``TrustLineageChain._serialize_delegation`` (the
+chain-level path every persistent store uses), the W3C VC interop serializer, the
+JWT interop serializer, and ``DelegationRecord.to_dict`` itself — MUST carry these
+fields through, or a v2/v3 delegation reloads with the fold fields ``None`` and
+its signature no longer verifies (``security.md`` § "Multi-Site Kwarg Plumbing" —
+the field plumbed through one serializer, missed the siblings). This module is
+the SINGLE shared helper both halves of that contract route through, so encode
+and decode cannot drift apart (``security.md`` § "Pre-Encoder Consolidation").
+
+Prune-when-unset: a legacy record (all five fields at their None/False default)
+serializes to a dict with NO fold-field keys, byte-identical to a pre-S2b record
+(``cross-sdk-inspection.md`` Rule 4d). A CONFIGURED value is emitted and, on
+reconstruction, cryptographically bound.
+
+The persistence dict is NOT itself a cross-SDK signing pre-image (the signing
+bytes come from :func:`delegation_canonical_payload_str` reading the RECORD
+FIELDS, not this dict), so the dict shape carries no cross-SDK byte-pin — it just
+faithfully round-trips the five fields. The snake_case shape matches
+``DelegationRecord.to_dict``; the camelCase shape matches the W3C VC convention.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    MultiSigSigningPolicy,
+    ResourceLimits,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only (avoids a chain <-> signing cycle)
+    from kailash.trust.chain import DelegationRecord
+
+__all__ = [
+    "serialize_fold_fields",
+    "deserialize_fold_fields",
+]
+
+# Attribute name -> serialized key, per case convention. ``constraints`` and
+# ``scope`` are identical in both; ``resource_limits`` / ``multi_sig`` /
+# ``multi_sig_policy`` differ. The W3C VC serializer emits camelCase; the
+# chain-level + JWT serializers (and DelegationRecord.to_dict) emit snake_case.
+_SNAKE_KEYS = {
+    "constraints": "constraints",
+    "resource_limits": "resource_limits",
+    "scope": "scope",
+    "multi_sig": "multi_sig",
+    "multi_sig_policy": "multi_sig_policy",
+}
+_CAMEL_KEYS = {
+    "constraints": "constraints",
+    "resource_limits": "resourceLimits",
+    "scope": "scope",
+    "multi_sig": "multiSig",
+    "multi_sig_policy": "multiSigPolicy",
+}
+
+
+def _keys(camel: bool) -> Dict[str, str]:
+    return _CAMEL_KEYS if camel else _SNAKE_KEYS
+
+
+def serialize_fold_fields(
+    record: "DelegationRecord", *, camel: bool = False
+) -> Dict[str, Any]:
+    """Serialize the five S2b fold-fields prune-when-unset.
+
+    Only fields with a non-default value are emitted, so a legacy record yields
+    an empty dict (no new keys — byte-identical to pre-S2b). Mirrors exactly the
+    fold-field emission in ``DelegationRecord.to_dict``.
+
+    Args:
+        record: The delegation record to read the fold fields from.
+        camel: Emit camelCase keys (W3C VC convention) instead of snake_case.
+
+    Returns:
+        A dict carrying only the SET fold fields (empty for a legacy record).
+    """
+    k = _keys(camel)
+    out: Dict[str, Any] = {}
+    if record.constraints is not None:
+        out[k["constraints"]] = record.constraints.to_dict()
+    if record.resource_limits is not None:
+        out[k["resource_limits"]] = record.resource_limits.to_dict()
+    if record.scope is not None:
+        out[k["scope"]] = record.scope.to_dict()
+    # multi_sig / multi_sig_policy prune-when-unset so a non-multi-sig record's
+    # dict carries NO multi_sig keys (byte-identical to a pre-S2b-2 record).
+    if record.multi_sig:
+        out[k["multi_sig"]] = True
+    if record.multi_sig_policy is not None:
+        out[k["multi_sig_policy"]] = record.multi_sig_policy.to_dict()
+    return out
+
+
+def deserialize_fold_fields(
+    data: Dict[str, Any],
+    *,
+    signing_payload_version: str,
+    camel: bool = False,
+    record_id: Any = None,
+) -> Dict[str, Any]:
+    """Reconstruct the five S2b fold-fields from a serialized delegation dict.
+
+    Backward-compatible: a pre-S2b dict has no fold-field keys, so every field
+    resolves to its None/False default and the record verifies as legacy.
+    ``MultiSigSigningPolicy.from_dict`` re-runs ``__post_init__`` (distinct-signer
+    / 32-byte / threshold<=N validation), so a store-tampered policy fails closed
+    on reconstruction.
+
+    Fail-closed consistency guard (defense in depth against a store-tampered
+    record): a multi-sig record MUST carry a policy AND declare the v3 version;
+    an isolated ``multi_sig_policy`` with ``multi_sig=False`` is a mis-constructed
+    record. These mirror the ``select_signing_version`` sign-time posture so a
+    tampered persisted record cannot reconstruct into an inconsistent state.
+
+    Args:
+        data: The serialized delegation dict.
+        signing_payload_version: The record's resolved signing-payload version
+            (already read by the caller), used for the multi_sig/version guard.
+        camel: Read camelCase keys (W3C VC convention) instead of snake_case.
+        record_id: The record id, for error-message context (optional).
+
+    Returns:
+        A kwargs dict ``{constraints, resource_limits, scope, multi_sig,
+        multi_sig_policy}`` suitable for the ``DelegationRecord`` constructor.
+
+    Raises:
+        ValueError: On an inconsistent multi-sig record (fail-closed).
+    """
+    # Import the version constant lazily to avoid a chain <-> signing import
+    # cycle (chain.py imports this module's package at load time).
+    from kailash.trust.chain import DELEGATION_SIGNING_VERSION_V3
+
+    k = _keys(camel)
+
+    raw_constraints = data.get(k["constraints"])
+    constraints = (
+        ConstraintDimensions.from_dict(raw_constraints)
+        if raw_constraints is not None
+        else None
+    )
+    raw_resource_limits = data.get(k["resource_limits"])
+    resource_limits = (
+        ResourceLimits.from_dict(raw_resource_limits)
+        if raw_resource_limits is not None
+        else None
+    )
+    raw_scope = data.get(k["scope"])
+    scope = DelegationScope.from_dict(raw_scope) if raw_scope is not None else None
+
+    multi_sig = bool(data.get(k["multi_sig"], False))
+    raw_multi_sig_policy = data.get(k["multi_sig_policy"])
+    multi_sig_policy = (
+        MultiSigSigningPolicy.from_dict(raw_multi_sig_policy)
+        if raw_multi_sig_policy is not None
+        else None
+    )
+
+    _reject_inconsistent_multi_sig(
+        multi_sig=multi_sig,
+        multi_sig_policy=multi_sig_policy,
+        signing_payload_version=signing_payload_version,
+        v3_version=DELEGATION_SIGNING_VERSION_V3,
+        record_id=record_id,
+    )
+
+    return {
+        "constraints": constraints,
+        "resource_limits": resource_limits,
+        "scope": scope,
+        "multi_sig": multi_sig,
+        "multi_sig_policy": multi_sig_policy,
+    }
+
+
+def _reject_inconsistent_multi_sig(
+    *,
+    multi_sig: bool,
+    multi_sig_policy: Any,
+    signing_payload_version: str,
+    v3_version: str,
+    record_id: Any,
+) -> None:
+    """Fail closed on a store-tampered / mis-constructed multi-sig record."""
+    ctx = f" (record_id={record_id!r})" if record_id is not None else ""
+    if multi_sig and multi_sig_policy is None:
+        raise ValueError(
+            "deserialized multi_sig=True record has no multi_sig_policy; a "
+            "multi-sig record cannot reconstruct its quorum binding (threshold + "
+            f"authorized_signers) without a policy — fail-closed{ctx}"
+        )
+    if multi_sig_policy is not None and not multi_sig:
+        raise ValueError(
+            "deserialized record carries a multi_sig_policy but multi_sig=False; "
+            f"a policy with no multi-sig flag is a mis-constructed record{ctx}"
+        )
+    if multi_sig and signing_payload_version != v3_version:
+        raise ValueError(
+            "deserialized multi_sig=True record declares signing_payload_version="
+            f"{signing_payload_version!r}, not {v3_version!r}; a multi-sig record "
+            f"MUST sign v3 (never legacy/v2 which drop the quorum binding){ctx}"
+        )

--- a/tests/regression/test_issue_1841_chain_serde_roundtrip.py
+++ b/tests/regression/test_issue_1841_chain_serde_roundtrip.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1841 chain/store/interop serializer fold-field round-trip (HIGH correctness).
+
+#1841 S2b-1/S2b-2 added structured signing fields (``constraints`` /
+``resource_limits`` / ``scope`` / ``multi_sig`` / ``multi_sig_policy``) to
+``DelegationRecord`` so a v2/v3 record signs the cross-SDK V2Complete/V3Complete
+pre-image. They extended ``DelegationRecord.to_dict`` / ``from_dict`` — BUT the
+SIBLING chain-level serializer ``TrustLineageChain._serialize_delegation`` /
+``_deserialize_delegation`` (used by ``TrustLineageChain.to_dict`` / ``from_dict``,
+the chain-level serialization every persistent store uses) AND the two interop
+serializers (W3C VC ``interop/w3c_vc.py`` + JWT ``interop/jwt.py``) OMITTED all
+five fold fields.
+
+RESULT (the break): a v2/v3 delegation serialized-then-deserialized through chain
+persistence (or interop) reloads with ``signing_payload_version`` set but the
+fold fields ``None`` → ``delegation_canonical_payload_str`` recomputes a DIFFERENT
+(or fail-closed) pre-image → ``verify_signature`` returns False. v2/v3 signing is
+non-functional end-to-end through the store — the ``security.md`` Multi-Site
+Kwarg Plumbing failure (fields plumbed through ONE serializer, missed the
+siblings).
+
+The persistence dict is NOT a cross-SDK signing pre-image (the signing bytes come
+from ``delegation_canonical_payload_str`` reading the RECORD FIELDS, not the
+dict) — so the dict shape needs NO cross-SDK byte-pin; it just needs to FAITHFULLY
+round-trip the five fields so the reconstructed record recomputes the SAME signing
+pre-image and the signature verifies.
+
+Tier-2: real Ed25519, NO mocking (the user-flow-validation MUST-7 write-surface
+boundary fixtures — the store/chain round-trip IS the persistence boundary).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.chain import (
+    ALL_DIMENSIONS,
+    DELEGATION_SIGNING_VERSION_LEGACY,
+    DELEGATION_SIGNING_VERSION_V2,
+    DELEGATION_SIGNING_VERSION_V3,
+    AuthorityType,
+    DelegationRecord,
+    GenesisRecord,
+    TrustLineageChain,
+)
+from kailash.trust.chain_store.sqlite import SqliteTrustStore
+from kailash.trust.interop import jwt as jwt_interop
+from kailash.trust.interop import w3c_vc
+from kailash.trust.interop.ucan import from_ucan, to_ucan
+from kailash.trust.signing.crypto import generate_keypair, sign, verify_signature
+from kailash.trust.signing.delegation_payload import (
+    ConstraintDimensions,
+    DelegationScope,
+    MultiSigSigningPolicy,
+    ResourceLimits,
+    TrustLevel,
+)
+from kailash.trust.signing.delegation_record_signing import (
+    delegation_canonical_payload_str,
+    select_signing_version,
+)
+
+pytestmark = pytest.mark.regression
+
+
+# --- Fixed inputs (mirror the S2b-1 / S2b-2 record builders) -----------------
+
+
+def _key(n: int) -> bytes:
+    return bytes([n]) * 32
+
+
+def _supervised_constraints() -> ConstraintDimensions:
+    return ConstraintDimensions.for_level(TrustLevel.SUPERVISED)
+
+
+def _supervised_limits() -> ResourceLimits:
+    return ResourceLimits.for_level(TrustLevel.SUPERVISED)
+
+
+def _engineering_read_scope() -> DelegationScope:
+    return DelegationScope.new("engineering").with_operation("read")
+
+
+def _v2_record(**overrides) -> DelegationRecord:
+    kwargs = dict(
+        id="00000000-0000-4000-8000-000000000001",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-fixed",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V2,
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _v3_record(**overrides) -> DelegationRecord:
+    kwargs = dict(
+        id="00000000-0000-4000-8000-000000000002",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-fixed",
+        capabilities_delegated=["LlmCall"],
+        constraint_subset=[],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+        constraints=_supervised_constraints(),
+        resource_limits=_supervised_limits(),
+        scope=_engineering_read_scope(),
+        multi_sig=True,
+        multi_sig_policy=MultiSigSigningPolicy.new(2, [_key(1), _key(2), _key(3)]),
+        signing_payload_version=DELEGATION_SIGNING_VERSION_V3,
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _legacy_record(**overrides) -> DelegationRecord:
+    kwargs = dict(
+        id="del-legacy-chainserde",
+        delegator_id="alice",
+        delegatee_id="bob",
+        task_id="task-legacy",
+        capabilities_delegated=["LlmCall", "FileRead"],
+        constraint_subset=["read_only"],
+        delegated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="",
+    )
+    kwargs.update(overrides)
+    return DelegationRecord(**kwargs)
+
+
+def _genesis() -> GenesisRecord:
+    return GenesisRecord(
+        id="genesis-1",
+        agent_id="agent-bob",
+        authority_id="org-acme",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        signature="genesis-sig",
+    )
+
+
+def _signed(record: DelegationRecord, private_key) -> DelegationRecord:
+    """Sign a record over its canonical pre-image (real Ed25519)."""
+    record.signature = sign(delegation_canonical_payload_str(record), private_key)
+    return record
+
+
+def _chain_with(record: DelegationRecord) -> TrustLineageChain:
+    return TrustLineageChain(genesis=_genesis(), delegations=[record])
+
+
+async def _store_roundtrip(record: DelegationRecord, db_path) -> DelegationRecord:
+    """Persist a signed delegation through a REAL SqliteTrustStore and reload.
+
+    The SqliteTrustStore serializes via ``chain.to_dict()`` then PATCHES IN the
+    genesis / capability / delegation signatures (to_dict omits them for inline
+    dicts) — but does NOT patch the S2b fold fields, so a chain serializer that
+    drops them makes the reloaded v2/v3 record unverifiable. This is the exact
+    end-to-end persistence path (user-flow-validation MUST-7 write boundary).
+    """
+    store = SqliteTrustStore(db_path=str(db_path))
+    await store.initialize()
+    try:
+        agent_id = await store.store_chain(_chain_with(record))
+        reloaded = await store.get_chain(agent_id)
+    finally:
+        await store.close()
+    (restored,) = reloaded.delegations
+    return restored
+
+
+# =============================================================================
+# STEP 1 — the break (v2/v3 non-functional through the store)
+# =============================================================================
+
+
+async def test_v2_record_verifies_after_store_roundtrip(tmp_path) -> None:
+    """A v2 record signed, persisted through the SQLite store, re-verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v2_record(), private_key)
+
+    restored = await _store_roundtrip(record, tmp_path / "v2.db")
+
+    # The fold fields survived the store round-trip (field-identical record).
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+    assert select_signing_version(restored) == DELEGATION_SIGNING_VERSION_V2
+
+    # The reconstructed record recomputes the SAME signing pre-image → verifies.
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v2 delegation signature invalid after store round-trip (fold fields dropped)"
+
+
+async def test_v3_record_verifies_after_store_roundtrip(tmp_path) -> None:
+    """A v3 multi-sig record signed, persisted through the store, re-verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v3_record(), private_key)
+
+    restored = await _store_roundtrip(record, tmp_path / "v3.db")
+
+    assert restored.multi_sig is True
+    assert restored.multi_sig_policy == record.multi_sig_policy
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+    assert select_signing_version(restored) == DELEGATION_SIGNING_VERSION_V3
+
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v3 delegation signature invalid after store round-trip (fold fields dropped)"
+
+
+# =============================================================================
+# STEP 4 — interop (W3C VC + JWT) round-trip: fold fields survive + verify
+# =============================================================================
+
+
+def _w3c_roundtrip(
+    record: DelegationRecord, private_key, public_key
+) -> DelegationRecord:
+    """Round a signed delegation through the real W3C VC export/import user path.
+
+    The VC PROOF is signed/verified with the issuer keypair (here reused as the
+    delegation keypair); the delegation's OWN Ed25519 signature is what the caller
+    re-verifies after import.
+    """
+    vc = w3c_vc.export_as_verifiable_credential(
+        _chain_with(record), issuer_did="did:eatp:org:acme", signing_key=private_key
+    )
+    restored_chain = w3c_vc.import_from_verifiable_credential(vc, public_key=public_key)
+    (restored,) = restored_chain.delegations
+    return restored
+
+
+def test_v2_record_survives_w3c_vc_roundtrip() -> None:
+    """A v2 record round-tripped through the W3C VC export/import path verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v2_record(), private_key)
+
+    restored = _w3c_roundtrip(record, private_key, public_key)
+
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v2 delegation signature invalid after W3C VC round-trip"
+
+
+def test_v3_record_survives_w3c_vc_roundtrip() -> None:
+    """A v3 record round-tripped through the W3C VC export/import path verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v3_record(), private_key)
+
+    restored = _w3c_roundtrip(record, private_key, public_key)
+
+    assert restored.multi_sig is True
+    assert restored.multi_sig_policy == record.multi_sig_policy
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v3 delegation signature invalid after W3C VC round-trip"
+
+
+def test_v2_record_survives_jwt_roundtrip() -> None:
+    """A v2 record round-tripped through the JWT serializer verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v2_record(), private_key)
+
+    serialized = jwt_interop._serialize_delegation(record)
+    restored = jwt_interop._deserialize_delegation(serialized)
+
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v2 delegation signature invalid after JWT round-trip"
+
+
+def test_v3_record_survives_jwt_roundtrip() -> None:
+    """A v3 record round-tripped through the JWT serializer verifies (quorum bound)."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v3_record(), private_key)
+
+    serialized = jwt_interop._serialize_delegation(record)
+    restored = jwt_interop._deserialize_delegation(serialized)
+
+    assert restored.multi_sig is True
+    assert restored.multi_sig_policy == record.multi_sig_policy
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v3 delegation signature invalid after JWT round-trip"
+
+
+def test_v2_record_survives_ucan_roundtrip() -> None:
+    """A v2 record round-tripped through the UCAN serializer verifies.
+
+    UCAN preserves the ORIGINAL EATP delegation signature (``eatp_original_
+    signature``); it is a fourth same-class serializer that dropped the fold
+    fields (found via the security.md multi-site sweep, not named in the brief).
+    """
+    private_key, public_key = generate_keypair()
+    record = _signed(_v2_record(), private_key)
+
+    restored = from_ucan(to_ucan(record, private_key), public_key)
+
+    assert restored.constraints == record.constraints
+    assert restored.resource_limits == record.resource_limits
+    assert restored.scope == record.scope
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V2
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v2 delegation signature invalid after UCAN round-trip"
+
+
+def test_v3_record_survives_ucan_roundtrip() -> None:
+    """A v3 record round-tripped through the UCAN serializer verifies (quorum bound)."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_v3_record(), private_key)
+
+    restored = from_ucan(to_ucan(record, private_key), public_key)
+
+    assert restored.multi_sig is True
+    assert restored.multi_sig_policy == record.multi_sig_policy
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_V3
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "v3 delegation signature invalid after UCAN round-trip"
+
+
+def test_legacy_record_survives_ucan_roundtrip() -> None:
+    """A legacy record still round-trips through UCAN + verifies (byte-neutral facts)."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_legacy_record(), private_key)
+
+    token = to_ucan(record, private_key)
+    restored = from_ucan(token, public_key)
+
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    assert restored.constraints is None
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "legacy delegation signature invalid after UCAN round-trip"
+
+
+# =============================================================================
+# BYTE-NEUTRALITY — a legacy record's chain-serialized dict is UNCHANGED
+# =============================================================================
+
+
+def test_legacy_record_chain_dict_carries_no_fold_keys() -> None:
+    """A legacy record's chain-serialized delegation dict has NO fold-field keys."""
+    chain = _chain_with(_legacy_record())
+    (deleg_dict,) = chain.to_dict()["delegations"]
+
+    for absent in (
+        "constraints",
+        "resource_limits",
+        "scope",
+        "multi_sig",
+        "multi_sig_policy",
+    ):
+        assert absent not in deleg_dict, (
+            f"legacy chain-serialized delegation leaked {absent!r} — prune-when-unset "
+            "byte-neutrality violated"
+        )
+
+
+async def test_legacy_record_verifies_after_store_roundtrip(tmp_path) -> None:
+    """A legacy record still signs + round-trips through the store + verifies."""
+    private_key, public_key = generate_keypair()
+    record = _signed(_legacy_record(), private_key)
+
+    restored = await _store_roundtrip(record, tmp_path / "legacy.db")
+
+    assert restored.signing_payload_version == DELEGATION_SIGNING_VERSION_LEGACY
+    assert restored.constraints is None
+    assert restored.resource_limits is None
+    assert restored.scope is None
+    assert restored.multi_sig is False
+    assert restored.multi_sig_policy is None
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "legacy delegation signature invalid after chain round-trip"
+
+
+# =============================================================================
+# STEP 3 — from_dict consistency reject (fail-closed on a tampered record)
+# =============================================================================
+
+
+def test_deserialize_rejects_multi_sig_without_policy() -> None:
+    """A persisted chain dict with multi_sig=True but no policy → ValueError."""
+    chain_dict = _chain_with(_v3_record()).to_dict()
+    (deleg,) = chain_dict["delegations"]
+    deleg.pop("multi_sig_policy", None)  # tamper: strip the policy
+
+    with pytest.raises(ValueError, match="multi_sig"):
+        TrustLineageChain.from_dict(chain_dict)
+
+
+def test_deserialize_rejects_multi_sig_with_non_v3_version() -> None:
+    """A persisted chain dict with multi_sig=True + v2 version → ValueError."""
+    chain_dict = _chain_with(_v3_record()).to_dict()
+    (deleg,) = chain_dict["delegations"]
+    deleg["signing_payload_version"] = DELEGATION_SIGNING_VERSION_V2  # tamper
+
+    with pytest.raises(ValueError, match="multi_sig"):
+        TrustLineageChain.from_dict(chain_dict)
+
+
+def test_record_from_dict_rejects_multi_sig_without_policy() -> None:
+    """DelegationRecord.from_dict itself fails closed on the inconsistent record."""
+    record_dict = _v3_record().to_dict()
+    record_dict.pop("multi_sig_policy", None)
+
+    with pytest.raises(ValueError, match="multi_sig"):
+        DelegationRecord.from_dict(record_dict)
+
+
+# =============================================================================
+# dimension_scope faithful round-trip (same serializer, same bug class)
+# =============================================================================
+
+
+async def test_narrowed_dimension_scope_survives_store_roundtrip(tmp_path) -> None:
+    """A legacy record with a NARROWED dimension_scope round-trips + verifies.
+
+    ``to_signing_payload`` (the legacy pre-image) binds ``sorted(dimension_scope)``;
+    the chain sibling serializer historically DROPPED dimension_scope → a narrowed
+    record reloaded as ALL_DIMENSIONS → different legacy pre-image → verify False.
+    Same serializer, same faithful-round-trip class as the fold fields.
+    """
+    private_key, public_key = generate_keypair()
+    record = _signed(
+        _legacy_record(dimension_scope=frozenset({"financial", "operational"})),
+        private_key,
+    )
+    assert frozenset(record.dimension_scope) != frozenset(ALL_DIMENSIONS)
+
+    restored = await _store_roundtrip(record, tmp_path / "narrowed.db")
+
+    assert frozenset(restored.dimension_scope) == frozenset(record.dimension_scope)
+    assert verify_signature(
+        delegation_canonical_payload_str(restored), restored.signature, public_key
+    ), "narrowed-dimension_scope legacy record fails verify after store round-trip"


### PR DESCRIPTION
## Summary
Fixes a HIGH correctness break in the merged #1841 work, surfaced by the holistic post-multi-wave redteam. S2b-1/S2b-2 added the structured signing fields (`constraints`/`resource_limits`/`scope`/`multi_sig`/`multi_sig_policy`) to `DelegationRecord` and plumbed them through `DelegationRecord.to_dict`/`from_dict` — but **NOT** through the sibling serializer `TrustLineageChain._serialize_delegation`/`_deserialize_delegation` used by chain-level persistence + interop. A v2/v3 delegation round-tripped through a store (or W3C-VC / JWT / UCAN) reloaded with `signing_payload_version` set but the fold fields = `None` → `delegation_canonical_payload_str` recomputed a different pre-image → **verify returned `valid=False`**. v2/v3 signing was non-functional end-to-end through the default `SqliteTrustStore`.

Fail-*closed* (no over-permit — the security-axis holistic review confirmed no fail-open / quorum-drop), but a real feature-non-functional break (zero-tolerance R6). This is the `security.md` Multi-Site Kwarg Plumbing failure: a field plumbed through one serializer, missed on the siblings.

## Fix
- **NEW** `signing/delegation_fold_serde.py` — one shared helper owns encode + decode of the fold fields (`security.md` Pre-Encoder Consolidation), so the four serializers + `DelegationRecord` cannot drift again.
- Wired into all four serializers that round-trip a **signed** delegation: `chain.py` (the store path — `SqliteTrustStore` + `FilesystemStore` both use `chain.to_dict`/`from_dict`), `interop/w3c_vc.py`, `interop/jwt.py`, `interop/ucan.py` (found via the mandated multi-site grep). `sd_jwt.py`/`biscuit.py` excluded (capability/envelope constraints only, not signed-delegation round-trip).
- Also carries **narrowed `dimension_scope`** (same serializer dropped it; it binds into the legacy signing pre-image) → a scoped legacy record now re-verifies.
- Deserializers **fail closed** on an inconsistent persisted record (`multi_sig=True` on non-v3, or without a policy) — matching `select_signing_version`'s sign-time posture.

## Verification
- Repro suite `test_issue_1841_chain_serde_roundtrip.py`: **15 passed** (v2 + v3 verify after real `SqliteTrustStore` round-trip; W3C-VC / JWT / UCAN round-trip; consistency-reject; legacy byte-neutrality).
- **Legacy byte-neutrality confirmed** — a legacy record's serialized dict carries **no new keys** across all four serializers (prune-when-unset).
- Cross-SDK **V2C/V3 byte-pins UNCHANGED** (`-k "1841 or delegation or signing or vectors"` → 248 passed).
- Trust unit+integration 925 passed; broad chain/interop/store sweep 2189 passed; pre-commit all green. Fixed 2 pre-existing E402 in `jwt.py` surfaced by the import restructure.

## Related issues
Refs #1841 (post-merge correctness fix — makes v2/v3 delegation persistence functional end-to-end)