### PR TITLE
fix(kaizen): infer provider from model prefix in zero-config Delegate (#1918)

### DIFF
--- a/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/config/loader.py
@@ -130,7 +130,17 @@ class KzConfig:
 
     # LLM settings
     model: str = ""
-    provider: str = "openai"
+    # Empty string is the "caller did not set a provider" sentinel (issue #1918).
+    # It MUST match get_adapter_for_model's own ``provider: str = ""`` unset
+    # sentinel: when empty, adapter selection falls through to model-name-prefix
+    # inference (``claude-*`` -> anthropic, ``gemini-*`` -> google) and then the
+    # ``openai`` default. A non-empty value (set via a ``.kz`` config file, the
+    # ``KZ_PROVIDER`` env var, or an explicit ``KzConfig(provider=...)``) is
+    # authoritative and wins over prefix inference. Previously this defaulted to
+    # the truthy ``"openai"``, which was forwarded to get_adapter_for_model as an
+    # EXPLICIT provider and short-circuited the prefix fallback, so a zero-config
+    # ``Delegate`` on a ``claude-*`` model silently hit the OpenAI wire.
+    provider: str = ""
     # Explicitly-passed deployment client (issue #1899). When ``base_url`` is
     # set, the client's endpoint wins over model-name-prefix detection — an
     # OpenAI-compatible / Azure / custom-endpoint deployment is identified by

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/print_mode.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/print_mode.py
@@ -57,6 +57,14 @@ class PrintRunner:
             config = KzConfig(
                 model=config.model,
                 provider=config.provider,
+                # Preserve the #1899 deployment client (base_url + api_key).
+                # Omitting them here dropped the explicitly-set endpoint/key on a
+                # max_turns override, so a claude-* model pinned to a custom
+                # base_url silently re-inferred to the prefix provider's real wire
+                # (api.anthropic.com) instead of the caller's deployment (#1918
+                # redteam INVEST-NOW; same base_url-precedence invariant #1899 set).
+                base_url=config.base_url,
+                api_key=config.api_key,
                 effort_level=config.effort_level,
                 max_turns=max_turns,
                 max_tokens=config.max_tokens,

--- a/packages/kaizen-agents/tests/unit/delegate/test_config.py
+++ b/packages/kaizen-agents/tests/unit/delegate/test_config.py
@@ -171,7 +171,11 @@ class TestLoadConfig:
         """No config files or env vars -> returns defaults."""
         config = load_config(project_root=tmp_path, user_home=tmp_path / "fakehome")
         assert config.model == ""  # empty until effort preset or CLI flag sets it
-        assert config.provider == "openai"
+        # Empty is the "caller did not set a provider" sentinel (issue #1918):
+        # zero-config leaves provider unset so adapter selection infers it from
+        # the model-name prefix, instead of forwarding a truthy "openai" default
+        # that pre-empts the prefix fallback and routes claude-* to the OpenAI wire.
+        assert config.provider == ""
         assert config.effort_level is EffortLevel.MEDIUM
         assert config.max_turns == 50
         assert config.max_tokens == 16384

--- a/packages/kaizen-agents/tests/unit/test_llm_routing.py
+++ b/packages/kaizen-agents/tests/unit/test_llm_routing.py
@@ -126,3 +126,132 @@ class TestLLMBasedSelectBest:
         ):
             best = await strategy.select_best("translate this document", caps)
             assert best is caps[0]
+
+
+# ==========================================================================
+# Issue #1918 — zero-config Delegate MUST infer the provider from the model
+# prefix, not silently route claude-*/gemini-* to the OpenAI wire.
+#
+# Before the fix, KzConfig.provider defaulted to the truthy "openai", which
+# AgentLoop._build_adapter forwarded to get_adapter_for_model as an EXPLICIT
+# provider — short-circuiting the model-name-prefix fallback. A bare
+# Delegate(model="claude-...") built an OpenAIStreamAdapter @ api.openai.com.
+#
+# These tests exercise the routing DISPATCH end-to-end through Delegate (the
+# path the bug lived on — NOT get_adapter_for_model directly, whose own default
+# provider="" already inferred correctly). Adapters construct without a live
+# network call; ungoverned=True bypasses the #1779 governance gate and the
+# api_key is a test-only fixture, not a real secret. The model-name literals are
+# prefix-SHAPE fixtures for the detection logic, not production model selection
+# (rules/env-models.md governs production paths; test fixtures are exempt).
+# --------------------------------------------------------------------------
+
+_FAKE_KEY = "test-routing-key"  # not a real secret; test-only fixture
+
+
+def _loop_adapter(delegate):
+    """The streaming adapter the delegate's loop will drive."""
+    return delegate._loop._adapter
+
+
+class TestZeroConfigDelegateProviderRouting:
+    """A bare Delegate(model=...) infers the provider from the model prefix."""
+
+    def test_zero_config_claude_routes_to_anthropic(self):
+        """Delegate(model="claude-*") builds an Anthropic adapter, NOT OpenAI."""
+        from kaizen_agents.delegate.adapters.anthropic_adapter import (
+            AnthropicStreamAdapter,
+        )
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(
+            model="claude-3-5-sonnet", api_key=_FAKE_KEY, ungoverned=True
+        )
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, AnthropicStreamAdapter), (
+            "zero-config claude-* must route to the Anthropic adapter, got "
+            f"{type(adapter).__name__} (the #1918 regression: it hit OpenAI)"
+        )
+        assert not isinstance(adapter, OpenAIStreamAdapter)
+        endpoint = str(adapter._client.base_url)
+        assert (
+            "api.openai.com" not in endpoint
+        ), f"claude-* routed to {endpoint!r} — the OpenAI wire (issue #1918)"
+        assert "anthropic" in endpoint
+
+    def test_zero_config_gemini_routes_to_google(self):
+        """Delegate(model="gemini-*") builds a Google adapter, NOT OpenAI."""
+        from kaizen_agents.delegate.adapters.google_adapter import GoogleStreamAdapter
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(
+            model="gemini-2.0-flash", api_key=_FAKE_KEY, ungoverned=True
+        )
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, GoogleStreamAdapter), (
+            "zero-config gemini-* must route to the Google adapter, got "
+            f"{type(adapter).__name__} (the #1918 regression: it hit OpenAI)"
+        )
+        # GoogleStreamAdapter constructs a genai.Client (no OpenAI wire); the
+        # isinstance check above is the "not api.openai.com" guarantee.
+        assert not isinstance(adapter, OpenAIStreamAdapter)
+
+    def test_zero_config_gpt_still_routes_to_openai(self):
+        """Non-regression: a bare gpt-* still routes to OpenAI @ api.openai.com."""
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(model="gpt-4o", api_key=_FAKE_KEY, ungoverned=True)
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, OpenAIStreamAdapter)
+        assert "api.openai.com" in str(adapter._client.base_url)
+
+    def test_zero_config_unknown_prefix_still_defaults_to_openai(self):
+        """Non-regression: an unknown-prefix model still defaults to OpenAI."""
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(
+            model="my-custom-deployment", api_key=_FAKE_KEY, ungoverned=True
+        )
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, OpenAIStreamAdapter)
+        assert "api.openai.com" in str(adapter._client.base_url)
+
+    def test_explicit_provider_wins_over_model_prefix(self):
+        """An explicit KzConfig.provider is authoritative over prefix inference:
+        provider="openai" on a claude-* model still builds the OpenAI adapter."""
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.config.loader import KzConfig
+        from kaizen_agents.delegate.delegate import Delegate
+
+        # api_key lives on the KzConfig: when config= is passed, Delegate uses it
+        # verbatim and does not thread the separate api_key= param onto it.
+        cfg = KzConfig(model="claude-3-5-sonnet", provider="openai", api_key=_FAKE_KEY)
+        delegate = Delegate(config=cfg, ungoverned=True)
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, OpenAIStreamAdapter), (
+            "an explicit provider='openai' must win over the claude-* prefix, "
+            f"got {type(adapter).__name__}"
+        )
+        assert "api.openai.com" in str(adapter._client.base_url)
+
+    def test_explicit_base_url_still_wins_over_prefix(self):
+        """Non-regression guard for #1899: a passed deployment endpoint on a
+        claude-* model still routes to the OpenAI-compatible wire at that
+        endpoint (base_url precedence unchanged by the #1918 fix)."""
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+        from kaizen_agents.delegate.delegate import Delegate
+
+        endpoint = "https://my-deployment.example.com/v1"
+        delegate = Delegate(
+            model="claude-3-5-sonnet",
+            base_url=endpoint,
+            api_key=_FAKE_KEY,
+            ungoverned=True,
+        )
+        adapter = _loop_adapter(delegate)
+        assert isinstance(adapter, OpenAIStreamAdapter)
+        assert str(adapter._client.base_url).rstrip("/") == endpoint

