### PR TITLE
fix(kaizen): keyless provider/model resolution fails loud instead of silent mock (#1952)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/_provider_env.py
+++ b/packages/kailash-kaizen/src/kaizen/core/_provider_env.py
@@ -12,33 +12,69 @@ this widely duplicated drifts silently unless consolidated).
 This is intentionally NOT `kaizen.config.providers.auto_detect_provider()`:
 that function checks 7 providers (openai/azure/anthropic/google/perplexity/
 ollama/docker) and RAISES `ConfigurationError` when none is available — a
-different, fail-loud contract used by a different call path. Every site this
-module serves currently defaults to the mock/test provider when no real key
-is present (a deliberate, existing, lenient-construction contract), so this
-helper mirrors ONLY `Agent._get_provider_for_config()`'s narrower 3-way
-order. Changing that contract (e.g. raising instead of defaulting to mock)
-is out of scope for this fix — see the LLMAgentNode provider `default="mock"`
-fail-loud change tracked as a separate, higher-blast-radius follow-up.
+different, fail-loud contract used by a different call path. This helper
+mirrors only `Agent._get_provider_for_config()`'s narrower openai -> anthropic
+order for the KEYED case.
+
+#1952 — keyless NO LONGER silently resolves to "mock". #1947 closed the
+silent-mock/fabricated-content class at the NODE: `LLMAgentNode` raises a
+typed `ConfigurationError` when `provider` resolves to `None`, and the mock
+provider stays reachable only when `provider="mock"` is passed EXPLICITLY.
+This helper is the residual keyless surface #1947 left open: a real (non-test)
+caller with no OPENAI/ANTHROPIC key and no explicit provider used to receive
+"mock" here and dispatch fabricated content as a real answer, PASSING the
+#1947 gate. It now returns `None` for the keyless case, so the unresolved
+provider flows to the node's #1947 fail-loud gate — the single, structural
+fail-loud point. The mock provider is legitimate; ONLY the silent keyless
+default was the hazard.
+
+The kaizen test harness runs deliberately keyless (the root `conftest.py`
+cost-guard actively scrubs provider secrets) with the mock provider registered
+in `tests/conftest.py`. It opts back into keyless->mock via the EXPLICIT
+`KAIZEN_ALLOW_KEYLESS_MOCK=1` env flag (set only by `tests/conftest.py`, in the
+same unit-mode branch that patches the mock provider registry) — mirroring the
+existing `KAIZEN_ALLOW_REAL_LLM` / `USE_REAL_PROVIDERS` opt-in shape. A real
+user never sets it, so real keyless callers fail loud.
 """
 
 import os
+from typing import Optional
 
 
-def detect_provider_from_env() -> str:
+def _keyless_mock_allowed() -> bool:
+    """True only when a test harness has EXPLICITLY opted into keyless->mock.
+
+    Real callers never set ``KAIZEN_ALLOW_KEYLESS_MOCK``; a keyless resolution
+    therefore returns ``None`` for them and fails loud at the node's #1947 gate.
+    The kaizen unit harness sets it in ``tests/conftest.py`` so the deliberately
+    keyless unit suite keeps dispatching to the registered mock provider.
     """
-    Env-first provider fallback: openai -> anthropic -> mock.
+    return os.environ.get("KAIZEN_ALLOW_KEYLESS_MOCK") == "1"
+
+
+def detect_provider_from_env() -> Optional[str]:
+    """
+    Env-first provider fallback: openai -> anthropic -> None (keyless).
 
     Returns:
         "openai" if OPENAI_API_KEY is set, else "anthropic" if
