### PR TITLE
release: kailash 2.60.0 + dataflow 2.19.1 + mcp 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.60.0] - 2026-07-21
+
+### Security (Trust Plane — constraint-enforcement store-tamper hardening)
+
+- **`verify()` now enforces constraints re-derived from signed sources, not the
+  unsigned persisted `constraint_envelope`.** The persisted envelope is an
+  unsigned derived cache covered by no signature at any verification level, so a
+  store-writer (the bounded-trust adversary the signed-revocation layer already
+  defends against) could strip an enforced constraint from a persisted chain —
+  delete a `read_only`, null the whole envelope, or strip it from a capability's
+  own constraint list — and `verify()` would enforce the weakened set,
+  escalating privilege undetected at STANDARD (the default) and FULL. `verify()`
+  now re-derives the enforced set from the signed sources (genesis metadata +
+  every capability's constraints), verifying **every** capability's Ed25519
+  signature (not only constraint-carrying ones, so a stripped-to-empty
+  capability cannot escape verification) plus the genesis signature, and failing
+  closed on any invalid signature; the persisted envelope is treated as an
+  untrusted cache. Delegation tightening is carried into signed derived
+  capabilities so it survives re-derivation. Regression tests:
+  `tests/trust/unit/test_constraint_envelope_tamper_resistance.py`. Reasoning-
+  trace requirement detection still reads the persisted policy (a lower-severity,
+  pre-existing surface tracked for the envelope-signing follow-up).
+
+### Docs
+
+- Corrected the `DelegationRecord.constraint_subset` docstring — the field is
+  advisory / reporting-only, not an enforced tightening guarantee (audit #1896).
+- Genericized private cross-SDK repository references in shipped source
+  docstrings (disclosure hygiene; behavior-neutral).
+
 ## [2.59.0] - 2026-07-21
 
 ### Added (Trust Plane — Delegation Signing)

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,13 @@
 # DataFlow Changelog
 
+## [2.19.1] - 2026-07-21
+
+### Docs
+
+- Genericized private cross-SDK repository references in shipped source
+  docstrings (`classification/masking.py`, `migration/security_definer.py`) —
+  disclosure hygiene, behavior-neutral.
+
 ## [Unreleased]
 
 ## [2.19.0] — 2026-07-21 — FieldType.Vector(dim) embedding column type (#1846)

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.19.0"
+version = "2.19.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.19.0"
+__version__ = "2.19.1"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Kailash MCP package will be documented in this file.
 
+## [0.4.3] — 2026-07-21 — Disclosure hygiene (docstrings)
+
+### Docs
+
+- Genericized private cross-SDK repository references in shipped source
+  docstrings (`auth/oauth.py`, `auth/providers.py`) — behavior-neutral.
+
 ## [0.4.2] — 2026-07-19 — Dependency pin fix: require kailash>=2.56.0
 
 ### Fixed

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.59.0"
+version = "2.60.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.59.0"
+__version__ = "2.60.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release-prep (version bumps + CHANGELOGs).

- **kailash 2.60.0** — trust-plane constraint-enforcement store-tamper hardening (#1907); docstring corrections (#1896); shipped-source disclosure hygiene (#1905).
- **kailash-dataflow 2.19.1** — F8 disclosure-hygiene docstrings (#1905).
- **kailash-mcp 0.4.3** — F8 disclosure-hygiene docstrings (#1905).

## Related issues
Closes the release of #1907 (trust security fix), #1905 (F8 disclosure), #1896 (docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)