### PR TITLE
docs: sync version references to kaizen 2.40.0 + dataflow 2.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@
 +------------------------------------------------------------------+
 |                    Application Frameworks                         |
 |                                                                   |
-|   Kaizen v2.3.0          Nexus v1.5.0        DataFlow v1.2.0     |
+|   Kaizen v2.40.0         Nexus v2.14.0       DataFlow v2.19.0    |
 |   AI Agents              Multi-Channel        Zero-Config DB      |
 |   CARE/EATP Trust        API + CLI + MCP      @db.model           |
 |   Multi-Agent Coord.     Auth + RBAC          11 Nodes/Model      |
 +------------------------------------------------------------------+
-|                    Core SDK v2.1.0                                 |
+|                    Core SDK v2.59.0                                 |
 |                                                                   |
 |   140+ Nodes    |  WorkflowBuilder   |  Runtime (Sync + Async)   |
 |   MCP Server    |  Cyclic Workflows  |  CARE Trust Layer          |
@@ -331,6 +331,7 @@ One decorator generates 11 database operation nodes per model. Supports PostgreS
 
 ```python
 from dataflow import DataFlow
+from dataflow.core import FieldType
 
 db = DataFlow("sqlite:///app.db")
 
@@ -340,11 +341,18 @@ class User:
     name: str
     email: str
 
+@db.model
+class Document:
+    id: str
+    embedding: FieldType.Vector(1536)  # pgvector column on PostgreSQL, TEXT elsewhere
+
 # Automatically generated:
 # UserCreateNode, UserReadNode, UserUpdateNode, UserDeleteNode,
 # UserListNode, UserCountNode, UserUpsertNode,
 # UserBulkCreateNode, UserBulkUpdateNode, UserBulkDeleteNode, UserBulkUpsertNode
 ```
