### PR TITLE
chore(release): kailash-kaizen 2.43.0 — LLMAgentNode fail-loud provider (#1947)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.43.0] — 2026-07-24 — LLMAgentNode fails loud on an unresolved provider (silent-mock class closed at the node)
+
+### Changed (behavior — potentially breaking)
+
+- **`LLMAgentNode` and `IterativeLLMAgentNode` now RAISE
+  `kaizen.config.providers.ConfigurationError` when `provider` is unresolved
+  (`None`) instead of silently dispatching the mock provider.** The
+  `LLMAgentNode` `provider` NodeParameter default changed from `"mock"` to
+  `None`, and `run()` raises a typed error when the provider is unresolved. This
+  structurally closes the silent-mock class that 2.41.0 (#1943) and 2.42.0
+  (#1946) patched site-by-site: a forgotten or new construction site now fails
+  LOUD instead of returning fabricated content as a real model answer.
+  `IterativeLLMAgentNode` (a public subclass) previously swallowed the inherited
+  guard in its 6-phase loop and returned `success=True` with a hand-built
+  template answer — it is now guarded at the top of `run()`. The closure is
+  pinned across the whole node family (`LLMAgentNode`, `IterativeLLMAgentNode`,
+  `A2AAgentNode`, `SelfOrganizingAgentNode`). Closes #1947.
+
+  **Migration:** pass `provider="mock"` EXPLICITLY where you previously relied on
+  the mock default (tests / dev harnesses); the mock provider remains reachable
+  when requested explicitly. Production sites that resolve a provider from the
+  environment (the `Agent` deployment surface, the RAG nodes) are unaffected —
+  they already pass a concrete provider. Under `node.execute()` / runtime
+  dispatch the `ConfigurationError` surfaces wrapped in `NodeExecutionError` (as
+  `__cause__`); direct `node.run()` raises it cleanly.
+
+### Notes
+
+- Two same-class residuals on other surfaces are tracked separately: the keyless
+  `detect_provider_from_env()` → `"mock"` env fallback and `EmbeddingGeneratorNode`
+  (#1952), and a distinct runtime-error-masking pattern in `IterativeLLMAgentNode`
+  synthesis (#1953).
+
 ## [2.42.0] — 2026-07-24 — RAG nodes resolve provider instead of silently mock-dispatching
 
 ### Fixed

--- a/packages/kailash-kaizen/README.md
+++ b/packages/kailash-kaizen/README.md
@@ -71,11 +71,11 @@ class MyAgent(BaseAgent):
 ### Installation
 
 ```bash
-# Install Kaizen framework (latest v2.42.0)
+# Install Kaizen framework (latest v2.43.0)
 pip install kailash-kaizen
 
 # Or specific version
-pip install kailash-kaizen==2.42.0
+pip install kailash-kaizen==2.43.0
 ```
 
 ### Your First Agent (3 Steps)

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.42.0"
+version = "2.43.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.42.0"
+__version__ = "2.43.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
Release cut for kailash-kaizen **2.43.0** (MINOR — behavior change).

Metadata-only: version anchors (`pyproject.toml` + `__init__.py`), `CHANGELOG.md`, `README.md`. The code (#1947 fail-loud provider) already merged to main via #1951.

## What ships

`LLMAgentNode` / `IterativeLLMAgentNode` now raise `ConfigurationError` on an unresolved (`None`) provider instead of silently dispatching the mock provider — closing the silent-mock (fabricated-content-as-real) class at the node family (base + Iterative + A2A + SelfOrganizing). Explicit `provider="mock"` preserved. Redteam-converged over 3 rounds.

## Related

Closes #1947. Follow-ups tracked: #1952, #1953.