### PR TITLE
fix(trust): close residual store-tamper vectors from 2.60.0 (2.60.1 hotfix)

### DIFF
--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -595,50 +595,54 @@ class TrustOperations:
         constraints: List[Constraint] = []
 
         # (1) Genesis-level constraints — SIGNED via genesis.to_signing_payload
-        #     (which covers ``metadata``). Verify the genesis signature before
-        #     trusting genesis.metadata["constraints"]; only when genesis
-        #     actually contributes constraints (a constraint-less genesis is not
-        #     a source, so no new signature gate for the common case).
-        genesis_constraint_names = chain.genesis.metadata.get("constraints", [])
-        if genesis_constraint_names:
-            genesis_payload = serialize_for_signing(chain.genesis.to_signing_payload())
-            try:
-                genesis_ok = await self.key_manager.verify(
-                    genesis_payload,
-                    chain.genesis.signature,
-                    authority.public_key,
+        #     (which covers the WHOLE ``metadata`` dict). Verify the genesis
+        #     signature UNCONDITIONALLY — NOT only when metadata["constraints"]
+        #     is currently non-empty. A store-writer who sets
+        #     metadata["constraints"] = [] (or drops the key) both strips the
+        #     genesis-level constraints AND, under a field-conditional check,
+        #     skips the very signature that covers metadata — so the gate must
+        #     not be keyed on the field being tampered (the genesis analogue of
+        #     the verify-EVERY-capability decision in (2) below). A signed empty-
+        #     metadata is byte-different from a signed populated one, so the
+        #     unconditional check is byte-neutral for legitimate chains. Fails
+        #     closed on any invalid signature.
+        genesis_payload = serialize_for_signing(chain.genesis.to_signing_payload())
+        try:
+            genesis_ok = await self.key_manager.verify(
+                genesis_payload,
+                chain.genesis.signature,
+                authority.public_key,
+            )
+        except InvalidSignatureError:
+            # A malformed / empty / wrong-length signature RAISES rather than
+            # returning False (mirrors _verify_capability_signature). A store-
+            # tampered genesis may carry exactly such a signature; treat it as
+            # invalid and fall through to the fail-closed denial below.
+            logger.warning(
+                "enforced-constraint derivation: genesis signature "
+                "malformed or unverifiable (fail-closed denial)",
+                extra={"genesis_id": chain.genesis.id},
+            )
+            genesis_ok = False
+        if not genesis_ok:
+            logger.warning(
+                "enforced-constraint derivation: genesis signature invalid "
+                "(fail-closed denial)",
+                extra={"genesis_id": chain.genesis.id},
+            )
+            return empty, "Genesis signature invalid — constraints untrusted"
+        # Mirror _compute_constraint_envelope's genesis construction exactly
+        # (type FINANCIAL, source "genesis") so the enforced set is byte-for-byte
+        # the legitimate set on an un-tampered chain.
+        for name in chain.genesis.metadata.get("constraints", []):
+            constraints.append(
+                Constraint(
+                    id=f"con-{uuid4()}",
+                    constraint_type=ConstraintType.FINANCIAL,
+                    value=name,
+                    source="genesis",
                 )
-            except InvalidSignatureError:
-                # A malformed / empty / wrong-length signature RAISES rather
-                # than returning False (mirrors _verify_capability_signature).
-                # A store-tampered genesis may carry exactly such a signature;
-                # treat it as invalid and fall through to the fail-closed
-                # denial below (log + deny) — never a silent swallow.
-                logger.warning(
-                    "enforced-constraint derivation: genesis signature "
-                    "malformed or unverifiable (fail-closed denial)",
-                    extra={"genesis_id": chain.genesis.id},
-                )
-                genesis_ok = False
-            if not genesis_ok:
-                logger.warning(
-                    "enforced-constraint derivation: genesis signature invalid "
-                    "(fail-closed denial)",
-                    extra={"genesis_id": chain.genesis.id},
-                )
-                return empty, "Genesis signature invalid — constraints untrusted"
-            # Mirror _compute_constraint_envelope's genesis construction exactly
-            # (type FINANCIAL, source "genesis") so the enforced set is
-            # byte-for-byte the legitimate set on an un-tampered chain.
-            for name in genesis_constraint_names:
-                constraints.append(
-                    Constraint(
-                        id=f"con-{uuid4()}",
-                        constraint_type=ConstraintType.FINANCIAL,
-                        value=name,
-                        source="genesis",
-                    )
-                )
+            )
 
         # (2) Capability-level constraints — SIGNED via cap.to_signing_payload
         #     (which covers ``constraints``). Verify EVERY capability's
@@ -654,14 +658,28 @@ class TrustOperations:
         #     STANDARD — the constraint-decision soundness cost.) Mirror
         #     _compute_constraint_envelope's capability construction (type
         #     OPERATIONAL, source "capability:<id>").
+        #     Byte-identical duplicate capabilities (a store-writer amplifying
+        #     one validly-signed cap into N copies to force O(N) Ed25519 verifies
+        #     per verify() — an availability vector, `trust-plane-security.md`
+        #     Rule 4) are verified ONCE: the dedup key is the (signed-payload,
+        #     signature) pair, so a crafted cap reusing a valid signature over
+        #     DIFFERENT content has a different key and is still verified (and
+        #     fails). Constraints are still collected from every cap instance.
+        verified_caps: set = set()
         for cap in chain.capabilities:
-            if not await self._verify_capability_signature(
-                chain, cap, authority=authority
-            ):
-                return (
-                    empty,
-                    f"Capability signature invalid — constraints untrusted: {cap.id}",
-                )
+            dedup_key = (
+                serialize_for_signing(cap.to_signing_payload()),
+                cap.signature,
+            )
+            if dedup_key not in verified_caps:
+                if not await self._verify_capability_signature(
+                    chain, cap, authority=authority
+                ):
+                    return (
+                        empty,
+                        f"Capability signature invalid — constraints untrusted: {cap.id}",
+                    )
+                verified_caps.add(dedup_key)
             for name in cap.constraints:
                 constraints.append(
                     Constraint(
@@ -1472,10 +1490,21 @@ class TrustOperations:
         Returns:
             True iff the signature is cryptographically valid.
         """
-        if authority is None:
+        # Resolve the authority that SIGNED THIS capability, keyed on the
+        # capability's own ``attester_id`` — NOT a single chain-wide genesis
+        # authority. A capability delegated into an existing chain is signed by
+        # the DELEGATOR's authority, which may differ from the delegatee chain's
+        # genesis authority; verifying every cap against the genesis authority
+        # would falsely reject a legitimately-signed cross-authority cap (denial
+        # of a legit delegatee). A pre-resolved ``authority`` is used ONLY when
+        # it matches this cap's attester (the same-authority fast path); a
+        # mismatch resolves the cap's actual attester. Falls back to the genesis
+        # authority when a cap carries no attester_id (legacy shape).
+        attester_id = getattr(cap, "attester_id", None) or chain.genesis.authority_id
+        if authority is None or getattr(authority, "id", None) != attester_id:
             try:
                 authority = await self.authority_registry.get_authority(
-                    chain.genesis.authority_id,
+                    attester_id,
                     include_inactive=True,  # historical verification
                 )
             except (AuthorityNotFoundError, AuthorityInactiveError):
@@ -1485,7 +1514,7 @@ class TrustOperations:
                     "capability signature verification failed: signing "
                     "authority unresolved (fail-closed denial)",
                     extra={
-                        "authority_id": chain.genesis.authority_id,
+                        "authority_id": attester_id,
                         "capability_id": cap.id,
                     },
                 )

--- a/tests/trust/unit/test_constraint_envelope_tamper_resistance.py
+++ b/tests/trust/unit/test_constraint_envelope_tamper_resistance.py
@@ -206,3 +206,105 @@ async def test_untampered_read_action_permitted(ops):
     await _establish_read_only(ops)
     result = await ops.verify(agent_id="agent-tamper", action="read_records")
     assert result.valid is True
+
+
+@pytest.mark.asyncio
+async def test_tamper_strip_genesis_constraint_still_denied(ops, store):
+    """GENESIS vector: strip a read_only carried at the GENESIS level.
+
+    The genesis signature covers the whole ``metadata`` dict, and the enforced-
+    set derivation verifies the genesis signature UNCONDITIONALLY (not only when
+    ``metadata['constraints']`` is currently non-empty). So a store-writer who
+    sets ``genesis.metadata['constraints'] = []`` — which both strips the
+    constraint AND invalidates the genesis signature — is caught fail-closed
+    rather than silently dropping the constraint.
+    """
+    await ops.establish(
+        agent_id="agent-gtamper",
+        authority_id="org-test",
+        capabilities=[
+            CapabilityRequest(
+                capability="write_records", capability_type=CapabilityType.ACTION
+            )
+        ],
+        metadata={"constraints": ["read_only"]},  # genesis-level constraint
+    )
+    base = await ops.verify(agent_id="agent-gtamper", action="write_records")
+    assert base.valid is False, "genesis read_only should deny the write"
+
+    chain = await store.get_chain("agent-gtamper")
+    chain.genesis.metadata["constraints"] = []  # strip (also breaks genesis sig)
+    if chain.constraint_envelope is not None:
+        chain.constraint_envelope.active_constraints = []
+    await store.store_chain(chain)
+
+    result = await ops.verify(agent_id="agent-gtamper", action="write_records")
+    assert result.valid is False, "genesis-constraint strip must NOT escalate"
+
+
+@pytest.mark.asyncio
+async def test_cross_authority_delegation_not_falsely_denied():
+    """Regression: a delegatee established under authority D, delegated into by a
+    delegator under a DIFFERENT authority G, must NOT be falsely denied.
+
+    The derived capability is signed by G's key; verifying every capability
+    against D (the delegatee chain's genesis authority) would wrongly reject the
+    legitimately-G-signed cap and deny every action. The fix resolves each
+    capability's signing authority per its own ``attester_id``.
+    """
+    priv_g, pub_g = generate_keypair()
+    priv_d, pub_d = generate_keypair()
+    km = TrustKeyManager()
+    km.register_key("key-g", priv_g)
+    km.register_key("key-d", priv_d)
+    reg = _Registry()
+    for aid, key, pub in (("auth-g", "key-g", pub_g), ("auth-d", "key-d", pub_d)):
+        reg.register(
+            OrganizationalAuthority(
+                id=aid,
+                name=aid,
+                authority_type=AuthorityType.ORGANIZATION,
+                public_key=pub,
+                signing_key_id=key,
+                permissions=[
+                    AuthorityPermission.CREATE_AGENTS,
+                    AuthorityPermission.DELEGATE_TRUST,
+                    AuthorityPermission.GRANT_CAPABILITIES,
+                ],
+            )
+        )
+    s = InMemoryTrustStore()
+    await s.initialize()
+    ops = TrustOperations(authority_registry=reg, key_manager=km, trust_store=s)
+    await ops.initialize()
+
+    await ops.establish(
+        agent_id="agent-d",
+        authority_id="auth-d",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_records", capability_type=CapabilityType.ACTION
+            )
+        ],
+    )
+    await ops.establish(
+        agent_id="delegator-g",
+        authority_id="auth-g",
+        capabilities=[
+            CapabilityRequest(
+                capability="write_records", capability_type=CapabilityType.ACTION
+            )
+        ],
+    )
+    base = await ops.verify(agent_id="agent-d", action="read_records")
+    assert base.valid is True, "agent-d should verify before the cross-auth delegation"
+
+    await ops.delegate(
+        delegator_id="delegator-g",
+        delegatee_id="agent-d",
+        task_id="t1",
+        capabilities=["write_records"],
+    )
+
+    result = await ops.verify(agent_id="agent-d", action="read_records")
+    assert result.valid is True, "cross-authority delegation must NOT falsely deny"


### PR DESCRIPTION
## Hotfix for two HIGH findings a dual-lens redteam surfaced in the 2.60.0 trust hardening (#1907)

**⚠️ Gated on the adversarial security-reviewer verdict (in progress). Correctness reviewer: CLEAN (re-verified Finding 1 with its exact probe + an adversarial follow-up).**

1. **Genesis-constraint strip (HIGH).** `_derive_enforced_envelope` verified the genesis signature *only* when `metadata["constraints"]` was non-empty, so a store-writer setting `metadata["constraints"] = []` both stripped the genesis-level constraints AND skipped the signature check that covers `metadata` — escalation at STANDARD. **Fix:** genesis signature verified **unconditionally** (byte-neutral for legit chains).

2. **Cross-authority delegation false-denial (HIGH regression).** verify() verified every capability against the delegatee chain's *single* genesis authority; a capability delegated into an existing chain is signed by the *delegator's* authority (which may differ), so a legit cross-authority delegatee was denied every action. **Fix:** `_verify_capability_signature` resolves each cap's signer per its own `attester_id` (same-authority fast path retained).

3. **Duplicate-capability DoS (MEDIUM).** Byte-identical duplicate caps now verify once (`(payload, signature)` dedup), bounding the O(N) Ed25519-verify amplification.

### Tests (the exact gaps the suite lacked)
- `test_cross_authority_delegation_not_falsely_denied`, `test_tamper_strip_genesis_constraint_still_denied` added. **3491 trust + delegate tests pass, 0 fail.**

### Documented residuals (envelope-signing follow-up — reviewer-agreed)
- Whole-capability deletion under asymmetric per-cap configs.
- Pre-2.60.0 chains that carried delegation tightening only in the unsigned `constraint_subset` lose it under signed-source enforcement (a migration would launder untrusted data, so documented not migrated).

## Related issues
Hotfix for the 2.60.0 release of #1907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)