### PR TITLE
release: kaizen-agents 0.11.5 (#1918) + kailash-pact 0.18.0 (#1919)

### DIFF
--- a/packages/kailash-pact/CHANGELOG.md
+++ b/packages/kailash-pact/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PACT Changelog
 
-## [Unreleased] — Deprecate the untrusted metadata['tenant_id'] tenant fallback (#1919)
+## [0.18.0] — 2026-07-22 — Deprecate the untrusted metadata['tenant_id'] tenant fallback (#1919)
 
 ### Changed (Security)
 

--- a/packages/kailash-pact/README.md
+++ b/packages/kailash-pact/README.md
@@ -83,7 +83,7 @@ enforces **today** versus what remains open — read it before relying on
 - **Verify:** `pytest packages/kailash-pact/tests/regression/test_issue_1843_mcp_tenant_isolation.py -v`
   exercises the fail-closed defaults, the impersonation-defeat contract, and
   the `resources/read` isolation-only surface end-to-end.
-- **Status:** v0 within a pre-1.0 package (`kailash-pact` 0.16.0) — the
+- **Status:** v0 within a pre-1.0 package (`kailash-pact` 0.18.0) — the
   isolation contract above is stable for this release; the deferred items
   may change shape (not just grow) before a 1.0 cut.
 

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.17.0"
+version = "0.18.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.5] — 2026-07-22 — Infer provider from model prefix in zero-config Delegate (#1918)
+
+### Fixed
+
+- **Zero-config `Delegate(model="claude-*")` no longer routes to the OpenAI wire (#1918).** `KzConfig.provider` defaulted to the non-empty string `"openai"`, which `AgentLoop._build_adapter` forwarded as an _explicit_ provider to `get_adapter_for_model`, short-circuiting the model-name-prefix fallback (`claude-`→anthropic, `gemini-`→google). A zero-config `claude-*`/`gemini-*` model therefore built an OpenAI adapter pointed at `api.openai.com` (sending the wrong provider's key to the wrong endpoint). The default is now the empty-string sentinel `""`, aligning with `get_adapter_for_model`'s own unset sentinel so the prefix fallback runs on the no-client path; explicit `provider=` / `KZ_PROVIDER` / `.kz` config still win, and zero-config `gpt-*`/unknown-prefix models still default to OpenAI (unchanged). The prior regression test called the registry directly (bypassing `Delegate`), masking the bug — new tests exercise the full `Delegate` → adapter path end-to-end.
+- **Print-mode `max_turns` override no longer drops the deployment client (#1918).** `PrintRunner`'s `max_turns`-override branch rebuilt `KzConfig` field-by-field and omitted `base_url`/`api_key`, silently dropping a #1899 deployment client; combined with the provider-default fix, a `claude-*` model pinned to a custom endpoint would then re-infer to the prefix provider's real wire instead of the caller's deployment. The reconstruction now preserves every field.
+
 ## [0.11.4] — 2026-07-22 — Route agent completion by the passed client, not the model prefix (#1899)
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.4"
+version = "0.11.5"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

Release-prep (metadata-only) for the two fixes merged this session.

| Package | From | To | Change |
| --- | --- | --- | --- |
| kaizen-agents | 0.11.4 | **0.11.5** (patch) | #1918 — zero-config `Delegate(model="claude-*")` no longer routes to the OpenAI wire; print-mode `max_turns` override no longer drops the deployment client |
| kailash-pact | 0.17.0 | **0.18.0** (minor) | #1919 — deprecates the untrusted `metadata['tenant_id']` tenant fallback (DeprecationWarning + fail-closed); secure default byte-identical |

## Version choice rationale

- **kaizen-agents 0.11.5** — patch: pure bug fix, no API/behavior change to correct usage.
- **kailash-pact 0.18.0** — minor: #1919 changes the behavior of the documented `require_caller_identity=False` weaker mode (the self-asserted `metadata['tenant_id']` fallback is no longer honored → `DeprecationWarning` + fail-closed). Shipped with a deprecation warning + CHANGELOG migration, not a hard removal; the secure default (`require_caller_identity=True`) is byte-identical. Pre-1.0 minor bump signals the behavior change, consistent with #1878 (0.17.0) and the trust-store hardening pattern.

## Verification (pre-merge)
- Both fixes merged to main (#1922 → ee36f700; #1923 → f98a6cc6), CI green on each.
- #1918 converged: 2 clean redteam rounds + in-session INVEST-NOW print_mode fix.
- #1919 converged: security CLEAN ×3 rounds (fail-open confirmed closed), correctness clean after a complete doc-sweep.
- Version consistency verified (pyproject == `__init__` for both packages).

## Related issues
Releases the fixes for #1918 and #1919. Metadata-only; the `release/*` branch auto-skips the heavy PR-gate matrix.