### PR TITLE
test(trust): migrate delegation-sig verify test to v1-subject-bound cap (#1912)

### DIFF
--- a/packages/kailash-kaizen/tests/unit/trust/test_delegation_signatures.py
+++ b/packages/kailash-kaizen/tests/unit/trust/test_delegation_signatures.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 import pytest
 from kailash.trust.chain import (
+    CAPABILITY_SIGNING_VERSION_V1,
     CapabilityAttestation,
     CapabilityType,
     ConstraintEnvelope,
@@ -739,7 +740,13 @@ class TestIntegrationWithExistingVerify:
         genesis_payload = serialize_for_signing(genesis.to_signing_payload())
         genesis.signature = sign(genesis_payload, private_key)
 
-        # Create a properly signed capability
+        # Create a properly signed capability. Post-#1912 (Wave 3 A1), an
+        # un-subject-bound legacy cap is rejected by default (transplantable
+        # across chains), so a "properly signed" cap is v1-subject-bound: the
+        # signature binds the HOLDER chain's genesis.agent_id ("agent-A") into
+        # the pre-image, exactly as the verify side recomputes it
+        # (operations `_verify_capability_signature` passes
+        # subject_agent_id=chain.genesis.agent_id).
         capability = CapabilityAttestation(
             id="cap-001",
             capability="analyze_data",
@@ -748,8 +755,11 @@ class TestIntegrationWithExistingVerify:
             attester_id="org-test",
             attested_at=datetime.now(timezone.utc),
             signature="",
+            signing_payload_version=CAPABILITY_SIGNING_VERSION_V1,
         )
-        cap_payload = serialize_for_signing(capability.to_signing_payload())
+        cap_payload = serialize_for_signing(
+            capability.to_signing_payload(subject_agent_id="agent-A")
+        )
         capability.signature = sign(cap_payload, private_key)
 
         # Create a properly signed delegation


### PR DESCRIPTION
## Summary

Fixes a **pre-existing deterministic failure on main**: `test_verify_signatures_validates_delegations` (kailash-kaizen trust suite) built an un-subject-bound **legacy** `CapabilityAttestation` and expected `valid=True`. Since **#1912 Wave 3 A1** (commit `46dee444a`), legacy caps are rejected by default (`allow_unbound_legacy_capabilities=False`) because they are transplantable across chains — so the test failed with `Invalid capability signature: cap-001`.

The test was authored pre-#1912 and never migrated. It only surfaced now because a kaizen-agents-only change doesn't trigger the full kailash-kaizen matrix; a workflow-touching PR (dependabot #1931) ran it and exposed the failure.

**Fix (test-only):** modernize the test cap to a **v1-subject-bound** capability that binds the holder chain's `genesis.agent_id` (`agent-A`) into the signed pre-image — exactly as the verify side recomputes it (`_verify_capability_signature` passes `subject_agent_id=chain.genesis.agent_id`). This tests the *secure* path rather than opting into the `allow_unbound_legacy_capabilities` migration window, strengthening coverage.

## Verification
- The failing test now passes **3/3** deterministically; full trust file **13 passed**.
- Same-class sweep: this was the only stale legacy-cap construction (CI showed 1 failed / 6555 passed).
- Test-only diff → build-repo-release carve-out (no `/release`).

## Related issues
Refs #1912 (the security hardening this test predates)