### PR TITLE
fix(kaizen): remove documented-but-unwired Delegate signature/inner_agent params (#1927)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.7] — 2026-07-23 — Remove documented-but-unwired Delegate `signature`/`inner_agent` params (#1927)
+
+### Removed
+
+- **Removed the unwired `Delegate(signature=…)` and `Delegate(inner_agent=…)` constructor params and the `Delegate.signature` property (#1927).** Both were accepted and documented but never wired — silent no-ops (the same documented-kwarg-drop class as the #1899 `base_url`/`api_key` and #1926 `temperature`/`max_tokens` fixes, but here the resolution is removal, not wiring):
+  - `signature` was documented as "enables structured outputs on the inner BaseAgent" but was only stored and returned by the `.signature` getter — never threaded to the loop/adapter, so structured outputs never took effect. The `Delegate` is a streaming autonomous-execution facade with no structured-output path by design; callers who need structured outputs should use the `BaseAgent` + `Signature` API (`kaizen.core`), which fully supports schema-constrained / response-format generation. Duplicating that into the streaming facade would have meant a second structured-output implementation across every provider adapter.
+  - `inner_agent` was documented as a "pre-built `BaseAgent` escape hatch" but was stored and never read — the `Delegate` always builds its own streaming loop. It is architecturally incompatible with the streaming `run()` (a generic `BaseAgent` exposes only batch `run`/`run_async`, no streaming interface). The `adapter=` and `config=` params remain the supported "bring your own engine" seams.
+  - The `core_agent` property docstring, which incorrectly claimed to return a "user-provided inner_agent", was corrected.
+  - Passing either keyword now raises `TypeError` — a loud, actionable failure — instead of silently doing nothing. Since neither param ever functioned, no caller could depend on the documented behavior; the only migration is to drop the now-rejected keyword.
+  - A structural completeness-guard test now asserts every `Delegate.__init__` param reaches a real consumer, so this documented-kwarg-drop class cannot silently regress.
+
 ## [0.11.6] — 2026-07-22 — Thread temperature/max_tokens overrides into the Delegate config build
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.6"
+version = "0.11.7"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.6"
+__version__ = "0.11.7"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
@@ -305,9 +305,6 @@ class Delegate:
     model:
         LLM model name (e.g., ``"claude-sonnet-4-20250514"``).
         Falls back to ``DEFAULT_LLM_MODEL`` env var if empty.
-    signature:
-        Optional Signature class for structured I/O.  When provided,
-        enables structured outputs on the inner BaseAgent.
     tools:
         List of tool names or a pre-built :class:`ToolRegistry`.
         When a list of strings is given, the Delegate creates an empty
@@ -334,9 +331,6 @@ class Delegate:
         Optional API key for the LLM provider.  Read from env if not set.
     base_url:
         Optional base URL override for the LLM provider endpoint.
-    inner_agent:
-        Optional pre-built :class:`BaseAgent` escape hatch.  When provided,
-        the Delegate wraps this agent directly instead of constructing one.
     adapter:
         Optional pre-built :class:`StreamingChatAdapter`.
     config:
@@ -353,7 +347,6 @@ class Delegate:
         self,
         model: str = "",
         *,
-        signature: type[Signature] | None = None,
         tools: ToolRegistry | list[str] | None = None,
         system_prompt: str | None = None,
         temperature: float | None = None,
@@ -364,7 +357,6 @@ class Delegate:
         envelope: ConstraintEnvelope | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
-        inner_agent: BaseAgent | None = None,
         adapter: StreamingChatAdapter | None = None,
         config: KzConfig | None = None,
         ungoverned: bool = False,
@@ -377,10 +369,8 @@ class Delegate:
                 raise ValueError("budget_usd must be non-negative")
 
         # Store new parameters for wrapper/introspection access
-        self._signature = signature
         self._api_key = api_key
         self._base_url = base_url
-        self._inner_agent = inner_agent
         # #1779 governance_required opt-out. Default False (fail-closed). The
         # _LoopAgent bridge below is built with llm_provider="mock" (a BRIDGE
         # ARTIFACT -- the real egress is the loop's adapter, gated with is_mock=
@@ -724,17 +714,12 @@ class Delegate:
 
     @property
     def core_agent(self) -> BaseAgent:
-        """The innermost BaseAgent (or user-provided inner_agent)."""
+        """The innermost BaseAgent in the wrapper stack (the ``_LoopAgent`` bridge)."""
         # Walk the wrapper stack via _loop_agent to the bottom
         agent = self._loop_agent
         while hasattr(agent, "_inner"):
             agent = agent._inner
         return agent
-
-    @property
-    def signature(self) -> type[Signature] | None:
-        """The Signature class passed to the constructor, or None."""
-        return self._signature
 
     @property
     def model(self) -> str:

--- a/packages/kaizen-agents/tests/unit/delegate/test_delegate_facade.py
+++ b/packages/kaizen-agents/tests/unit/delegate/test_delegate_facade.py
@@ -4,7 +4,8 @@
 
 Covers:
     - TASK-05-01: Module scaffold and imports
-    - TASK-05-02: Constructor signature with new params (signature, envelope, inner_agent)
+    - TASK-05-02: Constructor signature with new params (envelope, api_key, base_url)
+      (signature/inner_agent removed in 0.11.7, #1927 — documented but never wired)
     - TASK-05-03: Inner BaseAgent core build
     - TASK-05-04/05/06: Wrapper stacking (Monitored, L3Governed, Streaming)
     - TASK-05-07: Model resolution with env fallback
@@ -15,7 +16,7 @@ Covers:
     - TASK-05-27: run() event passthrough
     - TASK-05-28: run_sync() refusal under running loop
     - TASK-05-30: close() proxy
-    - TASK-05-31: Introspection properties (core_agent, signature, model)
+    - TASK-05-31: Introspection properties (core_agent, model)
     - TASK-05-32: consumed_usd / budget_remaining
 """
 
@@ -172,13 +173,16 @@ class TestConstructorSignature:
             ), f"Parameter {param_name} should be keyword-only"
 
     def test_new_parameters_present(self):
-        """SPEC-05 new parameters are present: signature, envelope, inner_agent."""
+        """SPEC-05 new parameters are present: envelope, api_key, base_url, etc.
+
+        ``signature`` and ``inner_agent`` were removed in 0.11.7 (#1927) — they
+        were documented but never wired (silent no-ops). See
+        ``test_removed_params_rejected`` below for the removal guard.
+        """
         sig = inspect.signature(Delegate.__init__)
         params = sig.parameters
 
-        assert "signature" in params
         assert "envelope" in params
-        assert "inner_agent" in params
         assert "api_key" in params
         assert "base_url" in params
         assert "temperature" in params
@@ -188,7 +192,7 @@ class TestConstructorSignature:
     def test_new_parameters_keyword_only(self):
         """All new parameters are keyword-only."""
         sig = inspect.signature(Delegate.__init__)
-        for name in ("signature", "envelope", "inner_agent", "api_key", "base_url"):
+        for name in ("envelope", "api_key", "base_url"):
             p = sig.parameters[name]
             assert (
                 p.kind == inspect.Parameter.KEYWORD_ONLY
@@ -198,9 +202,7 @@ class TestConstructorSignature:
         """New optional params default to None."""
         sig = inspect.signature(Delegate.__init__)
         for name in (
-            "signature",
             "envelope",
-            "inner_agent",
             "api_key",
             "base_url",
             "temperature",
@@ -212,6 +214,106 @@ class TestConstructorSignature:
                 p.default is None
             ), f"Parameter {name} should default to None, got {p.default}"
 
+    def test_removed_params_rejected(self):
+        """#1927 — signature/inner_agent were removed; passing them raises TypeError.
+
+        Both were documented but never wired (silent no-ops). Removal turns the
+        silent no-op into a loud error that points callers at the real
+        structured-output path (the BaseAgent/Signature stack).
+        """
+        sig = inspect.signature(Delegate.__init__)
+        assert "signature" not in sig.parameters
+        assert "inner_agent" not in sig.parameters
+
+        with pytest.raises(TypeError):
+            Delegate(model="test-model", signature=object(), adapter=_simple_adapter())
+        with pytest.raises(TypeError):
+            Delegate(
+                model="test-model", inner_agent=object(), adapter=_simple_adapter()
+            )
+
+    def test_every_init_param_reaches_a_consumer(self):
+        """#1927 completeness guard — no Delegate.__init__ param may be a
+        stored-and-never-read silent no-op.
+
+        This is the structural regression guard for the documented-kwarg-drop
+        class (#1899 base_url/api_key, #1926 temperature/max_tokens, #1927
+        signature/inner_agent): a param accepted + documented but never wired.
+        Every constructor param MUST be READ in the ``__init__`` body somewhere
+        other than its own ``self._x = x`` storage line — i.e. passed to a
+        callee, tested in a branch, or otherwise consumed. A param whose only
+        use is being stored to an attribute fails this test loudly.
+
+        Structural (AST) check — no LLM, no regex over prose.
+        """
+        import ast
+        import textwrap
+
+        from kaizen_agents.delegate import delegate as _delegate_mod
+
+        src = textwrap.dedent(inspect.getsource(_delegate_mod.Delegate.__init__))
+        init_fn = ast.parse(src).body[0]
+        assert isinstance(init_fn, ast.FunctionDef)
+
+        params = [
+            a.arg
+            for a in (
+                init_fn.args.posonlyargs + init_fn.args.args + init_fn.args.kwonlyargs
+            )
+            if a.arg != "self"
+        ]
+
+        loads: dict[str, int] = {p: 0 for p in params}
+        store_only: dict[str, int] = {p: 0 for p in params}
+
+        def _is_pure_self_store(target: ast.expr, value: ast.expr | None) -> str | None:
+            """Return the param name iff this is a pure ``self._x = <param>`` store.
+
+            A pure store is a single ``self.<attr>`` target whose RHS is the bare
+            param Name — no transform. A transform-on-store RHS (``self._x = x or
+            default``, ``self._x = list(x)``) is NOT a pure store: the transform is
+            real logic that consumes the value, so it is left to count as a Load.
+            Both ``ast.Assign`` (``self._x = x``) and ``ast.AnnAssign``
+            (``self._x: T = x``) storage forms are handled so an annotated store
+            cannot slip a silent no-op past the guard.
+            """
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+                and isinstance(value, ast.Name)
+                and value.id in store_only
+            ):
+                return value.id
+            return None
+
+        for node in ast.walk(init_fn):
+            # Count every Load-context use of a param name.
+            if (
+                isinstance(node, ast.Name)
+                and isinstance(node.ctx, ast.Load)
+                and node.id in loads
+            ):
+                loads[node.id] += 1
+            # Count the `self._x = <param>` / `self._x: T = <param>` storage-only
+            # assignments so we can exclude them: storing a value is not
+            # "consuming" it.
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                stored = _is_pure_self_store(node.targets[0], node.value)
+                if stored is not None:
+                    store_only[stored] += 1
+            elif isinstance(node, ast.AnnAssign):
+                stored = _is_pure_self_store(node.target, node.value)
+                if stored is not None:
+                    store_only[stored] += 1
+
+        silent_noops = [p for p in params if loads[p] <= store_only[p]]
+        assert not silent_noops, (
+            "Delegate.__init__ params accepted but never consumed (stored-and-"
+            f"never-read silent no-ops — the #1927 class): {silent_noops}. "
+            "Wire each into a real consumer or remove it from the constructor."
+        )
+
     def test_minimal_construction_works(self):
         """Delegate(model='x') does not raise."""
         d = Delegate(model="test-model", adapter=_simple_adapter())
@@ -221,7 +323,6 @@ class TestConstructorSignature:
         """Delegate with all new params does not raise."""
         d = Delegate(
             model="test-model",
-            signature=None,
             tools=None,
             system_prompt="You are helpful.",
             temperature=0.5,
@@ -232,7 +333,6 @@ class TestConstructorSignature:
             envelope=None,
             api_key=None,
             base_url=None,
-            inner_agent=None,
             adapter=_simple_adapter(),
         )
         assert d is not None
@@ -454,27 +554,20 @@ class TestCloseProxy:
 
 
 class TestIntrospectionProperties:
-    """TASK-05-31: core_agent, signature, model properties."""
+    """TASK-05-31: core_agent, model properties.
+
+    The ``signature`` property was removed in 0.11.7 (#1927) alongside the
+    unwired ``signature`` constructor param.
+    """
 
     def test_model_property(self):
         d = Delegate(model="my-model", adapter=_simple_adapter())
         assert d.model == "my-model"
 
-    def test_signature_property_none(self):
+    def test_signature_property_removed(self):
+        """#1927 — the .signature property was removed with the unwired param."""
         d = Delegate(model="test-model", adapter=_simple_adapter())
-        assert d.signature is None
-
-    def test_signature_property_set(self):
-        from kaizen.signatures import InputField, OutputField, Signature
-
-        class MySignature(Signature):
-            question: str = InputField(desc="A question")
-            answer: str = OutputField(desc="An answer")
-
-        d = Delegate(
-            model="test-model", signature=MySignature, adapter=_simple_adapter()
-        )
-        assert d.signature is MySignature
+        assert not hasattr(d, "signature")
 
     def test_wrapper_stack_returns_baseagent(self):
         from kaizen.core.base_agent import BaseAgent

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.11.6"
+version = "0.11.7"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "anthropic" },

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -1,70 +1,52 @@
-# Session Notes — 2026-07-22 (cont-12)
+# Session Notes — 2026-07-22 (cont-13)
 
 ## Where we are
 
-Clean board (0 open PRs). cont-11 shipped + released #1918 (kaizen-agents 0.11.5) and
-#1919 (kailash-pact 0.18.0) to PyPI, both live + verified. This session (cont-12) closed
-out the two remaining tracked follow-ups — **F2 deferred-quality** and **F1 cross-SDK** —
-with NO code changes required. Main @ post-release (c54fc9df1). Phase: post-release, board clean.
+Independent cross-session `/redteam` of the delivered #1720 surfaces caught + fixed a real
+Delegate bug cont-12 missed, released it, and tracked two deeper same-class follow-ups.
+Main @ `dd0064479`. kaizen-agents 0.11.6 live on PyPI (verified). Board otherwise clean.
 
 ## Read first
 
-1. `workspaces/issue-1720-llm-consolidation/launch-ledger-cont12.md` — full cont-12 record
-   (F2 reconciliation verdicts + F1 cross-SDK investigation evidence). START HERE.
-2. `launch-ledger-cont11.md` — prior session (the #1918/#1919 impl + release).
-
-## Executed this session (cont-12)
-
-- **F2 deferred-quality backlog — RECONCILED, all WONT-FIX/STALE (no code change).** Two
-  parallel read-only recon agents verified every item against HEAD c54fc9df1 (wave-loop MUST-7):
-  - DQ-1919-casevariant / -direct-enforcer / -warnflood → all WONT-FIX. #1919 severed the
-    metadata→tenant-decision path entirely; residuals are audit-echo-only (no decision impact),
-    trusted-internal-caller-only, or standard once-per-site DeprecationWarning semantics.
-  - DQ-1918-caseprefix → WONT-FIX (low-value; no real caller supplies capitalized model prefixes).
-  - LATENT-printmode-maxturns → STALE/CLOSED. The single `KzConfig(...)` reconstruction copies
-    all 12 fields incl base_url+api_key (e586eb30f, the PR #1922 fold). #1899-class drop closed.
-  - **Disposition: do NOT re-queue at /sweep.** No substantive change → no redteam-to-converge
-    (manufacturing one = recommendation-quality clean-gate violation).
-- **F1 cross-SDK #1919 → Rust SDK — INVESTIGATED, NO GAP, NOTHING FILED.** User authorized
-  "file if found" (AskUserQuestion, genuine turn). Ran `/cross-repo-authorize` → write-tier
-  receipt (committed 249ce99d6). READ-investigated `esperie-enterprise/kailash-rs` (private)
-  `crates/eatp/src/mcp/governance.rs`. **No #1919-class gap** — different, already-hardened
-  architecture: (1) zero tenant concept in the MCP path (CallerIdentity has only subject+issuer,
-  no tenant field); (2) CallerIdentity derives no Serialize/Deserialize → un-forgeable from client
-  params; (3) network transport passes `permit_self_asserted=false` (mod.rs:328) → self-asserted
-  identity fail-closed over the wire, closing prior #1518 redteam HIGH; (4) regression tests over
-  real run_sse TCP prove it. Adversarial verifier tried to refute on all 5 axes → could not.
-  **Converged (2 independent confirmations) → no issue filed** (gap not found; filing would be noise).
+1. `workspaces/issue-1720-llm-consolidation/launch-ledger-cont13.md` — full cont-13 record
+   (R1/R2 redteam verdicts, the fix, release, security-review, #1927 disposition).
+2. `CLAUDE.md` — project context. Board empty except tracked follow-up #1927; fresh work OK.
 
 ## In-flight state
 
-- Branch `chore/cont12-f1-crossrepo-authz`: authz receipt (249ce99d6) + this .session-notes.
-  → open PR + admin-merge to land the durable cross-repo audit trail on main.
-- No uncommitted code. No package release (no code changed this session).
+- None. Working tree clean (only untracked durable workspace records). No uncommitted code.
+
+## Executed this session
+
+- Released **kaizen-agents 0.11.6** to PyPI (tag `kaizen-agents-v0.11.6`; OIDC publish SUCCESS;
+  clean-venv + fix-behavior verified on the published wheel). Not in this repo's `git log`.
+
+## Wave tracker
+
+None — no waves in flight.
+
+## Unreleased packages
+
+- **kailash core** — one unreleased `src/` commit since `v2.61.0`: the `constraint_subset`
+  docstring correction (`9f2f9755b`). Doc-only / runtime-inert; user approved deferring it rather
+  than cut 2.61.1 for a docstring. Next session: bundle with the next core change, or cut 2.61.1.
 
 ## Outstanding ledger (forest)
 
-| ID  | Item                                            | Status                                                       |
-| --- | ----------------------------------------------- | ------------------------------------------------------------ |
-| F1  | Cross-SDK #1919 → Rust SDK MCP-governance check  | **CLOSED** — investigated, no gap, nothing filed (cont-12)   |
-| F2  | Deferred-quality backlog (5 items)              | **CLOSED** — all WONT-FIX/STALE, evidence-backed (cont-12)   |
+| ID  | Item                                                                    | Value-anchor (MUST-1)                                          | Status                |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------- |
+| F3  | kaizen Delegate `signature`/`inner_agent` documented but never wired    | user literal "approved" this session of filing + disposition (→ #1927) | queued (design shard) |
 
-Board is now genuinely empty — no tracked follow-ups remain.
+Closed this session: none carried (F1/F2 closed cont-12; the temperature/max_tokens fix is in `git log` + PyPI, not a forest item).
 
 ## Traps
 
-- Auto-merge DISABLED — pinned-head CI READ then separate MERGE (git.md); `release/*` auto-skips matrix.
-- Cross-repo Rust SDK access requires a committed `/cross-repo-authorize` receipt in
-  `.claude/cross-repo-authz/` BEFORE any `gh --repo esperie-enterprise/kailash-rs` command.
-- Rust SDK slug is `esperie-enterprise/kailash-rs` (private), NOT terrene-foundation.
-- Reviewer/recon fan-out dying on weekly usage limit = ZERO evidence (evidence gate); re-run after swap.
-
-## Hygiene (surface, do NOT act unprompted — feedback_no_bulk_worktree_discard)
-
-- Untracked test-artifact clutter in `packages/kaizen-agents/` (hello_world.py, *.txt/*.json,
-  task_*/, evaluations/, proposal/, rationale/, tasks/) + old workspace launch-ledgers.
-  Pre-existing since before cont-11. User hygiene decision still pending — NOT touched.
+- `Delegate.__init__` documented-kwarg-drop is a RECURRING class: #1899 (base_url/api_key),
+  #1926 (temperature/max_tokens), #1927 (signature/inner_agent). #1927 AC asks for a completeness guard.
+- CI flakes here: DataFlow bulk-multi-tenant Postgres isolation race + Windows SQLite "database is
+  locked". Both cleared on re-run; re-run failed jobs (pinned-head READ + separate merge), don't merge over red.
+- `.venv/bin/pre-commit` has a stale shebang (points to a `loom/kailash-py` path) — run `uv run pre-commit`.
 
 ## Open questions for the human
 
-- Hygiene cleanup of the untracked kaizen-agents test artifacts + old launch-ledgers — clean up, or leave?
+- F3/#1927 wire-vs-remove: recommended split (wire `signature`, remove `inner_agent`) — a design shard when you prioritize it.

--- a/workspaces/issue-1720-llm-consolidation/cross-sdk-behavioral-conformance-proposal.md
+++ b/workspaces/issue-1720-llm-consolidation/cross-sdk-behavioral-conformance-proposal.md
@@ -1,0 +1,63 @@
+# Proposal — Extend cross-SDK conformance vectors from byte-shape to BEHAVIORAL surfaces
+
+**Status:** DRAFT (2026-07-19) — for methodology-lane routing (loom Gate-1). Authored during the #1720-followup session after verifying the Rust SDK (`@4b357dec`) is at parity/ahead on the security surfaces; the divergence that _did_ occur (kailash-py behind on webhook fail-closed / OIDC nonce+PKCE / Gemini guard) was invisible to the existing vectors.
+
+## Problem (root cause)
+
+"Independent implementations, matching semantics" (EATP D6) is enforced by human memory + reactive per-issue mirroring, not a mechanical gate. Existing cross-SDK vectors pin **static byte-shapes** (`cross_sdk_llm_deployment_presets.rs` + `test-vectors/llm-deployment-presets.json`; `cross_sdk_agent_result`, `cross_sdk_trace_event`; the `kailash-coc-conformer` crate) — preset names, wire kinds, fingerprints. They do **not** pin **behavioral contracts** (request→payload transforms, verdict decisions, guard conditions). So behavioral divergence is caught only reactively as a bug.
+
+## Key insight — the pattern already exists in THIS repo (promote, don't build)
+
+`tests/trust/pact/conformance/vectors/circuit_breaker.json` + `test_bh5_circuit_breaker_conformance.py` already pin **observable state-machine verdicts** (not bytes), including a **fail-closed case via `expect_error`**, with an **exact-set orphan guard**. This is a proven, shipping in-repo behavioral-vector pattern. The proposal is to **promote it from the PACT/trust family to the LLM/auth surfaces** — lower-risk than a net-new suite.
+
+## 1. Behavioral-vector schema
+
+Generalize `circuit_breaker.json`'s `{config, events → expected}` to `{surface, input, expect}`:
+
+```json
+{
+  "surface": "gemini.build_request_payload",
+  "input": {
+    "tools": [{ "name": "get_weather" }],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": { "name": "r", "schema": { "type": "object" } }
+    }
+  },
+  "expect": {
+    "payload.tools": "present",
+    "payload.generationConfig.responseMimeType": "absent",
+    "payload.generationConfig.responseSchema": "absent",
+    "signal": "suppression_warn"
+  }
+}
+```
+
+Seed vectors (3 surfaces): **Gemini tools+response_format mutual-exclusion** (above); **webhook signature verdict** (`{payload, secret_state} → accept|reject|error`, incl. the no-secret **fail-closed** case via `expect_error`); **OIDC PKCE/nonce** (`verifier → S256 challenge`; nonce match→accept / mismatch→`expect_error`).
+
+## 2. Runner contract (reuse existing mechanism)
+
+- **Python:** a pytest walk modeled on the shipping BH5 runner — drives the REAL surface (`google_generate_content.build_request_payload`, `WebhookTransport.verify_signature`, `SSOAuthenticationNode` PKCE/nonce), deterministic oracle, exact-set orphan guard.
+- **Rust:** via the existing `cross_sdk_*` test pattern + shared walk logic in `kailash-coc-conformer`.
+- No net-new suite; the vector JSON is the single source of truth.
+
+## 3. Single-source-of-truth + CI gate
+
+Vendor the canonical vectors (`cross-sdk-inspection.md` Rule 4a) + pin an integrity manifest (Rule 4c `*.sha256`). A fix updates the vector once; the un-fixed SDK's CI goes red until it complies. **Canonical-home is a loom/methodology Gate-1 routing decision** — lean: seed vendored-from-one-BUILD-repo, flag loom-canonical for scaling. (For ratification, not decided here.)
+
+## 4. Anti-rot discipline (teeth)
+
+"New shared behavioral surface ⇒ new vector" MUST (analogous to Rule 4/4a), enforced by two structural teeth: the **exact-set orphan guard** (BH5 pattern) + a **`/redteam` coverage lens**. Land the rule + guard in the SAME change as the seed vectors — vectors without the anti-rot rule rot.
+
+## 5. Scope boundaries
+
+**In:** shared behavioral surfaces (wire-payload shaping, auth verdicts, signature verdicts). **Out:** SDK-internal impl / serialization order, non-shared surfaces, timing, semantic judgments. **Migration:** seed with the 3 surfaces; backfill opportunistically.
+
+## 6. Trade-offs
+
+**Pros:** promotes a proven in-repo pattern (low risk); aligned with D6 (enforces "matching semantics" without coupling code); retires the reactive-mirroring failure class; extends proven infra rather than building.
+**Cons (honest):** coverage is the ceiling — an un-vectored shared surface still diverges silently (mitigated by the anti-rot rule + coverage lens); discipline dependency (vectors rot without the rule); upfront cost of the behavioral-runner harness in both SDKs.
+
+## Grounding
+
+`tests/trust/pact/conformance/vectors/circuit_breaker.json` + `test_bh5_circuit_breaker_conformance.py`; Rust `crates/kailash-kaizen/tests/cross_sdk_llm_deployment_presets.rs` + `test-vectors/llm-deployment-presets.json` + `crates/kailash-coc-conformer`; `rules/cross-sdk-inspection.md` Rule 4/4a/4c. Rust-side claims are from this session's read-only recon (`@4b357dec`), not re-verified here.

--- a/workspaces/issue-1720-llm-consolidation/journal/0011-DISCOVERY-1896-constraint-subset-unsigned-dataflow-confirmed.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0011-DISCOVERY-1896-constraint-subset-unsigned-dataflow-confirmed.md
@@ -1,0 +1,52 @@
+# DISCOVERY — #1896 audit: constraint_subset is unsigned AND feeds the effective-constraint surface (enforcement-consumption link unproven)
+
+Date: 2026-07-21 (cont-6). Repo class: BUILD. Coordination OFF (un-enrolled public repo).
+Read-only audit; no code changed. Advances F5/#1896 from journal 0009 "For Discussion" item 1.
+
+## Question (journal 0009 F5)
+
+Does v2/v3 delegation enforcement read `constraint_subset` (a field that round-trips
+faithfully but is NOT in the v2/v3 signed pre-image), making it a live tamper surface?
+
+## FACTS (each quoted/verified this session)
+
+1. **`constraint_subset` is NOT in the signed pre-image.** `_FoldSourceRecord`
+   (`src/kailash/trust/signing/delegation_fold_serde.py:53-67`) folds exactly:
+   `constraints`, `resource_limits`, `scope`, `multi_sig`, `multi_sig_policy`.
+   `constraint_subset` is ABSENT. → editing a persisted `constraint_subset` does NOT
+   break the delegation signature.
+2. **`constraint_subset` and the signed `constraints` are DIFFERENT fields.**
+   `DelegationRecord.constraint_subset: List[str]` (chain.py:294, "Additional constraints
+   (tightening only)") vs the signed `constraints: Optional[ConstraintDimensions]`
+   (chain.py:334). The fold signs `constraints` (dimensions object); the runtime
+   aggregation reads `constraint_subset` (the list).
+3. **`constraint_subset` flows into the effective-constraint surface.**
+   `TrustLineageChain.get_effective_constraints` (chain.py:933) does
+   `constraints.update(delegation.constraint_subset)` → returned as
+   `VerificationResult.effective_constraints` (operations/**init**.py:735, populated at the
+   point `valid=True` is ALREADY decided — a REPORTING field, not the gate) →
+   `runtime/trust/verifier.py:398` builds `constraints={c: True for c in
+kaizen_result.effective_constraints}` AND `trusted_agent.py:693` sets
+   `ctx.effective_constraints = ...`.
+
+## INFERENCE (labeled — NOT proven)
+
+Whether the `{c: True}` runtime constraints map / `ctx.effective_constraints` is READ to
+make an allow/deny/restrict decision. A bounded grep found it surfaced into the runtime
+result map (verifier.py:343 `constraints=result.constraints`), the trust context merge
+(context.py:231), and the TrustedAgent execution ctx — but NO definitive SDK-core gate that
+DENIES on a missing/edited effective-constraint. It reads as advisory/contextual;
+applications MAY enforce it. The enforcement-consumption link is the remaining open question.
+
+## DISPOSITION
+
+The tamper surface is **REAL in dataflow** (an unsigned field, `constraint_subset`, reaches
+the effective-constraint reporting/context surface, and what is SIGNED — `constraints`
+dimensions — differs from what the runtime aggregates — `constraint_subset`). Severity is
+**bounded**: no confirmed privilege-escalation, because no SDK-core enforcement gate on
+`effective_constraints` was found this audit. This CONFIRMS F5 as a genuine
+integrity-hygiene gap for the #1841 signing-coverage owners, and does NOT overclaim it as an
+exploitable escalation. Recommended fix (owner decision): fold `constraint_subset` into the
+v2/v3 signed pre-image (defense-in-depth; it is documented "tightening only" and is
+security-relevant), OR document that `effective_constraints` is advisory-not-enforced.
+Not fixed here — #1896 stays OPEN with this evidence attached (value-bearing; no user close-gate given).

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont12.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont12.md
@@ -1,0 +1,66 @@
+# Launch Ledger — cont-12 (2026-07-22) — F2 deferred-quality reconcile + drive
+
+Durable orchestration ledger per `orchestration-launch-ledger.md` MUST-1. Consult BEFORE every spawn; match every completion against it.
+
+## Objective
+
+User: "continue from last session, /autonomize with as many parallelized workflows as possible and /redteam to convergence."
+
+cont-11 shipped #1918 + #1919 to PyPI (kaizen-agents 0.11.5 / kailash-pact 0.18.0), both live + verified. Board clean (0 open PRs, main @ c54fc9df1). Remaining tracked follow-ups:
+
+- **F1** — cross-SDK #1919 → Rust SDK MCP-governance check. BLOCKED on user cross-repo authorization (private repo; repo-scope-discipline — cannot self-authorize). Surface a SPECIFIC ask (handoff-completion MUST-3).
+- **F2** — deferred-quality backlog (all INCREMENTAL last session) + 1 latent print_mode finding. Reconcile-first (wave-loop MUST-7), then execute worthwhile hardening, dispose by-design with rationale.
+
+## F2 items to reconcile (from cont-11 ledger)
+
+| ID                        | Claim                                                                                                                 | Prior disposition                      |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| DQ-1919-casevariant       | `Tenant_Id`/` tenant_id` case-variant survives literal `!= "tenant_id"` scrub into AUDIT echo only (no decision infl) | INCREMENTAL — optional case-norm scrub |
+| DQ-1919-direct-enforcer   | direct enforcer.check_tool_call (bypass middleware) echoes arbitrary metadata to audit                                | INCREMENTAL — pre-existing generic     |
+| DQ-1919-warnflood         | DeprecationWarning flood only under caller's own simplefilter("always")                                               | LOW — config not SDK                   |
+| DQ-1918-caseprefix        | registry `_MODEL_PREFIX_MAP` startswith case-sensitive (`Claude-`→openai default)                                     | INCREMENTAL — same dest pre/post       |
+| LATENT-printmode-maxturns | print_mode.py:56-68 max_turns-override branch rebuilds KzConfig OMITTING base_url+api_key (#1899-class)               | Out-of-scope #1918; decide at wrapup   |
+
+## Wave tracker (durable)
+
+| track           | agent               | branch/scope                                                     | status                                                               |
+| --------------- | ------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------- |
+| RECON-pact-1919 | Explore (read-only) | reconcile DQ-1919 casevariant/direct-enforcer/warnflood vs main  | **DONE** — all 3 WONT-FIX                                            |
+| RECON-kaizen    | Explore (read-only) | reconcile DQ-1918-caseprefix + LATENT-printmode-maxturns vs main | **DONE** — caseprefix WONT-FIX; printmode STALE (fixed by e586eb30f) |
+
+## RECON VERDICTS (evidence-backed, HEAD c54fc9df1)
+
+**ALL of F2 is WONT-FIX or STALE. No local fix warranted → no release cycle.**
+
+- **DQ-1919-casevariant** — WONT-FIX. Scrub is literal `k != "tenant_id"` (middleware.py:130,217; types.py:476,594); case-variant survives into AUDIT echo ONLY. Decision read doubly inert: `_resolve_effective_tenant` (enforcer.py:152) exact-match `.get("tenant_id")` AND #1919 severed metadata→decision (returns None on that path). Audit echoes ALL client metadata by design.
+- **DQ-1919-direct-enforcer** — WONT-FIX. `**(context.metadata or {})` audit splat (enforcer.py:374,460) reachable only by TRUSTED internal callers (middleware is the network boundary + scrubs). No trust-boundary crossing; decision unaffected.
+- **DQ-1919-warnflood** — WONT-FIX. Static-message `DeprecationWarning` (enforcer.py:154-163) dedups once-per-site; str-guard; flood requires caller's own `simplefilter("always")`. Config-not-SDK; weaker mode opt-in (default `require_caller_identity=True`, types.py:245).
+- **DQ-1918-caseprefix** — WONT-FIX (low-value). `_MODEL_PREFIX_MAP` startswith case-sensitive (registry.py:274); no real caller supplies capitalized prefixes (vendor slugs lowercase). Optional 1-line `model.lower()`; not a bug.
+- **LATENT-printmode-maxturns** — STALE / CLOSED. print_mode.py has ONE `KzConfig(...)` (line 57, max_turns branch), copies ALL 12 fields incl `base_url`(L66)+`api_key`(L67), authored by e586eb30f (PR #1922 fold). #1899-class drop closed.
+
+**Disposition:** F2 cleared — record WONT-FIX rationale, do NOT re-queue at /sweep. No code change → no redteam-to-converge (manufacturing a change = recommendation-quality clean-gate violation).
+
+## F1 (cross-SDK) — USER AUTHORIZED "file if found" (AskUserQuestion genuine turn)
+
+Target: Rust SDK (esperie-enterprise/kailash-rs, private). Sequence: /cross-repo-authorize (receipt) → READ-investigate MCP governance tenant surface → if #1919-class gap, draft SCRUBBED issue (upstream-issue-hygiene MUST-2/3) → confirm exact body with user (MUST-1) → file.
+
+| track          | agent                       | branch/scope                                                      | status                                           |
+| -------------- | --------------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| F1-authorize   | /cross-repo-authorize       | write receipt esperie-enterprise/kailash-rs (committed 249ce99d6) | **DONE**                                         |
+| F1-investigate | orchestrator (gh api reads) | Rust SDK eatp MCP governance tenant surface                       | **DONE — NO GAP**                                |
+| F1-adversarial | Explore (bg)                | adversarial refutation of "no gap"                                | **DONE — NO GAP (all 5 axes, could not refute)** |
+
+## F1 CONVERGED — NO GAP, NOTHING FILED
+
+Two independent confirmations (orchestrator direct reads + adversarial refutation) agree: no #1919-class gap in the Rust SDK MCP governance. Adversarial adds: real `run_sse` TCP regression tests (`sse_http_transport_trusted_self_asserted_gate_denies_over_network`, `governed_delegate_keys_on_verified_subject_not_params_agent_id`) prove network body-asserted identity cannot spoof; tenant logic lives in eatp `vault/*` but MCP dispatch reaches 0 of it. Finding-class mechanically disproven → NOT running further rounds (recommendation-quality clean-gate). Per user "file if found" → **NO issue filed** (correct; would be noise). Receipt 249ce99d6 = the durable cross-repo audit trail; reads only, no Rust write. F1 CLOSED.
+
+## F1 INVESTIGATION — NO #1919-CLASS GAP IN RUST SDK (evidence, kailash-rs/main)
+
+Rust MCP governance = `crates/eatp/src/mcp/governance.rs` (sibling of Python pact MCP middleware). The #1919 gap CANNOT exist here — different, already-hardened architecture:
+
+1. **Zero tenant concept in the MCP path.** `grep -ci tenant` across eatp mcp module = 0 (governance/mod/tools/resources/jsonrpc). `CallerIdentity` (governance.rs:71) has ONLY `subject` + `issuer` — NO tenant field. No tenant-keyed MCP decision to spoof.
+2. **CallerIdentity un-forgeable from client params.** governance.rs:61-63: "intentionally derives no Serialize/Deserialize, so a caller cannot forge one by placing fields in the JSON-RPC params." Subject from an AUTHENTICATED source (verified bearer token) only.
+3. **Network transport fail-closes self-asserted identity.** `authorize()` (governance.rs:385+): no-verified + (opt-in OFF or network)→DENY. `run_sse` passes `permit_self_asserted=false` (mod.rs:328, closing prior #1518 redteam HIGH). Regression test `self_asserted_refused_on_network_transport_even_when_granted` (governance.rs:627).
+4. **Prior hardening = Rust-side equivalent of #1919.** Comments cite #1498 (out-of-band caller identity) + #1518 (network fail-closed) — structurally predate + prevent the #1919 client-metadata-tenant-spoof class.
+
+**Disposition:** gap NOT found → per user "file if found" → do NOT file. Confirm via adversarial verifier convergence, then close F1 (receipt = audit trail; no cross-repo write).

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont13.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont13.md
@@ -1,0 +1,75 @@
+# Launch Ledger — cont-13 (2026-07-22) — independent cross-session convergence re-verification
+
+Durable orchestration ledger per `orchestration-launch-ledger.md` MUST-1. Consult BEFORE every spawn; match every completion against it.
+
+## Objective
+
+User (this session): "continue from last session, /autonomize with as many parallelized workflows as possible and /redteam to convergence."
+
+Ground truth at session start (verified live): board = **0 open PRs, 0 open issues**; main @ `d8715f199` (unchanged since cont-12); versions consistent (kailash 2.61.0 · kaizen-agents 0.11.5 · kailash-pact 0.18.0); #1899/#1912/#1918/#1919/#1896 all CLOSED/COMPLETED. cont-12 already converged F1 (Rust cross-SDK, 5-axis adversarial refutation → no gap) + F2 (5 deferred-quality items → all WONT-FIX/STALE, evidence-backed).
+
+**cont-13 scope:** cont-12's convergence is self-attested. Run ONE bounded, INDEPENDENT (cross-session) adversarial verification wave over the DELIVERED #1720 surfaces to convert self-attestation → independent evidence. NOT a full-SDK redteam (that would manufacture work over a clean board = recommendation-quality MUST-3 / wave-loop MUST-6 violation). Bounded to the exact file:line surfaces cont-12 dispositioned.
+
+## Wave tracker (durable)
+
+| track               | agent (workflow)            | branch/scope                                      | status                                                     |
+| ------------------- | --------------------------- | ------------------------------------------------- | ---------------------------------------------------------- |
+| CONV-kaizen-routing | adv reviewer (wf wdd166hze) | REFUTE #1918/#1899 + printmode                    | **DONE — BUG FOUND**                                       |
+| CONV-pact-tenant    | adv reviewer (wf wdd166hze) | REFUTE #1919 + 3 DQ-1919 WONT-FIX                 | **DONE — CLEAN** (INCREMENTAL audit-echo, matches cont-12) |
+| CONV-trust-signing  | adv reviewer (wf wdd166hze) | REFUTE #1896 + #1912                              | **DONE — CLEAN** (INCREMENTAL doc-precision)               |
+| CONV-confirm-r2     | independent confirm         | 2nd round: kaizen fix + sibling sweep + trust doc | **DONE — 2 MORE same-class BUGs + doc nuance**             |
+
+## R2 VERDICT (independent reviewer) — NOT clean; caught more
+
+- **temperature/max_tokens fix: CONFIRMED CORRECT** (conditional forward, no clobber, reaches _config).
+- **inner_agent: BUG** — documented escape-hatch (delegate.py:337-339) stored L383, NEVER read; construction unconditionally builds `_LoopAgent`. Documented behavior never fires. VERIFIED.
+- **signature: BUG** — documented "structured outputs" (L308-310) stored L380 + getter L737, NEVER passed to _LoopAgent (hardcodes `_DelegateSignature()` L206). No-op. VERIFIED.
+- **trust docstring: 2 residual INCREMENTAL** — (a) cited non-existent `establish_delegation`; (b) "gates nothing" understated (tightening IS enforced via signed derived caps `_build_signed_derived_caps` L788 / `CapabilityAttestation(constraints=constraint_subset)` L848). Both FIXED.
+
+## DISPOSITION
+
+- **temperature/max_tokens BUG + trust docstring** → FIXED, **PR #1926** (HEAD 9f2f9755, CI matrix running). Merge (pinned-head READ + separate admin-merge) → release kaizen-agents 0.11.6.
+- **inner_agent + signature BUGs** → same class but EXCEED mechanical shard budget (need wire-into-loop-architecture OR public-API removal w/ deprecation per zero-tolerance 6/6a). autonomous-execution Rule 4 bound: exceeds budget → new shard. Surfaced to user for wire-vs-remove-vs-defer (product/API call, not self-executed).
+
+## CI + FOLLOW-UP (post-user-approval)
+
+- **PR #1926 CI**: changed surfaces GREEN (Trust Unit, PACT, DataFlow Tier-1, kaizen routing). 2 UNRELATED flakes: (1) DataFlow infra-regression Postgres parallel-isolation race (`relation ... does not exist` + concurrent dup-key, run 29926702105); (2) Windows 3.12 SQLite `database is locked` in test_sqlite_trust_store TestConcurrentAccess (4636 passed/1 failed, run 29926743046). Neither in my diff's path (kaizen config-thread + runtime-inert docstring). Branch protection requires 0 checks. Re-running both to confirm transient before merge (feedback_ci_discipline — no merge over red without green re-run).
+- **inner_agent + signature** → user APPROVED option (a): tracking **issue #1927** filed (scrubbed, SDK-surface; wire signature / remove inner_agent w/ deprecation + completeness-guard AC). handoff-completion satisfied (real tracked issue, not local note).
+
+## SHIPPED + RELEASED
+
+- **PR #1926 MERGED** → main `e1031cc9a` (temperature/max_tokens fix + trust docstring). CI: 2 unrelated flakes (DataFlow isolation race + Windows SQLite lock) both cleared on re-run; changed surfaces green throughout.
+- **Release PR #1928 MERGED** → main `1fe2197c1`; tag `kaizen-agents-v0.11.6` pushed → publish-pypi.yml **SUCCESS**.
+- **kaizen-agents 0.11.6 LIVE on PyPI** — clean-venv verified: `__version__==0.11.6`; FIX VERIFIED on published wheel (override 0.91/1234 applied; defaults 0.4/16384 preserved). build-repo-release-discipline Rule 2 done-gate satisfied.
+- trust docstring: doc-only in kailash core (2.61.0), rides next core release (no bump for a docstring).
+- security-reviewer on the diff (mandatory /release gate, deployment.md) — **CLEAN, no findings** (config-value threading + inert docstring; no secret/injection/authz/crypto surface).
+
+## CONVERGENCE
+
+- PR #1926 diff: converged (BUG independently confirmed; docstring source-verified; pre-commit clean).
+- Session: all found BUG/INVEST-NOW fixed (temp/max_tokens) or dispositioned+surfaced (inner_agent/signature).
+
+## R1 VERDICT (wf wdd166hze, 3 agents, 470k tok) — NOT CONVERGED, 1 BUG
+
+- **kaizen: BUG** — `delegate.py:409` KzConfig build dropped documented `temperature`/`max_tokens` (accepted+documented `__init__` L358-360/docstring L317-320, omitted → KzConfig defaults 0.4/16384 silently won). #1899-class documented-kwarg drop, one field over. cont-12 checked only base_url/api_key → missed this. **Why independent cross-session verification mattered.**
+- **pact: CLEAN** — case-variant tenant key → audit echo ONLY (enforcer.py:377/463); decision doubly-severed. INCREMENTAL, matches cont-12 WONT-FIX.
+- **trust: CLEAN** — INCREMENTAL doc: `chain.py:352` "NOT part of signed pre-image" inaccurate — legacy (default) DOES sign constraint_subset (`to_signing_payload` L469 / delegation_record_signing.py:237); only v2/v3 fold omits. Either way gates nothing (#1896 disposition holds).
+
+## FIXES APPLIED (verified)
+
+1. **kaizen `delegate.py`** — thread temperature/max_tokens into KzConfig conditionally (forward only when set; None would clobber non-Optional defaults). +2 regression tests. Runtime-verified (override 0.9/999; defaults 0.4/16384). **598 delegate tests + 2 new pass.**
+2. **trust `chain.py`** — docstring → version-dependent accurate (legacy signs / v2/v3 omits / gates nothing). Doc-only; module loads clean.
+
+## COMPLETENESS (bug-class closure, manual enumeration)
+
+Every documented `Delegate.__init__` param → consumer: signature L380, tools L432, system_prompt L451, temperature/max_tokens L426-428 (FIX), max_turns/base_url/api_key KzConfig, mcp_servers L393, budget_usd L438/443/479, envelope L462, adapter L450, inner_agent L383, ungoverned L453. **temperature/max_tokens were the ONLY drops — class fully closed.**
+
+## Pending user-authorization items (NOT self-executed — surfaced for gate)
+
+1. **rs2063 cross-SDK handoff** — Rust equivalent of #1912 subject-binding + chain-state signing. DRAFT correctly surfaced pending-with-authorization (handoff-completion MUST-1b/3). Filing = cross-repo WRITE to private `esperie-enterprise/kailash-rs` → needs `/cross-repo-authorize` receipt + user yes/no. NOT self-authorizable (repo-scope-discipline).
+2. **cross-sdk-behavioral-conformance-proposal** — methodology-lane DRAFT for loom Gate-1 routing. Needs routing decision (issue-triage-routing: this repo is coc-build → `/codify` Step 7a upflow, or loom Gate-1).
+
+## Housekeeping
+
+- Untracked durable workspace records (sweep-cont12, ledger-cont12, journal 0011, rs2063-draft, conformance-proposal) + modified .session-notes → commit as durable session records.
+- Journal 0011 (#1896): stale "stays OPEN" — #1896 CLOSED via #1906 advisory-only. No /codify owed (learning captured journal 0009/0010). Cosmetic phase staleness only.

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
@@ -1,0 +1,27 @@
+# Launch Ledger — cont-14 (2026-07-22) — #1927 Delegate signature/inner_agent design shard
+
+Durable orchestration ledger per `orchestration-launch-ledger.md` MUST-1. Consult BEFORE every spawn; match every completion against it.
+
+## Objective
+
+User: "continue from last session, /autonomize with as many parallelized workflows as possible and /redteam to convergence."
+
+Forest has ONE real item: **#1927** (F3) — `Delegate(signature=…)` / `Delegate(inner_agent=…)` documented-but-silent-no-op (bug-labeled, independently confirmed cont-13 R2). Design shard now prioritized via /autonomize.
+
+Ground truth at start (verified live): main @ `dd0064479`, 0 open PRs, #1927 the only open issue. Both no-ops CONFIRMED at HEAD:
+- `inner_agent` (delegate.py:367→383 stored, never read; L458 always builds `_LoopAgent`)
+- `signature` (delegate.py:356→380 stored + getter L735; `_LoopAgent.__init__` L203 hardcodes `_DelegateSignature()`; `run()` L615 streams raw text from `self._loop`, bypassing BaseAgent signature path)
+
+Consumer surface (grep): only delegate.py references the Delegate-specific params; NO codebase caller passes `signature=`/`inner_agent=` to a Delegate. Deprecation surface is bounded.
+
+## Wave tracker (durable)
+
+| track                | agent                       | branch/scope                                              | status |
+| -------------------- | --------------------------- | -------------------------------------------------------- | ------ |
+| INV-signature-feasib | Explore (investigation)     | loop.py + adapters/ structured-output feasibility        | spawned |
+| INV-inner-agent-arch | Explore (investigation)     | wrapper stack / streaming model / inner_agent compat     | spawned |
+| INV-consumer-tests   | Explore (investigation)     | full signature=/inner_agent= consumer + test + doc surface | spawned |
+
+## Disposition (to be decided post-investigation, per /autonomize)
+
+Issue #1927 recommends: signature→WIRE, inner_agent→REMOVE(deprecation). Validate against architecture evidence before committing.

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
@@ -34,10 +34,26 @@ Consumer surface (grep): only delegate.py references the Delegate-specific param
 
 ## Implementation (branch fix/kaizen-delegate-signature-inner-agent-1927)
 
-- delegate.py: removed `signature`/`inner_agent` params + storage + docstrings + `.signature` property; fixed `core_agent` docstring (was wrongly claiming "user-provided inner_agent"). Runtime-verified: both params ABSENT from Delegate.__init__.
+- delegate.py: removed `signature`/`inner_agent` params + storage + docstrings + `.signature` property; fixed `core_agent` docstring (was wrongly claiming "user-provided inner_agent"). Runtime-verified: both params ABSENT from Delegate.**init**.
 - test_delegate_facade.py: swept 4 param-enumeration tests + removed 2 signature-property tests; ADDED `test_removed_params_rejected` (TypeError guard) + `test_signature_property_removed` + `test_every_init_param_reaches_a_consumer` (structural AST completeness guard — #1927 AC#3). Guard teeth-verified against a synthetic stored-only param.
-- CHANGELOG 0.11.7 entry (### Removed). Version bumped atomically: pyproject.toml + __init__.py → 0.11.7.
+- CHANGELOG 0.11.7 entry (### Removed). Version bumped atomically: pyproject.toml + **init**.py → 0.11.7.
 - 559 delegate unit tests pass; collateral grep clean (no other Delegate signature/inner_agent usage). Full unit suite running (bbejg2pfi).
+
+## Redteam wave (durable — orchestration-launch-ledger MUST-1)
+
+Commit c35df4cd8 (branch fix/kaizen-delegate-signature-inner-agent-1927). Diff materialized: redteam-cont14-diff.patch.
+
+| track          | agent                        | scope                                                                 | status                                                                                                                                                    |
+| -------------- | ---------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RT-reviewer R1 | reviewer (ad1c7d35)          | removal correctness / completeness / test quality / CHANGELOG+version | **DONE — CLEAN** (no BUG/INVEST-NOW; mutation-tested the AST guard; version consistency verified 4 locations; 2 INCREMENTAL notes)                        |
+| RT-security R1 | security-reviewer (a7d55f0e) | security implications of removal + diff scrub                         | **DONE — SECURITY-NEUTRAL, 0 findings** (govt/envelope/is_mock gates intact; no secret exposure; AST guard trusted-input; CHANGELOG clean; genuinely ran) |
+| RT-reviewer R2 | reviewer (ad68db4d)          | confirm hardened guard (AnnAssign) + re-confirm removal/version       | **DONE — CLEAN** (reproduced guard vs 6 synthetic cases, no false pos/neg; orphan-grep clean; version 0.11.7 all anchors; no new warnings; genuinely ran) |
+
+**CONVERGENCE REACHED** — 2 consecutive clean rounds on BUG/INVEST-NOW (R1 reviewer+security, R2 reviewer); all 3 reviewers genuinely ran (evidence gate). Deferred INCREMENTAL (value-anchored, NOT blocking): AST guard tuple-target-store edge (`self._x, self._y = x, y` escapes `_is_pure_self_store`) — value-anchor = maximal future-proofing of the #1927 tripwire; NOT present in real Delegate.**init**, theoretical only; diminishing returns to chase further.
+
+## Round 1 → round 2 delta
+
+R1 CLEAN both reviewers (both genuinely ran — evidence gate satisfied). INCREMENTAL note #2 (AST guard didn't handle AnnAssign/transform-RHS stores) FIXED in warm context: added `_is_pure_self_store` helper + AnnAssign branch (commit 14392da83, test-only). Hardened guard mutation-verified to catch AnnAssign-stored no-op. INCREMENTAL note #1 (Rule-6a deprecation tension) = no action (reviewer + security-reviewer both agree hard removal is the correct Rule-6a exception for a never-worked zero-caller param). Production/security surface byte-identical since R1 → security not re-run (test-only delta).
 
 ## Remaining
 

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
@@ -9,6 +9,7 @@ User: "continue from last session, /autonomize with as many parallelized workflo
 Forest has ONE real item: **#1927** (F3) — `Delegate(signature=…)` / `Delegate(inner_agent=…)` documented-but-silent-no-op (bug-labeled, independently confirmed cont-13 R2). Design shard now prioritized via /autonomize.
 
 Ground truth at start (verified live): main @ `dd0064479`, 0 open PRs, #1927 the only open issue. Both no-ops CONFIRMED at HEAD:
+
 - `inner_agent` (delegate.py:367→383 stored, never read; L458 always builds `_LoopAgent`)
 - `signature` (delegate.py:356→380 stored + getter L735; `_LoopAgent.__init__` L203 hardcodes `_DelegateSignature()`; `run()` L615 streams raw text from `self._loop`, bypassing BaseAgent signature path)
 
@@ -16,12 +17,29 @@ Consumer surface (grep): only delegate.py references the Delegate-specific param
 
 ## Wave tracker (durable)
 
-| track                | agent                       | branch/scope                                              | status |
-| -------------------- | --------------------------- | -------------------------------------------------------- | ------ |
-| INV-signature-feasib | Explore (investigation)     | loop.py + adapters/ structured-output feasibility        | spawned |
-| INV-inner-agent-arch | Explore (investigation)     | wrapper stack / streaming model / inner_agent compat     | spawned |
-| INV-consumer-tests   | Explore (investigation)     | full signature=/inner_agent= consumer + test + doc surface | spawned |
+| track                | agent              | branch/scope                                               | status                                                                              |
+| -------------------- | ------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| INV-signature-feasib | Explore (a67b1cd7) | loop.py + adapters/ structured-output feasibility          | in-flight                                                                           |
+| INV-inner-agent-arch | Explore (a6c09fd6) | wrapper stack / streaming model / inner_agent compat       | **DONE — REMOVE** (arch-incompatible w/ streaming; core_agent docstring also wrong) |
+| INV-consumer-tests   | Explore (ac157d9)  | full signature=/inner_agent= consumer + test + doc surface | in-flight                                                                           |
 
-## Disposition (to be decided post-investigation, per /autonomize)
+## Decision so far
 
-Issue #1927 recommends: signature→WIRE, inner_agent→REMOVE(deprecation). Validate against architecture evidence before committing.
+- **inner_agent → REMOVE.** run() streams from AgentLoop.run_turn (delegate.py:615), never invokes the wrapper stack; BaseAgent has no streaming interface (batch run/run_async→dict only); honoring it needs a degraded non-streaming branch forfeiting streaming/tool-events/budget/interrupt. adapter=/config=/loop already cover BYO-engine streaming-compatibly. ALSO fix core_agent docstring (:727) — same-class doc bug.
+- **signature → PENDING** INV-signature-feasib.
+
+## Disposition — DECIDED (user-ratified via AskUserQuestion 2026-07-23)
+
+**REMOVE BOTH** signature + inner_agent (clean removal, no deprecation shim, per feedback_no_shims; framed as the #1927 bug fix since both were never-worked silent no-ops with zero callers). User selected "Remove both (Recommended)".
+
+## Implementation (branch fix/kaizen-delegate-signature-inner-agent-1927)
+
+- delegate.py: removed `signature`/`inner_agent` params + storage + docstrings + `.signature` property; fixed `core_agent` docstring (was wrongly claiming "user-provided inner_agent"). Runtime-verified: both params ABSENT from Delegate.__init__.
+- test_delegate_facade.py: swept 4 param-enumeration tests + removed 2 signature-property tests; ADDED `test_removed_params_rejected` (TypeError guard) + `test_signature_property_removed` + `test_every_init_param_reaches_a_consumer` (structural AST completeness guard — #1927 AC#3). Guard teeth-verified against a synthetic stored-only param.
+- CHANGELOG 0.11.7 entry (### Removed). Version bumped atomically: pyproject.toml + __init__.py → 0.11.7.
+- 559 delegate unit tests pass; collateral grep clean (no other Delegate signature/inner_agent usage). Full unit suite running (bbejg2pfi).
+
+## Remaining
+
+- Full unit suite green confirm → commit → PR → redteam to convergence → merge → release 0.11.7 (build-repo-release discipline) → uv.lock sync.
+- Cross-SDK (cross-sdk-inspection Rule 1): Delegate facade is a Python kaizen-agents construct; assess whether Rust SDK has equivalent no-op params — defer to wrapup (needs cross-repo authz, not self-authorizable).

--- a/workspaces/issue-1720-llm-consolidation/rs2063-handoff-draft.md
+++ b/workspaces/issue-1720-llm-consolidation/rs2063-handoff-draft.md
@@ -1,0 +1,43 @@
+# rs#2063 cross-SDK handoff — DRAFT issue body (NOT yet filed)
+
+Status: DRAFT. Filing is a cross-repo write requiring (a) `/cross-repo-authorize <rust-sdk-repo> "file the #1912-equivalent subject-binding + chain-state issue"` receipt AND (b) user yes/no per repo-scope-discipline User-Authorized-Exception + upstream-issue-hygiene MUST-1. Do NOT imply-done (handoff-completion).
+
+Scrubbed per upstream-issue-hygiene MUST-2 (SDK-API-surface only; no workspace paths, finding tags, session context, or consumer identifiers). Five-section minimal-repro shape.
+
+---
+
+**Title:** security(trust): bind holder subject into capability signing pre-image + sign the capability-set / chain-state envelope (store-tamper hardening)
+
+**Labels:** `cross-sdk`, `security`
+
+## Affected API
+
+The trust-plane capability-signing + chain-verification path — the equivalent of the Python SDK's `verify()` / capability-signing pre-image + chain-state envelope signature.
+
+## Summary
+
+The trust plane's persisted capability signatures do not bind the holder's `agent_id` into the signed pre-image, and the capability-set / chain-state envelope is unsigned. Under the bounded-trust store-writer threat model (a party with write access to the persisted trust store), this permits:
+
+1. **Cross-chain capability transplant** — a capability signed by authority A for holder/chain X verifies identically for a different holder/chain Y, because the subject is not in the signed bytes.
+2. **Silent constraint / envelope tamper** — the capability set and its constraint envelope carry no signature, so a store-writer can strip a constraint (or an entire capability's constraints) and verification still accepts the weakened set.
+
+## Expected vs actual
+
+- **Expected:** the signed capability pre-image binds the holder subject (so a capability cannot be transplanted to a different holder/chain), and the capability-set / chain-state envelope carries a signature that fails closed when absent, stripped, or invalid.
+- **Actual:** subject is not bound in the pre-image; the envelope is unsigned; a store-writer can transplant capabilities across chains and strip constraints undetected.
+
+## Severity
+
+HIGH (store-tamper) + two MEDIUM (constraint-strip variants) — affects every trust-plane deployment that persists chains a store-writer can reach.
+
+## Acceptance criteria
+
+- [ ] Capability signing pre-image binds the holder subject id; a capability signed for one holder/chain fails verification for a different holder/chain.
+- [ ] Capability-set / chain-state envelope is signed; an absent / stripped / invalid signature fails closed (denies) by default.
+- [ ] A migration path re-signs the installed base (subject-bind existing capabilities + add the envelope signature), verifying each existing signature against the genesis authority BEFORE re-signing (no laundering of a forged/transplanted capability), gated on an explicit trust-the-store-snapshot acknowledgment for every write surface.
+- [ ] Fail-closed enforcement of the new posture by default, with a loud, documented, migration-window opt-out.
+- [ ] Cross-SDK: the capability pre-image byte layout (including the bound subject) matches the Python SDK's, verified by a shared byte-pin vector.
+
+## Cross-SDK alignment
+
+This is the Rust-SDK equivalent of the Python SDK's subject-binding + chain-state-signing hardening (originating issue: kailash-py #1912). The capability pre-image + envelope byte layout is a cross-SDK signed contract, so the subject-binding + envelope-signature shapes MUST match for cross-SDK trust-plane interop on these artifacts (per cross-sdk-inspection Rule 4 — pin shared byte vectors).

--- a/workspaces/issue-1720-llm-consolidation/sweep-cont12-report.md
+++ b/workspaces/issue-1720-llm-consolidation/sweep-cont12-report.md
@@ -1,0 +1,32 @@
+# /sweep — Full-Repo Management Decision Report (cont-12, 2026-07-22)
+
+Invoked as the end-of-cycle gate before /wrapup. Main @ d8715f199. Coordination OFF (public un-enrolled repo).
+
+## 1. Completion status — COMPLETE + VISIBLE
+
+- **LLM-consolidation (#1720) work stream: COMPLETE.** All follow-ups shipped + released + verified live on PyPI.
+  - Receipts: #1918 → PR #1922 (kaizen-agents 0.11.5); #1919 → PR #1923 + release PR #1924 (kailash-pact 0.18.0); both tags OIDC-published + clean-venv-verified (cont-11). #1899/#1912/#1896 closed 2026-07-21/22.
+- Version anchors consistent + released: kailash 2.61.0 · kaizen-agents 0.11.5 · kailash-pact 0.18.0.
+- **Board: 0 open issues, 0 open PRs.** Working tree clean (only 4 durable workspace records untracked).
+- No active todos outside `workspaces/_archive/`. No non-archive workspace has in-flight work.
+
+## 2. ETA to completion — ZERO remaining BUG/INVEST-NOW
+
+No open BUG or INVEST-NOW work anywhere in the repo. The committed scope is fully delivered + visible. ETA: 0 cycles.
+
+## 3. Prioritized immediate queue — EMPTY
+
+No open BUGs or INVEST-NOW issues. Nothing to rank.
+
+## 4. Deferred-quality backlog — EMPTY (F2 cleared this session)
+
+- No `deferred-quality`-labelled GH issues (Sweep-N enumeration returned 0).
+- The cont-11 F2 residuals (DQ-1919-casevariant/-direct-enforcer/-warnflood, DQ-1918-caseprefix, LATENT-printmode-maxturns) were reconciled against ground truth this session (cont-12) and all dispositioned **WONT-FIX/STALE** with quoted evidence — not re-queued (correct per product-completion-first: they are no-decision-impact audit-echo / config-not-SDK / already-fixed, not off-path INCREMENTAL work owed).
+
+## 5. Decision points (judgment calls for co-owner direction)
+
+- **Journal codify candidate 0011 (LOW).** `0011-DISCOVERY-1896-*` documents the #1896 `constraint_subset` audit. Ground truth: #1896 CLOSED by #1906 (advisory-only disposition shipped; docstring corrected). The cross-project learning (signing-coverage / cross-serializer completeness) is already codified via journal 0009/0010 DECISION-codify entries. **Recommendation:** no new /codify obligation — 0011 is a resolved-instance record. Pros of leaving as-is: no churn, learning already captured. Cons: the workspace phase still reads "05-codify / pending 1" (cosmetic staleness). Disposition for your ratify: leave it (recommended), or run a confirmatory /codify pass.
+
+## 6. Recommendation
+
+The repo is at a genuinely clean, fully-shipped state — no bugs, no open issues/PRs, no deferred backlog, no in-flight waves. **Recommended next step: /wrapup for a fresh session.** Nothing is owed; this is a complete hand-to-human gate, not a checkpoint. (If you'd rather I run the confirmatory /codify on 0011 first, say so — but it's optional.)


### PR DESCRIPTION
## Summary

Resolves #1927 — both `Delegate(signature=…)` and `Delegate(inner_agent=…)` were accepted and documented on the constructor but **never wired** (silent no-ops), the same documented-kwarg-drop class as #1899 (`base_url`/`api_key`) and #1926 (`temperature`/`max_tokens`) — but here the correct resolution is **removal, not wiring**.

- **`signature`** was documented as "enables structured outputs on the inner BaseAgent" but was only stored + returned by the `.signature` getter, never threaded to the loop/adapter → structured outputs never took effect. The `Delegate` is a streaming autonomous-execution facade with no structured-output path by design; structured output already exists complete in the `BaseAgent` + `Signature` path (`kaizen.core`). Wiring it here would mean a second structured-output implementation across every provider adapter.
- **`inner_agent`** was documented as a "pre-built BaseAgent escape hatch" but was stored and never read — architecturally incompatible with the streaming `run()` (a generic `BaseAgent` exposes only batch `run`/`run_async`, no streaming). `adapter=`/`config=` remain the supported bring-your-own-engine seams.
- The `core_agent` property docstring that falsely claimed to return a "user-provided inner_agent" is corrected (it never did, even before removal).
- Passing either keyword now raises `TypeError` — loud, actionable — instead of silently doing nothing.

**No deprecation shim** (deliberate, correct Rule-6a exception): the params were provably non-functional no-ops with zero possible dependent callers, so no caller could rely on the documented behavior; a hard `TypeError` is more actionable than a warning.

## Regression guard

A structural **AST completeness-guard** test (`test_every_init_param_reaches_a_consumer`) asserts every `Delegate.__init__` param reaches a real consumer (read beyond its own `self._x = x` storage), so this documented-kwarg-drop class cannot silently regress. Handles both `Assign` and `AnnAssign` storage forms; mutation-verified to flag stored-only no-ops while passing genuinely-consumed params.

## Verification

- Full kaizen-agents unit suite: **3135 passed, 61 skipped**.
- `/redteam` to convergence — **2 consecutive clean rounds** on BUG/INVEST-NOW:
  - Round 1: reviewer CLEAN (mutation-tested the guard; version consistency verified) + security-reviewer **SECURITY-NEUTRAL** (governance/envelope/is_mock gates intact; no secret exposure; no disclosure leak).
  - Round 2: reviewer CLEAN (reproduced the guard vs 6 synthetic cases; orphan-grep clean).
- Version bumped atomically → **0.11.7** (`pyproject.toml` + `__init__.py` + `uv.lock`); CHANGELOG entry added.

## Related issues

Fixes #1927