### PR TITLE
fix(kaizen-agents): create checkpoint dir lazily, not in the constructor (0.11.8)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.8] — 2026-07-23 — Stop `BaseAutonomousAgent` from creating `./checkpoints/` in the caller's cwd on construction
+
+### Fixed
+
+- **`BaseAutonomousAgent` no longer litters the caller's working directory with an empty `checkpoints/` directory on construction.** `__init__` unconditionally called `self.checkpoint_dir.mkdir(parents=True, exist_ok=True)` (default `checkpoint_dir=Path("./checkpoints")`), so merely _constructing_ an autonomous agent — or any subclass, including the Codex and Claude-Code adapters — created a `./checkpoints/` folder in whatever directory the process was launched from, even for agents that never checkpoint (the base run loop persists via `state_manager`/DataFlow, not this directory). Directory creation is now **lazy**: it happens on the first actual checkpoint write inside `_save_checkpoint`. This is non-breaking — agents that do checkpoint get the identical directory at the identical location, created on demand; agents that don't get no stray folder. Reads were already `.exists()`-guarded, so resume/load paths are unaffected. Behavioral regression tests pin all three cases (construction creates no dir; first write creates dir+file; an explicit `checkpoint_dir` is likewise lazy).
+
 ## [0.11.7] — 2026-07-23 — Remove documented-but-unwired Delegate `signature`/`inner_agent` params (#1927)
 
 ### Removed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.7"
+version = "0.11.8"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/packages/kaizen-agents/src/kaizen_agents/agents/autonomous/base.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/autonomous/base.py
@@ -219,7 +219,11 @@ class BaseAutonomousAgent(BaseAgent):
 
         # Autonomous-specific state
         self.checkpoint_dir = checkpoint_dir or Path("./checkpoints")
-        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        # NOTE: the directory is created lazily, on the first checkpoint write
+        # (see _save_checkpoint), NOT here. Creating it in __init__ littered the
+        # caller's cwd with an empty ./checkpoints/ on every construction — even
+        # for agents that never checkpoint (the base run loop persists via
+        # state_manager/DataFlow, not this directory).
         self.current_plan: list[dict[str, Any]] = []
         self.cycle_count: int = 0
 
@@ -731,6 +735,9 @@ class BaseAutonomousAgent(BaseAgent):
         }
 
         try:
+            # Create the checkpoint directory lazily, on first write, so merely
+            # constructing an agent never litters the caller's cwd (see __init__).
+            self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
             with open(checkpoint_file, "a") as f:
                 f.write(json.dumps(checkpoint_data) + "\n")
 

--- a/packages/kaizen-agents/tests/regression/test_checkpoint_dir_no_cwd_litter.py
+++ b/packages/kaizen-agents/tests/regression/test_checkpoint_dir_no_cwd_litter.py
@@ -1,0 +1,79 @@
+"""Regression: autonomous-agent construction must not litter the caller's cwd.
+
+Pins the F-TESTHYG fix: ``BaseAutonomousAgent.__init__`` previously created its
+``checkpoint_dir`` (default ``./checkpoints``) unconditionally via ``mkdir`` in
+the constructor, so merely *constructing* an agent dropped an empty
+``checkpoints/`` directory into the caller's current working directory — even
+for agents that never checkpoint (the base run loop persists via
+``state_manager``/DataFlow, not this directory). The directory is now created
+lazily, on the first checkpoint write.
+
+Behavioral tests (call the code, observe the filesystem) per rules/testing.md —
+NOT source-grep. NEVER delete (rules/testing.md § Regression Testing).
+"""
+
+import pytest
+
+from kaizen.signatures import InputField, OutputField, Signature
+from kaizen_agents.agents.autonomous.base import AutonomousConfig, BaseAutonomousAgent
+
+
+class _TaskSignature(Signature):
+    """Minimal signature for constructing an agent under test."""
+
+    task: str = InputField(description="Task to perform")
+    result: str = OutputField(description="Result")
+
+
+def _make_config() -> AutonomousConfig:
+    # Mirrors the construction pattern used across the autonomous unit suite;
+    # ollama/local model — no network, no API key, construction never calls out.
+    return AutonomousConfig(
+        max_cycles=3, llm_provider="ollama", model="llama3.1:8b-instruct-q8_0"
+    )
+
+
+@pytest.mark.regression
+def test_construction_does_not_create_checkpoint_dir(tmp_path, monkeypatch):
+    """Constructing an agent must NOT create ./checkpoints in the caller's cwd."""
+    monkeypatch.chdir(tmp_path)
+
+    BaseAutonomousAgent(config=_make_config(), signature=_TaskSignature())
+
+    assert not (tmp_path / "checkpoints").exists(), (
+        "constructing BaseAutonomousAgent created ./checkpoints in the caller's "
+        "cwd — the directory must be created lazily on first checkpoint write"
+    )
+
+
+@pytest.mark.regression
+def test_checkpoint_write_creates_dir_lazily(tmp_path, monkeypatch):
+    """First checkpoint write must create the dir + file (fix is non-breaking)."""
+    monkeypatch.chdir(tmp_path)
+    agent = BaseAutonomousAgent(config=_make_config(), signature=_TaskSignature())
+
+    assert not (tmp_path / "checkpoints").exists()  # precondition: still absent
+
+    agent._save_checkpoint({"status": "ok"}, cycle_num=1)
+
+    assert (tmp_path / "checkpoints").exists(), "dir must be created on first write"
+    assert (
+        tmp_path / "checkpoints" / "checkpoint_cycle_001.jsonl"
+    ).exists(), "checkpoint file must be written under the lazily-created directory"
+
+
+@pytest.mark.regression
+def test_explicit_checkpoint_dir_also_lazy(tmp_path, monkeypatch):
+    """An explicit checkpoint_dir is likewise not created until first write."""
+    monkeypatch.chdir(tmp_path)
+    cp_dir = tmp_path / "custom_cp"
+    agent = BaseAutonomousAgent(
+        config=_make_config(), signature=_TaskSignature(), checkpoint_dir=cp_dir
+    )
+
+    assert not cp_dir.exists(), "explicit checkpoint_dir must not be eagerly created"
+
+    agent._save_checkpoint({"status": "ok"}, cycle_num=2)
+
+    assert cp_dir.exists(), "explicit checkpoint_dir must be created on first write"
+    assert (cp_dir / "checkpoint_cycle_002.jsonl").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.11.7"
+version = "0.11.8"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "anthropic" },