-        ANTHROPIC_API_KEY is set, else "mock". Mirrors
-        `Agent._get_provider_for_config()`'s exact fallback order — callers
-        with an explicit provider configured MUST check that first and only
-        fall back to this helper when none was given, so a real API key is
-        never silently ignored in favor of LLMAgentNode's own "mock"
-        parameter default.
+        ANTHROPIC_API_KEY is set, else ``None`` (#1952 — keyless no longer
+        silently resolves to "mock"). Callers with an explicit provider
+        configured MUST check that first and only fall back to this helper when
+        none was given, so a real API key is never silently ignored. When this
+        returns ``None`` the unresolved provider flows to ``LLMAgentNode``'s
+        #1947 fail-loud ``ConfigurationError`` gate rather than dispatching
+        fabricated mock content as a real answer.
+
+        Exception (explicit test-harness opt-in): when
+        ``KAIZEN_ALLOW_KEYLESS_MOCK=1`` is set — only the kaizen unit harness
+        sets it — the keyless case returns "mock" so the deliberately-keyless
+        unit suite keeps working. Real callers never set it and fail loud.
     """
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
     if os.environ.get("ANTHROPIC_API_KEY"):
         return "anthropic"
-    return "mock"
+    if _keyless_mock_allowed():
+        return "mock"
+    return None

--- a/packages/kailash-kaizen/src/kaizen/core/agents.py
+++ b/packages/kailash-kaizen/src/kaizen/core/agents.py
@@ -1159,23 +1159,30 @@ CRITICAL RULES:
 
         return response_structure
 
-    def _get_provider_for_config(self) -> str:
+    def _get_provider_for_config(self) -> Optional[str]:
         """
         Determine the appropriate LLM provider based on configuration and environment.
 
         Returns:
