### PR TITLE
fix(kaizen): IterativeLLMAgentNode synthesis failure surfaces success=False, not a template answer (#1953)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
@@ -13,6 +13,26 @@ from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 from kaizen.nodes.ai.llm_agent import LLMAgentNode
 
 
+class SynthesisError(Exception):
+    """Raised when the synthesis-phase LLM call genuinely fails.
+
+    #1953: the run() provider guard (#1947) guarantees a resolved, non-mock
+    provider by the time synthesis dispatches, so a synthesis LLM call that
+    throws OR returns an unsuccessful response is a GENUINE runtime failure
+    (bad key, network, rate-limit) — NOT a missing-provider config error. The
+    old code swallowed that failure and returned a hand-built ``## Analysis
+    Results`` template inside ``{"success": True, "final_response": ...}``,
+    masking a real LLM failure as success. This typed error carries the
+    sanitized underlying error plus the degraded process-report (a summary of
+    the real iteration results) so run() can surface ``success=False`` with the
+    report under a clearly-named non-``final_response`` key.
+    """
+
+    def __init__(self, message: str, degraded_report: str = "") -> None:
+        super().__init__(message)
+        self.degraded_report = degraded_report
+
+
 def _resolve_action_model(kwargs: dict) -> str:
     """Env-first model for the action/synthesis LLM call.
 
@@ -444,6 +464,32 @@ class IterativeLLMAgentNode(LLMAgentNode):
                 "convergence_reason": convergence_reason,
                 "total_iterations": len(iterations),
                 "total_duration": total_duration,
+                "resource_usage": self._calculate_resource_usage(iterations),
+                "metadata": {
+                    "max_iterations": max_iterations,
+                    "discovery_mode": discovery_mode,
+                    "reflection_enabled": reflection_enabled,
+                    "adaptation_strategy": adaptation_strategy,
+                },
+            }
+
+        except SynthesisError as e:
+            # #1953: the iterations ran, but the synthesis-phase LLM call
+            # genuinely failed (resolved, non-mock provider). Surface
+            # success=False with the underlying error and preserve the degraded
+            # process-report under a clearly-named NON-`final_response` key so no
+            # caller mistakes the template for a real model answer.
+            return {
+                "success": False,
+                "synthesis_failed": True,
+                "error": str(e),
+                "error_type": "SynthesisError",
+                "degraded_synthesis": e.degraded_report,
+                "iterations": [iter_state.to_dict() for iter_state in iterations],
+                "discoveries": global_discoveries,
+                "total_iterations": len(iterations),
+                "total_duration": time.time() - start_time,
+                "convergence_reason": convergence_reason,
                 "resource_usage": self._calculate_resource_usage(iterations),
                 "metadata": {
                     "max_iterations": max_iterations,
@@ -910,9 +956,9 @@ class IterativeLLMAgentNode(LLMAgentNode):
                                 "tool_outputs", {}
                             ).get(tool, step_result["output"])
                         else:
-                            execution_results["tool_outputs"][tool] = (
-                                f"Error executing {tool}: {step_result.get('error', 'Unknown error')}"
-                            )
+                            execution_results["tool_outputs"][
+                                tool
+                            ] = f"Error executing {tool}: {step_result.get('error', 'Unknown error')}"
                 else:
                     # Store LLM response output
                     execution_results["tool_outputs"][f"step_{step_num}_llm"] = (
@@ -1537,9 +1583,9 @@ class IterativeLLMAgentNode(LLMAgentNode):
                 improvement = current_score - previous_score
 
                 diminishing_returns = improvement < min_improvement
-                convergence_result["criteria_met"]["diminishing_returns"] = (
-                    diminishing_returns
-                )
+                convergence_result["criteria_met"][
+                    "diminishing_returns"
+                ] = diminishing_returns
 
                 # Only stop for diminishing returns if we already have decent confidence
                 if (
@@ -1654,7 +1700,7 @@ class IterativeLLMAgentNode(LLMAgentNode):
                         total_custom_weight += criterion_weight
                         convergence_result["criteria_met"][
                             f"custom_{criterion_name}"
-                        ] = criterion_score > 0.5
+                        ] = (criterion_score > 0.5)
 
                     except Exception as e:
                         self.logger.warning(
@@ -1754,6 +1800,7 @@ provide your best analysis of the query directly.""",
             },
         ]
 
