### PR TITLE
fix(kaizen): resolve provider at RAG node LLMAgentNode sites (2.42.0, closes #1946)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.42.0] — 2026-07-24 — RAG nodes resolve provider instead of silently mock-dispatching
+
+### Fixed
+
+- **`kaizen.nodes.rag` nodes now resolve a provider at every `LLMAgentNode`
+  construction site.** 2.41.0 (#1943) closed provider omission across the `Agent`
+  deployment surface, but the RAG workflow nodes still built their inner
+  `LLMAgentNode` stages without a `provider` key at 26 sites across 7 files
+  (`query_processing`, `agentic`, `conversational`, `evaluation`, `graph`,
+  `similarity`, `multimodal`). Because `LLMAgentNode`'s `provider` parameter
+  defaults to `"mock"`, those RAG stages silently mock-dispatched regardless of any
+  configured `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`. Every omitting site now
+  resolves through the shared `kaizen.core._provider_env.detect_provider_from_env()`
+  helper (env-first: openai → anthropic → mock), so a real API key is honoured
+  instead of being masked by the mock default (zero-tolerance Rule 2/3). Closes
+  #1946. (`workflows.py` already set a provider and is unchanged.)
+
 ## [2.41.0] — 2026-07-24 — Provider-dispatch integrity: mock-upgrade gated, provider resolved at every site
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.41.0"
+version = "2.42.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.41.0"
+__version__ = "2.42.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -28,6 +28,7 @@ from kailash.workflow.graph import Workflow
 # LLMAgentNode is imported for its @register_node side effect: the
 # sub-workflows reference it by the string "LLMAgentNode".
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -929,6 +930,7 @@ class AgenticRAGNode(WorkflowNode):
             "LLMAgentNode",
             node_id="planner_agent",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""You are a research planning agent. Given a query, create a step-by-step plan.
 
 Available tools: {", ".join(self.tools)}
@@ -956,6 +958,7 @@ Return JSON:
             "LLMAgentNode",
             node_id="react_agent",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""You are a ReAct agent that reasons step-by-step and uses tools.
 
 Available tools:
@@ -1006,6 +1009,7 @@ Maximum steps: {self.max_reasoning_steps}""",
                 "LLMAgentNode",
                 node_id="verifier_agent",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """You are a fact-checking agent. Verify the accuracy of the answer.
 
 Check for:
@@ -1452,6 +1456,7 @@ class ReasoningRAGNode(WorkflowNode):
             "LLMAgentNode",
             node_id="problem_decomposer",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""Break down complex problems into reasoning steps.
 
 Strategy: {self.strategy}
@@ -1479,6 +1484,7 @@ Return JSON:
             "LLMAgentNode",
             node_id="step_reasoner",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Execute one reasoning step at a time.
 
 Given:
@@ -1502,6 +1508,7 @@ Be explicit about your logic.""",
             "LLMAgentNode",
             node_id="logic_verifier",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Verify the logical consistency of reasoning.
 
 Check:

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
@@ -31,6 +31,7 @@ from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -851,6 +852,7 @@ class ConversationalRAGNode(WorkflowNode):
                 "LLMAgentNode",
                 node_id="coreference_resolver",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """Resolve coreferences in the user query based on conversation context.
 
 Replace pronouns (it, they, this, that, these, those) and other references with their specific antecedents from the conversation history.
@@ -923,6 +925,7 @@ If no coreferences found, return the original query.""",
             "LLMAgentNode",
             node_id="response_generator",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""Generate a contextual response considering the conversation history.
 
 Guidelines:
@@ -956,6 +959,7 @@ Keep responses conversational and engaging.""",
                 "LLMAgentNode",
                 node_id="context_summarizer",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """Summarize the conversation history concisely.
 
 Focus on:

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
@@ -37,6 +37,7 @@ from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -858,6 +859,7 @@ class RAGEvaluationNode(WorkflowNode):
             "LLMAgentNode",
             node_id="faithfulness_evaluator",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Evaluate the faithfulness of each generated answer to its retrieved contexts.
 
 Faithfulness measures whether the answer is grounded in the retrieved information.
@@ -885,6 +887,7 @@ Return a JSON ARRAY with exactly one object per test, in the SAME numbered order
             "LLMAgentNode",
             node_id="relevance_evaluator",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Evaluate the relevance of each answer to its query.
 
 The user message contains one or more numbered tests (Test 1, Test 2, ...). For
@@ -934,6 +937,7 @@ Return a JSON ARRAY with exactly one object per test, in the SAME numbered order
                 "LLMAgentNode",
                 node_id="answer_quality_evaluator",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """Compare each generated answer with its reference answer.
 
 The user message contains one or more numbered tests (Test 1, Test 2, ...). For

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -24,6 +24,7 @@ from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401  registers "LLMAgentNode"
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -943,6 +944,7 @@ class GraphRAGNode(WorkflowNode):
             "LLMAgentNode",
             node_id="entity_extractor",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""Extract entities and relationships from text.
 
                 Entity types: {", ".join(self.entity_types)}
@@ -996,6 +998,7 @@ class GraphRAGNode(WorkflowNode):
             "LLMAgentNode",
             node_id="query_processor",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Analyze the query to identify:
                 1. Key entities mentioned or implied
                 2. Types of relationships being asked about
@@ -1048,6 +1051,7 @@ class GraphRAGNode(WorkflowNode):
                 "LLMAgentNode",
                 node_id="summary_generator",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """Generate high-level summaries of document communities.
                     Focus on main themes, key entities, and important relationships.
                     Be concise but comprehensive.""",

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
@@ -30,6 +30,7 @@ from kailash.workflow import Workflow
 from kailash.workflow.builder import WorkflowBuilder
 
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,7 @@ class MultimodalRAGNode(WorkflowNode):
             "LLMAgentNode",
             node_id="query_analyzer",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Analyze the query to determine required modalities.
 
 Identify:
@@ -387,6 +389,7 @@ def retrieve_multimodal(encoded_data, modality_analysis):
             "LLMAgentNode",
             node_id="response_generator",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Generate a comprehensive response using both text and image results.
 
 Structure your response to:

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -39,6 +39,7 @@ from kailash.workflow.graph import Workflow
 # namespace. The static-analyzer "unused import" finding is a known
 # false-positive for monkeypatch-target imports.
 from ..ai.llm_agent import LLMAgentNode  # noqa: F401
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -915,6 +916,7 @@ class QueryExpansionNode(Node):
             "LLMAgentNode",
             node_id="llm_expander",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": f"""You are a query expansion expert.
                 Generate {self.num_expansions} variations of the given query that capture different aspects:
 
@@ -1131,6 +1133,7 @@ class QueryDecompositionNode(Node):
             "LLMAgentNode",
             node_id="query_decomposer",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """You are a query decomposition expert.
                 Break down complex queries into simpler sub-questions that can be answered independently.
 
@@ -1366,6 +1369,7 @@ class QueryRewritingNode(Node):
             "LLMAgentNode",
             node_id="query_analyzer",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Analyze the query for potential issues and improvements:
 
                 1. Spelling and grammar errors
@@ -1392,6 +1396,7 @@ class QueryRewritingNode(Node):
             "LLMAgentNode",
             node_id="query_rewriter",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Rewrite the query for optimal retrieval based on the analysis.
 
                 Create multiple versions:
@@ -1761,6 +1766,7 @@ class QueryIntentClassifierNode(Node):
             "LLMAgentNode",
             node_id="intent_classifier",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Classify the query intent and characteristics:
 
                 1. Query Type:
@@ -2032,6 +2038,7 @@ class MultiHopQueryPlannerNode(Node):
             "LLMAgentNode",
             node_id="hop_planner",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Plan a multi-hop retrieval strategy for the query.
 
                 Identify:

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
@@ -21,6 +21,7 @@ import numpy as np
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
+from kaizen.core._provider_env import detect_provider_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -415,6 +416,7 @@ class SparseRetrievalNode(Node):
                 "LLMAgentNode",
                 node_id="query_expander",
                 config={
+                    "provider": detect_provider_from_env(),
                     "system_prompt": """You are a query expansion expert.
                     Generate 3-5 related terms or synonyms for the given query.
                     Return as JSON: {"expanded_terms": ["term1", "term2", ...]}"""
@@ -1152,6 +1154,7 @@ class CrossEncoderRerankNode(Node):
             "LLMAgentNode",
             node_id="cross_encoder",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """You are a relevance scoring system.
                 Given a query and document, score their relevance from 0 to 1.
                 Consider semantic similarity, keyword overlap, and topical relevance.
@@ -1731,6 +1734,7 @@ class PropositionBasedRetrievalNode(Node):
             "LLMAgentNode",
             node_id="proposition_extractor",
             config={
+                "provider": detect_provider_from_env(),
                 "system_prompt": """Extract atomic facts or propositions from the given text.
                 Each proposition should be:
                 1. A single, complete fact

--- a/packages/kailash-kaizen/tests/regression/test_issue_1946_rag_provider_resolution.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1946_rag_provider_resolution.py
@@ -1,0 +1,165 @@
+"""Issue #1946 regression — ``kaizen.nodes.rag`` LLMAgentNode sites must
+RESOLVE a provider instead of silently mock-dispatching.
+
+kaizen 2.41.0 (#1943) resolved provider omission across the ``Agent``
+deployment surface via the shared helper
+``kaizen.core._provider_env.detect_provider_from_env()`` (env-first:
+``OPENAI_API_KEY`` -> openai, ``ANTHROPIC_API_KEY`` -> anthropic, else mock).
+But every ``kaizen.nodes.rag.*`` workflow node built its inner
+``LLMAgentNode`` stages WITHOUT a ``provider`` key, and
+``LLMAgentNode.get_parameters()["provider"]`` defaults to ``"mock"`` — so
+those RAG nodes silently mock-dispatched their LLM stages regardless of any
+configured real API key. #1946 threads ``detect_provider_from_env()`` through
+all 26 provider-omitting LLMAgentNode construction sites across the 7 affected
+files (query_processing, agentic, conversational, evaluation, graph,
+similarity, multimodal); ``workflows.py`` already set a provider and is left
+untouched.
+
+Assertion surface — the UNBUILT builder config, not the built workflow:
+``WorkflowBuilder.build()`` materialises each ``LLMAgentNode`` into a
+``NodeInstance`` whose ``.config`` AUTO-FILLS the ``"mock"`` provider default,
+which would MASK a missing ``provider`` key (a built node always reports
+``provider="mock"`` whether or not the raw config carried the key). So these
+tests spy on ``WorkflowBuilder.build`` to snapshot the RAW ``self.nodes`` dict
+(``{id: {"type": ..., "config": {...}}}``) BEFORE the build auto-fill runs —
+exactly the surface the 2.41.0 (#1943) provider tests assert against.
+
+Two contracts, one representative node per affected file:
+  1. ``test_rag_llm_agent_carries_provider_key`` — the raw config for every
+     ``LLMAgentNode`` site carries a ``provider`` key. This is the env-INDEPENDENT
+     regression driver: reverting the fix removes the key, and the built
+     node's "mock" auto-fill cannot mask a raw-config absence here.
+  2. ``test_rag_provider_resolves_from_env`` — with ``OPENAI_API_KEY`` set the
+     resolved provider is ``"openai"`` (env-first), proving the value is
+     resolved through ``detect_provider_from_env()`` and NOT a hardcoded
+     ``"mock"`` literal.
+
+Env-var isolation (rules/testing.md § Env-Var Test Isolation MUST): every test
+that reads or mutates the provider-affecting environment acquires the
+module-scope ``_ENV_LOCK`` via the ``env`` fixture so xdist-parallel runs
+cannot race, and clears ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` so an
+ambient ``.env`` cannot bleed into assertions. These are Tier-1 unit tests: no
+network call and no real LLM dispatch — the inner workflow is only built, never
+executed.
+"""
+
+import threading
+import warnings
+from typing import Callable, Dict, Iterator, Tuple
+
+import pytest
+
+from kailash.workflow.builder import WorkflowBuilder
+
+pytestmark = pytest.mark.regression
+
+# Module-scope env lock per rules/testing.md § Env-Var Test Isolation.
+_ENV_LOCK = threading.Lock()
+
+# Env vars that steer detect_provider_from_env()'s env-first fallback. Cleared
+# before each test so an ambient .env never leaks into a provider assertion.
+_PROVIDER_VARS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch) -> Iterator[pytest.MonkeyPatch]:
+    """Serialized + cleared provider environment for a deterministic fallback."""
+    with _ENV_LOCK:
+        for var in _PROVIDER_VARS:
+            monkeypatch.delenv(var, raising=False)
+        yield monkeypatch
+
+
+def _representative_factories() -> Dict[str, Callable[[], object]]:
+    """One representative node per affected file whose ``_create_workflow``
+    builds >=1 provider-resolving ``LLMAgentNode`` stage. Imports are local so
+    a collection-time import error in one RAG module cannot mask the others."""
+    from kaizen.nodes.rag.agentic import AgenticRAGNode
+    from kaizen.nodes.rag.conversational import ConversationalRAGNode
+    from kaizen.nodes.rag.evaluation import RAGEvaluationNode
+    from kaizen.nodes.rag.graph import GraphRAGNode
+    from kaizen.nodes.rag.multimodal import MultimodalRAGNode
+    from kaizen.nodes.rag.query_processing import QueryDecompositionNode
+    from kaizen.nodes.rag.similarity import CrossEncoderRerankNode
+
+    # WorkflowNode subclasses build their inner workflow inside __init__
+    # (super().__init__(workflow=self._create_workflow())); plain Node
+    # subclasses build lazily, so call _create_workflow() explicitly. Either
+    # way the build spy captures the raw LLMAgentNode config.
+    return {
+        "query_processing": lambda: QueryDecompositionNode()._create_workflow(),
+        "agentic": lambda: AgenticRAGNode(),
+        "conversational": lambda: ConversationalRAGNode(),
+        "evaluation": lambda: RAGEvaluationNode(),
+        "graph": lambda: GraphRAGNode(),
+        "similarity": lambda: CrossEncoderRerankNode()._create_workflow(),
+        "multimodal": lambda: MultimodalRAGNode(),
+    }
+
+
+def _capture_llm_agent_configs(
+    factory: Callable[[], object],
+) -> Dict[str, Tuple[bool, object]]:
+    """Run ``factory`` while spying on ``WorkflowBuilder.build`` to snapshot the
+    RAW (pre-build-auto-fill) config of every ``LLMAgentNode`` stage.
+
+    Returns ``{node_id: (provider_key_present, provider_value)}``. The snapshot
+    reads ``self.nodes`` — the unbuilt builder dict — so the built
+    ``NodeInstance``'s ``provider="mock"`` auto-fill never masks an omission.
+    """
+    captured: Dict[str, Tuple[bool, object]] = {}
+    original_build = WorkflowBuilder.build
+
+    def _spy(self, *args, **kwargs):
+        for node_id, spec in self.nodes.items():
+            if spec.get("type") == "LLMAgentNode":
+                config = spec.get("config", {})
+                captured[node_id] = ("provider" in config, config.get("provider"))
+        return original_build(self, *args, **kwargs)
+
+    # PythonCodeNode line-count UserWarnings are cosmetic build-time noise.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(WorkflowBuilder, "build", _spy)
+            factory()
+
+    assert captured, "factory built no LLMAgentNode stage — test wiring is stale"
+    return captured
+
+
+@pytest.mark.parametrize("module", sorted(_representative_factories()))
+def test_rag_llm_agent_carries_provider_key(env, module: str) -> None:
+    """Every LLMAgentNode's RAW config carries a ``provider`` key.
+
+    Env-independent regression driver: with the fix the key is present (value
+    resolves to "mock" only because no key is set here); reverting the fix drops
+    the key entirely — and the built node's "mock" auto-fill cannot mask a
+    raw-config absence, so this assertion flips to fail on revert.
+    """
+    factory = _representative_factories()[module]
+    captured = _capture_llm_agent_configs(factory)
+
+    missing = [nid for nid, (present, _) in captured.items() if not present]
+    assert not missing, (
+        f"{module}: LLMAgentNode site(s) {missing} omit the 'provider' key — "
+        f"they silently mock-dispatch (issue #1946)"
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_representative_factories()))
+def test_rag_provider_resolves_from_env(env, module: str) -> None:
+    """With ``OPENAI_API_KEY`` set, every LLMAgentNode resolves ``provider`` to
+    ``"openai"`` — proving env-first resolution through
+    ``detect_provider_from_env()``, not a hardcoded ``"mock"`` literal."""
+    env.setenv("OPENAI_API_KEY", "sk-test-1946")
+    factory = _representative_factories()[module]
+    captured = _capture_llm_agent_configs(factory)
+
+    unresolved = {
+        nid: value for nid, (_, value) in captured.items() if value != "openai"
+    }
+    assert not unresolved, (
+        f"{module}: LLMAgentNode site(s) did not resolve provider from env "
+        f"(expected 'openai', got {unresolved}) — issue #1946"
+    )


### PR DESCRIPTION
## Summary
RAG nodes (`kaizen.nodes.rag.*`) built `LLMAgentNode` at 26 `add_node` sites across 7 files without a `provider` key. `LLMAgentNode`'s `provider` defaults to `"mock"`, so these RAG nodes silently mock-dispatched regardless of configured API keys — the same class as #1943 (2.41.0), on the RAG subsystem.

## Fix
Resolve provider env-first via the shared `kaizen.core._provider_env.detect_provider_from_env()` helper at all 26 sites (query_processing 6, agentic 6, conversational 3, evaluation 3, graph 3, similarity 3, multimodal 2). `workflows.py` already set provider (untouched). The 5 direct `LLMAgentNode(...)` instantiations in `advanced.py`/`router.py` already set provider (hardcoded `"openai"` / `self.provider`) — not the silent-mock class; their literal fallback is tracked in #1948.

## Verification
- All 32 RAG construction sites enumerated exhaustively (26 fixed + 1 pre-set + 5 direct-set).
- 14 regression tests (assert the **unbuilt** config — the built NodeInstance auto-fills the mock default; mutation-proven non-vacuous).
- 1327 RAG tests pass; purely-additive diff; no circular imports.
- Redteamed to convergence (reviewer + adversarial, both CONVERGED with independent repros).

## Related issues
Closes #1946