--- a/workspaces/issue-1720-llm-consolidation/04-validate/f-testhyg-followup.md
+++ b/workspaces/issue-1720-llm-consolidation/04-validate/f-testhyg-followup.md
@@ -53,3 +53,57 @@ covers everything). Touches src → its own redteam + a kaizen-agents release.
   new scratch at the package root WITHOUT relying on `.gitignore`.
 - (iv) **Revisit trigger:** `after-milestone:1720-wave2` (bundle with the Wave-2
   kaizen-agents release, since both touch kaizen-agents src + release).
+
+## Reconciliation — 2026-07-23 (cont-15, revisit trigger FIRED)
+
+The `after-milestone:1720-wave2` trigger has **passed without bundling**: cont-14 shipped
+**kaizen-agents 0.11.7** as #1720's final release (#1927), but F-TESTHYG was NOT bundled in.
+The item is now an **orphaned INCREMENTAL deferral** whose original revisit trigger expired.
+
+Re-scoped effort (grep evidence, cont-15): the class-2 write sites are **NOT statically
+locatable** — `consensus_<hash>.json` / `detailed_proposal.txt` / `proposal_evaluation.txt`
+appear nowhere as literal write sites in `packages/kaizen-agents/src` (dynamically
+constructed filenames; observable only under real-LLM runs — where the Wave-1A agent hit
+its session limit). The real fix therefore requires real-LLM reproduction to locate the
+sites, then a src change + kaizen-agents redteam + a **patch release** — for test-run
+scratch litter that is already `.gitignore`-masked (#1808) and has **zero runtime / user
+impact**.
+
+The class-1 chdir fixture alone delivers no net value: it does not let us remove the
+`.gitignore` band-aid (class-2 still leaks), which is why cont-14's predecessor left it
+un-merged.
+
+**Value re-validation (value-prioritization MUST-3):** LOW — anchor is the owner's minor
+test-hygiene note; not a shipped/runtime defect. Disposition is a **user gate**
+(value-prioritization MUST-4: value-bearing deferred work is not closed nor re-actioned
+without owner sign-off). **Re-anchored trigger:** `next kaizen-agents src change OR owner
+prioritizes test-hygiene` (removes the expired release-bundle coupling).
+
+## RESOLVED — 2026-07-23 (cont-15, owner-approved "action it now")
+
+The bounded investigation **corrected the premise**: there is NO "class-2 root-discovery src
+bug." The `consensus_*.json` / `detailed_proposal.txt` names appear in src only as dict/memory
+keys (no disk-write site) — those scratch files were **example-script output**, not shipped
+package behavior. The real, confirmed defect was narrower AND user-facing (not test-only):
+
+- **`BaseAutonomousAgent.__init__` created `./checkpoints/` in the caller's cwd on EVERY
+  construction** (base.py:222 unconditional `mkdir`) — even for agents that never checkpoint
+  (base run loop persists via `state_manager`/DataFlow). Confirmed runtime, not test litter.
+
+**Fix (non-breaking):** dir creation moved to lazy (first checkpoint write in `_save_checkpoint`).
+Construct → no folder; checkpoint → identical dir/location on demand. Reads already
+`.exists()`-guarded. Verified: runtime walk + 3 behavioral regression tests
+(`tests/regression/test_checkpoint_dir_no_cwd_litter.py`) + 44 autonomous unit tests + 3478
+collect clean + 0 WARN+. Redteam 2 clean rounds (reviewer + security-reviewer NO FINDINGS;
+same-class sweep found no sibling defect). Shipped in **kaizen-agents 0.11.8**.
+
+### Residuals surfaced to owner (NOT actioned — separate decisions)
+
+1. **Running-agent default location.** A _running_ codex/claude_code autonomous agent still
+   defaults checkpoints to `./checkpoints` in the user's cwd. Lazy-mkdir fixes construct-time
+   litter only; changing the documented default location (→ temp/state dir) is a
+   behavior-change / owner call.
+2. **Pre-existing checkpoint perms (different bug class).** Checkpoint dir/files use default
+   umask (world-readable) and `state` may contain PII (security-reviewer, pre-existing). The
+   delegate `SessionManager` is the in-repo secure reference (`chmod 0o700` dir + `_secure_write`
+   `0o600` files). Hardening the checkpoint path to match is a separate, owner-gated change.

--- a/workspaces/issue-1720-llm-consolidation/launch-ledger-cont15.md
+++ b/workspaces/issue-1720-llm-consolidation/launch-ledger-cont15.md
@@ -1,0 +1,35 @@
+# Launch Ledger — cont-15 (F-TESTHYG checkpoint-dir fix)
+
+Durable record of background agents spawned this session (orchestration-launch-ledger MUST-1).
+Self-launched; match completion notifications against this table before reacting.
+
+## Task
+
+F-TESTHYG (reconciled from the orphaned cont-14 deferral): `BaseAutonomousAgent.__init__`
+created `./checkpoints/` in the caller's cwd unconditionally on construction. Fix = lazy dir
+creation (moved `mkdir` from `__init__` into `_save_checkpoint`). User approved "action it now".
+
+## Change set (implemented + verified, pre-redteam)
+
+- `packages/kaizen-agents/src/kaizen_agents/agents/autonomous/base.py` — removed eager `mkdir`
+  from `__init__`; added lazy `mkdir` in `_save_checkpoint` (first-write).
+- `packages/kaizen-agents/tests/regression/test_checkpoint_dir_no_cwd_litter.py` — NEW, 3
+  behavioral regression tests. All pass; 44 autonomous unit tests pass; 3478 collect clean; 0 WARN+.
+- Runtime walk confirmed: construct → no dir; first `_save_checkpoint` → dir + file created.
+
+## Background agents (redteam round 1)
+
+| agent             | scope                                 | status    |
+| ----------------- | ------------------------------------- | --------- |
+| reviewer          | correctness / missed consumers of dir | in-flight |
+| security-reviewer | error-hiding / path / posture         | in-flight |
+
+## Release target (staged, NOT yet cut — awaits redteam convergence)
+
+kaizen-agents 0.11.7 → **0.11.8** (patch, `### Fixed`). Anchors: pyproject.toml + **init**.py.
+
+## Residual for owner (surfaced, not actioned)
+
+Running codex/claude_code autonomous agents still default checkpoints to `./checkpoints` in the
+user's cwd (documented default-location; lazy-mkdir fixes only the construct-time litter). Changing
+the default location is a documented-behavior change — owner decision, not made unilaterally.


### PR DESCRIPTION
## Summary

`BaseAutonomousAgent.__init__` unconditionally created its `checkpoint_dir`
(default `Path("./checkpoints")`) via `mkdir` in the constructor — so merely
**constructing** an autonomous agent (or any subclass, including the Codex and
Claude-Code adapters) dropped an empty `checkpoints/` directory into the
caller's current working directory, even for agents that never checkpoint (the
base run loop persists via `state_manager`/DataFlow, not this directory).

