### PR TITLE
security(trust): subject-bind capabilities + sign capability-set envelope (#1912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (Trust Plane — #1912 capability subject-binding + chain-state signing)
+
+Three coordinated waves close a capability-transplant HIGH and two store-writer
+MEDIUMs in the trust plane. The bounded-trust adversary is a store-writer with
+write access to persisted trust chains (the same threat model the signed-
+revocation layer already defends against).
+
+- **Wave 1 — capability subject-binding (HIGH).** A capability signature
+  previously bound the attester but NO holder subject, so a genuine capability
+  copied from chain A into chain B verified fine — a cross-chain transplant.
+  New capabilities are now `v1-subject-bound`: the signature covers the holder
+  chain's `genesis.agent_id`, and `verify()` recomputes the subject from the
+  chain, so a transplanted capability recomputes a different pre-image and its
+  signature no longer matches. Downgrade-resistant (stripping the version reverts
+  to the legacy no-subject pre-image, which no longer matches the v1 signature).
+  Wired through every capability sign site (establish, delegate, key rotation,
+  the CLI `establish` / `delegate` commands) and every serializer (chain-level
+  `to_dict`, JWT, W3C VC, SD-JWT) via one shared `capability_fold_serde` helper.
+
+- **Wave 2 — chain-state signature (MEDIUMs).** One Ed25519 signature by the
+  genesis authority over a deterministic chain-state pre-image
+  (`{genesis_id, sorted capability_ids, sorted delegation_ids, recomputed
+constraint_hash}`) detects **MED-1** (whole-capability-set deletion — the
+  deleted id leaves `capability_ids`) and **MED-2** (constraint /
+  `REASONING_REQUIRED` suppression — the recomputed `constraint_hash` changes).
+  The pre-image RE-COMPUTES the constraint hash from live constraints (never the
+  stored field), so a strip-without-rehash is still caught. Re-issued at every
+  chain-mutation site; verified at STANDARD+.
+
+- **Wave 3 (A1) — fail-closed enforcement + re-signing migration. ⚠️ BREAKING.**
+  `verify()` now **REJECTS** a legacy (un-subject-bound) capability and a chain
+  with NO chain-state signature by default (previously accepted-with-WARN). This
+  closes the installed-base residual — an un-migrated chain, or a store-writer
+  who strips the chain-state signature to downgrade a tampered chain to
+  "legacy", is now denied rather than accepted. Two independent migration-window
+  opt-outs on `TrustOperations`, each defaulting to `False` (fail-closed) and
+  each gating a distinct security dimension, restore the prior accept behavior
+  with a loud one-time WARN while chains are migrated:
+  `allow_unbound_legacy_capabilities` (Wave-1 transplant axis) and
+  `allow_unsigned_chain_state` (Wave-2 set-deletion/suppression axis).
+
+  A standalone, idempotent re-signing migration
+  (`kailash.trust.migrations.subject_binding_1912.SubjectBindingMigration`)
+  promotes the installed base to the Wave-3 posture: it enumerates persisted
+  chains, promotes each locally-signable legacy capability to `v1-subject-bound`
+  and re-signs it, and adds a chain-state signature where absent. It is
+  failure-atomic (a mid-apply failure restores every changed chain), explicitly
+  reversible (`rollback()` byte-exact restores the pre-migration snapshots),
+  supports `dry_run=True`, and REPORTS — never silently drops — capabilities it
+  cannot re-sign locally (an external attester, or an absent genesis signing
+  key). It is a deliberate operator action, never auto-run.
+
+  **Upgrade path for trust-plane deployments:** on upgrade, set
+  `allow_unbound_legacy_capabilities=True` and `allow_unsigned_chain_state=True`,
+  then run `SubjectBindingMigration(...).migrate(trust_store_placement=True)`
+  **against a trusted store state**, confirm the report is `fully_migrated`, and
+  clear both flags to enforce. Every re-signing write the migration makes —
+  legacy-cap promotion AND fresh chain-state signing — requires the explicit
+  `trust_store_placement=True` acknowledgment, because the migration re-signs
+  stored content (a legacy cap carries no holder subject; a fresh chain-state
+  signature covers the chain's current, unverifiable constraint envelope) and so
+  can only trust the store's current state; run from a snapshot taken before the
+  store was exposed to untrusted writers. A deployment that does not migrate and
+  does not set the opt-outs will have its legacy chains rejected on upgrade. See
+  `docs/trust/1912-subject-binding-migration.md`.
+
+  Cross-SDK: the capability and chain-state signatures are deployment-local (no
+  fixed cross-deployment byte vector), so this ships Python-independent; the
+  canonical pre-image ENCODINGS are pinned as cross-SDK tripwires
+  (cross-sdk-inspection.md Rule 4b/4d). The sibling SDK needs the equivalent fix
+  before its trust plane interoperates on subject-bound artifacts.
+
 ## [2.60.1] - 2026-07-21
 
 ### Security (Trust Plane — hotfix for 2.60.0)

--- a/docs/trust/1912-subject-binding-migration.md
+++ b/docs/trust/1912-subject-binding-migration.md
@@ -1,0 +1,154 @@
+# #1912 Migration Guide — Subject-Binding + Chain-State Signing (Wave 3, fail-closed)
+
+Issue #1912 hardened the trust plane against a store-writer (an adversary with
+write access to persisted trust chains). It landed in three waves; **Wave 3 (A1)
+is a breaking change** to `TrustOperations.verify()`. This guide is the upgrade
+path for any deployment that persists trust chains.
+
+## What changed
+
+| Wave | Defense                                                                                                                                                                             | verify() behavior after Wave 3                                         |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1    | Capabilities bind the holder subject (`v1-subject-bound`) — a transplanted capability no longer verifies on another chain.                                                          | A **legacy** (pre-#1912, un-subject-bound) capability is **REJECTED**. |
+| 2    | One genesis-authority `chain_state_signature` over the chain-state pre-image detects whole-capability-set deletion (MED-1) and constraint/`REASONING_REQUIRED` suppression (MED-2). | A chain with **no chain-state signature** is **REJECTED**.             |
+
+Before Wave 3, both cases were _accepted with a WARN_ (secure-default, verify-if-
+present). Wave 3 flips them to **fail-closed** so the installed-base residual —
+and the "strip the signature to downgrade a tampered chain to legacy" bypass —
+is closed.
+
+## Who is affected
+
+Any deployment whose trust store holds chains **established before this release**.
+Those chains carry legacy capabilities and no chain-state signature, so under the
+new default they are rejected until re-signed.
+
+Chains established _after_ upgrading are already at the Wave-3 posture
+(`establish` / `delegate` mint `v1-subject-bound` caps and issue a chain-state
+signature) and need no migration.
+
+## The two migration-window opt-outs
+
+`TrustOperations` accepts two independent keyword flags, each defaulting to
+`False` (fail-closed). Each gates a distinct security dimension — a deployment
+MAY enforce one while still migrating the other:
+
+```python
+ops = TrustOperations(
+    authority_registry=registry,
+    key_manager=key_manager,
+    trust_store=store,
+    allow_unbound_legacy_capabilities=True,  # Wave-1 axis: accept legacy caps
+    allow_unsigned_chain_state=True,          # Wave-2 axis: accept unsigned chains
+)
+```
+
+Each opt-out that is `True` emits ONE loud WARN naming the OFF protection. They
+are for the **migration window only** — leave them `False` in steady state.
+
+## Upgrade path (recommended)
+
+1. **Deploy with both opt-outs ON.** No existing agent breaks; verify still
+   accepts legacy/unsigned chains, loudly warning that the defenses are OFF.
+
+   ```python
+   ops = TrustOperations(
+       authority_registry=registry, key_manager=key_manager, trust_store=store,
+       allow_unbound_legacy_capabilities=True, allow_unsigned_chain_state=True,
+   )
+   ```
+
+2. **Dry-run the migration** to see what will change and what cannot be migrated
+   locally, without writing anything:
+
+   ```python
+   from kailash.trust.migrations.subject_binding_1912 import SubjectBindingMigration
+
+   migration = SubjectBindingMigration(registry, key_manager, store)
+   report = await migration.migrate(dry_run=True)
+   print(report.to_dict())
+   ```
+
+3. **Run the migration from a TRUSTED store state.** Promoting a legacy
+   capability requires an explicit `trust_store_placement=True` acknowledgment.
+   A legacy capability carries no holder subject in its signed bytes (the Wave-1
+   vulnerability), so the migration cannot cryptographically verify a legacy
+   cap's original holder — it binds the cap to the chain it _currently_ sits in.
+   A store-writer who transplanted a genuine legacy capability into another
+   chain _before_ the migration would otherwise have that transplant blessed
+   into a valid v1 cap. Set `trust_store_placement=True` **only** when running
+   against a trusted store state — a snapshot taken before the store was exposed
+   to untrusted writers, or a locked-down maintenance window. (Post-migration,
+   every cap is `v1-subject-bound`, so the runtime transplant defense is fully in
+   force and any _future_ transplant is rejected by `verify()`.)
+
+   ```python
+   report = await migration.migrate(trust_store_placement=True)
+   assert report.fully_migrated, report.unmigratable  # nothing left un-migrated
+   ```
+
+   With `trust_store_placement=False` (the default) every write is _reported_ as
+   requiring the acknowledgment and nothing is re-signed — a safe default in the
+   shape of `force_drop` / `force_downgrade`. The acknowledgment covers **both**
+   legacy-capability promotion **and** fresh chain-state signing (adding a
+   signature where a chain has none): the latter re-signs over the chain's
+   current, unverifiable constraint envelope, so a store-writer who stripped a
+   constraint _and_ the old signature must not have it silently re-blessed. A
+   chain that already carries a _valid_ chain-state signature is left untouched,
+   so idempotent re-runs need no acknowledgment.
+
+   The migration is **idempotent** (re-running changes nothing once a chain is
+   current), **failure-atomic** (a mid-apply error restores every changed chain
+   to its pre-migration state), and **reversible** — keep the returned `report`
+   and call `await migration.rollback(report)` for a byte-exact restore.
+
+4. **Handle un-migratable items.** `report.unmigratable` lists anything the local
+   genesis key could not re-sign — never silently dropped:
+
+   - **External-attester capability** (`kind == "capability"`): the capability was
+     attested by a _different_ authority. The local genesis key cannot re-sign
+     for it; the owning attester must re-sign it (or the capability must be
+     re-issued). Until then, verifying that chain requires
+     `allow_unbound_legacy_capabilities=True`.
+   - **Un-resolvable / key-absent chain** (`kind == "chain"`): the chain's genesis
+     authority could not be resolved, or its signing key is absent from the local
+     `TrustKeyManager`. Register the key (or resolve the authority) and re-run.
+
+5. **Enforce.** Once `report.fully_migrated` is `True` (or the residual
+   un-migratable items are accepted and tracked), remove BOTH opt-outs so
+   `TrustOperations` is constructed fail-closed:
+
+   ```python
+   ops = TrustOperations(authority_registry=registry, key_manager=key_manager,
+                         trust_store=store)  # both flags default False → enforced
+   ```
+
+## If you do not migrate
+
+A deployment that upgrades **without** migrating and **without** setting the
+opt-outs will have its legacy chains **rejected** by `verify()`. This is
+intentional fail-closed behavior — a rejected verify denies the action rather
+than authorizing a transplantable/unsigned chain. Set the opt-outs to keep
+running while you migrate.
+
+## Report fields
+
+`MigrationReport` (`.to_dict()` for a serializable summary):
+
+| Field                          | Meaning                                            |
+| ------------------------------ | -------------------------------------------------- |
+| `total_chains`                 | chains enumerated                                  |
+| `migrated_chains`              | chains changed (or would-change under `dry_run`)   |
+| `promoted_capabilities`        | legacy caps promoted to `v1-subject-bound`         |
+| `added_chain_state_signatures` | chains that gained a chain-state signature         |
+| `already_current_chains`       | chains already at the Wave-3 posture (no change)   |
+| `unmigratable`                 | items the local key could not re-sign (see step 4) |
+| `fully_migrated`               | `True` iff `unmigratable` is empty                 |
+
+## Cross-SDK note
+
+The capability and chain-state signatures are deployment-local (they bind random
+per-deployment UUIDs signed by the deployment's own key), so this fix ships
+independently per SDK. The canonical pre-image _encodings_ are pinned as cross-
+SDK tripwires; a sibling SDK must land the equivalent subject-binding + chain-
+state fix before its trust plane interoperates on these artifacts.

--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -32,6 +32,14 @@ from kailash.trust.signing.crypto import (
 # Safe at module scope: this file already imports kailash.trust.signing.crypto
 # above (initialising the signing package), and delegation_payload depends only
 # on kailash.trust._json — no cycle back to chain.
+from kailash.trust.signing.capability_fold_serde import (
+    deserialize_capability_fold_fields,
+    serialize_capability_fold_fields,
+)
+from kailash.trust.signing.chain_state_serde import (
+    deserialize_chain_state_signature_fields,
+    serialize_chain_state_signature_fields,
+)
 from kailash.trust.signing.delegation_fold_serde import (
     deserialize_fold_fields,
     serialize_fold_fields,
@@ -77,6 +85,29 @@ ALL_DIMENSIONS: frozenset[str] = VALID_DIMENSION_NAMES
 DELEGATION_SIGNING_VERSION_LEGACY: str = "legacy-python-v0"
 DELEGATION_SIGNING_VERSION_V2: str = "v2-complete"
 DELEGATION_SIGNING_VERSION_V3: str = "v3-complete"
+
+# Capability signing-payload version discriminator (#1912 Wave 1).
+#
+# A CapabilityAttestation records WHICH pre-image shape its Ed25519 signature was
+# produced over, so the verifier can dispatch to the matching builder:
+#
+# * ``legacy-python-v0`` (the DEFAULT) — the pre-#1912 pre-image emitted by
+#   ``CapabilityAttestation.to_signing_payload()`` (id / capability /
+#   capability_type / sorted constraints / attester_id / attested_at /
+#   expires_at / scope). It binds the ATTESTER but NO subject, so a genuine cap
+#   copied from chain A into chain B verifies — the transplant vulnerability
+#   (#1912). A cap deserialized with NO version field resolves to this value
+#   (from_dict backward-compat), so every existing signed cap keeps verifying
+#   byte-identically.
+# * ``v1-subject-bound`` — the legacy pre-image PLUS ``subject_agent_id`` = the
+#   HOLDER chain's ``genesis.agent_id`` (derived from the chain at sign AND
+#   verify, NEVER stored on the cap). Transplanting a v1 cap into another chain
+#   recomputes a DIFFERENT pre-image (a different subject) → the signature no
+#   longer verifies. New caps sign v1; verify dispatches on the persisted field
+#   (a v1 cap whose version is stripped defaults to legacy → the legacy verify
+#   recomputes WITHOUT the subject → the v1 signature fails → downgrade-resistant).
+CAPABILITY_SIGNING_VERSION_LEGACY: str = "legacy-python-v0"
+CAPABILITY_SIGNING_VERSION_V1: str = "v1-subject-bound"
 
 if TYPE_CHECKING:
     from kailash.trust.execution_context import HumanOrigin
@@ -239,15 +270,40 @@ class CapabilityAttestation:
     expires_at: Optional[datetime] = None
     scope: Optional[Dict[str, Any]] = None
 
+    # Signing-payload version discriminator (#1912 Wave 1). Records which
+    # pre-image shape the signature was produced over. Defaults to the pre-#1912
+    # legacy schema (``legacy-python-v0``); a cap deserialized with NO version
+    # field also resolves here (from_dict backward-compat), so existing signed
+    # caps verify unchanged. A v1 cap binds the HOLDER subject into the signed
+    # pre-image (see ``to_signing_payload``), closing the cross-chain transplant.
+    signing_payload_version: str = CAPABILITY_SIGNING_VERSION_LEGACY
+
     def is_expired(self) -> bool:
         """Check if this capability attestation has expired."""
         if self.expires_at is None:
             return False
         return datetime.now(timezone.utc) > self.expires_at
 
-    def to_signing_payload(self) -> dict:
-        """Get payload for signature verification."""
-        return {
+    def to_signing_payload(self, subject_agent_id: Optional[str] = None) -> dict:
+        """Get payload for signature verification.
+
+        Dispatches on ``signing_payload_version`` (#1912 Wave 1):
+
+        * ``legacy-python-v0`` (or any non-v1 value) → the pre-#1912 dict EXACTLY
+          (byte-identical — no new key), regardless of ``subject_agent_id``. This
+          keeps every existing signed cap verifying unchanged.
+        * ``v1-subject-bound`` → the legacy dict PLUS ``subject_agent_id`` = the
+          holder chain's ``genesis.agent_id``, passed IN by the caller (derived
+          from the chain, NEVER stored on the cap). Binding the subject into the
+          signed bytes means a cap transplanted into a DIFFERENT chain recomputes
+          a different pre-image and its signature fails.
+
+        Args:
+            subject_agent_id: The HOLDER chain's ``genesis.agent_id``. Bound into
+                the pre-image ONLY for a ``v1-subject-bound`` cap; ignored for a
+                legacy cap (so a legacy caller passing nothing is byte-identical).
+        """
+        payload = {
             "id": self.id,
             "capability": self.capability,
             "capability_type": self.capability_type.value,
@@ -257,6 +313,22 @@ class CapabilityAttestation:
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
             "scope": self.scope,
         }
+        if self.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1:
+            # v1 binds the holder subject into the signed bytes. A transplanted
+            # cap verified against a DIFFERENT chain recomputes a different
+            # subject → the signature no longer matches (the #1912 fix).
+            # Fail closed on an empty/absent subject: a v1 pre-image with no
+            # holder binding is meaningless and would collapse the transplant
+            # defense (all empty-subject caps share one pre-image). At sign time
+            # this surfaces a caller bug loudly; verify sites catch it and deny
+            # (operations `_verify_capability_signature`). #1912 RT-sec LOW.
+            if not subject_agent_id:
+                raise ValueError(
+                    "v1-subject-bound capability requires a non-empty "
+                    "subject_agent_id (the holder chain's genesis.agent_id)"
+                )
+            payload["subject_agent_id"] = subject_agent_id
+        return payload
 
 
 @dataclass
@@ -803,6 +875,30 @@ class TrustLineageChain:
     constraint_envelope: Optional[ChainConstraintEnvelope] = None
     audit_anchors: List[AuditAnchor] = field(default_factory=list)
 
+    # Chain-state signature (#1912 Wave 2). ONE Ed25519 signature by the genesis
+    # authority over the canonical chain-state pre-image
+    # (kailash.trust.signing.chain_state_signing) — binds capability-SET
+    # membership (delete a cap → capability_ids change → sig breaks: MED-1) AND
+    # the constraint envelope incl REASONING_REQUIRED / directly-injected
+    # constraints (strip one → recomputed constraint_hash changes → sig breaks:
+    # MED-2). Defaults to None (a legacy / pre-Wave-2 chain); prune-when-unset
+    # in to_dict so a legacy chain serializes BYTE-IDENTICALLY to pre-Wave-2.
+    # Verified at STANDARD+ (operations._verify_chain_state_signature). New
+    # chains ALWAYS get it at issuance.
+    #
+    # SCOPE (#1912, Wave 3 A1 LANDED): MED-1/MED-2 are closed against a
+    # store-writer who tampers a signed chain and LEAVES the (now-stale)
+    # signature — the tamper is caught (the recomputed pre-image no longer
+    # matches). A store-writer who ALSO deletes this field (or drops the key from
+    # the persisted dict → None) downgrades the chain to "legacy"; Wave-3 A1
+    # enforcement REJECTS that stripped/absent signature by default
+    # (fail-closed), so the downgrade bypass is closed. The migration window
+    # opt-out ``allow_unsigned_chain_state=True`` accepts an absent signature
+    # with a loud one-time WARN while the installed base is re-signed by the
+    # #1912 migration. (Wave 2 shipped the mechanism verify-if-present; Wave 3
+    # flipped it fail-closed + added the re-signing migration.)
+    chain_state_signature: Optional[str] = None
+
     def __post_init__(self):
         """Initialize constraint envelope if not provided."""
         if self.constraint_envelope is None:
@@ -1149,9 +1245,59 @@ class TrustLineageChain:
             **fold,
         )
 
+    @staticmethod
+    def _serialize_capability(cap: CapabilityAttestation) -> Dict[str, Any]:
+        """Serialize a capability attestation for chain-level serialization.
+
+        Carries the #1912 ``signing_payload_version`` prune-when-unset via the
+        SHARED serde, so a v1 (subject-bound) capability reconstructed by a
+        persistent store recomputes the SAME subject-bound signing pre-image and
+        its signature verifies. A legacy capability emits NO version key
+        (byte-identical to a pre-#1912 dict).
+        """
+        result = {
+            "id": cap.id,
+            "capability": cap.capability,
+            "capability_type": cap.capability_type.value,
+            "constraints": cap.constraints,
+            "attester_id": cap.attester_id,
+            "attested_at": cap.attested_at.isoformat(),
+            "expires_at": cap.expires_at.isoformat() if cap.expires_at else None,
+            "scope": cap.scope,
+        }
+        # #1912 signing-payload version (shared serde — prune-when-unset).
+        result.update(serialize_capability_fold_fields(cap))
+        return result
+
+    @staticmethod
+    def _deserialize_capability(data: Dict[str, Any]) -> CapabilityAttestation:
+        """Deserialize a capability attestation from a chain-level dict.
+
+        Backward compatible — a pre-#1912 dict has no ``signing_payload_version``
+        key, so the shared serde defaults it to legacy and the cap verifies
+        unchanged.
+        """
+        return CapabilityAttestation(
+            id=data["id"],
+            capability=data["capability"],
+            capability_type=CapabilityType(data["capability_type"]),
+            constraints=data["constraints"],
+            attester_id=data["attester_id"],
+            attested_at=datetime.fromisoformat(data["attested_at"]),
+            expires_at=(
+                datetime.fromisoformat(data["expires_at"])
+                if data.get("expires_at")
+                else None
+            ),
+            signature=data.get("signature", ""),
+            scope=data.get("scope"),
+            # #1912 signing-payload version (shared serde — legacy when absent).
+            **deserialize_capability_fold_fields(data),
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
-        return {
+        result: Dict[str, Any] = {
             "genesis": {
                 "id": self.genesis.id,
                 "agent_id": self.genesis.agent_id,
@@ -1167,19 +1313,7 @@ class TrustLineageChain:
                 "metadata": self.genesis.metadata,
             },
             "capabilities": [
-                {
-                    "id": cap.id,
-                    "capability": cap.capability,
-                    "capability_type": cap.capability_type.value,
-                    "constraints": cap.constraints,
-                    "attester_id": cap.attester_id,
-                    "attested_at": cap.attested_at.isoformat(),
-                    "expires_at": (
-                        cap.expires_at.isoformat() if cap.expires_at else None
-                    ),
-                    "scope": cap.scope,
-                }
-                for cap in self.capabilities
+                self._serialize_capability(cap) for cap in self.capabilities
             ],
             "delegations": [self._serialize_delegation(d) for d in self.delegations],
             "constraint_envelope": (
@@ -1203,6 +1337,12 @@ class TrustLineageChain:
             ),
             "chain_hash": self.hash(),
         }
+        # #1912 Wave 2 chain-state signature (shared serde — prune-when-unset).
+        # A legacy chain emits NO chain_state_signature key (byte-identical to a
+        # pre-Wave-2 dict); a signed chain emits it so from_dict re-binds it and
+        # the chain-state signature re-verifies.
+        result.update(serialize_chain_state_signature_fields(self))
+        return result
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TrustLineageChain":
@@ -1225,22 +1365,7 @@ class TrustLineageChain:
         )
 
         capabilities = [
-            CapabilityAttestation(
-                id=cap["id"],
-                capability=cap["capability"],
-                capability_type=CapabilityType(cap["capability_type"]),
-                constraints=cap["constraints"],
-                attester_id=cap["attester_id"],
-                attested_at=datetime.fromisoformat(cap["attested_at"]),
-                expires_at=(
-                    datetime.fromisoformat(cap["expires_at"])
-                    if cap.get("expires_at")
-                    else None
-                ),
-                signature=cap.get("signature", ""),
-                scope=cap.get("scope"),
-            )
-            for cap in data.get("capabilities", [])
+            cls._deserialize_capability(cap) for cap in data.get("capabilities", [])
         ]
 
         delegations = [
@@ -1271,6 +1396,9 @@ class TrustLineageChain:
             capabilities=capabilities,
             delegations=delegations,
             constraint_envelope=constraint_envelope,
+            # #1912 Wave 2 chain-state signature (shared serde — None when absent,
+            # so a pre-Wave-2 chain reconstructs as legacy).
+            **deserialize_chain_state_signature_fields(data),
         )
 
 
@@ -1578,6 +1706,8 @@ __all__ = [
     "DELEGATION_SIGNING_VERSION_LEGACY",
     "DELEGATION_SIGNING_VERSION_V2",
     "DELEGATION_SIGNING_VERSION_V3",
+    "CAPABILITY_SIGNING_VERSION_LEGACY",
+    "CAPABILITY_SIGNING_VERSION_V1",
     # Enums
     "AuthorityType",
     "CapabilityType",

--- a/src/kailash/trust/cli/commands.py
+++ b/src/kailash/trust/cli/commands.py
@@ -37,6 +37,9 @@ from kailash.trust.exceptions import (
     TrustError,
     UnsupportedSigningPayloadVersionError,
 )
+from kailash.trust.signing.chain_state_signing import (
+    chain_state_canonical_payload_str,
+)
 from kailash.trust.signing.crypto import (
     generate_keypair,
     serialize_for_signing,
@@ -225,6 +228,23 @@ def _load_private_key(store_dir: str, key_id: str) -> str:
     raise click.ClickException(
         f"Key not found: '{key_id}'. Run 'eatp init' to generate keys."
     )
+
+
+def _issue_chain_state_signature(store_dir: str, chain: TrustLineageChain) -> None:
+    """(Re)issue the #1912 Wave 2 chain-state signature on a CLI-managed chain.
+
+    Signs the canonical chain-state pre-image (capability-SET membership +
+    constraint envelope) with the chain owner's genesis-authority private key
+    and sets ``chain.chain_state_signature`` IN PLACE. Called at every CLI site
+    that creates OR mutates a persisted chain (establish, both delegate
+    branches, revoke) so a stale signature is never persisted — matching the
+    ``TrustOperations`` sign sites, so a CLI-managed chain verifies under
+    ``operations.verify()`` at STANDARD+ (#1912 Wave 2).
+    """
+    authority = _load_authority(store_dir, chain.genesis.authority_id)
+    private_key = _load_private_key(store_dir, authority.signing_key_id)
+    payload = chain_state_canonical_payload_str(chain)
+    chain.chain_state_signature = sign(payload, private_key)
 
 
 def _find_delegation_in_store(store_dir: str, delegation_id: str) -> tuple:
@@ -416,6 +436,7 @@ def establish_cmd(
 
     # Build the chain using the operations primitives directly
     from kailash.trust.chain import (
+        CAPABILITY_SIGNING_VERSION_V1,
         CapabilityAttestation,
         Constraint,
         ConstraintEnvelope,
@@ -449,8 +470,14 @@ def establish_cmd(
             attester_id=auth.id,
             attested_at=datetime.now(timezone.utc),
             signature="",
+            # #1912: mint subject-bound v1 caps so a CLI-created capability
+            # cannot be transplanted into another holder's chain. The holder
+            # is this chain's genesis agent (agent_name).
+            signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
         )
-        cap_payload = serialize_for_signing(attestation.to_signing_payload())
+        cap_payload = serialize_for_signing(
+            attestation.to_signing_payload(subject_agent_id=agent_name)
+        )
         attestation.signature = sign(cap_payload, private_key)
         cap_attestations.append(attestation)
 
@@ -470,6 +497,9 @@ def establish_cmd(
         constraint_envelope=envelope,
         audit_anchors=[],
     )
+
+    # Issue the #1912 Wave 2 chain-state signature (new chains ALWAYS get it).
+    _issue_chain_state_signature(store_dir, chain)
 
     # Store chain
     _run_async(store.store_chain(chain))
@@ -581,6 +611,7 @@ def delegate_cmd(
     private_key = _load_private_key(store_dir, auth.signing_key_id)
 
     from kailash.trust.chain import (
+        CAPABILITY_SIGNING_VERSION_V1,
         CapabilityAttestation,
         ConstraintEnvelope,
         DelegationRecord,
@@ -621,6 +652,9 @@ def delegate_cmd(
     try:
         delegatee_chain = _run_async(store.get_chain(to_agent))
         delegatee_chain.delegations.append(delegation)
+        # Re-issue the chain-state signature: the appended delegation changed
+        # delegation_ids, so the prior signature is stale (#1912 Wave 2).
+        _issue_chain_state_signature(store_dir, delegatee_chain)
         _run_async(store.update_chain(to_agent, delegatee_chain))
     except TrustChainNotFoundError:
         # Create derived chain for delegatee
@@ -662,8 +696,13 @@ def delegate_cmd(
                 attested_at=datetime.now(timezone.utc),
                 signature="",
                 scope=cap_scope,
+                # #1912: mint subject-bound v1 caps. The holder is the
+                # delegatee chain's genesis agent (to_agent).
+                signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
             )
-            cap_payload = serialize_for_signing(derived_cap.to_signing_payload())
+            cap_payload = serialize_for_signing(
+                derived_cap.to_signing_payload(subject_agent_id=to_agent)
+            )
             derived_cap.signature = sign(cap_payload, private_key)
             derived_caps.append(derived_cap)
 
@@ -681,6 +720,8 @@ def delegate_cmd(
             constraint_envelope=envelope,
             audit_anchors=[],
         )
+        # Issue the chain-state signature for the new derived chain (#1912 Wave 2).
+        _issue_chain_state_signature(store_dir, delegatee_chain)
         _run_async(store.store_chain(delegatee_chain))
 
     if json_output:
@@ -872,6 +913,11 @@ def revoke_cmd(
     _run_async(store.initialize())
 
     chain.delegations.pop(deleg_idx)
+    # Re-issue the chain-state signature: removing a delegation changed
+    # delegation_ids, so the prior signature is stale (#1912 Wave 2). Only
+    # re-sign a chain that already carries one (a legacy chain stays legacy).
+    if chain.chain_state_signature is not None:
+        _issue_chain_state_signature(store_dir, chain)
     _run_async(store.update_chain(agent_id, chain))
 
     if json_output:
@@ -1365,9 +1411,23 @@ def verify_chain_cmd(
     if not verify_signature(genesis_payload, chain.genesis.signature, auth.public_key):
         issues.append(f"Invalid genesis signature (genesis_id={chain.genesis.id})")
 
-    # Verify capability signatures
+    # Verify capability signatures over the version-gated pre-image (#1912). A
+    # v1 cap binds the holder chain's genesis agent as its subject; passing it
+    # here recomputes the same subject-bound pre-image (a legacy cap ignores the
+    # subject → byte-identical). A cap transplanted from another chain would
+    # recompute a different subject and fail here.
     for cap in chain.capabilities:
-        cap_payload = serialize_for_signing(cap.to_signing_payload())
+        try:
+            cap_payload = serialize_for_signing(
+                cap.to_signing_payload(subject_agent_id=chain.genesis.agent_id)
+            )
+        except ValueError:
+            # v1 cap over an empty holder subject (an anomalous/tampered chain
+            # whose genesis.agent_id is empty) makes to_signing_payload raise
+            # (#1912 empty-subject guard). Treat it as an invalid signature and
+            # fail closed — never crash — mirroring the delegation loop below.
+            issues.append(f"Invalid capability signature (cap_id={cap.id})")
+            continue
         if not verify_signature(cap_payload, cap.signature, auth.public_key):
             issues.append(f"Invalid capability signature (cap_id={cap.id})")
 

--- a/src/kailash/trust/interop/jwt.py
+++ b/src/kailash/trust/interop/jwt.py
@@ -51,6 +51,10 @@ from kailash.trust.chain import (
     TrustLineageChain,
 )
 from kailash.trust.reasoning.traces import ConfidentialityLevel
+from kailash.trust.signing.capability_fold_serde import (
+    deserialize_capability_fold_fields,
+    serialize_capability_fold_fields,
+)
 from kailash.trust.signing.delegation_fold_serde import (
     deserialize_fold_fields,
     serialize_fold_fields,
@@ -108,7 +112,7 @@ def _serialize_genesis(genesis: GenesisRecord) -> Dict[str, Any]:
 
 def _serialize_capability(cap: CapabilityAttestation) -> Dict[str, Any]:
     """Serialize a CapabilityAttestation to a JSON-safe dict."""
-    return {
+    d = {
         "id": cap.id,
         "capability": cap.capability,
         "capability_type": cap.capability_type.value,
@@ -119,6 +123,10 @@ def _serialize_capability(cap: CapabilityAttestation) -> Dict[str, Any]:
         "signature": cap.signature,
         "scope": cap.scope,
     }
+    # #1912 signing-payload version (shared serde — prune-when-unset). A v1 cap
+    # must carry its version so a subject-bound signature re-verifies after import.
+    d.update(serialize_capability_fold_fields(cap))
+    return d
 
 
 def _serialize_delegation(delegation: DelegationRecord) -> Dict[str, Any]:
@@ -274,6 +282,8 @@ def _deserialize_capability(data: Dict[str, Any]) -> CapabilityAttestation:
             else None
         ),
         scope=data.get("scope"),
+        # #1912 signing-payload version (shared serde — legacy when absent).
+        **deserialize_capability_fold_fields(data),
     )
 
 

--- a/src/kailash/trust/interop/sd_jwt.py
+++ b/src/kailash/trust/interop/sd_jwt.py
@@ -48,6 +48,9 @@ from typing import Any, Dict, List, Optional
 from kailash.trust.chain import CapabilityAttestation, TrustLineageChain
 from kailash.trust.exceptions import InvalidSignatureError
 from kailash.trust.reasoning.traces import ConfidentialityLevel, ReasoningTrace
+from kailash.trust.signing.capability_fold_serde import (
+    serialize_capability_fold_fields,
+)
 from kailash.trust.signing.crypto import hash_reasoning_trace
 
 logger = logging.getLogger(__name__)
@@ -154,7 +157,7 @@ def _serialize_chain_claims(chain: TrustLineageChain) -> Dict[str, Any]:
 
 def _serialize_capability_claims(attestation: CapabilityAttestation) -> Dict[str, Any]:
     """Convert a CapabilityAttestation to flat claims dict for SD-JWT."""
-    return {
+    claims = {
         "id": attestation.id,
         "capability": attestation.capability,
         "capability_type": attestation.capability_type.value,
@@ -167,6 +170,11 @@ def _serialize_capability_claims(attestation: CapabilityAttestation) -> Dict[str
         "signature": attestation.signature,
         "scope": attestation.scope,
     }
+    # #1912 signing-payload version (shared serde — prune-when-unset). A v1 cap
+    # must carry its version so an external verifier reconstructs the
+    # subject-bound pre-image.
+    claims.update(serialize_capability_fold_fields(attestation))
+    return claims
 
 
 # ===================================================================

--- a/src/kailash/trust/interop/w3c_vc.py
+++ b/src/kailash/trust/interop/w3c_vc.py
@@ -34,6 +34,10 @@ from kailash.trust.chain import (
     TrustLineageChain,
 )
 from kailash.trust.reasoning.traces import ConfidentialityLevel, ReasoningTrace
+from kailash.trust.signing.capability_fold_serde import (
+    deserialize_capability_fold_fields,
+    serialize_capability_fold_fields,
+)
 from kailash.trust.signing.crypto import serialize_for_signing, sign, verify_signature
 from kailash.trust.signing.delegation_fold_serde import (
     deserialize_fold_fields,
@@ -114,6 +118,8 @@ def _serialize_capability(cap: CapabilityAttestation) -> Dict[str, Any]:
         result["expiresAt"] = _iso(cap.expires_at)
     if cap.scope is not None:
         result["scope"] = cap.scope
+    # #1912 signing-payload version (shared serde, camelCase — prune-when-unset).
+    result.update(serialize_capability_fold_fields(cap, camel=True))
     return result
 
 
@@ -551,6 +557,8 @@ def import_from_verifiable_credential(
                 ),
                 signature=c.get("signature", ""),
                 scope=c.get("scope"),
+                # #1912 signing-payload version (shared serde, camelCase).
+                **deserialize_capability_fold_fields(c, camel=True),
             )
         )
 

--- a/src/kailash/trust/migrations/subject_binding_1912.py
+++ b/src/kailash/trust/migrations/subject_binding_1912.py
@@ -281,6 +281,24 @@ class SubjectBindingMigration:
         :meth:`_apply_atomically` commits it.
         """
         gen_authority_id = chain.genesis.authority_id
+        # An empty genesis.agent_id cannot be bound as a v1 capability subject
+        # (to_signing_payload raises on an empty subject, chain.py). Without a
+        # subject NO cap in this chain is promotable, so the WHOLE chain is
+        # un-migratable — report it and change nothing, rather than letting the
+        # per-cap re-sign raise and abort the entire migration run mid-pass
+        # (RT-sec-w3 gate-review: fail-soft per-chain, not a run-wide DoS).
+        if not chain.genesis.agent_id:
+            report.unmigratable.append(
+                UnmigratableItem(
+                    agent_id=chain.genesis.agent_id,
+                    kind="chain",
+                    reason=(
+                        "genesis agent_id is empty — cannot bind a v1 capability "
+                        "subject; chain is un-migratable (re-issue the genesis)"
+                    ),
+                )
+            )
+            return False
         # Resolve the genesis authority + confirm the local key can sign. If not,
         # the WHOLE chain is un-migratable locally (report, change nothing).
         try:

--- a/src/kailash/trust/migrations/subject_binding_1912.py
+++ b/src/kailash/trust/migrations/subject_binding_1912.py
@@ -1,0 +1,539 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1912 re-signing migration — promote legacy chains to the Wave-3 posture.
+
+#1912 hardened the trust plane in three waves:
+
+* **Wave 1** bound each capability to its holder subject (``v1-subject-bound``),
+  closing the cross-chain capability-transplant HIGH.
+* **Wave 2** added ONE genesis-authority ``chain_state_signature`` over the
+  chain-state pre-image, closing whole-capability-set deletion (MED-1) and
+  constraint/REASONING_REQUIRED suppression (MED-2).
+* **Wave 3 (A1)** flips :meth:`~kailash.trust.operations.TrustOperations.verify`
+  to FAIL CLOSED: a legacy (un-subject-bound) capability is REJECTED, and a
+  chain with NO chain-state signature is REJECTED (each gated by a distinct
+  migration-window opt-out — ``allow_unbound_legacy_capabilities`` /
+  ``allow_unsigned_chain_state`` — that default to ``False``).
+
+The installed base — chains persisted before #1912 — carries legacy caps and
+NO chain-state signature. Under Wave-3 fail-closed enforcement those chains
+would be rejected on upgrade. This migration re-signs the installed base to the
+Wave-3 posture so a deployment can flip enforcement on (clear both opt-outs)
+without breaking existing agents.
+
+STANDALONE, NOT auto-run
+------------------------
+This migration is a deliberate operator action, never triggered implicitly by
+``verify`` / ``establish``. Run it once during the migration window, confirm the
+report, then clear the opt-out flags.
+
+TRUSTED-STORE PRECONDITION (``trust_store_placement``)
+------------------------------------------------------
+Promoting a legacy capability BINDS it to the chain it CURRENTLY sits in. A
+legacy cap carries NO holder subject in its signed bytes (the exact Wave-1
+transplant vulnerability), so the migration CANNOT cryptographically verify a
+legacy cap's original holder — it can only trust the store's current placement.
+A store-writer who transplanted a genuine legacy capability (signed by the same
+authority) into another chain BEFORE the migration would have that transplant
+laundered into a valid v1 cap. Therefore legacy-cap promotion is REFUSED by
+default and requires ``migrate(trust_store_placement=True)``, which the operator
+sets ONLY when running against a TRUSTED store state — a snapshot taken before
+the store was exposed to untrusted writers, or a locked-down maintenance window
+(the ``force_drop`` / ``force_downgrade`` safe-default idiom). Post-migration
+every cap is v1-subject-bound, so the RUNTIME transplant defense is fully in
+force and any FUTURE transplant is rejected by ``verify``.
+
+What it does per chain (IDEMPOTENT — safe to re-run)
+----------------------------------------------------
+* With ``trust_store_placement=True``: promote every LOCALLY-SIGNABLE legacy
+  capability to ``v1-subject-bound`` and re-sign it over the holder-subject
+  pre-image (``genesis.agent_id``) with the chain's genesis-authority key. A cap
+  already at v1 is left untouched. With ``trust_store_placement=False`` (default)
+  legacy caps are REPORTED, not promoted.
+* Add a genesis-authority ``chain_state_signature`` when the chain has none AND
+  no legacy cap was left un-promoted (signing a set that still holds an
+  un-enforceable legacy cap would attest an incompletely-migrated chain). FRESH
+  chain-state signing ALSO requires ``trust_store_placement=True``: it re-signs
+  over the chain's CURRENT constraint envelope + id-set, which the migration
+  cannot verify (there is no prior chain-state signature to check against), so a
+  store-writer who stripped a constraint AND the old signature would have the
+  suppression blessed (MED-2/MED-1) — the same trust-the-store decision as
+  legacy-cap promotion (RT-sec-w3r3 Finding D). A chain already carrying a VALID
+  chain-state signature is left untouched (the ``is None`` guard), so idempotent
+  re-runs and genuinely-signed chains need no ack. (Promoting a cap does NOT
+  change ``capability_ids`` / ``constraint_hash``, so it never invalidates an
+  existing chain-state signature.)
+
+What it CANNOT migrate (reported, never silently dropped)
+---------------------------------------------------------
+* A capability whose ``attester_id`` is NOT the chain's genesis authority (an
+  external attester the local genesis key cannot re-sign for). It is left legacy
+  and reported — verifying it needs the external attester's own re-signing.
+* A chain whose genesis-authority signing key is absent from the local
+  ``TrustKeyManager`` (or whose authority cannot be resolved). Nothing on that
+  chain can be re-signed locally; the whole chain is reported un-migratable.
+
+Reversibility
+-------------
+The apply is failure-atomic: every CHANGED chain is snapshotted (a byte-exact
+pre-migration copy) BEFORE any write; on ANY apply error every snapshot is
+restored and :class:`SubjectBindingMigrationError` is raised, so a failed run
+leaves the store exactly as it found it. The snapshots are also returned on the
+report, so a SUCCESSFUL migration is explicitly reversible via
+:meth:`SubjectBindingMigration.rollback` (a byte-exact restore — NOT a
+security-downgrading logical demote, which this migration deliberately does not
+offer). ``dry_run=True`` computes the full report and changes nothing.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_LEGACY,
+    CAPABILITY_SIGNING_VERSION_V1,
+    TrustLineageChain,
+)
+from kailash.trust.exceptions import (
+    AuthorityInactiveError,
+    AuthorityNotFoundError,
+    InvalidSignatureError,
+    TrustError,
+)
+from kailash.trust.signing.chain_state_signing import chain_state_canonical_payload_str
+from kailash.trust.signing.crypto import serialize_for_signing
+
+__all__ = [
+    "SubjectBindingMigration",
+    "SubjectBindingMigrationError",
+    "MigrationReport",
+    "UnmigratableItem",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class SubjectBindingMigrationError(TrustError):
+    """Raised when the #1912 re-signing migration fails to apply.
+
+    On apply failure the store is restored to its pre-migration state (see the
+    module docstring § Reversibility) before this is raised.
+    """
+
+
+@dataclass
+class UnmigratableItem:
+    """A chain or capability the local genesis key could not re-sign."""
+
+    agent_id: str
+    kind: str  # "capability" | "chain"
+    reason: str
+    capability_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "kind": self.kind,
+            "reason": self.reason,
+            "capability_id": self.capability_id,
+        }
+
+
+@dataclass
+class MigrationReport:
+    """Outcome of a #1912 re-signing migration run."""
+
+    total_chains: int = 0
+    migrated_chains: int = 0
+    promoted_capabilities: int = 0
+    added_chain_state_signatures: int = 0
+    already_current_chains: int = 0
+    unmigratable: List[UnmigratableItem] = field(default_factory=list)
+    dry_run: bool = False
+    # Byte-exact pre-migration copies of every CHANGED chain, keyed by agent_id.
+    # Populated on a non-dry-run apply; consumed by ``rollback``. Excluded from
+    # ``to_dict`` (it holds full chain objects, not a serialisable summary).
+    snapshots: Dict[str, TrustLineageChain] = field(default_factory=dict)
+
+    @property
+    def fully_migrated(self) -> bool:
+        """True when every chain reached the Wave-3 posture (no un-migratable items)."""
+        return not self.unmigratable
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total_chains": self.total_chains,
+            "migrated_chains": self.migrated_chains,
+            "promoted_capabilities": self.promoted_capabilities,
+            "added_chain_state_signatures": self.added_chain_state_signatures,
+            "already_current_chains": self.already_current_chains,
+            "unmigratable": [u.to_dict() for u in self.unmigratable],
+            "fully_migrated": self.fully_migrated,
+            "dry_run": self.dry_run,
+        }
+
+
+class SubjectBindingMigration:
+    """Re-sign the installed base to the #1912 Wave-3 fail-closed posture.
+
+    Construct with the same three dependencies :class:`TrustOperations` uses, run
+    :meth:`migrate`, inspect the :class:`MigrationReport`, then clear the
+    ``allow_unbound_legacy_capabilities`` / ``allow_unsigned_chain_state``
+    opt-outs to enforce.
+    """
+
+    def __init__(self, authority_registry: Any, key_manager: Any, trust_store: Any):
+        self.authority_registry = authority_registry
+        self.key_manager = key_manager
+        self.trust_store = trust_store
+
+    async def migrate(
+        self,
+        *,
+        trust_store_placement: bool = False,
+        dry_run: bool = False,
+        batch_size: int = 100,
+    ) -> MigrationReport:
+        """Enumerate persisted chains and re-sign them to the Wave-3 posture.
+
+        Args:
+            trust_store_placement: Explicit acknowledgment (default ``False`` =
+                REFUSE) required to PROMOTE a legacy capability. A legacy cap
+                carries NO holder subject in its signed bytes (that is the exact
+                Wave-1 transplant vulnerability), so the migration CANNOT
+                cryptographically verify a legacy cap's original holder — it can
+                only bind the cap to the chain it CURRENTLY sits in. A
+                store-writer who transplanted a genuine legacy capability (signed
+                by the same authority) into another chain BEFORE the migration
+                would have that transplant blessed into a valid v1 cap
+                (RT-sec-w3r2 Finding C). Set ``True`` ONLY when running against a
+                TRUSTED store state — a snapshot taken before the store was
+                exposed to untrusted writers, or a locked-down maintenance
+                window. With ``False`` every legacy cap is REPORTED as requiring
+                the acknowledgment and is NOT promoted (the codebase
+                ``force_drop`` / ``force_downgrade`` safe-default idiom). This
+                ALSO gates FRESH chain-state signing (adding a signature where the
+                chain has none) — re-signing over the chain's current,
+                unverifiable constraint envelope is the same trust-the-store
+                decision (RT-sec-w3r3 Finding D). A chain already carrying a VALID
+                chain-state signature is left untouched, so idempotent re-runs
+                need no ack.
+            dry_run: When True, compute the full report but write NOTHING.
+            batch_size: Pagination size for ``trust_store.list_chains``.
+
+        Returns:
+            A :class:`MigrationReport`. On a non-dry-run it carries the
+            pre-migration ``snapshots`` for :meth:`rollback`.
+
+        Raises:
+            SubjectBindingMigrationError: If a write fails; the store is restored
+                to its pre-migration state before this is raised.
+        """
+        report = MigrationReport(dry_run=dry_run)
+        # (agent_id, updated_chain, original_chain) for every CHANGED chain.
+        updates: List[Tuple[str, TrustLineageChain, TrustLineageChain]] = []
+
+        offset = 0
+        while True:
+            chains = await self.trust_store.list_chains(
+                active_only=True, limit=batch_size, offset=offset
+            )
+            if not chains:
+                break
+            for chain in chains:
+                report.total_chains += 1
+                original = copy.deepcopy(chain)
+                updated = copy.deepcopy(chain)
+                changed = await self._migrate_chain_in_place(
+                    updated, report, trust_store_placement
+                )
+                if changed:
+                    updates.append((updated.genesis.agent_id, updated, original))
+                else:
+                    report.already_current_chains += 1
+            if len(chains) < batch_size:
+                break
+            offset += batch_size
+
+        report.migrated_chains = len(updates)
+        if dry_run or not updates:
+            return report
+
+        await self._apply_atomically(updates, report)
+        return report
+
+    async def _migrate_chain_in_place(
+        self,
+        chain: TrustLineageChain,
+        report: MigrationReport,
+        trust_store_placement: bool,
+    ) -> bool:
+        """Promote legacy caps + add a chain-state signature. Returns True if changed.
+
+        Reports (never silently drops) any cap/chain the local genesis key cannot
+        re-sign, or any legacy cap the operator has not acknowledged trusting the
+        placement of (``trust_store_placement``). A deep-COPY is passed in, so
+        mutation here never touches the persisted original until
+        :meth:`_apply_atomically` commits it.
+        """
+        gen_authority_id = chain.genesis.authority_id
+        # Resolve the genesis authority + confirm the local key can sign. If not,
+        # the WHOLE chain is un-migratable locally (report, change nothing).
+        try:
+            authority = await self.authority_registry.get_authority(
+                gen_authority_id, include_inactive=True
+            )
+        except (AuthorityNotFoundError, AuthorityInactiveError):
+            report.unmigratable.append(
+                UnmigratableItem(
+                    agent_id=chain.genesis.agent_id,
+                    kind="chain",
+                    reason=(
+                        f"genesis authority {gen_authority_id!r} unresolved — "
+                        "cannot re-sign locally"
+                    ),
+                )
+            )
+            return False
+
+        signing_key_id = getattr(authority, "signing_key_id", None)
+        if not signing_key_id or not self.key_manager.get_key(signing_key_id):
+            report.unmigratable.append(
+                UnmigratableItem(
+                    agent_id=chain.genesis.agent_id,
+                    kind="chain",
+                    reason=(
+                        f"genesis signing key {signing_key_id!r} absent from the "
+                        "local key manager — cannot re-sign locally"
+                    ),
+                )
+            )
+            return False
+
+        changed = False
+        # Track whether any legacy cap was left un-promoted (external attester,
+        # forged signature, or trust-placement not acknowledged). If so, the chain
+        # still holds an un-enforceable cap, so a chain-state signature over that
+        # set MUST NOT be added — signing it would attest a set the operator has
+        # not fully migrated (RT-sec-w3r2 Q2 hardening).
+        has_unpromoted_legacy = False
+
+        # 1. Promote every locally-signable, placement-acknowledged legacy
+        #    capability to v1-subject-bound.
+        for cap in chain.capabilities:
+            version = getattr(
+                cap, "signing_payload_version", CAPABILITY_SIGNING_VERSION_LEGACY
+            )
+            if version != CAPABILITY_SIGNING_VERSION_LEGACY:
+                continue  # already v1 (or a recognised non-legacy) — idempotent skip
+            if getattr(cap, "attester_id", None) != gen_authority_id:
+                # External attester — the local genesis key cannot re-sign FOR it.
+                report.unmigratable.append(
+                    UnmigratableItem(
+                        agent_id=chain.genesis.agent_id,
+                        kind="capability",
+                        reason=(
+                            f"capability attester {getattr(cap, 'attester_id', None)!r}"
+                            f" != genesis authority {gen_authority_id!r} — needs the "
+                            "external attester to re-sign"
+                        ),
+                        capability_id=cap.id,
+                    )
+                )
+                has_unpromoted_legacy = True
+                continue
+            # SECURITY (#1912 Wave 3 — RT-sec-w3r2 Finding C, the TRANSPLANT axis):
+            # a legacy cap carries NO holder subject in its signed bytes, so its
+            # signature verifies IDENTICALLY on ANY chain under the same attester.
+            # Promoting it binds it to the chain it CURRENTLY sits in — an
+            # unverifiable trust-the-store-placement decision. A store-writer who
+            # transplanted a genuine legacy cap into this chain before the
+            # migration would have that transplant laundered into a valid v1 cap.
+            # REFUSE unless the operator explicitly acknowledges a trusted store
+            # snapshot (the force_drop / force_downgrade safe-default idiom).
+            if not trust_store_placement:
+                report.unmigratable.append(
+                    UnmigratableItem(
+                        agent_id=chain.genesis.agent_id,
+                        kind="capability",
+                        reason=(
+                            "legacy capability promotion requires "
+                            "trust_store_placement=True — the migration binds a "
+                            "legacy cap to its CURRENT chain and cannot verify a "
+                            "legacy cap's original holder (no subject in the signed "
+                            "bytes); run against a TRUSTED store snapshot"
+                        ),
+                        capability_id=cap.id,
+                    )
+                )
+                has_unpromoted_legacy = True
+                continue
+            # SECURITY (#1912 Wave 3 — RT-sec-w3 Finding A): VERIFY the cap's
+            # EXISTING legacy signature BEFORE re-signing it. The migration is the
+            # ONLY component holding the genesis key that touches persisted store
+            # content, so re-signing an UN-verified legacy cap would launder a
+            # store-writer's injected/tampered capability into a valid v1 cap — a
+            # signature-laundering oracle that defeats the exact bounded-trust
+            # store-writer threat model #1912 defends against (the attester_id
+            # check above is NOT sufficient: attester_id is attacker-writable). A
+            # cap whose existing legacy signature does not verify against the
+            # genesis authority is REPORTED, never promoted. The legacy pre-image
+            # is deterministic (no subject), so this is a cheap, exact check.
+            legacy_payload = serialize_for_signing(cap.to_signing_payload())
+            try:
+                legacy_ok = await self.key_manager.verify(
+                    legacy_payload, cap.signature, authority.public_key
+                )
+            except (InvalidSignatureError, ValueError):
+                legacy_ok = False
+            if not legacy_ok:
+                report.unmigratable.append(
+                    UnmigratableItem(
+                        agent_id=chain.genesis.agent_id,
+                        kind="capability",
+                        reason=(
+                            "existing legacy signature does not verify against the "
+                            "genesis authority — refusing to re-sign (possible store "
+                            "tamper / injection); re-issue this capability"
+                        ),
+                        capability_id=cap.id,
+                    )
+                )
+                has_unpromoted_legacy = True
+                continue
+            cap.signing_payload_version = CAPABILITY_SIGNING_VERSION_V1
+            cap_payload = serialize_for_signing(
+                cap.to_signing_payload(subject_agent_id=chain.genesis.agent_id)
+            )
+            cap.signature = await self.key_manager.sign(cap_payload, signing_key_id)
+            report.promoted_capabilities += 1
+            changed = True
+
+        # 2. Add a chain-state signature when absent — but ONLY if no legacy cap
+        #    was left un-promoted (signing a chain-state that still contains an
+        #    un-enforceable legacy cap would attest an incompletely-migrated set,
+        #    RT-sec-w3r2 Q2). An EXISTING valid chain-state signature is preserved,
+        #    not re-issued (the ``is None`` guard) — promoting a cap does not change
+        #    capability_ids/constraint_hash, and idempotent re-runs need no ack.
+        if (
+            not has_unpromoted_legacy
+            and getattr(chain, "chain_state_signature", None) is None
+        ):
+            # SECURITY (#1912 Wave 3 — RT-sec-w3r3 Finding D, enforcement-surface
+            # parity with Finding C): FRESH chain-state signing re-signs over the
+            # chain's CURRENT constraint envelope + id-set, which the migration
+            # CANNOT verify (there is no prior chain-state signature to check
+            # against — that is why we are adding one). A store-writer who stripped
+            # a REASONING_REQUIRED / spend constraint AND the old signature leaves a
+            # chain byte-shape-identical to a legitimate post-Wave-1/pre-Wave-2
+            # target; re-signing it would BLESS the suppression (MED-2/MED-1 bypass).
+            # This is the SAME trust-the-store-placement decision as legacy-cap
+            # promotion, so it ALSO requires the trusted-snapshot acknowledgment.
+            if not trust_store_placement:
+                report.unmigratable.append(
+                    UnmigratableItem(
+                        agent_id=chain.genesis.agent_id,
+                        kind="chain",
+                        reason=(
+                            "chain-state signing requires trust_store_placement="
+                            "True — the migration re-signs over the chain's CURRENT "
+                            "(unverified) constraint envelope and id-set; a store-"
+                            "writer could have stripped a constraint AND the old "
+                            "signature. Run against a TRUSTED store snapshot"
+                        ),
+                    )
+                )
+            else:
+                cs_payload = chain_state_canonical_payload_str(chain)
+                chain.chain_state_signature = await self.key_manager.sign(
+                    cs_payload, signing_key_id
+                )
+                report.added_chain_state_signatures += 1
+                changed = True
+
+        return changed
+
+    async def _apply_atomically(
+        self,
+        updates: List[Tuple[str, TrustLineageChain, TrustLineageChain]],
+        report: MigrationReport,
+    ) -> None:
+        """Write every changed chain; roll back ALL on any failure.
+
+        Snapshots (the pre-migration originals) are recorded on the report BEFORE
+        any write, so a partial failure restores the store to its pre-migration
+        state, and a SUCCESSFUL run remains reversible via :meth:`rollback`.
+        """
+        applied: List[str] = []
+        for snap_agent_id, _updated, original in updates:
+            report.snapshots[snap_agent_id] = original
+        current_agent = ""
+        try:
+            for agent_id, updated, _original in updates:
+                current_agent = agent_id
+                await self.trust_store.update_chain(agent_id, updated)
+                applied.append(agent_id)
+        except Exception as exc:  # noqa: BLE001 — restore then re-raise (fail-closed)
+            restore_failures = await self._restore(applied, report.snapshots)
+            if restore_failures:
+                logger.critical(
+                    "subject_binding_1912 migration rollback INCOMPLETE — the "
+                    "trust store is in an inconsistent state; agents whose "
+                    "restore failed: %s",
+                    restore_failures,
+                )
+            report.snapshots.clear()
+            report.migrated_chains = 0
+            raise SubjectBindingMigrationError(
+                f"#1912 re-signing migration failed applying chain "
+                f"{current_agent!r}: {exc}"
+            ) from exc
+
+    async def rollback(self, report: MigrationReport) -> int:
+        """Byte-exact restore of every chain a prior :meth:`migrate` changed.
+
+        Restores the pre-migration snapshots captured by the run that produced
+        ``report``. This is a byte-exact revert, NOT a security-downgrading
+        logical demote. Returns the number of chains restored.
+
+        Raises:
+            SubjectBindingMigrationError: If any restore write fails.
+        """
+        if not report.snapshots:
+            return 0
+        agent_ids = list(report.snapshots.keys())
+        restore_failures = await self._restore(agent_ids, report.snapshots)
+        if restore_failures:
+            raise SubjectBindingMigrationError(
+                f"#1912 migration rollback failed for chains: {restore_failures}"
+            )
+        return len(agent_ids)
+
+    async def _restore(
+        self, agent_ids: List[str], snapshots: Dict[str, TrustLineageChain]
+    ) -> List[str]:
+        """Best-effort restore of the given agents from snapshots.
+
+        Returns the list of agent_ids whose restore write RAISED (so the caller
+        can escalate an inconsistent-state CRITICAL), attempting every remaining
+        restore rather than aborting on the first failure.
+        """
+        failures: List[str] = []
+        for agent_id in agent_ids:
+            original = snapshots.get(agent_id)
+            if original is None:
+                continue
+            try:
+                await self.trust_store.update_chain(agent_id, original)
+            except Exception:  # noqa: BLE001 — collect, keep restoring
+                logger.exception(
+                    "subject_binding_1912: failed to restore chain %s during "
+                    "rollback",
+                    agent_id,
+                )
+                failures.append(agent_id)
+        return failures

--- a/src/kailash/trust/operations/__init__.py
+++ b/src/kailash/trust/operations/__init__.py
@@ -28,6 +28,8 @@ from kailash.trust.authority import (
     OrganizationalAuthority,
 )
 from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_LEGACY,
+    CAPABILITY_SIGNING_VERSION_V1,
     ActionResult,
     AuditAnchor,
     CapabilityAttestation,
@@ -57,6 +59,9 @@ from kailash.trust.exceptions import (
     UnsupportedSigningPayloadVersionError,
 )
 from kailash.trust.execution_context import ExecutionContext, get_current_context
+from kailash.trust.signing.chain_state_signing import (
+    chain_state_canonical_payload_str,
+)
 from kailash.trust.signing.crypto import (
     hash_chain,
     serialize_for_signing,
@@ -248,6 +253,9 @@ class TrustOperations:
         trust_store: TrustStore,
         max_delegation_depth: int = MAX_DELEGATION_DEPTH,
         revocation_verifier: "SignedRevocationVerifier | None" = None,
+        *,
+        allow_unbound_legacy_capabilities: bool = False,
+        allow_unsigned_chain_state: bool = False,
     ):
         """
         Initialize TrustOperations.
@@ -265,16 +273,52 @@ class TrustOperations:
                 unverifiable ledger/head, never falling open to the unsigned
                 ``revoked`` flag. When ``None`` (default), verify behaviour is
                 unchanged (the in-memory cascade remains the only surface).
+            allow_unbound_legacy_capabilities: #1912 Wave 3 A1 migration-window
+                opt-out. Default ``False`` = FAIL-CLOSED: :meth:`verify` REJECTS a
+                legacy (pre-#1912, un-subject-bound) capability, because a legacy
+                cap is transplantable across chains (the HIGH #1912 closes). Set
+                ``True`` ONLY during the migration window to accept legacy caps
+                over their legacy pre-image while chains are re-signed by the
+                #1912 re-signing migration (:mod:`kailash.trust.migrations.
+                subject_binding_1912`); verify emits ONE loud WARN that the
+                transplant defense is OFF. This is a hard-to-reverse security
+                relaxation — leave it ``False`` unless actively migrating.
+            allow_unsigned_chain_state: #1912 Wave 3 A1 migration-window opt-out.
+                Default ``False`` = FAIL-CLOSED: :meth:`verify` REJECTS a chain
+                that carries NO chain-state signature, because an unsigned chain
+                has no defense against whole-capability-set deletion (MED-1) or
+                constraint/REASONING_REQUIRED suppression (MED-2). Set ``True``
+                ONLY during the migration window to accept unsigned chains while
+                they are re-signed by the migration; verify emits ONE loud WARN
+                that set-deletion/suppression detection is OFF. Independent of
+                ``allow_unbound_legacy_capabilities`` (they gate distinct
+                security dimensions — a deployment MAY enforce one while migrating
+                the other).
         """
         self.authority_registry = authority_registry
         self.key_manager = key_manager
         self.trust_store = trust_store
         self.max_delegation_depth = max_delegation_depth
         self.revocation_verifier = revocation_verifier
+        # #1912 Wave 3 A1 — fail-closed enforcement opt-outs (default False). Each
+        # gates a DISTINCT security dimension; each has its OWN one-time WARN latch
+        # (below) so the OFF-protection state is observable exactly once whether it
+        # is the fail-closed REJECT (default) or the opt-out ACCEPT (migration
+        # window). security.md § Secure-Default / feedback_no_shims (optimal-clean).
+        self.allow_unbound_legacy_capabilities = allow_unbound_legacy_capabilities
+        self.allow_unsigned_chain_state = allow_unsigned_chain_state
         # FIX 4 (#1842) — one-time WARN latch. When no signed-ledger verifier is
         # wired, the authoritative resurrection/rollback defenses are OFF; verify()
         # emits ONE WARN the first time it runs unprotected (observability Rule 4).
         self._revocation_verifier_absent_warned = False
+        # #1912 Wave 3 — one-time WARN latches for the two A1 enforcement axes.
+        # The chain-state latch fires on the absent-sig path (REJECT by default,
+        # or ACCEPT under allow_unsigned_chain_state); the legacy-cap latch fires
+        # on the legacy-version path (REJECT by default, or ACCEPT under
+        # allow_unbound_legacy_capabilities). One WARN per axis per instance
+        # (observability Rule 4) — the systemic cause, not per-verify spam.
+        self._chain_state_sig_absent_warned = False
+        self._unbound_legacy_cap_warned = False
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -368,6 +412,7 @@ class TrustOperations:
                 authority=authority,
                 global_constraints=constraints,
                 expires_at=expires_at,
+                subject_agent_id=agent_id,
             )
             capability_attestations.append(attestation)
 
@@ -387,6 +432,11 @@ class TrustOperations:
             constraint_envelope=constraint_envelope,
             audit_anchors=[],
         )
+
+        # 8b. Issue the #1912 Wave 2 chain-state signature (new chains ALWAYS get
+        # it — fail-closed at issuance). Binds the capability SET + constraint
+        # envelope under the genesis authority's Ed25519 key.
+        await self._issue_chain_state_signature(chain, authority=authority)
 
         # 9. Store chain
         await self.trust_store.store_chain(chain, expires_at)
@@ -418,6 +468,7 @@ class TrustOperations:
         authority: OrganizationalAuthority,
         global_constraints: List[str],
         expires_at: Optional[datetime],
+        subject_agent_id: str,
     ) -> CapabilityAttestation:
         """
         Create and sign a capability attestation.
@@ -427,6 +478,10 @@ class TrustOperations:
             authority: The attesting authority
             global_constraints: Constraints applied to all capabilities
             expires_at: Optional expiration
+            subject_agent_id: The HOLDER agent this capability is attested FOR
+                (the chain's ``genesis.agent_id``). Bound into the v1 signing
+                pre-image so the cap cannot be transplanted into another chain
+                (#1912).
 
         Returns:
             Signed CapabilityAttestation
@@ -449,10 +504,16 @@ class TrustOperations:
             expires_at=expires_at,
             signature="",
             scope=cap_request.scope,
+            # New caps are v1-subject-bound (#1912): the signature covers the
+            # holder subject, so a genuine cap copied into another chain fails
+            # verification.
+            signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
         )
 
-        # Sign attestation
-        payload = serialize_for_signing(attestation.to_signing_payload())
+        # Sign attestation over the v1 pre-image (holder subject bound in).
+        payload = serialize_for_signing(
+            attestation.to_signing_payload(subject_agent_id=subject_agent_id)
+        )
         attestation.signature = await self.key_manager.sign(
             payload, authority.signing_key_id
         )
@@ -667,10 +728,34 @@ class TrustOperations:
         #     fails). Constraints are still collected from every cap instance.
         verified_caps: set = set()
         for cap in chain.capabilities:
-            dedup_key = (
-                serialize_for_signing(cap.to_signing_payload()),
-                cap.signature,
-            )
+            # Dedup key reflects the ACTUAL pre-image that will be verified: for a
+            # v1 cap it includes the holder subject (#1912), matching
+            # _verify_capability_signature's dispatch, so two caps that verify
+            # over DIFFERENT bytes never collide. An UNRECOGNISED version emits
+            # legacy-shaped bytes (no raise) and its denial happens in the verify
+            # call below. An empty holder subject on a v1 cap (an anomalous /
+            # tampered chain whose genesis.agent_id is empty) makes
+            # to_signing_payload RAISE (the #1912 empty-subject guard) — this is
+            # a sibling verify-site of _verify_capability_signature, so it MUST
+            # fail closed the same way here, never propagate the ValueError up
+            # the public verify() FULL path.
+            try:
+                dedup_key = (
+                    serialize_for_signing(
+                        cap.to_signing_payload(subject_agent_id=chain.genesis.agent_id)
+                    ),
+                    cap.signature,
+                )
+            except ValueError:
+                logger.warning(
+                    "capability constraint derivation failed: v1 capability over "
+                    "an empty holder subject (fail-closed denial)",
+                    extra={"capability_id": cap.id},
+                )
+                return (
+                    empty,
+                    f"Capability signature invalid — constraints untrusted: {cap.id}",
+                )
             if dedup_key not in verified_caps:
                 if not await self._verify_capability_signature(
                     chain, cap, authority=authority
@@ -709,6 +794,7 @@ class TrustOperations:
         authority: Any,
         authority_id: str,
         expires_at: Optional[datetime],
+        subject_agent_id: str,
     ) -> List[CapabilityAttestation]:
         """Build SIGNED derived capabilities carrying a delegation's tightening.
 
@@ -734,6 +820,10 @@ class TrustOperations:
             authority: The resolved signing authority.
             authority_id: The signing authority id (attester).
             expires_at: The derived capability expiry.
+            subject_agent_id: The HOLDER of the derived capabilities (the
+                ``delegatee_id`` — equal to the delegatee chain's
+                ``genesis.agent_id``). Bound into the v1 signing pre-image so a
+                derived cap cannot be transplanted into another chain (#1912).
 
         Returns:
             A list of signed :class:`CapabilityAttestation` (one per matched
@@ -761,14 +851,158 @@ class TrustOperations:
                 expires_at=expires_at,
                 signature="",
                 scope=source_cap.scope,
+                # Derived caps are v1-subject-bound (#1912) to the delegatee.
+                signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
             )
-            cap_payload = serialize_for_signing(derived_cap.to_signing_payload())
+            cap_payload = serialize_for_signing(
+                derived_cap.to_signing_payload(subject_agent_id=subject_agent_id)
+            )
             derived_cap.signature = await self.key_manager.sign(
                 cap_payload,
                 authority.signing_key_id,
             )
             derived.append(derived_cap)
         return derived
+
+    async def _issue_chain_state_signature(
+        self,
+        chain: TrustLineageChain,
+        *,
+        authority: Optional[Any] = None,
+    ) -> None:
+        """(Re)issue the #1912 Wave 2 chain-state signature IN PLACE.
+
+        Signs the canonical chain-state pre-image (capability-SET membership +
+        constraint envelope) with the CHAIN OWNER's genesis-authority key and
+        sets ``chain.chain_state_signature``. Called at EVERY site that creates
+        OR mutates a persisted chain (establish + both delegate branches +
+        revoke_delegation) so a stale chain-state signature is never persisted —
+        a mutation that changed ``capability_ids`` / ``delegation_ids`` /
+        ``constraint_hash`` without re-issuing would fail closed at verify.
+
+        The signer is ALWAYS ``chain.genesis.authority_id`` (the chain owner),
+        because verify (:meth:`_verify_chain_state_signature`) resolves that same
+        authority — binding to the mutating delegator's authority instead would
+        make verify resolve the wrong public key. A pre-resolved ``authority`` is
+        used only when it matches the chain's genesis authority (the establish /
+        new-delegatee fast path); otherwise the owner authority is resolved here.
+        """
+        gen_authority_id = chain.genesis.authority_id
+        if authority is None or getattr(authority, "id", None) != gen_authority_id:
+            authority = await self.authority_registry.get_authority(gen_authority_id)
+        payload = chain_state_canonical_payload_str(chain)
+        chain.chain_state_signature = await self.key_manager.sign(
+            payload, authority.signing_key_id
+        )
+
+    async def _verify_chain_state_signature(
+        self,
+        chain: TrustLineageChain,
+        level: VerificationLevel,
+    ) -> Optional[VerificationResult]:
+        """Verify the #1912 Wave 2 chain-state signature (verify-if-present).
+
+        Returns a DENY :class:`VerificationResult` when the chain carries a
+        chain-state signature that does NOT verify over the recomputed pre-image
+        (a store-writer deleted a whole capability — MED-1 — or stripped a
+        constraint / REASONING_REQUIRED entry from the persisted envelope —
+        MED-2), OR when the signing authority cannot be resolved / the signature
+        is malformed (fail-closed). #1912 Wave 3 A1: a chain with NO signature is
+        also DENIED (an unsigned chain has no MED-1/MED-2 defense, and stripping
+        the signature is the downgrade-to-legacy bypass) — UNLESS the deployment
+        set ``allow_unsigned_chain_state=True`` for the migration window, in which
+        case an unsigned chain is accepted with a loud one-time WARN. Returns
+        ``None`` when the signature verifies (or under the opt-out).
+        """
+        sig = getattr(chain, "chain_state_signature", None)
+        if sig is None:
+            # #1912 Wave 3 A1 enforcement. An unsigned chain has NO defense against
+            # whole-capability-set deletion (MED-1) or constraint/REASONING_REQUIRED
+            # suppression (MED-2), and stripping the signature is exactly the
+            # downgrade-to-legacy bypass. FAIL CLOSED: DENY unless the deployment
+            # explicitly opted into the migration window. Both the reject-path
+            # (default) and the opt-out-accept-path emit ONE latched WARN naming
+            # the OFF protection (observability Rule 4).
+            if not self.allow_unsigned_chain_state:
+                if not self._chain_state_sig_absent_warned:
+                    self._chain_state_sig_absent_warned = True
+                    logger.warning(
+                        "trust verify: REJECTING chain with NO chain-state "
+                        "signature (#1912 Wave 3 A1) — whole-capability-set-"
+                        "deletion and constraint-suppression detection require the "
+                        "signature. Re-sign chains with the #1912 migration "
+                        "(kailash.trust.migrations.subject_binding_1912), or set "
+                        "TrustOperations(allow_unsigned_chain_state=True) for the "
+                        "migration window.",
+                        extra={"agent_id": chain.genesis.agent_id},
+                    )
+                return VerificationResult(
+                    valid=False,
+                    reason=(
+                        "Chain has no chain-state signature — set-deletion / "
+                        "constraint-suppression protection is unavailable; re-sign "
+                        "via the #1912 migration or set "
+                        "allow_unsigned_chain_state=True (#1912 Wave 3)"
+                    ),
+                    level=level,
+                )
+            if not self._chain_state_sig_absent_warned:
+                self._chain_state_sig_absent_warned = True
+                logger.warning(
+                    "trust verify: ACCEPTING chains with NO chain-state signature "
+                    "because allow_unsigned_chain_state=True (#1912 Wave 3 "
+                    "migration window) — whole-capability-set-deletion and "
+                    "constraint-suppression detection are OFF. Re-sign chains with "
+                    "the #1912 migration and clear this flag to fail closed.",
+                    extra={"agent_id": chain.genesis.agent_id},
+                )
+            return None
+
+        try:
+            authority = await self.authority_registry.get_authority(
+                chain.genesis.authority_id,
+                include_inactive=True,  # historical verification
+            )
+        except (AuthorityNotFoundError, AuthorityInactiveError):
+            logger.warning(
+                "chain-state signature verification: signing authority "
+                "unresolved (fail-closed deny)",
+                extra={"authority_id": chain.genesis.authority_id},
+            )
+            return VerificationResult(
+                valid=False,
+                reason="Chain-state signature authority unresolved — chain untrusted",
+                level=level,
+            )
+
+        # Build the pre-image + verify INSIDE the fail-closed try: a tampered /
+        # anomalous chain must DENY, never crash the public verify() path
+        # (WAVE-1 lesson — wrap every verify-path pre-image site).
+        try:
+            payload = chain_state_canonical_payload_str(chain)
+            ok = await self.key_manager.verify(payload, sig, authority.public_key)
+        except (InvalidSignatureError, ValueError) as exc:
+            logger.warning(
+                "chain-state signature malformed or unverifiable (fail-closed " "deny)",
+                extra={"agent_id": chain.genesis.agent_id, "error": str(exc)},
+            )
+            ok = False
+
+        if not ok:
+            logger.warning(
+                "chain-state signature INVALID (#1912 Wave 2 fail-closed deny) — "
+                "capability set or constraint envelope may be tampered",
+                extra={"agent_id": chain.genesis.agent_id},
+            )
+            return VerificationResult(
+                valid=False,
+                reason=(
+                    "Chain-state signature invalid — capability set or constraint "
+                    "envelope may be tampered (#1912)"
+                ),
+                level=level,
+            )
+        return None
 
     # =========================================================================
     # VERIFY Operation
@@ -848,6 +1082,18 @@ class TrustOperations:
         # QUICK level: Just check hash and expiration
         if level == VerificationLevel.QUICK:
             return await self._verify_quick(chain, level)
+
+        # #1912 chain-state signature gate (STANDARD+). Verifies the ONE
+        # genesis-authority signature over the chain-state pre-image (capability-
+        # SET membership + constraint envelope) BEFORE the matched-capability and
+        # constraint checks, so a whole-cap deletion (MED-1) or a constraint /
+        # REASONING_REQUIRED suppression (MED-2) fails closed here. Under Wave-3 A1
+        # a chain with NO signature is REJECTED by default (fail-closed); the
+        # migration-window opt-out allow_unsigned_chain_state=True accepts it with
+        # a loud one-time WARN.
+        chain_state_denial = await self._verify_chain_state_signature(chain, level)
+        if chain_state_denial is not None:
+            return chain_state_denial
 
         # STANDARD level: Check capabilities and constraints
         capability = self._match_capability(chain, action)
@@ -1519,19 +1765,83 @@ class TrustOperations:
                     },
                 )
                 return False
-        cap_payload = serialize_for_signing(cap.to_signing_payload())
+        # Dispatch on the capability's signing-payload version (#1912 Wave 1).
+        # An UNRECOGNISED version fails closed (never falls through to the legacy
+        # verifier, which would check the WRONG pre-image). The v1 pre-image binds
+        # THIS chain's holder subject, so a genuine cap transplanted from another
+        # chain recomputes a different subject and its signature no longer matches;
+        # a v1 cap whose version was stripped defaults to legacy and its legacy
+        # re-verification (no subject) also fails (downgrade-resistant).
+        version = getattr(
+            cap, "signing_payload_version", CAPABILITY_SIGNING_VERSION_LEGACY
+        )
+        if version not in (
+            CAPABILITY_SIGNING_VERSION_LEGACY,
+            CAPABILITY_SIGNING_VERSION_V1,
+        ):
+            logger.warning(
+                "capability signature verification failed: unrecognised "
+                "signing_payload_version (fail-closed denial)",
+                extra={
+                    "capability_id": cap.id,
+                    "signing_payload_version": version,
+                },
+            )
+            return False
+        if version == CAPABILITY_SIGNING_VERSION_LEGACY:
+            # #1912 Wave 3 A1 enforcement. A legacy (pre-#1912) capability signs a
+            # pre-image with NO holder subject, so it verifies IDENTICALLY on ANY
+            # chain — the exact capability-transplant HIGH #1912 closes for v1
+            # caps. FAIL CLOSED: reject the legacy cap unless the deployment has
+            # explicitly opted into the migration window. The reject-path and the
+            # opt-out-accept-path EACH emit one latched WARN naming the systemic
+            # cause (this deployment holds un-migrated legacy caps), never
+            # per-verify spam (observability Rule 4).
+            if not self.allow_unbound_legacy_capabilities:
+                if not self._unbound_legacy_cap_warned:
+                    self._unbound_legacy_cap_warned = True
+                    logger.warning(
+                        "trust verify: REJECTING legacy (un-subject-bound) "
+                        "capability (#1912 Wave 3 A1) — legacy caps are "
+                        "transplantable across chains. Re-sign chains with the "
+                        "#1912 migration (kailash.trust.migrations."
+                        "subject_binding_1912), or set "
+                        "TrustOperations(allow_unbound_legacy_capabilities=True) "
+                        "for the migration window.",
+                        extra={"capability_id": cap.id},
+                    )
+                return False
+            if not self._unbound_legacy_cap_warned:
+                self._unbound_legacy_cap_warned = True
+                logger.warning(
+                    "trust verify: ACCEPTING legacy (un-subject-bound) "
+                    "capabilities because allow_unbound_legacy_capabilities=True "
+                    "(#1912 Wave 3 migration window) — the capability-transplant "
+                    "defense is OFF. Re-sign chains with the #1912 migration and "
+                    "clear this flag to fail closed.",
+                    extra={"capability_id": cap.id},
+                )
         try:
+            # Build the pre-image INSIDE the fail-closed try: a v1 cap on a chain
+            # whose genesis.agent_id is empty/absent (an anomalous/tampered state)
+            # makes to_signing_payload raise ValueError; treat that as a denial,
+            # never a crash (#1912 RT-sec LOW — verify fail-closes on the empty
+            # subject the sign-time guard rejects at mint).
+            cap_payload = serialize_for_signing(
+                cap.to_signing_payload(subject_agent_id=chain.genesis.agent_id)
+            )
             return await self.key_manager.verify(
                 cap_payload,
                 cap.signature,
                 authority.public_key,
             )
-        except InvalidSignatureError:
+        except (InvalidSignatureError, ValueError):
             # verify_signature() returns False on a BadSignatureError but RAISES
             # InvalidSignatureError on a malformed / empty / wrong-length
-            # signature. A tampered stored grant may carry exactly such a
-            # signature, so treat the raise as an invalid signature and fail
-            # closed (mirrors _verify_reasoning_traces). Observable, not silent.
+            # signature; a v1 pre-image over an empty subject raises ValueError.
+            # A tampered stored grant may carry exactly such a signature, so treat
+            # the raise as an invalid signature and fail closed (mirrors
+            # _verify_reasoning_traces). Observable, not silent.
             logger.warning(
                 "capability signature verification failed: malformed or "
                 "unverifiable signature (fail-closed denial)",
@@ -1730,6 +2040,37 @@ class TrustOperations:
                 subject_id,
                 f"source chain failed integrity verification: {integrity.reason}",
                 violations=["chain_integrity_failed"],
+            )
+
+        # (d) #1912 Wave 3 — enforce the chain-state signature at the mint surface
+        # too (rules/security.md § Enforcement-Surface Parity). verify() gates the
+        # chain-state signature at STANDARD+ (whole-capability-set deletion MED-1 /
+        # constraint-suppression MED-2); this mint gate is an INDEPENDENT validation
+        # surface that produces a signed, portable artifact, so a store-writer who
+        # deletes a constraint-bearing capability or strips a constraint — breaking
+        # the chain-state signature — must NOT be able to mint from the weakened
+        # chain (RT-sec-w3 Finding B). _verify_capability_signature (called via
+        # _verify_signatures above) already carries the LEGACY-cap A1 flip, so only
+        # the chain-state dimension needs adding here for parity. Honors the same
+        # allow_unsigned_chain_state migration-window opt-out (the check reads it),
+        # and never raises (it returns a DENY VerificationResult or None).
+        chain_state_denial = await self._verify_chain_state_signature(
+            chain, VerificationLevel.STANDARD
+        )
+        if chain_state_denial is not None:
+            logger.warning(
+                "mint refused: source chain-state signature invalid/absent "
+                "(#1912 Wave 3, fail-closed)",
+                extra={
+                    "subject_id": subject_id,
+                    "reason": chain_state_denial.reason,
+                },
+            )
+            raise InvalidTrustChainError(
+                subject_id,
+                f"source chain failed chain-state verification: "
+                f"{chain_state_denial.reason}",
+                violations=["chain_state_verification_failed"],
             )
 
     async def _verify_delegation_signature(
@@ -2274,6 +2615,7 @@ class TrustOperations:
                         authority=authority,
                         authority_id=authority_id,
                         expires_at=expires_at,
+                        subject_agent_id=delegatee_id,
                     )
                 )
             # Recompute the (advisory) persisted constraint envelope cache.
@@ -2283,6 +2625,12 @@ class TrustOperations:
                 capabilities=delegatee_chain.capabilities,
                 delegations=delegatee_chain.delegations,
             )
+            # Re-issue the #1912 Wave 2 chain-state signature: the appended
+            # delegation + derived caps + recomputed envelope changed the pre-
+            # image, so the prior signature is now stale and would fail closed at
+            # verify. Signed by the delegatee chain's OWN genesis authority (the
+            # chain owner), which verify resolves — not the delegator's authority.
+            await self._issue_chain_state_signature(delegatee_chain)
             await self.trust_store.update_chain(delegatee_id, delegatee_chain)
         except TrustChainNotFoundError:
             # Create a derived chain for the delegatee
@@ -2322,6 +2670,7 @@ class TrustOperations:
                 authority=authority,
                 authority_id=authority_id,
                 expires_at=expires_at,
+                subject_agent_id=delegatee_id,
             )
 
             # Compute constraint envelope
@@ -2339,6 +2688,12 @@ class TrustOperations:
                 delegations=[delegation],
                 constraint_envelope=constraint_envelope,
                 audit_anchors=[],
+            )
+            # Issue the #1912 Wave 2 chain-state signature for the new derived
+            # chain (new chains ALWAYS get it). The derived genesis authority ==
+            # the delegator's authority, so the already-resolved authority signs.
+            await self._issue_chain_state_signature(
+                delegatee_chain, authority=authority
             )
             await self.trust_store.store_chain(delegatee_chain, expires_at)
 
@@ -2580,6 +2935,13 @@ class TrustOperations:
             capabilities=chain.capabilities,
             delegations=chain.delegations,
         )
+
+        # Re-issue the #1912 Wave 2 chain-state signature: removing a delegation
+        # changed delegation_ids + the recomputed envelope, so the prior
+        # signature is stale. A legitimate revocation must NOT leave a stale
+        # signature that would then fail closed at verify.
+        if chain.chain_state_signature is not None:
+            await self._issue_chain_state_signature(chain)
 
         await self.trust_store.update_chain(delegatee_id, chain)
 

--- a/src/kailash/trust/signing/capability_fold_serde.py
+++ b/src/kailash/trust/signing/capability_fold_serde.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared serialization for the #1912 capability signing-payload version.
+
+#1912 Wave 1 added the ``signing_payload_version`` discriminator to
+``CapabilityAttestation`` (``legacy-python-v0`` / ``v1-subject-bound``). A v1
+cap's signature verifies ONLY if the version survives persistence: the
+reconstructed cap MUST recompute the SAME (subject-bound) pre-image the
+signature was made over. If ANY serializer drops the version key, a v1 cap
+reloads as legacy → the legacy verify recomputes WITHOUT the subject → the v1
+signature fails (``security.md`` § "Multi-Site Kwarg Plumbing" — the field
+plumbed through one serializer, missed the siblings).
+
+This module is the SINGLE shared helper every capability serializer routes
+through — ``TrustLineageChain.to_dict`` (the chain-level path every persistent
+store uses), the JWT / W3C VC / SD-JWT interop serializers — so the encode and
+decode halves cannot drift (``security.md`` § "Pre-Encoder Consolidation").
+
+Prune-when-unset: a legacy cap (version at its ``legacy-python-v0`` default)
+serializes to a dict with NO ``signing_payload_version`` key, byte-identical to
+a pre-#1912 cap (``cross-sdk-inspection.md`` Rule 4d). A v1 cap emits the key,
+and on reconstruction it is bound back so the subject-bound pre-image
+re-verifies. The snake_case shape matches ``TrustLineageChain.to_dict`` / JWT;
+the camelCase shape matches the W3C VC convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+__all__ = [
+    "serialize_capability_fold_fields",
+    "deserialize_capability_fold_fields",
+]
+
+
+class _CapabilityFoldSource(Protocol):
+    """Structural type for the cap field ``serialize_capability_fold_fields`` reads.
+
+    A LOCAL Protocol (not an import of
+    ``kailash.trust.chain.CapabilityAttestation``) mirrors the sibling
+    ``delegation_fold_serde._FoldSourceRecord`` shape; ``CapabilityAttestation``
+    satisfies it structurally. The one carried field is the authoritative
+    fold-field set the structural-parity test derives non-circularly.
+    """
+
+    signing_payload_version: str
+
+
+# Attribute name -> serialized key, per case convention. The chain-level + JWT
+# serializers emit snake_case; the W3C VC serializer emits camelCase.
+_SNAKE_KEYS = {"signing_payload_version": "signing_payload_version"}
+_CAMEL_KEYS = {"signing_payload_version": "signingPayloadVersion"}
+
+
+def _keys(camel: bool) -> Dict[str, str]:
+    return _CAMEL_KEYS if camel else _SNAKE_KEYS
+
+
+def serialize_capability_fold_fields(
+    cap: _CapabilityFoldSource, *, camel: bool = False
+) -> Dict[str, Any]:
+    """Serialize the capability signing-payload version prune-when-unset.
+
+    The version key is emitted ONLY when NON-legacy, so a legacy cap yields an
+    empty dict (no new key — byte-identical to a pre-#1912 cap).
+
+    Args:
+        cap: The capability to read ``signing_payload_version`` from.
+        camel: Emit camelCase keys (W3C VC convention) instead of snake_case.
+
+    Returns:
+        A dict carrying ``{signing_payload_version: <value>}`` for a v1 cap, or
+        an empty dict for a legacy cap.
+    """
+    # Import lazily so this low-level serde never imports the high-level ``chain``
+    # module at module scope — chain.py imports THIS module at module scope, so a
+    # back-edge here would form a load-time cycle (mirrors delegation_fold_serde's
+    # one-way dependency; keeps CodeQL py/unsafe-cyclic-import clear).
+    from kailash.trust.chain import CAPABILITY_SIGNING_VERSION_LEGACY
+
+    k = _keys(camel)
+    if cap.signing_payload_version != CAPABILITY_SIGNING_VERSION_LEGACY:
+        return {k["signing_payload_version"]: cap.signing_payload_version}
+    return {}
+
+
+def deserialize_capability_fold_fields(
+    data: Dict[str, Any], *, camel: bool = False
+) -> Dict[str, Any]:
+    """Reconstruct the capability signing-payload version from a serialized dict.
+
+    Backward-compatible: a pre-#1912 dict has no version key, so the field
+    resolves to ``legacy-python-v0`` and the cap verifies as legacy.
+
+    Args:
+        data: The serialized capability dict.
+        camel: Read camelCase keys (W3C VC convention) instead of snake_case.
+
+    Returns:
+        A kwargs dict ``{signing_payload_version: <value>}`` suitable for the
+        ``CapabilityAttestation`` constructor.
+    """
+    # Lazy import (see serialize_capability_fold_fields) — avoids a load-time
+    # cycle with the high-level ``chain`` module.
+    from kailash.trust.chain import CAPABILITY_SIGNING_VERSION_LEGACY
+
+    k = _keys(camel)
+    return {
+        "signing_payload_version": data.get(
+            k["signing_payload_version"], CAPABILITY_SIGNING_VERSION_LEGACY
+        )
+    }

--- a/src/kailash/trust/signing/chain_state_serde.py
+++ b/src/kailash/trust/signing/chain_state_serde.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared serialization for the #1912 Wave 2 chain-state signature field.
+
+#1912 Wave 2 added ``chain_state_signature: Optional[str]`` to
+``TrustLineageChain`` — ONE Ed25519 signature by the genesis authority over the
+canonical chain-state pre-image (``chain_state_signing``). The signature
+verifies ONLY if the field survives persistence: the reconstructed chain MUST
+carry the SAME signature the pre-image was signed with. If a serializer drops
+the field, a signed chain reloads as legacy → Wave-2 verify accepts it with a
+WARN instead of enforcing (``security.md`` § "Multi-Site Kwarg Plumbing" — the
+field plumbed through one serializer, missed the siblings).
+
+This module is the SINGLE shared helper every chain serializer routes through —
+``TrustLineageChain.to_dict`` (the chain-level path every persistent store uses)
+— so the encode and decode halves cannot drift (``security.md`` §
+"Pre-Encoder Consolidation").
+
+Prune-when-unset: a legacy chain (field at its ``None`` default) serializes to a
+dict with NO ``chain_state_signature`` key, byte-identical to a pre-Wave-2 chain
+(``cross-sdk-inspection.md`` Rule 4d). A signed chain emits the key, and on
+reconstruction it is bound back so the chain-state signature re-verifies. The
+snake_case shape matches ``TrustLineageChain.to_dict``; the camelCase shape
+matches the W3C VC convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Protocol
+
+__all__ = [
+    "serialize_chain_state_signature_fields",
+    "deserialize_chain_state_signature_fields",
+]
+
+
+class _ChainStateSignatureSource(Protocol):
+    """Structural type for the field ``serialize_...`` reads.
+
+    A LOCAL Protocol (not an import of ``kailash.trust.chain.TrustLineageChain``)
+    mirrors the sibling ``capability_fold_serde._CapabilityFoldSource`` shape;
+    ``TrustLineageChain`` satisfies it structurally.
+    """
+
+    chain_state_signature: Optional[str]
+
+
+_SNAKE_KEYS = {"chain_state_signature": "chain_state_signature"}
+_CAMEL_KEYS = {"chain_state_signature": "chainStateSignature"}
+
+
+def _keys(camel: bool) -> Dict[str, str]:
+    return _CAMEL_KEYS if camel else _SNAKE_KEYS
+
+
+def serialize_chain_state_signature_fields(
+    chain: _ChainStateSignatureSource, *, camel: bool = False
+) -> Dict[str, Any]:
+    """Serialize the chain-state signature prune-when-unset.
+
+    The key is emitted ONLY when the field is set, so a legacy chain yields an
+    empty dict (no new key — byte-identical to a pre-Wave-2 chain).
+
+    Args:
+        chain: The chain to read ``chain_state_signature`` from.
+        camel: Emit camelCase keys (W3C VC convention) instead of snake_case.
+
+    Returns:
+        A dict carrying ``{chain_state_signature: <value>}`` for a signed chain,
+        or an empty dict for a legacy chain.
+    """
+    k = _keys(camel)
+    if chain.chain_state_signature is not None:
+        return {k["chain_state_signature"]: chain.chain_state_signature}
+    return {}
+
+
+def deserialize_chain_state_signature_fields(
+    data: Dict[str, Any], *, camel: bool = False
+) -> Dict[str, Any]:
+    """Reconstruct the chain-state signature from a serialized dict.
+
+    Backward-compatible: a pre-Wave-2 dict has no key, so the field resolves to
+    ``None`` and the chain reconstructs as legacy (Wave-2 verify accepts it with
+    a WARN).
+
+    Args:
+        data: The serialized chain dict.
+        camel: Read camelCase keys (W3C VC convention) instead of snake_case.
+
+    Returns:
+        A kwargs dict ``{chain_state_signature: <value-or-None>}`` suitable for
+        the ``TrustLineageChain`` constructor.
+    """
+    k = _keys(camel)
+    return {"chain_state_signature": data.get(k["chain_state_signature"])}

--- a/src/kailash/trust/signing/chain_state_signing.py
+++ b/src/kailash/trust/signing/chain_state_signing.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical chain-state signing pre-image (#1912 Wave 2).
+
+Wave 2 binds the WHOLE chain state under ONE Ed25519 signature by the genesis
+authority, closing two store-writer vectors nothing else signs:
+
+* MED-1 (whole-capability-set deletion) — deleting a capability that carries a
+  constraint (while another capability still grants the action) silently drops
+  the constraint. The capability id leaves ``capability_ids`` → the pre-image
+  changes → the signature breaks.
+* MED-2 (reasoning-suppression + directly-injected constraints) — the persisted
+  ``ChainConstraintEnvelope`` is UNSIGNED; a store-writer strips a
+  ``REASONING_REQUIRED`` (or any directly-injected) constraint with nothing to
+  break. The constraint feeds ``constraint_hash`` in the pre-image → stripping
+  it changes the recomputed hash → the signature breaks.
+
+The pre-image is a DETERMINISTIC, reproducible-at-verify dict:
+
+    {genesis_id, sorted(capability_ids), sorted(delegation_ids), constraint_hash}
+
+Distinct from ``TrustLineageChain.hash()``:
+
+* ``hash()`` (unsalted variant) reads the STORED ``constraint_envelope.constraint_hash``
+  field verbatim. A store-writer who strips a constraint from
+  ``active_constraints`` AND leaves the stored ``constraint_hash`` untouched
+  would keep ``hash()`` unchanged. This pre-image RE-COMPUTES the constraint
+  hash from ``active_constraints`` (via ``ChainConstraintEnvelope._compute_hash``),
+  so a strip-without-rehash is still caught — the recomputed hash differs from
+  the one the signature was made over.
+* ``hash()`` also has a salted (deployment-local) linked-hashing variant; this
+  pre-image never uses a salt, so it is byte-reproducible at verify across
+  processes and stores.
+
+Cross-SDK classification (``cross-sdk-inspection.md`` Rule 4d): the SIGNATURE is
+deployment-local (it binds random ``gen-``/``cap-``/``del-`` UUIDs + a SHA-256
+constraint hash, signed by the deployment's genesis-authority key), so there is
+no fixed cross-deployment byte vector to pin. The pre-image ENCODING, however,
+routes through ``serialize_for_signing`` — the shared cross-SDK trust-plane
+canonical contract (sorted keys, ``ensure_ascii=True``, ``allow_nan=False``).
+Chain-state signing is a NEW Python-only Wave-2 feature; the Rust SDK has no
+equivalent yet, so a not-configured chain signs BYTE-IDENTICALLY to pre-Wave-2
+(the field prunes-when-unset — see ``chain_state_serde``). If the sibling SDK
+adds chain-state signing, it MUST mirror THIS pre-image dict shape + the
+``serialize_for_signing`` encoding (a cross-SDK structure contract, filed
+separately); a fixed-input canonical-form regression pins the encoding here as a
+tripwire.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Protocol
+
+from kailash.trust.signing.crypto import serialize_for_signing
+
+__all__ = ["chain_state_canonical_payload", "chain_state_canonical_payload_str"]
+
+
+class _EnvelopeLike(Protocol):
+    """Structural type for the constraint envelope the pre-image reads."""
+
+    active_constraints: List[Any]
+
+    def _compute_hash(self) -> str: ...
+
+
+class _GenesisLike(Protocol):
+    id: str
+
+
+class _ChainStateSource(Protocol):
+    """Structural type for the chain fields the pre-image reads.
+
+    A LOCAL Protocol (not an import of ``kailash.trust.chain.TrustLineageChain``)
+    keeps this low-level signing module one-way dependent on ``chain`` — the
+    high-level ``chain`` module imports THIS module at module scope, so a
+    back-edge would form a load-time cycle (mirrors ``delegation_fold_serde`` /
+    ``capability_fold_serde``). ``TrustLineageChain`` satisfies it structurally.
+    """
+
+    genesis: _GenesisLike
+    capabilities: List[Any]
+    delegations: List[Any]
+    constraint_envelope: Optional[_EnvelopeLike]
+
+
+def _constraint_component(env: Optional[_EnvelopeLike]) -> str:
+    """RE-COMPUTE the constraint hash from ``active_constraints``.
+
+    Mirrors ``ChainConstraintEnvelope.__post_init__``'s empty-case convention
+    (an empty / absent envelope → ``""``) so a legitimate empty chain signs a
+    stable pre-image. For a non-empty envelope the hash is RE-DERIVED from the
+    live ``active_constraints`` (never the stored ``constraint_hash`` field), so
+    a store-writer stripping a constraint without re-writing the stored hash is
+    still detected at verify.
+    """
+    if env is None or not env.active_constraints:
+        return ""
+    return env._compute_hash()
+
+
+def chain_state_canonical_payload(chain: _ChainStateSource) -> dict:
+    """Build the deterministic chain-state pre-image dict (#1912 Wave 2)."""
+    return {
+        "genesis_id": chain.genesis.id,
+        "capability_ids": sorted(c.id for c in chain.capabilities),
+        "delegation_ids": sorted(d.id for d in chain.delegations),
+        "constraint_hash": _constraint_component(chain.constraint_envelope),
+    }
+
+
+def chain_state_canonical_payload_str(chain: _ChainStateSource) -> str:
+    """Serialize the chain-state pre-image for signing / verification.
+
+    Routes through ``serialize_for_signing`` (the shared cross-SDK trust-plane
+    canonical encoder: sorted keys, ``ensure_ascii=True``, ``allow_nan=False``),
+    so the sign and verify sites recompute byte-identical pre-images.
+    """
+    return serialize_for_signing(chain_state_canonical_payload(chain))

--- a/src/kailash/trust/signing/rotation.py
+++ b/src/kailash/trust/signing/rotation.py
@@ -34,6 +34,9 @@ from kailash.trust.exceptions import (
     TrustError,
 )
 from kailash.trust.operations import TrustKeyManager
+from kailash.trust.signing.chain_state_signing import (
+    chain_state_canonical_payload_str,
+)
 from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign
 from kailash.trust.signing.delegation_record_signing import (
     delegation_canonical_payload_str,
@@ -525,11 +528,17 @@ class CredentialRotationManager:
                 new_signature = await self.key_manager.sign(genesis_payload, new_key_id)
                 updated_chain.genesis.signature = new_signature
 
-                # Re-sign capability attestations
+                # Re-sign capability attestations over the version-gated
+                # pre-image (#1912). The cap's version is PRESERVED (a legacy cap
+                # re-signs legacy — byte-identical; a v1 cap re-signs v1 with the
+                # holder subject bound), so key rotation never strips a v1 cap's
+                # subject binding. The subject is the holder chain's genesis agent.
                 for capability in updated_chain.capabilities:
                     if capability.attester_id == authority_id:
                         cap_payload = serialize_for_signing(
-                            capability.to_signing_payload()
+                            capability.to_signing_payload(
+                                subject_agent_id=updated_chain.genesis.agent_id
+                            )
                         )
                         new_signature = await self.key_manager.sign(
                             cap_payload, new_key_id
@@ -548,6 +557,19 @@ class CredentialRotationManager:
                             del_payload, new_key_id
                         )
                         delegation.signature = new_signature
+
+                # Re-issue the #1912 Wave 2 chain-state signature under the NEW
+                # key. The chain-state signature is by the chain's genesis
+                # authority (the authority being rotated for these chains), so the
+                # OLD-key signature would fail closed at verify against the new
+                # public key. Only re-sign a chain that ALREADY carries one — a
+                # legacy chain (no signature) stays legacy (never gains one during
+                # rotation, preserving its pre-Wave-2 byte shape).
+                if updated_chain.chain_state_signature is not None:
+                    cs_payload = chain_state_canonical_payload_str(updated_chain)
+                    updated_chain.chain_state_signature = await self.key_manager.sign(
+                        cs_payload, new_key_id
+                    )
 
                 chain_updates.append((updated_chain.genesis.agent_id, updated_chain))
 

--- a/tests/regression/test_capability_serializer_set_parity.py
+++ b/tests/regression/test_capability_serializer_set_parity.py
@@ -1,0 +1,699 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural serializer-set-parity regression for the #1912 capability version.
+
+#1912 Wave 1 added ``signing_payload_version`` to ``CapabilityAttestation`` and
+made a v1 cap's signature bind the holder subject. That field must survive
+EVERY capability serializer, or a v1 cap reloads as legacy → the legacy verify
+recomputes WITHOUT the subject → the v1 signature fails
+(``security.md`` § "Multi-Site Kwarg Plumbing"; ``cross-sdk-inspection.md``
+Rule 4e). This module is the mechanical backstop that a serializer cannot drop
+the field.
+
+Mirrors ``test_delegation_serializer_set_parity.py`` with a NON-CIRCULAR
+discovery predicate (AST signature/body shape, NEVER "does it import the
+serde"), adapted for two capability-specific realities:
+
+  * the serializer set is ASYMMETRIC — SD-JWT is export-only (no capability
+    reconstruction), so serialize and deserialize candidate counts differ; and
+  * a PUBLIC wrapper (``export_capability_as_vc``) DELEGATES capability
+    serialization to the private ``_serialize_capability`` rather than calling
+    the shared serde itself — so compliance is "routes through the serde
+    DIRECTLY, or delegates to another discovered capability serializer".
+
+Checks:
+
+1. **Authoritative field set** — derived from ``_CapabilityFoldSource`` (the
+   shared serde's OWN structural input-contract), cross-validated against the
+   ``CapabilityAttestation`` dataclass. Never from a serializer's output.
+2. **Structural discovery** — every function taking a ``CapabilityAttestation``
+   and returning a dict (serialize) / constructing a ``CapabilityAttestation``
+   (deserialize), by AST shape.
+3. **Compliance** — every discovered candidate routes through the shared serde
+   directly OR delegates to another discovered candidate; a re-implementing
+   dropper is caught by name.
+4. **Behavioral positive round-trip** — a v1 cap through every round-trippable
+   pair preserves ``signing_payload_version``; a legacy cap emits NO version key
+   (prune-when-unset, byte-identical to pre-#1912).
+5. **Negative pole** — stripping the version key from real wire output yields a
+   reloaded cap whose (legacy) pre-image no longer verifies against the original
+   v1 signature.
+
+Tier-2 style: real Ed25519, real chain / interop serializers, NO mocking.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, FrozenSet, List, Tuple
+
+import pytest
+
+from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_LEGACY,
+    CAPABILITY_SIGNING_VERSION_V1,
+    AuthorityType,
+    CapabilityAttestation,
+    CapabilityType,
+    GenesisRecord,
+    TrustLineageChain,
+)
+from kailash.trust.interop import jwt as jwt_interop
+from kailash.trust.interop import sd_jwt as sd_jwt_interop
+from kailash.trust.interop import w3c_vc
+from kailash.trust.signing.capability_fold_serde import _CapabilityFoldSource
+from kailash.trust.signing.crypto import generate_keypair, sign, verify_signature
+
+pytestmark = pytest.mark.regression
+
+FIXED_TS = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+SUBJECT = "agent-holder"
+
+
+# =============================================================================
+# 1. AUTHORITATIVE FOLD-FIELD SET
+# =============================================================================
+
+
+def _authoritative_fields() -> Tuple[str, ...]:
+    protocol_fields = tuple(_CapabilityFoldSource.__annotations__.keys())
+    dataclass_names = {f.name for f in dataclasses.fields(CapabilityAttestation)}
+    missing = [f for f in protocol_fields if f not in dataclass_names]
+    assert not missing, (
+        f"_CapabilityFoldSource declares field(s) {missing!r} not on "
+        f"CapabilityAttestation — the serde's input contract drifted from the "
+        f"signed model."
+    )
+    assert protocol_fields, "_CapabilityFoldSource declared ZERO fields"
+    return protocol_fields
+
+
+FOLD_FIELDS: Tuple[str, ...] = _authoritative_fields()
+
+
+def test_authoritative_field_set_is_signing_payload_version() -> None:
+    """Human-legible pin of the structurally-derived field set."""
+    assert set(FOLD_FIELDS) == {"signing_payload_version"}
+
+
+# =============================================================================
+# 2. STRUCTURAL SERIALIZER-SET DISCOVERY
+# =============================================================================
+
+# The scanned module set is CODEBASE-DERIVED, never a hardcoded allowlist
+# (#1912 RT-sec INVEST-NOW). Every ``.py`` under ``src/kailash/trust/`` is
+# scanned, so a capability serializer added in any module UNDER THAT TREE —
+# a new interop format or a new subpackage — is discovered automatically and
+# trips ``test_discovered_serializer_set_matches_expected`` loudly, rather than
+# silently escaping a 4-module allowlist. The shape-based ``_discover``
+# predicate returns [] for the vast majority of files (no cap-serializing
+# function), so the discovered set stays exactly the real serializers.
+# Scope: the trust plane is the sole owner of CapabilityAttestation signing;
+# a cap serializer elsewhere (e.g. under packages/*/src) would NOT be scanned —
+# no such site exists today, and one would be a cross-package layering break to
+# review on its own. Widen _TRUST_ROOT_REL if that ever changes.
+_TRUST_ROOT_REL = "src/kailash/trust"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _all_trust_modules() -> List[Tuple[str, str]]:
+    """(module_label, rel_path) for every ``.py`` under the trust package.
+
+    Returned as a LIST (not a dict) so duplicate file stems — every
+    ``__init__.py`` shares the stem ``__init__`` — are each scanned
+    independently instead of colliding on a dict key and dropping a module
+    from the sweep. ``module_label`` is the file stem (matching the short keys
+    the expected-set assertions pin: ``chain`` / ``w3c_vc`` / ``jwt`` /
+    ``sd_jwt``).
+    """
+    root = _repo_root() / _TRUST_ROOT_REL
+    mods: List[Tuple[str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(_repo_root()).as_posix()
+        mods.append((path.stem, rel))
+    return mods
+
+
+def _unparse(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return ""
+
+
+def _called_names(node: ast.AST) -> FrozenSet[str]:
+    """Every function name called anywhere in `node`'s subtree (bare + attr)."""
+    names = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            func = sub.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return frozenset(names)
+
+
+def _local_capability_aliases(tree: ast.Module) -> FrozenSet[str]:
+    aliases = {"CapabilityAttestation"}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.endswith("trust.chain")
+        ):
+            for alias in node.names:
+                if alias.name == "CapabilityAttestation":
+                    aliases.add(alias.asname or alias.name)
+    return frozenset(aliases)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Candidate:
+    module: str
+    qualname: str
+    func_name: str
+    # "serialize" (cap -> dict) | "construct" (builds a CapabilityAttestation:
+    # a round-trip DESERIALIZER, a fresh MINT, or an UNSIGNED emission).
+    kind: str
+    called_names: FrozenSet[str]
+    # For a "construct" candidate:
+    #   sets_version  — EVERY signed (non-UNSIGNED) construction sets
+    #                   signing_payload_version=V1 (a mint that originates a
+    #                   transplant-resistant cap). A function that mints even ONE
+    #                   signed cap without V1 is NOT compliant on this flag.
+    #   all_unsigned  — ALL constructions are signature="UNSIGNED" (a non-verify
+    #                   emission — the fold field is irrelevant).
+    # Both default False.
+    sets_version: bool = False
+    all_unsigned: bool = False
+
+
+def _cap_construction_flags(
+    node: ast.AST, cap_aliases: FrozenSet[str]
+) -> Tuple[bool, bool]:
+    """Inspect every ``CapabilityAttestation(...)`` call inside ``node``.
+
+    Returns ``(sets_version, all_unsigned)``:
+      * ``sets_version`` — there is ≥1 SIGNED construction AND **EVERY** signed
+        (non-``signature="UNSIGNED"``) construction passes
+        ``signing_payload_version=`` bound to the **V1 (subject-bound)** constant.
+        Requiring EVERY signed construction (not just one) closes the mixed-mint
+        hole: a function that mints one V1 cap AND one legacy cap ships a
+        transplantable legacy cap and MUST still be flagged. Setting a version to
+        LEGACY, or omitting it, on any signed construction fails this flag.
+      * ``all_unsigned`` — EVERY construction passes ``signature="UNSIGNED"``
+        (an emission that never enters the Ed25519 verify path, so the fold
+        field is irrelevant — e.g. PACT ``grant_clearance``).
+    """
+    constructions: List[ast.Call] = []
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        fn = sub.func
+        name = (
+            fn.id
+            if isinstance(fn, ast.Name)
+            else (fn.attr if isinstance(fn, ast.Attribute) else "")
+        )
+        if name in cap_aliases:
+            constructions.append(sub)
+    if not constructions:
+        return False, False
+
+    def _is_unsigned(call: ast.Call) -> bool:
+        return any(
+            kw.arg == "signature"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "UNSIGNED"
+            for kw in call.keywords
+        )
+
+    def _sets_v1(call: ast.Call) -> bool:
+        return any(
+            kw.arg == "signing_payload_version"
+            and "CAPABILITY_SIGNING_VERSION_V1" in _unparse(kw.value)
+            for kw in call.keywords
+        )
+
+    signed = [c for c in constructions if not _is_unsigned(c)]
+    sets_version = bool(signed) and all(_sets_v1(c) for c in signed)
+    all_unsigned = all(_is_unsigned(c) for c in constructions)
+    return sets_version, all_unsigned
+
+
+def _discover(module_key: str, rel_path: str) -> List[_Candidate]:
+    path = _repo_root() / rel_path
+    return _discover_tree(module_key, ast.parse(path.read_text(), filename=str(path)))
+
+
+def _discover_tree(module_key: str, tree: ast.Module) -> List[_Candidate]:
+    cap_aliases = _local_capability_aliases(tree)
+    out: List[_Candidate] = []
+
+    class _V(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack: List[str] = []
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            self.stack.append(node.name)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def _fn(self, node: Any) -> None:
+            qualname = ".".join(self.stack + [node.name])
+            called = _called_names(node)
+
+            # SERIALIZE-shaped: a CapabilityAttestation-annotated param with a
+            # dict-ish (or unannotated) return. Discovery is by SHAPE — it finds
+            # a re-implementing dropper as readily as a compliant serializer.
+            # ``to_signing_payload`` (param ``self``/``subject_agent_id``) is NOT
+            # matched (no CapabilityAttestation-annotated param) — it is the
+            # signing pre-image, whose SHAPE encodes the version, not a wire dict.
+            is_serialize = False
+            for arg in list(node.args.args) + list(node.args.kwonlyargs):
+                if arg.arg in ("self", "cls"):
+                    continue
+                if "CapabilityAttestation" in _unparse(arg.annotation):
+                    ret = _unparse(node.returns)
+                    if ret == "" or "Dict" in ret or "dict" in ret:
+                        is_serialize = True
+            if is_serialize:
+                out.append(
+                    _Candidate(module_key, qualname, node.name, "serialize", called)
+                )
+
+            # CONSTRUCT-shaped: builds a CapabilityAttestation somewhere in its
+            # body (by any resolved local alias). This covers a round-trip
+            # DESERIALIZER (must route the fold field back through the serde), a
+            # fresh MINT (must SET the version at construction), and an UNSIGNED
+            # emission (exempt — never verified). The producer-compliance rule
+            # below distinguishes them; a signed cap produced with neither a
+            # serde route nor an explicit version is the transplant-bug class.
+            if called & cap_aliases:
+                sets_version, all_unsigned = _cap_construction_flags(node, cap_aliases)
+                out.append(
+                    _Candidate(
+                        module_key,
+                        qualname,
+                        node.name,
+                        "construct",
+                        called,
+                        sets_version=sets_version,
+                        all_unsigned=all_unsigned,
+                    )
+                )
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self._fn(node)
+            self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._fn(node)
+            self.generic_visit(node)
+
+    _V().visit(tree)
+    return out
+
+
+def _discover_all() -> List[_Candidate]:
+    out: List[_Candidate] = []
+    for module_label, rel_path in _all_trust_modules():
+        out.extend(_discover(module_label, rel_path))
+    return out
+
+
+_EXPECTED_SERIALIZE = {
+    ("chain", "TrustLineageChain._serialize_capability"),
+    ("w3c_vc", "_serialize_capability"),
+    ("w3c_vc", "export_capability_as_vc"),
+    ("jwt", "_serialize_capability"),
+    ("sd_jwt", "_serialize_capability_claims"),
+}
+_EXPECTED_CONSTRUCT = {
+    # Round-trip DESERIALIZERS (route the fold field back through the serde).
+    ("chain", "TrustLineageChain._deserialize_capability"),
+    ("w3c_vc", "import_from_verifiable_credential"),
+    ("jwt", "_deserialize_capability"),
+    # Fresh MINTS (originate the fold field: signing_payload_version=V1).
+    ("__init__", "TrustOperations._create_capability_attestation"),
+    ("__init__", "TrustOperations._build_signed_derived_caps"),
+    ("commands", "establish_cmd"),
+    ("commands", "delegate_cmd"),
+    # UNSIGNED emissions (signature="UNSIGNED"; never reach the verify path).
+    ("engine", "GovernanceEngine.grant_clearance"),
+    ("engine", "GovernanceEngine.transition_clearance"),
+}
+
+
+def test_discovered_serializer_set_matches_expected() -> None:
+    """Pin the discovered set so a NEW capability serializer fails loudly here.
+
+    Guards every downstream assertion against a vacuous AST scan (a path typo /
+    predicate drift making "assert all compliant" pass on an empty set), and
+    forces a new serializer to add matching behavioral coverage below.
+    """
+    cands = _discover_all()
+    serialize = {(c.module, c.qualname) for c in cands if c.kind == "serialize"}
+    construct = {(c.module, c.qualname) for c in cands if c.kind == "construct"}
+    assert serialize == _EXPECTED_SERIALIZE, (
+        f"discovered capability serialize set changed:\n"
+        f"  unexpected: {serialize - _EXPECTED_SERIALIZE}\n"
+        f"  missing:    {_EXPECTED_SERIALIZE - serialize}"
+    )
+    assert construct == _EXPECTED_CONSTRUCT, (
+        f"discovered capability CONSTRUCT set changed — a new function builds a "
+        f"CapabilityAttestation. Add it to _EXPECTED_CONSTRUCT and ensure it is "
+        f"producer-compliant (routes the serde, sets signing_payload_version=, "
+        f"or is an UNSIGNED emission):\n"
+        f"  unexpected: {construct - _EXPECTED_CONSTRUCT}\n"
+        f"  missing:    {_EXPECTED_CONSTRUCT - construct}"
+    )
+
+
+def _producer_compliant(
+    c: _Candidate, serialize_names: FrozenSet[str], construct_names: FrozenSet[str]
+) -> bool:
+    """The producer-compliance rule (cross-sdk-inspection.md Rule 4e), by kind.
+
+    * ``serialize`` — routes the fold field OUT through the shared serde, OR
+      delegates to another discovered serializer.
+    * ``construct`` — routes the field back through the serde (a round-trip
+      DESERIALIZER), OR delegates, OR SETS ``signing_payload_version=V1`` at the
+      construction (a fresh MINT that originates a subject-bound cap), OR builds
+      only UNSIGNED caps (an emission that never reaches the Ed25519 verify path).
+
+    The load-bearing case: a SIGNED cap produced with neither a serde route nor a
+    V1 version is NON-compliant — the exact transplant-bug class the CLI sign
+    sites shipped (a mint that defaulted to legacy → transplantable).
+    """
+    if c.kind == "serialize":
+        direct = "serialize_capability_fold_fields" in c.called_names
+        delegates = bool(c.called_names & (serialize_names - {c.func_name}))
+        return direct or delegates
+    direct = "deserialize_capability_fold_fields" in c.called_names
+    delegates = bool(c.called_names & (construct_names - {c.func_name}))
+    return direct or delegates or c.sets_version or c.all_unsigned
+
+
+def test_every_producer_handles_the_fold_field() -> None:
+    cands = _discover_all()
+    serialize_names = frozenset(c.func_name for c in cands if c.kind == "serialize")
+    construct_names = frozenset(c.func_name for c in cands if c.kind == "construct")
+
+    non_compliant = [
+        f"  - {c.module}.{c.qualname} ({c.kind}) — a SIGNED cap produced with no "
+        f"serde route AND no signing_payload_version=V1 (transplant-bug class, "
+        f"cross-sdk-inspection.md Rule 4e)"
+        for c in cands
+        if not _producer_compliant(c, serialize_names, construct_names)
+    ]
+    assert not non_compliant, (
+        "the following capability producer(s) do not handle the "
+        "signing_payload_version fold field:\n" + "\n".join(non_compliant)
+    )
+
+
+def test_producer_compliance_rule_fires_on_the_bug_class() -> None:
+    """NEGATIVE POLE: the compliance rule MUST flag a signed mint that omits the
+    version or sets it to legacy, and MUST accept the V1/unsigned/serde forms.
+
+    Without this, the rule could be silently vacuous (always-pass) and give false
+    convergence. Synthetic source is fed through the SAME discovery + compliance
+    predicate the real sweep uses (cross-sdk-inspection.md Rule 4e negative pole).
+    """
+    src = (
+        "from kailash.trust.chain import CapabilityAttestation\n"
+        "def mint_no_version():\n"
+        "    return CapabilityAttestation(id='x', signature='sig')\n"
+        "def mint_legacy():\n"
+        "    return CapabilityAttestation(\n"
+        "        id='x', signature='sig',\n"
+        "        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY)\n"
+        "def mint_v1():\n"
+        "    return CapabilityAttestation(\n"
+        "        id='x', signature='sig',\n"
+        "        signing_payload_version=CAPABILITY_SIGNING_VERSION_V1)\n"
+        "def emit_unsigned():\n"
+        "    return CapabilityAttestation(id='x', signature='UNSIGNED')\n"
+        "def mint_mixed():\n"
+        "    a = CapabilityAttestation(\n"
+        "        id='x', signature='sig',\n"
+        "        signing_payload_version=CAPABILITY_SIGNING_VERSION_V1)\n"
+        "    b = CapabilityAttestation(id='y', signature='sig2')\n"
+        "    return a, b\n"
+        "def deser(d):\n"
+        "    v = deserialize_capability_fold_fields(d)\n"
+        "    return CapabilityAttestation(id=d['id'], signature=d['sig'], **v)\n"
+    )
+    cands = _discover_tree("synthetic", ast.parse(src))
+    by_name = {c.func_name: c for c in cands}
+    construct_names = frozenset(c.func_name for c in cands if c.kind == "construct")
+    empty: FrozenSet[str] = frozenset()
+
+    # The bug class MUST be flagged:
+    assert not _producer_compliant(by_name["mint_no_version"], empty, construct_names)
+    assert not _producer_compliant(by_name["mint_legacy"], empty, construct_names)
+    # MIXED mint (one V1 + one legacy SIGNED cap) MUST be flagged — a single
+    # V1 construction does not excuse a sibling legacy (transplantable) cap.
+    assert not _producer_compliant(by_name["mint_mixed"], empty, construct_names)
+    # The correct forms MUST pass:
+    assert _producer_compliant(by_name["mint_v1"], empty, construct_names)
+    assert _producer_compliant(by_name["emit_unsigned"], empty, construct_names)
+    assert _producer_compliant(by_name["deser"], empty, construct_names)
+
+
+# =============================================================================
+# 3. FIXTURES
+# =============================================================================
+
+
+def _v1_cap(**overrides: Any) -> CapabilityAttestation:
+    kwargs: Dict[str, Any] = dict(
+        id="cap-1912-parity",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=["read_only", "no_pii"],
+        attester_id="org-acme",
+        attested_at=FIXED_TS,
+        signature="",
+        scope={"tables": ["transactions"]},
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
+    )
+    kwargs.update(overrides)
+    return CapabilityAttestation(**kwargs)
+
+
+def _legacy_cap() -> CapabilityAttestation:
+    return _v1_cap(
+        id="cap-legacy", signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY
+    )
+
+
+def _genesis() -> GenesisRecord:
+    return GenesisRecord(
+        id="gen-parity",
+        agent_id=SUBJECT,
+        authority_id="org-acme",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="gs",
+    )
+
+
+def _chain_with(cap: CapabilityAttestation) -> TrustLineageChain:
+    return TrustLineageChain(genesis=_genesis(), capabilities=[cap])
+
+
+# =============================================================================
+# 4. BEHAVIORAL POSITIVE ROUND-TRIP + PRUNE-WHEN-UNSET
+# =============================================================================
+
+
+def _rt_chain(cap: CapabilityAttestation) -> CapabilityAttestation:
+    restored = TrustLineageChain.from_dict(_chain_with(cap).to_dict())
+    (out,) = restored.capabilities
+    return out
+
+
+def _rt_jwt(cap: CapabilityAttestation) -> CapabilityAttestation:
+    return jwt_interop._deserialize_capability(jwt_interop._serialize_capability(cap))
+
+
+def _rt_w3c(cap: CapabilityAttestation) -> CapabilityAttestation:
+    private_key, public_key = generate_keypair()
+    vc = w3c_vc.export_as_verifiable_credential(
+        _chain_with(cap), issuer_did="did:eatp:org:acme", signing_key=private_key
+    )
+    restored = w3c_vc.import_from_verifiable_credential(vc, public_key=public_key)
+    (out,) = restored.capabilities
+    return out
+
+
+_RT_PAIRS: Tuple[
+    Tuple[str, Callable[[CapabilityAttestation], CapabilityAttestation]], ...
+] = (
+    ("chain._serialize_/_deserialize_capability", _rt_chain),
+    ("jwt._serialize_/_deserialize_capability", _rt_jwt),
+    ("w3c_vc.export/import_verifiable_credential", _rt_w3c),
+)
+
+
+@pytest.mark.parametrize("label,rt", _RT_PAIRS, ids=[p[0] for p in _RT_PAIRS])
+def test_v1_version_survives_every_roundtrippable_serializer(
+    label: str, rt: Callable[[CapabilityAttestation], CapabilityAttestation]
+) -> None:
+    restored = rt(_v1_cap())
+    assert restored.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1, (
+        f"{label}: signing_payload_version did NOT survive round-trip "
+        f"(got {restored.signing_payload_version!r}) — this serializer dropped "
+        f"the #1912 subject-binding discriminator."
+    )
+
+
+@pytest.mark.parametrize("label,rt", _RT_PAIRS, ids=[p[0] for p in _RT_PAIRS])
+def test_legacy_version_roundtrips_as_legacy(
+    label: str, rt: Callable[[CapabilityAttestation], CapabilityAttestation]
+) -> None:
+    restored = rt(_legacy_cap())
+    assert restored.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+
+
+def test_prune_when_unset_no_version_key_for_legacy_cap() -> None:
+    """A legacy cap emits NO version key across EVERY serializer (byte-identical
+    to a pre-#1912 dict); a v1 cap emits it."""
+    legacy, v1 = _legacy_cap(), _v1_cap()
+
+    # chain-level
+    lc = TrustLineageChain._serialize_capability(legacy)
+    vc = TrustLineageChain._serialize_capability(v1)
+    assert "signing_payload_version" not in lc
+    assert vc["signing_payload_version"] == CAPABILITY_SIGNING_VERSION_V1
+
+    # jwt (snake)
+    assert "signing_payload_version" not in jwt_interop._serialize_capability(legacy)
+    assert (
+        jwt_interop._serialize_capability(v1)["signing_payload_version"]
+        == CAPABILITY_SIGNING_VERSION_V1
+    )
+
+    # w3c_vc (camel)
+    assert "signingPayloadVersion" not in w3c_vc._serialize_capability(legacy)
+    assert (
+        w3c_vc._serialize_capability(v1)["signingPayloadVersion"]
+        == CAPABILITY_SIGNING_VERSION_V1
+    )
+
+    # sd_jwt (export-only, snake)
+    assert "signing_payload_version" not in sd_jwt_interop._serialize_capability_claims(
+        legacy
+    )
+    assert (
+        sd_jwt_interop._serialize_capability_claims(v1)["signing_payload_version"]
+        == CAPABILITY_SIGNING_VERSION_V1
+    )
+
+
+def test_legacy_chain_cap_dict_is_byte_identical_to_pre_1912() -> None:
+    """Empirical byte-identity: a legacy cap's chain-level dict carries EXACTLY
+    the pre-#1912 8 keys — no null version key (cross-sdk-inspection.md Rule 4d)."""
+    d = TrustLineageChain._serialize_capability(_legacy_cap())
+    assert set(d.keys()) == {
+        "id",
+        "capability",
+        "capability_type",
+        "constraints",
+        "attester_id",
+        "attested_at",
+        "expires_at",
+        "scope",
+    }
+
+
+# =============================================================================
+# 5. NEGATIVE POLE — strip the version, the reloaded cap no longer verifies
+# =============================================================================
+
+
+def _strip_chain(cap: CapabilityAttestation) -> CapabilityAttestation:
+    d = TrustLineageChain._serialize_capability(cap)
+    d.pop("signing_payload_version", None)
+    return TrustLineageChain._deserialize_capability(d)
+
+
+def _strip_jwt(cap: CapabilityAttestation) -> CapabilityAttestation:
+    d = jwt_interop._serialize_capability(cap)
+    d.pop("signing_payload_version", None)
+    return jwt_interop._deserialize_capability(d)
+
+
+def _strip_w3c(cap: CapabilityAttestation) -> CapabilityAttestation:
+    private_key, _ = generate_keypair()
+    vc = w3c_vc.export_as_verifiable_credential(
+        _chain_with(cap), issuer_did="did:eatp:org:acme", signing_key=private_key
+    )
+    (cap_dict,) = vc["credentialSubject"]["capabilities"]
+    cap_dict.pop("signingPayloadVersion", None)
+    # public_key=None skips the VC's OWN proof (a separate concern), leaving the
+    # EATP capability signature this test probes.
+    restored = w3c_vc.import_from_verifiable_credential(vc, public_key=None)
+    (out,) = restored.capabilities
+    return out
+
+
+_STRIP_FNS: Tuple[
+    Tuple[str, Callable[[CapabilityAttestation], CapabilityAttestation]], ...
+] = (
+    ("chain._serialize_/_deserialize_capability", _strip_chain),
+    ("jwt._serialize_/_deserialize_capability", _strip_jwt),
+    ("w3c_vc.export/import_verifiable_credential", _strip_w3c),
+)
+
+
+@pytest.mark.parametrize("label,strip", _STRIP_FNS, ids=[p[0] for p in _STRIP_FNS])
+def test_stripped_version_fails_closed_through_every_serializer(
+    label: str, strip: Callable[[CapabilityAttestation], CapabilityAttestation]
+) -> None:
+    """Strip the version from real wire output; the reloaded (legacy) cap's
+    pre-image no longer verifies against the original v1 signature."""
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    private_key, public_key = generate_keypair()
+    cap = _v1_cap()
+    # Sign over the v1 (subject-bound) pre-image.
+    cap.signature = sign(
+        serialize_for_signing(cap.to_signing_payload(subject_agent_id=SUBJECT)),
+        private_key,
+    )
+
+    stripped = strip(cap)
+    assert stripped.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY, (
+        f"{label}: fixture bug — stripping the version key should default the "
+        f"reloaded cap to legacy"
+    )
+    # The reloaded legacy cap recomputes WITHOUT the subject; its pre-image no
+    # longer matches the v1 signature.
+    recomputed = serialize_for_signing(
+        stripped.to_signing_payload(subject_agent_id=SUBJECT)
+    )
+    assert not verify_signature(recomputed, cap.signature, public_key), (
+        f"{label}: stripping signing_payload_version from the real wire output "
+        f"did NOT invalidate the v1 signature — a downgrade-to-legacy still "
+        f"verifies (subject-binding negative pole violated)."
+    )
+
+
+def test_roundtrip_and_strip_pair_counts_match() -> None:
+    """Behavioral coverage ties to the round-trippable subset of the discovered
+    set (chain + jwt + w3c_vc; sd_jwt is export-only, covered by the
+    prune-when-unset emit test)."""
+    assert len(_RT_PAIRS) == len(_STRIP_FNS) == 3

--- a/tests/regression/test_issue_1912_capability_subject_binding.py
+++ b/tests/regression/test_issue_1912_capability_subject_binding.py
@@ -1,0 +1,671 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1912 capability subject-binding (transplant defense).
+
+Before #1912, ``CapabilityAttestation.to_signing_payload()`` bound the ATTESTER
+but NO subject ``agent_id``, and ``_verify_capability_signature`` verified the
+signature with NO check that the cap was attested FOR the verifying chain's
+holder. A genuine capability copied from chain A into chain B verified fine —
+the cross-chain transplant vulnerability.
+
+Wave 1 makes NEW caps ``v1-subject-bound``: the signature covers the holder
+chain's ``genesis.agent_id``, and verify dispatches on the persisted version.
+
+Scenarios (task step 9), all against REAL Ed25519, NO mocking:
+
+  (a) a v1 cap signed for chain A, copied into chain B, fails verify against B;
+  (b) a v1 cap in its OWN chain verifies TRUE (no false positive);
+  (c) a v1 cap whose ``signing_payload_version`` is stripped fails verify
+      (downgrade resistance — it defaults to legacy and the legacy re-verify,
+      recomputed WITHOUT the subject, no longer matches the v1 signature);
+  (d) #1912 Wave 3 A1 enforcement: a legacy (un-subject-bound) cap is REJECTED
+      by default (fail-closed — legacy caps are transplantable), and ACCEPTED
+      only under the migration-window opt-out
+      ``allow_unbound_legacy_capabilities=True``.
+
+Plus an end-to-end proof that ``establish`` → store → ``verify`` at STANDARD
+authorizes a v1 cap on its own chain (the happy path is not broken).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_LEGACY,
+    CAPABILITY_SIGNING_VERSION_V1,
+    AuthorityType,
+    CapabilityAttestation,
+    CapabilityType,
+    GenesisRecord,
+    TrustLineageChain,
+    VerificationLevel,
+)
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.exceptions import AuthorityInactiveError, AuthorityNotFoundError
+from kailash.trust.operations import (
+    CapabilityRequest,
+    TrustKeyManager,
+    TrustOperations,
+)
+from kailash.trust.signing.crypto import generate_keypair
+
+pytestmark = pytest.mark.regression
+
+FIXED_TS = datetime(2026, 3, 11, 14, 30, 0, tzinfo=timezone.utc)
+
+
+class SimpleAuthorityRegistry:
+    """Real in-memory authority registry (NOT a mock)."""
+
+    def __init__(self) -> None:
+        self._authorities: Dict[str, OrganizationalAuthority] = {}
+
+    async def initialize(self) -> None:
+        pass
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            raise AuthorityNotFoundError(authority_id)
+        if not authority.is_active and not include_inactive:
+            raise AuthorityInactiveError(authority_id)
+        return authority
+
+    async def update_authority(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def authority(keypair):
+    _, public_key = keypair
+    return OrganizationalAuthority(
+        id="org-test",
+        name="Test Corp",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="test-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.DELEGATE_TRUST,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+
+
+@pytest.fixture
+def registry(authority):
+    reg = SimpleAuthorityRegistry()
+    reg.register(authority)
+    return reg
+
+
+@pytest.fixture
+def key_manager(keypair):
+    private_key, _ = keypair
+    km = TrustKeyManager()
+    km.register_key("test-key-001", private_key)
+    return km
+
+
+@pytest.fixture
+async def memory_store():
+    store = InMemoryTrustStore()
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+async def ops(registry, key_manager, memory_store):
+    operations = TrustOperations(
+        authority_registry=registry,
+        key_manager=key_manager,
+        trust_store=memory_store,
+    )
+    await operations.initialize()
+    return operations
+
+
+async def _establish(ops: TrustOperations, agent_id: str, caps: List[str]):
+    await ops.establish(
+        agent_id=agent_id,
+        authority_id="org-test",
+        capabilities=[
+            CapabilityRequest(capability=c, capability_type=CapabilityType.ACTION)
+            for c in caps
+        ],
+    )
+    return await ops.trust_store.get_chain(agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Sign-time posture: establish now produces v1-subject-bound caps
+# ---------------------------------------------------------------------------
+
+
+async def test_establish_produces_v1_subject_bound_caps(ops):
+    chain = await _establish(ops, "agent-a", ["read_data"])
+    assert chain.capabilities, "establish produced no capabilities"
+    for cap in chain.capabilities:
+        assert cap.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1, (
+            "establish must produce v1-subject-bound caps (#1912), got "
+            f"{cap.signing_payload_version!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (a) TRANSPLANT: a v1 cap from chain A fails verify against chain B
+# ---------------------------------------------------------------------------
+
+
+async def test_v1_capability_transplant_into_other_chain_fails(ops):
+    chain_a = await _establish(ops, "agent-a", ["read_data"])
+    chain_b = await _establish(ops, "agent-b", ["write_data"])
+    cap_from_a = chain_a.capabilities[0]
+
+    # Sanity: the genuine cap verifies in its OWN chain (b) below.
+    ok_own = await ops._verify_capability_signature(chain_a, cap_from_a)
+    assert ok_own is True, "fixture bug: genuine cap must verify in its own chain"
+
+    # Transplant: the SAME genuine, validly-signed cap verified against chain B
+    # (a DIFFERENT holder) recomputes a different subject → signature fails.
+    transplanted = await ops._verify_capability_signature(chain_b, cap_from_a)
+    assert transplanted is False, (
+        "a genuine v1 cap transplanted from chain A into chain B verified — the "
+        "#1912 cross-chain transplant is NOT closed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) NO FALSE POSITIVE: a v1 cap verifies in its own chain
+# ---------------------------------------------------------------------------
+
+
+async def test_v1_capability_verifies_in_own_chain(ops):
+    chain_a = await _establish(ops, "agent-a", ["read_data"])
+    cap = chain_a.capabilities[0]
+    assert await ops._verify_capability_signature(chain_a, cap) is True
+
+
+# ---------------------------------------------------------------------------
+# (c) DOWNGRADE RESISTANCE: stripping the version fails verify
+# ---------------------------------------------------------------------------
+
+
+async def test_v1_capability_with_version_stripped_fails(ops):
+    chain_a = await _establish(ops, "agent-a", ["read_data"])
+    cap = chain_a.capabilities[0]
+    # Simulate a store-writer stripping the version discriminator (a
+    # from_dict-of-a-tampered-record defaults to legacy). The v1 signature was
+    # made over the subject-bound pre-image; the legacy re-verify (no subject)
+    # no longer matches.
+    downgraded = dataclasses.replace(
+        cap, signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY
+    )
+    assert await ops._verify_capability_signature(chain_a, downgraded) is False, (
+        "a v1 cap whose signing_payload_version was stripped to legacy still "
+        "verified — downgrade resistance is broken"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) #1912 Wave 3 A1: a legacy cap is REJECTED by default, ACCEPTED under opt-out
+# ---------------------------------------------------------------------------
+
+
+def _build_legacy_cap_chain(key_manager_signature: str = "") -> TrustLineageChain:
+    """A LEGACY cap (pre-#1912, no subject in the pre-image) in its own chain."""
+    legacy_cap = CapabilityAttestation(
+        id="cap-legacy",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=["read_only"],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature=key_manager_signature,
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    genesis = GenesisRecord(
+        id="gen-legacy",
+        agent_id="agent-legacy",
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="gs",
+    )
+    return TrustLineageChain(genesis=genesis, capabilities=[legacy_cap])
+
+
+async def test_legacy_capability_rejected_by_default(ops, key_manager, caplog):
+    """#1912 Wave 3 A1: a legacy (un-subject-bound) cap is fail-closed REJECTED.
+
+    A legacy cap verifies IDENTICALLY on any chain (no holder subject in the
+    pre-image) — the transplant HIGH. With the default fail-closed posture
+    (allow_unbound_legacy_capabilities=False) it is REJECTED even though its
+    signature is cryptographically valid over the legacy pre-image.
+    """
+    import logging
+
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    chain = _build_legacy_cap_chain()
+    legacy_cap = chain.capabilities[0]
+    payload = serialize_for_signing(legacy_cap.to_signing_payload())
+    legacy_cap.signature = await key_manager.sign(payload, "test-key-001")
+
+    with caplog.at_level(logging.WARNING, logger="kailash.trust.operations"):
+        result = await ops._verify_capability_signature(chain, legacy_cap)
+    assert result is False, (
+        "a legacy (un-subject-bound) cap must be REJECTED by default — #1912 "
+        "Wave 3 A1 fail-closed enforcement (legacy caps are transplantable)"
+    )
+    assert any(
+        "REJECTING legacy" in r.message for r in caplog.records
+    ), "the fail-closed reject must emit the loud A1 WARN naming the migration path"
+
+
+async def test_legacy_capability_accepted_with_opt_out(
+    registry, key_manager, memory_store, caplog
+):
+    """The migration-window opt-out accepts a legacy cap over its legacy pre-image.
+
+    allow_unbound_legacy_capabilities=True restores the pre-Wave-3 behavior
+    (accept a legacy cap whose signature is valid over the no-subject pre-image)
+    so a deployment can keep running WHILE its chains are re-signed by the #1912
+    migration — with a loud one-time WARN that the transplant defense is OFF.
+    """
+    import logging
+
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    ops_optout = TrustOperations(
+        authority_registry=registry,
+        key_manager=key_manager,
+        trust_store=memory_store,
+        allow_unbound_legacy_capabilities=True,
+    )
+    await ops_optout.initialize()
+
+    chain = _build_legacy_cap_chain()
+    legacy_cap = chain.capabilities[0]
+    payload = serialize_for_signing(legacy_cap.to_signing_payload())
+    legacy_cap.signature = await key_manager.sign(payload, "test-key-001")
+
+    with caplog.at_level(logging.WARNING, logger="kailash.trust.operations"):
+        result = await ops_optout._verify_capability_signature(chain, legacy_cap)
+    assert result is True, (
+        "with allow_unbound_legacy_capabilities=True a legacy cap valid over its "
+        "legacy pre-image must be ACCEPTED (migration window)"
+    )
+    assert any(
+        "allow_unbound_legacy_capabilities=True" in r.message for r in caplog.records
+    ), "the opt-out accept must emit the loud one-time WARN that the defense is OFF"
+
+
+# ---------------------------------------------------------------------------
+# Empty-subject invariant (#1912 RT-sec LOW): a v1 pre-image MUST bind a
+# non-empty holder. Sign time raises loudly (caller bug); verify fail-closes
+# (never crashes) on an anomalous chain whose genesis.agent_id is empty.
+# ---------------------------------------------------------------------------
+
+
+def test_v1_pre_image_rejects_empty_subject_at_sign_time():
+    cap = CapabilityAttestation(
+        id="cap-x",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
+    )
+    for bad in ("", None):
+        with pytest.raises(ValueError, match="non-empty subject_agent_id"):
+            cap.to_signing_payload(subject_agent_id=bad)
+    # A legacy cap ignores the subject entirely — no raise (byte-neutral).
+    legacy = dataclasses.replace(
+        cap, signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY
+    )
+    assert "subject_agent_id" not in legacy.to_signing_payload(subject_agent_id="")
+
+
+async def test_verify_fail_closes_on_empty_subject_v1_cap(ops):
+    # A genuine v1 cap signed for a real holder...
+    chain_a = await _establish(ops, "agent-a", ["read_data"])
+    cap = chain_a.capabilities[0]
+
+    # ...verified against an anomalous chain whose genesis.agent_id is empty
+    # (a tampered/corrupt state). Verify must DENY (return False), never raise
+    # the ValueError the empty-subject guard emits.
+    empty_genesis = GenesisRecord(
+        id="gen-empty",
+        agent_id="",
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="gs",
+    )
+    empty_chain = TrustLineageChain(genesis=empty_genesis, capabilities=[cap])
+    assert await ops._verify_capability_signature(empty_chain, cap) is False, (
+        "verify must fail-closed (deny) on a v1 cap whose chain has an empty "
+        "genesis.agent_id — not raise, not authorize"
+    )
+
+
+async def test_public_verify_fail_closes_on_empty_subject_chain_all_levels(
+    ops, key_manager
+):
+    """The empty-subject guard MUST fail-closed at EVERY verify-path pre-image
+    site, not just _verify_capability_signature. Drives the PUBLIC verify() API
+    at STANDARD and FULL over an anomalous empty-genesis chain: STANDARD hits the
+    matched-cap gate, FULL hits _derive_enforced_envelope's dedup key (ops:693)
+    AND _verify_signatures (ops:1584). Before the sibling-site fix, FULL RAISED
+    an uncaught ValueError on the primary security API (#1912 RT-corr round-2 BUG).
+    """
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    # A genuine v1 cap signed for a real holder.
+    src_chain = await _establish(ops, "agent-src", ["read_data"])
+    v1_cap = src_chain.capabilities[0]
+
+    # An anomalous chain: a VALIDLY-SIGNED genesis whose agent_id is empty,
+    # holding the v1 cap. verify() loads it by agent_id and recomputes the
+    # cap pre-image with subject="" → the guard raises → must fail closed.
+    empty_genesis = GenesisRecord(
+        id="gen-empty",
+        agent_id="",
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="",
+    )
+    empty_genesis.signature = await key_manager.sign(
+        serialize_for_signing(empty_genesis.to_signing_payload()), "test-key-001"
+    )
+    anomalous = TrustLineageChain(genesis=empty_genesis, capabilities=[v1_cap])
+    await ops.trust_store.store_chain(anomalous)
+
+    for level in (VerificationLevel.STANDARD, VerificationLevel.FULL):
+        result = await ops.verify(agent_id="", action="read_data", level=level)
+        assert result.valid is False, (
+            f"public verify(level={level}) on an empty-subject v1-cap chain must "
+            f"fail-closed (valid=False), not crash and not authorize; got "
+            f"valid={result.valid} reason={result.reason!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: establish -> store -> verify authorizes a v1 cap (happy path)
+# ---------------------------------------------------------------------------
+
+
+async def test_establish_then_verify_authorizes_v1_cap_end_to_end(ops):
+    await _establish(ops, "agent-a", ["read_data"])
+    result = await ops.verify(
+        agent_id="agent-a",
+        action="read_data",
+        level=VerificationLevel.STANDARD,
+    )
+    assert result.valid is True, (
+        f"establish -> verify(STANDARD) denied a legitimately-established v1 cap: "
+        f"{result.reason}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Key rotation (#1912 RT-corr round-3 INVEST-NOW): the re-sign path
+# (CredentialRotationManager) is a subject-binding SIGN site — the same class as
+# the CLI-mint HIGH. It re-signs a v1 cap over the version-gated pre-image with
+# the holder subject bound; WITHOUT the subject_agent_id= arg, a rotated v1 cap
+# would be signed over the no-subject pre-image and FAIL verify after every
+# rotation. This test is the regression guard for that sign site (previously
+# uncovered by any behavioral test AND excluded from the structural parity
+# sweep — a future arg-drop would otherwise break v1 verify silently).
+# ---------------------------------------------------------------------------
+
+
+async def test_v1_cap_survives_key_rotation_and_stays_transplant_resistant(
+    ops, registry, key_manager, memory_store
+):
+    from kailash.trust.signing.rotation import CredentialRotationManager
+
+    chain_a = await _establish(ops, "agent-a", ["read_data"])
+    chain_b = await _establish(ops, "agent-b", ["write_data"])
+    original_sig = chain_a.capabilities[0].signature
+    assert (
+        chain_a.capabilities[0].signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+    )
+
+    # Rotate the authority's signing key → re-signs every chain it attested,
+    # binding each v1 cap to its holder's genesis.agent_id under the NEW key.
+    mgr = CredentialRotationManager(
+        key_manager=key_manager,
+        trust_store=memory_store,
+        authority_registry=registry,
+    )
+    await mgr.initialize()
+    await mgr.rotate_key("org-test")
+
+    rotated_a = await memory_store.get_chain("agent-a")
+    rotated_cap = rotated_a.capabilities[0]
+
+    # Re-signed (new key) and version PRESERVED (rotation never strips binding).
+    assert rotated_cap.signature != original_sig, "rotation did not re-sign the cap"
+    assert rotated_cap.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+
+    # The load-bearing assertion: the re-signed v1 cap verifies TRUE in its own
+    # chain against the rotated authority key. This FAILS if the rotation re-sign
+    # site drops subject_agent_id= (signs no-subject bytes; verify recomputes WITH
+    # the subject → mismatch) — the silent-regression the guard exists to catch.
+    assert await ops._verify_capability_signature(rotated_a, rotated_cap) is True, (
+        "a v1 cap re-signed by key rotation failed verify in its own chain — the "
+        "rotation re-sign site is not binding the holder subject (#1912)"
+    )
+
+    # And still transplant-resistant after rotation: into agent-b's chain → FALSE.
+    assert await ops._verify_capability_signature(chain_b, rotated_cap) is False, (
+        "a rotated v1 cap transplanted into another chain verified — rotation "
+        "weakened the #1912 subject binding"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (#1912 RT-sec/RT-corr HIGH): the `eatp` CLI establish + delegate
+# commands must ALSO mint v1-subject-bound caps. Before this fix the CLI sign
+# sites (cli/commands.py:453/:666) minted LEGACY caps, so every cap created via
+# the CLI stayed cross-chain transplantable — the #1912 vuln open on a real,
+# supported new-cap surface. These drive the ACTUAL click commands end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def _cli_init_authority(runner, store_dir: str) -> str:
+    import json as _json
+    from pathlib import Path as _Path
+
+    from kailash.trust.cli import main
+
+    r = runner.invoke(main, ["--store-dir", store_dir, "init", "--name", "cli-auth"])
+    assert r.exit_code == 0, f"init failed: {r.output}"
+    auth_files = list((_Path(store_dir) / "authorities").glob("*.json"))
+    return _json.loads(auth_files[0].read_text())["id"]
+
+
+def test_cli_establish_mints_v1_and_is_transplant_resistant(tmp_path):
+    from click.testing import CliRunner
+
+    from kailash.trust.cli import main
+    from kailash.trust.cli.commands import _create_store, _load_authority, _run_async
+
+    runner = CliRunner()
+    store_dir = str(tmp_path / ".eatp")
+    (tmp_path / ".eatp").mkdir()
+    authority_id = _cli_init_authority(runner, store_dir)
+
+    for agent in ("agent-a", "agent-b"):
+        r = runner.invoke(
+            main,
+            [
+                "--store-dir",
+                store_dir,
+                "establish",
+                agent,
+                "--authority",
+                authority_id,
+                "--capabilities",
+                "read_data",
+            ],
+        )
+        assert r.exit_code == 0, f"establish {agent} failed: {r.output}"
+
+    store = _create_store(store_dir)
+    _run_async(store.initialize())
+    chain_a = _run_async(store.get_chain("agent-a"))
+    chain_b = _run_async(store.get_chain("agent-b"))
+
+    # 1. CLI-created caps are v1-subject-bound (not legacy).
+    assert chain_a.capabilities, "CLI establish produced no capabilities"
+    for cap in chain_a.capabilities:
+        assert cap.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1, (
+            "CLI `establish` must mint v1-subject-bound caps (#1912); got "
+            f"{cap.signing_payload_version!r} — the CLI sign site is unmigrated"
+        )
+
+    # 2. Transplant a CLI-created cap into another holder's chain → verify FALSE.
+    auth = _load_authority(store_dir, authority_id)
+    reg = SimpleAuthorityRegistry()
+    reg.register(auth)
+    ops = TrustOperations(
+        authority_registry=reg, key_manager=TrustKeyManager(), trust_store=store
+    )
+    _run_async(ops.initialize())
+    cap_from_a = chain_a.capabilities[0]
+    assert (
+        _run_async(ops._verify_capability_signature(chain_a, cap_from_a)) is True
+    ), "fixture bug: a CLI-established cap must verify in its OWN chain"
+    assert _run_async(ops._verify_capability_signature(chain_b, cap_from_a)) is False, (
+        "a CLI-established cap transplanted into another chain verified — the "
+        "#1912 transplant defense does not cover the CLI surface"
+    )
+
+
+def test_cli_delegate_mints_v1_caps(tmp_path):
+    from click.testing import CliRunner
+
+    from kailash.trust.cli import main
+    from kailash.trust.cli.commands import _create_store, _run_async
+
+    runner = CliRunner()
+    store_dir = str(tmp_path / ".eatp")
+    (tmp_path / ".eatp").mkdir()
+    authority_id = _cli_init_authority(runner, store_dir)
+
+    r = runner.invoke(
+        main,
+        [
+            "--store-dir",
+            store_dir,
+            "establish",
+            "agent-root",
+            "--authority",
+            authority_id,
+            "--capabilities",
+            "read_data",
+        ],
+    )
+    assert r.exit_code == 0, f"establish failed: {r.output}"
+
+    r = runner.invoke(
+        main,
+        [
+            "--store-dir",
+            store_dir,
+            "delegate",
+            "--from",
+            "agent-root",
+            "--to",
+            "agent-child",
+            "--capabilities",
+            "read_data",
+        ],
+    )
+    assert r.exit_code == 0, f"delegate failed: {r.output}"
+
+    store = _create_store(store_dir)
+    _run_async(store.initialize())
+    child = _run_async(store.get_chain("agent-child"))
+    assert child.capabilities, "CLI delegate produced no capabilities"
+    for cap in child.capabilities:
+        assert cap.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1, (
+            "CLI `delegate` must mint v1-subject-bound caps (#1912); got "
+            f"{cap.signing_payload_version!r} — the delegate sign site is unmigrated"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK byte-pin tripwire for the v1 (subject-bound) pre-image
+# (cross-sdk-inspection.md Rule 4b/4d — the CONFIGURED case is the lockstep case)
+# ---------------------------------------------------------------------------
+
+
+def test_v1_capability_preimage_is_pinned():
+    """Pin the canonical v1 (subject-bound) capability pre-image on a fixed input.
+
+    The legacy (not-configured) pre-image is byte-identical to pre-#1912 and is
+    pinned separately (test_capability_serializer_set_parity). This pins the
+    CONFIGURED v1 shape — sorted keys, sorted constraints, ``subject_agent_id``
+    bound — which is the cross-SDK signing-format LOCKSTEP case
+    (cross-sdk-inspection.md Rule 4d): a change here diverges every v1 signature
+    from the sibling SDK and MUST break this tripwire loudly. Re-pin ONLY in
+    lockstep with the sibling SDK.
+    """
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    cap = CapabilityAttestation(
+        id="cap-fixed",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=["read_only", "no_export"],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
+    )
+    payload = cap.to_signing_payload(subject_agent_id="agent-fixed")
+    assert payload == {
+        "id": "cap-fixed",
+        "capability": "read_data",
+        "capability_type": "action",
+        "constraints": ["no_export", "read_only"],
+        "attester_id": "org-test",
+        "attested_at": "2026-03-11T14:30:00+00:00",
+        "expires_at": None,
+        "scope": None,
+        "subject_agent_id": "agent-fixed",
+    }
+    expected = (
+        '{"attested_at":"2026-03-11T14:30:00+00:00","attester_id":"org-test",'
+        '"capability":"read_data","capability_type":"action",'
+        '"constraints":["no_export","read_only"],"expires_at":null,'
+        '"id":"cap-fixed","scope":null,"subject_agent_id":"agent-fixed"}'
+    )
+    assert serialize_for_signing(payload) == expected, (
+        "v1 capability pre-image encoding changed — this is a cross-SDK signing-"
+        "format change; re-pin ONLY in lockstep with the sibling SDK (#1912)"
+    )

--- a/tests/regression/test_issue_1912_chain_state_signing.py
+++ b/tests/regression/test_issue_1912_chain_state_signing.py
@@ -1,0 +1,731 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1912 Wave 2 chain-state signature (whole-set + envelope tamper).
+
+Wave 1 bound each capability to its holder subject (transplant defense). Wave 2
+binds the WHOLE chain state under ONE Ed25519 signature by the genesis authority,
+closing two store-writer vectors nothing else signs:
+
+  MED-1 (whole-capability-set deletion): a store-writer deletes a capability that
+    carries a constraint while another capability still grants the action; the
+    constraint silently drops. The deleted cap's id leaves ``capability_ids`` →
+    the chain-state pre-image changes → the signature breaks → verify DENIES.
+
+  MED-2 (reasoning-suppression + directly-injected constraints): the persisted
+    ``ChainConstraintEnvelope`` is UNSIGNED; a store-writer strips a
+    ``REASONING_REQUIRED`` (or any directly-injected) constraint with nothing to
+    break. The constraint feeds the RE-COMPUTED ``constraint_hash`` in the pre-
+    image → stripping / editing it changes the recomputed hash → verify DENIES.
+
+Scenarios (task step 9), all against REAL Ed25519, NO mocking:
+
+  (a) whole-cap DELETION detected (fail-closed);
+  (b) reasoning-SUPPRESSION (strip REASONING_REQUIRED) detected;
+  (c) directly-injected-constraint value tamper detected;
+  (d) happy path: a legit chain verifies TRUE;
+  (e) #1912 Wave 3 A1: a legacy chain (no chain-state sig) is REJECTED by default
+      (fail-closed) and ACCEPTED only under the migration-window opt-out
+      allow_unsigned_chain_state=True, each with a loud one-time WARN;
+  (f) byte-identity: a legacy chain's dict carries NO chain_state_signature key
+      (prune-when-unset); a signed chain's dict carries it and round-trips.
+
+Plus: the cross-SDK canonical pre-image encoding is pinned as a tripwire, the
+field round-trips through to_dict/from_dict (serializer completeness), and key
+rotation re-issues the signature so a rotated chain still verifies.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import (
+    AuthorityType,
+    CapabilityAttestation,
+    CapabilityType,
+    Constraint,
+    ConstraintType,
+    GenesisRecord,
+    TrustLineageChain,
+    VerificationLevel,
+)
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.exceptions import AuthorityInactiveError, AuthorityNotFoundError
+from kailash.trust.operations import (
+    CapabilityRequest,
+    TrustKeyManager,
+    TrustOperations,
+)
+from kailash.trust.signing.chain_state_signing import (
+    chain_state_canonical_payload,
+    chain_state_canonical_payload_str,
+)
+from kailash.trust.signing.crypto import generate_keypair
+
+pytestmark = pytest.mark.regression
+
+FIXED_TS = datetime(2026, 3, 11, 14, 30, 0, tzinfo=timezone.utc)
+
+
+class SimpleAuthorityRegistry:
+    """Real in-memory authority registry (NOT a mock)."""
+
+    def __init__(self) -> None:
+        self._authorities: Dict[str, OrganizationalAuthority] = {}
+
+    async def initialize(self) -> None:
+        pass
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            raise AuthorityNotFoundError(authority_id)
+        if not authority.is_active and not include_inactive:
+            raise AuthorityInactiveError(authority_id)
+        return authority
+
+    async def update_authority(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def authority(keypair):
+    _, public_key = keypair
+    return OrganizationalAuthority(
+        id="org-test",
+        name="Test Corp",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="test-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.DELEGATE_TRUST,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+
+
+@pytest.fixture
+def registry(authority):
+    reg = SimpleAuthorityRegistry()
+    reg.register(authority)
+    return reg
+
+
+@pytest.fixture
+def key_manager(keypair):
+    private_key, _ = keypair
+    km = TrustKeyManager()
+    km.register_key("test-key-001", private_key)
+    return km
+
+
+@pytest.fixture
+async def memory_store():
+    store = InMemoryTrustStore()
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+async def ops(registry, key_manager, memory_store):
+    operations = TrustOperations(
+        authority_registry=registry,
+        key_manager=key_manager,
+        trust_store=memory_store,
+    )
+    await operations.initialize()
+    return operations
+
+
+async def _establish(
+    ops: TrustOperations, agent_id: str, caps: List[CapabilityRequest]
+):
+    await ops.establish(agent_id=agent_id, authority_id="org-test", capabilities=caps)
+    return await ops.trust_store.get_chain(agent_id)
+
+
+def _cap_req(name: str, constraints: List[str]) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability=name,
+        capability_type=CapabilityType.ACTION,
+        constraints=constraints,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sign-time posture: establish now issues a chain-state signature
+# ---------------------------------------------------------------------------
+
+
+async def test_establish_issues_chain_state_signature(ops):
+    chain = await _establish(ops, "agent-a", [_cap_req("read_data", [])])
+    assert chain.chain_state_signature, (
+        "establish must issue a chain-state signature (#1912 Wave 2) — new "
+        "chains ALWAYS get it, fail-closed at issuance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) HAPPY PATH: a legitimately-signed chain verifies TRUE
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_verifies_true(ops):
+    await _establish(ops, "agent-a", [_cap_req("read_data", ["read_only"])])
+    result = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        result.valid is True
+    ), f"a legit chain-state-signed chain was denied at STANDARD: {result.reason}"
+    # FULL level (which also runs the full-chain signature verify) must agree.
+    result_full = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.FULL
+    )
+    assert result_full.valid is True, f"FULL denied a legit chain: {result_full.reason}"
+
+
+# ---------------------------------------------------------------------------
+# (a) MED-1: whole-capability-set deletion detected
+# ---------------------------------------------------------------------------
+
+
+async def test_whole_cap_deletion_detected(ops, memory_store):
+    # Two caps: one plain grant for the action, one constraint-bearing cap.
+    await _establish(
+        ops,
+        "agent-a",
+        [
+            _cap_req("read_data", []),
+            _cap_req("read_pii", ["read_only", "no_pii_export"]),
+        ],
+    )
+    # Sanity: verify authorizes read_data on the intact, signed chain.
+    ok = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert ok.valid is True, f"fixture bug: intact chain denied: {ok.reason}"
+
+    # Store-writer DELETES the constraint-bearing cap while read_data still
+    # grants the action — WITHOUT re-issuing the chain-state signature.
+    chain = await memory_store.get_chain("agent-a")
+    before = len(chain.capabilities)
+    chain.capabilities = [c for c in chain.capabilities if c.capability != "read_pii"]
+    assert len(chain.capabilities) == before - 1, "fixture bug: cap not deleted"
+    await memory_store.update_chain("agent-a", chain)
+
+    # The capability_ids changed → recomputed pre-image differs from the signed
+    # one → chain-state signature no longer verifies → fail-closed DENY.
+    tampered = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        tampered.valid is False
+    ), "a whole-capability deletion was NOT detected — MED-1 is not closed"
+    assert "chain-state signature" in tampered.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# (b) MED-2: REASONING_REQUIRED suppression detected
+# ---------------------------------------------------------------------------
+
+
+async def test_reasoning_required_suppression_detected(ops, memory_store):
+    await _establish(ops, "agent-a", [_cap_req("read_data", ["read_only"])])
+    chain = await memory_store.get_chain("agent-a")
+
+    # Configure REASONING_REQUIRED by injecting it directly into the persisted
+    # envelope, THEN re-issue the chain-state signature so it covers the
+    # constraint (the correct, tamper-evident configuration posture).
+    chain.constraint_envelope.active_constraints.append(
+        Constraint(
+            id="con-reasoning",
+            constraint_type=ConstraintType.REASONING_REQUIRED,
+            value="reasoning_required",
+            source="policy",
+        )
+    )
+    await ops._issue_chain_state_signature(chain)
+    await memory_store.update_chain("agent-a", chain)
+
+    # Sanity: STANDARD still authorizes (REASONING_REQUIRED is a non-blocking
+    # finding at STANDARD) and the chain-state signature now covers it.
+    ok = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        ok.valid is True
+    ), f"fixture bug: reasoning-configured chain denied: {ok.reason}"
+
+    # Store-writer STRIPS the REASONING_REQUIRED constraint WITHOUT re-signing.
+    chain2 = await memory_store.get_chain("agent-a")
+    chain2.constraint_envelope.active_constraints = [
+        c
+        for c in chain2.constraint_envelope.active_constraints
+        if c.constraint_type != ConstraintType.REASONING_REQUIRED
+    ]
+    await memory_store.update_chain("agent-a", chain2)
+
+    # The recomputed constraint_hash changes → chain-state signature breaks → DENY.
+    tampered = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert tampered.valid is False, (
+        "stripping a REASONING_REQUIRED constraint was NOT detected — MED-2 "
+        "reasoning-suppression is not closed"
+    )
+    assert "chain-state signature" in tampered.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# (c) MED-2: directly-injected-constraint value tamper detected
+# ---------------------------------------------------------------------------
+
+
+async def test_injected_constraint_value_tamper_detected(ops, memory_store):
+    await _establish(ops, "agent-a", [_cap_req("read_data", ["read_only"])])
+    chain = await memory_store.get_chain("agent-a")
+
+    # Inject a directly-configured (non-capability) constraint, then sign.
+    chain.constraint_envelope.active_constraints.append(
+        Constraint(
+            id="con-injected",
+            constraint_type=ConstraintType.DATA_ACCESS,
+            value="max_rows=100",
+            source="policy",
+        )
+    )
+    await ops._issue_chain_state_signature(chain)
+    await memory_store.update_chain("agent-a", chain)
+
+    # Store-writer WIDENS the injected constraint's value WITHOUT re-signing.
+    chain2 = await memory_store.get_chain("agent-a")
+    for c in chain2.constraint_envelope.active_constraints:
+        if c.id == "con-injected":
+            c.value = "max_rows=100000"
+    await memory_store.update_chain("agent-a", chain2)
+
+    tampered = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert tampered.valid is False, (
+        "editing a directly-injected constraint's value was NOT detected — the "
+        "constraint envelope is not bound by the chain-state signature"
+    )
+    assert "chain-state signature" in tampered.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# (e) #1912 Wave 3 A1: a legacy chain (no chain-state sig) is REJECTED by
+#     default; ACCEPTED only under the migration-window opt-out.
+# ---------------------------------------------------------------------------
+
+
+async def _ops_with(registry, key_manager, memory_store, **flags):
+    operations = TrustOperations(
+        authority_registry=registry,
+        key_manager=key_manager,
+        trust_store=memory_store,
+        **flags,
+    )
+    await operations.initialize()
+    return operations
+
+
+async def test_legacy_chain_rejected_by_default(ops, memory_store, caplog):
+    """#1912 Wave 3 A1: an unsigned chain is fail-closed REJECTED.
+
+    Stripping the chain-state signature is exactly the downgrade-to-legacy bypass
+    of MED-1/MED-2. With the default fail-closed posture
+    (allow_unsigned_chain_state=False) the unsigned chain is DENIED.
+    """
+    await _establish(ops, "agent-a", [_cap_req("read_data", [])])
+    # Simulate a pre-Wave-2 / downgraded chain: strip the chain-state signature.
+    chain = await memory_store.get_chain("agent-a")
+    chain.chain_state_signature = None
+    await memory_store.update_chain("agent-a", chain)
+
+    with caplog.at_level(logging.WARNING, logger="kailash.trust.operations"):
+        result = await ops.verify(
+            agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+        )
+    assert result.valid is False, (
+        "an unsigned chain (no chain-state signature) must be REJECTED by "
+        f"default — #1912 Wave 3 A1 fail-closed enforcement: {result.reason}"
+    )
+    assert "chain-state signature" in result.reason.lower()
+    assert any(
+        "REJECTING chain with NO chain-state signature" in rec.message
+        for rec in caplog.records
+    ), "the fail-closed reject must emit the loud A1 WARN naming the migration path"
+
+
+async def test_absent_reject_warn_is_one_time_latched(ops, memory_store, caplog):
+    """The absent-signature reject WARN is one-time-latched (no per-verify spam)."""
+    await _establish(ops, "agent-a", [_cap_req("read_data", [])])
+    chain = await memory_store.get_chain("agent-a")
+    chain.chain_state_signature = None
+    await memory_store.update_chain("agent-a", chain)
+
+    with caplog.at_level(logging.WARNING, logger="kailash.trust.operations"):
+        await ops.verify(agent_id="agent-a", action="read_data")
+        await ops.verify(agent_id="agent-a", action="read_data")
+        await ops.verify(agent_id="agent-a", action="read_data")
+    absent_warns = [
+        r for r in caplog.records if "NO chain-state signature" in r.message
+    ]
+    assert (
+        len(absent_warns) == 1
+    ), f"the absent-signature WARN must be one-time-latched, saw {len(absent_warns)}"
+
+
+async def test_legacy_chain_accepted_with_opt_out(
+    registry, key_manager, memory_store, caplog
+):
+    """The migration-window opt-out accepts an unsigned chain with a loud WARN.
+
+    allow_unsigned_chain_state=True restores the pre-Wave-3 verify-if-present
+    behavior so a deployment keeps running WHILE its chains are re-signed by the
+    #1912 migration — with a loud one-time WARN that set-deletion / suppression
+    detection is OFF.
+    """
+    ops_optout = await _ops_with(
+        registry, key_manager, memory_store, allow_unsigned_chain_state=True
+    )
+    await _establish(ops_optout, "agent-a", [_cap_req("read_data", [])])
+    chain = await memory_store.get_chain("agent-a")
+    chain.chain_state_signature = None
+    await memory_store.update_chain("agent-a", chain)
+
+    with caplog.at_level(logging.WARNING, logger="kailash.trust.operations"):
+        result = await ops_optout.verify(
+            agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+        )
+    assert result.valid is True, (
+        "with allow_unsigned_chain_state=True an unsigned chain must be ACCEPTED "
+        f"(migration window): {result.reason}"
+    )
+    assert any(
+        "allow_unsigned_chain_state=True" in rec.message for rec in caplog.records
+    ), "the opt-out accept must emit the loud one-time WARN that detection is OFF"
+
+
+# ---------------------------------------------------------------------------
+# (f) PRUNE-WHEN-UNSET byte-identity + serializer round-trip
+# ---------------------------------------------------------------------------
+
+
+def _legacy_chain() -> TrustLineageChain:
+    genesis = GenesisRecord(
+        id="gen-legacy",
+        agent_id="agent-legacy",
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="gs",
+    )
+    return TrustLineageChain(genesis=genesis)
+
+
+def test_legacy_chain_dict_has_no_chain_state_signature_key():
+    chain = _legacy_chain()
+    assert chain.chain_state_signature is None
+    data = chain.to_dict()
+    assert "chain_state_signature" not in data, (
+        "a legacy chain (no chain-state signature) must serialize prune-when-unset "
+        "— the dict must carry NO chain_state_signature key (byte-identical to "
+        "pre-Wave-2)"
+    )
+    # Empirical byte-identity: removing the field entirely reproduces the exact
+    # same dict, so a pre-Wave-2 chain and a None-field chain serialize identically.
+    assert data == {k: v for k, v in data.items() if k != "chain_state_signature"}
+
+
+def test_signed_chain_dict_carries_key_and_round_trips():
+    chain = _legacy_chain()
+    chain.chain_state_signature = "c2lnbmF0dXJl"  # opaque base64-ish token
+    data = chain.to_dict()
+    assert (
+        data["chain_state_signature"] == "c2lnbmF0dXJl"
+    ), "a signed chain must emit chain_state_signature in to_dict"
+    restored = TrustLineageChain.from_dict(data)
+    assert (
+        restored.chain_state_signature == "c2lnbmF0dXJl"
+    ), "chain_state_signature must survive to_dict/from_dict round-trip"
+    # Discriminating: a legacy dict round-trips to None (not the signed value).
+    legacy_restored = TrustLineageChain.from_dict(_legacy_chain().to_dict())
+    assert legacy_restored.chain_state_signature is None
+
+
+async def test_signed_chain_survives_store_round_trip(ops, memory_store):
+    """The signature must survive a full store serialize/deserialize (the path
+    every persistent store uses is to_dict/from_dict)."""
+    from kailash.trust.chain_store.filesystem import FilesystemStore
+    import tempfile
+
+    await _establish(ops, "agent-a", [_cap_req("read_data", ["read_only"])])
+    chain = await memory_store.get_chain("agent-a")
+    original_sig = chain.chain_state_signature
+    assert original_sig
+
+    with tempfile.TemporaryDirectory() as d:
+        fs = FilesystemStore(base_dir=d)
+        await fs.initialize()
+        await fs.store_chain(chain)
+        reloaded = await fs.get_chain("agent-a")
+    assert reloaded.chain_state_signature == original_sig, (
+        "chain-state signature did not survive filesystem store round-trip — a "
+        "serializer dropped the field (security.md § Multi-Site Kwarg Plumbing)"
+    )
+    # And the reloaded chain still verifies against operations (structure intact).
+    ops.trust_store = memory_store  # keep verify wired to the in-memory chain
+    result = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK canonical pre-image encoding tripwire (fixed input → pinned bytes)
+# ---------------------------------------------------------------------------
+
+
+def test_chain_state_preimage_is_deterministic_and_pinned():
+    """Pins the canonical pre-image ENCODING (sorted keys, sorted id lists, no
+    whitespace, empty-envelope constraint_hash) on a fixed input. A change to the
+    pre-image shape/encoding is a cross-SDK signing-format change and must break
+    this tripwire loudly (cross-sdk-inspection.md Rule 4b/4d)."""
+    genesis = GenesisRecord(
+        id="gen-fixed",
+        agent_id="agent-fixed",
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature="gs",
+    )
+    # Two caps in NON-sorted id order to prove the pre-image sorts them.
+    cap_b = CapabilityAttestation(
+        id="cap-b",
+        capability="write_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="s",
+    )
+    cap_a = CapabilityAttestation(
+        id="cap-a",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="s",
+    )
+    chain = TrustLineageChain(genesis=genesis, capabilities=[cap_b, cap_a])
+    # Empty constraint envelope → constraint_hash component "".
+    chain.constraint_envelope.active_constraints = []
+
+    payload = chain_state_canonical_payload(chain)
+    assert payload == {
+        "genesis_id": "gen-fixed",
+        "capability_ids": ["cap-a", "cap-b"],
+        "delegation_ids": [],
+        "constraint_hash": "",
+    }
+    expected = (
+        '{"capability_ids":["cap-a","cap-b"],"constraint_hash":"",'
+        '"delegation_ids":[],"genesis_id":"gen-fixed"}'
+    )
+    assert chain_state_canonical_payload_str(chain) == expected, (
+        "chain-state canonical pre-image encoding changed — this is a cross-SDK "
+        "signing-format change; re-pin ONLY in lockstep with the sibling SDK"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delegation + rotation: mutation surfaces re-issue the signature
+# ---------------------------------------------------------------------------
+
+
+async def test_delegation_reissues_chain_state_signature_and_verifies(
+    ops, memory_store
+):
+    from kailash.trust.execution_context import ExecutionContext, HumanOrigin
+
+    await _establish(ops, "agent-root", [_cap_req("read_data", [])])
+    ctx = ExecutionContext(
+        human_origin=HumanOrigin(
+            human_id="alice@corp.com",
+            display_name="Alice",
+            auth_provider="test",
+            session_id="sess-1",
+            authenticated_at=FIXED_TS,
+        )
+    )
+    await ops.delegate(
+        delegator_id="agent-root",
+        delegatee_id="agent-child",
+        task_id="t-1",
+        capabilities=["read_data"],
+        context=ctx,
+    )
+    child = await memory_store.get_chain("agent-child")
+    assert (
+        child.chain_state_signature
+    ), "delegate (new-delegatee branch) must issue a chain-state signature"
+    result = await ops.verify(
+        agent_id="agent-child", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        result.valid is True
+    ), f"a delegated chain failed chain-state verification: {result.reason}"
+
+
+async def test_key_rotation_reissues_chain_state_signature(
+    ops, registry, key_manager, memory_store
+):
+    from kailash.trust.signing.rotation import CredentialRotationManager
+
+    await _establish(ops, "agent-a", [_cap_req("read_data", ["read_only"])])
+    original_sig = (await memory_store.get_chain("agent-a")).chain_state_signature
+    assert original_sig
+
+    mgr = CredentialRotationManager(
+        key_manager=key_manager,
+        trust_store=memory_store,
+        authority_registry=registry,
+    )
+    await mgr.initialize()
+    await mgr.rotate_key("org-test")
+
+    rotated = await memory_store.get_chain("agent-a")
+    assert rotated.chain_state_signature, "rotation dropped the chain-state signature"
+    assert rotated.chain_state_signature != original_sig, (
+        "rotation did not re-sign the chain-state signature with the new key — a "
+        "stale old-key signature would fail closed at verify after every rotation"
+    )
+    # The load-bearing assertion: the re-signed chain still verifies.
+    result = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        result.valid is True
+    ), f"a chain re-signed by key rotation failed chain-state verify: {result.reason}"
+
+
+# ---------------------------------------------------------------------------
+# Wave-3 A1 enforcement contract (#1912 RT-sec-w2 INVEST-NOW), now LANDED.
+# A store-writer who strips chain_state_signature downgrades the chain to
+# "legacy". Under Wave 2 that was ACCEPTED-with-WARN (a full bypass of
+# MED-1/MED-2); Wave 3 A1 enforcement REQUIRES the signature and REJECTS a
+# stripped/absent one. The self-clearing xfail-strict tripwire XPASSed when
+# Wave 3 landed and was removed here — this is now a normal passing test.
+# ---------------------------------------------------------------------------
+
+
+async def test_sig_strip_downgrade_rejected(ops, memory_store):
+    # A store-writer deletes a constraint-bearing cap AND strips the chain-state
+    # signature to HIDE the tamper (downgrade to legacy). Wave 2 accepts it
+    # (valid=True); Wave 3 A1 must reject a chain with no valid chain-state sig.
+    await _establish(
+        ops,
+        "agent-a",
+        [
+            _cap_req("read_data", []),
+            _cap_req("read_pii", ["read_only", "no_pii_export"]),
+        ],
+    )
+    chain = await memory_store.get_chain("agent-a")
+    chain.capabilities = [c for c in chain.capabilities if c.capability != "read_pii"]
+    chain.chain_state_signature = None  # the downgrade: strip the sig
+    await memory_store.update_chain("agent-a", chain)
+
+    result = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    # Wave 3 A1: a stripped/absent chain-state signature MUST be rejected.
+    assert result.valid is False, (
+        "sig-strip downgrade was accepted — Wave 3 A1 enforcement must reject a "
+        "chain whose chain-state signature is stripped/absent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RT-sec-w3 Finding B: the MINT gate enforces the chain-state signature too
+# (enforcement-surface parity — a portable artifact must not be minted from a
+# chain-state-tampered/unsigned chain).
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_gate_refuses_chain_with_broken_chain_state_signature(
+    ops, memory_store
+):
+    from kailash.trust.exceptions import InvalidTrustChainError
+
+    await _establish(
+        ops,
+        "agent-a",
+        [
+            _cap_req("read_data", []),
+            _cap_req("read_pii", ["read_only", "no_pii_export"]),
+        ],
+    )
+    # Store-writer deletes a constraint-bearing cap WITHOUT re-signing → the
+    # chain-state signature no longer matches the recomputed pre-image.
+    chain = await memory_store.get_chain("agent-a")
+    chain.capabilities = [c for c in chain.capabilities if c.capability != "read_pii"]
+    await memory_store.update_chain("agent-a", chain)
+    tampered = await memory_store.get_chain("agent-a")
+
+    # The mint gate must REFUSE — verify() would reject this chain, so mint (which
+    # produces a signed, portable artifact) must not accept it either.
+    with pytest.raises(InvalidTrustChainError):
+        await ops._verify_source_chain_before_mint(tampered, "agent-a")
+
+
+async def test_mint_gate_refuses_unsigned_chain_by_default(ops, memory_store):
+    from kailash.trust.exceptions import InvalidTrustChainError
+
+    await _establish(ops, "agent-a", [_cap_req("read_data", [])])
+    chain = await memory_store.get_chain("agent-a")
+    chain.chain_state_signature = None  # simulate a pre-Wave-2 / downgraded chain
+    await memory_store.update_chain("agent-a", chain)
+    tampered = await memory_store.get_chain("agent-a")
+
+    with pytest.raises(InvalidTrustChainError):
+        await ops._verify_source_chain_before_mint(tampered, "agent-a")
+
+
+async def test_mint_gate_accepts_unsigned_chain_under_opt_out(
+    registry, key_manager, memory_store
+):
+    # Under the migration-window opt-out the mint gate matches verify(): an
+    # unsigned chain (valid v1 caps) is accepted rather than refused.
+    ops_optout = await _ops_with(
+        registry, key_manager, memory_store, allow_unsigned_chain_state=True
+    )
+    await _establish(ops_optout, "agent-a", [_cap_req("read_data", [])])
+    chain = await memory_store.get_chain("agent-a")
+    chain.chain_state_signature = None
+    await memory_store.update_chain("agent-a", chain)
+    tampered = await memory_store.get_chain("agent-a")
+
+    # No raise — the opt-out permits minting from an unsigned chain.
+    await ops_optout._verify_source_chain_before_mint(tampered, "agent-a")

--- a/tests/regression/test_issue_1912_subject_binding_migration.py
+++ b/tests/regression/test_issue_1912_subject_binding_migration.py
@@ -338,6 +338,43 @@ async def test_migration_reports_chain_when_signing_key_absent(
     assert unchanged.chain_state_signature is None
 
 
+async def test_migration_reports_empty_genesis_agent_id_without_aborting(
+    registry, key_manager, memory_store
+):
+    """An anomalous chain with an empty genesis.agent_id is reported
+    un-migratable — the migration MUST NOT raise (which would abort the whole
+    run mid-pass, a run-wide DoS) but fail-soft per-chain (RT-sec-w3 gate).
+    """
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-empty", ["read_data"])
+
+    # Simulate the anomaly: a persisted chain whose genesis carries no agent_id.
+    chain = await memory_store.get_chain("agent-empty")
+    object.__setattr__(chain.genesis, "agent_id", "")
+    await memory_store.update_chain("agent-empty", chain)
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    # The whole point: this returns a report, it does NOT raise.
+    report = await migration.migrate(trust_store_placement=True)
+
+    assert report.migrated_chains == 0
+    assert report.promoted_capabilities == 0
+    assert report.fully_migrated is False
+    empty_items = [
+        u for u in report.unmigratable if "genesis agent_id is empty" in u.reason
+    ]
+    assert len(empty_items) == 1
+    assert empty_items[0].kind == "chain"
+    # Nothing was written — the caps are still legacy, no chain-state sig added.
+    unchanged = await memory_store.get_chain("agent-empty")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+        for c in unchanged.capabilities
+    )
+    assert unchanged.chain_state_signature is None
+
+
 # ---------------------------------------------------------------------------
 # Idempotency, dry-run, rollback, failure-atomicity
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_issue_1912_subject_binding_migration.py
+++ b/tests/regression/test_issue_1912_subject_binding_migration.py
@@ -1,0 +1,738 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1912 Wave 3 re-signing migration (installed-base → Wave-3 posture).
+
+The migration promotes a pre-#1912 chain (legacy caps + no chain-state signature)
+to the Wave-3 posture (v1-subject-bound caps + a chain-state signature) so a
+deployment can flip fail-closed enforcement on without breaking existing agents.
+
+Tested against REAL stores (InMemory AND a real on-disk Filesystem store), REAL
+Ed25519, NO mocking. Scenarios:
+
+  * promote legacy chain → v1 + chain-state sig; verify() then PASSES fail-closed;
+  * real on-disk Filesystem store round-trip (serialization survives disk);
+  * external-attester cap reported un-migratable (local key cannot re-sign FOR it);
+  * chain reported un-migratable when the genesis signing key is absent locally;
+  * idempotent (a second run changes nothing);
+  * dry_run writes nothing;
+  * rollback restores the byte-exact pre-migration state;
+  * apply failure rolls back ALL changes (failure-atomicity).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict
+
+import pytest
+
+from kailash.trust.authority import AuthorityPermission, OrganizationalAuthority
+from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_LEGACY,
+    CAPABILITY_SIGNING_VERSION_V1,
+    AuthorityType,
+    CapabilityAttestation,
+    CapabilityType,
+    Constraint,
+    ConstraintType,
+    GenesisRecord,
+    TrustLineageChain,
+    VerificationLevel,
+)
+from kailash.trust.chain_store.filesystem import FilesystemStore
+from kailash.trust.chain_store.memory import InMemoryTrustStore
+from kailash.trust.exceptions import AuthorityInactiveError, AuthorityNotFoundError
+from kailash.trust.migrations.subject_binding_1912 import (
+    SubjectBindingMigration,
+    SubjectBindingMigrationError,
+)
+from kailash.trust.operations import (
+    CapabilityRequest,
+    TrustKeyManager,
+    TrustOperations,
+)
+from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing
+
+pytestmark = pytest.mark.regression
+
+FIXED_TS = datetime(2026, 3, 11, 14, 30, 0, tzinfo=timezone.utc)
+
+
+class SimpleAuthorityRegistry:
+    """Real in-memory authority registry (NOT a mock)."""
+
+    def __init__(self) -> None:
+        self._authorities: Dict[str, OrganizationalAuthority] = {}
+
+    async def initialize(self) -> None:
+        pass
+
+    def register(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+    async def get_authority(
+        self, authority_id: str, include_inactive: bool = False
+    ) -> OrganizationalAuthority:
+        authority = self._authorities.get(authority_id)
+        if authority is None:
+            raise AuthorityNotFoundError(authority_id)
+        if not authority.is_active and not include_inactive:
+            raise AuthorityInactiveError(authority_id)
+        return authority
+
+    async def update_authority(self, authority: OrganizationalAuthority) -> None:
+        self._authorities[authority.id] = authority
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def authority(keypair):
+    _, public_key = keypair
+    return OrganizationalAuthority(
+        id="org-test",
+        name="Test Corp",
+        authority_type=AuthorityType.ORGANIZATION,
+        public_key=public_key,
+        signing_key_id="test-key-001",
+        permissions=[
+            AuthorityPermission.CREATE_AGENTS,
+            AuthorityPermission.DELEGATE_TRUST,
+            AuthorityPermission.GRANT_CAPABILITIES,
+        ],
+    )
+
+
+@pytest.fixture
+def registry(authority):
+    reg = SimpleAuthorityRegistry()
+    reg.register(authority)
+    return reg
+
+
+@pytest.fixture
+def key_manager(keypair):
+    private_key, _ = keypair
+    km = TrustKeyManager()
+    km.register_key("test-key-001", private_key)
+    return km
+
+
+@pytest.fixture
+async def memory_store():
+    store = InMemoryTrustStore()
+    await store.initialize()
+    return store
+
+
+def _fail_closed_ops(registry, key_manager, store) -> TrustOperations:
+    """A TrustOperations with BOTH #1912 Wave-3 opt-outs OFF (fail-closed)."""
+    return TrustOperations(
+        authority_registry=registry, key_manager=key_manager, trust_store=store
+    )
+
+
+async def _establish_then_downgrade(ops, key_manager, agent_id, caps):
+    """Establish a v1 chain, then downgrade it to a pre-#1912 (legacy) chain."""
+    await ops.establish(
+        agent_id=agent_id,
+        authority_id="org-test",
+        capabilities=[
+            CapabilityRequest(capability=c, capability_type=CapabilityType.ACTION)
+            for c in caps
+        ],
+    )
+    chain = await ops.trust_store.get_chain(agent_id)
+    # Simulate the installed base: every cap legacy (re-signed over the no-subject
+    # legacy pre-image), and NO chain-state signature.
+    for cap in chain.capabilities:
+        cap.signing_payload_version = CAPABILITY_SIGNING_VERSION_LEGACY
+        payload = serialize_for_signing(cap.to_signing_payload())
+        cap.signature = await key_manager.sign(payload, "test-key-001")
+    chain.chain_state_signature = None
+    await ops.trust_store.update_chain(agent_id, chain)
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Core: promote a legacy chain and make it verify under fail-closed enforcement
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_promotes_legacy_chain_to_v1_and_signs(
+    registry, key_manager, memory_store
+):
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+
+    # Pre-migration: the downgraded legacy chain is REJECTED by fail-closed verify.
+    before = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert before.valid is False, "fixture bug: legacy chain should be rejected"
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+
+    assert report.total_chains == 1
+    assert report.migrated_chains == 1
+    assert report.promoted_capabilities == 1
+    assert report.added_chain_state_signatures == 1
+    assert report.fully_migrated is True
+    assert report.unmigratable == []
+
+    # Post-migration: caps are v1, a chain-state sig exists, and fail-closed
+    # verify() now PASSES.
+    migrated = await memory_store.get_chain("agent-a")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+        for c in migrated.capabilities
+    )
+    assert migrated.chain_state_signature is not None
+    after = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        after.valid is True
+    ), f"a migrated chain must verify under fail-closed enforcement: {after.reason}"
+    # FULL level (full-chain signature verify) must also pass.
+    after_full = await ops.verify(
+        agent_id="agent-a", action="read_data", level=VerificationLevel.FULL
+    )
+    assert (
+        after_full.valid is True
+    ), f"FULL denied a migrated chain: {after_full.reason}"
+
+
+async def test_migration_real_filesystem_store(registry, key_manager, tmp_path):
+    """The migration round-trips through a REAL on-disk Filesystem store."""
+    store = FilesystemStore(base_dir=str(tmp_path / "chains"))
+    await store.initialize()
+    ops = _fail_closed_ops(registry, key_manager, store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-fs", ["read_data"])
+
+    migration = SubjectBindingMigration(registry, key_manager, store)
+    report = await migration.migrate(trust_store_placement=True)
+    assert report.migrated_chains == 1
+    assert report.fully_migrated is True
+
+    # Re-read from disk (fresh store instance) — the v1 promotion + chain-state
+    # signature must survive serialization to disk and back.
+    store2 = FilesystemStore(base_dir=str(tmp_path / "chains"))
+    await store2.initialize()
+    ops2 = _fail_closed_ops(registry, key_manager, store2)
+    await ops2.initialize()
+    reloaded = await store2.get_chain("agent-fs")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+        for c in reloaded.capabilities
+    )
+    assert reloaded.chain_state_signature is not None
+    result = await ops2.verify(
+        agent_id="agent-fs", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        result.valid is True
+    ), f"migrated chain failed after disk round-trip: {result.reason}"
+
+
+# ---------------------------------------------------------------------------
+# Un-migratable reporting (never silently dropped)
+# ---------------------------------------------------------------------------
+
+
+def _signed_genesis(key_manager_sign_sig: str, agent_id: str) -> GenesisRecord:
+    return GenesisRecord(
+        id=f"gen-{agent_id}",
+        agent_id=agent_id,
+        authority_id="org-test",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=FIXED_TS,
+        signature=key_manager_sign_sig,
+    )
+
+
+async def test_migration_reports_external_attester_cap(
+    registry, key_manager, memory_store
+):
+    # A chain with one LOCAL legacy cap (attester=org-test) and one EXTERNAL
+    # legacy cap (attester=org-other) the local genesis key cannot re-sign FOR.
+    genesis = _signed_genesis("gs", "agent-x")
+    local_cap = CapabilityAttestation(
+        id="cap-local",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    # A GENUINELY-signed legacy cap (Fix A refuses to promote an unverified one).
+    local_cap.signature = await key_manager.sign(
+        serialize_for_signing(local_cap.to_signing_payload()), "test-key-001"
+    )
+    external_cap = CapabilityAttestation(
+        id="cap-external",
+        capability="write_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-other",
+        attested_at=FIXED_TS,
+        signature="s2",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    chain = TrustLineageChain(genesis=genesis, capabilities=[local_cap, external_cap])
+    await memory_store.store_chain(chain)
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+
+    assert report.promoted_capabilities == 1, "the local cap should be promoted"
+    assert report.fully_migrated is False
+    external = [u for u in report.unmigratable if u.capability_id == "cap-external"]
+    assert len(external) == 1
+    assert external[0].kind == "capability"
+    assert "org-other" in external[0].reason
+    # The migrated chain: local cap v1, external cap still legacy.
+    migrated = await memory_store.get_chain("agent-x")
+    by_id = {c.id: c for c in migrated.capabilities}
+    assert by_id["cap-local"].signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+    assert (
+        by_id["cap-external"].signing_payload_version
+        == CAPABILITY_SIGNING_VERSION_LEGACY
+    )
+
+
+async def test_migration_reports_chain_when_signing_key_absent(
+    registry, key_manager, memory_store
+):
+    # Persist a legacy chain using a key manager that HAS the key.
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-nokey", ["read_data"])
+
+    # Now run the migration with a key manager that LACKS the signing key.
+    empty_km = TrustKeyManager()
+    migration = SubjectBindingMigration(registry, empty_km, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+
+    assert report.migrated_chains == 0
+    assert report.promoted_capabilities == 0
+    assert report.fully_migrated is False
+    chain_items = [u for u in report.unmigratable if u.kind == "chain"]
+    assert len(chain_items) == 1
+    assert "signing key" in chain_items[0].reason
+    # Nothing was written — the chain is unchanged (still legacy).
+    unchanged = await memory_store.get_chain("agent-nokey")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+        for c in unchanged.capabilities
+    )
+    assert unchanged.chain_state_signature is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency, dry-run, rollback, failure-atomicity
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_is_idempotent(registry, key_manager, memory_store):
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    first = await migration.migrate(trust_store_placement=True)
+    assert first.migrated_chains == 1
+
+    second = await migration.migrate(trust_store_placement=True)
+    assert second.total_chains == 1
+    assert second.migrated_chains == 0, "a re-run must change nothing (idempotent)"
+    assert second.promoted_capabilities == 0
+    assert second.added_chain_state_signatures == 0
+    assert second.already_current_chains == 1
+
+
+async def test_migration_dry_run_writes_nothing(registry, key_manager, memory_store):
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True, dry_run=True)
+    assert report.dry_run is True
+    assert report.migrated_chains == 1  # would-migrate count
+    assert report.snapshots == {}
+
+    # Store is UNCHANGED — still a legacy chain.
+    unchanged = await memory_store.get_chain("agent-a")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+        for c in unchanged.capabilities
+    )
+    assert unchanged.chain_state_signature is None
+
+
+async def test_migration_rollback_restores_pre_migration_state(
+    registry, key_manager, memory_store
+):
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+    pre = await memory_store.get_chain("agent-a")
+    pre_versions = [c.signing_payload_version for c in pre.capabilities]
+    pre_sigs = [c.signature for c in pre.capabilities]
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+    assert report.migrated_chains == 1
+
+    restored_count = await migration.rollback(report)
+    assert restored_count == 1
+
+    # Byte-exact restore: versions + signatures + chain-state sig back to legacy.
+    restored = await memory_store.get_chain("agent-a")
+    assert [c.signing_payload_version for c in restored.capabilities] == pre_versions
+    assert [c.signature for c in restored.capabilities] == pre_sigs
+    assert restored.chain_state_signature is None
+
+
+class _FailOnNthUpdateStore:
+    """Wraps a real store; raises on the Nth update_chain to test atomicity."""
+
+    def __init__(self, inner, fail_on: int):
+        self._inner = inner
+        self._fail_on = fail_on
+        self._updates = 0
+
+    async def initialize(self):
+        await self._inner.initialize()
+
+    async def list_chains(self, **kw):
+        return await self._inner.list_chains(**kw)
+
+    async def get_chain(self, agent_id, **kw):
+        return await self._inner.get_chain(agent_id, **kw)
+
+    async def store_chain(self, chain, **kw):
+        return await self._inner.store_chain(chain, **kw)
+
+    async def update_chain(self, agent_id, chain):
+        self._updates += 1
+        if self._updates == self._fail_on:
+            raise RuntimeError("simulated store failure")
+        return await self._inner.update_chain(agent_id, chain)
+
+
+async def test_migration_atomic_rollback_on_apply_failure(
+    registry, key_manager, memory_store
+):
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    # Two legacy chains; the store fails on the 2nd update mid-apply.
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+    await _establish_then_downgrade(ops, key_manager, "agent-b", ["read_data"])
+    pre_a = await memory_store.get_chain("agent-a")
+    pre_a_versions = [c.signing_payload_version for c in pre_a.capabilities]
+
+    failing = _FailOnNthUpdateStore(memory_store, fail_on=2)
+    migration = SubjectBindingMigration(registry, key_manager, failing)
+    with pytest.raises(SubjectBindingMigrationError):
+        await migration.migrate(trust_store_placement=True)
+
+    # Atomicity: the first-applied chain was ROLLED BACK to its legacy state.
+    post_a = await memory_store.get_chain("agent-a")
+    assert [
+        c.signing_payload_version for c in post_a.capabilities
+    ] == pre_a_versions, "a mid-apply failure must restore ALL applied chains"
+    assert post_a.chain_state_signature is None
+    post_b = await memory_store.get_chain("agent-b")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+        for c in post_b.capabilities
+    )
+
+
+# ---------------------------------------------------------------------------
+# RT-sec-w3 Finding A: the migration MUST NOT launder an unverified legacy cap
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_refuses_to_resign_forged_legacy_cap(
+    registry, key_manager, memory_store
+):
+    """A store-writer's injected/tampered legacy cap must be REPORTED, never
+    re-signed into a valid v1 cap.
+
+    Threat: a bounded-trust store-writer (no signing key) injects a legacy cap
+    with `attester_id` == the genesis authority but an INVALID signature. On a
+    pre-#1912 chain this is undetected. If the migration re-signed it with the
+    genesis key it would launder the forgery into a valid v1 cap (privilege
+    escalation THROUGH the migration). The migration must verify the existing
+    legacy signature first and report the forgery instead.
+    """
+    genesis = _signed_genesis("gs", "agent-forge")
+    # A GENUINE legacy cap (validly signed over the legacy pre-image) — promoted.
+    good_cap = CapabilityAttestation(
+        id="cap-good",
+        capability="read_data",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    good_cap.signature = await key_manager.sign(
+        serialize_for_signing(good_cap.to_signing_payload()), "test-key-001"
+    )
+    # A FORGED cap: attester spoofed to the genesis authority, garbage signature.
+    forged_cap = CapabilityAttestation(
+        id="cap-forged",
+        capability="admin_all",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="deadbeef-not-a-real-signature",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    chain = TrustLineageChain(genesis=genesis, capabilities=[good_cap, forged_cap])
+    await memory_store.store_chain(chain)
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+
+    # The genuine cap is promoted; the forged cap is REPORTED, never laundered.
+    assert report.promoted_capabilities == 1
+    forged_items = [u for u in report.unmigratable if u.capability_id == "cap-forged"]
+    assert len(forged_items) == 1
+    assert "does not verify" in forged_items[0].reason
+    migrated = await memory_store.get_chain("agent-forge")
+    by_id = {c.id: c for c in migrated.capabilities}
+    assert by_id["cap-good"].signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+    # The forged cap stays legacy with its ORIGINAL (invalid) signature — the
+    # genesis key never signed it, so Wave-3 verify still rejects it.
+    assert (
+        by_id["cap-forged"].signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+    )
+    assert by_id["cap-forged"].signature == "deadbeef-not-a-real-signature"
+
+
+# ---------------------------------------------------------------------------
+# RT-sec-w3r2 Finding C: legacy-cap promotion requires explicit trust ack
+# (the migration cannot verify a legacy cap's original holder → transplant risk)
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_refuses_legacy_promotion_without_trust_ack(
+    registry, key_manager, memory_store
+):
+    """By default (trust_store_placement=False) legacy caps are REPORTED, not
+    promoted — the migration will not make an unverifiable trust-the-placement
+    decision silently.
+    """
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_then_downgrade(ops, key_manager, "agent-a", ["read_data"])
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate()  # no trust_store_placement ack
+
+    assert report.promoted_capabilities == 0
+    assert report.fully_migrated is False
+    ack_items = [u for u in report.unmigratable if "trust_store_placement" in u.reason]
+    assert len(ack_items) == 1
+    # Nothing written: the chain stays legacy, and NO chain-state signature was
+    # added over the un-promoted legacy set.
+    unchanged = await memory_store.get_chain("agent-a")
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_LEGACY
+        for c in unchanged.capabilities
+    )
+    assert unchanged.chain_state_signature is None
+
+
+async def test_migration_refuses_to_launder_transplanted_legacy_cap(
+    registry, key_manager, memory_store
+):
+    """RT-sec-w3r2 Finding C: a GENUINE legacy cap (validly signed by the
+    authority, but NOT originally bound to this chain — legacy caps carry no
+    subject) must NOT be silently laundered into a valid v1 cap. Because Fix A's
+    signature check passes for a genuine-but-transplanted cap, the trust ack is
+    the ONLY gate — the default must refuse.
+    """
+    # A legacy cap validly signed by org-test (the authority), placed into a
+    # chain whose genesis it was NOT issued for (the transplant).
+    transplanted = CapabilityAttestation(
+        id="cap-transplant",
+        capability="admin_all",
+        capability_type=CapabilityType.ACTION,
+        constraints=[],
+        attester_id="org-test",
+        attested_at=FIXED_TS,
+        signature="",
+        signing_payload_version=CAPABILITY_SIGNING_VERSION_LEGACY,
+    )
+    # Genuine signature over the (subjectless) legacy pre-image — verifies fine.
+    transplanted.signature = await key_manager.sign(
+        serialize_for_signing(transplanted.to_signing_payload()), "test-key-001"
+    )
+    genesis = _signed_genesis("gs", "agent-victim")
+    chain = TrustLineageChain(genesis=genesis, capabilities=[transplanted])
+    await memory_store.store_chain(chain)
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate()  # default: no trust ack
+
+    # The genuine-signature check (Fix A) would PASS — only the trust ack stops
+    # the laundering. Default refuses: reported, not promoted.
+    assert report.promoted_capabilities == 0
+    laundered = await memory_store.get_chain("agent-victim")
+    assert (
+        laundered.capabilities[0].signing_payload_version
+        == CAPABILITY_SIGNING_VERSION_LEGACY
+    ), "a transplanted legacy cap was laundered into v1 WITHOUT the trust ack"
+    assert any("trust_store_placement" in u.reason for u in report.unmigratable)
+
+
+async def _establish_all_v1_no_sig(ops, memory_store, agent_id):
+    """Establish an all-v1 chain, then strip ONLY its chain-state signature
+    (the legitimate post-Wave-1 / pre-Wave-2 migration-target shape)."""
+    await ops.establish(
+        agent_id=agent_id,
+        authority_id="org-test",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data", capability_type=CapabilityType.ACTION
+            )
+        ],
+    )
+    chain = await memory_store.get_chain(agent_id)
+    assert all(
+        c.signing_payload_version == CAPABILITY_SIGNING_VERSION_V1
+        for c in chain.capabilities
+    )
+    chain.chain_state_signature = None
+    await memory_store.update_chain(agent_id, chain)
+    return chain
+
+
+async def test_migration_signs_all_v1_chain_with_trust_ack(
+    registry, key_manager, memory_store
+):
+    """An all-v1 chain missing its chain-state signature is re-signed WHEN the
+    operator acknowledges a trusted store snapshot (trust_store_placement=True).
+    """
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_all_v1_no_sig(ops, memory_store, "agent-v1")
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate(trust_store_placement=True)
+
+    assert report.promoted_capabilities == 0
+    assert report.added_chain_state_signatures == 1
+    assert report.fully_migrated is True
+    resigned = await memory_store.get_chain("agent-v1")
+    assert resigned.chain_state_signature is not None
+    result = await ops.verify(
+        agent_id="agent-v1", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert (
+        result.valid is True
+    ), f"all-v1 chain failed after chain-state re-sign: {result.reason}"
+
+
+async def test_migration_refuses_fresh_chain_state_signing_without_ack(
+    registry, key_manager, memory_store
+):
+    """RT-sec-w3r3 Finding D: FRESH chain-state signing (adding a signature where
+    the chain has none) re-signs over an UNVERIFIED constraint envelope, so it
+    requires the trust ack. Without it, the chain is REPORTED, not signed.
+    """
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await _establish_all_v1_no_sig(ops, memory_store, "agent-v1")
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate()  # no ack
+
+    assert report.added_chain_state_signatures == 0
+    assert report.fully_migrated is False
+    chain_ack_items = [
+        u
+        for u in report.unmigratable
+        if u.kind == "chain" and "chain-state signing requires" in u.reason
+    ]
+    assert len(chain_ack_items) == 1
+    # The chain is UNCHANGED — no fresh signature was minted over unverified state.
+    unchanged = await memory_store.get_chain("agent-v1")
+    assert unchanged.chain_state_signature is None
+
+
+async def test_migration_does_not_rebless_stripped_constraint_without_ack(
+    registry, key_manager, memory_store
+):
+    """RT-sec-w3r3 Finding D (the MED-2 scenario): a store-writer strips a
+    directly-injected constraint AND the chain-state signature, leaving a chain
+    shaped like a legit all-v1 migration target. Without the trust ack the
+    migration MUST NOT mint a fresh chain-state signature that would bless the
+    suppressed envelope.
+    """
+    ops = _fail_closed_ops(registry, key_manager, memory_store)
+    await ops.initialize()
+    await ops.establish(
+        agent_id="agent-med2",
+        authority_id="org-test",
+        capabilities=[
+            CapabilityRequest(
+                capability="read_data", capability_type=CapabilityType.ACTION
+            )
+        ],
+    )
+    chain = await memory_store.get_chain("agent-med2")
+    # Inject a directly-configured constraint + re-sign (the legit configured state).
+    chain.constraint_envelope.active_constraints.append(
+        Constraint(
+            id="con-reasoning",
+            constraint_type=ConstraintType.REASONING_REQUIRED,
+            value="reasoning_required",
+            source="policy",
+        )
+    )
+    await ops._issue_chain_state_signature(chain)
+    await memory_store.update_chain("agent-med2", chain)
+
+    # Store-writer STRIPS the constraint AND the chain-state signature.
+    tampered = await memory_store.get_chain("agent-med2")
+    tampered.constraint_envelope.active_constraints = [
+        c
+        for c in tampered.constraint_envelope.active_constraints
+        if c.constraint_type != ConstraintType.REASONING_REQUIRED
+    ]
+    tampered.chain_state_signature = None
+    await memory_store.update_chain("agent-med2", tampered)
+
+    migration = SubjectBindingMigration(registry, key_manager, memory_store)
+    report = await migration.migrate()  # no ack — must refuse to bless
+
+    assert report.added_chain_state_signatures == 0
+    # The suppressed-envelope chain was NOT freshly signed → verify still rejects
+    # it (no chain-state signature), so the suppression is not blessed.
+    not_reblessed = await memory_store.get_chain("agent-med2")
+    assert not_reblessed.chain_state_signature is None
+    rejected = await ops.verify(
+        agent_id="agent-med2", action="read_data", level=VerificationLevel.STANDARD
+    )
+    assert rejected.valid is False, (
+        "a stripped-constraint chain was re-blessed without the trust ack — "
+        "Finding D MED-2 laundering re-opened"
+    )

--- a/tests/trust/unit/test_reasoning_integration.py
+++ b/tests/trust/unit/test_reasoning_integration.py
@@ -218,6 +218,10 @@ async def _establish_agent_with_capability(
         chain = await ops.trust_store.get_chain(agent_id)
         for constraint in constraints:
             chain.constraint_envelope.active_constraints.append(constraint)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
 
@@ -304,6 +308,10 @@ class TestReasoningEndToEndFlow:
             "agent-e2e-1", reasoning_trace, private_key
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         # Verify at FULL level
@@ -349,6 +357,10 @@ class TestReasoningEndToEndFlow:
             "agent-e2e-2", audit_trace, private_key
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         # Verify at FULL level
@@ -394,6 +406,10 @@ class TestReasoningEndToEndFlow:
             signature=sign("test-payload", private_key),
         )
         chain.delegations.append(del_without)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -441,6 +457,10 @@ class TestReasoningEndToEndFlow:
             signature=sign("test-payload", private_key),
         )
         chain.delegations.append(del_without)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         score = await compute_trust_score("agent-e2e-4", ops.trust_store)
@@ -460,6 +480,10 @@ class TestReasoningEndToEndFlow:
             deleg_id="del-scored-full",
         )
         chain_full.delegations.append(del_full)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain_full)
         await ops.trust_store.store_chain(chain_full)
 
         score_full = await compute_trust_score("agent-e2e-4-full", ops.trust_store)
@@ -506,6 +530,10 @@ class TestReasoningEndToEndFlow:
         )
         anchor.action = "analyze"
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         # Step 4: Verify
@@ -565,6 +593,10 @@ class TestReasoningAdversarial:
         delegation.reasoning_trace_hash = "tampered_hash_0000000000000000"
 
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -612,6 +644,10 @@ class TestReasoningAdversarial:
         delegation.signature = sign(del_payload, private_key)
 
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -790,6 +826,10 @@ class TestReasoningAdversarial:
             "agent-concurrent", reasoning_trace, private_key
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         # Run 10 concurrent verify calls
@@ -847,6 +887,10 @@ class TestReasoningAdversarial:
             "agent-enforce", reasoning_trace, private_key
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1000,6 +1044,10 @@ class TestReasoningBackwardCompat:
             signature=sign("test", private_key),
         )
         chain1.delegations.append(del1)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain1)
         await ops.trust_store.store_chain(chain1)
         score1 = await compute_trust_score("agent-compat-1", ops.trust_store)
 
@@ -1016,6 +1064,10 @@ class TestReasoningBackwardCompat:
             "agent-compat-2", reasoning_trace, private_key, deleg_id="del-compat-2"
         )
         chain2.delegations.append(del2)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain2)
         await ops.trust_store.store_chain(chain2)
         score2 = await compute_trust_score("agent-compat-2", ops.trust_store)
 

--- a/tests/trust/unit/test_reasoning_transplant_attack.py
+++ b/tests/trust/unit/test_reasoning_transplant_attack.py
@@ -199,6 +199,10 @@ async def _establish_agent_with_capability(
         chain = await ops.trust_store.get_chain(agent_id)
         for constraint in constraints:
             chain.constraint_envelope.active_constraints.append(constraint)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
 
@@ -404,6 +408,10 @@ class TestVerifyDetectsTransplantAttack:
         del_payload = serialize_for_signing(transplant_delegation.to_signing_payload())
         transplant_delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(transplant_delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -459,6 +467,10 @@ class TestVerifyDetectsTransplantAttack:
             reasoning_signature=stolen_reasoning_signature,
         )
         chain.audit_anchors.append(transplant_anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(

--- a/tests/trust/unit/test_verify_reasoning.py
+++ b/tests/trust/unit/test_verify_reasoning.py
@@ -206,6 +206,10 @@ async def _establish_agent_with_capability(
         chain = await ops.trust_store.get_chain(agent_id)
         for constraint in constraints:
             chain.constraint_envelope.active_constraints.append(constraint)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
 
@@ -367,6 +371,10 @@ class TestVerifyStandardReasoningPresence:
             reasoning_signature=sign_reasoning_trace(reasoning_trace, private_key),
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -402,6 +410,10 @@ class TestVerifyStandardReasoningPresence:
             # No reasoning_trace, reasoning_trace_hash, or reasoning_signature
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -438,6 +450,10 @@ class TestVerifyStandardReasoningPresence:
             reasoning_signature=sign_reasoning_trace(reasoning_trace, private_key),
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -471,6 +487,10 @@ class TestVerifyStandardReasoningPresence:
             # No reasoning trace
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -545,6 +565,10 @@ class TestVerifyFullReasoningCrypto:
         delegation.signature = sign(del_payload, private_key)
 
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -585,6 +609,10 @@ class TestVerifyFullReasoningCrypto:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -625,6 +653,10 @@ class TestVerifyFullReasoningCrypto:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -670,6 +702,10 @@ class TestVerifyFullReasoningCrypto:
             ),
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -706,6 +742,10 @@ class TestVerifyFullReasoningCrypto:
             reasoning_signature=sign_reasoning_trace(reasoning_trace, private_key),
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -825,6 +865,10 @@ class TestVerifyMixedReasoningRecords:
             signature=sign("test-payload-b", private_key),
         )
         chain.delegations.extend([del_with, del_without])
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -881,6 +925,10 @@ class TestVerifyFullReasoningSignatureCryptoVerification:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -921,6 +969,10 @@ class TestVerifyFullReasoningSignatureCryptoVerification:
             reasoning_signature="AAAA_not_a_real_signature_AAAA",
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -967,6 +1019,10 @@ class TestVerifyFullReasoningSignatureCryptoVerification:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1019,6 +1075,10 @@ class TestVerifyStandardMissingReasoningViolations:
             # No reasoning_trace, no reasoning_trace_hash, no reasoning_signature
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1061,6 +1121,10 @@ class TestVerifyStandardMissingReasoningViolations:
             # No reasoning trace
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1104,6 +1168,10 @@ class TestVerifyStandardMissingReasoningViolations:
             reasoning_signature=sign_reasoning_trace(reasoning_trace, private_key),
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1174,6 +1242,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
             # No reasoning_trace, no reasoning_trace_hash, no reasoning_signature
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1226,6 +1298,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1261,6 +1337,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
             # No reasoning trace
         )
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1300,6 +1380,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
             # No reasoning trace
         )
         chain.audit_anchors.append(anchor)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1372,6 +1456,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
         )
 
         chain.delegations.extend([del_with, del_without])
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(
@@ -1418,6 +1506,10 @@ class TestVerifyFullReasoningRequiredHardFailure:
         del_payload = serialize_for_signing(delegation.to_signing_payload())
         delegation.signature = sign(del_payload, private_key)
         chain.delegations.append(delegation)
+        # #1912 Wave 2: re-issue the chain-state signature after the
+        # in-memory mutation above (mirrors ops.delegate) so the stored
+        # chain is internally consistent for verify().
+        await ops._issue_chain_state_signature(chain)
         await ops.trust_store.store_chain(chain)
 
         result = await ops.verify(

--- a/uv.lock
+++ b/uv.lock
@@ -1786,7 +1786,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.59.0"
+version = "2.60.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2119,7 +2119,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "rl-bridge", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.18.0"
+version = "2.19.1"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "asyncpg" },
@@ -2288,7 +2288,7 @@ provides-extras = ["providers-azure", "providers-google", "providers-tokens", "p
 
 [[package]]
 name = "kailash-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "packages/kailash-mcp" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes a store-tamper **HIGH** + two **MEDIUM** vectors affecting every trust-plane deployment. Capability signatures now bind the holder's `agent_id` (blocks cross-chain transplant) and the capability-set / chain-state envelope is signed (blocks silent constraint-strip).

- **v1 subject-bound capability pre-image** — `agent_id` in signed bytes; legacy unbound caps rejected fail-closed at verify/mint (A1 enforcement).
- **Chain-state envelope signature** — absent/stripped signature denies fail-closed. Both gates carry loud one-time-WARN opt-outs (`allow_unbound_legacy_capabilities` / `allow_unsigned_chain_state`) for the migration window only.
- **`SubjectBindingMigration`** — verifies each legacy cap's existing signature against genesis authority BEFORE promoting to v1 (refuses to launder a forged/transplanted cap), re-signs, adds chain-state sig; idempotent, dry-run, failure-atomic with rollback; reports un-migratable items. Every write surface requires an explicit `trust_store_placement` ack.
- **Cross-SDK byte-pin tripwire** for Rust-SDK capability pre-image parity.

## Breaking change

`verify()` now rejects legacy unbound capabilities and unsigned chain-state **by default**. Existing stores must run `SubjectBindingMigration` or opt out explicitly during the migration window. Migration guide: `docs/trust/1912-subject-binding-migration.md`.

## Verification

Converged across **5 adversarial redteam rounds** (6 findings fixed — two HIGH laundering/transplant vectors + the fresh-chain-state re-bless vector) plus a holistic cross-wave round. Full trust suite **6496 passed / 0 failed**; #1912 regression suite 62 passed; modified reasoning suite 79 passed; ruff clean.

## Related issues

Closes #1912

🤖 Generated with [Claude Code](https://claude.com/claude-code)