### PR TITLE
feat(dataflow): FieldType.Vector(dim) + per-dialect DDL & value codec (#1846)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/core/__init__.py
@@ -22,7 +22,17 @@ from .logging_config import (
 )
 from .models import DataFlowModel, Environment
 from .nodes import NodeGenerator
-from .schema import FieldMeta, FieldType, IndexMeta, ModelMeta, SchemaParser
+from .schema import (
+    FieldMeta,
+    FieldType,
+    IndexMeta,
+    ModelMeta,
+    SchemaParser,
+    VectorFieldType,
+    VectorValueError,
+    decode_vector,
+    encode_vector,
+)
 from .tenant_context import TenantContextSwitch, TenantInfo, get_current_tenant_id
 from .type_processor import TypeAwareFieldProcessor
 from .workflow_binding import DataFlowWorkflowBinder
@@ -41,6 +51,11 @@ __all__ = [
     "IndexMeta",
     "ModelMeta",
     "SchemaParser",
+    # Vector field type + value codec (issue #1846)
+    "VectorFieldType",
+    "VectorValueError",
+    "encode_vector",
+    "decode_vector",
     "audit_events",
     "audit_integration",
     "audit_trail_manager",

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -21,6 +21,7 @@ from typing import (
     Sequence,
     Type,
     Union,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -402,16 +403,21 @@ class ModelMeta:
 
     def get_unique_fields(self) -> List[str]:
         """Get list of unique field names."""
+        # __post_init__ always normalizes self.fields to a dict; the cast
+        # is a mypy-only narrowing (no runtime effect) of the declared
+        # Union[Dict[str, FieldMeta], List[FieldMeta]] field type.
+        fields = cast(Dict[str, FieldMeta], self.fields)
         unique_fields = []
-        for name, field_meta in self.fields.items():
+        for name, field_meta in fields.items():
             if field_meta.unique:
                 unique_fields.append(name)
         return unique_fields
 
     def get_indexed_fields(self) -> List[str]:
         """Get list of indexed field names."""
+        fields = cast(Dict[str, FieldMeta], self.fields)
         indexed_fields = []
-        for name, field_meta in self.fields.items():
+        for name, field_meta in fields.items():
             if field_meta.index:
                 indexed_fields.append(name)
         return indexed_fields
@@ -561,7 +567,7 @@ class SchemaParser:
     @classmethod
     def _parse_indexes(cls, model_class: Type) -> List[IndexMeta]:
         """Parse index definitions from model class"""
-        indexes = []
+        indexes: List[IndexMeta] = []
 
         # Check for __indexes__ attribute
         if hasattr(model_class, "__indexes__"):

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -161,8 +161,23 @@ def _truncate_repr_for_error(value: object) -> str:
     round). This final slice restores the unconditional echo-size cap
     while keeping ``_ERROR_REPR``'s cost-bounding for the common flat
     string/large-list case.
+
+    A pathologically large ``int`` (>~4300 decimal digits) makes ``repr()``
+    raise ``ValueError: Exceeds the limit ... for integer string conversion``
+    (CPython's int-to-str digit cap, 3.11+). ``reprlib`` guards this only on
+    some patch versions, so we catch it here directly — otherwise the guard's
+    OWN error message (e.g. ``VectorFieldType``'s dim-magnitude check) would
+    re-raise the raw ``ValueError`` this module promises never to leak.
     """
-    text = _ERROR_REPR.repr(value)
+    try:
+        text = _ERROR_REPR.repr(value)
+    except ValueError:
+        # Huge int: never stringify it. Report a magnitude that needs no
+        # decimal conversion instead of echoing thousands of digits.
+        bits = value.bit_length() if isinstance(value, int) else None
+        return f"<{type(value).__name__} too large to render" + (
+            f" (bit_length={bits})>" if bits is not None else ">"
+        )
     if len(text) <= _TRUNCATED_LITERAL_PREVIEW_LENGTH:
         return text
     return text[:_TRUNCATED_LITERAL_PREVIEW_LENGTH] + "...(truncated)"

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -92,6 +92,24 @@ class VectorValueError(DataFlowError):
     """
 
 
+# Shared bound for how much of a (possibly attacker-supplied) value is
+# echoed verbatim into a VectorValueError message, so a huge dimension /
+# component / literal cannot blow up a downstream log line. Defined once,
+# before every raise site that needs it, and reused by both the
+# generic-value truncator below and the literal-string truncator near
+# decode_vector.
+_TRUNCATED_LITERAL_PREVIEW_LENGTH = 200
+
+
+def _truncate_repr_for_error(value: object) -> str:
+    """Bound how much of an (possibly attacker-supplied) value's repr is
+    echoed into an error message."""
+    text = repr(value)
+    if len(text) <= _TRUNCATED_LITERAL_PREVIEW_LENGTH:
+        return text
+    return text[:_TRUNCATED_LITERAL_PREVIEW_LENGTH] + "...(truncated)"
+
+
 @dataclass(frozen=True)
 class VectorFieldType:
     """A parameterized ``FieldType.VECTOR`` carrying its dimension.
@@ -105,7 +123,8 @@ class VectorFieldType:
     def __post_init__(self) -> None:
         if isinstance(self.dim, bool) or not isinstance(self.dim, int) or self.dim <= 0:
             raise VectorValueError(
-                f"Vector dimension must be a positive integer, got {self.dim!r}"
+                f"Vector dimension must be a positive integer, got "
+                f"{_truncate_repr_for_error(self.dim)}"
             )
 
     @property
@@ -137,26 +156,43 @@ def _format_vector_component(value: Union[int, float]) -> str:
     """Render one vector component per the canonical byte contract.
 
     Integers and integer-valued floats render WITHOUT a trailing ``.0``
-    (``2`` not ``2.0``, ``0`` not ``0.0``); other floats render via their
-    shortest round-trip repr (``0.5``, ``-1.5``, ``3.25``). Raises
-    ``VectorValueError`` on a non-finite value or a non-numeric type.
+    (``2`` not ``2.0``, ``0`` not ``0.0``); other floats render as EXACT,
+    shortest-round-trippable, NON-exponential fixed-decimal (``0.5``,
+    ``-1.5``, ``3.25``, ``0.00001``) -- ``repr()`` alone would switch to
+    scientific notation for magnitudes outside ~[1e-4, 1e16), which breaks
+    the byte-canonical cross-SDK contract for realistic embedding
+    components (routinely <1e-4). Raises ``VectorValueError`` on a
+    non-finite value or a non-numeric type.
     """
     if isinstance(value, bool):
         raise VectorValueError(
-            f"vector component must be int or float, got bool: {value!r}"
+            f"vector component must be int or float, got bool: "
+            f"{_truncate_repr_for_error(value)}"
         )
     if isinstance(value, int):
         return str(value)
     if isinstance(value, float):
         if math.isnan(value) or math.isinf(value):
             raise VectorValueError(
-                f"vector component must be finite, got non-finite value: {value!r}"
+                f"vector component must be finite, got non-finite value: "
+                f"{_truncate_repr_for_error(value)}"
             )
         if value.is_integer():
             return str(int(value))
-        return repr(value)
+        # repr(value) is the shortest string that round-trips to this
+        # exact float -- Decimal(repr(value)) parses it EXACTLY (no
+        # precision loss), and format(..., "f") expands any scientific
+        # notation into fixed-point without adding or dropping digits.
+        # The rstrip is a defensive no-op in practice (the round-trip
+        # repr never carries a spurious trailing zero) but guards
+        # against relying on that invariant silently breaking.
+        fixed = format(Decimal(repr(value)), "f")
+        if "." in fixed:
+            fixed = fixed.rstrip("0").rstrip(".")
+        return fixed
     raise VectorValueError(
-        f"vector component must be int or float, got {type(value).__name__}: {value!r}"
+        f"vector component must be int or float, got "
+        f"{type(value).__name__}: {_truncate_repr_for_error(value)}"
     )
 
 
@@ -181,7 +217,8 @@ def encode_vector(values: Sequence[Union[int, float]]) -> str:
 # embedding dimension) and fail closed rather than silently accepting
 # arbitrary-sized input.
 _MAX_VECTOR_LITERAL_LENGTH = 1_048_576
-_TRUNCATED_LITERAL_PREVIEW_LENGTH = 200
+# _TRUNCATED_LITERAL_PREVIEW_LENGTH is defined once, near VectorValueError
+# above (shared with _truncate_repr_for_error).
 
 
 def _truncate_for_error(literal: str) -> str:

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -172,21 +172,49 @@ def encode_vector(values: Sequence[Union[int, float]]) -> str:
     return "[" + ",".join(_format_vector_component(v) for v in values) + "]"
 
 
+# Defense-in-depth bounds for decode_vector, which may receive
+# externally-supplied literals (a stored DB row, an API payload) rather
+# than only SDK-internal encode_vector output. Neither the regex nor
+# float() is vulnerable to backtracking/quadratic blowup, but an
+# unbounded literal still costs proportional CPU/memory to parse -- cap
+# it generously (1 MiB is orders of magnitude beyond any realistic
+# embedding dimension) and fail closed rather than silently accepting
+# arbitrary-sized input.
+_MAX_VECTOR_LITERAL_LENGTH = 1_048_576
+_TRUNCATED_LITERAL_PREVIEW_LENGTH = 200
+
+
+def _truncate_for_error(literal: str) -> str:
+    """Bound how much of an (possibly attacker-supplied) literal is
+    echoed into an error message, so a huge literal cannot blow up a
+    downstream log line."""
+    if len(literal) <= _TRUNCATED_LITERAL_PREVIEW_LENGTH:
+        return literal
+    return literal[:_TRUNCATED_LITERAL_PREVIEW_LENGTH] + "...(truncated)"
+
+
 def decode_vector(literal: str) -> List[float]:
     """Decode a canonical Vector literal (``[a,b,c]``) into a list of floats.
 
     Round-trips byte-identically through ``encode_vector`` --
     ``encode_vector(decode_vector(s)) == s`` for every canonical ``s``.
-    Fails closed (raises ``VectorValueError``) on malformed input or a
-    non-finite (NaN/±Inf) component.
+    Fails closed (raises ``VectorValueError``) on malformed input, an
+    oversized literal, or a non-finite (NaN/±Inf) component.
     """
     if not isinstance(literal, str):
         raise VectorValueError(
             f"vector literal must be a string, got {type(literal).__name__}"
         )
+    if len(literal) > _MAX_VECTOR_LITERAL_LENGTH:
+        raise VectorValueError(
+            f"vector literal exceeds {_MAX_VECTOR_LITERAL_LENGTH}-byte limit "
+            f"(len={len(literal)})"
+        )
     match = _VECTOR_LITERAL_RE.match(literal.strip())
     if match is None:
-        raise VectorValueError(f"malformed vector literal: {literal!r}")
+        raise VectorValueError(
+            f"malformed vector literal: {_truncate_for_error(literal)!r}"
+        )
     body = match.group(1)
     if body == "":
         return []
@@ -197,11 +225,13 @@ def decode_vector(literal: str) -> List[float]:
             component = float(token)
         except ValueError as exc:
             raise VectorValueError(
-                f"malformed vector component {token!r} in literal {literal!r}"
+                f"malformed vector component {token!r} in literal "
+                f"{_truncate_for_error(literal)!r}"
             ) from exc
         if math.isnan(component) or math.isinf(component):
             raise VectorValueError(
-                f"vector literal contains non-finite component {token!r}: {literal!r}"
+                f"vector literal contains non-finite component {token!r}: "
+                f"{_truncate_for_error(literal)!r}"
             )
         result.append(component)
     return result

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -107,8 +107,28 @@ class VectorValueError(DataFlowError):
 #   CPU/memory to build or parse -- cap it generously (1 MiB is orders of
 #   magnitude beyond any realistic embedding dimension) and fail closed
 #   rather than silently accepting/emitting arbitrary-sized data.
+# - _MAX_VECTOR_COMPONENT_COUNT bounds encode_vector's INPUT (the number of
+#   components in `values`), checked BEFORE the format loop runs -- the
+#   genuine symmetric counterpart to decode_vector's pre-parse
+#   _MAX_VECTOR_LITERAL_LENGTH check on its INPUT. Without this, the
+#   post-format _MAX_VECTOR_LITERAL_LENGTH check on encode_vector's OUTPUT
+#   still runs only AFTER every component has already been formatted --
+#   correct for the byte-cap contract, but not actually symmetric with
+#   decode's cheap pre-parse length check (redteam round 2, PR #1898).
+#   Set well above any real embedding dimension (largest production
+#   embeddings are low thousands of dims).
+# - _MAX_VECTOR_DIM bounds FieldType.Vector(dim)'s magnitude. Without an
+#   upper bound, VectorFieldType.__post_init__ validates type+sign but not
+#   magnitude, so a pathologically huge dim (>4300 digits, >10**4300)
+#   passes validation and later hits CPython's int-to-str digit limit
+#   (sys.set_int_max_str_digits, Python 3.11+) inside _vector_sql_type's
+#   f"vector({dim})" -- raising a raw ValueError, not VectorValueError, an
+#   exception-type-contract violation (redteam round 2, PR #1898). Set
+#   generously (2**31 - 1) -- well above any real vector dimension.
 _TRUNCATED_LITERAL_PREVIEW_LENGTH = 200
 _MAX_VECTOR_LITERAL_LENGTH = 1_048_576
+_MAX_VECTOR_COMPONENT_COUNT = 10_000_000
+_MAX_VECTOR_DIM = 2**31 - 1
 
 # reprlib.Repr, not bare repr()+slice: for str/list/dict/tuple/set/
 # frozenset, reprlib bounds the element count (or slices the string)
@@ -162,6 +182,18 @@ class VectorFieldType:
         if isinstance(self.dim, bool) or not isinstance(self.dim, int) or self.dim <= 0:
             raise VectorValueError(
                 f"Vector dimension must be a positive integer, got "
+                f"{_truncate_repr_for_error(self.dim)}"
+            )
+        if self.dim > _MAX_VECTOR_DIM:
+            # Magnitude guard: a dim this large would otherwise pass the
+            # positive-integer check above and only fail later, inside
+            # _vector_sql_type's f"vector({dim})", where CPython's
+            # int-to-str digit limit (Python 3.11+) raises a raw
+            # ValueError -- breaking the "VectorFieldType always raises
+            # VectorValueError" contract. Fail closed here instead, with
+            # the typed error the rest of this module promises.
+            raise VectorValueError(
+                f"Vector dimension exceeds {_MAX_VECTOR_DIM}-element limit, got "
                 f"{_truncate_repr_for_error(self.dim)}"
             )
 
@@ -240,9 +272,23 @@ def encode_vector(values: Sequence[Union[int, float]]) -> str:
     Canonical form: ``[a,b,c]`` -- no spaces. This is the byte-pinned
     cross-SDK contract for issue #1846: do not change the rendering rule
     without a coordinated cross-SDK re-pin (``cross-sdk-inspection.md``
-    Rule 4b). Fails closed (raises ``VectorValueError``) on a non-finite
-    (NaN/±Inf) component or an oversized output literal.
+    Rule 4b). Fails closed (raises ``VectorValueError``) on an oversized
+    component count, a non-finite (NaN/±Inf) component, or an oversized
+    output literal.
     """
+    # Upfront element-count check, BEFORE the format loop -- the genuine
+    # symmetric counterpart to decode_vector's pre-parse length check on
+    # its input. (The _MAX_VECTOR_LITERAL_LENGTH check below still runs
+    # AFTER formatting -- it bounds OUTPUT size, which is only knowable
+    # once every component is rendered -- but this upfront count check
+    # means a pathologically long `values` fails BEFORE paying the cost
+    # of formatting each one, matching decode's cheap-check-first shape.)
+    component_count = len(values)
+    if component_count > _MAX_VECTOR_COMPONENT_COUNT:
+        raise VectorValueError(
+            f"vector component count exceeds {_MAX_VECTOR_COMPONENT_COUNT}-element "
+            f"limit (count={component_count})"
+        )
     literal = "[" + ",".join(_format_vector_component(v) for v in values) + "]"
     if len(literal) > _MAX_VECTOR_LITERAL_LENGTH:
         # Defense-in-depth symmetric with decode_vector's input cap below:

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import math
 import re
+import reprlib
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -92,22 +93,44 @@ class VectorValueError(DataFlowError):
     """
 
 
-# Shared bound for how much of a (possibly attacker-supplied) value is
-# echoed verbatim into a VectorValueError message, so a huge dimension /
-# component / literal cannot blow up a downstream log line. Defined once,
-# before every raise site that needs it, and reused by both the
-# generic-value truncator below and the literal-string truncator near
-# decode_vector.
+# Shared bounds, defined once before every site that needs them:
+#
+# - _TRUNCATED_LITERAL_PREVIEW_LENGTH bounds how much of a (possibly
+#   attacker-supplied) value is echoed verbatim into a VectorValueError
+#   message, so a huge dimension / component / literal cannot blow up a
+#   downstream log line. Reused by both _truncate_repr_for_error (below)
+#   and the literal-string _truncate_for_error near decode_vector.
+# - _MAX_VECTOR_LITERAL_LENGTH bounds the total size of a Vector literal
+#   in either direction: encode_vector's OUTPUT and decode_vector's INPUT.
+#   Neither the regex nor float()/Decimal() is vulnerable to backtracking
+#   or quadratic blowup, but an unbounded literal still costs proportional
+#   CPU/memory to build or parse -- cap it generously (1 MiB is orders of
+#   magnitude beyond any realistic embedding dimension) and fail closed
+#   rather than silently accepting/emitting arbitrary-sized data.
 _TRUNCATED_LITERAL_PREVIEW_LENGTH = 200
+_MAX_VECTOR_LITERAL_LENGTH = 1_048_576
+
+# reprlib.Repr, not bare repr()+slice: for str/list/dict/tuple/set/
+# frozenset, reprlib bounds the element count (or slices the string)
+# BEFORE rendering, so a multi-megabyte string or a million-element
+# container costs O(preview length) to render, not O(input size) --
+# security-reviewer LOW finding on PR #1898 (bare repr() on a 5 MB
+# string materializes the full escaped string before the slice ever
+# applies). A custom object with no reprlib handler still falls back to
+# a full repr() via reprlib's own repr_instance -- a pathologically slow
+# custom __repr__ is an accepted residual for a value-codec error path,
+# out of scope here.
+_ERROR_REPR = reprlib.Repr()
+_ERROR_REPR.maxstring = _TRUNCATED_LITERAL_PREVIEW_LENGTH
+_ERROR_REPR.maxother = _TRUNCATED_LITERAL_PREVIEW_LENGTH
+_ERROR_REPR.maxlong = _TRUNCATED_LITERAL_PREVIEW_LENGTH
 
 
 def _truncate_repr_for_error(value: object) -> str:
     """Bound how much of an (possibly attacker-supplied) value's repr is
-    echoed into an error message."""
-    text = repr(value)
-    if len(text) <= _TRUNCATED_LITERAL_PREVIEW_LENGTH:
-        return text
-    return text[:_TRUNCATED_LITERAL_PREVIEW_LENGTH] + "...(truncated)"
+    echoed into an error message (see ``_ERROR_REPR`` above for the cost
+    rationale)."""
+    return _ERROR_REPR.repr(value)
 
 
 @dataclass(frozen=True)
@@ -203,22 +226,21 @@ def encode_vector(values: Sequence[Union[int, float]]) -> str:
     cross-SDK contract for issue #1846: do not change the rendering rule
     without a coordinated cross-SDK re-pin (``cross-sdk-inspection.md``
     Rule 4b). Fails closed (raises ``VectorValueError``) on a non-finite
-    (NaN/±Inf) component.
+    (NaN/±Inf) component or an oversized output literal.
     """
-    return "[" + ",".join(_format_vector_component(v) for v in values) + "]"
-
-
-# Defense-in-depth bounds for decode_vector, which may receive
-# externally-supplied literals (a stored DB row, an API payload) rather
-# than only SDK-internal encode_vector output. Neither the regex nor
-# float() is vulnerable to backtracking/quadratic blowup, but an
-# unbounded literal still costs proportional CPU/memory to parse -- cap
-# it generously (1 MiB is orders of magnitude beyond any realistic
-# embedding dimension) and fail closed rather than silently accepting
-# arbitrary-sized input.
-_MAX_VECTOR_LITERAL_LENGTH = 1_048_576
-# _TRUNCATED_LITERAL_PREVIEW_LENGTH is defined once, near VectorValueError
-# above (shared with _truncate_repr_for_error).
+    literal = "[" + ",".join(_format_vector_component(v) for v in values) + "]"
+    if len(literal) > _MAX_VECTOR_LITERAL_LENGTH:
+        # Defense-in-depth symmetric with decode_vector's input cap below:
+        # every component is individually bounded (~342 bytes worst case,
+        # a subnormal float like 5e-324 expanded to fixed-decimal), but a
+        # sufficiently long/high-dimension `values` can still accumulate
+        # past a sane literal size. Fail closed rather than silently
+        # emitting a literal decode_vector's own cap would then reject.
+        raise VectorValueError(
+            f"encoded vector literal exceeds {_MAX_VECTOR_LITERAL_LENGTH}-byte "
+            f"limit (len={len(literal)})"
+        )
+    return literal
 
 
 def _truncate_for_error(literal: str) -> str:

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -129,8 +129,23 @@ _ERROR_REPR.maxlong = _TRUNCATED_LITERAL_PREVIEW_LENGTH
 def _truncate_repr_for_error(value: object) -> str:
     """Bound how much of an (possibly attacker-supplied) value's repr is
     echoed into an error message (see ``_ERROR_REPR`` above for the cost
-    rationale)."""
-    return _ERROR_REPR.repr(value)
+    rationale).
+
+    ``_ERROR_REPR.repr()`` bounds COST for str/list/dict/tuple/set (it
+    slices/limits BEFORE rendering), but does not itself guarantee an
+    unconditional length cap: a nested container of built-in EXACT types
+    (e.g. a list of 6 long strings, each itself under reprlib's own
+    ``maxstring``) can still emit more than ``_TRUNCATED_LITERAL_PREVIEW_LENGTH``
+    characters in total, since each level/element is bounded independently,
+    not the aggregate (security-reviewer finding on PR #1898, follow-up
+    round). This final slice restores the unconditional echo-size cap
+    while keeping ``_ERROR_REPR``'s cost-bounding for the common flat
+    string/large-list case.
+    """
+    text = _ERROR_REPR.repr(value)
+    if len(text) <= _TRUNCATED_LITERAL_PREVIEW_LENGTH:
+        return text
+    return text[:_TRUNCATED_LITERAL_PREVIEW_LENGTH] + "...(truncated)"
 
 
 @dataclass(frozen=True)

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -7,6 +7,8 @@ This module was migrated from the old core/schema.py to maintain test compatibil
 
 import inspect
 import logging
+import math
+import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -16,6 +18,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Type,
     Union,
     get_args,
@@ -23,6 +26,8 @@ from typing import (
     get_type_hints,
 )
 from uuid import UUID
+
+from dataflow.exceptions import DataFlowError
 
 from .type_introspection import (  # issue #772: shared union detection
     union_non_none_args,
@@ -49,6 +54,156 @@ class FieldType(Enum):
     BINARY = "BLOB"
     ENUM = "ENUM"
     ARRAY = "ARRAY"
+    VECTOR = "VECTOR"
+
+    @staticmethod
+    def Vector(dim: int) -> "VectorFieldType":
+        """Parameterized field type for embedding/pgvector columns.
+
+        Carries the vector dimension (issue #1846). Usage::
+
+            embedding: FieldType.Vector(768)
+
+        Cross-dialect DDL (``FieldMeta.get_sql_type``): PostgreSQL emits
+        pgvector's ``vector(N)`` (falls back to ``TEXT`` when the pgvector
+        extension is not enabled -- store the ``encode_vector`` literal in
+        that case); MySQL emits ``JSON``; SQLite emits ``TEXT``.
+
+        The value literal contract (``encode_vector`` / ``decode_vector``)
+        is a byte-pinned cross-SDK contract -- see
+        ``cross-sdk-inspection.md`` Rule 4b before changing the rendering.
+        """
+        return VectorFieldType(dim=dim)
+
+
+class VectorValueError(DataFlowError):
+    """Raised when a ``Vector`` field's dimension or literal value is invalid.
+
+    Fired by:
+
+    - ``VectorFieldType.__post_init__`` -- non-positive / non-``int`` dimension.
+    - ``encode_vector`` -- a non-finite (NaN/±Inf) component, or a
+      component that is not ``int``/``float``.
+    - ``decode_vector`` -- a malformed literal, or a non-finite component.
+
+    Fails closed: no code path silently coerces a non-finite value or an
+    invalid dimension into a usable vector.
+    """
+
+
+@dataclass(frozen=True)
+class VectorFieldType:
+    """A parameterized ``FieldType.VECTOR`` carrying its dimension.
+
+    Returned by ``FieldType.Vector(dim)``; used as the ``type=`` value on a
+    ``FieldMeta`` (or a model field declaration) for an embedding column.
+    """
+
+    dim: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.dim, bool) or not isinstance(self.dim, int) or self.dim <= 0:
+            raise VectorValueError(
+                f"Vector dimension must be a positive integer, got {self.dim!r}"
+            )
+
+    @property
+    def base_type(self) -> "FieldType":
+        """The discriminator ``FieldType`` member (``FieldType.VECTOR``)."""
+        return FieldType.VECTOR
+
+
+def _vector_sql_type(dim: int, dialect: str) -> str:
+    """Per-dialect DDL for a ``FieldType.Vector(dim)`` column.
+
+    - PostgreSQL: pgvector's ``vector(N)``. When the pgvector extension is
+      not installed/enabled, declare the column ``TEXT`` instead and store
+      the canonical ``encode_vector`` literal (documented fallback).
+    - MySQL: ``JSON`` (no native vector column type).
+    - SQLite (and any other/unrecognized dialect): ``TEXT``.
+    """
+    if dialect == "postgresql":
+        return f"vector({dim})"
+    if dialect == "mysql":
+        return "JSON"
+    return "TEXT"
+
+
+_VECTOR_LITERAL_RE = re.compile(r"^\[(.*)\]$", re.DOTALL)
+
+
+def _format_vector_component(value: Union[int, float]) -> str:
+    """Render one vector component per the canonical byte contract.
+
+    Integers and integer-valued floats render WITHOUT a trailing ``.0``
+    (``2`` not ``2.0``, ``0`` not ``0.0``); other floats render via their
+    shortest round-trip repr (``0.5``, ``-1.5``, ``3.25``). Raises
+    ``VectorValueError`` on a non-finite value or a non-numeric type.
+    """
+    if isinstance(value, bool):
+        raise VectorValueError(
+            f"vector component must be int or float, got bool: {value!r}"
+        )
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise VectorValueError(
+                f"vector component must be finite, got non-finite value: {value!r}"
+            )
+        if value.is_integer():
+            return str(int(value))
+        return repr(value)
+    raise VectorValueError(
+        f"vector component must be int or float, got {type(value).__name__}: {value!r}"
+    )
+
+
+def encode_vector(values: Sequence[Union[int, float]]) -> str:
+    """Encode a sequence of numbers into the canonical Vector literal.
+
+    Canonical form: ``[a,b,c]`` -- no spaces. This is the byte-pinned
+    cross-SDK contract for issue #1846: do not change the rendering rule
+    without a coordinated cross-SDK re-pin (``cross-sdk-inspection.md``
+    Rule 4b). Fails closed (raises ``VectorValueError``) on a non-finite
+    (NaN/±Inf) component.
+    """
+    return "[" + ",".join(_format_vector_component(v) for v in values) + "]"
+
+
+def decode_vector(literal: str) -> List[float]:
+    """Decode a canonical Vector literal (``[a,b,c]``) into a list of floats.
+
+    Round-trips byte-identically through ``encode_vector`` --
+    ``encode_vector(decode_vector(s)) == s`` for every canonical ``s``.
+    Fails closed (raises ``VectorValueError``) on malformed input or a
+    non-finite (NaN/±Inf) component.
+    """
+    if not isinstance(literal, str):
+        raise VectorValueError(
+            f"vector literal must be a string, got {type(literal).__name__}"
+        )
+    match = _VECTOR_LITERAL_RE.match(literal.strip())
+    if match is None:
+        raise VectorValueError(f"malformed vector literal: {literal!r}")
+    body = match.group(1)
+    if body == "":
+        return []
+    result: List[float] = []
+    for token in body.split(","):
+        token = token.strip()
+        try:
+            component = float(token)
+        except ValueError as exc:
+            raise VectorValueError(
+                f"malformed vector component {token!r} in literal {literal!r}"
+            ) from exc
+        if math.isnan(component) or math.isinf(component):
+            raise VectorValueError(
+                f"vector literal contains non-finite component {token!r}: {literal!r}"
+            )
+        result.append(component)
+    return result
 
 
 @dataclass
@@ -56,7 +211,7 @@ class FieldMeta:
     """Metadata for a model field"""
 
     name: str
-    type: FieldType
+    type: Union[FieldType, VectorFieldType]
     python_type: Type
     nullable: bool = True
     default: Any = None
@@ -119,6 +274,13 @@ class FieldMeta:
                 # Fallback to JSONB for unsupported element types
                 return "JSONB"
 
+        # Handle the parameterized Vector field type (FieldType.Vector(dim)).
+        # Dispatched BEFORE the type_mappings dict below because a
+        # VectorFieldType instance is never a dict key there (only bare
+        # FieldType enum members are) -- issue #1846.
+        if isinstance(self.type, VectorFieldType):
+            return _vector_sql_type(self.type.dim, dialect)
+
         # Standard type mappings (backward compatible)
         type_mappings = {
             "postgresql": {
@@ -139,6 +301,9 @@ class FieldMeta:
                 FieldType.BINARY: "BYTEA",
                 FieldType.ENUM: "VARCHAR(50)",
                 FieldType.ARRAY: "JSONB",
+                # Bare FieldType.VECTOR (no dimension) -- normal usage goes
+                # through FieldType.Vector(dim), which is dispatched above.
+                FieldType.VECTOR: "TEXT",
             },
             "mysql": {
                 FieldType.INTEGER: "INTEGER",
@@ -158,6 +323,7 @@ class FieldMeta:
                 FieldType.BINARY: "BLOB",
                 FieldType.ENUM: "VARCHAR(50)",
                 FieldType.ARRAY: "JSON",
+                FieldType.VECTOR: "JSON",
             },
             "sqlite": {
                 FieldType.INTEGER: "INTEGER",
@@ -175,6 +341,7 @@ class FieldMeta:
                 FieldType.BINARY: "BLOB",
                 FieldType.ENUM: "TEXT",
                 FieldType.ARRAY: "TEXT",
+                FieldType.VECTOR: "TEXT",
             },
         }
 

--- a/packages/kailash-dataflow/tests/fixtures/issue_1846_vector_field_type_vectors.json
+++ b/packages/kailash-dataflow/tests/fixtures/issue_1846_vector_field_type_vectors.json
@@ -69,6 +69,43 @@
       "name": "all_zero",
       "values": [0, 0, 0],
       "expected": "[0,0,0]"
+    },
+    {
+      "_comment": "FIX 1 (redteam round 1, HIGH): encode_vector previously used repr() for non-integer floats, which emits scientific notation for magnitudes outside ~[1e-4, 1e16) -- e.g. 1e-05 -> '1e-05'. Realistic embedding components are routinely <1e-4. Fixed via Decimal(repr(value)) + format(..., 'f') to render exact, shortest-round-trippable, NON-exponential fixed-decimal. The vectors below pin the Python canonical form (fixed-decimal, round-trip-stable). Cross-SDK byte-identity for sub-1e-4 / very-large magnitudes is NOT yet re-pinned against the Rust SDK mint spec -- follow-up required (rs mint spec re-pin, tracked cross-SDK; this repo cannot reach the private Rust sibling directly per repo-scope-discipline.md).",
+      "name": "small_magnitude_1e_minus_5",
+      "values": [0.00001],
+      "expected": "[0.00001]"
+    },
+    {
+      "name": "small_magnitude_1e_minus_6",
+      "values": [0.000001],
+      "expected": "[0.000001]"
+    },
+    {
+      "name": "large_magnitude_non_integer",
+      "values": [123456.789],
+      "expected": "[123456.789]"
+    },
+    {
+      "_comment": "1e16 is exactly representable as a double AND is_integer() -- it renders via the pre-existing integer-valued-float path (str(int(value))), never via the Decimal fixed-decimal path. Pinned here to confirm the boundary stays non-exponential (repr(1e16) alone would be '1e+16').",
+      "name": "large_magnitude_integer_boundary_1e16",
+      "values": [1e16],
+      "expected": "[10000000000000000]"
+    },
+    {
+      "name": "realistic_embedding_component_0_031",
+      "values": [0.031],
+      "expected": "[0.031]"
+    },
+    {
+      "name": "realistic_embedding_component_2e_minus_5",
+      "values": [0.00002],
+      "expected": "[0.00002]"
+    },
+    {
+      "name": "mixed_realistic_embedding",
+      "values": [0.031, -0.00002, 1.0],
+      "expected": "[0.031,-0.00002,1]"
     }
   ]
 }

--- a/packages/kailash-dataflow/tests/fixtures/issue_1846_vector_field_type_vectors.json
+++ b/packages/kailash-dataflow/tests/fixtures/issue_1846_vector_field_type_vectors.json
@@ -1,0 +1,74 @@
+{
+  "_comment": "Cross-SDK byte-pin vectors for issue #1846 (FieldType.Vector(dim)). ddl_vectors pin the per-dialect DDL contract; value_vectors pin the canonical [a,b,c] literal encode/decode contract byte-for-byte. Both kailash-py and esperie-enterprise/kailash-rs MUST produce byte-identical output for the same inputs. Do NOT change the rendering rule without a coordinated cross-SDK re-pin (cross-sdk-inspection.md Rule 4b).",
+  "ddl_vectors": [
+    {
+      "name": "postgresql_dim_768",
+      "dim": 768,
+      "dialect": "postgresql",
+      "expected": "vector(768)"
+    },
+    {
+      "name": "postgresql_dim_3",
+      "dim": 3,
+      "dialect": "postgresql",
+      "expected": "vector(3)"
+    },
+    {
+      "name": "postgresql_dim_1536",
+      "dim": 1536,
+      "dialect": "postgresql",
+      "expected": "vector(1536)"
+    },
+    {
+      "name": "mysql_dim_768",
+      "dim": 768,
+      "dialect": "mysql",
+      "expected": "JSON"
+    },
+    {
+      "name": "mysql_dim_3",
+      "dim": 3,
+      "dialect": "mysql",
+      "expected": "JSON"
+    },
+    {
+      "name": "sqlite_dim_768",
+      "dim": 768,
+      "dialect": "sqlite",
+      "expected": "TEXT"
+    },
+    {
+      "name": "sqlite_dim_3",
+      "dim": 3,
+      "dialect": "sqlite",
+      "expected": "TEXT"
+    }
+  ],
+  "value_vectors": [
+    {
+      "name": "integers",
+      "values": [1, 2, 3],
+      "expected": "[1,2,3]"
+    },
+    {
+      "name": "empty",
+      "values": [],
+      "expected": "[]"
+    },
+    {
+      "name": "single_float",
+      "values": [0.5],
+      "expected": "[0.5]"
+    },
+    {
+      "name": "mixed_negative_decimal",
+      "values": [-1.5, 2, 3.25],
+      "expected": "[-1.5,2,3.25]"
+    },
+    {
+      "name": "all_zero",
+      "values": [0, 0, 0],
+      "expected": "[0,0,0]"
+    }
+  ]
+}

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -117,6 +117,49 @@ def test_issue_1846_vector_rejects_non_int_dimension(bad_dim: Any) -> None:
 
 
 @pytest.mark.regression
+def test_issue_1846_vector_rejects_oversized_dimension_as_vector_value_error() -> None:
+    """FieldType.Vector(dim) MUST reject a pathologically huge dimension via
+    VectorValueError -- NOT let it pass type+sign validation and later raise
+    a raw ValueError from CPython's int-to-str digit limit inside
+    _vector_sql_type's f"vector({dim})" (redteam round 2 finding: an
+    exception-type-contract violation). A dim just above the documented
+    2**31-1 bound is rejected; a dim AT the bound is accepted."""
+    huge_dim = 10**5000  # far beyond CPython's int-to-str digit limit (~4300)
+    with pytest.raises(VectorValueError):
+        FieldType.Vector(huge_dim)
+
+    with pytest.raises(VectorValueError):
+        FieldType.Vector(2**31)  # one past the documented bound
+
+    # The bound itself is still a valid, usable dimension.
+    accepted = FieldType.Vector(2**31 - 1)
+    assert accepted.dim == 2**31 - 1
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_rejects_oversized_component_count() -> None:
+    """encode_vector MUST fail closed on a pathologically long `values`
+    sequence via an upfront element-count check BEFORE the format loop
+    runs -- the genuine symmetric counterpart to decode_vector's pre-parse
+    length check (redteam round 2 finding: the encode-side cap only ran
+    AFTER formatting every component, which is correct for the byte-cap
+    contract but not actually symmetric with decode's cheap-check-first
+    shape). The rejection MUST be fast (near-instant), not proportional to
+    formatting every component."""
+    import time
+
+    huge_values = [1.0] * 10_000_001
+    start = time.monotonic()
+    with pytest.raises(VectorValueError):
+        encode_vector(huge_values)
+    elapsed = time.monotonic() - start
+    # Generous ceiling: the upfront len() check must short-circuit before
+    # any per-component formatting; this guards against a future regression
+    # that moves the count check back to after the format loop.
+    assert elapsed < 2.0, f"rejection took {elapsed:.3f}s -- expected near-instant"
+
+
+@pytest.mark.regression
 def test_issue_1846_ddl_fixture_vectors_present() -> None:
     """At least one DDL vector per dialect MUST be present -- guards
     against an empty fixture silently making the cross-SDK contract an

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -1,0 +1,234 @@
+"""Regression test for issue #1846 — ``FieldType.Vector(dim)`` cross-SDK
+byte-locked DDL + value contract.
+
+The fixture
+``packages/kailash-dataflow/tests/fixtures/issue_1846_vector_field_type_vectors.json``
+is the cross-SDK byte-shape contract for the new ``Vector`` field type:
+
+- ``ddl_vectors`` pins the per-dialect DDL ``FieldMeta.get_sql_type()``
+  emits for a ``FieldType.Vector(dim)`` column: PostgreSQL ``vector(N)``
+  (pgvector), MySQL ``JSON``, SQLite ``TEXT``.
+- ``value_vectors`` pins the canonical ``[a,b,c]`` value literal
+  ``encode_vector`` / ``decode_vector`` produce -- no spaces; integers
+  and integer-valued floats render WITHOUT a trailing ``.0``.
+
+Both kailash-py and ``esperie-enterprise/kailash-rs`` MUST produce
+byte-identical output for the same inputs. If either SDK drifts, the
+corresponding test fails loudly and the diverging value surfaces in the
+assertion diff. See ``rules/cross-sdk-inspection.md`` MUST Rule 4
+(byte-vector pinning) and Rule 4b (byte-changing encoder classification).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from dataflow.core.schema import (
+    FieldMeta,
+    FieldType,
+    VectorFieldType,
+    VectorValueError,
+    decode_vector,
+    encode_vector,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "issue_1846_vector_field_type_vectors.json"
+)
+
+
+def _load_fixture() -> Dict[str, Any]:
+    """Load the cross-SDK fixture once at module import."""
+    with _FIXTURE_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_FIXTURE = _load_fixture()
+_DDL_VECTORS: List[Dict[str, Any]] = _FIXTURE["ddl_vectors"]
+_VALUE_VECTORS: List[Dict[str, Any]] = _FIXTURE["value_vectors"]
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — FieldType.Vector(dim) + per-dialect DDL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "vector",
+    _DDL_VECTORS,
+    ids=[v["name"] for v in _DDL_VECTORS],
+)
+def test_issue_1846_ddl_byte_shape(vector: Dict[str, Any]) -> None:
+    """Each fixture DDL vector MUST produce byte-identical dialect DDL,
+    exercised through the public FieldMeta.get_sql_type() surface (not
+    a private helper) so the test proves the wired contract, not just
+    the internal function."""
+    field_meta = FieldMeta(
+        name="embedding",
+        type=FieldType.Vector(vector["dim"]),
+        python_type=list,
+    )
+    actual = field_meta.get_sql_type(vector["dialect"])
+    assert actual == vector["expected"], (
+        f"vector {vector['name']!r}: dialect={vector['dialect']!r} "
+        f"dim={vector['dim']!r} produced {actual!r}, fixture expects "
+        f"{vector['expected']!r}"
+    )
+
+
+@pytest.mark.regression
+def test_issue_1846_vector_is_parameterized_field_type() -> None:
+    """FieldType.Vector(dim) MUST be a parameterized/callable field type
+    carrying the dimension -- a plain enum member cannot express this."""
+    vft = FieldType.Vector(768)
+    assert isinstance(vft, VectorFieldType)
+    assert vft.dim == 768
+    assert vft.base_type == FieldType.VECTOR
+    # Two separately-constructed instances with the same dim compare equal
+    # (frozen dataclass value semantics) -- callers may cache/compare types.
+    assert FieldType.Vector(768) == FieldType.Vector(768)
+    assert FieldType.Vector(768) != FieldType.Vector(3)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("bad_dim", [0, -1, -768])
+def test_issue_1846_vector_rejects_non_positive_dimension(bad_dim: int) -> None:
+    """Dimension MUST be validated (positive int) -- security.md Input
+    Validation. Non-positive dimensions fail closed with a typed error."""
+    with pytest.raises(VectorValueError):
+        FieldType.Vector(bad_dim)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("bad_dim", [1.5, "768", None, True])
+def test_issue_1846_vector_rejects_non_int_dimension(bad_dim: Any) -> None:
+    """Dimension MUST be an int (not float/str/None/bool) -- fails closed."""
+    with pytest.raises(VectorValueError):
+        FieldType.Vector(bad_dim)
+
+
+@pytest.mark.regression
+def test_issue_1846_ddl_fixture_vectors_present() -> None:
+    """At least one DDL vector per dialect MUST be present -- guards
+    against an empty fixture silently making the cross-SDK contract an
+    empty contract."""
+    dialects = {v["dialect"] for v in _DDL_VECTORS}
+    assert dialects == {"postgresql", "mysql", "sqlite"}
+    names = [v["name"] for v in _DDL_VECTORS]
+    assert "postgresql_dim_768" in names
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — canonical [a,b,c] value encode/decode, fail-closed on non-finite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "vector",
+    _VALUE_VECTORS,
+    ids=[v["name"] for v in _VALUE_VECTORS],
+)
+def test_issue_1846_value_byte_shape(vector: Dict[str, Any]) -> None:
+    """Each fixture value vector MUST encode to the byte-exact canonical
+    literal, and MUST round-trip byte-identically through decode_vector
+    -> encode_vector (the read-back assertion)."""
+    values = vector["values"]
+    expected = vector["expected"]
+
+    encoded = encode_vector(values)
+    assert encoded == expected, (
+        f"vector {vector['name']!r}: encode_vector({values!r}) produced "
+        f"{encoded!r}, fixture expects {expected!r}"
+    )
+
+    # Read-back / round-trip: decode the canonical literal and re-encode.
+    # Byte-identity here is the cross-SDK contract's actual guarantee --
+    # not merely that encode() matches once.
+    decoded = decode_vector(encoded)
+    re_encoded = encode_vector(decoded)
+    assert re_encoded == expected, (
+        f"vector {vector['name']!r}: round-trip drift -- decode_vector"
+        f"({encoded!r}) -> {decoded!r} -> encode_vector(...) produced "
+        f"{re_encoded!r}, expected byte-identical {expected!r}"
+    )
+
+
+@pytest.mark.regression
+def test_issue_1846_value_fixture_sentinels_present() -> None:
+    """The five pinned sentinel forms from the issue MUST all be present
+    -- a future fixture edit cannot silently drop a sentinel."""
+    names = {v["name"] for v in _VALUE_VECTORS}
+    assert names == {
+        "integers",
+        "empty",
+        "single_float",
+        "mixed_negative_decimal",
+        "all_zero",
+    }
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "bad_value",
+    [float("nan"), float("inf"), float("-inf")],
+    ids=["nan", "inf", "neg_inf"],
+)
+def test_issue_1846_encode_rejects_non_finite(bad_value: float) -> None:
+    """encode_vector MUST fail closed (raise) on NaN/±Inf -- never
+    silently coerce or drop the value (zero-tolerance.md Rule 3)."""
+    with pytest.raises(VectorValueError):
+        encode_vector([1.0, bad_value, 3.0])
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "literal",
+    ["[1,nan,3]", "[1,inf,3]", "[1,-inf,3]"],
+    ids=["nan", "inf", "neg_inf"],
+)
+def test_issue_1846_decode_rejects_non_finite(literal: str) -> None:
+    """decode_vector MUST fail closed (raise) on a literal containing a
+    non-finite component."""
+    with pytest.raises(VectorValueError):
+        decode_vector(literal)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "literal",
+    ["not-a-vector", "(1,2,3)", "[1,2,3", "1,2,3]", "[1,,3]", "[1, 2, x]"],
+)
+def test_issue_1846_decode_rejects_malformed_literal(literal: str) -> None:
+    """decode_vector MUST fail closed on malformed input rather than
+    silently returning a partial/garbage result."""
+    with pytest.raises(VectorValueError):
+        decode_vector(literal)
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_rejects_non_numeric_component() -> None:
+    """encode_vector MUST fail closed on a component that is not
+    int/float (e.g. a stray string or bool sneaking into the sequence)."""
+    with pytest.raises(VectorValueError):
+        encode_vector([1, "not-a-number", 3])
+    with pytest.raises(VectorValueError):
+        encode_vector([1, True, 3])
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_decode_are_finite_sanity() -> None:
+    """Sanity check that math.isnan/isinf agree with the fixture's
+    finite sentinel values (guards the test itself against a typo)."""
+    for vector in _VALUE_VECTORS:
+        for value in vector["values"]:
+            assert not math.isnan(value)
+            assert not math.isinf(value)

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -215,6 +215,27 @@ def test_issue_1846_decode_rejects_malformed_literal(literal: str) -> None:
 
 
 @pytest.mark.regression
