### PR TITLE
release(dataflow): 2.19.0 — FieldType.Vector(dim) (#1846)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [2.19.0] — 2026-07-21 — FieldType.Vector(dim) embedding column type (#1846)
+
+### Added
+
+- **`FieldType.Vector(dim)` — a parameterized embedding/pgvector column type
+  (#1846; cross-SDK byte-locked with the Rust SDK).** Per-dialect DDL emission
+  (PostgreSQL `vector(N)` via pgvector, with a documented `TEXT` fallback when
+  the extension is off; SQLite `TEXT`; MySQL `JSON`) plus a canonical `[a,b,c]`
+  value codec (`encode_vector` / `decode_vector`) that emits **fixed-decimal,
+  never scientific notation** (so real embedding magnitudes below `1e-4`
+  round-trip byte-identically), and **fails closed** with a typed
+  `VectorValueError` on non-finite values (`NaN`/`±Inf`, any spelling), a
+  non-positive / non-int / out-of-range dimension, or an oversized input.
+  New public symbols (re-exported from `dataflow.core`): `FieldType.Vector`,
+  `FieldType.VECTOR`, `VectorFieldType`, `VectorValueError`, `encode_vector`,
+  `decode_vector`. Byte-pinned cross-SDK regression vectors ship under
+  `tests/fixtures/issue_1846_vector_field_type_vectors.json`.
+
 ## [2.18.0] — 2026-07-14 — Complete token-based DB auth across every connection path (#1741)
 
 ### Added

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.18.0"
+version = "2.19.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.18.0"
+__version__ = "2.19.0"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Release-prep (metadata-only: version anchors + CHANGELOG) for kailash-dataflow 2.19.0 — the FieldType.Vector(dim) embedding column type (#1846, merged to main). Tag `dataflow-v2.19.0` after merge triggers the OIDC publish workflow.

## Related issues
Refs #1846.