-            str: Provider name ("openai", "anthropic", "smart_mock", etc.)
+            Optional[str]: Provider name ("openai", "anthropic", "mock", etc.)
+            when explicitly configured or resolvable from a real API key, else
+            ``None`` when keyless (#1952). A ``None`` result flows to
+            ``LLMAgentNode``'s #1947 fail-loud ``ConfigurationError`` gate — a
+            forgotten provider becomes a typed error, never fabricated mock
+            content returned as a real answer.
         """
         # If provider is explicitly set, use it
         if "provider" in self.config:
             return self.config["provider"]
 
-        # Env-first fallback (openai -> anthropic -> mock). This IS the
-        # canonical order every other LLMAgentNode-param-building site in
+        # Env-first fallback (openai -> anthropic -> None when keyless). This IS
+        # the canonical order every other LLMAgentNode-param-building site in
         # the Agent deployment surface mirrors via `detect_provider_from_env`
         # (`kaizen/core/_provider_env.py`) — kept inline here (rather than
         # delegating) so this method stays the single documented source of
-        # the contract; the shared helper exists for OTHER call sites.
+        # the contract; the shared helper exists for OTHER call sites. Returns
+        # None when keyless so the unresolved provider fails loud at the node
+        # (#1952 closes the keyless-mock residual of #1947).
         return _detect_provider_from_env()
 
     def _is_mock_provider_active(self) -> bool:

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -598,9 +598,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
         if self.config.model is not None:
             node_config["model"] = self.config.model
-        node_config["provider"] = (
-            current_provider  # keyless → None → LLMAgentNode #1947 fail-loud gate (#1952)
-        )
+        node_config["provider"] = current_provider  # None keyless → #1947 gate
         # generation_config is LLMAgentNode's declared dict param (the only one
         # llm_agent.py reads at runtime) — top-level temperature/max_tokens
         # aren't declared NodeParameters and the Kailash validator flags them

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -598,7 +598,9 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
         if self.config.model is not None:
             node_config["model"] = self.config.model
-        node_config["provider"] = current_provider  # required; else defaults to "mock"
+        node_config["provider"] = (
+            current_provider  # keyless → None → LLMAgentNode #1947 fail-loud gate (#1952)
+        )
         # generation_config is LLMAgentNode's declared dict param (the only one
         # llm_agent.py reads at runtime) — top-level temperature/max_tokens
         # aren't declared NodeParameters and the Kailash validator flags them

--- a/packages/kailash-kaizen/src/kaizen/llm/reasoning.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/reasoning.py
@@ -39,6 +39,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
+from kaizen.config.providers import ConfigurationError
+from kaizen.core._provider_env import _keyless_mock_allowed
 from kaizen.core.base_agent import BaseAgent, BaseAgentConfig
 from kaizen.signatures import InputField, OutputField, Signature
 
@@ -211,9 +213,13 @@ def _resolve_reasoning_config(
     cheap. If no config is supplied, fall back to `.env`-defined model with
     the same defaults per `rules/env-models`.
 
-    Last-resort fallback is the `mock` provider: this keeps unit tests that
-    pass bare `Mock(spec=BaseAgent)` stubs working without real API keys,
-    while production paths always route through an explicit config.
+    If no model is configured (neither `OPENAI_PROD_MODEL` nor
+    `DEFAULT_LLM_MODEL`), this FAILS LOUD with a typed `ConfigurationError`
+    rather than silently returning a `mock` config that would fabricate
+    reasoning as a real answer (#1952 same-class as the keyless-provider
+    fail-loud). The `mock` config is returned ONLY under the explicit
+    test-harness opt-in `KAIZEN_ALLOW_KEYLESS_MOCK` — real callers always
+    route through a real model or an explicit config.
     """
     if config is None:
         model = os.environ.get("OPENAI_PROD_MODEL") or os.environ.get(
@@ -221,7 +227,18 @@ def _resolve_reasoning_config(
         )
         provider = os.environ.get("DEFAULT_LLM_PROVIDER")
         if not model:
-            # Last-resort test/offline fallback: mock provider.
+            # #1952 same-class: a keyless/modelless REAL caller must fail loud,
+            # not silently get mock reasoning presented as a real answer. Mock
+            # is returned ONLY under the explicit test-harness opt-in, mirroring
+            # detect_provider_from_env()'s keyless contract.
+            if not _keyless_mock_allowed():
+                raise ConfigurationError(
+                    "No model configured for the reasoning agent: set "
+                    "OPENAI_PROD_MODEL or DEFAULT_LLM_MODEL, or pass an explicit "
+                    "config. Refusing to silently dispatch the mock provider "
+                    "(which would fabricate reasoning as a real answer)."
+                )
+            # Explicit test/offline opt-in only: mock provider.
             return BaseAgentConfig(
                 llm_provider="mock",
                 model="mock-model",

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/embedding_generator.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 
+from kaizen.config.providers import ConfigurationError
+
 
 @register_node()
 class EmbeddingGeneratorNode(Node):
@@ -236,7 +238,13 @@ class EmbeddingGeneratorNode(Node):
         # four-axis embed egress (_generate_provider_embedding) can honor it,
         # mirroring LLMAgentNode. Fail-closed default False.
         self._ungoverned = kwargs.get("ungoverned", False)
-        provider = kwargs.get("provider", "mock")
+        # #1952: no silent "mock" default. A forgotten provider used to become
+        # "mock" here (kwargs.get("provider", "mock")) and silently return
+        # fabricated mock vectors as real embeddings — the embedding-surface
+        # twin of the #1947 silent-mock hazard. Resolve to None (the param's
+        # get_parameters() default), then fail loud below for any embedding-
+        # PRODUCING operation. provider="mock" passed EXPLICITLY is honored.
+        provider = kwargs.get("provider")
         model = kwargs.get("model", "default")
         input_text = kwargs.get("input_text")
         input_texts = kwargs.get("input_texts", [])
@@ -252,6 +260,27 @@ class EmbeddingGeneratorNode(Node):
         normalize = kwargs.get("normalize", True)
         timeout = kwargs.get("timeout", 60)
         max_retries = kwargs.get("max_retries", 3)
+
+        # #1952: fail loud on an unresolved provider for any embedding-PRODUCING
+        # operation, BEFORE the try block so it propagates as a typed raise (not
+        # a success:False dict). calculate_similarity over two SUPPLIED vectors
+        # needs no provider; every embedding-producing path does. This mirrors
+        # LLMAgentNode's #1947 run() gate so a forgotten provider becomes a
+        # typed ConfigurationError instead of fabricated mock embeddings.
+        _needs_provider = operation in (
+            "embed_text",
+            "embed_batch",
+            "embed_mcp_resource",
+        ) or (operation == "calculate_similarity" and not (embedding_1 and embedding_2))
+        if _needs_provider and provider is None:
+            raise ConfigurationError(
+                "EmbeddingGeneratorNode: 'provider' is unresolved (None) for "
+                f"operation '{operation}'. A missing provider no longer silently "
+                "defaults to the mock provider (closes the keyless-mock residual "
+                "of #1947, #1952). Set a real provider explicitly "
+                "(provider='openai' / 'ollama' / 'cohere' / 'huggingface'), or "
+                "pass provider='mock' to use the mock provider for testing."
+            )
 
         try:
             if operation == "embed_text":

--- a/packages/kailash-kaizen/src/kaizen/signatures/core.py
+++ b/packages/kailash-kaizen/src/kaizen/signatures/core.py
@@ -1315,8 +1315,9 @@ class SignatureCompiler:
         # mock responses on a production path). Delegates to the shared
         # `detect_provider_from_env()` (kaizen/core/_provider_env.py) so an
         # unconfigured provider resolves to a real key when one is present,
-        # falling back to "mock" only when neither is set — the SAME
-        # env-first order `Agent._get_provider_for_config()` uses.
+        # else to None (keyless) so LLMAgentNode's #1947 fail-loud gate fires
+        # rather than silently dispatching "mock" — the SAME env-first order
+        # `Agent._get_provider_for_config()` uses (#1952).
         # LOCAL import: `kaizen.core.__init__` imports `kaizen.signatures`
         # at module scope, and `kaizen.signatures.__init__` imports `.core`
         # (this file) at module scope — a module-level import here would

--- a/packages/kailash-kaizen/tests/conftest.py
+++ b/packages/kailash-kaizen/tests/conftest.py
@@ -23,6 +23,16 @@ from pathlib import Path
 use_real_providers = os.getenv("USE_REAL_PROVIDERS", "").lower() == "true"
 
 if not use_real_providers:
+    # #1952: the unit suite runs deliberately keyless (the package-root
+    # cost-guard scrubs provider secrets) and relies on the mock provider
+    # registered below. detect_provider_from_env() now returns None when keyless
+    # so REAL callers fail loud at LLMAgentNode's #1947 gate instead of silently
+    # dispatching fabricated mock content. The harness opts back into
+    # keyless->mock via this EXPLICIT flag — set ONLY here, in the same unit-mode
+    # branch that patches the mock registry. A real user never sets it, so real
+    # keyless callers stay fail-loud.
+    os.environ.setdefault("KAIZEN_ALLOW_KEYLESS_MOCK", "1")
+
     # Patch the canonical provider registry for unit tests
     try:
         import kaizen.providers as providers_module

--- a/packages/kailash-kaizen/tests/regression/test_issue_1952_keyless_provider_fail_loud.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1952_keyless_provider_fail_loud.py
@@ -1,0 +1,236 @@
+"""Regression test — keyless provider resolution fails loud (#1952).
+
+#1947 (kaizen 2.43.0) closed the silent-mock / fabricated-content class at the
+NODE: ``LLMAgentNode.get_parameters()["provider"].default`` is ``None`` and
+``run()`` raises ``ConfigurationError`` when ``provider`` resolves to ``None``.
+Mock stays reachable only when ``provider="mock"`` is passed EXPLICITLY.
+
+#1952 closes the RESIDUAL surface #1947 left open — the *keyless dispatch
+resolution*:
+
+1. ``kaizen.core._provider_env.detect_provider_from_env()`` used to return
+   ``"mock"`` when NO ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` was set. The
+   Agent surface (``core/agents.py`` ``_get_provider_for_config``,
+   ``core/base_agent.py``) and ~30 RAG dispatch sites pass that resolved string
+   straight into ``LLMAgentNode(provider=...)``. So a real caller with no key
+   and no explicit provider silently received ``"mock"`` (never ``None``),
+   PASSED the #1947 fail-loud gate, and got FABRICATED content as a real answer.
+   ``detect_provider_from_env()`` now returns ``None`` when keyless, so the
+   unresolved provider flows to the node's #1947 gate — the single, structural
+   fail-loud point. This is a STRUCTURAL closure, not an env heuristic.
+
+2. ``EmbeddingGeneratorNode.run()`` used ``kwargs.get("provider", "mock")`` —
+   a forgotten provider silently produced mock vectors returned as real
+   embeddings. It now resolves ``None`` and fails loud with a typed
+   ``ConfigurationError`` for every embedding-producing operation.
+
+The mock provider is LEGITIMATE and stays fully reachable when requested
+explicitly (``provider="mock"``); only the SILENT keyless default was the
+hazard.
+
+Env discipline: the kaizen unit harness runs deliberately keyless (the
+package-root cost-guard scrubs provider secrets) with the mock provider
+registered, and opts back into keyless->mock via the explicit
+``KAIZEN_ALLOW_KEYLESS_MOCK=1`` flag set in ``tests/conftest.py``. These tests
+reproduce a REAL keyless user by removing that flag (and the API keys) via
+``monkeypatch`` — so they assert the real user's fail-loud behaviour regardless
+of the harness opt-in. The embedding-surface tests need no env control:
+``EmbeddingGeneratorNode`` reads ``provider`` straight from kwargs and never
+consults the env fallback.
+"""
+
+import pytest
+
+from kaizen.config.providers import ConfigurationError
+from kaizen.core._provider_env import detect_provider_from_env
+from kaizen.nodes.ai.embedding_generator import EmbeddingGeneratorNode
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+pytestmark = pytest.mark.regression
+
+_MESSAGES = [{"role": "user", "content": "What is 2 + 2?"}]
+
+
+@pytest.fixture
+def _keyless_env(monkeypatch):
+    """Reproduce a REAL keyless user: no provider key, no test-mode opt-in.
+
+    The root cost-guard already scrubs ``*_API_KEY``; this also removes the
+    harness's ``KAIZEN_ALLOW_KEYLESS_MOCK`` opt-in so ``detect_provider_from_env``
+    resolves the way it does for a real keyless caller, not the way the unit
+    harness configures it. ``monkeypatch`` restores every var at teardown.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+    # A model is required to construct/execute an Agent (env-models.md); the
+    # provider fail-loud fires before any model is used, but construction needs
+    # the value present.
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+
+class TestDetectProviderKeylessDoesNotReturnMock:
+    """Structural pin (task deliverable iii): keyless resolution is NOT 'mock'."""
+
+    def test_keyless_returns_none_not_mock(self, _keyless_env):
+        # The load-bearing structural invariant. If a future edit reverts this
+        # to `return "mock"`, the keyless-mock class re-opens and this fails.
+        resolved = detect_provider_from_env()
+        assert resolved is None, (
+            f"detect_provider_from_env() returned {resolved!r} when keyless; "
+            f'expected None. A "mock" keyless default re-opens the fabricated-'
+            f"content class (#1952, the residual of #1947)."
+        )
+        assert resolved != "mock"
+
+    def test_openai_key_still_resolves_openai(self, _keyless_env, monkeypatch):
+        # A real key is never ignored — the keyed path is unchanged by #1952.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-not-a-real-key")
+        assert detect_provider_from_env() == "openai"
+
+    def test_anthropic_key_still_resolves_anthropic(self, _keyless_env, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-not-a-real-key")
+        assert detect_provider_from_env() == "anthropic"
+
+    def test_explicit_test_opt_in_restores_keyless_mock(
+        self, _keyless_env, monkeypatch
+    ):
+        # The harness contract: an EXPLICIT opt-in (never set by a real user)
+        # restores keyless->mock so the deliberately-keyless unit suite works.
+        monkeypatch.setenv("KAIZEN_ALLOW_KEYLESS_MOCK", "1")
+        assert detect_provider_from_env() == "mock"
+
+
+class TestAgentSurfaceKeylessFailsLoud:
+    """Task deliverable (i), Agent surface: keyless -> fail-loud, not fabricated."""
+
+    def test_agent_get_provider_is_none_when_keyless(self, _keyless_env):
+        from kaizen.core.agents import Agent
+
+        # The resolution seam every Agent dispatch site feeds into. None here
+        # is what flows to LLMAgentNode(provider=None) -> the #1947 gate.
+        assert Agent("qa", {})._get_provider_for_config() is None
+
+    def test_agent_get_provider_explicit_mock_still_works(self, _keyless_env):
+        from kaizen.core.agents import Agent
+
+        assert Agent("qa", {"provider": "mock"})._get_provider_for_config() == "mock"
+
+    def test_agent_resolved_none_dispatched_to_node_fails_loud(self, _keyless_env):
+        from kaizen.core.agents import Agent
+
+        # Composition: the None the Agent surface resolves, handed to a real
+        # LLMAgentNode exactly as every dispatch site does, fails loud — no
+        # fabricated content is producible on the keyless Agent path.
+        resolved = Agent("qa", {})._get_provider_for_config()
+        assert resolved is None
+        with pytest.raises(ConfigurationError) as exc_info:
+            LLMAgentNode().run(provider=resolved, messages=_MESSAGES)
+        assert "provider" in str(exc_info.value).lower()
+
+    def test_agent_execute_keyless_surfaces_error_not_fabricated_content(
+        self, _keyless_env
+    ):
+        # Real end-to-end: a genuine Kaizen agent executed keyless surfaces the
+        # fail-loud provider error, NOT a fabricated mock answer. No mocking —
+        # a real framework runs the real workflow and hits the node's gate.
+        from kaizen.core.framework import Kaizen
+
+        agent = Kaizen().create_agent("qa", signature="question -> answer")
+        raised = None
+        result = None
+        try:
+            result = agent.execute(question="What is 2+2?")
+        except Exception as e:  # noqa: BLE001 - asserting fail-loud either shape
+            raised = e
+
+        # Whether the framework raises or surfaces the error in the result, the
+        # observable must be the fail-loud provider error, never a fabricated
+        # answer produced by a silent mock.
+        surfaced = str(raised) if raised is not None else repr(result)
+        lowered = surfaced.lower()
+        assert "provider" in lowered and (
+            "unresolved" in lowered or "#1947" in surfaced or "#1952" in surfaced
+        ), (
+            "keyless Agent execute did not surface the fail-loud provider error; "
+            f"observed: {surfaced[:300]!r}"
+        )
+
+
+class TestEmbeddingSurfaceKeylessFailsLoud:
+    """Task deliverable (i), embedding surface + (ii) explicit mock still works.
+
+    Env-independent: EmbeddingGeneratorNode reads `provider` from kwargs and
+    never consults the env fallback, so no monkeypatch is needed.
+    """
+
+    @pytest.mark.parametrize(
+        "op_kwargs",
+        [
+            {"operation": "embed_text", "input_text": "hello world"},
+            {"operation": "embed_batch", "input_texts": ["a", "b"]},
+            {"operation": "embed_mcp_resource", "mcp_resource_uri": "data://x.json"},
+        ],
+    )
+    def test_keyless_embedding_operation_raises(self, op_kwargs):
+        # A forgotten provider on an embedding-PRODUCING op fails loud (raise),
+        # never silently returns fabricated mock vectors as real embeddings.
+        with pytest.raises(ConfigurationError) as exc_info:
+            EmbeddingGeneratorNode().run(**op_kwargs)
+        msg = str(exc_info.value)
+        assert "provider" in msg.lower()
+        assert "#1952" in msg
+
+    def test_keyless_similarity_from_texts_raises(self):
+        # calculate_similarity from TEXTS needs a provider to embed them first.
+        with pytest.raises(ConfigurationError):
+            EmbeddingGeneratorNode().run(
+                operation="calculate_similarity",
+                input_texts=["cat", "dog"],
+            )
+
+    def test_similarity_of_two_supplied_vectors_needs_no_provider(self):
+        # Pure vector math needs no provider — must NOT fail loud.
+        result = EmbeddingGeneratorNode().run(
+            operation="calculate_similarity",
+            embedding_1=[0.1, 0.2, 0.3],
+            embedding_2=[0.1, 0.2, 0.3],
+        )
+        assert isinstance(result, dict)
+        assert result.get("success") is True
+
+    def test_explicit_mock_embedding_still_works(self):
+        # The test-harness contract: explicit provider="mock" produces a
+        # deterministic mock embedding — legitimate, never a silent default.
+        result = EmbeddingGeneratorNode().run(
+            operation="embed_text", input_text="hello world", provider="mock"
+        )
+        assert isinstance(result, dict)
+        assert result.get("success") is True
+        assert result.get("embedding"), "explicit mock provider returned no embedding"
+
+    def test_explicit_mock_embedding_via_execute_still_works(self):
+        # execute() applies get_parameters() defaults then run(); explicit mock
+        # dispatches the mock embedding through the full Node.execute path.
+        result = EmbeddingGeneratorNode().execute(
+            operation="embed_text", input_text="hello world", provider="mock"
+        )
+        assert isinstance(result, dict)
+        assert result.get("success") is True
+
+    def test_keyless_execute_fails_loud_not_silent_mock(self):
+        # execute() runs validate_inputs (applies the None default) then run();
+        # run()'s ConfigurationError is raised BEFORE the try block, so the
+        # framework surfaces a LOUD failure — never a fabricated-embedding dict.
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011 - chain asserted
+            EmbeddingGeneratorNode().execute(
+                operation="embed_text", input_text="hello world"
+            )
+        chain = []
+        err = exc_info.value
+        while err is not None:
+            chain.append(err)
+            err = getattr(err, "__cause__", None)
+        assert any(isinstance(e, ConfigurationError) for e in chain) or (
+            "ConfigurationError" in str(exc_info.value)
+        ), f"expected ConfigurationError in the failure chain, got {chain!r}"

--- a/packages/kailash-kaizen/tests/regression/test_issue_1952_keyless_provider_fail_loud.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1952_keyless_provider_fail_loud.py
@@ -234,3 +234,47 @@ class TestEmbeddingSurfaceKeylessFailsLoud:
         assert any(isinstance(e, ConfigurationError) for e in chain) or (
             "ConfigurationError" in str(exc_info.value)
         ), f"expected ConfigurationError in the failure chain, got {chain!r}"
+
+
+class TestReasoningConfigModellessFailsLoud:
+    """`_resolve_reasoning_config` must not silently mock a modelless real caller.
+
+    Same fabricated-content class as the keyless-provider fail-loud: when neither
+    ``OPENAI_PROD_MODEL`` nor ``DEFAULT_LLM_MODEL`` is configured and no explicit
+    config is passed, a real caller previously received a ``mock`` config that
+    fabricated reasoning as a real answer. It now fails loud unless the explicit
+    test-harness opt-in ``KAIZEN_ALLOW_KEYLESS_MOCK`` is set.
+    """
+
+    def test_modelless_keyless_reasoning_config_fails_loud(self, monkeypatch):
+        from kaizen.llm.reasoning import _resolve_reasoning_config
+
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+        monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            _resolve_reasoning_config(None)
+        # Names the env vars to set — actionable, no fabricated reasoning.
+        assert "OPENAI_PROD_MODEL" in str(exc_info.value)
+        assert "DEFAULT_LLM_MODEL" in str(exc_info.value)
+
+    def test_modelless_with_explicit_optin_returns_mock(self, monkeypatch):
+        from kaizen.llm.reasoning import _resolve_reasoning_config
+
+        monkeypatch.delenv("OPENAI_PROD_MODEL", raising=False)
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+        monkeypatch.setenv("KAIZEN_ALLOW_KEYLESS_MOCK", "1")
+
+        cfg = _resolve_reasoning_config(None)
+        assert cfg.llm_provider == "mock"
+
+    def test_model_configured_returns_real_config_not_mock(self, monkeypatch):
+        from kaizen.llm.reasoning import _resolve_reasoning_config
+
+        monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+        monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o-mini")
+
+        cfg = _resolve_reasoning_config(None)
+        assert cfg.llm_provider != "mock"
+        assert cfg.model == "gpt-4o-mini"


### PR DESCRIPTION
## Summary
Closes the remaining silent-mock / fabricated-content sites after #1947. A real caller with no API key / no configured model and no explicit provider previously silently received the `mock` provider and got **fabricated AI content presented as a real answer**. Now it fails loud.

- `detect_provider_from_env()` returns `None` (not `"mock"`) when keyless → flows to `LLMAgentNode`'s existing #1947 `ConfigurationError` gate (structural, single fail-loud point).
- `EmbeddingGeneratorNode` raises a typed `ConfigurationError` on an unresolved provider (was a silent `kwargs.get("provider","mock")`); the `_fallback_provider_embedding` twin also raises instead of returning a mock vector.
- `reasoning.py::_resolve_reasoning_config` fails loud on a missing model instead of returning a silent mock config (same class, surfaced by redteam).
- Explicit `provider="mock"` stays fully supported; the keyless mock path is reachable ONLY under the explicit test-harness opt-in `KAIZEN_ALLOW_KEYLESS_MOCK` (set only in `tests/conftest.py`).

Behavior change → this rides a minor version bump (2.44.0).

## Testing
New regression file `tests/regression/test_issue_1952_keyless_provider_fail_loud.py` (Agent surface keyless → raises not fabricates; embedding surface fail-loud; explicit mock still works; reasoning modelless fail-loud + opt-in). Full kaizen unit suite green (3 pre-existing perf/timing flakes only, one fails on unmodified main). Adversarially redteamed to convergence (reviewer + security-reviewer, 2 rounds).

## Related issues
Fixes #1952