### PR TITLE
chore(workspace): cont-14 session records (#1927 shipped kaizen-agents 0.11.7)

### DIFF
--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -1,52 +1,65 @@
-# Session Notes — 2026-07-22 (cont-13)
+# Session Notes — 2026-07-23 (cont-14)
 
 ## Where we are
 
-Independent cross-session `/redteam` of the delivered #1720 surfaces caught + fixed a real
-Delegate bug cont-12 missed, released it, and tracked two deeper same-class follow-ups.
-Main @ `dd0064479`. kaizen-agents 0.11.6 live on PyPI (verified). Board otherwise clean.
+The last outstanding #1720 forest item — **#1927** (Delegate `signature`/`inner_agent`
+documented-but-silent-no-op) — is RESOLVED, RELEASED, and verified on the published wheel.
+Forest is now EMPTY. Main @ `6484d62db`. kaizen-agents **0.11.7 LIVE on PyPI**. Board clean.
 
 ## Read first
 
-1. `workspaces/issue-1720-llm-consolidation/launch-ledger-cont13.md` — full cont-13 record
-   (R1/R2 redteam verdicts, the fix, release, security-review, #1927 disposition).
-2. `CLAUDE.md` — project context. Board empty except tracked follow-up #1927; fresh work OK.
+1. `workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md` — full cont-14 record
+   (architecture investigation, user-ratified remove-both decision, implementation, 2-round
+   redteam convergence, release + wheel verification).
+2. `CLAUDE.md` — project context.
 
 ## In-flight state
 
-- None. Working tree clean (only untracked durable workspace records). No uncommitted code.
+- None. Working tree: only the modified `.session-notes` + `launch-ledger-cont14.md` post-release
+  edits (workspace records; persist via a workspace-only carve-out PR — no /release owed).
 
-## Executed this session
+## Executed this session (cont-14)
 
-- Released **kaizen-agents 0.11.6** to PyPI (tag `kaizen-agents-v0.11.6`; OIDC publish SUCCESS;
-  clean-venv + fix-behavior verified on the published wheel). Not in this repo's `git log`.
-
-## Wave tracker
-
-None — no waves in flight.
+- Resolved **#1927** by REMOVING `Delegate(signature=…)` + `Delegate(inner_agent=…)` (user-ratified
+  "remove both" via AskUserQuestion — both were never-worked silent no-ops; wiring signature would
+  duplicate the BaseAgent/Signature structured-output path across 4 adapters; inner_agent is
+  arch-incompatible with the streaming run()). Fixed the wrong `core_agent` docstring. Added a
+  structural AST **completeness-guard** test (every Delegate.__init__ param must reach a consumer —
+  closes the #1899/#1926/#1927 recurring documented-kwarg-drop class for the Delegate).
+- **PR #1932 MERGED** → `6484d62db`; **#1927 CLOSED**. 3135-test unit suite green; /redteam 2 clean
+  rounds (reviewer + security-reviewer, all genuinely ran).
+- Released **kaizen-agents 0.11.7** (tag `kaizen-agents-v0.11.7`; publish SUCCESS; clean-venv wheel
+  verified). Not in this repo's `git log` (PyPI-side).
 
 ## Unreleased packages
 
-- **kailash core** — one unreleased `src/` commit since `v2.61.0`: the `constraint_subset`
-  docstring correction (`9f2f9755b`). Doc-only / runtime-inert; user approved deferring it rather
-  than cut 2.61.1 for a docstring. Next session: bundle with the next core change, or cut 2.61.1.
+- **kailash core** — one unreleased `src/` commit since v2.61.0: the `constraint_subset` docstring
+  correction (`9f2f9755b`). Doc-only / runtime-inert; version NOT bumped (still 2.61.0 == PyPI).
+  User approved deferring. Next core change bundles it, or cut 2.61.1.
 
 ## Outstanding ledger (forest)
 
-| ID  | Item                                                                    | Value-anchor (MUST-1)                                          | Status                |
-| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------- |
-| F3  | kaizen Delegate `signature`/`inner_agent` documented but never wired    | user literal "approved" this session of filing + disposition (→ #1927) | queued (design shard) |
+EMPTY — F3/#1927 closed this session (F1/F2 closed cont-12). No queued items.
 
-Closed this session: none carried (F1/F2 closed cont-12; the temperature/max_tokens fix is in `git log` + PyPI, not a forest item).
+## Open considerations for the human (surfaced, not blocking)
 
-## Traps
+1. **Cross-SDK inspection (#1927 / cross-sdk-inspection Rule 1)** — NOT completed: checking whether
+   the Rust SDK (kailash-rs) has an equivalent Delegate facade with unwired params needs cross-repo
+   READ authorization (repo-scope-discipline — not self-authorizable). Assessment: LIKELY LOW-VALUE —
+   this was a Python-facade-specific API cleanup, not a shared-architecture bug (trust-plane/DataFlow
+   class). Authorize a check only if you want cross-SDK parity confirmed.
+2. **Codify opportunity** — the AST completeness-guard pattern (assert every documented constructor
+   param reaches a real consumer) is a reusable structural defense against the documented-kwarg-drop
+   class that recurred 3× on the Delegate (#1899/#1926/#1927). Currently lives as a kaizen-agents
+   regression test. Consider /codify to a reusable skill/reviewer-lens if you want it applied to
+   other multi-param facades SDK-wide. Workspace phase shows 05-codify with 2 journal candidates
+   pending. Not auto-run (codify is a structural human gate).
 
-- `Delegate.__init__` documented-kwarg-drop is a RECURRING class: #1899 (base_url/api_key),
-  #1926 (temperature/max_tokens), #1927 (signature/inner_agent). #1927 AC asks for a completeness guard.
+## Traps (carried)
+
 - CI flakes here: DataFlow bulk-multi-tenant Postgres isolation race + Windows SQLite "database is
-  locked". Both cleared on re-run; re-run failed jobs (pinned-head READ + separate merge), don't merge over red.
-- `.venv/bin/pre-commit` has a stale shebang (points to a `loom/kailash-py` path) — run `uv run pre-commit`.
-
-## Open questions for the human
-
-- F3/#1927 wire-vs-remove: recommended split (wire `signature`, remove `inner_agent`) — a design shard when you prioritize it.
+  locked". Both clear on re-run; re-run failed jobs (pinned-head READ + separate merge), don't merge
+  over red. (Did NOT recur on #1932.)
+- `.venv/bin/pre-commit` has a stale shebang (loom/kailash-py path) — run `uv run pre-commit`.
+- Stale `packages/kaizen-agents/build/lib/` holds pre-edit copies (gitignored, not shipped); pyright
+  may read it and show phantom diagnostics — runtime imports resolve to `src/` (verified).

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont14.md
@@ -55,6 +55,14 @@ Commit c35df4cd8 (branch fix/kaizen-delegate-signature-inner-agent-1927). Diff m
 
 R1 CLEAN both reviewers (both genuinely ran — evidence gate satisfied). INCREMENTAL note #2 (AST guard didn't handle AnnAssign/transform-RHS stores) FIXED in warm context: added `_is_pure_self_store` helper + AnnAssign branch (commit 14392da83, test-only). Hardened guard mutation-verified to catch AnnAssign-stored no-op. INCREMENTAL note #1 (Rule-6a deprecation tension) = no action (reviewer + security-reviewer both agree hard removal is the correct Rule-6a exception for a never-worked zero-caller param). Production/security surface byte-identical since R1 → security not re-run (test-only delta).
 
+## SHIPPED + RELEASED (build-repo-release-discipline done-gate satisfied)
+
+- **PR #1932 MERGED** → main `6484d62db`; issue **#1927 auto-CLOSED**; branch deleted. CI: 20 pass / 4 skip / 0 fail on pinned head `f5b0ab35` (no flakes; pinned-head READ separate from admin-merge per git.md).
+- Release scope enumerated (build-repo-release Rule 3): ONLY kaizen-agents (main 0.11.7 > PyPI 0.11.6); all 8 siblings main==PyPI (kailash core 2.61.0==2.61.0 — the 9f2f9755b docstring commit did NOT bump version, rides next core release per cont-13 deferral). Within user-approved scope.
+- Tag `kaizen-agents-v0.11.7` pushed → publish-pypi.yml run 29972794131 **SUCCESS** (OIDC; GitHub Release auto-created).
+- **kaizen-agents 0.11.7 LIVE on PyPI** — clean-venv verified (Rule 2 done-gate): `__version__==0.11.7`; FIX VERIFIED on published wheel (signature/inner_agent ABSENT; `signature=` → TypeError; 14 real params remain).
+- security-reviewer ran (R1, /release mandatory gate): SECURITY-NEUTRAL, 0 findings.
+
 ## Remaining
 
 - Full unit suite green confirm → commit → PR → redteam to convergence → merge → release 0.11.7 (build-repo-release discipline) → uv.lock sync.


### PR DESCRIPTION
Post-release durable workspace records for cont-14: #1927 (Delegate signature/inner_agent removal) resolved, kaizen-agents 0.11.7 live on PyPI, #1720 forest empty. Workspace-only diff (session notes + launch ledger) — no code/version change, release carve-out applies per build-repo-release-discipline §1a.

## Related issues
Refs #1927 (closed via #1932)