### PR TITLE
release: kaizen-agents 0.11.6 — Delegate temperature/max_tokens override fix

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.6] — 2026-07-22 — Thread temperature/max_tokens overrides into the Delegate config build
+
+### Fixed
+
+- **`Delegate(temperature=…, max_tokens=…)` now actually applies the override.** Both params were accepted and documented on `Delegate.__init__` as LLM overrides, but the zero-config `KzConfig` build omitted them — so an explicit caller override was silently dropped and the `KzConfig` defaults (`temperature=0.4`, `max_tokens=16384`) always won. A caller pinning `temperature=0` for determinism silently got `0.4`. Same documented-kwarg-drop class as the #1899 `base_url`/`api_key` fix, one field over. Both are now forwarded onto `KzConfig`, and only when set (an unspecified override still inherits the `KzConfig` default, since the fields are non-Optional). A completeness sweep of `Delegate.__init__` confirmed `temperature`/`max_tokens` were the only two params silently dropped in the config path. (Two further documented-but-unwired params, `signature` and `inner_agent`, are tracked separately in #1927 — they need a wire-vs-remove design decision, not a mechanical thread.)
+
 ## [0.11.5] — 2026-07-22 — Infer provider from model prefix in zero-config Delegate (#1918)
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.5"
+version = "0.11.6"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

Release PR for **kaizen-agents 0.11.6** (patch). Ships the fix merged in #1926 (`e1031cc9a`): `Delegate(temperature=…, max_tokens=…)` now applies the override instead of silently dropping it (the KzConfig defaults 0.4/16384 previously always won).

Metadata-only:
- `pyproject.toml` + `__init__.py` → `0.11.6` (version consistency)
- `CHANGELOG.md` → `[0.11.6]` entry

On merge, tag `kaizen-agents-v0.11.6` triggers the OIDC PyPI publish.

## Related issues

- Ships #1926 (the temperature/max_tokens fix). Same class as #1899.
- Follow-up #1927 (documented-but-unwired `signature`/`inner_agent`) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)