--- a/packages/kaizen-agents/tests/unit/test_print_mode.py
+++ b/packages/kaizen-agents/tests/unit/test_print_mode.py
@@ -62,6 +62,55 @@ class TestPrintResult:
 # ---------------------------------------------------------------------------
 
 
+class TestPrintRunnerMaxTurnsOverridePreservesClient:
+    """Regression for the #1918 red-team INVEST-NOW finding.
+
+    The ``max_turns`` override in ``PrintRunner.__init__`` rebuilds ``KzConfig``
+    field-by-field, and previously omitted ``base_url`` + ``api_key`` — silently
+    dropping a #1899 deployment client. Combined with the #1918 provider-default
+    fix, a claude-* model pinned to a custom ``base_url`` would then re-infer to
+    the prefix provider's real wire (api.anthropic.com) instead of the caller's
+    deployment. The reconstruction MUST preserve every field.
+    """
+
+    def test_max_turns_override_preserves_base_url_and_api_key(self) -> None:
+        from kaizen_agents.delegate.loop import ToolRegistry
+
+        cfg = KzConfig(
+            model="claude-3-5-sonnet",
+            base_url="https://my-deployment.example.com/v1",
+            api_key="sk-fake-not-real-test-only",
+        )
+        # mock client → no adapter/governance construction; the reconstruction
+        # under the max_turns override is what we assert on (runner._config).
+        runner = PrintRunner(
+            config=cfg,
+            tools=ToolRegistry(),
+            client=AsyncMock(),
+            max_turns=5,
+        )
+        assert runner._config.base_url == "https://my-deployment.example.com/v1"
+        assert runner._config.api_key == "sk-fake-not-real-test-only"
+        # the override itself + the previously-preserved fields still hold
+        assert runner._config.max_turns == 5
+        assert runner._config.model == "claude-3-5-sonnet"
+        assert runner._config.provider == cfg.provider
+
+    def test_no_override_passes_config_through_untouched(self) -> None:
+        from kaizen_agents.delegate.loop import ToolRegistry
+
+        cfg = KzConfig(
+            model="claude-3-5-sonnet",
+            base_url="https://my-deployment.example.com/v1",
+            api_key="sk-fake-not-real-test-only",
+        )
+        runner = PrintRunner(config=cfg, tools=ToolRegistry(), client=AsyncMock())
+        # no max_turns override → the same config object flows through unchanged
+        assert runner._config is cfg
+        assert runner._config.base_url == "https://my-deployment.example.com/v1"
+        assert runner._config.api_key == "sk-fake-not-real-test-only"
+
+
 class TestPrintRunnerFormatting:
     def _make_runner(self) -> PrintRunner:
         """Create a PrintRunner with a mock client to avoid API key checks."""


