### PR TITLE
fix(kaizen): route agent completion by the passed client, not the model prefix (#1899)

### DIFF
--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/registry.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/registry.py
@@ -195,14 +195,27 @@ def get_adapter_for_model(
     model: str,
     *,
     provider: str = "",
+    api_key: str | None = None,
+    base_url: str | None = None,
     ungoverned: bool = False,
     **kwargs: Any,
 ) -> StreamingChatAdapter:
-    """Auto-detect the provider from a model name and create an adapter.
+    """Resolve an adapter for ``model``, honouring an explicitly-passed client.
 
-    If ``provider`` is explicitly given and non-empty, it takes precedence
-    over model-name heuristics.  Otherwise the model name prefix is
-    checked against known provider patterns.
+    Provider resolution order (issue #1899 — an explicitly-passed deployment
+    client's provider/endpoint MUST win over the model-name prefix):
+
+    1. Explicit ``provider`` name (if set) — authoritative.
+    2. Explicit client endpoint (``base_url`` set) — an OpenAI-compatible /
+       Azure / custom-endpoint deployment client is identified by its endpoint,
+       NOT a routable model prefix. Its endpoint wins; the OpenAI-compatible
+       wire is used regardless of the model string's prefix (a ``gpt-*`` /
+       ``claude-*`` / short-alias / bare deployment name all route to the
+       passed client). Model-prefix detection is demoted to the fallback below.
+    3. FALLBACK — model-name prefix heuristic (``claude-*`` -> anthropic, etc.),
+       used ONLY when no explicit client provider/endpoint was supplied so the
+       zero-config ``claude-*`` / ``gemini-*`` behaviour is unchanged.
+    4. Default: ``openai``.
 
     Parameters
     ----------
@@ -210,6 +223,13 @@ def get_adapter_for_model(
         The model name (e.g., ``"claude-sonnet-4-6"``, ``"gemini-2.0-flash"``).
     provider:
         Optional explicit provider override.
+    api_key:
+        Optional API key for the explicitly-passed client (Azure / OpenAI-
+        compatible / custom-endpoint deployment). Forwarded to the adapter.
+    base_url:
+        Optional endpoint for the explicitly-passed client. When set (and no
+        ``provider`` is given) the client's endpoint wins over model-prefix
+        detection — the fix for issue #1899.
     ungoverned:
         #1779 opt-out threaded into the constructed adapter's governance gate.
         Default False (fail-closed).
@@ -221,9 +241,35 @@ def get_adapter_for_model(
     A :class:`StreamingChatAdapter` instance.
     """
     if provider:
-        return get_adapter(provider, model=model, ungoverned=ungoverned, **kwargs)
+        return get_adapter(
+            provider,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            ungoverned=ungoverned,
+            **kwargs,
+        )
 
-    # Auto-detect from model name prefix
+    # An explicitly-passed deployment client (identified by its endpoint) wins
+    # over the model-name prefix. Azure OpenAI / OpenAI-compatible / custom
+    # endpoints speak the OpenAI chat wire, so route to the OpenAI adapter
+    # pointed at that endpoint regardless of the model's prefix (issue #1899).
+    if base_url:
+        logger.debug(
+            "Routing model %r to the explicitly-passed client endpoint "
+            "(base_url set); model-prefix detection demoted to fallback",
+            model,
+        )
+        return get_adapter(
+            "openai",
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            ungoverned=ungoverned,
+            **kwargs,
+        )
+
+    # FALLBACK: auto-detect from model name prefix (zero-config, unchanged).
     for prefix, detected_provider in _MODEL_PREFIX_MAP:
         if model.startswith(prefix):
             logger.debug(
@@ -232,8 +278,20 @@ def get_adapter_for_model(
                 prefix,
             )
             return get_adapter(
-                detected_provider, model=model, ungoverned=ungoverned, **kwargs
+                detected_provider,
+                model=model,
+                api_key=api_key,
+                base_url=base_url,
+                ungoverned=ungoverned,
+                **kwargs,
             )
 
     # Default to OpenAI
-    return get_adapter("openai", model=model, ungoverned=ungoverned, **kwargs)
+    return get_adapter(
+        "openai",
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        ungoverned=ungoverned,
+        **kwargs,
+    )

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
@@ -138,8 +138,11 @@ class KzConfig:
     # ``Delegate(base_url=..., api_key=...)`` params); intentionally NOT wired
     # into the file/env config maps (an endpoint/credential belongs in the
     # explicit call, not a discovered kz config file).
-    base_url: str | None = None
-    api_key: str | None = None
+    # repr=False: these carry an endpoint + credential; keep them out of the
+    # default dataclass repr so a future diagnostic log of the config object
+    # cannot leak the api_key (security.md § "No secrets in logs").
+    base_url: str | None = field(default=None, repr=False)
+    api_key: str | None = field(default=None, repr=False)
     effort_level: EffortLevel = EffortLevel.MEDIUM
 
     # Generation settings

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
@@ -131,6 +131,15 @@ class KzConfig:
     # LLM settings
     model: str = ""
     provider: str = "openai"
+    # Explicitly-passed deployment client (issue #1899). When ``base_url`` is
+    # set, the client's endpoint wins over model-name-prefix detection — an
+    # OpenAI-compatible / Azure / custom-endpoint deployment is identified by
+    # its endpoint, not a routable model prefix. Programmatic-only (set via the
+    # ``Delegate(base_url=..., api_key=...)`` params); intentionally NOT wired
+    # into the file/env config maps (an endpoint/credential belongs in the
+    # explicit call, not a discovered kz config file).
+    base_url: str | None = None
+    api_key: str | None = None
     effort_level: EffortLevel = EffortLevel.MEDIUM
 
     # Generation settings

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
@@ -400,9 +400,17 @@ class Delegate:
         if config is not None:
             self._config = config
         else:
+            # Thread the explicitly-passed deployment client (endpoint + key)
+            # onto the config so its provider/endpoint wins over model-name-
+            # prefix detection (issue #1899). Previously base_url/api_key were
+            # stored on the Delegate but never reached the adapter, so an
+            # OpenAI-compatible / Azure / custom-endpoint deployment client was
+            # dropped and every completion hit api.openai.com.
             self._config = KzConfig(
                 model=resolved_model,
                 max_turns=max_turns,
+                base_url=base_url,
+                api_key=api_key,
             )
 
         # Build tool registry

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
@@ -422,9 +422,14 @@ class AgentLoop:
         from kaizen_agents.delegate.adapters.registry import get_adapter_for_model
 
         model = self._config.model or os.environ.get("DEFAULT_LLM_MODEL", "")
+        # Thread the explicitly-passed deployment client (endpoint + key) so it
+        # wins over model-name-prefix detection (issue #1899). When base_url is
+        # unset these are None and routing is byte-identical to zero-config.
         return get_adapter_for_model(
             model=model,
             provider=self._config.provider,
+            api_key=getattr(self._config, "api_key", None),
+            base_url=getattr(self._config, "base_url", None),
             temperature=self._config.temperature,
             max_tokens=self._config.max_tokens,
             ungoverned=getattr(self, "_ungoverned", False),

--- a/packages/kaizen-agents/tests/unit/delegate/adapters/test_registry_explicit_client_routing.py
+++ b/packages/kaizen-agents/tests/unit/delegate/adapters/test_registry_explicit_client_routing.py
@@ -122,3 +122,24 @@ def test_delegate_threads_explicit_client_endpoint_to_loop_adapter() -> None:
     adapter = delegate._loop._adapter
     assert isinstance(adapter, OpenAIStreamAdapter)
     assert _client_base_url(adapter) == _DEPLOYMENT_BASE_URL
+
+
+# --- Credential hygiene: the api_key MUST NOT leak into the config repr --------
+
+
+def test_kzconfig_repr_does_not_leak_api_key() -> None:
+    """KzConfig.api_key/base_url carry a credential + endpoint; they MUST be
+    excluded from the default dataclass repr so a future diagnostic log of the
+    config object cannot leak the key (security.md § 'No secrets in logs')."""
+    from kaizen_agents.delegate.config.loader import KzConfig
+
+    cfg = KzConfig(
+        model="gpt-5-my-deployment",
+        base_url=_DEPLOYMENT_BASE_URL,
+        api_key="sk-super-secret-deployment-key",
+    )
+    rendered = repr(cfg)
+    assert "sk-super-secret-deployment-key" not in rendered
+    assert _DEPLOYMENT_BASE_URL not in rendered
+    # The value is still readable programmatically (only the repr is scrubbed).
+    assert cfg.api_key == "sk-super-secret-deployment-key"

--- a/packages/kaizen-agents/tests/unit/delegate/adapters/test_registry_explicit_client_routing.py
+++ b/packages/kaizen-agents/tests/unit/delegate/adapters/test_registry_explicit_client_routing.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1899 — an explicitly-passed deployment client's
+provider/endpoint MUST win over model-name-prefix detection.
+
+Before the fix, ``Delegate(model="gpt-...", base_url=..., api_key=...)`` dropped
+the ``base_url``/``api_key`` (the OpenAI-compatible / Azure / custom-endpoint
+deployment client) and routed the completion by the ``model`` string's prefix,
+sending every request to ``api.openai.com`` and demanding ``OPENAI_API_KEY``.
+The passed deployment client was never used.
+
+These tests exercise the routing DISPATCH only (adapter construction), not a
+live LLM call. The model-name literals below are prefix-SHAPE fixtures for the
+detection logic, not production model selection (rules/env-models.md applies to
+production paths; test fixtures are exempt).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen_agents.delegate.adapters.anthropic_adapter import AnthropicStreamAdapter
+from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+from kaizen_agents.delegate.adapters.registry import get_adapter_for_model
+
+# An OpenAI-compatible deployment endpoint (e.g. Azure OpenAI / custom proxy).
+# A deployment client is identified by its endpoint, not a routable model prefix.
+_DEPLOYMENT_BASE_URL = "https://my-deployment.example.com/v1"
+_DEPLOYMENT_KEY = "test-deployment-key"  # not a real secret; test-only fixture
+
+
+def _client_base_url(adapter: OpenAIStreamAdapter) -> str:
+    """The endpoint the constructed adapter's underlying client will call."""
+    return str(adapter._client.base_url).rstrip("/")
+
+
+# --- AC #1 / #2: the passed client's endpoint wins over the model prefix ------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",  # short alias — AC #2
+        "gpt-4",  # short alias — AC #2
+        "o1",  # short alias — AC #2
+        "gpt-3.5-turbo",  # short alias — AC #2
+        "gpt-5-my-deployment",  # gpt-* deployment name — AC #1
+        "claude-3-5-sonnet",  # non-openai prefix on an openai-compatible client — AC #1
+        "my-custom-deployment",  # non-prefixed deployment name — AC #1
+    ],
+)
+def test_explicit_client_endpoint_wins_over_model_prefix(model: str) -> None:
+    """A deployment client (base_url + api_key) MUST be used regardless of the
+    model string's provider prefix — including a gpt-* / claude-* shape."""
+    adapter = get_adapter_for_model(
+        model=model,
+        api_key=_DEPLOYMENT_KEY,
+        base_url=_DEPLOYMENT_BASE_URL,
+        ungoverned=True,  # routing test; not exercising the governance gate
+    )
+    assert isinstance(adapter, OpenAIStreamAdapter), (
+        f"model {model!r} with an explicit deployment endpoint must route to the "
+        f"OpenAI-compatible adapter, got {type(adapter).__name__}"
+    )
+    assert _client_base_url(adapter) == _DEPLOYMENT_BASE_URL, (
+        f"model {model!r} routed to {_client_base_url(adapter)!r}, not the passed "
+        f"deployment endpoint {_DEPLOYMENT_BASE_URL!r} — the client was ignored"
+    )
+
+
+def test_explicit_provider_still_wins_over_endpoint_and_prefix() -> None:
+    """An explicit provider name remains authoritative (unchanged precedence)."""
+    adapter = get_adapter_for_model(
+        model="gpt-4o",
+        provider="anthropic",
+        api_key=_DEPLOYMENT_KEY,
+        base_url=_DEPLOYMENT_BASE_URL,
+        ungoverned=True,
+    )
+    assert isinstance(adapter, AnthropicStreamAdapter)
+
+
+# --- AC #3: prefix detection stays the FALLBACK for zero-config callers --------
+
+
+def test_zero_config_claude_prefix_unchanged() -> None:
+    """No explicit client → claude-* still detects Anthropic (fallback intact)."""
+    adapter = get_adapter_for_model(
+        model="claude-3-5-sonnet",
+        api_key=_DEPLOYMENT_KEY,  # anthropic adapter reads its own key; harmless here
+        ungoverned=True,
+    )
+    assert isinstance(adapter, AnthropicStreamAdapter)
+
+
+def test_zero_config_gpt_prefix_uses_default_openai_endpoint() -> None:
+    """No explicit client → gpt-* routes to plain OpenAI at the default endpoint."""
+    adapter = get_adapter_for_model(
+        model="gpt-4o",
+        api_key=_DEPLOYMENT_KEY,
+        ungoverned=True,
+    )
+    assert isinstance(adapter, OpenAIStreamAdapter)
+    assert _client_base_url(adapter) != _DEPLOYMENT_BASE_URL
+    assert "api.openai.com" in _client_base_url(adapter)
+
+
+# --- End-to-end: Delegate threads the passed client through to the loop --------
+
+
+def test_delegate_threads_explicit_client_endpoint_to_loop_adapter() -> None:
+    """Delegate(model=gpt-*, base_url=, api_key=) must build a loop adapter that
+    targets the passed deployment endpoint — not drop it and hit api.openai.com."""
+    from kaizen_agents.delegate.delegate import Delegate
+
+    delegate = Delegate(
+        model="gpt-5-my-deployment",
+        base_url=_DEPLOYMENT_BASE_URL,
+        api_key=_DEPLOYMENT_KEY,
+        ungoverned=True,
+    )
+    adapter = delegate._loop._adapter
+    assert isinstance(adapter, OpenAIStreamAdapter)
+    assert _client_base_url(adapter) == _DEPLOYMENT_BASE_URL


### PR DESCRIPTION
## Summary

Fixes #1899 — an explicitly-passed deployment client (Azure OpenAI / OpenAI-compatible / custom-endpoint) was silently ignored because completion routing used the `model` string's provider prefix instead of the passed client's endpoint.

Root cause (sharper than the issue's illustrative repro): `Delegate` accepted `base_url`/`api_key` (the deployment client) but **dropped them** — `KzConfig` had no such fields, so `AgentLoop._build_adapter` always built a plain-OpenAI adapter at `api.openai.com`. Separately, `get_adapter_for_model` let the model-name prefix (`claude-*`/`gemini-*`) **override** an explicit endpoint (wrong precedence).

## Fix

The passed client's endpoint is now authoritative; model-prefix detection is demoted to a fallback:
- `get_adapter_for_model` gains explicit `api_key`/`base_url` params + precedence: explicit `provider` wins → explicit `base_url` routes to the OpenAI-compatible wire at that endpoint regardless of prefix → only if neither is set does prefix detection fire (fallback) → default openai.
- `KzConfig` gains `base_url`/`api_key` (programmatic-only); `Delegate.__init__` threads them through; `AgentLoop._build_adapter` forwards them.
- Zero-config `gpt-*`/`claude-*` (no explicit client) behaviour is byte-identical.

## Verification

11 new routing tests (RED confirmed pre-fix: 2 failed / 9 passed → 11 passed), authoritative re-run from the main checkout; broader delegate regression **558 passed**; ruff clean. Real adapter objects, no mocking of the routing logic.

## Related issues

Closes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)