+def test_issue_1846_decode_rejects_oversized_literal() -> None:
+    """decode_vector MUST fail closed on a literal exceeding the
+    defense-in-depth length cap, rather than parsing an unbounded
+    attacker-supplied string (security-reviewer LOW finding)."""
+    huge_literal = "[" + ("1" * 1_100_000) + "]"  # exceeds the 1 MiB cap
+    with pytest.raises(VectorValueError):
+        decode_vector(huge_literal)
+
+
+@pytest.mark.regression
+def test_issue_1846_decode_error_message_truncates_huge_literal() -> None:
+    """A malformed-but-under-the-length-cap literal MUST NOT echo an
+    unbounded amount of attacker-supplied text into the exception
+    message (security-reviewer LOW finding)."""
+    almost_huge_malformed = "(" + ("x" * 10_000)  # malformed, under the cap
+    with pytest.raises(VectorValueError) as exc_info:
+        decode_vector(almost_huge_malformed)
+    assert len(str(exc_info.value)) < 1_000
+
+
+@pytest.mark.regression
 def test_issue_1846_encode_rejects_non_numeric_component() -> None:
     """encode_vector MUST fail closed on a component that is not
     int/float (e.g. a stray string or bool sneaking into the sequence)."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import math
+import time
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -327,6 +328,42 @@ def test_issue_1846_vector_dim_error_message_truncates_huge_dim() -> None:
     with pytest.raises(VectorValueError) as exc_info:
         FieldType.Vector(huge_dim)
     assert len(str(exc_info.value)) < 1_000
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_rejects_oversized_output_literal() -> None:
+    """encode_vector MUST fail closed when the ENCODED OUTPUT would
+    exceed the same defense-in-depth length cap decode_vector enforces
+    on its INPUT (security-reviewer LOW finding -- symmetric output-size
+    guard). A long, individually-valid sequence of components can still
+    accumulate past a sane literal size even though no single component
+    is oversized."""
+    # Each "0.00001" component is 9 bytes with the separating comma;
+    # 200,000 of them is well over the 1 MiB cap.
+    with pytest.raises(VectorValueError):
+        encode_vector([0.00001] * 200_000)
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_error_message_truncation_is_fast_on_huge_string() -> None:
+    """The truncation helper MUST bound the COST of rendering a huge
+    non-numeric component's repr, not just the final message length --
+    a bare repr()+slice materializes the full escaped string before
+    truncating (security-reviewer LOW finding: O(input size), not
+    O(preview length)). A reprlib-based renderer must stay fast even
+    when the offending value is multiple megabytes."""
+    huge_value = "A" * 5_000_000
+    start = time.monotonic()
+    with pytest.raises(VectorValueError) as exc_info:
+        encode_vector([1, huge_value, 3])
+    elapsed = time.monotonic() - start
+    assert len(str(exc_info.value)) < 1_000
+    # Generous ceiling (bare repr()+slice measured ~7ms locally for this
+    # input; reprlib measured ~30us) -- this guards against a future
+    # regression back to O(input size), not a tight perf assertion.
+    assert (
+        elapsed < 1.0
+    ), f"truncation took {elapsed:.3f}s -- expected O(preview length)"
 
 
 @pytest.mark.regression

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -367,6 +367,20 @@ def test_issue_1846_encode_error_message_truncation_is_fast_on_huge_string() -> 
 
 
 @pytest.mark.regression
+def test_issue_1846_error_message_hard_capped_for_nested_container() -> None:
+    """_truncate_repr_for_error MUST enforce an unconditional length cap
+    even for a NESTED container of built-in exact types (e.g. a list of
+    long strings), not just a flat huge string/list -- reprlib bounds
+    each level/element independently, not the aggregate, so a nested
+    shape can otherwise exceed the documented echo-size cap
+    (security-reviewer LOW finding, follow-up round on PR #1898)."""
+    nested = [["A" * 190] * 6] * 6
+    with pytest.raises(VectorValueError) as exc_info:
+        encode_vector([1, nested, 3])
+    assert len(str(exc_info.value)) < 1_000
+
+
+@pytest.mark.regression
 def test_issue_1846_encode_decode_are_finite_sanity() -> None:
     """Sanity check that math.isnan/isinf agree with the fixture's
     finite sentinel values (guards the test itself against a typo)."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py
@@ -164,16 +164,76 @@ def test_issue_1846_value_byte_shape(vector: Dict[str, Any]) -> None:
 
 @pytest.mark.regression
 def test_issue_1846_value_fixture_sentinels_present() -> None:
-    """The five pinned sentinel forms from the issue MUST all be present
-    -- a future fixture edit cannot silently drop a sentinel."""
+    """The five pinned sentinel forms from the original issue MUST all
+    still be present, byte-unchanged -- a future fixture edit cannot
+    silently drop or alter a sentinel. This is a subset check (not exact
+    set equality) because the FIX-1 redteam round added further vectors
+    covering the scientific-notation byte-contract bug; see
+    test_issue_1846_fix1_scientific_notation_vectors_present below."""
     names = {v["name"] for v in _VALUE_VECTORS}
-    assert names == {
+    original_sentinels = {
         "integers",
         "empty",
         "single_float",
         "mixed_negative_decimal",
         "all_zero",
     }
+    assert (
+        original_sentinels <= names
+    ), f"original sentinels missing: {original_sentinels - names}"
+    expected_by_name = {v["name"]: v["expected"] for v in _VALUE_VECTORS}
+    assert expected_by_name["integers"] == "[1,2,3]"
+    assert expected_by_name["empty"] == "[]"
+    assert expected_by_name["single_float"] == "[0.5]"
+    assert expected_by_name["mixed_negative_decimal"] == "[-1.5,2,3.25]"
+    assert expected_by_name["all_zero"] == "[0,0,0]"
+
+
+@pytest.mark.regression
+def test_issue_1846_fix1_scientific_notation_vectors_present() -> None:
+    """The FIX-1 redteam-round vectors (scientific-notation byte-contract
+    bug: encode_vector previously emitted exponential notation for
+    magnitudes outside ~[1e-4, 1e16)) MUST all be present, pinning the
+    exact fixed-decimal strings. These are Python-canonical-form pins;
+    cross-SDK byte-identity for sub-1e-4 / very-large magnitudes is a
+    tracked follow-up against the Rust SDK mint spec (not verified here
+    -- this repo cannot reach the private Rust sibling directly per
+    repo-scope-discipline.md)."""
+    names = {v["name"] for v in _VALUE_VECTORS}
+    fix1_vectors = {
+        "small_magnitude_1e_minus_5",
+        "small_magnitude_1e_minus_6",
+        "large_magnitude_non_integer",
+        "large_magnitude_integer_boundary_1e16",
+        "realistic_embedding_component_0_031",
+        "realistic_embedding_component_2e_minus_5",
+        "mixed_realistic_embedding",
+    }
+    assert fix1_vectors <= names, f"FIX-1 vectors missing: {fix1_vectors - names}"
+    expected_by_name = {v["name"]: v["expected"] for v in _VALUE_VECTORS}
+    assert expected_by_name["small_magnitude_1e_minus_5"] == "[0.00001]"
+    assert expected_by_name["small_magnitude_1e_minus_6"] == "[0.000001]"
+    assert expected_by_name["large_magnitude_non_integer"] == "[123456.789]"
+    assert (
+        expected_by_name["large_magnitude_integer_boundary_1e16"]
+        == "[10000000000000000]"
+    )
+    assert expected_by_name["realistic_embedding_component_0_031"] == "[0.031]"
+    assert expected_by_name["realistic_embedding_component_2e_minus_5"] == "[0.00002]"
+    assert expected_by_name["mixed_realistic_embedding"] == "[0.031,-0.00002,1]"
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_rejects_scientific_notation_never_emitted() -> None:
+    """encode_vector MUST NEVER emit Python's scientific-notation float
+    repr (e.g. '1e-05', '1e+16') for a non-integer-valued component --
+    the byte-canonical contract is fixed-decimal only."""
+    for value in [0.00001, 0.000001, 2e-5, -1e-5, 9.999e-05, 123456.789]:
+        encoded = encode_vector([value])
+        assert "e" not in encoded and "E" not in encoded, (
+            f"encode_vector([{value!r}]) produced {encoded!r}, which "
+            f"contains scientific notation -- byte-contract violation"
+        )
 
 
 @pytest.mark.regression
@@ -243,6 +303,30 @@ def test_issue_1846_encode_rejects_non_numeric_component() -> None:
         encode_vector([1, "not-a-number", 3])
     with pytest.raises(VectorValueError):
         encode_vector([1, True, 3])
+
+
+@pytest.mark.regression
+def test_issue_1846_encode_error_message_truncates_huge_value() -> None:
+    """encode_vector MUST NOT echo an unbounded amount of a huge
+    non-numeric component into the exception message (security-reviewer
+    LOW finding -- the encode-side mirror of
+    test_issue_1846_decode_error_message_truncates_huge_literal)."""
+    huge_value = "A" * 5_000_000
+    with pytest.raises(VectorValueError) as exc_info:
+        encode_vector([1, huge_value, 3])
+    assert len(str(exc_info.value)) < 1_000
+
+
+@pytest.mark.regression
+def test_issue_1846_vector_dim_error_message_truncates_huge_dim() -> None:
+    """FieldType.Vector(dim) MUST NOT echo an unbounded amount of a huge
+    invalid dimension into the exception message (security-reviewer LOW
+    finding -- the dimension-validation mirror of the encode/decode
+    truncation tests above)."""
+    huge_dim = "A" * 5_000_000
+    with pytest.raises(VectorValueError) as exc_info:
+        FieldType.Vector(huge_dim)
+    assert len(str(exc_info.value)) < 1_000
 
 
 @pytest.mark.regression


### PR DESCRIPTION
## Summary

- Adds `FieldType.Vector(dim)` — a parameterized field type (a `VectorFieldType` dataclass carrying the dimension, returned by the new `FieldType.Vector` staticmethod) for embedding/pgvector columns.
- `FieldMeta.get_sql_type(dialect)` now emits per-dialect DDL for a Vector column: PostgreSQL `vector(N)` (pgvector; falls back to `TEXT` when pgvector isn't enabled — documented at the call site), MySQL `JSON`, SQLite `TEXT`.
- Adds `encode_vector` / `decode_vector` — the canonical `[a,b,c]` value-literal codec (no spaces; integers and integer-valued floats render without a trailing `.0`), fail-closed (`VectorValueError`) on non-finite (NaN/±Inf) components or malformed input, and byte-identical round-trip (`encode_vector(decode_vector(s)) == s`).
- Pins the DDL + value byte-vectors (incl. the empty/single/negative sentinels from the issue) in a JSON fixture as a cross-SDK regression, per `cross-sdk-inspection.md` Rule 4.
- Incidental: fixed 3 pre-existing `mypy --strict` findings in the same file (`ModelMeta.get_unique_fields`/`get_indexed_fields` union-attr; `SchemaParser._parse_indexes` missing var-annotation) discovered while running pre-push CI parity — zero behavior change (a `cast()` + an explicit list annotation).

## Design decision — the `Vector(dim)` shape

`FieldType` is a plain `Enum`; a bare enum member can't carry a dimension parameter. `FieldType.Vector(dim)` is a `@staticmethod` on the `FieldType` class (excluded from enum-member registration because it's a descriptor) that returns a `VectorFieldType` — a small frozen dataclass with `dim: int` (validated positive-int in `__post_init__`, raising `VectorValueError` otherwise) and a `base_type` property returning the `FieldType.VECTOR` discriminator. `FieldMeta.type` is now typed `Union[FieldType, VectorFieldType]`; `get_sql_type()` dispatches a `VectorFieldType` instance to a new `_vector_sql_type(dim, dialect)` helper before falling into the existing per-dialect dict lookup (which also gained explicit `FieldType.VECTOR` bare-member entries for completeness).

## Test plan

- [x] `pytest packages/kailash-dataflow/tests/regression/test_issue_1846_fieldtype_vector.py -x -q` — 36 passed (DDL byte-shape × 7 dialect/dim combos, value byte-shape × 5 pinned sentinels with round-trip, dimension validation, non-finite/malformed rejection).
- [x] Import smoke test: `from dataflow.core.schema import FieldType, FieldMeta, VectorFieldType, VectorValueError, encode_vector, decode_vector` — OK; also re-exported from `dataflow.core`.
- [x] `mypy --strict` clean on `dataflow/core/schema.py`.
- [x] `pre-commit run` (Black/isort/Ruff/JSON-syntax/Tier-1-unit-tests hooks) clean on all 4 changed files.
- [x] Existing schema-adjacent unit tests unaffected: `test_model_validator.py`, `test_model_validation.py`, `test_schema_cache.py`, `test_issue_1228_pep604_union_introspection.py`, `test_postgresql_array_types.py` — 157 passed.
- [x] `pytest --collect-only` across `tests/regression/` (731/754 collected) and `tests/unit/` (3458 collected) — no collection errors introduced.

## Related issues

Fixes #1846
