### PR TITLE
Release v2.39.0: kailash-kaizen google_embeddings + azure_ai_foundry deprecation

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,7 +2,40 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
-## [Unreleased]
+## [2.39.0] — 2026-07-21 — Google Gemini embeddings wire + legacy azure_ai_foundry provider deprecation (#1818, #1720)
+
+### Added
+
+- **`LlmClient.embed()` now supports Google Gemini embeddings — completes
+  the four-axis embed provider set (#1818).** The four-axis `LlmClient`
+  already had a Google CHAT wire (`google_generate_content`) but no Google
+  EMBED wire — a caller with a Gemini embedding deployment previously hit
+  `NotImplementedError` instead of a real vector (a known 2.36.0 CHANGELOG
+  gap). New module `kaizen.llm.wire_protocols.google_embeddings` shapes the
+  request/response for Gemini's `POST /v1beta/models/{model}:batchEmbedContents`
+  endpoint and is wired into `_EMBED_DISPATCH` on the shared
+  `WireProtocol.GoogleGenerateContent` wire family — Gemini serves both chat
+  and embeddings on one wire family, the same way `CohereGenerate` already
+  serves both. The endpoint is called unconditionally in batch form so one
+  shaper handles one-or-many texts, matching the "always send the list"
+  contract every other embed wire (`openai_embeddings`, `cohere_embeddings`)
+  already follows. The model travels in the URL path; each request also
+  carries the `models/`-prefixed model id the Gemini batch contract
+  requires. Reuses the existing `google_preset` auth/endpoint
+  (`X-Goog-Api-Key`, `generativelanguage.googleapis.com/v1beta`). Model and
+  key are env-sourced (`GOOGLE_EMBEDDING_MODEL` / `GOOGLE_API_KEY`), never
+  hardcoded in the wire.
+
+  `LlmClient.embed()`'s supported-wire error message now lists
+  `GoogleGenerateContent` alongside `OpenAiChat`, `OllamaNative`,
+  `CohereGenerate`, and `HuggingFaceInference`.
+
+  The end-to-end integration test
+  (`test_llmclient_embed_google_real`) runs live against Gemini when a real
+  `GOOGLE_API_KEY` is configured, and skips cleanly (rather than failing)
+  when the credential's Google Cloud project has not enabled the
+  Generative Language API — a credential-provisioning gap, not a wire
+  defect.
 
 ### Deprecated
 
@@ -26,15 +59,6 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
   Mistral, Cohere served via the AI Foundry inference endpoint) there is no
   four-axis equivalent yet — a four-axis `azure_ai_foundry` wire is tracked
   as future work; those deployments must wait for that wire before migrating.
-
-<!-- PENDING: ### Deprecated section for the azure_ai_foundry legacy-provider
-     DeprecationWarning shim (#1720, branch deprecate/1720-azure-ai-foundry-legacy,
-     under review as of 2026-07-21). DO NOT write this entry until that branch is
-     MERGED to main — every claim in it (symbol names, warning message, migration
-     path) MUST be verified against the merged code per verify-claims-before-write.md,
-     not drafted from the branch-in-review. Once merged: append a "### Deprecated"
-     section here (above this comment, still under the 2.39.0 heading) documenting
-     the shim, then delete this placeholder comment. -->
 
 ## [2.38.0] — 2026-07-20 — Governance gate extended to the provider/backend layer (#1803)
 

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -27,6 +27,15 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
   four-axis equivalent yet — a four-axis `azure_ai_foundry` wire is tracked
   as future work; those deployments must wait for that wire before migrating.
 
+<!-- PENDING: ### Deprecated section for the azure_ai_foundry legacy-provider
+     DeprecationWarning shim (#1720, branch deprecate/1720-azure-ai-foundry-legacy,
+     under review as of 2026-07-21). DO NOT write this entry until that branch is
+     MERGED to main — every claim in it (symbol names, warning message, migration
+     path) MUST be verified against the merged code per verify-claims-before-write.md,
+     not drafted from the branch-in-review. Once merged: append a "### Deprecated"
+     section here (above this comment, still under the 2.39.0 heading) documenting
+     the shim, then delete this placeholder comment. -->
+
 ## [2.38.0] — 2026-07-20 — Governance gate extended to the provider/backend layer (#1803)
 
 ### Added (Security)

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.38.0"
+version = "2.39.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.38.0"
+__version__ = "2.39.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Version-bump + CHANGELOG release-prep for **kailash-kaizen 2.39.0** — bundles two independently-merged changes into one minor release. **No source-code changes** — version anchors + CHANGELOG only.

- **kailash-kaizen 2.38.0 -> 2.39.0** (minor)
  - **Added (#1818):** `LlmClient.embed()` now supports Google Gemini embeddings via a new `google_embeddings` wire, completing the four-axis embed provider set. PR #1886.
  - **Deprecated (#1720):** the legacy `azure_ai_foundry` provider path (the last provider without a four-axis wire) now emits a one-time `DeprecationWarning` + `logger.warning` naming the migration path; the path still functions. PR #1891.

## Version-bump rationale

Minor (semver): #1818 is purely additive; #1720's deprecation shim adds a warning but does not remove or break the existing path (removal is planned for a future minor per the deprecate-and-remove disposition) — no breaking change to any existing public surface.

## Verification performed

- **#1818 claims** verified against `packages/kailash-kaizen/src/kaizen/llm/wire_protocols/google_embeddings.py` + the `client.py` `_EMBED_DISPATCH` wiring (same verification as the original prep of this entry).
- **#1720 claims verified against the MERGED code** (not carried forward from the PR description): read `packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py` — confirmed `_provider_llm_response` (line 2381) calls `_legacy_provider_chat` (line 2451/2562), confirmed the one-time `_AZURE_AI_FOUNDRY_DEPRECATION_WARNED`-gated `warnings.warn(_msg, DeprecationWarning, ...)` + `logger.warning(...)` (lines 2592-2612), and confirmed the exact migration-guidance wording in `_msg` matches the CHANGELOG's Migration paragraph verbatim.
- **CHANGELOG structure**: folded both entries into ONE `## [2.39.0]` section (`### Added` + `### Deprecated`); removed the dangling `## [Unreleased]` header the #1720 PR had introduced independently. Verified via `grep -n "^## \["` that only one `[2.39.0]` heading exists and no `[Unreleased]` remains at the top of the file.
- **Version consistency**: `packages/kailash-kaizen/pyproject.toml` and `packages/kailash-kaizen/src/kaizen/__init__.py` both read `2.39.0`; grepped for stray `2.38.0` references outside CHANGELOG history — none found.
- **Rebase self-check**: the initial rebase of the held branch onto the post-azure-merge main silently regressed kaizen's version files back to `2.38.0` (a no-op-diff artifact — the version bump was invisible to the rebase because it was unchanged between this branch's commit and its old parent). Caught and fixed before this push; verified `pyproject.toml`/`__init__.py` both now read `2.39.0` via `tomllib`/`ast.parse`.
- Diff swept for private Rust-SDK references (`kailash-rs`, org slug) and secrets/credentials — clean. Diff confirmed metadata-only: `CHANGELOG.md` + 2 version files.

## Related issues

Relates to #1818, #1720.

## Test plan

- [ ] CI green (Build Documentation + Version Consistency; full matrix auto-skips on `release/v*`)
- [ ] Awaiting human authorization for PyPI publish — **this PR does NOT publish**, per BUILD-repo release discipline (release authorization is a structural human gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)