### PR TITLE
fix(kaizen-agents): default checkpoints to per-user state dir + owner-only perms (0.12.0)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] — 2026-07-23 — Default autonomous-agent checkpoints to a per-user state dir (off cwd) + owner-only permissions
+
+### Changed
+
+- **BREAKING (default location): `BaseAutonomousAgent` now checkpoints to a per-user state directory by default, not `./checkpoints` in the current working directory.** With no explicit `checkpoint_dir`, the default resolves via `platformdirs.user_state_dir("kaizen")` (`$XDG_STATE_HOME`/`~/.local/state/kaizen/checkpoints` on Linux, `~/Library/Application Support/kaizen/checkpoints` on macOS, `%LOCALAPPDATA%\kaizen\checkpoints` on Windows) — so the SDK no longer writes checkpoint files into whatever directory the process was launched from. **Migration:** to keep the old behavior, pass `checkpoint_dir=Path("./checkpoints")` explicitly; existing checkpoint files under a project-local `./checkpoints/` are not auto-migrated and will not be found by the new default (recovery from them requires passing the explicit path). This completes the cwd-litter fix started in 0.11.8 (which stopped the _construct-time_ directory creation); 0.12.0 additionally relocates the _run-time_ checkpoint writes off the cwd.
+
+### Security
+
+- **Checkpoint directory and files are now created with owner-only permissions on POSIX** (`0o700` dir / `0o600` files), matching the delegate `SessionManager` secure-write pattern. Checkpoint payloads can contain conversation and plan state; they were previously created world-readable under the default umask. On Windows, POSIX modes do not apply and a plain append is used.
+
 ## [0.11.8] — 2026-07-23 — Stop `BaseAutonomousAgent` from creating `./checkpoints/` in the caller's cwd on construction
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.11.8"
+version = "0.12.0"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -44,6 +44,9 @@ dependencies = [
     # Gemini paths raise ImportError at adapter construction.
     "anthropic>=0.40.0",
     "google-genai>=1.0.0",
+    # platformdirs: per-user state dir for autonomous-agent checkpoints
+    # (agents/autonomous/base.py::_default_checkpoint_dir) — module-scope import.
+    "platformdirs>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.11.8"
+__version__ = "0.12.0"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/packages/kaizen-agents/src/kaizen_agents/agents/autonomous/base.py
+++ b/packages/kaizen-agents/src/kaizen_agents/agents/autonomous/base.py
@@ -32,10 +32,13 @@ Updated: 2025-10-26 (Standardized to .run() interface)
 import asyncio
 import json
 import logging
+import os
 from dataclasses import dataclass
 from datetime import UTC
 from pathlib import Path
 from typing import Any
+
+import platformdirs
 
 from kaizen.core.autonomy.interrupts.manager import InterruptManager
 from kaizen.core.autonomy.interrupts.types import (
@@ -51,6 +54,50 @@ from kaizen.signatures import Signature
 from kaizen.strategies.multi_cycle import MultiCycleStrategy
 
 logger = logging.getLogger(__name__)
+
+
+def _default_checkpoint_dir() -> Path:
+    """Per-user state directory for autonomous-agent checkpoints.
+
+    Resolves to the platform's user-state location (``$XDG_STATE_HOME`` /
+    ``~/.local/state`` on Linux, ``~/Library/Application Support`` on macOS,
+    ``%LOCALAPPDATA%`` on Windows) so the SDK never writes checkpoint files into
+    the caller's *current working directory*. Pass an explicit ``checkpoint_dir``
+    to override (e.g. a project-local path).
+    """
+    return Path(platformdirs.user_state_dir("kaizen")) / "checkpoints"
+
+
+def _append_checkpoint_line(directory: Path, filename: str, line: str) -> Path:
+    """Append one line to ``directory/filename`` with owner-only permissions.
+
+    Creates ``directory`` (mode ``0o700`` on POSIX) and the file (mode ``0o600``
+    on POSIX) so checkpoint payloads — which may contain conversation/plan state
+    — are not world-readable. On Windows, POSIX modes do not apply and a plain
+    append is used.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    if os.name != "posix":
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+        return path
+    # POSIX: create dir/file with owner-only perms, no world-readable window.
+    try:
+        os.chmod(directory, 0o700)
+    except OSError:
+        pass  # best-effort tightening; a pre-existing dir may be owned elsewhere
+    # O_NOFOLLOW: refuse to write THROUGH a symlink at the leaf path — if a caller
+    # supplies a world-writable checkpoint_dir, an attacker cannot pre-place a
+    # symlink there to redirect checkpoint payloads (security.md § Path Containment,
+    # sink-level enforcement). The default per-user dir is 0o700 so this is
+    # defense-in-depth; the failure (ELOOP) surfaces via the caller's try/except.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+    return path
 
 
 @dataclass
@@ -217,13 +264,18 @@ class BaseAutonomousAgent(BaseAgent):
             **kwargs,
         )
 
-        # Autonomous-specific state
-        self.checkpoint_dir = checkpoint_dir or Path("./checkpoints")
-        # NOTE: the directory is created lazily, on the first checkpoint write
-        # (see _save_checkpoint), NOT here. Creating it in __init__ littered the
-        # caller's cwd with an empty ./checkpoints/ on every construction — even
-        # for agents that never checkpoint (the base run loop persists via
-        # state_manager/DataFlow, not this directory).
+        # Autonomous-specific state.
+        # Default checkpoints go to a per-user state directory (see
+        # _default_checkpoint_dir), NOT the caller's cwd — an SDK must not write
+        # files into whatever directory the process was launched from. Pass an
+        # explicit checkpoint_dir for a project-local location. The directory is
+        # created lazily, on the first checkpoint write (see _save_checkpoint),
+        # so construction has no filesystem side effect at all.
+        self.checkpoint_dir = (
+            Path(checkpoint_dir)
+            if checkpoint_dir is not None
+            else _default_checkpoint_dir()
+        )
         self.current_plan: list[dict[str, Any]] = []
         self.cycle_count: int = 0
 
@@ -722,11 +774,10 @@ class BaseAutonomousAgent(BaseAgent):
 
         Example:
             >>> agent._save_checkpoint(result, cycle_num=5)
-            # Saves to: ./checkpoints/task_<timestamp>_cycle_5.jsonl
+            # Saves to: <checkpoint_dir>/checkpoint_cycle_005.jsonl
+            # (checkpoint_dir defaults to the per-user state dir, not the cwd)
         """
-        checkpoint_file = (
-            self.checkpoint_dir / f"checkpoint_cycle_{cycle_num:03d}.jsonl"
-        )
+        checkpoint_filename = f"checkpoint_cycle_{cycle_num:03d}.jsonl"
 
         checkpoint_data = {
             "cycle": cycle_num,
@@ -735,12 +786,14 @@ class BaseAutonomousAgent(BaseAgent):
         }
 
         try:
-            # Create the checkpoint directory lazily, on first write, so merely
-            # constructing an agent never litters the caller's cwd (see __init__).
-            self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
-            with open(checkpoint_file, "a") as f:
-                f.write(json.dumps(checkpoint_data) + "\n")
-
+            # Create dir + file lazily with owner-only permissions on first write
+            # (see _append_checkpoint_line): construction never touches the fs, and
+            # checkpoint payloads (conversation/plan state) are not world-readable.
+            checkpoint_file = _append_checkpoint_line(
+                self.checkpoint_dir,
+                checkpoint_filename,
+                json.dumps(checkpoint_data) + "\n",
+            )
             logger.debug(f"Checkpoint saved: {checkpoint_file}")
         except Exception as e:
             logger.warning(f"Failed to save checkpoint: {e}")

--- a/packages/kaizen-agents/tests/regression/test_checkpoint_dir_no_cwd_litter.py
+++ b/packages/kaizen-agents/tests/regression/test_checkpoint_dir_no_cwd_litter.py
@@ -1,17 +1,24 @@
-"""Regression: autonomous-agent construction must not litter the caller's cwd.
+"""Regression: autonomous-agent checkpoints never litter the caller's cwd.
 
-Pins the F-TESTHYG fix: ``BaseAutonomousAgent.__init__`` previously created its
-``checkpoint_dir`` (default ``./checkpoints``) unconditionally via ``mkdir`` in
-the constructor, so merely *constructing* an agent dropped an empty
-``checkpoints/`` directory into the caller's current working directory — even
-for agents that never checkpoint (the base run loop persists via
-``state_manager``/DataFlow, not this directory). The directory is now created
-lazily, on the first checkpoint write.
+Pins two related fixes:
+
+- **0.11.8** — ``BaseAutonomousAgent.__init__`` no longer creates its
+  ``checkpoint_dir`` eagerly (construction has no filesystem side effect; the
+  directory is created lazily on the first checkpoint write).
+- **0.12.0** — the DEFAULT checkpoint location is a per-user state directory
+  (``platformdirs.user_state_dir("kaizen")/checkpoints``), NOT ``./checkpoints``
+  in the current working directory; the directory/files are created with
+  owner-only permissions (``0o700``/``0o600``) on POSIX.
 
 Behavioral tests (call the code, observe the filesystem) per rules/testing.md —
-NOT source-grep. NEVER delete (rules/testing.md § Regression Testing).
+NOT source-grep. Write-triggering tests use an EXPLICIT tmp ``checkpoint_dir`` so
+they never write into the real per-user state directory. NEVER delete.
 """
 
+import os
+import stat
+
+import platformdirs
 import pytest
 
 from kaizen.signatures import InputField, OutputField, Signature
@@ -34,46 +41,74 @@ def _make_config() -> AutonomousConfig:
 
 
 @pytest.mark.regression
-def test_construction_does_not_create_checkpoint_dir(tmp_path, monkeypatch):
-    """Constructing an agent must NOT create ./checkpoints in the caller's cwd."""
+def test_construction_creates_no_dir_and_default_is_off_cwd(tmp_path, monkeypatch):
+    """Constructing an agent creates nothing, and the default dir is NOT cwd."""
     monkeypatch.chdir(tmp_path)
 
-    BaseAutonomousAgent(config=_make_config(), signature=_TaskSignature())
+    agent = BaseAutonomousAgent(config=_make_config(), signature=_TaskSignature())
 
-    assert not (tmp_path / "checkpoints").exists(), (
-        "constructing BaseAutonomousAgent created ./checkpoints in the caller's "
-        "cwd — the directory must be created lazily on first checkpoint write"
-    )
+    # 0.11.8: no eager creation anywhere.
+    assert not (tmp_path / "checkpoints").exists()
+    # 0.12.0: the default resolves off the cwd, under the per-user state dir.
+    assert not str(agent.checkpoint_dir).startswith(str(tmp_path))
+    assert agent.checkpoint_dir.is_absolute()
 
 
 @pytest.mark.regression
-def test_checkpoint_write_creates_dir_lazily(tmp_path, monkeypatch):
-    """First checkpoint write must create the dir + file (fix is non-breaking)."""
+def test_default_location_is_user_state_dir(tmp_path, monkeypatch):
+    """The default checkpoint dir is platformdirs' per-user state location."""
     monkeypatch.chdir(tmp_path)
     agent = BaseAutonomousAgent(config=_make_config(), signature=_TaskSignature())
 
-    assert not (tmp_path / "checkpoints").exists()  # precondition: still absent
-
-    agent._save_checkpoint({"status": "ok"}, cycle_num=1)
-
-    assert (tmp_path / "checkpoints").exists(), "dir must be created on first write"
-    assert (
-        tmp_path / "checkpoints" / "checkpoint_cycle_001.jsonl"
-    ).exists(), "checkpoint file must be written under the lazily-created directory"
+    expected_root = platformdirs.user_state_dir("kaizen")
+    assert str(agent.checkpoint_dir).startswith(expected_root)
+    assert agent.checkpoint_dir.name == "checkpoints"
 
 
 @pytest.mark.regression
-def test_explicit_checkpoint_dir_also_lazy(tmp_path, monkeypatch):
-    """An explicit checkpoint_dir is likewise not created until first write."""
-    monkeypatch.chdir(tmp_path)
+def test_explicit_checkpoint_dir_lazy_and_owner_only(tmp_path):
+    """Explicit dir: not created on construction; on first write dir+file exist,
+    owner-only on POSIX (0o700 dir / 0o600 file)."""
     cp_dir = tmp_path / "custom_cp"
     agent = BaseAutonomousAgent(
-        config=_make_config(), signature=_TaskSignature(), checkpoint_dir=cp_dir
+        config=_make_config(),
+        signature=_TaskSignature(),
+        checkpoint_dir=cp_dir,
     )
 
-    assert not cp_dir.exists(), "explicit checkpoint_dir must not be eagerly created"
+    assert not cp_dir.exists()  # construction must not create it
 
     agent._save_checkpoint({"status": "ok"}, cycle_num=2)
 
-    assert cp_dir.exists(), "explicit checkpoint_dir must be created on first write"
-    assert (cp_dir / "checkpoint_cycle_002.jsonl").exists()
+    cp_file = cp_dir / "checkpoint_cycle_002.jsonl"
+    assert cp_dir.exists()
+    assert cp_file.exists()
+
+    if os.name == "posix":
+        assert stat.S_IMODE(cp_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cp_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.regression
+@pytest.mark.skipif(os.name != "posix", reason="O_NOFOLLOW/symlinks are POSIX-only")
+def test_checkpoint_write_refuses_symlink_at_leaf(tmp_path):
+    """A symlink pre-placed at the checkpoint file path must NOT be written
+    through (O_NOFOLLOW sink hardening, security.md § Path Containment)."""
+    cp_dir = tmp_path / "cp"
+    cp_dir.mkdir()
+    target = tmp_path / "victim.txt"
+    target.write_text("original", encoding="utf-8")
+    # Attacker pre-places a symlink where cycle-3's checkpoint file would land.
+    (cp_dir / "checkpoint_cycle_003.jsonl").symlink_to(target)
+
+    agent = BaseAutonomousAgent(
+        config=_make_config(), signature=_TaskSignature(), checkpoint_dir=cp_dir
+    )
+    # _save_checkpoint swallows the write failure (logs a warning); the point is
+    # the victim target is NOT appended to through the symlink.
+    agent._save_checkpoint({"status": "ok"}, cycle_num=3)
+
+    assert target.read_text(encoding="utf-8") == "original", (
+        "checkpoint write followed a symlink and corrupted the target — "
+        "O_NOFOLLOW must refuse the write"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.11.8"
+version = "0.12.0"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "anthropic" },
@@ -2530,6 +2530,7 @@ dependencies = [
     { name = "kailash" },
     { name = "kailash-kaizen" },
     { name = "openai" },
+    { name = "platformdirs" },
 ]
 
 [package.metadata]
@@ -2542,6 +2543,7 @@ requires-dist = [
     { name = "kailash-kaizen", specifier = ">=2.36.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "openai", specifier = ">=1.30.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },


### PR DESCRIPTION
## Summary

Completes the checkpoint-cwd-litter fix. **0.11.8** stopped the *construct-time* `./checkpoints/` creation; **0.12.0** stops the *run-time* checkpoint writes from landing in the caller's cwd, and hardens permissions.

- **Default location moved off cwd** — with no explicit `checkpoint_dir`, checkpoints now go to `platformdirs.user_state_dir("kaizen")/checkpoints` (`~/.local/state` Linux, `~/Library/Application Support` macOS, `%LOCALAPPDATA%` Windows). An SDK must not write into the process launch directory. Pass an explicit `checkpoint_dir` for a project-local path.
- **Owner-only permissions on POSIX** — dir `0o700`, files `0o600`, with `O_NOFOLLOW` at the write sink (refuses to write through a symlink pre-placed in a caller-supplied hostile world-writable dir). Checkpoint payloads carry conversation/plan state (`security.md` § Path Containment).
- New dep `platformdirs>=4.0` (declared where imported).

## BREAKING (default location)

Existing `./checkpoints/` files are **not auto-migrated** and won't be found by the new default. Migration: pass `checkpoint_dir=Path("./checkpoints")` to keep the old behavior. Documented in CHANGELOG. Minor bump (behavior change, pre-1.0).

## Redteam — 2 rounds

- **reviewer:** NO FINDINGS (save/load symmetry, subclass constructors, append correctness, doc drift, version consistency, dep hygiene).
- **security-reviewer:** net security-positive; one LOW (missing `O_NOFOLLOW`) **fixed** and pinned by a symlink-refusal regression test.
- 45 regression + autonomous tests pass; runtime-verified default is off-cwd with `0o700`/`0o600`.

## Version

kaizen-agents `0.11.8` → `0.12.0`. `pyproject.toml` + `__init__.py` + `CHANGELOG.md` + `uv.lock` consistent.

## Related issues

No GitHub issue — F-TESTHYG follow-up (checkpoint hygiene), continues PR #1939 / kaizen-agents 0.11.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)