### PR DESCRIPTION
## Summary

Fixes the zero-config routing bug in #1918: `Delegate(model="claude-3-5-sonnet")` with no explicit provider and no `base_url` silently routed to the **OpenAI** wire.

**Root cause:** `KzConfig.provider` defaulted to the non-empty string `"openai"`. `AgentLoop._build_adapter` forwarded that default to `get_adapter_for_model` as an *explicit* `provider=` argument, which short-circuited the already-correct `_MODEL_PREFIX_MAP` fallback (`claude-`→anthropic, `gemini-`→google) that only fires when no provider is explicitly set. So a `claude-*` model was sent to `api.openai.com`.

**Fix:** flip `KzConfig.provider`'s default from `"openai"` to the empty-string sentinel `""`, aligning it with `get_adapter_for_model`'s own `provider: str = ""` unset-sentinel. The config default no longer masquerades as an explicit provider, so the existing prefix-inference fallback runs for the no-client path. Explicit `provider=` / `KZ_PROVIDER` / `.kz` config still win (unchanged precedence).

## Why this was invisible

The prior regression test `test_zero_config_claude_prefix_unchanged` called `get_adapter_for_model` **directly** (registry default `provider=""`), bypassing the `Delegate → KzConfig → AgentLoop` path where the bug lived — it was green while the real path was broken. New tests go end-to-end through `Delegate(...)`.

## Invariants held
- Zero-config `claude-*` → `AnthropicStreamAdapter` @ api.anthropic.com; `gemini-*` → `GoogleStreamAdapter`.
- Zero-config `gpt-*` and unknown-prefix models still → `OpenAIStreamAdapter` @ api.openai.com (default unchanged for those).
- Explicit `provider="openai"` on a claude model still → OpenAI (explicit wins over prefix).
- #1899 explicit-`base_url` client precedence unregressed.

## Tests
`573 passed` (`pytest packages/kaizen-agents/tests/unit/delegate packages/kaizen-agents/tests/unit/test_llm_routing.py`); ruff clean. New end-to-end `TestZeroConfigDelegateProviderRouting` (6 cases through `Delegate`). Also corrected two pre-existing assertions that encoded the buggy `"openai"`-default contract.

## Related issues
Fixes #1918. Follow-up to #1899.