+
+`FieldType.Vector(dim)` is a parameterized embedding column type -- `vector(N)` via pgvector on PostgreSQL (with a documented `TEXT` fallback when the extension is off), `TEXT` on SQLite, `JSON` on MySQL. Values encode/decode through a canonical `[a,b,c]` codec that never emits scientific notation (small embedding magnitudes round-trip byte-identically) and fails closed on non-finite values or a malformed dimension.
 
 `pip install kailash-dataflow` | [Repository](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-dataflow) | [Documentation](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-dataflow#readme)
 
@@ -387,7 +395,7 @@ if result.allowed:
 
 ## Key Features
 
-### Core SDK (v0.12.5)
+### Core SDK (v2.59.0)
 
 - **140+ production nodes**: AI, API, code execution, data, database, file, logic, monitoring, transform
 - **Runtime parity**: `LocalRuntime` (sync) and `AsyncLocalRuntime` (async) with identical return structures
@@ -400,15 +408,15 @@ if result.allowed:
 
 ### Ecosystem Frameworks
 
-| Framework                                                                                        | Version | Key Capabilities                                                                                                     |
-| ------------------------------------------------------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| [Kaizen](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-kaizen)     | v2.20.0 | Signature-based AI agents, multi-agent coordination, CARE/EATP trust, FallbackRouter, MCP sessions                   |
-| [Nexus](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-nexus)       | v2.6.2  | Multi-channel deploy (API+CLI+MCP), handler pattern, NexusAuthPlugin, presets, middleware API                        |
-| [DataFlow](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-dataflow) | v2.8.1  | 11 nodes per model, PostgreSQL/MySQL/SQLite parity, auto-wired multi-tenancy, async transactions, append-only models |
-| [MCP](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-mcp)           | v0.2.12 | Production-ready MCP client/server, transports (stdio/SSE/HTTP), service discovery                                   |
-| [PACT](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-pact)         | v0.11.0 | Governance — D/T/R addressing, envelopes, clearance, verification gradient                                           |
-| [ML](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-ml)             | v1.7.2  | ML lifecycle — feature stores, model registry, AutoML, drift detection                                               |
-| [Align](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-align)       | v0.7.0  | LLM fine-tuning + alignment (DPO/SFT/LoRA), GGUF export, Ollama/vLLM serving                                         |
+| Framework                                                                                        | Version | Key Capabilities                                                                                                                            |
+| ------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Kaizen](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-kaizen)     | v2.40.0 | Signature-based AI agents, multi-agent coordination, CARE/EATP trust, FallbackRouter, MCP sessions                                          |
+| [Nexus](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-nexus)       | v2.14.0 | Multi-channel deploy (API+CLI+MCP), handler pattern, NexusAuthPlugin, presets, middleware API                                               |
+| [DataFlow](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-dataflow) | v2.19.0 | 11 nodes per model, PostgreSQL/MySQL/SQLite parity, auto-wired multi-tenancy, async transactions, `FieldType.Vector(dim)` embedding columns |
+| [MCP](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-mcp)           | v0.4.2  | Production-ready MCP client/server, transports (stdio/SSE/HTTP), service discovery                                                          |
+| [PACT](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-pact)         | v0.16.1 | Governance — D/T/R addressing, envelopes, clearance, verification gradient                                                                  |
+| [ML](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-ml)             | v2.2.2  | ML lifecycle — feature stores, model registry, AutoML, drift detection                                                                      |
+| [Align](https://github.com/terrene-foundation/kailash-py/tree/main/packages/kailash-align)       | v0.7.4  | LLM fine-tuning + alignment (DPO/SFT/LoRA), GGUF export, Ollama/vLLM serving                                                                |
 
 ---
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,7 +2,7 @@
 Getting Started
 ===============
 
-Welcome to the Kailash SDK v2.55.0. This guide walks you through core concepts and
+Welcome to the Kailash SDK v2.59.0. This guide walks you through core concepts and
 patterns you will use in every Kailash project.
 
 Prerequisites
@@ -210,14 +210,14 @@ The Core SDK is always available. Frameworks build on top of it for specific use
    * - **Core SDK**
      - Custom workflows, fine-grained control
      - ``pip install kailash``
-   * - **Kaizen** (v1.2.5)
+   * - **Kaizen** (v2.40.0)
      - AI agents, signatures, multi-agent teams
      - ``pip install kailash-kaizen``
-   * - **Nexus** (v1.4.2)
+   * - **Nexus** (v2.14.0)
      - Multi-channel (API + CLI + MCP)
      - ``pip install kailash-nexus``
-   * - **DataFlow** (v0.12.4)
-     - Database operations, auto-generated nodes
+   * - **DataFlow** (v2.19.0)
+     - Database operations, auto-generated nodes, ``FieldType.Vector(dim)`` embeddings
      - ``pip install kailash-dataflow``
 
 All frameworks use the same underlying workflow execution:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Kailash SDK Documentation
    :target: https://www.python.org/downloads/
    :alt: Python Version
 
-.. image:: https://img.shields.io/badge/version-2.55.0-green.svg
+.. image:: https://img.shields.io/badge/version-2.59.0-green.svg
    :alt: SDK Version
 
 .. image:: https://img.shields.io/badge/trust-CARE%20%2F%20EATP-blueviolet.svg
@@ -20,7 +20,7 @@ workflows with cryptographic trust chains, multi-channel deployment, and zero-co
 database operations. From a single workflow to orchestrated multi-agent systems, Kailash
 provides the foundation for verifiable, auditable AI applications.
 
-**Current Release: v0.12.5** (Core SDK) | DataFlow v0.12.4 | Nexus v1.4.2 | Kaizen v1.2.5
+**Current Release: v2.59.0** (Core SDK) | DataFlow v2.19.0 | Nexus v2.14.0 | Kaizen v2.40.0
 
 Quick Links
 -----------
@@ -34,9 +34,9 @@ Quick Links
    :doc:`CARE trust chains <core/trust>`.
 
 **Frameworks**
-   - **Kaizen** (v1.2.5): :doc:`AI agents <frameworks/kaizen>` with signatures, multi-agent coordination, and CARE trust
-   - **Nexus** (v1.4.2): :doc:`Multi-channel platform <frameworks/nexus>` -- API + CLI + MCP from one codebase
-   - **DataFlow** (v0.12.4): :doc:`Zero-config database <frameworks/dataflow>` with 11 auto-generated nodes per model
+   - **Kaizen** (v2.40.0): :doc:`AI agents <frameworks/kaizen>` with signatures, multi-agent coordination, and CARE trust
+   - **Nexus** (v2.14.0): :doc:`Multi-channel platform <frameworks/nexus>` -- API + CLI + MCP from one codebase
+   - **DataFlow** (v2.19.0): :doc:`Zero-config database <frameworks/dataflow>` with 11 auto-generated nodes per model, including `FieldType.Vector(dim)` embedding columns
 
 **Enterprise**
    :doc:`Security <enterprise/security>`, :doc:`compliance <enterprise/compliance>`,

--- a/packages/kailash-dataflow/README.md
+++ b/packages/kailash-dataflow/README.md
@@ -342,6 +342,7 @@ class User:  # Same name, different instance - works!
 - **Deferred Schema Operations**: Better performance with lazy table creation (v0.4.7+)
 - **Vector Similarity Search**: PostgreSQL pgvector support for semantic search, RAG, and AI applications (v0.6.0+)
 - **MongoDB Document Database**: Complete NoSQL support with flexible schema, aggregation pipelines, and 8 specialized workflow nodes (v0.6.0+)
+- **`FieldType.Vector(dim)` Embedding Columns** (v2.19.0+): a declarative, parameterized embedding column type for `@db.model` fields — `vector(N)` DDL via pgvector on PostgreSQL (documented `TEXT` fallback when the extension is off), `TEXT` on SQLite, `JSON` on MySQL. A canonical `[a,b,c]` value codec (`encode_vector`/`decode_vector`) emits fixed-decimal notation (never scientific, so small embedding magnitudes round-trip byte-identically) and fails closed with `VectorValueError` on non-finite values or an invalid dimension. Cross-SDK byte-locked with the Rust SDK.
 
 ### ⚠️ Current Limitations
 

--- a/packages/kailash-kaizen/README.md
+++ b/packages/kailash-kaizen/README.md
@@ -11,6 +11,7 @@ Kaizen transforms AI agent development through **signature-based programming** a
 ### Core Value Propositions
 
 **Traditional AI Agent Development:**
+
 ```python
 # Build everything from scratch
 class MyAgent:
@@ -26,6 +27,7 @@ class MyAgent:
 ```
 
 **Kaizen Signature-Based Development:**
+
 ```python
 from kaizen.core.base_agent import BaseAgent
 from kaizen.signatures import Signature, InputField, OutputField
@@ -53,6 +55,7 @@ class MyAgent(BaseAgent):
 ```
 
 **Key Benefits:**
+
 - **Unified Architecture**: BaseAgent provides common infrastructure (87% code reduction)
 - **Type-Safe Signatures**: Define inputs/outputs, framework handles validation
 - **Auto-Optimization**: Automatic async execution, lazy initialization, performance tracking
@@ -68,11 +71,11 @@ class MyAgent(BaseAgent):
 ### Installation
 
 ```bash
-# Install Kaizen framework (latest v0.7.0)
+# Install Kaizen framework (latest v2.40.0)
 pip install kailash-kaizen
 
 # Or specific version
-pip install kailash-kaizen==0.7.0
+pip install kailash-kaizen==2.40.0
 ```
 
 ### Your First Agent (3 Steps)
@@ -176,6 +179,7 @@ class SimpleQAAgent(BaseAgent):
 ### What BaseAgent Provides
 
 **Automatic Features** (inherited by all agents):
+
 1. **Config Auto-Extraction**: Converts domain config → BaseAgentConfig
 2. **Async Execution**: AsyncSingleShotStrategy for 2-3x performance improvement
 3. **Error Handling**: Automatic retries, timeouts, graceful degradation
@@ -186,6 +190,7 @@ class SimpleQAAgent(BaseAgent):
 8. **Workflow Generation**: `to_workflow()` for Core SDK integration
 
 **Code Reduction:**
+
 - Traditional agent: ~496 lines
 - BaseAgent-based: ~65 lines
 - **87% reduction** with more features
@@ -213,6 +218,7 @@ from kaizen.agents import (
 ### Usage Examples
 
 **SimpleQAAgent - Question Answering:**
+
 ```python
 from kaizen.agents import SimpleQAAgent
 from kaizen.agents.specialized.simple_qa import SimpleQAConfig
@@ -225,6 +231,7 @@ print(result["confidence"])  # 0.95
 ```
 
 **ChainOfThoughtAgent - Step-by-Step Reasoning:**
+
 ```python
 from kaizen.agents import ChainOfThoughtAgent
 from kaizen.agents.specialized.chain_of_thought import ChainOfThoughtConfig
@@ -237,6 +244,7 @@ print(result["final_answer"])     # "8 apples"
 ```
 
 **VisionAgent - Image Analysis:**
+
 ```python
 from kaizen.agents import VisionAgent, VisionAgentConfig
 
@@ -252,6 +260,7 @@ print(result['answer'])  # "$42.99"
 ```
 
 **TranscriptionAgent - Audio Transcription:**
+
 ```python
 from kaizen.agents import TranscriptionAgent, TranscriptionAgentConfig
 
@@ -399,15 +408,19 @@ agent = BaseAgent(
 ### 12 Builtin Tools
 
 **File Operations (5 tools):**
+
 - `read_file`, `write_file`, `delete_file`, `list_directory`, `file_exists`
 
 **HTTP Requests (4 tools):**
+
 - `http_get`, `http_post`, `http_put`, `http_delete`
 
 **System Operations (1 tool):**
+
 - `bash_command`
 
 **Web Scraping (2 tools):**
+
 - `fetch_url`, `extract_links`
 
 ### Tool Discovery and Execution
@@ -436,6 +449,7 @@ results = await agent.execute_tool_chain([
 ### Approval Workflows
 
 Tools are classified by danger level:
+
 - **SAFE**: Auto-approved (no side effects) - `list_directory`, `file_exists`
 - **LOW**: Read-only operations - `read_file`, `http_get`
 - **MEDIUM**: Data modification - `write_file`, `http_post`
@@ -798,6 +812,7 @@ examples/
 ## ⚠️ Common Mistakes
 
 ### 1. Missing .env Configuration
+
 ```python
 # ❌ WRONG: Not loading environment variables
 from kaizen.agents import SimpleQAAgent
@@ -811,6 +826,7 @@ agent = SimpleQAAgent(SimpleQAConfig(llm_provider="openai"))  # Works!
 ```
 
 ### 2. Wrong Vision Agent API
+
 ```python
 # ❌ WRONG: Using 'prompt' and 'response'
 result = vision_agent.analyze(image=img, prompt="What is this?")
@@ -822,6 +838,7 @@ answer = result['answer']
 ```
 
 ### 3. Using BaseAgentConfig Directly
+
 ```python
 # ❌ WRONG: Using BaseAgentConfig directly
 from kaizen.core.config import BaseAgentConfig
@@ -836,6 +853,7 @@ agent = SimpleQAAgent(config)  # Auto-extraction happens here
 ## 🔗 Additional Resources
 
 ### Documentation
+
 - **[CLAUDE.md](CLAUDE.md)** - Quick reference for Claude Code
 - **[Examples](../../../packages/kailash-kaizen/examples/)** - 35+ working implementations
 - **[Core SDK](../../2-core-concepts/)** - Foundation patterns
@@ -843,6 +861,7 @@ agent = SimpleQAAgent(config)  # Auto-extraction happens here
 - **[Nexus](../nexus/)** - Multi-channel platform integration
 
 ### Guides
+
 - **[Installation Guide](docs/getting-started/installation.md)** - Setup and dependencies
 - **[Quickstart Tutorial](docs/getting-started/quickstart.md)** - Your first agent
 - **[Signature Programming](docs/guides/signature-programming.md)** - Type-safe I/O
@@ -851,11 +870,13 @@ agent = SimpleQAAgent(config)  # Auto-extraction happens here
 - **[Multi-Agent Coordination](docs/guides/multi-agent.md)** - A2A protocol
 
 ### Reference
+
 - **[API Reference](docs/reference/api-reference.md)** - Complete API docs
 - **[Configuration Guide](docs/reference/configuration.md)** - All config options
 - **[Troubleshooting](docs/reference/troubleshooting.md)** - Common issues
 
 ### Community
+
 - **[GitHub Repository](https://github.com/terrene-foundation/kailash-py)** - Source code and issues
 - **[Kailash SDK Documentation](../../../CLAUDE.md)** - Main SDK documentation
 

--- a/src/kailash/runtime/durable.py
+++ b/src/kailash/runtime/durable.py
@@ -1399,8 +1399,8 @@ class DurableExecutionEngine:
         :class:`~kailash.runtime.dispatcher.Dispatcher` whose ``enqueue``
         catches its own failures.
 
-        Routing — execution_mode contract (issue #882)
-        ----------------------------------------------
+        **Routing — execution_mode contract (issue #882)**
+
         The branch taken is determined by :attr:`execution_mode`:
 
         * ``"in_process_only"`` — runs in-process; skips enqueue even if


### PR DESCRIPTION
## Summary

- Updates stale framework version references (README.md, docs/index.rst,
  docs/getting_started.rst, dataflow + kaizen package READMEs) to current
  main: core kailash 2.59.0, kaizen 2.40.0, dataflow 2.19.0, nexus 2.14.0,
  mcp 0.4.2, pact 0.16.1, ml 2.2.2, align 0.7.4. Several of these were
  stale by dozens of releases (e.g. docs/index.rst cited core "v0.12.5").
- Documents the new `FieldType.Vector(dim)` embedding column type (#1846)
  in the top-level README's DataFlow section and the DataFlow package
  README's feature list.
- Fixes a pre-existing Sphinx build warning in
  `kailash.runtime.durable.DurableExecutionEngine.execute`'s docstring
  (`CRITICAL: Unexpected section title`) — an ad-hoc "Routing" sub-heading
  used a section-title underline inside a Napoleon-rendered `Notes` body,
  which docutils rejects. Converted to bold-emphasis text. **Docstring
  only — zero behavior change** (verified via `ast.parse`).

**Note on scope:** this PR touches one file under `src/kailash/` — the
docstring fix above. Everything else is doc content
(README.md/*.rst/package READMEs). No version bump; no functional/runtime
change. `cd docs && python build_docs.py` now builds with zero warnings
(previously 1 warning).

## Test plan

- [x] `cd docs && .venv/bin/python -m sphinx -b html . _build/html` — build succeeded, 0 warnings (was 1 warning before this PR)
- [x] `python3 -c "import ast; ast.parse(open('src/kailash/runtime/durable.py').read())"` — parses cleanly
- [x] Manual diff review of every version-reference edit against `packages/*/pyproject.toml::version` ground truth

## Related issues

Docs follow-up for #1846 (dataflow `FieldType.Vector(dim)`) and the kaizen 2.40.0 / dataflow 2.19.0 release wave.