### PR TITLE
deprecate(kaizen): DeprecationWarning on legacy azure_ai_foundry provider path (#1720)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [Unreleased]
+
+### Deprecated
+
+- **The legacy `azure_ai_foundry` provider path is deprecated (#1720).**
+  `azure_ai_foundry` is the LAST provider still served by the legacy
+  `get_provider(...).chat(...)` fallback in
+  `LLMAgentNode._provider_llm_response` — every other provider now runs on
+  the four-axis `kaizen.llm.LlmClient`. It has no confirmed four-axis wire
+  (`kaizen.llm.deployment_resolver.resolve_deployment_for` raises
+  `UnsupportedDeploymentProvider` for it), so it stays on the legacy path.
+  When a deployment resolves to that path, the node now emits a one-time
+  `DeprecationWarning` plus a one-time `logger.warning` naming the migration.
+  The path STILL functions — this is the deprecation shim only; removal is
+  planned for a future minor release (per the deprecate-and-remove
+  disposition on #1720).
+
+  **Migration:** For Azure OpenAI models, switch from `azure_ai_foundry` to
+  the `azure` (or `azure_openai`) provider, which is fully supported on the
+  four-axis path — set `AZURE_ENDPOINT` / `AZURE_API_KEY` (the canonical
+  Azure env vars). For non-Azure-OpenAI AI Foundry models (e.g. Meta Llama,
+  Mistral, Cohere served via the AI Foundry inference endpoint) there is no
+  four-axis equivalent yet — a four-axis `azure_ai_foundry` wire is tracked
+  as future work; those deployments must wait for that wire before migrating.
+
 ## [2.38.0] — 2026-07-20 — Governance gate extended to the provider/backend layer (#1803)
 
 ### Added (Security)

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -9,6 +9,7 @@ import os
 import threading
 import time
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal
@@ -19,6 +20,16 @@ from kaizen.config.providers import DEFAULT_OPENAI_MODEL
 from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 
 logger = logging.getLogger(__name__)
+
+# #1720 — one-time deprecation guard for the legacy azure_ai_foundry provider
+# path. azure_ai_foundry is the LAST provider still served by the legacy
+# get_provider(...).chat(...) fallback (every other provider is on the
+# four-axis LlmClient). Per the deprecate-and-remove disposition, the fallback
+# STILL functions but emits a one-time DeprecationWarning + loud WARN so an
+# operator running it learns the path is being retired. Module-level flag →
+# fires once per process, never per-call (rules/observability.md — no hot-loop
+# log spam). The actual removal is a future-minor step (zero-tolerance Rule 6a).
+_AZURE_AI_FOUNDRY_DEPRECATION_WARNED = False
 
 # ---------------------------------------------------------------------------
 # #1720 Wave-2 — dual-run shadow validation (KAIZEN_LLM_DUAL_RUN)
@@ -2569,6 +2580,37 @@ Final Answer: 6 hours"""
         caller's ``except ImportError`` / ``except Exception`` handlers (invariants
         #5 and #6).
         """
+        # #1720 deprecate-and-remove: azure_ai_foundry is the LAST provider on
+        # this legacy fallback (no confirmed four-axis wire —
+        # resolve_deployment_for raises UnsupportedDeploymentProvider for it).
+        # Emit a ONE-TIME DeprecationWarning + loud WARN so an operator running
+        # the legacy path learns it is being retired. The path STILL functions
+        # (this is the deprecation shim, not the removal — zero-tolerance Rule
+        # 6a; removal follows in a future minor). Guarded on the provider name +
+        # a module-level flag so it fires once per process, never per-call
+        # (rules/observability.md — no hot-loop log spam).
+        if provider == "azure_ai_foundry":
+            global _AZURE_AI_FOUNDRY_DEPRECATION_WARNED
+            if not _AZURE_AI_FOUNDRY_DEPRECATION_WARNED:
+                _AZURE_AI_FOUNDRY_DEPRECATION_WARNED = True
+                _msg = (
+                    "The legacy 'azure_ai_foundry' provider path is deprecated "
+                    "and will be removed in a future minor release. It is the "
+                    "last provider still served by the legacy "
+                    "get_provider(...).chat(...) fallback; every other provider "
+                    "runs on the four-axis kaizen.llm.LlmClient. Migration: for "
+                    "Azure OpenAI models, switch to the 'azure' (or "
+                    "'azure_openai') provider, which is fully supported on the "
+                    "four-axis path (set AZURE_ENDPOINT / AZURE_API_KEY). For "
+                    "non-Azure-OpenAI AI Foundry models (e.g. Meta Llama, "
+                    "Mistral, Cohere served via the AI Foundry inference "
+                    "endpoint) there is no four-axis equivalent yet — a "
+                    "four-axis azure_ai_foundry wire is tracked as future work; "
+                    "such deployments must wait for that wire before migrating."
+                )
+                warnings.warn(_msg, DeprecationWarning, stacklevel=2)
+                logger.warning("llm_agent.azure_ai_foundry.deprecated %s", _msg)
+
         # #1779 governance_required posture: this is the ONLY legacy egress that
         # does NOT route through the four-axis LlmClient (providers with no
         # four-axis wire, e.g. azure_ai_foundry), so the LlmClient construction

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_azure_ai_foundry_deprecation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_azure_ai_foundry_deprecation.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1720 — legacy azure_ai_foundry provider-path deprecation shim (behavioral).
+
+`azure_ai_foundry` is the LAST provider still served by the legacy
+`get_provider(...).chat(...)` fallback in
+`LLMAgentNode._provider_llm_response` (every other provider is on the four-axis
+`kaizen.llm.LlmClient`). Per the deprecate-and-remove disposition on #1720,
+STEP 1 is the deprecation shim: when a deployment resolves to that legacy path
+the node emits a ONE-TIME `DeprecationWarning` + one-time `logger.warning`
+naming the migration, while the path STILL functions (removal is a future
+minor). These tests DRIVE the method (never grep source), Tier-1 offline +
+deterministic, following the existing B1a cutover regression conventions
+(`test_issue_1720_b1a_live_cutover.py::test_azure_ai_foundry_routes_legacy_provider_chat`):
+
+* the DeprecationWarning fires when the azure_ai_foundry legacy path is taken;
+* it fires ONCE per process, not per call (module-level `_warned` flag);
+* the legacy path STILL WORKS — the deprecation warns but does not break it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import kaizen.nodes.ai.llm_agent as llm_agent_mod
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+pytestmark = pytest.mark.regression
+
+_MSGS = [{"role": "user", "content": "What is the capital of France?"}]
+
+
+class _FoundryStub:
+    """Legacy provider stub mirroring the B1a cutover test's convention —
+    is_available() True + a deterministic chat() return in the legacy shape."""
+
+    def __init__(self) -> None:
+        self.chat_calls: list[dict] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def chat(self, **kwargs: Any) -> dict:
+        self.chat_calls.append(kwargs)
+        return {
+            "content": "legacy foundry answer",
+            "role": "assistant",
+            "model": kwargs["model"],
+            "tool_calls": [],
+            "finish_reason": "stop",
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            },
+        }
+
+
+@pytest.fixture
+def _reset_deprecation_flag():
+    """Reset the module-level one-time-warning flag so each test observes the
+    first-fire behavior deterministically regardless of collection order."""
+    original = llm_agent_mod._AZURE_AI_FOUNDRY_DEPRECATION_WARNED
+    llm_agent_mod._AZURE_AI_FOUNDRY_DEPRECATION_WARNED = False
+    try:
+        yield
+    finally:
+        llm_agent_mod._AZURE_AI_FOUNDRY_DEPRECATION_WARNED = original
+
+
+def _wire_legacy_foundry(monkeypatch, stub: _FoundryStub) -> None:
+    """Route get_provider to the stub AND make the four-axis path blow up loudly
+    if (wrongly) taken — identical to the B1a cutover test's guard."""
+    monkeypatch.setattr(
+        "kaizen.providers.registry.get_provider",
+        lambda name, **kw: stub,
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(
+            lambda cls, *a, **kw: (_ for _ in ()).throw(
+                AssertionError("four-axis path taken for azure_ai_foundry")
+            )
+        ),
+    )
+
+
+def test_deprecation_warning_fires_on_legacy_azure_ai_foundry_path(
+    monkeypatch, _reset_deprecation_flag
+):
+    """Taking the legacy azure_ai_foundry fallback emits a DeprecationWarning
+    that names the retirement + the migration."""
+    stub = _FoundryStub()
+    _wire_legacy_foundry(monkeypatch, stub)
+
+    agent = LLMAgentNode()
+    with pytest.warns(DeprecationWarning, match="azure_ai_foundry"):
+        response = agent._provider_llm_response(
+            provider="azure_ai_foundry",
+            model="phi-4",
+            messages=_MSGS,
+            tools=[],
+            generation_config={},
+        )
+
+    # Deprecation warns but does NOT break the legacy path — it still works.
+    assert response["content"] == "legacy foundry answer"
+    assert stub.chat_calls, "legacy get_provider(...).chat(...) was never called"
+
+
+def test_deprecation_warning_fires_once_not_per_call(
+    monkeypatch, _reset_deprecation_flag
+):
+    """The DeprecationWarning is guarded by a module-level flag: it fires on the
+    FIRST legacy call and stays silent on subsequent calls (no hot-loop spam)."""
+    stub = _FoundryStub()
+    _wire_legacy_foundry(monkeypatch, stub)
+    agent = LLMAgentNode()
+
+    def _call() -> None:
+        agent._provider_llm_response(
+            provider="azure_ai_foundry",
+            model="phi-4",
+            messages=_MSGS,
+            tools=[],
+            generation_config={},
+        )
+
+    # First call: exactly one azure_ai_foundry DeprecationWarning.
+    with pytest.warns(DeprecationWarning) as first:
+        _call()
+    foundry_first = [w for w in first if "azure_ai_foundry" in str(w.message)]
+    assert len(foundry_first) == 1
+
+    # Subsequent calls: the guard flag is set, so NO further warning is emitted.
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        _call()  # would raise if a second azure_ai_foundry warning fired
+        _call()
+
+    # The legacy path kept functioning across all three calls.
+    assert len(stub.chat_calls) == 3
+
+
+def test_deprecation_warning_absent_for_four_axis_providers(monkeypatch):
+    """A four-axis provider (openai) never touches the legacy fallback, so no
+    azure_ai_foundry DeprecationWarning is emitted for it."""
+
+    async def _complete(*_a: Any, **_kw: Any) -> dict:
+        return {
+            "text": "ok",
+            "stop_reason": "stop",
+            "model": "gpt-4o-mini",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    client.complete = _complete
+    monkeypatch.setattr(
+        "kaizen.llm.deployment_resolver.resolve_deployment_for",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "kaizen.llm.client.LlmClient.from_deployment_sync",
+        classmethod(lambda cls, *a, **kw: client),
+    )
+
+    import warnings
+
+    agent = LLMAgentNode()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        agent._provider_llm_response(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=_MSGS,
+            tools=[],
+            generation_config={},
+        )
+
+    assert not [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "azure_ai_foundry" in str(w.message)
+    ]


### PR DESCRIPTION
## Summary
#1720 disposition (deprecate-and-remove) — **STEP 1: deprecate**. `azure_ai_foundry` is the last provider still served by the legacy `get_provider(...).chat(...)` fallback; every other provider runs on the four-axis `LlmClient`. Per zero-tolerance Rule 6a this lands the DeprecationWarning shim + CHANGELOG migration; the actual removal is a future-minor step (tracked separately) once the shim has lived through ≥1 minor release.

## What
- One-time `DeprecationWarning` + operational `logger.warning` at `LLMAgentNode._legacy_provider_chat` (the exact + only chokepoint the `except UnsupportedDeploymentProvider:` fallback routes `azure_ai_foundry` through), guarded by a module-level flag so it fires **once per process**, not per-call (no hot-loop spam).
- **Honest, code-traced migration guidance:** Azure OpenAI models → migrate to the `azure`/`azure_openai` provider (fully supported on the four-axis path today via `AZURE_ENDPOINT`/`AZURE_API_KEY`). Non-Azure-OpenAI AI Foundry models (Llama/Mistral/Cohere) have **no four-axis equivalent yet** — the message says so honestly; those deployments wait for a future four-axis wire.
- The legacy path **still functions** (deprecation warns, does not break) until the removal minor.
- kaizen CHANGELOG "Deprecated" entry.

## Verification
- 3 regression tests: warning fires on the legacy path (+ path still returns the real answer); fires **once** not per-call; **absent** for four-axis providers. `3 passed`.
- 118 passing in the azure/provider/llm_agent regression surface — no regression; `azure_ai_foundry` + `azure`/`azure_openai` still work.
- black + ruff clean.

## Related issues
Refs #1720 (STEP 1 of deprecate-and-remove; removal tracked as a follow-up)