### PR TITLE
chore(trust,docs): remove dead imports + derive Sphinx version dynamically

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,17 +7,34 @@ from the SDK's docstrings and provides interactive examples.
 """
 
 import os
+import re
 import sys
+from pathlib import Path
 
 # Add the source directory to Python path
 sys.path.insert(0, os.path.abspath("../../src"))
+
+
+def _read_version() -> str:
+    """Derive the version from the package __version__ so docs never drift.
+
+    Reads the literal ``__version__`` assignment from ``src/kailash/__init__.py``
+    without importing the package (avoids heavy import side effects at doc-build
+    time). Falls back to ``0.0.0`` only if the assignment cannot be found.
+    """
+    init = Path(__file__).resolve().parent.parent / "src" / "kailash" / "__init__.py"
+    match = re.search(
+        r'^__version__\s*=\s*["\']([^"\']+)["\']', init.read_text(), re.MULTILINE
+    )
+    return match.group(1) if match else "0.0.0"
+
 
 # Project information
 project = "Kailash Python SDK"
 copyright = "2026, Terrene Foundation"
 author = "Terrene Foundation"
-release = "2.1.0"
-version = "2.1"
+release = _read_version()
+version = ".".join(release.split(".")[:2])
 
 # General configuration
 extensions = [

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -19,7 +19,6 @@ import hmac
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -31,7 +30,6 @@ from kailash.trust.authority import (
 from kailash.trust.chain import (
     ActionResult,
     AuditAnchor,
-    AuthorityType,
     CapabilityAttestation,
     CapabilityType,
     Constraint,
@@ -57,13 +55,8 @@ from kailash.trust.exceptions import (
     TrustChainNotFoundError,
     TrustError,
     UnsupportedSigningPayloadVersionError,
-    VerificationFailedError,
 )
-from kailash.trust.execution_context import (
-    ExecutionContext,
-    HumanOrigin,
-    get_current_context,
-)
+from kailash.trust.execution_context import ExecutionContext, get_current_context
 from kailash.trust.signing.crypto import (
     hash_chain,
     serialize_for_signing,


### PR DESCRIPTION
## Summary

Clears the two pre-existing, non-blocking follow-ups surfaced during the #1841 release cycle (kailash 2.59.0). Both were correctly out of the release PRs' diff scope; fixed here rather than deferred (zero-tolerance Rule 1).

- **`trust/operations/__init__.py`** — remove 4 unused imports (`Enum`, `AuthorityType`, `VerificationFailedError`, `HumanOrigin`) flagged by ruff F401. Base-identical dead imports.
- **`docs/conf.py`** — `release`/`version` were pinned `"2.1.0"`/`"2.1"`, ~50 releases stale. Now **derived at build time** from `src/kailash/__init__.py::__version__` (read via regex, no package import) so the docs version can never drift again.

## Verification

- `ruff check` (F401) clean on the touched file; full pre-commit suite green on the diff (Black, isort, Ruff, Tier-1 unit tests all Passed).
- Module import smoke test: `from kailash.trust.operations import TrustOperations, TrustKeyManager, CapabilityRequest` → OK.
- `conf.py` derivation verified to resolve `release = 2.59.0`, `version = 2.59`.

No consumer-facing behavior or version change — internal cleanup only, no PyPI release warranted.

## Related issues

None (housekeeping surfaced by the #1841 launch ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)