### PR TITLE
release: kailash 2.61.0 + kailash-pact 0.17.0 + kaizen-agents 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.61.0] — 2026-07-22 — Trust-plane capability subject-binding + chain-state signing (#1912)
+
 ### Security (Trust Plane — #1912 capability subject-binding + chain-state signing)
 
 Three coordinated waves close a capability-transplant HIGH and two store-writer

--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PACT Changelog
 
+## [0.17.0] — 2026-07-22 — First-class server-verified tenant field on McpActionContext (#1878)
+
+### Added (Security)
+
+- **`McpActionContext` / `McpResourceContext` gain a first-class, server-verified `tenant` field (#1878).** MCP governance tenant isolation previously keyed on a client-body-copyable `metadata['tenant_id']`, letting an authenticated caller assert an arbitrary tenant. The new `tenant` field is populated server-side from the authenticated transport at the network boundary and is excluded from `to_dict`/`from_dict` (the on-the-wire envelope stays byte-identical to 0.16.x — no cross-SDK wire change). `_resolve_effective_tenant` ranks it above caller-identity and metadata; both enforcement surfaces plus the rate-limit re-resolution read the verified field; `from_network_transport` strips any body-supplied `tenant_id`. Fail-closed: tenant isolation active + no verified tenant → DENY.
+
 ## [0.16.1] — 2026-07-20 — Export the tenant-isolation types at the `pact` top level
 
 ### Fixed

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.16.1"
+version = "0.17.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] — 2026-07-22 — Route agent completion by the passed client, not the model prefix (#1899)
+
+### Fixed
+
+- **`Delegate(base_url=…, api_key=…)` now routes to the passed deployment client's endpoint (#1899).** An explicitly-passed OpenAI-compatible / Azure / custom-endpoint deployment client was silently ignored: `Delegate` accepted `base_url`/`api_key` but dropped them (no `KzConfig` fields), and model-name-prefix detection overrode an explicit endpoint. The passed client's endpoint is now authoritative; prefix detection is demoted to a fallback used only when no explicit client is set (zero-config `gpt-*`/`claude-*` unchanged). `KzConfig.api_key`/`base_url` carry `repr=False` so the credential cannot leak into a config log.
+
 ## [0.11.3] — 2026-07-19 — RAGResearchAgent lazy-loads so bare install imports without numpy (#1849)
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.3"
+version = "0.11.4"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.60.1"
+version = "2.61.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.60.1"
+__version__ = "2.61.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Coordinated 3-package version bump preparing tag-triggered OIDC publishing. This PR is metadata-only (version anchors + CHANGELOG entries) — no source changes. Per the release-prep workflow, this PR does NOT merge and NO tags are pushed here; the orchestrator handles the admin-merge and tag-push (the irreversible publish trigger) separately.

**Packages / versions / tags:**

| Package | Version | Tag |
|---|---|---|
| kailash (core) | 2.60.1 → 2.61.0 | `v2.61.0` |
| kailash-pact | 0.16.1 → 0.17.0 | `pact-v0.17.0` |
| kaizen-agents | 0.11.3 → 0.11.4 | `kaizen-agents-v0.11.4` |

**What's in each bump:**

- **kailash 2.61.0** — converts the `## [Unreleased]` #1912 trust-plane entry (capability subject-binding + chain-state signing, 3 waves) into a dated `## [2.61.0] — 2026-07-22` released section. No prose changes to the existing #1912 body.
- **kailash-pact 0.17.0** — closes #1878: `McpActionContext` / `McpResourceContext` gain a first-class, server-verified `tenant` field, populated server-side from the authenticated transport rather than trusted from a client-copyable `metadata['tenant_id']`. Wire format unchanged (field excluded from `to_dict`/`from_dict`); fail-closed when tenant isolation is active and no verified tenant is present.
- **kaizen-agents 0.11.4** — closes #1899: `Delegate(base_url=…, api_key=…)` now routes to the passed deployment client's endpoint instead of being silently overridden by model-name-prefix detection; prefix detection demoted to a fallback for zero-config `gpt-*`/`claude-*` usage.

Version bumped atomically (`pyproject.toml::version` + `__init__.py::__version__`) for all three packages per `zero-tolerance.md` Rule 5; every current-and-new value was grep-verified before and after edit per `verify-claims-before-write.md`.

## Related issues

Closes #1912
Closes #1878
Closes #1899

## Test plan

- [x] Verified all 6 version locations (3 packages × pyproject.toml + `__init__.py`) grep-match the intended target values
- [x] Verified CHANGELOG headers landed correctly in all 3 files (core, pact, kaizen-agents)
- [x] Confirmed diff is metadata-only (9 files: 3× `pyproject.toml`, 3× `__init__.py`, 3× `CHANGELOG.md`) — no source changes
- [ ] Orchestrator: confirm CI green on this branch, admin-merge, then cut + push the 3 release tags (`v2.61.0`, `pact-v0.17.0`, `kaizen-agents-v0.11.4`) to trigger OIDC publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)