### PR TITLE
feat(mcp): first-class server-verified tenant field on McpActionContext (#1878)

### DIFF
--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -104,29 +104,35 @@ def _resolve_effective_tenant(
     metadata: Mapping[str, Any],
     caller_identity: McpCallerIdentity | None,
     *,
+    verified_tenant: str | None = None,
     require_caller_identity: bool = False,
 ) -> str | None:
-    """Resolve the AUTHORITATIVE tenant for an MCP call (issue #1843).
+    """Resolve the AUTHORITATIVE tenant for an MCP call (issue #1843/#1878).
 
-    The trusted ``caller_identity`` -- resolved by the transport/auth layer,
-    never attacker-controlled -- OVERWRITES any self-asserted
-    ``metadata["tenant_id"]`` (impersonation defeat): a caller cannot widen
-    its own access by putting a different tenant in the request body. Only
-    when no trusted identity (or no identity tenant) is supplied does this
-    fall back to the self-asserted metadata channel -- UNLESS
-    ``require_caller_identity`` is set, in which case the metadata fallback is
-    never consulted at all: an absent (or tenant-less) trusted identity
-    resolves straight to None (fail-closed), rather than trusting a
-    caller-supplied ``metadata["tenant_id"]``. Deployments with no
-    transport-level identity resolution (no caller_identity ever wired) MUST
-    set ``McpGovernanceConfig.require_caller_identity=True`` to get a REAL
-    isolation guarantee; without it, the self-asserted metadata channel is a
-    legitimate but attacker-controlled fallback (documented, not a bypass).
+    Trust precedence, highest first:
+
+    1. ``verified_tenant`` -- the first-class, SERVER-VERIFIED
+       ``McpActionContext.tenant`` / ``McpResourceContext.tenant`` field
+       (issue #1878), populated at the network boundary from the
+       authenticated transport/token and never from the client body. When
+       set, it is the authoritative tenant; nothing overrides it.
+    2. ``caller_identity.tenant`` -- the sidecar trusted identity (issue
+       #1843), also transport-resolved. Consulted when no first-class
+       verified tenant is present.
+    3. ``metadata["tenant_id"]`` -- the self-asserted, attacker-controlled
+       fallback. Consulted ONLY when ``require_caller_identity`` is False AND
+       neither trusted source resolved a tenant. Under the secure default
+       (``require_caller_identity=True``) it is never consulted.
+
+    A caller cannot widen its own access by putting a different tenant in the
+    request body: both trusted sources (1) and (2) win over the body, and the
+    body channel (3) is disabled by default.
 
     Returns:
-        The tenant string, or None if neither the caller identity nor the
-        (optionally-disabled) metadata channel carries one.
+        The tenant string, or None if no source resolves one.
     """
+    if verified_tenant is not None:
+        return verified_tenant
     if caller_identity is not None and caller_identity.tenant is not None:
         return caller_identity.tenant
     if require_caller_identity:
@@ -389,6 +395,7 @@ class McpGovernanceEnforcer:
                 timestamp=context.timestamp,
                 metadata=context.metadata,
                 caller_identity=caller_identity,
+                verified_tenant=context.tenant,
             )
             if decision is None:
                 decision = GovernanceDecision(
@@ -440,13 +447,17 @@ class McpGovernanceEnforcer:
         timestamp: datetime,
         metadata: Mapping[str, Any],
         caller_identity: McpCallerIdentity | None,
+        verified_tenant: str | None = None,
     ) -> GovernanceDecision | None:
         """Shared tenant-isolation gate for BOTH tools/call and resources/read.
 
         This is the single decision-building function BOTH _evaluate (Step
         0, tools/call) and check_resource_read (resources/read) call --
         security.md Enforcement-Surface Parity: one shared function so the
-        two enforcement surfaces cannot silently diverge.
+        two enforcement surfaces cannot silently diverge. ``verified_tenant``
+        is the first-class server-verified context field (issue #1878),
+        threaded in from both surfaces so the enforcement point reads the
+        verified value.
 
         Returns None (isolation OFF, or tenant check satisfied -- caller
         continues) or a BLOCKED GovernanceDecision (fail-closed).
@@ -460,6 +471,7 @@ class McpGovernanceEnforcer:
         tenant = _resolve_effective_tenant(
             metadata,
             caller_identity,
+            verified_tenant=verified_tenant,
             require_caller_identity=self._config.require_caller_identity,
         )
         if tenant is None:
@@ -726,6 +738,7 @@ class McpGovernanceEnforcer:
             timestamp=context.timestamp,
             metadata=context.metadata,
             caller_identity=caller_identity,
+            verified_tenant=context.tenant,
         )
         if tenant_decision is not None:
             return tenant_decision
@@ -863,6 +876,7 @@ class McpGovernanceEnforcer:
                 _resolve_effective_tenant(
                     context.metadata,
                     caller_identity,
+                    verified_tenant=context.tenant,
                     require_caller_identity=self._config.require_caller_identity,
                 )
                 if self._config.tenant_grants

--- a/packages/kailash-pact/src/pact/mcp/middleware.py
+++ b/packages/kailash-pact/src/pact/mcp/middleware.py
@@ -112,6 +112,14 @@ class McpGovernanceMiddleware:
             McpInvocationResult with the governance decision and tool result.
         """
         now = datetime.now(UTC)
+        # The middleware IS the network boundary: populate the first-class,
+        # server-verified tenant field (issue #1878) from the AUTHENTICATED
+        # caller_identity (transport/token-resolved), NEVER from the request
+        # body. The enforcer then reads context.tenant as the authoritative
+        # tenant-isolation input.
+        verified_tenant = (
+            caller_identity.tenant if caller_identity is not None else None
+        )
         context = McpActionContext(
             tool_name=tool_name,
             args=args or {},
@@ -120,6 +128,7 @@ class McpGovernanceMiddleware:
             cost_estimate=cost_estimate,
             caller_clearance=caller_clearance,
             metadata=metadata or {},
+            tenant=verified_tenant,
         )
 
         # Governance check
@@ -185,11 +194,17 @@ class McpGovernanceMiddleware:
             configured.
         """
         now = datetime.now(UTC)
+        # Network boundary: populate the first-class verified tenant (issue
+        # #1878) from the authenticated caller_identity, never the body.
+        verified_tenant = (
+            caller_identity.tenant if caller_identity is not None else None
+        )
         context = McpResourceContext(
             uri=uri,
             agent_id=agent_id,
             timestamp=now,
             metadata=metadata or {},
+            tenant=verified_tenant,
         )
 
         decision = self._enforcer.check_resource_read(

--- a/packages/kailash-pact/src/pact/mcp/types.py
+++ b/packages/kailash-pact/src/pact/mcp/types.py
@@ -332,17 +332,32 @@ class McpActionContext:
         metadata: Additional context for governance evaluation. Carries the
             free-form, SELF-ASSERTED ``metadata["tenant_id"]`` channel
             (issue #1843) -- a caller-supplied value the enforcer treats as
-            untrusted input. When a trusted ``McpCallerIdentity`` is passed
-            to ``check_tool_call`` / ``check_resource_read`` and carries a
-            tenant, that identity's tenant OVERWRITES this self-asserted
-            value (impersonation defeat); ``metadata["tenant_id"]`` is
-            consulted only as a fallback when no trusted identity (or no
-            identity tenant) is supplied. No new first-class serialized
-            field was added to this envelope for tenant isolation --
-            byte-neutral by design.
+            untrusted input. It is the WEAKER, opt-in fallback consulted ONLY
+            when ``McpGovernanceConfig.require_caller_identity`` is False AND
+            neither the first-class ``tenant`` field nor a trusted
+            ``McpCallerIdentity`` resolves a tenant. Under the secure default
+            (``require_caller_identity=True``) it is NEVER trusted for the
+            governance decision.
+        tenant: The FIRST-CLASS, SERVER-VERIFIED tenant for this call (issue
+            #1878), DISTINCT from the free-form ``metadata`` map. This is the
+            AUTHORITATIVE tenant-isolation input: governance enforcement reads
+            THIS field (highest trust), ranking it above both the sidecar
+            ``McpCallerIdentity`` and the self-asserted
+            ``metadata["tenant_id"]``. It is populated SERVER-SIDE at the
+            network boundary from the authenticated transport/token (see
+            ``from_network_transport`` and ``McpGovernanceMiddleware``), NEVER
+            from the client wire body. Deliberately EXCLUDED from the wire
+            serialization (``to_dict`` never emits it; ``from_dict`` never
+            reads it) so a client cannot assert an arbitrary tenant by copying
+            it into the request body, AND so the on-the-wire envelope stays
+            byte-identical to the issue #1843 contract -- no cross-SDK wire
+            lockstep is required (mirrors how ``McpCallerIdentity`` is
+            deliberately non-serialized). None means no verified tenant was
+            resolved; under active isolation that fails closed (BLOCKED).
 
     Raises:
-        ValueError: If cost_estimate is NaN, Inf, or negative.
+        ValueError: If cost_estimate is NaN, Inf, or negative; or if tenant
+            is neither a string nor None.
     """
 
     tool_name: str
@@ -352,6 +367,7 @@ class McpActionContext:
     cost_estimate: float | None = None
     caller_clearance: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    tenant: str | None = None
 
     def __post_init__(self) -> None:
         if not self.tool_name:
@@ -366,6 +382,12 @@ class McpActionContext:
                 raise ValueError(
                     f"cost_estimate must be non-negative, got {self.cost_estimate!r}"
                 )
+        # Defense-in-depth: the verified tenant is a dict-key for grant lookup;
+        # a non-str value would silently never match. Mirror McpCallerIdentity.
+        if self.tenant is not None and not isinstance(self.tenant, str):
+            raise ValueError(
+                f"tenant must be a string or None, got {type(self.tenant).__name__}"
+            )
         # H3: Replace mutable dicts with immutable MappingProxyType.
         object.__setattr__(
             self,
@@ -379,7 +401,13 @@ class McpActionContext:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to a JSON-compatible dictionary."""
+        """Serialize to a JSON-compatible dictionary.
+
+        The first-class ``tenant`` field is DELIBERATELY omitted -- it is a
+        server-verified, in-memory-only field (issue #1878), never part of
+        the wire envelope, so the serialized bytes stay identical to the
+        issue #1843 byte-neutral contract.
+        """
         return {
             "tool_name": self.tool_name,
             "args": self.args,
@@ -392,7 +420,13 @@ class McpActionContext:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> McpActionContext:
-        """Deserialize from a dictionary."""
+        """Deserialize from a dictionary.
+
+        NEVER populates the server-verified ``tenant`` field from ``data`` --
+        a wire body cannot set the verified tenant (issue #1878). Use
+        ``from_network_transport`` at the network boundary to populate the
+        verified field from the authenticated transport/token.
+        """
         ts = data.get("timestamp")
         if isinstance(ts, str):
             ts = datetime.fromisoformat(ts)
@@ -404,6 +438,54 @@ class McpActionContext:
             cost_estimate=data.get("cost_estimate"),
             caller_clearance=data.get("caller_clearance"),
             metadata=data.get("metadata", {}),
+        )
+
+    @classmethod
+    def from_network_transport(
+        cls,
+        data: dict[str, Any],
+        *,
+        verified_tenant: str | None = None,
+    ) -> McpActionContext:
+        """Deserialize an UNTRUSTED wire body at the network boundary (#1878).
+
+        This is the deserializer a network transport (HTTP/SSE/WebSocket) MUST
+        use for a client-supplied body. Unlike ``from_dict`` it:
+
+        * STRIPS any body-supplied top-level ``tenant`` / ``tenant_id`` key --
+          a client cannot set the verified field by putting it in the body.
+        * STRIPS ``metadata["tenant_id"]`` -- the self-asserted tenant channel
+          is not trusted on a network transport; the verified field replaces
+          it.
+        * Sets the first-class ``tenant`` field ONLY from ``verified_tenant``,
+          which the caller resolves from the AUTHENTICATED transport/token
+          (NOT the request body). None means the transport resolved no tenant
+          -- under active isolation the enforcer then fails closed.
+
+        Args:
+            data: The untrusted, client-supplied wire body.
+            verified_tenant: The server-verified tenant from the authenticated
+                transport/token, or None if none resolved.
+        """
+        ts = data.get("timestamp")
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        raw_metadata = data.get("metadata", {})
+        # Strip the self-asserted tenant_id from the body metadata -- it is
+        # never trusted on a network transport.
+        scrubbed_metadata = {
+            k: v for k, v in dict(raw_metadata).items() if k != "tenant_id"
+        }
+        return cls(
+            tool_name=data["tool_name"],
+            args=data.get("args", {}),
+            agent_id=data.get("agent_id", ""),
+            timestamp=ts or datetime.now(UTC),
+            cost_estimate=data.get("cost_estimate"),
+            caller_clearance=data.get("caller_clearance"),
+            metadata=scrubbed_metadata,
+            # NEVER data.get("tenant") -- the body cannot set the verified field.
+            tenant=verified_tenant,
         )
 
 
@@ -427,21 +509,33 @@ class McpResourceContext:
         timestamp: When the invocation was initiated.
         metadata: Additional context for governance evaluation. Carries the
             same free-form, self-asserted ``metadata["tenant_id"]`` channel
-            as :attr:`McpActionContext.metadata` -- see that field's
-            docstring for the impersonation-defeat contract.
+            as :attr:`McpActionContext.metadata` -- the weaker, opt-in
+            fallback, never trusted under the secure default.
+        tenant: The FIRST-CLASS, SERVER-VERIFIED tenant for this resource read
+            (issue #1878), DISTINCT from the free-form ``metadata`` map and
+            the authoritative tenant-isolation input -- see
+            :attr:`McpActionContext.tenant` for the full contract. Populated
+            server-side at the network boundary; EXCLUDED from the wire
+            serialization (byte-neutral). None fails closed under active
+            isolation.
 
     Raises:
-        ValueError: If uri is empty.
+        ValueError: If uri is empty; or if tenant is neither a string nor None.
     """
 
     uri: str
     agent_id: str = ""
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     metadata: dict[str, Any] = field(default_factory=dict)
+    tenant: str | None = None
 
     def __post_init__(self) -> None:
         if not self.uri:
             raise ValueError("uri must not be empty")
+        if self.tenant is not None and not isinstance(self.tenant, str):
+            raise ValueError(
+                f"tenant must be a string or None, got {type(self.tenant).__name__}"
+            )
         object.__setattr__(
             self,
             "metadata",
@@ -449,7 +543,11 @@ class McpResourceContext:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to a JSON-compatible dictionary."""
+        """Serialize to a JSON-compatible dictionary.
+
+        The first-class ``tenant`` field is DELIBERATELY omitted (issue
+        #1878) -- server-verified, in-memory-only, never on the wire.
+        """
         return {
             "uri": self.uri,
             "agent_id": self.agent_id,
@@ -459,7 +557,11 @@ class McpResourceContext:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> McpResourceContext:
-        """Deserialize from a dictionary."""
+        """Deserialize from a dictionary.
+
+        NEVER populates the server-verified ``tenant`` field from ``data``
+        (issue #1878); use ``from_network_transport`` at the network boundary.
+        """
         ts = data.get("timestamp")
         if isinstance(ts, str):
             ts = datetime.fromisoformat(ts)
@@ -468,6 +570,35 @@ class McpResourceContext:
             agent_id=data.get("agent_id", ""),
             timestamp=ts or datetime.now(UTC),
             metadata=data.get("metadata", {}),
+        )
+
+    @classmethod
+    def from_network_transport(
+        cls,
+        data: dict[str, Any],
+        *,
+        verified_tenant: str | None = None,
+    ) -> McpResourceContext:
+        """Deserialize an UNTRUSTED wire body at the network boundary (#1878).
+
+        Strips any body-supplied top-level ``tenant`` and
+        ``metadata["tenant_id"]``; sets the verified ``tenant`` field ONLY
+        from ``verified_tenant`` (the authenticated transport/token). See
+        :meth:`McpActionContext.from_network_transport` for the full contract.
+        """
+        ts = data.get("timestamp")
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        raw_metadata = data.get("metadata", {})
+        scrubbed_metadata = {
+            k: v for k, v in dict(raw_metadata).items() if k != "tenant_id"
+        }
+        return cls(
+            uri=data["uri"],
+            agent_id=data.get("agent_id", ""),
+            timestamp=ts or datetime.now(UTC),
+            metadata=scrubbed_metadata,
+            tenant=verified_tenant,
         )
 
 

--- a/packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py
@@ -785,24 +785,40 @@ class TestMiddlewareTenantIsolation:
 
 
 class TestByteNeutralStructuralInvariants:
-    """Pins the byte-diff verdict: NO first-class serialized tenant field
-    was added to McpActionContext / McpResourceContext, and McpCallerIdentity
-    is deliberately NOT serialized. If a future refactor adds a first-class
-    ``tenant`` / ``tenant_id`` field to either wire envelope, or gives
-    McpCallerIdentity to_dict/from_dict, this test forces a re-audit against
-    the issue #1843 byte-neutral contract."""
+    """Pins the byte-neutral WIRE contract. Issue #1878 added a first-class,
+    server-verified ``tenant`` field to McpActionContext / McpResourceContext
+    (the re-audit this pin's earlier form forced), but that field is
+    SERVER-SIDE ONLY: it is DELIBERATELY excluded from the wire serialization
+    (``to_dict`` never emits it; ``from_dict`` never reads it) exactly as
+    McpCallerIdentity is deliberately non-serialized. So the ON-THE-WIRE
+    envelope stays byte-identical to the issue #1843 contract and NO cross-SDK
+    wire lockstep is required. If a future refactor serializes the ``tenant``
+    field (adds it to to_dict/from_dict), or gives McpCallerIdentity
+    to_dict/from_dict, this test forces a re-audit -- that WOULD be a
+    byte-changing wire-envelope change requiring cross-SDK lockstep
+    (cross-sdk-inspection.md Rule 4b)."""
 
-    def test_mcp_action_context_carries_no_first_class_tenant_field(self) -> None:
+    def test_mcp_action_context_verified_tenant_is_not_wire_serialized(self) -> None:
+        """The first-class tenant field EXISTS (issue #1878) but is NOT part
+        of the wire envelope -- to_dict omits it and from_dict never reads
+        it, so the serialized bytes are unchanged from #1843."""
         field_names = {f.name for f in dataclasses.fields(McpActionContext)}
-        assert "tenant" not in field_names
-        assert "tenant_id" not in field_names
-        assert "metadata" in field_names  # the free-form channel
+        assert "tenant" in field_names  # first-class server-verified field (#1878)
+        assert "metadata" in field_names  # the free-form channel (unchanged)
+        ctx = McpActionContext(tool_name="t", tenant="tenant-a", timestamp=_T0)
+        assert "tenant" not in ctx.to_dict()  # server-side only, never on wire
+        # A body-supplied top-level tenant is never trusted on deserialization.
+        assert (
+            McpActionContext.from_dict({"tool_name": "t", "tenant": "x"}).tenant is None
+        )
 
-    def test_mcp_resource_context_carries_no_first_class_tenant_field(self) -> None:
+    def test_mcp_resource_context_verified_tenant_is_not_wire_serialized(self) -> None:
         field_names = {f.name for f in dataclasses.fields(McpResourceContext)}
-        assert "tenant" not in field_names
-        assert "tenant_id" not in field_names
+        assert "tenant" in field_names
         assert "metadata" in field_names
+        ctx = McpResourceContext(uri="u", tenant="tenant-a", timestamp=_T0)
+        assert "tenant" not in ctx.to_dict()
+        assert McpResourceContext.from_dict({"uri": "u", "tenant": "x"}).tenant is None
 
     def test_mcp_caller_identity_is_not_serialized(self) -> None:
         """McpCallerIdentity has no to_dict/from_dict -- it is a trusted,

--- a/packages/kailash-pact/tests/regression/test_issue_1878_mcp_verified_tenant.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1878_mcp_verified_tenant.py
@@ -1,0 +1,399 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1878 -- first-class, server-verified ``tenant``
+field on ``McpActionContext`` / ``McpResourceContext`` for robust tenant
+isolation.
+
+Issue #1843 routed the tenant through the free-form, self-asserted
+``metadata["tenant_id"]`` channel (client-body-copyable) plus a sidecar
+``McpCallerIdentity``. #1878 promotes the verified tenant to a FIRST-CLASS
+field ON the context, DISTINCT from the free-form metadata map:
+
+* AC#1 -- ``McpActionContext`` / ``McpResourceContext`` expose a first-class
+  ``tenant`` field, separate from ``metadata``.
+* AC#2 -- governance enforcement reads the VERIFIED first-class field, not
+  ``metadata["tenant_id"]``.
+* AC#3 -- any body-supplied ``tenant`` / ``tenant_id`` is stripped / not
+  trusted on network transports: the verified field is populated at the
+  network boundary from the authenticated transport/token, NEVER from the
+  wire body (``from_network_transport`` strips it; ``from_dict`` never reads
+  the first-class field; ``to_dict`` never emits it -- byte-neutral wire
+  contract preserved, so NO cross-SDK wire lockstep is required).
+* AC#4 -- fail-closed: isolation active + no verified tenant resolves =>
+  access DENIED (never defaulted / allowed).
+
+The verified field is SERVER-SIDE ONLY -- it is a dataclass field but is
+excluded from the wire serialization (``to_dict`` / ``from_dict``), exactly
+as ``McpCallerIdentity`` is deliberately non-serialized. This keeps the
+issue #1843 byte-neutral wire contract intact: a Rust peer's on-the-wire
+``McpActionContext`` bytes are unchanged.
+
+All tests are BEHAVIORAL -- they construct real enforcers / middleware and
+assert the resulting decision. The governance path is NEVER mocked
+(testing.md Tier-2; the spoof-attempt test is mandatory, security-relevant).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pact.mcp.enforcer import McpGovernanceEnforcer
+from pact.mcp.middleware import McpGovernanceMiddleware
+from pact.mcp.types import (
+    DefaultPolicy,
+    McpActionContext,
+    McpCallerIdentity,
+    McpGovernanceConfig,
+    McpResourceContext,
+    McpTenantGrant,
+    McpToolPolicy,
+)
+
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _config(
+    tenant_grants: dict[str, McpTenantGrant] | None = None,
+    tool_policies: dict[str, McpToolPolicy] | None = None,
+    default_policy: DefaultPolicy = DefaultPolicy.ALLOW,
+    require_caller_identity: bool | None = None,
+) -> McpGovernanceConfig:
+    kwargs: dict[str, Any] = {}
+    if require_caller_identity is not None:
+        kwargs["require_caller_identity"] = require_caller_identity
+    return McpGovernanceConfig(
+        default_policy=default_policy,
+        tool_policies=tool_policies or {},
+        tenant_grants=tenant_grants or {},
+        audit_enabled=False,
+        **kwargs,
+    )
+
+
+def _two_tenant_grants() -> dict[str, McpTenantGrant]:
+    return {
+        "tenant-a": McpTenantGrant(
+            tenant="tenant-a",
+            tools=frozenset({"tool-a"}),
+            resources=frozenset({"resource://tenant-a/doc"}),
+        ),
+        "tenant-b": McpTenantGrant(
+            tenant="tenant-b",
+            tools=frozenset({"tool-b"}),
+            resources=frozenset({"resource://tenant-b/doc"}),
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC#1 -- first-class tenant field, distinct from the metadata map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestFirstClassTenantField:
+    def test_action_context_exposes_first_class_tenant_field(self) -> None:
+        field_names = {f.name for f in dataclasses.fields(McpActionContext)}
+        assert "tenant" in field_names
+        assert "metadata" in field_names
+        assert "tenant" != "metadata"  # distinct surfaces
+
+    def test_resource_context_exposes_first_class_tenant_field(self) -> None:
+        field_names = {f.name for f in dataclasses.fields(McpResourceContext)}
+        assert "tenant" in field_names
+        assert "metadata" in field_names
+
+    def test_tenant_field_defaults_none(self) -> None:
+        assert McpActionContext(tool_name="t").tenant is None
+        assert McpResourceContext(uri="u").tenant is None
+
+    def test_tenant_field_is_separate_from_metadata(self) -> None:
+        ctx = McpActionContext(
+            tool_name="t", tenant="tenant-a", metadata={"tenant_id": "tenant-b"}
+        )
+        # The verified field and the free-form channel hold DISTINCT values --
+        # they are not aliased.
+        assert ctx.tenant == "tenant-a"
+        assert ctx.metadata["tenant_id"] == "tenant-b"
+
+    def test_non_string_tenant_rejected(self) -> None:
+        with pytest.raises(ValueError, match="tenant must be a string or None"):
+            McpActionContext(tool_name="t", tenant=123)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="tenant must be a string or None"):
+            McpResourceContext(uri="u", tenant=123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AC#2 -- governance reads the VERIFIED field, not metadata["tenant_id"]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestGovernanceReadsVerifiedField:
+    def test_verified_tenant_grants_own_tool(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(tool_name="tool-a", tenant="tenant-a", timestamp=_T0)
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "auto_approved"
+
+    def test_verified_tenant_denied_other_tenant_tool(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(tool_name="tool-b", tenant="tenant-a", timestamp=_T0)
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "tenant-a" in decision.reason
+
+    def test_verified_tenant_used_over_metadata_tenant_id(self) -> None:
+        """The verified field says tenant-a; the body metadata claims
+        tenant-b (which owns tool-b). Governance MUST evaluate as tenant-a
+        (the verified field) and BLOCK the tool-b call -- proving the
+        decision reads the verified field, not metadata."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(
+            tool_name="tool-b",
+            tenant="tenant-a",
+            metadata={"tenant_id": "tenant-b"},
+            timestamp=_T0,
+        )
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "tenant-a" in decision.reason
+        assert "tenant-b" not in decision.reason
+
+    def test_verified_tenant_read_on_resource_surface(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpResourceContext(
+            uri="resource://tenant-b/doc", tenant="tenant-a", timestamp=_T0
+        )
+        decision = enf.check_resource_read(ctx)
+        assert decision.level == "blocked"
+        assert "tenant-a" in decision.reason
+
+    def test_verified_tenant_ranks_over_caller_identity_and_metadata(self) -> None:
+        """Verified first-class field is the highest-trust source: even a
+        caller_identity carrying a different tenant does not override the
+        first-class verified field."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(tool_name="tool-a", tenant="tenant-a", timestamp=_T0)
+        identity = McpCallerIdentity(agent_id="x", tenant="tenant-b")
+        decision = enf.check_tool_call(ctx, caller_identity=identity)
+        # tenant-a (verified field) owns tool-a -> approved. If caller_identity
+        # (tenant-b) had won, tool-a would be BLOCKED for tenant-b.
+        assert decision.level == "auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# AC#3 -- body-supplied tenant stripped / not trusted on network transports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestBodySuppliedTenantStripped:
+    def test_from_network_transport_strips_body_top_level_tenant(self) -> None:
+        """A client that puts a first-class-looking ``tenant`` in the wire
+        body cannot set the verified field -- the network deserializer
+        ignores it and uses the authenticated transport value."""
+        body = {"tool_name": "tool-a", "tenant": "tenant-b", "agent_id": "x"}
+        ctx = McpActionContext.from_network_transport(body, verified_tenant="tenant-a")
+        assert ctx.tenant == "tenant-a"
+
+    def test_from_network_transport_strips_metadata_tenant_id(self) -> None:
+        body = {
+            "tool_name": "tool-a",
+            "metadata": {"tenant_id": "tenant-b", "trace": "keep-me"},
+        }
+        ctx = McpActionContext.from_network_transport(body, verified_tenant="tenant-a")
+        assert ctx.tenant == "tenant-a"
+        assert "tenant_id" not in ctx.metadata  # stripped
+        assert ctx.metadata["trace"] == "keep-me"  # other metadata preserved
+
+    def test_from_network_transport_no_verified_tenant_yields_none(self) -> None:
+        """No authenticated transport tenant -> verified field is None (the
+        fail-closed input); body tenant is still stripped, never trusted."""
+        body = {"tool_name": "tool-a", "metadata": {"tenant_id": "tenant-b"}}
+        ctx = McpActionContext.from_network_transport(body)
+        assert ctx.tenant is None
+        assert "tenant_id" not in ctx.metadata
+
+    def test_network_transport_spoof_denied_end_to_end(self) -> None:
+        """The full spoof-attack path: a tenant-a caller crafts a body that
+        claims tenant-b (owner of tool-b). Under the secure default the
+        deserialized context carries verified tenant-a and BLOCKS."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        malicious_body = {
+            "tool_name": "tool-b",
+            "tenant": "tenant-b",
+            "metadata": {"tenant_id": "tenant-b"},
+        }
+        ctx = McpActionContext.from_network_transport(
+            malicious_body, verified_tenant="tenant-a"
+        )
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "tenant-a" in decision.reason
+
+    def test_from_network_transport_resource_strips_body_tenant(self) -> None:
+        body = {
+            "uri": "resource://tenant-b/doc",
+            "tenant": "tenant-b",
+            "metadata": {"tenant_id": "tenant-b"},
+        }
+        ctx = McpResourceContext.from_network_transport(
+            body, verified_tenant="tenant-a"
+        )
+        assert ctx.tenant == "tenant-a"
+        assert "tenant_id" not in ctx.metadata
+
+
+# ---------------------------------------------------------------------------
+# AC#4 -- fail-closed when isolation active and no verified tenant resolves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestFailClosedNoVerifiedTenant:
+    def test_no_verified_tenant_blocks_tool_call(self) -> None:
+        """Isolation ON, no verified field, no caller_identity, secure
+        default (require_caller_identity=True) -> the untrusted metadata
+        channel is never consulted -> BLOCKED."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(
+            tool_name="tool-a", metadata={"tenant_id": "tenant-a"}, timestamp=_T0
+        )
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "no tenant was declared" in decision.reason
+
+    def test_no_verified_tenant_blocks_resource_read(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpResourceContext(
+            uri="resource://tenant-a/doc",
+            metadata={"tenant_id": "tenant-a"},
+            timestamp=_T0,
+        )
+        decision = enf.check_resource_read(ctx)
+        assert decision.level == "blocked"
+        assert "no tenant was declared" in decision.reason
+
+    def test_empty_string_verified_tenant_treated_as_absent(self) -> None:
+        """An empty verified tenant is not a real tenant -> fail-closed."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(tool_name="tool-a", tenant="", timestamp=_T0)
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+
+    def test_unknown_verified_tenant_blocks(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        ctx = McpActionContext(tool_name="tool-a", tenant="tenant-x", timestamp=_T0)
+        decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "not a recognized tenant" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# Wire contract unchanged -- verified field is server-side only (byte-neutral)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestVerifiedFieldNotWireSerialized:
+    def test_to_dict_does_not_emit_verified_tenant(self) -> None:
+        ctx = McpActionContext(tool_name="t", tenant="tenant-a", timestamp=_T0)
+        assert "tenant" not in ctx.to_dict()
+
+    def test_resource_to_dict_does_not_emit_verified_tenant(self) -> None:
+        ctx = McpResourceContext(uri="u", tenant="tenant-a", timestamp=_T0)
+        assert "tenant" not in ctx.to_dict()
+
+    def test_from_dict_never_populates_verified_tenant_from_body(self) -> None:
+        """Even if a crafted wire body carries a top-level ``tenant`` key,
+        the generic ``from_dict`` deserializer never trusts it."""
+        restored = McpActionContext.from_dict(
+            {"tool_name": "t", "tenant": "tenant-evil"}
+        )
+        assert restored.tenant is None
+
+    def test_metadata_tenant_id_still_round_trips_through_wire(self) -> None:
+        """The free-form metadata channel remains byte-neutral (issue #1843
+        backward-compat) -- to_dict/from_dict round-trips it untouched."""
+        ctx = McpActionContext(
+            tool_name="t", metadata={"tenant_id": "tenant-a"}, timestamp=_T0
+        )
+        restored = McpActionContext.from_dict(ctx.to_dict())
+        assert restored.metadata["tenant_id"] == "tenant-a"
+
+
+# ---------------------------------------------------------------------------
+# Middleware populates the verified field at the network boundary
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHandler:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __call__(self, tool_name: str, args: dict) -> str:
+        self.calls.append((tool_name, args))
+        return "ok"
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestMiddlewarePopulatesVerifiedField:
+    @pytest.mark.asyncio
+    async def test_invoke_populates_verified_tenant_from_caller_identity(self) -> None:
+        """The middleware is the network boundary: it derives the verified
+        tenant from the authenticated caller_identity, so a cross-tenant tool
+        is blocked even though no metadata tenant is set."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        handler = _RecordingHandler()
+        mw = McpGovernanceMiddleware(enforcer=enf, handler=handler)
+        identity = McpCallerIdentity(agent_id="agent-1", tenant="tenant-a")
+
+        result = await mw.invoke(
+            "tool-b", {}, agent_id="agent-1", caller_identity=identity
+        )
+        assert result.decision.level == "blocked"
+        assert result.executed is False
+        assert handler.calls == []
+
+    @pytest.mark.asyncio
+    async def test_invoke_allows_own_tenant_via_populated_verified_field(self) -> None:
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        handler = _RecordingHandler()
+        mw = McpGovernanceMiddleware(enforcer=enf, handler=handler)
+        identity = McpCallerIdentity(agent_id="agent-1", tenant="tenant-a")
+
+        result = await mw.invoke(
+            "tool-a", {}, agent_id="agent-1", caller_identity=identity
+        )
+        assert result.decision.allowed is True
+        assert result.executed is True
+
+    @pytest.mark.asyncio
+    async def test_invoke_body_metadata_tenant_cannot_override_verified(self) -> None:
+        """A caller passes a spoofed metadata tenant_id (tenant-b, owner of
+        tool-b) but the authenticated identity is tenant-a. The verified
+        field wins -> tool-b BLOCKED."""
+        enf = McpGovernanceEnforcer(_config(tenant_grants=_two_tenant_grants()))
+        handler = _RecordingHandler()
+        mw = McpGovernanceMiddleware(enforcer=enf, handler=handler)
+        identity = McpCallerIdentity(agent_id="agent-1", tenant="tenant-a")
+
+        result = await mw.invoke(
+            "tool-b",
+            {},
+            agent_id="agent-1",
+            caller_identity=identity,
+            metadata={"tenant_id": "tenant-b"},
+        )
+        assert result.decision.level == "blocked"
+        assert "tenant-a" in result.decision.reason
+        assert handler.calls == []


### PR DESCRIPTION
## Summary

Closes #1878 — MCP governance tenant isolation keyed on a `tenant_id` in the client-body-copyable metadata map, letting an authenticated caller assert an arbitrary tenant. Adds a first-class, **server-verified** `tenant` field distinct from metadata.

## Fix

- `McpActionContext` / `McpResourceContext` gain a `tenant` dataclass field, server-side only: **excluded from `to_dict`/`from_dict`** (mirrors `McpCallerIdentity`), so the on-the-wire envelope stays **byte-identical** to #1843 — no cross-SDK wire-contract change, no Rust coordination needed.
- `_resolve_effective_tenant` ranks the verified field highest (above caller-identity, above metadata); both enforcement surfaces + the rate-limit re-resolution thread it through that one shared function (Enforcement-Surface Parity).
- New `from_network_transport` classmethod strips any body-supplied top-level `tenant` **and** `metadata['tenant_id']`, setting the verified field only from the authenticated transport. Middleware populates `context.tenant` from `caller_identity` at the network boundary.
- Fail-closed unchanged: tenant isolation active + no verified tenant resolves → DENY.

## Verification

26 new #1878 regression tests (first-class field, governance-reads-verified-over-metadata + over-caller-identity, network-transport strip incl. end-to-end spoof denial, fail-closed on absent/empty/unknown, wire byte-neutrality, middleware spoof defeat); #1843 byte-neutral pin updated; authoritative re-run from main checkout: **75 regression + 134 MCP-unit passed**; ruff clean. Real objects, no mocking of the governance path.

## Related issues

Closes #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)