### PR TITLE
hardening(mcp): deprecate untrusted metadata['tenant_id'] tenant fallback (#1919)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,5 +1,15 @@
 # PACT Changelog
 
+## [Unreleased] — Deprecate the untrusted metadata['tenant_id'] tenant fallback (#1919)
+
+### Changed (Security)
+
+- **The client-asserted `metadata['tenant_id']` tenant fallback is deprecated and no longer honored in ANY mode (#1919).** Issue #1843 shipped MCP tenant isolation with a secure default (`require_caller_identity=True`) and a documented weaker mode (`require_caller_identity=False`) that, as a last-resort fallback, trusted a client-supplied `metadata['tenant_id']` as the effective tenant. Under that documented weaker mode a client could influence a tenant-isolation decision via the request body — the exact impersonation surface first-class tenant isolation exists to close, narrowed to one opt-in mode. The single enforcer decision chokepoint (`_resolve_effective_tenant`) now NO LONGER trusts `metadata['tenant_id']` in the weaker branch: when a caller exercises the now-deprecated path a `DeprecationWarning` fires and the resolution returns `None`, which **fails the tenant-isolation decision CLOSED** (never fail-open). A client-asserted tenant can no longer influence a tenant decision in any mode. Defense-in-depth: `McpGovernanceMiddleware.invoke` / `invoke_resource_read` now scrub `metadata['tenant_id']` at the boundary before building the context (mirroring `from_network_transport`), so the client value never propagates into audit/echo surfaces either.
+
+  - **Behavior change:** a deployment on the weaker mode (`require_caller_identity=False`) that relied on the metadata fallback will see previously-approved calls now BLOCKED (fail-closed) plus a `DeprecationWarning`.
+  - **Migration:** provide a trusted caller identity (`McpCallerIdentity.tenant`) or a server-verified context tenant (`McpActionContext.tenant` / `McpResourceContext.tenant`, populated server-side at the network boundary), OR set `McpGovernanceConfig.require_caller_identity=True` (the secure default). The `require_caller_identity=False` mode still exists — only its trust of the client-asserted metadata tenant is removed.
+  - **Unchanged:** the secure default (`require_caller_identity=True`) is byte-identical — it never consulted the metadata channel and does not warn. Verified/trusted tenant precedence (verified context tenant > caller identity) is unchanged.
+
 ## [0.17.0] — 2026-07-22 — First-class server-verified tenant field on McpActionContext (#1878)
 
 ### Added (Security)

--- a/packages/kailash-pact/README.md
+++ b/packages/kailash-pact/README.md
@@ -55,26 +55,31 @@ enforces **today** versus what remains open — read it before relying on
   `dict[str, McpTenantGrant]`) scopes both `tools/call` and `resources/read`
   to the caller's tenant through one shared, fail-closed restrictiveness
   function, evaluated before tool registration (so it applies even under
-  `DefaultPolicy.ALLOW`). `McpCallerIdentity.tenant` — resolved by your
-  transport/auth layer and passed to `check_tool_call`/`check_resource_read`
-  — always overwrites a self-asserted `metadata["tenant_id"]`, defeating
+  `DefaultPolicy.ALLOW`). The effective tenant is resolved from the
+  server-verified `tenant` field (populated server-side at the network
+  boundary, #1878) or a trusted `McpCallerIdentity.tenant` (resolved by your
+  transport/auth layer and passed to `check_tool_call`/`check_resource_read`);
+  the self-asserted `metadata["tenant_id"]` channel is deprecated and no
+  longer consulted for tenant resolution in any mode (#1919), defeating
   impersonation. `require_caller_identity` defaults to `True`: with no
-  trusted identity wired, the self-asserted body value is never trusted and
-  the call fails closed rather than silently falling back to it.
+  verified/trusted tenant the call fails closed.
 - **Deferred:** `resources/read` has ONLY the tenant-isolation check today —
   no cost, argument, clearance, or rate-limit governance layer exists yet
   for that surface (that richer contract exists only for `tools/call` via
-  `McpToolPolicy`). No first-class serialized `tenant_id` field exists on
-  the wire envelope; tenant rides the existing free-form
-  `metadata["tenant_id"]` channel by design (byte-neutral with the Rust
-  SDK's frozen envelope) and may change if the ecosystems converge on a
-  first-class field later.
+  `McpToolPolicy`). The server-verified `tenant` field (#1878) is populated
+  server-side and deliberately excluded from the wire envelope
+  (`to_dict`/`from_dict` never emit it — byte-neutral with the Rust SDK's
+  frozen envelope); it is NOT a client-serialized field, and the self-asserted
+  `metadata["tenant_id"]` channel is no longer consulted for tenant
+  resolution (#1919).
 - **Non-promises:** `tenant_grants` being empty is NOT "tenant isolation
   enabled with an empty allowlist" — it is isolation OFF entirely (every
   call auto-approved on that axis, byte-identical to pre-0.16.0 behavior).
   Passing `require_caller_identity=False` is NOT a recommended production
-  setting — it exists only for deployments with no transport-level identity
-  resolution, and re-enables the weaker, spoofable metadata fallback.
+  setting — it exists only for the documented #1843 weaker-mode surface. As
+  of #1919 it NO LONGER re-enables a trusted metadata fallback: a caller that
+  relied on the self-asserted `metadata["tenant_id"]` now receives a
+  `DeprecationWarning` and the decision fails closed.
 - **Verify:** `pytest packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py -v`
   exercises the fail-closed defaults, the impersonation-defeat contract, and
   the `resources/read` isolation-only surface end-to-end.

--- a/packages/kailash-pact/src/pact/mcp/__init__.py
+++ b/packages/kailash-pact/src/pact/mcp/__init__.py
@@ -17,8 +17,10 @@ enforcement as a middleware layer:
   .tenant_grants scopes BOTH tools/call and resources/read to the caller's
   tenant through one shared restrictiveness function, fail-closed on an
   absent/unknown/ungranted tenant. Empty tenant_grants (the default) is a
-  byte-neutral no-op. A trusted McpCallerIdentity's tenant overwrites any
-  self-asserted metadata["tenant_id"] (impersonation defeat).
+  byte-neutral no-op. The tenant is resolved only from the server-verified
+  context tenant or a trusted McpCallerIdentity; the self-asserted
+  metadata["tenant_id"] channel is deprecated and no longer consulted for
+  tenant resolution in any mode (issue #1919).
 
 Architecture:
     pact.mcp.types      -- McpToolPolicy, McpGovernanceConfig, McpActionContext,

--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
+import warnings
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -119,17 +120,20 @@ def _resolve_effective_tenant(
     2. ``caller_identity.tenant`` -- the sidecar trusted identity (issue
        #1843), also transport-resolved. Consulted when no first-class
        verified tenant is present.
-    3. ``metadata["tenant_id"]`` -- the self-asserted, attacker-controlled
-       fallback. Consulted ONLY when ``require_caller_identity`` is False AND
-       neither trusted source resolved a tenant. Under the secure default
-       (``require_caller_identity=True``) it is never consulted.
 
-    A caller cannot widen its own access by putting a different tenant in the
-    request body: both trusted sources (1) and (2) win over the body, and the
-    body channel (3) is disabled by default.
+    A client-asserted ``metadata["tenant_id"]`` is NEVER a trusted source of
+    the effective tenant. Under the secure default
+    (``require_caller_identity=True``) the body channel was never consulted.
+    Under the documented weaker mode (``require_caller_identity=False``, the
+    issue #1843 opt-in) it was previously consulted as a last-resort
+    fallback; that fallback is DEPRECATED and no longer honored (issue
+    #1919). A caller relying on it now gets a ``DeprecationWarning`` and the
+    resolution returns ``None`` -- which fails the downstream tenant-isolation
+    decision CLOSED (never fail-open). A caller can no longer influence the
+    tenant decision by putting a tenant in the request body in ANY mode.
 
     Returns:
-        The tenant string, or None if no source resolves one.
+        The tenant string from a trusted source, or None if none resolves.
     """
     if verified_tenant is not None:
         return verified_tenant
@@ -137,8 +141,25 @@ def _resolve_effective_tenant(
         return caller_identity.tenant
     if require_caller_identity:
         return None
+    # require_caller_identity is False: the documented #1843 weaker mode. The
+    # metadata["tenant_id"] fallback that this branch previously trusted is
+    # DEPRECATED (#1919) -- a client-asserted tenant must never influence the
+    # decision. If a caller was relying on that fallback (a str tenant_id is
+    # present), warn with the migration path and return None so the
+    # tenant-isolation decision fails CLOSED downstream.
     metadata_tenant = metadata.get("tenant_id") if metadata else None
-    return metadata_tenant if isinstance(metadata_tenant, str) else None
+    if isinstance(metadata_tenant, str):
+        warnings.warn(
+            "MCP tenant isolation: trusting a client-asserted "
+            "metadata['tenant_id'] as the effective tenant is deprecated and "
+            "is no longer honored (#1919). The request now fails closed (no "
+            "tenant resolved). Migrate by providing a trusted caller identity "
+            "(McpCallerIdentity.tenant) or a server-verified context tenant, "
+            "or set McpGovernanceConfig.require_caller_identity=True.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return None
 
 
 def _tenant_grant_permits(

--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -19,9 +19,11 @@ Security invariants (per pact-governance.md):
    non-empty, BOTH tools/call (keyed on tool name) and resources/read (keyed
    on URI) are scoped through ONE shared restrictiveness function
    (_tenant_isolation_decision), fail-closed on an absent, unrecognized, or
-   ungranted tenant (security.md Enforcement-Surface Parity). A trusted
-   McpCallerIdentity's tenant OVERWRITES any self-asserted
-   metadata["tenant_id"] (impersonation defeat). Empty tenant_grants (the
+   ungranted tenant (security.md Enforcement-Surface Parity). The tenant is
+   resolved ONLY from the server-verified context tenant or a trusted
+   McpCallerIdentity; the self-asserted metadata["tenant_id"] channel is
+   deprecated and no longer consulted for tenant resolution in ANY mode
+   (issue #1919). Empty tenant_grants (the
    default) means isolation is OFF -- byte-neutral backward compatibility.
 """
 
@@ -313,8 +315,10 @@ class McpGovernanceEnforcer:
         0. Check tenant isolation (issue #1843, fail-closed) -- SKIPPED
            entirely when McpGovernanceConfig.tenant_grants is empty (isolation
            OFF, byte-neutral backward compatibility); when non-empty, the
-           trusted caller_identity's tenant (or the self-asserted
-           metadata["tenant_id"] fallback) must hold a grant for this tool.
+           tenant -- from the server-verified context tenant or the trusted
+           caller_identity, NOT the self-asserted metadata["tenant_id"]
+           channel (deprecated + no longer consulted, issue #1919) -- must
+           hold a grant for this tool.
            Evaluated BEFORE tool registration so isolation applies uniformly
            regardless of default_policy (DENY or ALLOW).
         1. Check if tool is registered (default-deny for unregistered)
@@ -333,11 +337,12 @@ class McpGovernanceEnforcer:
         Args:
             context: The MCP action context describing the tool call.
             caller_identity: The trusted caller identity resolved by the
-                transport/auth layer, if any. Its tenant (when set)
-                OVERWRITES any self-asserted context.metadata["tenant_id"]
-                (impersonation defeat). None means no trusted identity was
-                supplied -- the enforcer falls back to the self-asserted
-                metadata channel.
+                transport/auth layer, if any. Its tenant (when set) is the
+                authoritative tenant when no server-verified context tenant is
+                present. None means no trusted identity was supplied; with no
+                context tenant the decision fails closed -- the self-asserted
+                metadata["tenant_id"] channel is no longer consulted
+                (issue #1919).
 
         Returns:
             A GovernanceDecision with the verdict.
@@ -401,9 +406,10 @@ class McpGovernanceEnforcer:
             context: The MCP resource context describing the resources/read
                 invocation.
             caller_identity: The trusted caller identity resolved by the
-                transport/auth layer, if any. Its tenant (when set)
-                OVERWRITES any self-asserted context.metadata["tenant_id"]
-                (impersonation defeat), mirroring check_tool_call.
+                transport/auth layer, if any. Its tenant (when set) is the
+                authoritative tenant when no server-verified context tenant is
+                present; the self-asserted metadata["tenant_id"] channel is no
+                longer consulted (issue #1919), mirroring check_tool_call.
 
         Returns:
             A GovernanceDecision with the verdict.

--- a/packages/kailash-pact/src/pact/mcp/middleware.py
+++ b/packages/kailash-pact/src/pact/mcp/middleware.py
@@ -120,6 +120,15 @@ class McpGovernanceMiddleware:
         verified_tenant = (
             caller_identity.tenant if caller_identity is not None else None
         )
+        # Defense-in-depth (#1919): scrub any client-asserted
+        # metadata["tenant_id"] at the boundary before building the context,
+        # mirroring McpActionContext.from_network_transport. A client-asserted
+        # tenant can never influence the decision (the enforcer no longer
+        # trusts it) AND must never propagate into audit/echo surfaces. The
+        # verified `tenant` field below is populated ONLY from caller_identity.
+        scrubbed_metadata = {
+            k: v for k, v in (metadata or {}).items() if k != "tenant_id"
+        }
         context = McpActionContext(
             tool_name=tool_name,
             args=args or {},
@@ -127,7 +136,7 @@ class McpGovernanceMiddleware:
             timestamp=now,
             cost_estimate=cost_estimate,
             caller_clearance=caller_clearance,
-            metadata=metadata or {},
+            metadata=scrubbed_metadata,
             tenant=verified_tenant,
         )
 
@@ -199,11 +208,18 @@ class McpGovernanceMiddleware:
         verified_tenant = (
             caller_identity.tenant if caller_identity is not None else None
         )
+        # Defense-in-depth (#1919): scrub any client-asserted
+        # metadata["tenant_id"] at the boundary before building the context,
+        # mirroring McpResourceContext.from_network_transport. The verified
+        # `tenant` field below is populated ONLY from caller_identity.
+        scrubbed_metadata = {
+            k: v for k, v in (metadata or {}).items() if k != "tenant_id"
+        }
         context = McpResourceContext(
             uri=uri,
             agent_id=agent_id,
             timestamp=now,
-            metadata=metadata or {},
+            metadata=scrubbed_metadata,
             tenant=verified_tenant,
         )
 

--- a/packages/kailash-pact/src/pact/mcp/middleware.py
+++ b/packages/kailash-pact/src/pact/mcp/middleware.py
@@ -102,10 +102,11 @@ class McpGovernanceMiddleware:
                 None means no clearance supplied (such tools are BLOCKED).
             caller_identity: The trusted caller identity resolved by the
                 transport/auth layer, if any (issue #1843). Its tenant (when
-                set) OVERWRITES any self-asserted metadata["tenant_id"]
-                (impersonation defeat). Forwarded to the enforcer's tenant
-                isolation gate; a no-op when McpGovernanceConfig.tenant_grants
-                is empty.
+                set) is the authoritative tenant when no server-verified
+                context tenant is present; the self-asserted
+                metadata["tenant_id"] is no longer consulted (issue #1919).
+                Forwarded to the enforcer's tenant isolation gate; a no-op when
+                McpGovernanceConfig.tenant_grants is empty.
             metadata: Additional context for governance evaluation.
 
         Returns:
@@ -192,9 +193,10 @@ class McpGovernanceMiddleware:
             uri: The MCP resource URI to read.
             agent_id: Identifier of the agent making the call.
             caller_identity: The trusted caller identity resolved by the
-                transport/auth layer, if any. Its tenant (when set)
-                OVERWRITES any self-asserted metadata["tenant_id"]
-                (impersonation defeat), mirroring invoke().
+                transport/auth layer, if any. Its tenant (when set) is the
+                authoritative tenant when no server-verified context tenant is
+                present; the self-asserted metadata["tenant_id"] is no longer
+                consulted (issue #1919), mirroring invoke().
             metadata: Additional context for governance evaluation.
 
         Returns:

--- a/packages/kailash-pact/src/pact/mcp/types.py
+++ b/packages/kailash-pact/src/pact/mcp/types.py
@@ -219,17 +219,18 @@ class McpGovernanceConfig:
             ``McpGovernanceEnforcer._tenant_isolation_decision`` (enforcer.py)
             -- the ONE shared restrictiveness function both surfaces call.
         require_caller_identity: When True (the default), the tenant resolver
-            NEVER consults the self-asserted ``metadata["tenant_id"]``
-            fallback -- an absent, or tenant-less, trusted ``McpCallerIdentity``
-            resolves straight to no-tenant (fail-closed), rather than trusting
-            a caller-supplied metadata value. SECURE BY DEFAULT: with no
-            existing users of the metadata-fallback behavior, True costs
-            nothing at zero backward-compat risk and closes the bypass where
-            a deployment sets tenant_grants but never wires caller_identity,
-            silently trusting the self-asserted body tenant_id. Pass False
-            explicitly to opt into the weaker metadata-fallback channel (only
-            appropriate for deployments with no transport-level identity
-            resolution). A no-op when tenant_grants is empty (isolation OFF).
+            resolves the tenant ONLY from the server-verified context tenant or
+            a trusted ``McpCallerIdentity``; an absent, or tenant-less, trusted
+            identity resolves straight to no-tenant (fail-closed). SECURE BY
+            DEFAULT: closes the bypass where a deployment sets tenant_grants but
+            never wires caller_identity. As of issue #1919 the self-asserted
+            ``metadata["tenant_id"]`` fallback is DEPRECATED and no longer
+            honored in ANY mode: passing False no longer opts into a trusted
+            metadata channel -- a caller that relied on it now receives a
+            ``DeprecationWarning`` and the decision fails closed (no tenant
+            resolved). False is retained only for the documented #1843
+            weaker-mode surface and no longer grants the metadata channel.
+            A no-op when tenant_grants is empty (isolation OFF).
 
     Raises:
         ValueError: If max_audit_entries is < 1, or a tenant_grants key does
@@ -332,18 +333,17 @@ class McpActionContext:
         metadata: Additional context for governance evaluation. Carries the
             free-form, SELF-ASSERTED ``metadata["tenant_id"]`` channel
             (issue #1843) -- a caller-supplied value the enforcer treats as
-            untrusted input. It is the WEAKER, opt-in fallback consulted ONLY
-            when ``McpGovernanceConfig.require_caller_identity`` is False AND
-            neither the first-class ``tenant`` field nor a trusted
-            ``McpCallerIdentity`` resolves a tenant. Under the secure default
-            (``require_caller_identity=True``) it is NEVER trusted for the
-            governance decision.
+            untrusted input. As of issue #1919 it is NEVER consulted for the
+            tenant governance decision in ANY mode; a caller that still sets it
+            under the deprecated ``require_caller_identity=False`` weaker mode
+            receives a ``DeprecationWarning`` and the decision fails closed.
         tenant: The FIRST-CLASS, SERVER-VERIFIED tenant for this call (issue
             #1878), DISTINCT from the free-form ``metadata`` map. This is the
             AUTHORITATIVE tenant-isolation input: governance enforcement reads
-            THIS field (highest trust), ranking it above both the sidecar
-            ``McpCallerIdentity`` and the self-asserted
-            ``metadata["tenant_id"]``. It is populated SERVER-SIDE at the
+            THIS field (highest trust), ranking it above the sidecar
+            ``McpCallerIdentity``; the self-asserted ``metadata["tenant_id"]``
+            is no longer a ranked resolution source (issue #1919). It is
+            populated SERVER-SIDE at the
             network boundary from the authenticated transport/token (see
             ``from_network_transport`` and ``McpGovernanceMiddleware``), NEVER
             from the client wire body. Deliberately EXCLUDED from the wire
@@ -509,8 +509,9 @@ class McpResourceContext:
         timestamp: When the invocation was initiated.
         metadata: Additional context for governance evaluation. Carries the
             same free-form, self-asserted ``metadata["tenant_id"]`` channel
-            as :attr:`McpActionContext.metadata` -- the weaker, opt-in
-            fallback, never trusted under the secure default.
+            as :attr:`McpActionContext.metadata` -- never consulted for the
+            tenant decision in any mode (issue #1919); exercising it under the
+            deprecated weaker mode emits a ``DeprecationWarning``.
         tenant: The FIRST-CLASS, SERVER-VERIFIED tenant for this resource read
             (issue #1878), DISTINCT from the free-form ``metadata`` map and
             the authoritative tenant-isolation input -- see
@@ -615,18 +616,20 @@ class McpCallerIdentity:
     Deliberately carries NO ``to_dict()`` / ``from_dict()``: this object is
     NOT part of the wire-serialized MCP envelope (``McpActionContext`` /
     ``McpResourceContext`` stay frozen -- byte-neutral per the issue #1843
-    contract). Its ``tenant`` is the AUTHORITATIVE tenant for the call and
-    OVERWRITES any self-asserted ``metadata["tenant_id"]`` on the action or
-    resource context -- the impersonation-defeat mechanism: a caller cannot
-    widen its own access by putting a different tenant in the request body,
-    because the enforcer trusts this identity over the body.
+    contract). Its ``tenant`` is the AUTHORITATIVE tenant for the call when no
+    server-verified context tenant is present -- the impersonation-defeat
+    mechanism: a caller cannot widen its own access by putting a different
+    tenant in the request body, because the self-asserted
+    ``metadata["tenant_id"]`` is no longer consulted for tenant resolution
+    (issue #1919).
 
     Attributes:
         agent_id: Identifier of the authenticated agent/caller.
         tenant: The tenant this caller was authenticated as. None means the
-            transport layer did not resolve a tenant for this caller (the
-            enforcer then falls back to the self-asserted
-            ``metadata["tenant_id"]``, which is weaker but not absent).
+            transport layer did not resolve a tenant for this caller; under
+            active isolation the decision then fails closed -- the
+            self-asserted ``metadata["tenant_id"]`` is no longer consulted
+            (issue #1919).
 
     Raises:
         ValueError: If tenant is not a string or None.

--- a/packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py
@@ -361,42 +361,56 @@ class TestImpersonationDefeat:
     def test_metadata_tenant_id_fallback_when_no_caller_identity_supplied(
         self,
     ) -> None:
-        """The metadata["tenant_id"] fallback is now OPT-IN
-        (require_caller_identity defaults to True -- secure by default,
-        issue #1843 redteam round 1). A deployment that explicitly opts
-        into the weaker channel (require_caller_identity=False) still
-        gets the fallback consulted when no trusted identity is supplied."""
+        """CONTRACT CHANGED (issue #1919): the metadata["tenant_id"] fallback
+        under the documented weaker mode (require_caller_identity=False) is
+        DEPRECATED and NO LONGER trusted. A client-asserted tenant can no
+        longer influence the decision in ANY mode. This test previously
+        expected auto_approved via the metadata fallback; it now expects a
+        DeprecationWarning AND a fail-closed BLOCKED decision (no tenant
+        resolved), never auto-approval."""
         enf = McpGovernanceEnforcer(
             _config(tenant_grants=_two_tenant_grants(), require_caller_identity=False)
         )
         ctx = _tool_ctx(tool_name="tool-a", metadata={"tenant_id": "tenant-a"})
-        decision = enf.check_tool_call(ctx)
-        assert decision.level == "auto_approved"
+        with pytest.warns(DeprecationWarning):
+            decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
+        assert "no tenant was declared" in decision.reason
 
     def test_metadata_tenant_id_fallback_still_fails_closed_if_ungranted(
         self,
     ) -> None:
-        """Opt-in fallback (require_caller_identity=False) still fails
-        closed when the self-asserted tenant lacks a grant for the tool --
-        the fallback is weaker than trusted identity, never permissive."""
+        """CONTRACT CHANGED (issue #1919): under the weaker mode
+        (require_caller_identity=False) a self-asserted tenant is no longer
+        trusted, so the decision fails closed on "no tenant declared" (not on
+        "not granted") and a DeprecationWarning fires. It remains BLOCKED --
+        the deprecated channel is never permissive."""
         enf = McpGovernanceEnforcer(
             _config(tenant_grants=_two_tenant_grants(), require_caller_identity=False)
         )
         ctx = _tool_ctx(tool_name="tool-b", metadata={"tenant_id": "tenant-a"})
-        decision = enf.check_tool_call(ctx)
+        with pytest.warns(DeprecationWarning):
+            decision = enf.check_tool_call(ctx)
         assert decision.level == "blocked"
 
-    def test_caller_identity_with_no_tenant_falls_back_to_metadata(self) -> None:
-        """With the opt-in weaker channel (require_caller_identity=False),
-        caller_identity is supplied but its own tenant is None -- the
-        metadata fallback still applies (not a hard override to "no tenant")."""
+    def test_caller_identity_with_no_tenant_no_longer_falls_back_to_metadata(
+        self,
+    ) -> None:
+        """CONTRACT CHANGED (issue #1919): with the weaker mode
+        (require_caller_identity=False) and a caller_identity whose own tenant
+        is None, the metadata fallback is NO LONGER consulted. This test
+        previously expected auto_approved via the metadata fallback; it now
+        expects a DeprecationWarning AND a fail-closed BLOCKED decision."""
         enf = McpGovernanceEnforcer(
             _config(tenant_grants=_two_tenant_grants(), require_caller_identity=False)
         )
         identity = McpCallerIdentity(agent_id="agent-1", tenant=None)
         ctx = _tool_ctx(tool_name="tool-a", metadata={"tenant_id": "tenant-a"})
-        decision = enf.check_tool_call(ctx, caller_identity=identity)
-        assert decision.level == "auto_approved"
+        with pytest.warns(DeprecationWarning):
+            decision = enf.check_tool_call(ctx, caller_identity=identity)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-pact/tests/regression/test_issue_1919_mcp_metadata_scrub.py
+++ b/packages/kailash-pact/tests/regression/test_issue_1919_mcp_metadata_scrub.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #1919 -- deprecate the untrusted
+metadata["tenant_id"] tenant fallback in MCP governance.
+
+Background (issue #1843 → #1919): #1843 introduced first-class MCP tenant
+isolation with a secure default (``require_caller_identity=True``) and a
+documented WEAKER mode (``require_caller_identity=False``) that, as a
+last-resort fallback, trusted a client-asserted ``metadata["tenant_id"]`` as
+the effective tenant. That fallback let a client-supplied body value influence
+a tenant-isolation decision -- exactly the impersonation surface first-class
+tenant isolation exists to close, merely narrowed to one opt-in mode.
+
+Issue #1919 (Option B, user-ratified): DEPRECATE that fallback so a
+client-asserted tenant can NEVER influence tenant decisions in ANY mode. The
+single enforcer decision chokepoint (``_resolve_effective_tenant``) no longer
+trusts ``metadata["tenant_id"]`` in the weaker branch; when a caller exercises
+the now-deprecated path a ``DeprecationWarning`` fires (naming the migration:
+provide a trusted caller identity / server-verified tenant, or set
+``require_caller_identity=True``) and the resolution returns ``None``, which
+fails the downstream tenant-isolation decision CLOSED. A defense-in-depth
+scrub at the middleware boundary drops ``metadata["tenant_id"]`` before the
+context is built, so the client-asserted value never propagates into
+audit/echo surfaces either.
+
+Invariants exercised here:
+
+1. Verified/trusted precedence unchanged (covered by #1843/#1878 suites).
+2. Secure default (``require_caller_identity=True``) is byte-identical /
+   inert to metadata AND does NOT warn (the deprecated path is never reached).
+3. Under ``require_caller_identity=False`` a client-asserted
+   ``metadata["tenant_id"]`` can NO LONGER influence the decision (AC#3) AND
+   the decision fails CLOSED (never fail-open) when no trusted tenant resolves.
+4. A ``DeprecationWarning`` fires EXACTLY when a caller exercises the
+   now-deprecated fallback path -- never on the secure-default path.
+
+Tier-2 real behavior: real ``McpGovernanceEnforcer`` / ``McpGovernanceConfig``
+/ ``McpGovernanceMiddleware`` objects; the enforcement decision is NEVER
+mocked. The middleware tests use a real capturing subclass that records the
+context the middleware built and delegates the actual decision to
+``super()``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pact.mcp.enforcer import GovernanceDecision, McpGovernanceEnforcer
+from pact.mcp.middleware import McpGovernanceMiddleware
+from pact.mcp.types import (
+    DefaultPolicy,
+    McpActionContext,
+    McpCallerIdentity,
+    McpGovernanceConfig,
+    McpResourceContext,
+    McpTenantGrant,
+)
+
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _grants() -> dict[str, McpTenantGrant]:
+    return {
+        "tenant-a": McpTenantGrant(
+            tenant="tenant-a",
+            tools=frozenset({"tool-a"}),
+            resources=frozenset({"resource://tenant-a/doc"}),
+        ),
+    }
+
+
+def _weaker_config() -> McpGovernanceConfig:
+    """The documented #1843 weaker mode -- the ONLY mode that ever consulted
+    the (now-deprecated) metadata fallback."""
+    return McpGovernanceConfig(
+        default_policy=DefaultPolicy.ALLOW,
+        tenant_grants=_grants(),
+        require_caller_identity=False,
+        audit_enabled=False,
+    )
+
+
+def _secure_config() -> McpGovernanceConfig:
+    """The secure default -- metadata is never consulted; no deprecation."""
+    return McpGovernanceConfig(
+        default_policy=DefaultPolicy.ALLOW,
+        tenant_grants=_grants(),
+        require_caller_identity=True,
+        audit_enabled=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC#3 -- a client-asserted metadata["tenant_id"] cannot influence the
+# decision even under the weaker mode, on BOTH surfaces.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestMetadataTenantCannotInfluenceDecision:
+    def test_tool_call_metadata_tenant_does_not_auto_approve(self) -> None:
+        """A body-asserted tenant that names a GRANTED tenant/tool would, under
+        the old fallback, have auto-approved. It now fails CLOSED (no tenant
+        resolved) -- the metadata value has zero influence on the decision."""
+        enf = McpGovernanceEnforcer(_weaker_config())
+        ctx = McpActionContext(
+            tool_name="tool-a",
+            agent_id="agent-1",
+            metadata={"tenant_id": "tenant-a"},  # matches a real grant
+            timestamp=_T0,
+        )
+        with pytest.warns(DeprecationWarning):
+            decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
+        assert "no tenant was declared" in decision.reason
+        # The client-asserted tenant name must NOT appear as the resolved
+        # tenant in the reason (it was not honored).
+        assert "not a recognized tenant" not in decision.reason
+
+    def test_resource_read_metadata_tenant_does_not_auto_approve(self) -> None:
+        """Same as above for the resources/read surface (Enforcement-Surface
+        Parity -- both surfaces share the one decision chokepoint)."""
+        enf = McpGovernanceEnforcer(_weaker_config())
+        ctx = McpResourceContext(
+            uri="resource://tenant-a/doc",
+            agent_id="agent-1",
+            metadata={"tenant_id": "tenant-a"},
+            timestamp=_T0,
+        )
+        with pytest.warns(DeprecationWarning):
+            decision = enf.check_resource_read(ctx)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
+        assert "no tenant was declared" in decision.reason
+
+    def test_trusted_identity_still_wins_over_body(self) -> None:
+        """Precedence invariant #1: a trusted caller_identity.tenant still
+        resolves the decision even under the weaker mode -- and because a
+        trusted source resolved, the deprecated metadata branch is never
+        reached, so NO DeprecationWarning fires."""
+        enf = McpGovernanceEnforcer(_weaker_config())
+        identity = McpCallerIdentity(agent_id="agent-1", tenant="tenant-a")
+        ctx = McpActionContext(
+            tool_name="tool-a",
+            agent_id="agent-1",
+            metadata={"tenant_id": "tenant-b"},  # a lie; must be ignored
+            timestamp=_T0,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            decision = enf.check_tool_call(ctx, caller_identity=identity)
+        assert decision.level == "auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed -- a None effective tenant DENIES, never fail-open.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestFailsClosedOnNoTenant:
+    def test_weaker_mode_no_metadata_no_identity_blocks(self) -> None:
+        """Weaker mode, isolation ON, no tenant from any source and NO
+        metadata tenant_id present (so no deprecated path exercised) -- the
+        decision fails CLOSED with no warning."""
+        enf = McpGovernanceEnforcer(_weaker_config())
+        ctx = McpActionContext(tool_name="tool-a", agent_id="agent-1", timestamp=_T0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
+        assert "no tenant was declared" in decision.reason
+
+    def test_non_string_metadata_tenant_does_not_warn_and_blocks(self) -> None:
+        """A non-str metadata tenant_id (e.g. a nested dict) was never a valid
+        fallback value; it does not trip the deprecation warning and still
+        fails closed."""
+        enf = McpGovernanceEnforcer(_weaker_config())
+        ctx = McpActionContext(
+            tool_name="tool-a",
+            agent_id="agent-1",
+            metadata={"tenant_id": {"nested": "obj"}},
+            timestamp=_T0,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Secure default is unchanged AND does not warn.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestSecureDefaultUnchanged:
+    def test_secure_default_blocks_body_tenant_without_warning(self) -> None:
+        """Invariant #2: the secure default returns None BEFORE the metadata
+        branch is ever reached, so a body-asserted tenant is inert AND no
+        DeprecationWarning fires (the deprecated path is unreachable here)."""
+        enf = McpGovernanceEnforcer(_secure_config())
+        ctx = McpActionContext(
+            tool_name="tool-a",
+            agent_id="agent-1",
+            metadata={"tenant_id": "tenant-a"},
+            timestamp=_T0,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            decision = enf.check_tool_call(ctx)
+        assert decision.level == "blocked"
+        assert "no tenant was declared" in decision.reason
+
+    def test_default_config_require_caller_identity_stays_true(self) -> None:
+        """The secure default byte-identity guard: an unset
+        require_caller_identity is True (unchanged by #1919)."""
+        assert McpGovernanceConfig().require_caller_identity is True
+
+
+# ---------------------------------------------------------------------------
+# Middleware defense-in-depth: metadata["tenant_id"] is scrubbed at the
+# boundary and never reaches the built context (audit/echo hygiene).
+# ---------------------------------------------------------------------------
+
+
+class _CapturingEnforcer(McpGovernanceEnforcer):
+    """Records the context the middleware built, then delegates the REAL
+    decision to ``super()``. Not a mock of the enforcement decision -- the
+    actual governance logic runs; this only observes the context that was
+    handed to it."""
+
+    def __init__(self, config: McpGovernanceConfig) -> None:
+        super().__init__(config)
+        self.captured_tool_ctx: McpActionContext | None = None
+        self.captured_resource_ctx: McpResourceContext | None = None
+
+    def check_tool_call(
+        self,
+        context: McpActionContext,
+        *,
+        caller_identity: McpCallerIdentity | None = None,
+    ) -> GovernanceDecision:
+        self.captured_tool_ctx = context
+        return super().check_tool_call(context, caller_identity=caller_identity)
+
+    def check_resource_read(
+        self,
+        context: McpResourceContext,
+        *,
+        caller_identity: McpCallerIdentity | None = None,
+    ) -> GovernanceDecision:
+        self.captured_resource_ctx = context
+        return super().check_resource_read(context, caller_identity=caller_identity)
+
+
+async def _noop_handler(tool_name: str, args: dict[str, Any]) -> Any:
+    return {"status": "ok"}
+
+
+async def _noop_resource_handler(uri: str) -> Any:
+    return {"body": "content"}
+
+
+@pytest.mark.regression
+@pytest.mark.security
+class TestMiddlewareScrubsMetadataTenant:
+    async def test_invoke_context_metadata_drops_tenant_id(self) -> None:
+        enf = _CapturingEnforcer(_weaker_config())
+        mw = McpGovernanceMiddleware(enf, _noop_handler)
+        # A client-asserted tenant_id plus a legitimate sibling key.
+        with warnings.catch_warnings():
+            # The scrub removes tenant_id BEFORE the enforcer sees it, so the
+            # deprecated fallback path is not exercised via the middleware --
+            # no DeprecationWarning is expected here.
+            warnings.simplefilter("error", DeprecationWarning)
+            await mw.invoke(
+                "tool-a",
+                agent_id="agent-1",
+                metadata={"tenant_id": "tenant-a", "trace": "keep-me"},
+            )
+        ctx = enf.captured_tool_ctx
+        assert ctx is not None
+        assert "tenant_id" not in ctx.metadata
+        # Non-tenant metadata is preserved.
+        assert ctx.metadata.get("trace") == "keep-me"
+        # The verified tenant field is populated only from caller_identity
+        # (absent here), never from the body.
+        assert ctx.tenant is None
+
+    async def test_invoke_resource_read_context_metadata_drops_tenant_id(
+        self,
+    ) -> None:
+        enf = _CapturingEnforcer(_weaker_config())
+        mw = McpGovernanceMiddleware(
+            enf, _noop_handler, resource_handler=_noop_resource_handler
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            await mw.invoke_resource_read(
+                "resource://tenant-a/doc",
+                agent_id="agent-1",
+                metadata={"tenant_id": "tenant-a", "trace": "keep-me"},
+            )
+        ctx = enf.captured_resource_ctx
+        assert ctx is not None
+        assert "tenant_id" not in ctx.metadata
+        assert ctx.metadata.get("trace") == "keep-me"
+        assert ctx.tenant is None
+
+    async def test_invoke_verified_tenant_still_from_caller_identity(self) -> None:
+        """The scrub does not disturb the verified tenant path: a trusted
+        caller_identity.tenant still populates context.tenant."""
+        enf = _CapturingEnforcer(_weaker_config())
+        mw = McpGovernanceMiddleware(enf, _noop_handler)
+        identity = McpCallerIdentity(agent_id="agent-1", tenant="tenant-a")
+        result = await mw.invoke(
+            "tool-a",
+            agent_id="agent-1",
+            caller_identity=identity,
+            metadata={"tenant_id": "tenant-b"},  # lie; scrubbed + ignored
+        )
+        ctx = enf.captured_tool_ctx
+        assert ctx is not None
+        assert "tenant_id" not in ctx.metadata
+        assert ctx.tenant == "tenant-a"
+        # A granted tenant/tool → the call is allowed and the handler ran.
+        assert result.decision.level == "auto_approved"
+        assert result.executed is True


### PR DESCRIPTION
## Summary

Closes #1919 (defense-in-depth follow-up to #1878). Deprecates the client-asserted `metadata['tenant_id']` tenant fallback so a self-asserted tenant can **never** influence a governance decision in **any** mode.

**User-ratified disposition (Option B):** revise the documented #1843 weaker mode rather than preserve it. Shipped with a `DeprecationWarning` + CHANGELOG migration guide.

## Behavior change

Under the **secure default** (`require_caller_identity=True`) — **byte-identical, no change**. The enforcer already short-circuits to `None` before ever reading `metadata['tenant_id']`; a client could not influence the tenant decision, and still cannot.

Under the **weaker mode** (`require_caller_identity=False`, the documented #1843 fallback) — **behavior revised**: `_resolve_effective_tenant` no longer trusts `metadata['tenant_id']`. When a caller relies on the deprecated path (no verified tenant, no caller identity, but a body `tenant_id` present), it now:
1. emits a `DeprecationWarning` naming the migration (provide caller identity, or set `require_caller_identity=True`), and
2. returns `None` → the decision **fails closed** (`blocked`, "no tenant was declared") instead of trusting the self-asserted tenant.

Defense-in-depth: the middleware `invoke` / `invoke_resource_read` now also scrub `metadata['tenant_id']` at the boundary (mirroring the existing `from_network_transport` scrub), so a client-asserted tenant never propagates into the governance context or audit surfaces.

## Why

A client-asserted `metadata['tenant_id']` could influence tenant-isolation decisions under the opt-in weaker mode — a self-asserted trust channel. This aligns MCP governance with the verified-identity trust model established by #1878/#1912 (verified fields win; self-assertion is never trusted).

## Enforcement-surface parity

Grep of every `metadata['tenant_id']` reader in `packages/kailash-pact/src`: the single MCP-governance decision-path reader is `enforcer.py::_resolve_effective_tenant` (now deprecated). Both `from_network_transport` surfaces already scrub. The middleware now scrubs. No third reader exists — all covered in this change.

## Migration (for deployments using `require_caller_identity=False` with body `tenant_id`)

Provide an authenticated caller identity (`caller_identity` with a `.tenant`), **or** keep `require_caller_identity=True` (the default). Relying on `metadata['tenant_id']` for tenant resolution now fails closed and warns.

## Tests
`276 passed` (`tests/regression` + `tests/unit/mcp`); ruff clean. Three #1843 regression tests revised to the new contract (with `#1919` provenance comments); new `test_issue_1919_mcp_metadata_scrub.py` (fail-closed on None tenant, DeprecationWarning fires on the deprecated path, secure default unchanged/no-warn, middleware context scrubbed, for both tool-call and resource-read).

## Related issues
Closes #1919. Follow-up to #1878. Revises the #1843 weaker-mode contract (documented + migration above).