### PR TITLE
chore(authz): #1947 cross-SDK authz receipt + session notes (no Rust hazard)

### DIFF
--- a/.claude/cross-repo-authz/2026-07-24-esperie-enterprise-kailash-rs-read-only-inspect-.md
+++ b/.claude/cross-repo-authz/2026-07-24-esperie-enterprise-kailash-rs-read-only-inspect-.md
@@ -1,0 +1,41 @@
+---
+type: cross-repo-authorization-receipt
+date: 2026-07-24
+timestamp: 2026-07-24T07:47:23.035Z
+requester: jack-hong
+target: esperie-enterprise/kailash-rs
+action: read-only inspect the Rust SDK LLMAgent-equivalent node for the provider mock-default hazard (kailash-py #1947 cross-SDK parity); if present, file ONE scrubbed issue on esperie-enterprise/kailash-rs
+mode: write
+---
+
+# Cross-Repo Authorization Receipt
+
+cross-repo-authorized: esperie-enterprise/kailash-rs write
+
+## Bounded action
+
+- **Target repo:** esperie-enterprise/kailash-rs
+- **Action (write):** read-only inspect the Rust SDK LLMAgent-equivalent node for the provider mock-default hazard (kailash-py #1947 cross-SDK parity); if present, file ONE scrubbed issue on esperie-enterprise/kailash-rs
+- **Requester (display_id):** jack-hong
+- **Authorized at:** 2026-07-24T07:47:23.035Z
+
+## Verbatim user instruction
+
+> User approved (2026-07-24) my explicit question: check the Rust SDK for the same LLMAgentNode mock-default silent-fabrication bug and file an issue there if it exists.
+
+## Five-condition attestation (repo-scope-discipline.md § User-Authorized Exception)
+
+- condition_1_user_initiated: REQUIRED — a genuine user turn (see verbatim below)
+- condition_2_explicit_specific: REQUIRED — names the target repo AND the exact bounded action
+- condition_3_confirmed: REQUIRED — the ceremony restated action+target and the user confirmed yes/no BEFORE this write
+- condition_4_receipt_before_acting: SATISFIED — THIS receipt is the durable witness, written BEFORE the command runs
+- condition_5_scoped_exactly: REQUIRED — only the named action against only the named repo
+
+<!--
+  This receipt is the ONLY distinguisher between an authorized and an
+  unauthorized cross-repo action. It is written by
+  .claude/bin/cross-repo-authorize.mjs AFTER the user confirmed the restated
+  action+target in chat, and BEFORE the action runs. The hook
+  (violation-patterns.js::hasCrossRepoAuthorizationReceipt) greps this file's
+  marker line within its mtime window; commit it for durable team audit.
+-->

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -1,49 +1,60 @@
-# Session Notes — 2026-07-23 (cont-15)
+# Session Notes — 2026-07-24 (cont)
 
 ## Where we are
 
-**SESSION CLOSED (cont-15).** Started from a verified-clean board; the one live thread was an
-orphaned **F-TESTHYG** deferral (its "bundle with the kaizen-agents release" trigger had passed
-without action). Reconciling it surfaced a real user-facing defect → fixed in two releases →
-all three owner-approved residuals resolved. Board clean again.
+#1947 (LLMAgentNode fail-loud provider — the structural root-cause fix) is DONE,
+merged, redteam-converged (3 rounds / 7 reviews), and RELEASED as
+**kailash-kaizen 2.43.0** on PyPI (clean-venv verified live).
 
-## Executed this session (cont-15)
+## Executed this session
 
-- **F-TESTHYG reconciled + premise corrected.** The followup doc's "class-2 root-discovery src
-  bug" did NOT exist — those scratch files were example-script output. The real defect:
-  `BaseAutonomousAgent` created `./checkpoints/` in the caller's cwd.
-- **kaizen-agents 0.11.8** (PR #1939) — construct-time fix: lazy dir creation (moved `mkdir` out
-  of `__init__`). Redteam 2 clean rounds. PyPI-published, clean-venv verified.
-- **kaizen-agents 0.12.0** (PR #1941) — the owner-approved residuals #1+#2:
-  - **#1 (default location):** default checkpoints now go to `platformdirs.user_state_dir("kaizen")/
-    checkpoints` (per-user state dir), NOT the cwd. **BREAKING** (documented): old `./checkpoints`
-    not auto-migrated; pass explicit `checkpoint_dir` to restore. New dep `platformdirs>=4.0`.
-  - **#2 (perms):** checkpoint dir/files owner-only on POSIX (`0o700`/`0o600`) with `O_NOFOLLOW`
-    at the write sink (refuses writing through a symlink in a caller-supplied hostile dir).
-  - Redteam 2 rounds: reviewer NO FINDINGS; security-reviewer net-positive, its one LOW (missing
-    `O_NOFOLLOW`) fixed + pinned by a symlink-refusal regression test. 45 tests + full CI matrix.
-  - **TestPyPI-validated first** (minor-release rule) → production PyPI → clean-venv verified
-    (v0.12.0, default off-cwd, modes 0o700/0o600).
-- **#3 (cross-SDK inspection) — DONE, no gap.** User-approved READ-tier cross-repo authorization
-  (receipt committed). The Rust SDK uses an explicit `CheckpointStore` (memory/SQLite at an
-  explicit path), NOT a cwd-defaulting `checkpoint_dir` — **no equivalent defect**; nothing filed.
-  See `cross-sdk-checkpoint-inspection.md` + `04-validate/f-testhyg-followup.md`.
+- **#1947 shipped**: `LLMAgentNode` provider default `"mock"`→`None`; `run()` raises
+  `ConfigurationError` on an unresolved provider. Silent-mock (fabricated-content-as-real)
+  class closed across the whole node family: base + `IterativeLLMAgentNode` (own guards) +
+  `A2AAgentNode` + `SelfOrganizingAgentNode` (inherited guard, pinned). Explicit
+  `provider="mock"` preserved.
+  - Redteam found + fixed: HIGH `IterativeLLMAgentNode` swallowed the guard (returned
+    success=True template); INVEST-NOW missed `provider="openai"` twin at synthesis.
+  - PR **#1951** merged (5 commits); PR **#1954** merged (release 2.43.0); tag `kaizen-v2.43.0`
+    → OIDC publish → verified `pip install kailash-kaizen==2.43.0` + fail-loud behavior.
+- **PR #1950** (2.42.0 docs release-record) merged.
+- Filed **#1952** (deferred same-class residuals: keyless `detect_provider_from_env()`→"mock"
+  on Agent/RAG surfaces; `EmbeddingGeneratorNode` silent-mock — both exceed the #1947 shard,
+  need own prod-audit + test sweep) and **#1953** (distinct class: `IterativeLLMAgentNode`
+  synthesis masks a RESOLVED-provider runtime LLM failure as success=True with a template).
 
-## Release scope (cont-15)
+## Cross-SDK check — DONE (user-authorized, no hazard, no issue filed)
 
-kaizen-agents 0.11.7 → 0.11.8 → **0.12.0** (all published + verified). All 8 sibling packages at
-PyPI parity — no drift swept. Core + others unchanged.
+- Cross-repo READ authorized (receipt `.claude/cross-repo-authz/2026-07-24-esperie-enterprise-kailash-rs-*`,
+  user-approved 2026-07-24). Inspected `esperie-enterprise/kailash-rs` (private).
+- **Verdict: the Rust SDK does NOT have the #1947 mock-default hazard** — it is already
+  fail-closed / explicit-opt-in: `LlmProvider` enum has NO `Mock` variant and NO `Default`
+  impl; mock is a separate `MockLlmProvider` reachable ONLY via explicit `LlmClient::from_mock()`
+  / `mock_with_responses()`; `crates/kailash-nodes/src/ai/provider.rs::detect_provider()` returns
+  `Result` (errors on unknown, never a mock fallback). No silent-mock default exists → the
+  conditional filing ("if the hazard exists") does NOT trigger. No issue filed. Scope respected.
 
 ## Outstanding ledger (forest)
 
-EMPTY. F-TESTHYG fully resolved (0.11.8 + 0.12.0); cross-SDK inspected (no gap). No queued items.
-Board: 0 open issues, 0 open PRs (this receipt PR merges as the close-out).
+| ID | Item | Value-anchor | Status |
+| --- | --- | --- | --- |
+| F1 | #1952 — remaining silent-mock sites (env fallback + EmbeddingGeneratorNode) | Fully closes fabricated-content integrity class (redteam HIGH) | QUEUED (own shard; prod-audit + test sweep) |
+| F2 | #1953 — IterativeLLMAgentNode synthesis masks runtime failure as success=True | Redteam finding; distinct error-masking class | QUEUED |
+| F3 | #1948 — provider-handling minor follow-ups (caching/flag-name/literal-fallback) | Redteam residuals from #1943 | QUEUED (non-blocking, pre-existing) |
+| F4 | Cross-SDK Rust-node mock-default check | #1947 note; cross-sdk parity | BLOCKED on user cross-repo authorization (see PENDING) |
 
-## Traps (carried, still valid)
+## Traps
 
-- Per-package CI path-gating hides sibling-package failures (journal/0013).
-- CI flakes clear on re-run; pinned-head READ + separate admin-merge, never merge over red.
-- `uv run pre-commit` (stale `.venv/bin` shebang). Stale `packages/*/build/lib/` confuse pyright
-  (all base.py warnings this session were pre-existing dynamic-attribute noise).
-- PyPI/uv index-cache lag on fresh publish → retry `uv pip install --refresh` (needed both releases).
-- TestPyPI install with uv needs `--index-strategy unsafe-best-match` (deps resolve from prod PyPI).
+- kaizen FAST-tier CI job ("expanded FAST unit tiers") flaked "0 selected / 8328 deselected"
+  on a pull_request run — TRANSIENT (same commit passed on push; local selects 6776/8328;
+  re-run green). Not a code issue; re-run if seen.
+- Regression tests are ENV-INDEPENDENT (node does no env detection; raw node → provider None →
+  raise). `detect_provider_from_env()` STILL returns "mock" keyless — that's the #1952 residual.
+- Release: git tag `kaizen-v<X.Y.Z>` → OIDC publish-pypi.yml; verify PyPI with
+  `uv pip install --refresh` (uv index cache lags even after metadata is live).
+- Reviewer/verifier reasoning can conflict — runtime evidence wins (round-1 reviewer
+  runtime-confirmed the Iterative swallow; the domain agent's reasoning missed it).
+
+## Wave tracker
+
+None in flight. All background agents (audit + 3 redteam rounds + release watchers) completed.

--- a/workspaces/issue-1720-llm-consolidation/04-validate/1947-changelog-draft.md
+++ b/workspaces/issue-1720-llm-consolidation/04-validate/1947-changelog-draft.md
@@ -1,0 +1,40 @@
+# CHANGELOG draft for kaizen 2.43.0 (paste at /release, verify version/symbols first)
+
+Version anchors to bump 2.42.0 → 2.43.0 (MINOR — behavior change, per redteam):
+
+- packages/kailash-kaizen/pyproject.toml:7
+- packages/kailash-kaizen/src/kaizen/**init**.py:9
+
+Release tag: `kaizen-v2.43.0` → OIDC publish-pypi.yml.
+
+---
+
+## [2.43.0] — <DATE> — LLMAgentNode fails loud on an unresolved provider (silent-mock class closed at the node)
+
+### Changed (behavior — potentially breaking)
+
+- **`LLMAgentNode` / `IterativeLLMAgentNode` now RAISE `ConfigurationError` when
+  `provider` is unresolved (`None`) instead of silently dispatching the mock
+  provider.** The `LLMAgentNode` `provider` NodeParameter default changed from
+  `"mock"` to `None`; `run()` raises a typed `kaizen.config.providers.ConfigurationError`
+  when the provider is unresolved. This structurally closes the silent-mock class
+  that #1943 (2.41.0) and #1946 (2.42.0) patched site-by-site: a forgotten/new
+  construction site now fails LOUD instead of returning fabricated content as a
+  real model answer. `IterativeLLMAgentNode` (a public subclass) previously
+  swallowed the inherited guard in its 6-phase loop and returned `success=True`
+  with a hand-built template answer — it is now guarded at the top of `run()`.
+
+  **Migration:** pass `provider="mock"` EXPLICITLY where you previously relied on
+  the mock default (e.g. tests/dev harnesses); the mock provider remains reachable
+  when requested explicitly. Production sites that resolve a provider from the
+  environment (the `Agent` deployment surface, the RAG nodes) are unaffected.
+  Under `node.execute()` / runtime dispatch the `ConfigurationError` surfaces
+  wrapped in `NodeExecutionError` (as `__cause__`); direct `node.run()` raises it
+  cleanly. Closes #1947.
+
+### Notes
+
+- Two same-class residuals on OTHER surfaces are tracked separately: the keyless
+  `detect_provider_from_env()` → `"mock"` env fallback (Agent/RAG) and
+  `EmbeddingGeneratorNode` (#1952); and a distinct runtime-error-masking pattern
+  in `IterativeLLMAgentNode` synthesis (#1953).

--- a/workspaces/issue-1720-llm-consolidation/04-validate/1947-launch-ledger.md
+++ b/workspaces/issue-1720-llm-consolidation/04-validate/1947-launch-ledger.md
@@ -1,0 +1,45 @@
+# #1947 Launch Ledger (durable — survives compaction)
+
+Branch: `fix/1947-llm-agent-fail-loud-provider` — **PR #1951** (base main).
+Commits: `809388c8e` (base node fail-loud), `8144ea5d3` (IterativeLLMAgentNode subclass fix), `df4bc4c3b` (docstrings). All pushed.
+
+## What landed
+
+- `llm_agent.py`: provider default "mock"→None; `run()` raises ConfigurationError when None.
+- `iterative_llm_agent.py`: guard at top of run() (subclass swallowed the base guard → success=True template); dropped 2 silent `provider="openai"`.
+- Docstrings (framework.py ×2, agents.py ×1): show explicit provider.
+- Regression test: base + iterative subclass (7 tests). 1 iterative unit test made provider explicit.
+
+## Verification (direct, runtime)
+
+- Base LLMAgentNode: no-provider → ConfigurationError; explicit mock works. Unit oracle: 1289 pass 0 provider-regressions.
+- IterativeLLMAgentNode: no-provider → ConfigurationError (was success=True template); explicit mock works. Iterative unit files: 18 pass.
+- A2AAgentNode: no-provider → ConfigurationError (fails loud). Only 2 real LLMAgentNode subclasses exist.
+- Non-unit 18 fails ALL pre-existing (stash-proven; real-API key + memory flake).
+- CI FAST-tier "0 selected" on first PR run = TRANSIENT FLAKE (same commit passed on push; re-run green; local selects 6776/8328).
+
+## Redteam
+
+- **Round 1** (reviewer aa204d…, security a211a8…, kaizen a6c709…): reviewer found HIGH IterativeLLMAgentNode swallow (runtime-confirmed) → FIXED. security found HIGH `detect_provider_from_env`→"mock" residual → #1952. kaizen: MINOR bump 2.42→2.43, ConfigurationError correct, 3 docstrings LOW → FIXED. All in-scope BUG/INVEST-NOW resolved.
+- **Round 2** DONE (both lenses): both independently found ONE in-scope item — the `iterative_llm_agent.py:1760` `provider="openai"` twin my replace_all missed (16 vs 20 space indent) + commit over-claim → FIXED in `d8c70bcfa`. Both confirmed class functionally CLOSED (mutation test: revert guard → regression test FAILS). Finding B (synthesis masks resolved-provider runtime failure as success=True) → **#1953** (distinct class).
+- **Round 3** DONE: **BOTH lenses CONVERGED** — no new in-scope BUG/INVEST-NOW; mutation-tested (revert guard → regression test FAILS); reviewer found a 4th family member `SelfOrganizingAgentNode(A2AAgentNode)` — also fails loud. One LOW (A2A closure inheritance-only + unpinned) → CLOSED via family-pin tests (`c5fb050f4`).
+
+## CONVERGED (7 reviews / 3 rounds)
+
+Silent-mock (fabricated-content-as-real) class CLOSED on the omitted-provider axis for the whole LLMAgentNode family: LLMAgentNode + IterativeLLMAgentNode (own guards) + A2AAgentNode + SelfOrganizingAgentNode (inherited guard, now pinned). Explicit provider="mock" preserved. All findings resolved or tracked (#1952 deferred residuals, #1953 runtime-error-masking).
+
+Commits (5): 809388c8e, 8144ea5d3, df4bc4c3b, d8c70bcfa, c5fb050f4 — all pushed. PR #1951.
+
+Commits now: 809388c8e, 8144ea5d3, df4bc4c3b, d8c70bcfa (all pushed).
+Issues filed: #1952 (deferred residuals), #1953 (runtime-error-masking, distinct class).
+
+## Deferred (tracked — NOT this shard)
+
+- **#1952** filed: (a) `detect_provider_from_env()`→"mock" keyless fallback (HIGH, Agent/RAG surface, 30+ sites); (b) EmbeddingGeneratorNode silent-mock (MED). Both exceed #1947 shard (own prod-audit + test sweep). Value-anchor: fully closes fabricated-content integrity class.
+
+## Next
+
+- Collect round-2 verdicts → if clean, that's 1 clean round (round 1 was NOT clean). Need 2 consecutive clean → run round 3 if round 2 clean.
+- Verify new-commit CI green (kaizen FAST flake watch).
+- On convergence + green CI: admin-merge PR #1951, then /release (kaizen MINOR 2.42.0→2.43.0; CHANGELOG behavior-change/migration note; feedback_build_repo_release).
+- Cross-SDK (cross-sdk-inspection MUST-1): Rust SDK equivalent node mock-default check — HUMAN-GATED cross-repo filing; surface as PENDING (handoff-completion), do NOT self-file.


### PR DESCRIPTION
Workspace + cross-repo authorization receipt for the #1947 cross-SDK inspection.

The Rust SDK (`esperie-enterprise/kailash-rs`) was inspected under user-authorized cross-repo READ. **No #1947 mock-default hazard exists** there — it is already fail-closed/explicit-opt-in (`LlmProvider` enum has no `Mock` variant / no `Default`; mock only via explicit `from_mock()`; `detect_provider()` returns `Result`). No issue filed (filing was conditional on the hazard existing).

Metadata/workspace-only — no code surface, no release.

## Related
Follows #1947 (closed), #1951 (merged), release 2.43.0.