### PR TITLE
fix(kaizen): thread temperature/max_tokens overrides into Delegate; docs(trust): correct constraint_subset docstring

### DIFF
--- a/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
@@ -406,11 +406,26 @@ class Delegate:
             # stored on the Delegate but never reached the adapter, so an
             # OpenAI-compatible / Azure / custom-endpoint deployment client was
             # dropped and every completion hit api.openai.com.
+            #
+            # Thread the documented temperature/max_tokens overrides onto the
+            # config too (same #1899-class drop, one field over): both are
+            # accepted + documented on __init__ but were omitted here, so the
+            # KzConfig defaults (temperature=0.4, max_tokens=16384) silently won
+            # over an explicit caller override. Only forward when set so an
+            # unspecified override still inherits the KzConfig default (the
+            # dataclass fields are non-Optional, so passing None would clobber
+            # the default with None).
+            _gen_overrides: dict[str, Any] = {}
+            if temperature is not None:
+                _gen_overrides["temperature"] = temperature
+            if max_tokens is not None:
+                _gen_overrides["max_tokens"] = max_tokens
             self._config = KzConfig(
                 model=resolved_model,
                 max_turns=max_turns,
                 base_url=base_url,
                 api_key=api_key,
+                **_gen_overrides,
             )
 
         # Build tool registry

--- a/packages/kaizen-agents/tests/unit/test_llm_routing.py
+++ b/packages/kaizen-agents/tests/unit/test_llm_routing.py
@@ -255,3 +255,39 @@ class TestZeroConfigDelegateProviderRouting:
         adapter = _loop_adapter(delegate)
         assert isinstance(adapter, OpenAIStreamAdapter)
         assert str(adapter._client.base_url).rstrip("/") == endpoint
+
+    def test_temperature_max_tokens_overrides_reach_config(self):
+        """Regression guard (#1899-class, one field over): the documented
+        temperature/max_tokens overrides on Delegate.__init__ MUST reach the
+        KzConfig the loop reads. Previously both were accepted + documented but
+        omitted from the zero-config KzConfig build, so the caller's override was
+        silently dropped and the KzConfig defaults (0.4 / 16384) always won."""
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(
+            model="gpt-4o",
+            temperature=0.91,
+            max_tokens=1234,
+            api_key=_FAKE_KEY,
+            ungoverned=True,
+        )
+        assert delegate._config.temperature == 0.91, (
+            "explicit temperature override was dropped before the KzConfig build "
+            "(#1899-class documented-kwarg drop)"
+        )
+        assert delegate._config.max_tokens == 1234, (
+            "explicit max_tokens override was dropped before the KzConfig build "
+            "(#1899-class documented-kwarg drop)"
+        )
+
+    def test_unset_temperature_max_tokens_inherit_config_defaults(self):
+        """A Delegate built WITHOUT temperature/max_tokens MUST inherit the
+        KzConfig defaults (0.4 / 16384), not None — the override plumbing only
+        forwards the values when the caller sets them (the dataclass fields are
+        non-Optional, so forwarding None would clobber the default)."""
+        from kaizen_agents.delegate.config.loader import KzConfig
+        from kaizen_agents.delegate.delegate import Delegate
+
+        delegate = Delegate(model="gpt-4o", api_key=_FAKE_KEY, ungoverned=True)
+        assert delegate._config.temperature == KzConfig.temperature
+        assert delegate._config.max_tokens == KzConfig.max_tokens

--- a/src/kailash/trust/chain.py
+++ b/src/kailash/trust/chain.py
@@ -21,17 +21,12 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from kailash.trust.signing.crypto import (
-    hash_trust_chain_state,
-    hash_trust_chain_state_salted,
-)
-
 # Structured engine-fold dataclasses (#1841 S2b-1). A DelegationRecord carrying
 # all three signs the cross-SDK V2Complete pre-image instead of legacy-python-v0
 # (see kailash.trust.signing.delegation_record_signing.select_signing_version).