+        synthesis_error: str | None = None
         try:
             # Use the parent's LLM capabilities to generate synthesis
             synthesis_kwargs = {
@@ -1769,12 +1816,30 @@ provide your best analysis of the query directly.""",
             synthesis_response = super().run(**synthesis_kwargs)
             if synthesis_response.get("success") and synthesis_response.get("response"):
                 return synthesis_response["response"].get("content", "")
-        except Exception as e:
-            self.logger.warning(
-                f"LLM synthesis failed: {sanitize_provider_error(e, 'LLM')}"
+            # #1953: resolved provider returned an UNSUCCESSFUL synthesis (no
+            # exception, but success=False or no response). Do NOT fall through
+            # to the template presented as a real answer — record it as a
+            # genuine synthesis failure so run() surfaces success=False.
+            synthesis_error = (
+                synthesis_response.get("error")
+                or "synthesis LLM call returned an unsuccessful response"
             )
+        except Exception as e:
+            # #1953: a genuine runtime LLM failure (bad key, network,
+            # rate-limit) with a resolved, non-mock provider — the #1947 guard
+            # already ruled out the missing-provider config case. Record it;
+            # the swallow-then-raise below propagates it to run() as
+            # success=False instead of masking it behind the template.
+            synthesis_error = sanitize_provider_error(e, "LLM")
+            self.logger.warning(f"LLM synthesis failed: {synthesis_error}")
 
-        # Fallback to basic synthesis if LLM fails
+        # Reached ONLY when the synthesis LLM call threw OR returned an
+        # unsuccessful response. Build the degraded process-report (a summary of
+        # the REAL iteration results — it carries value) but raise SynthesisError
+        # so run() returns success=False with the report under a clearly-named
+        # NON-`final_response` key. Returning this template as the answer with
+        # success=True would mask a real LLM failure (#1953 error-masking class;
+        # consistent with the #1947 fabricated-content-as-real guard above).
         synthesis = f"## Analysis Results for: {user_query}\n\n"
 
         if all_results:
@@ -1793,7 +1858,12 @@ provide your best analysis of the query directly.""",
             f"- {successful_iterations}/{len(iterations)} iterations successful\n\n"
         )
 
-        return synthesis
+        # #1953: surface the synthesis failure to run() (success=False) with the
+        # degraded process-report attached — never return it as final_response.
+        raise SynthesisError(
+            synthesis_error or "synthesis LLM call failed",
+            degraded_report=synthesis,
+        )
 
     def _update_global_discoveries(
         self, global_discoveries: dict[str, Any], new_discoveries: dict[str, Any]

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
@@ -1103,10 +1103,14 @@ class IterativeLLMAgentNode(LLMAgentNode):
                     )
                     step_result["success"] = False
             except Exception as e:
+                # #1953 (return/log parity): a bad-key/rate-limit exception can
+                # embed a credential; sanitize ONCE so the stored output that
+                # flows into degraded_synthesis is redacted too (mirrors L1046).
+                error_msg = sanitize_provider_error(e, "LLM")
                 self.logger.error(
-                    f"LLM fallback failed for action {action}: {sanitize_provider_error(e, 'LLM')}"
+                    f"LLM fallback failed for action {action}: {error_msg}"
                 )
-                step_result["output"] = f"Error executing {action}: {str(e)}"
+                step_result["output"] = f"Error executing {action}: {error_msg}"
                 step_result["success"] = False
 
         step_result["duration"] = time.time() - start_time