Directory creation is now **lazy** — it happens on the first actual checkpoint
write inside `_save_checkpoint`.

- **Non-breaking:** checkpointing agents get the identical directory at the
  identical location, created on demand; agents that don't checkpoint get no
  stray folder. Reads were already `.exists()`-guarded, so resume/load paths
  are unaffected.
- **Runtime-verified:** construct → no dir; first `_save_checkpoint` → dir +
  file created.

## Tests

- New behavioral regression file `tests/regression/test_checkpoint_dir_no_cwd_litter.py`
  (3 cases: construction creates no dir; first write creates dir+file; explicit
  `checkpoint_dir` is likewise lazy).
- 44 autonomous unit tests pass; 3478 collect cleanly; zero WARN+.
- Redteam: 2 clean rounds (reviewer + security-reviewer NO FINDINGS; same-class
  sweep found no sibling construct-time-litter defect).

## Version

kaizen-agents `0.11.7` → `0.11.8` (patch). `pyproject.toml` + `__init__.py` +
`CHANGELOG.md` updated atomically.

## Residuals (surfaced, not in this PR — owner decisions)

1. A *running* codex/claude_code agent still defaults checkpoints to
   `./checkpoints` in the cwd; changing the documented default location is a
   behavior change.
2. Pre-existing: checkpoint dir/files use default umask (world-readable) and
   `state` may contain PII — a separate hardening (the delegate `SessionManager`
   is the in-repo secure reference: `chmod 0o700` + `_secure_write` `0o600`).

## Related issues

No GitHub issue — internal F-TESTHYG follow-up from workspace
`issue-1720-llm-consolidation` (reconciled this session: its original
"bundle with the kaizen-agents release" revisit trigger had expired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)