-# Safe at module scope: this file already imports kailash.trust.signing.crypto
-# above (initialising the signing package), and delegation_payload depends only
-# on kailash.trust._json — no cycle back to chain.
+# Safe at module scope: importing these kailash.trust.signing submodules
+# initialises the signing package, and delegation_payload depends only on
+# kailash.trust._json — no cycle back to chain.
 from kailash.trust.signing.capability_fold_serde import (
     deserialize_capability_fold_fields,
     serialize_capability_fold_fields,
@@ -39,6 +34,10 @@ from kailash.trust.signing.capability_fold_serde import (
 from kailash.trust.signing.chain_state_serde import (
     deserialize_chain_state_signature_fields,
     serialize_chain_state_signature_fields,
+)
+from kailash.trust.signing.crypto import (
+    hash_trust_chain_state,
+    hash_trust_chain_state_salted,
 )
 from kailash.trust.signing.delegation_fold_serde import (
     deserialize_fold_fields,
@@ -348,12 +347,20 @@ class DelegationRecord:
         delegatee_id: Agent receiving trust
         task_id: Associated task identifier
         capabilities_delegated: Which capabilities are delegated
-        constraint_subset: Additional advisory constraint labels. Reporting-only:
-            surfaced in VerificationResult.effective_constraints but read by NO
-            allow/deny gate, and NOT part of the signed delegation pre-image.
-            The "tightening" is advisory — establish_delegation unions these
-            labels with no subset check; enforcement lives in constraint_envelope
-            (a separate, signed structure), not here. See issue #1896.
+        constraint_subset: Additional "tightening-only" constraint labels. The
+            RAW field is reporting-only — surfaced in
+            VerificationResult.effective_constraints but read by NO allow/deny
+            gate, and DELIBERATELY EXCLUDED from the enforced envelope
+            (``_derive_enforced_envelope``, advisory per #1896). Its signing
+            coverage is version-dependent: the legacy (default) pre-image signs
+            it via ``to_signing_payload()`` (so tampering breaks the signature
+            on legacy records), while the v2/v3 engine fold omits it
+            (``_FoldSourceRecord``). The tightening is NOT a no-op, though: the
+            same labels are bound into SIGNED derived capabilities at delegation
+            time (``_build_signed_derived_caps``) and verify() re-derives the
+            enforced constraint set from those signed sources — so the tightening
+            IS enforced and a store-writer editing only the raw field cannot
+            strip it. See issue #1896.
         delegated_at: When delegation occurred
         expires_at: Optional expiration
         signature: Delegator's signature


### PR DESCRIPTION
## Summary

Two fixes surfaced by an **independent cross-session adversarial `/redteam`** of the delivered #1720 surfaces (the prior session declared convergence on self-attestation; this pass verified it against ground truth and found a real bug the earlier check missed).

### 1. `fix(kaizen)` — `Delegate` dropped documented `temperature`/`max_tokens` overrides (BUG)

`Delegate.__init__` accepts and documents `temperature` and `max_tokens` as LLM override params, but the zero-config `KzConfig` build omitted both — so an explicit caller override was silently dropped and the KzConfig defaults (`temperature=0.4`, `max_tokens=16384`) always won. A caller pinning `temperature=0` for determinism silently got `0.4`.

This is the **same documented-kwarg-drop class as the shipped #1899 `base_url`/`api_key` fix, one field over** — the #1720 cont-12 convergence only checked `base_url`/`api_key` and stopped there.

- Fix threads both into the config build, forwarding **only when set** (the KzConfig fields are non-Optional with defaults, so forwarding `None` would clobber the default).
- **Completeness sweep**: every documented `Delegate.__init__` param was traced to its consumer — `temperature`/`max_tokens` were the only two silent drops in the *config* path. (Two further documented-but-unwired params — `inner_agent`, `signature` — are a separate, deeper disposition tracked outside this PR; they need a wire-vs-remove decision, not a mechanical thread.)
- +2 regression tests in `test_llm_routing.py` (override reaches config; unset inherits default). 600 delegate-surface tests pass.

### 2. `docs(trust)` — corrected `constraint_subset` docstring (#1896)

The docstring claimed `constraint_subset` is "NOT part of the signed pre-image" and "gates nothing" — both imprecise:
- The **legacy (default)** pre-image *does* sign it via `to_signing_payload` (tampering breaks the signature there); only the v2/v3 fold omits it.
- While the **raw field** is read by no allow/deny gate and is excluded from the enforced envelope (`_derive_enforced_envelope`, advisory per #1896), the **tightening it carries IS enforced** — the same labels are bound into signed derived capabilities (`_build_signed_derived_caps`) that `verify()` re-derives enforcement from, so a store-writer editing only the raw field cannot strip it.

Docstring-only; runtime-inert. #1896's advisory-only disposition is unchanged. Also folds an incidental isort import-order normalization in the touched file.

## Test plan

- `pytest packages/kaizen-agents/tests/unit/test_llm_routing.py test_print_mode.py` → 39 pass (incl. 2 new regression tests)
- Broader kaizen delegate surface → 598 pass
- `constraint_subset` docstring claims verified against source (`to_signing_payload` L473, `_derive_enforced_envelope` L596, `_build_signed_derived_caps` L788)
- `pre-commit run` clean on all changed files

## Related issues

- Same bug class as #1899 (provider/deployment-client drop); one field over.
- Docstring correction for #1896 (`constraint_subset` advisory disposition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)