@@ -1824,6 +1828,10 @@ provide your best analysis of the query directly.""",
                 synthesis_response.get("error")
                 or "synthesis LLM call returned an unsuccessful response"
             )
+            # #1953 (observability parity with the exception branch below): a
+            # non-exception synthesis failure is still a real failure — WARN so
+            # it is visible in logs, not only in the success=False return.
+            self.logger.warning(f"LLM synthesis failed: {synthesis_error}")
         except Exception as e:
             # #1953: a genuine runtime LLM failure (bad key, network,
             # rate-limit) with a resolved, non-mock provider — the #1947 guard

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
@@ -430,13 +430,19 @@ class IterativeLLMAgentNode(LLMAgentNode):
                     iteration_state.end_time = time.time()
 
                 except Exception as e:
-                    iteration_state.error = str(e)
+                    # #1953 (return/log parity): iteration_state.error flows into
+                    # the returned "iterations" array via to_dict(); a bad-key/
+                    # rate-limit exception can embed a credential, so sanitize
+                    # ONCE and store the redacted form (same class as the L1109
+                    # + synthesis folds; mirrors the already-sanitized L439 log).
+                    error_msg = sanitize_provider_error(e, "iteration")
+                    iteration_state.error = error_msg
                     iteration_state.success = False
                     iteration_state.end_time = time.time()
 
                     if enable_detailed_logging:
                         self.logger.error(
-                            f"Iteration {iteration_num} failed: {sanitize_provider_error(e, 'iteration')}"
+                            f"Iteration {iteration_num} failed: {error_msg}"
                         )
 
                 iterations.append(iteration_state)

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/iterative_llm_agent.py
@@ -605,15 +605,20 @@ class IterativeLLMAgentNode(LLMAgentNode):
                 )
 
             except Exception as e:
+                # #1953 (return/log parity): this "error" flows into the returned
+                # iterations[].discoveries array via to_dict(); sanitize ONCE and
+                # reuse in both the log and the stored dict (same class as the
+                # L438 iteration fold — closes the last adjacent-log asymmetry).
+                error_msg = sanitize_provider_error(e, "MCP")
                 self.logger.debug(
-                    f"Discovery failed for server {server_id}: {sanitize_provider_error(e, 'MCP')}"
+                    f"Discovery failed for server {server_id}: {error_msg}"
                 )
                 discoveries["new_servers"].append(
                     {
                         "id": server_id,
                         "config": server_config,
                         "discovered_at": datetime.now().isoformat(),
-                        "error": str(e),
+                        "error": error_msg,
                         "tools_count": 0,
                         "resources_count": 0,
                     }

--- a/packages/kailash-kaizen/tests/regression/test_issue_1953_synthesis_no_success_masking.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1953_synthesis_no_success_masking.py
@@ -1,0 +1,170 @@
+"""Regression test — synthesis-phase LLM failure is NOT masked as success (#1953).
+
+Distinct from #1947 (a forgotten/omitted provider — closed by the run() guard)
+and #1952 (keyless-mock): #1953 is reachable ONLY AFTER the #1947 provider guard
+has passed. With a RESOLVED, non-mock provider, a genuine runtime synthesis LLM
+failure (bad key, network, rate-limit) at ``IterativeLLMAgentNode._phase_synthesis``
+was swallowed by an ``except Exception`` that logged a warning and fell through to
+a hand-built ``## Analysis Results`` template. ``run()`` then returned that template
+inside ``{"success": True, "final_response": <template>, ...}`` — presenting a real
+LLM failure to the caller as SUCCESS with a non-LLM answer.
+
+The fix (#1953): a synthesis-phase LLM failure (a thrown exception OR an
+unsuccessful response) with a resolved provider raises ``SynthesisError``, which
+``run()`` surfaces as ``success=False`` with a ``synthesis_failed`` marker and the
+underlying error. The degraded process-report (a summary of the REAL iteration
+results — it carries value) is preserved under the clearly-named
+``degraded_synthesis`` key, NEVER as ``final_response`` — so no caller mistakes the
+template for a real model answer. Consistent with the #1947 fabricated-content-as-
+real guard in the same file.
+
+These are Tier 1 unit tests. They monkeypatch the base ``LLMAgentNode.run``
+(the ``super().run()`` synthesis dispatches through) to RAISE — a resolved,
+non-mock provider whose synthesis call genuinely fails at runtime — and observe
+the REAL returned success flag / raised error, never a mock that hides the mask.
+"""
+
+import pytest
+
+from kaizen.nodes.ai.iterative_llm_agent import (
+    IterationState,
+    IterativeLLMAgentNode,
+    SynthesisError,
+)
+from kaizen.nodes.ai.llm_agent import LLMAgentNode
+
+pytestmark = pytest.mark.regression
+
+_MESSAGES = [{"role": "user", "content": "Why did revenue drop last quarter?"}]
+_REAL_FINDING = "Finding: revenue dropped 12% driven by enterprise churn"
+
+
+def _iteration_with_real_results() -> IterationState:
+    """A successful iteration carrying real execution results the template summarizes."""
+    return IterationState(
+        iteration=1,
+        phase="synthesis",
+        start_time=0.0,
+        end_time=1.0,
+        execution_results={"intermediate_results": [_REAL_FINDING]},
+        success=True,
+    )
+
+
+class TestPhaseSynthesisRaisesOnResolvedProviderFailure:
+    """A resolved-provider synthesis LLM failure raises SynthesisError, not a template return."""
+
+    def test_synthesis_llm_exception_raises_synthesis_error(self, monkeypatch):
+        # Resolved provider whose synthesis call throws at runtime (bad key etc.).
+        def _raise(self, **kwargs):
+            raise RuntimeError("simulated runtime LLM failure: invalid api key")
+
+        monkeypatch.setattr(LLMAgentNode, "run", _raise)
+
+        node = IterativeLLMAgentNode()
+        iterations = [_iteration_with_real_results()]
+        kwargs = {"provider": "mock", "messages": _MESSAGES}
+
+        with pytest.raises(SynthesisError) as exc_info:
+            node._phase_synthesis(kwargs, iterations, global_discoveries={})
+
+        # The degraded process-report is preserved on the error (it summarizes the
+        # REAL iteration results) — but it is an ERROR, never a success return.
+        report = exc_info.value.degraded_report
+        assert (
+            "## Analysis Results" in report
+        ), "the degraded process-report should still be built and attached"
+        assert (
+            _REAL_FINDING in report
+        ), "the degraded report should summarize the real iteration results"
+        # The failure is surfaced (non-empty error message), never silently swallowed.
+        assert str(exc_info.value)
+
+    def test_synthesis_unsuccessful_response_raises_synthesis_error(self, monkeypatch):
+        # A resolved provider that returns success=False (no exception) is ALSO a
+        # genuine failure — it MUST NOT fall through to the template-as-answer.
+        def _unsuccessful(self, **kwargs):
+            return {"success": False, "error": "rate limited"}
+
+        monkeypatch.setattr(LLMAgentNode, "run", _unsuccessful)
+
+        node = IterativeLLMAgentNode()
+        iterations = [_iteration_with_real_results()]
+        kwargs = {"provider": "mock", "messages": _MESSAGES}
+
+        with pytest.raises(SynthesisError) as exc_info:
+            node._phase_synthesis(kwargs, iterations, global_discoveries={})
+        assert "rate limited" in str(exc_info.value)
+
+
+class TestRunReturnPathNotMaskedAsSuccess:
+    """run() surfaces a synthesis failure as success=False, not a fabricated answer."""
+
+    def test_run_synthesis_failure_is_not_success_with_template(self, monkeypatch):
+        # Fail ONLY the synthesis dispatch (distinguished by its system prompt),
+        # so the iterations run with a resolved provider and only the final
+        # synthesis LLM call fails at runtime — the exact masking scenario.
+        def _synthesis_only_failure(self, **kwargs):
+            messages = kwargs.get("messages", [])
+            system_text = " ".join(
+                m.get("content", "")
+                for m in messages
+                if isinstance(m, dict) and m.get("role") == "system"
+            )
+            if "synthesizing results" in system_text.lower():
+                raise RuntimeError("simulated runtime LLM failure: network error")
+            return {"success": True, "response": {"content": _REAL_FINDING}}
+
+        monkeypatch.setattr(LLMAgentNode, "run", _synthesis_only_failure)
+
+        node = IterativeLLMAgentNode()
+        result = node.run(provider="mock", messages=_MESSAGES, max_iterations=1)
+
+        assert isinstance(result, dict)
+        # THE regression guarantee: never success=True with a fabricated
+        # `## Analysis Results` body presented as the answer.
+        assert not (
+            result.get("success") is True
+            and "## Analysis Results" in str(result.get("final_response", ""))
+        ), "a resolved-provider synthesis failure was masked as success=True"
+        # The failure is observable to the caller.
+        assert result.get("success") is False
+        assert result.get("synthesis_failed") is True
+        assert result.get("error"), "the underlying synthesis error must be surfaced"
+        # The template, if kept, is under a clearly-named NON-final_response key.
+        assert (
+            "final_response" not in result
+        ), "the template must not be presented as final_response on failure"
+        assert "## Analysis Results" in str(
+            result.get("degraded_synthesis", "")
+        ), "the degraded process-report should be preserved under degraded_synthesis"
+
+    def test_run_all_llm_calls_failing_still_not_masked(self, monkeypatch):
+        # Even when every LLM call fails (no iteration results), the synthesis
+        # failure MUST NOT be returned as success=True with a template.
+        def _raise(self, **kwargs):
+            raise RuntimeError("simulated runtime LLM failure: 401 unauthorized")
+
+        monkeypatch.setattr(LLMAgentNode, "run", _raise)
+
+        node = IterativeLLMAgentNode()
+        result = node.run(provider="mock", messages=_MESSAGES, max_iterations=1)
+
+        assert result.get("success") is False
+        assert result.get("synthesis_failed") is True
+        assert not (
+            result.get("success") is True
+            and "## Analysis Results" in str(result.get("final_response", ""))
+        )
+
+
+class TestSuccessfulSynthesisStillWorks:
+    """Happy path unchanged: an explicit mock provider that succeeds returns success."""
+
+    def test_explicit_mock_returns_success_with_final_response(self):
+        node = IterativeLLMAgentNode()
+        result = node.execute(provider="mock", messages=_MESSAGES, max_iterations=1)
+        assert isinstance(result, dict)
+        assert result.get("success") is True
+        assert result.get("synthesis_failed") is not True
+        assert "final_response" in result


### PR DESCRIPTION
## Summary
A synthesis-phase LLM failure (resolved, non-mock provider — bad key/network/rate-limit at runtime) was swallowed and returned as `{"success": True, "final_response": <hand-built template>}` — masking a genuine runtime failure as success (zero-tolerance Rule 3 error-masking).

- Adds a typed `SynthesisError`; `run()` now returns `{"success": False, "synthesis_failed": True, "error": <sanitized>, "degraded_synthesis": <process-report>, ...}` with NO `final_response`, so no caller mistakes the template for a real model answer.
- Redteam surfaced 3 same-class credential-leak siblings (raw `str(e)` stored into caller-facing return dicts while the adjacent log already sanitized): `degraded_synthesis` (L1109), the per-iteration `iteration_state.error` → `iterations[]` (L433), and MCP-discovery `error` → `iterations[].discoveries` (L616). All routed through `sanitize_provider_error`. Every other error-return site proven safe-by-construction (base `LLMAgentNode` sanitizes at its return + raise boundaries).

## Testing
New regression `tests/regression/test_issue_1953_synthesis_no_success_masking.py` (resolved provider whose synthesis call raises → not success=True, failure observable). Redteamed to convergence over 3 rounds (reviewer + security-reviewer) exhaustively dispositioning every raw-error store.

## Related issues
Fixes #1953