### PR TITLE
chore: cross-repo read authz receipt + #1927 cross-SDK inspection result (no gap)

### DIFF
--- a/.claude/cross-repo-authz/2026-07-23-esperie-enterprise-kailash-rs-read-only-cross-sd.md
+++ b/.claude/cross-repo-authz/2026-07-23-esperie-enterprise-kailash-rs-read-only-cross-sd.md
@@ -1,0 +1,41 @@
+---
+type: cross-repo-authorization-receipt
+date: 2026-07-23
+timestamp: 2026-07-23T05:54:51.246Z
+requester: jack-hong
+target: esperie-enterprise/kailash-rs
+action: READ-only cross-SDK inspection for #1927: grep/read source for a Delegate/agent facade accepting documented-but-unwired constructor params (signature/inner_agent no-op equivalent). No writes.
+mode: read
+---
+
+# Cross-Repo Authorization Receipt
+
+cross-repo-authorized: esperie-enterprise/kailash-rs read
+
+## Bounded action
+
+- **Target repo:** esperie-enterprise/kailash-rs
+- **Action (read):** READ-only cross-SDK inspection for #1927: grep/read source for a Delegate/agent facade accepting documented-but-unwired constructor params (signature/inner_agent no-op equivalent). No writes.
+- **Requester (display_id):** jack-hong
+- **Authorized at:** 2026-07-23T05:54:51.246Z
+
+## Verbatim user instruction
+
+> yes please proceed with the cross-sdk check
+
+## Five-condition attestation (repo-scope-discipline.md § User-Authorized Exception)
+
+- condition_1_user_initiated: REQUIRED — a genuine user turn
+- condition_2_explicit_specific: REQUIRED — names the target repo AND the exact bounded READ
+- condition_3_confirmed: REQUIRED — the ceremony restated action+target and the user confirmed yes/no BEFORE this write
+- condition_4_receipt_before_acting: DOWNGRADED (READ tier) — one-line affordance receipt; a read leaves no durable trace in the target
+- condition_5_scoped_exactly: REQUIRED — only the named read against only the named repo
+
+<!--
+  This receipt is the ONLY distinguisher between an authorized and an
+  unauthorized cross-repo action. It is written by
+  .claude/bin/cross-repo-authorize.mjs AFTER the user confirmed the restated
+  action+target in chat, and BEFORE the action runs. The hook
+  (violation-patterns.js::hasCrossRepoAuthorizationReceipt) greps this file's
+  marker line within its mtime window; commit it for durable team audit.
+-->

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -41,18 +41,20 @@ failure on main** (unrelated to #1927). Board otherwise clean.
 
 EMPTY. #1927 (F3) closed. No queued code items.
 
-## Open considerations for the human (surfaced, not blocking)
+## Both user-approved follow-ups — DONE this session
 
-1. **Full /codify is a dedicated session, not done here.** The codify backlog enumerator shows
-   **602 items** anchored 2026-07-21 (mostly prior-session `test_pattern` telemetry + other sessions'
-   deltas) — far beyond the single completeness-guard pattern approved this session. This session
-   captured its two learnings as `journal/0012` + `journal/0013` (durable, feeds a future codify)
-   WITHOUT advancing `last_codified` (preserving the backlog). Recommend a dedicated /codify session
-   for the full backlog + a loom Step-7a proposal to cascade the completeness-guard as a cross-SDK
-   validation lens.
-2. **Cross-SDK inspection (#1927)** — checking whether the Rust SDK has an equivalent Delegate with
-   unwired params needs cross-repo READ authorization (not self-authorizable). Assessed LIKELY
-   LOW-VALUE (Python-facade cleanup, not shared-architecture). See `journal/0012` For-Discussion #3.
+1. **Full /codify — DONE (PR #1936 merged).** Backlog was ~99% auto-captured `test_pattern`
+   telemetry (not individually codifiable); actionable delta dispositioned (1 redundant RISK stub
+   deleted, 1 advisory violation reviewed benign). Codified the ONE cascade-valuable pattern — the
+   AST param-completeness-guard — as a `16-validation-patterns` skill_update proposal appended to
+   `.claude/.proposals/latest.yaml` (change #31, `global`; loom Gate-1 owns placement + eval-coverage).
+   Anchor advanced (local, gitignored). cc-architect redteam CLEAN. Learnings: journals 0012/0013;
+   DECISION 0014.
+2. **Cross-SDK inspection (#1927) — DONE (user-authorized READ; receipt committed).** NO equivalent
+   gap in the Rust SDK — its `Delegate` is a trust-plane primitive, its agent facade is
+   `GovernedAgentRuntime` (functional params only), and its live `inner_agent` usage is
+   functionally-wired. The documented-kwarg-drop class is Python-facade-specific. No issue filed
+   (no gap). See `journal/0015`. Confirms the pre-inspection low-value assessment.
 
 ## Traps (carried)
 

--- a/workspaces/issue-1720-llm-consolidation/journal/0015-DISCOVERY-cross-sdk-1927-no-equivalent-gap.md
+++ b/workspaces/issue-1720-llm-consolidation/journal/0015-DISCOVERY-cross-sdk-1927-no-equivalent-gap.md
@@ -1,0 +1,51 @@
+# DISCOVERY — Cross-SDK inspection for #1927: no equivalent unwired-param gap in the Rust SDK
+
+Date: 2026-07-23. Repo class: BUILD. Author: agent. Phase: codify.
+relates_to: 0012-DISCOVERY-param-completeness-guard-vs-documented-kwarg-drop
+
+## The inspection (cross-sdk-inspection Rule 1)
+
+User-authorized READ-only inspection of the Rust SDK (receipt:
+`.claude/cross-repo-authz/2026-07-23-esperie-enterprise-kailash-rs-read-only-cross-sd.md`,
+READ tier). Question: does the Rust SDK expose a `Delegate`/agent facade with
+documented-but-unwired constructor params — the #1927 `signature`/`inner_agent` no-op
+equivalent? **Answer: NO.** The architecture differs materially, so the class does not exist there.
+
+## Evidence
+
+- The Rust SDK's `Delegate` (`bindings/kailash-python/.../kaizen/__init__.pyi`) is a
+  **trust-plane delegation primitive** (`"Trust-plane delegation primitive"`), NOT the Python
+  kaizen-agents streaming autonomous-execution facade. Different purpose entirely.
+- The Rust agent-execution facade is `GovernedAgentRuntime(agent, llm_client, spec_version)` —
+  every constructor param is functional; there is no `signature`/`inner_agent` param. (The
+  ungoverned `DelegateEngine` is DEPRECATED, superseded by `GovernedAgentRuntime`.)
+- Where `inner_agent` appears in LIVE Rust code (`StreamingAgent::wrap(inner_agent)`,
+  `GovernedAgent::new(inner_agent, ...)`, `agent.clone_inner()`) it is a FUNCTIONALLY-WIRED
+  wrapped agent, never a stored-and-never-read no-op.
+- `signature` in the Rust SDK refers to an agent-contract `SignatureMismatch` error
+  (`crates/kailash-kaizen/src/error.rs`), a different concept from the Python Delegate's
+  structured-output `signature` param.
+- An ARCHIVED spec (`workspaces/_archive/.../05-spec-delegate-engine.md`) carries the ORIGINAL
+  Python Delegate design with `inner_agent` intended to be wired (`if inner_agent is not None:
+core = inner_agent`) — confirming the param was DESIGNED functional; the Python impl never
+  wired it, the Rust SDK implements a different facade.
+
+## Disposition
+
+No cross-SDK issue filed (no gap → nothing to file → no separate filing authorization needed).
+The #1927 documented-kwarg-drop class is Python-kaizen-agents-facade-specific. cross-sdk-inspection
+Rule 1 checklist satisfied: checked, no equivalent, no file. Confirms the pre-inspection
+low-value assessment. handoff-completion satisfied: the check was EXECUTED, not left implied.
+
+## For Discussion
+
+1. The Rust SDK reached the SAME end-state (a governed agent runtime with only functional
+   constructor params) by a DIFFERENT path (GovernedAgentRuntime + trust-plane Delegate split),
+   never accumulating the documented-but-unwired params the Python facade did. Is that because
+   Rust's stricter constructor ergonomics (no silent `**kwargs` drop; an unused param is a
+   compile warning) structurally resist the class — i.e. is the completeness-guard (journal 0012)
+   a Python-specific need the Rust type system already enforces?
+2. Counterfactual: had the Python Delegate been generated FROM the same spec as the Rust one
+   (`05-spec-delegate-engine.md`, which wired `inner_agent`), would #1899/#1926/#1927 have
+   happened at all — i.e. is the root cause a Python impl that drifted from its own spec, and does
+   that argue for a spec-conformance test over (or alongside) the AST completeness-guard?


### PR DESCRIPTION
User-authorized READ-only cross-SDK inspection for #1927 (repo-scope-discipline User-Authorized Exception, READ tier; receipt committed for durable audit). **Result: no equivalent gap** in the Rust SDK — its `Delegate` is a trust-plane primitive, its agent facade is `GovernedAgentRuntime` (functional params only), live `inner_agent` usage is functionally-wired. The documented-kwarg-drop class is Python-facade-specific; no issue filed. Details in journal 0015. Workspace + authz-receipt only — release carve-out.

## Related issues
Refs #1927 (closed via #1932)