### PR TITLE
docs(trust): correct constraint_subset docstring — advisory, not enforced tightening (#1896)

### DIFF
--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -276,7 +276,12 @@ class DelegationRecord:
         delegatee_id: Agent receiving trust
         task_id: Associated task identifier
         capabilities_delegated: Which capabilities are delegated
-        constraint_subset: Additional constraints (tightening only)
+        constraint_subset: Additional advisory constraint labels. Reporting-only:
+            surfaced in VerificationResult.effective_constraints but read by NO
+            allow/deny gate, and NOT part of the signed delegation pre-image.
+            The "tightening" is advisory — establish_delegation unions these
+            labels with no subset check; enforcement lives in constraint_envelope
+            (a separate, signed structure), not here. See issue #1896.
         delegated_at: When delegation occurred
         expires_at: Optional expiration
         signature: Delegator's signature


### PR DESCRIPTION
## Summary

Resolves the code half of the **#1896** audit. A definitive read-only audit (evidence in the issue-1720 workspace journal + posted to #1896) established that `DelegationRecord.constraint_subset`:

- is **read by no allow/deny gate** — every SDK-core gate keys on `.allowed`/`valid` (`runtime/base.py:505/569`, `runtime/local.py:4063`, `runtime/access_controlled.py:166/280/305`);
- is **not in the signed delegation pre-image** (`delegation_fold_serde.py` folds only `constraints`/`resource_limits`/`scope`/`multi_sig`/`multi_sig_policy`);
- has its only verify-time consumer — `VerificationResult.effective_constraints` — populated **after** `valid=True` is already decided (a reporting field read by no gate);
- is built by **union with no subset check** in `establish_delegation` (`operations/__init__.py:1867-1874`).

So the docstring's **"tightening only"** advertised an enforcement guarantee the code never performs — a deceptive-doc surface (`zero-tolerance.md` — no deceptive classification/guarantees). Corrected to describe the field accurately: an advisory, reporting-only list; real enforcement lives in the separate, signed `constraint_envelope`.

## Verification
Docstring-only; behavior-neutral. `kailash.trust.chain` + the signing modules import clean.

## Related issues
Refs #1896 (constraint_subset enforcement-link audit — verdict: ADVISORY-ONLY, no escalation via this field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)