### PR TITLE
release: sync uv.lock to shipped workspace versions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1786,7 +1786,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.60.1"
+version = "2.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2483,7 +2483,7 @@ provides-extras = ["metrics", "dev"]
 
 [[package]]
 name = "kailash-pact"
-version = "0.16.1"
+version = "0.18.0"
 source = { editable = "packages/kailash-pact" }
 dependencies = [
     { name = "click" },
@@ -2521,7 +2521,7 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.11.3"
+version = "0.11.6"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Metadata-only: `uv lock` regenerated to sync the committed lockfile with the released `pyproject` versions. The lock lagged (`kailash 2.60.1 / kailash-pact 0.16.1 / kaizen-agents 0.11.3`) while main ships `2.61.0 / 0.18.0 / 0.11.6` — cont-11/12 + this session's releases bumped pyproject without syncing the lock.

Diff is **3 lines** — only the workspace member version pins, zero transitive dependency churn. A stale lock breaks `uv sync --locked` reproducibility for consumers.

## Related issues

- Lock catch-up for the releases in #1918/#1919 (cont-11/12) and #1926 (kaizen-agents 0.11.6, this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)