### PR TITLE
fix(kaizen): provider-handling minor follow-ups — cache keys, gate docstring, env detection (#1948)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/mixins/caching_mixin.py
+++ b/packages/kailash-kaizen/src/kaizen/core/mixins/caching_mixin.py
@@ -100,8 +100,14 @@ class CachingMixin:
 
     Cache can be bypassed by passing cache_bypass=True to run().
 
+    Enabled via the ``batch_processing_enabled`` config flag — that is the
+    field BaseAgent maps to this mixin (see ``BaseAgent._MIXIN_MAP``). There
+    is no ``caching_enabled`` field on BaseAgentConfig; passing one has no
+    effect on caching. The TTL is read from ``config.cache_ttl`` when present
+    (falling back to the ``apply(ttl=...)`` default of 300s otherwise).
+
     Example:
-        config = BaseAgentConfig(caching_enabled=True, cache_ttl=600)
+        config = BaseAgentConfig(batch_processing_enabled=True)
         agent = SimpleQAAgent(config)
 
         # First call - executes and caches
@@ -206,8 +212,25 @@ class CachingMixin:
         Returns:
             SHA256 hash of inputs
         """
+        # #1948: include the RESOLVED provider so a response computed under
+        # one provider is never replayed after the provider changes (an agent
+        # with no explicit llm_provider resolves via ambient env keys, so the
+        # same inputs can dispatch to a different provider across calls). The
+        # resolved provider is a bare name ("openai"/"anthropic"/"mock"), never
+        # a credential — safe to embed in the key.
+        from kaizen.core._provider_env import detect_provider_from_env
+
+        config = getattr(agent, "config", None)
+        llm_provider = (
+            getattr(config, "llm_provider", None) if config is not None else None
+        )
+        resolved_provider = llm_provider or detect_provider_from_env()
+
         key_data = {
             "agent_class": agent.__class__.__name__,
+            # str() the provider so the key is JSON-serializable and stable
+            # for any config shape (matches the args/kwargs treatment below).
+            "provider": str(resolved_provider),
             "args": [str(a) for a in args] if args else [],
             "kwargs": {k: str(v) for k, v in sorted(kwargs.items())},
         }

--- a/packages/kailash-kaizen/src/kaizen/core/workflow_generator.py
+++ b/packages/kailash-kaizen/src/kaizen/core/workflow_generator.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Dict, List, Optional
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.credentials import get_credential_store
 
+from kaizen.core._provider_env import detect_provider_from_env
 from kaizen.core.config import BaseAgentConfig
 from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 from kaizen.signatures import Signature
@@ -158,6 +159,11 @@ class WorkflowGenerator:
             if hasattr(self.config, "llm_provider")
             else self.config.get("llm_provider")
         )
+        # #1948: when no provider is explicitly configured, resolve it from the
+        # environment (openai -> anthropic -> mock) instead of hardcoding
+        # "openai". An agent with only ANTHROPIC_API_KEY set would otherwise be
+        # dispatched to OpenAI and fail with an auth error.
+        resolved_provider = llm_provider or detect_provider_from_env()
         model = (
             getattr(self.config, "model", None)
             if hasattr(self.config, "model")
@@ -213,7 +219,7 @@ class WorkflowGenerator:
         # - Google/Gemini: Translates to response_mime_type + response_json_schema
         # - Azure: Translates to JsonSchemaFormat
         providers_with_structured_output = ["openai", "google", "gemini", "azure"]
-        effective_provider = llm_provider or "openai"
+        effective_provider = resolved_provider
 
         if structured_output_mode == "off":
             response_format = None
@@ -269,7 +275,7 @@ class WorkflowGenerator:
 
         # Create LLMAgentNode with signature-based configuration
         node_config = {
-            "provider": llm_provider or "openai",
+            "provider": resolved_provider,
             "model": model or os.environ.get("DEFAULT_LLM_MODEL"),
             "system_prompt": self._get_system_prompt(),
             "generation_config": generation_config,
@@ -367,7 +373,7 @@ class WorkflowGenerator:
 
                     # Convert to provider-specific format
                     provider_tools = get_tools_for_provider(
-                        mcp_tools, llm_provider or "openai"
+                        mcp_tools, resolved_provider
                     )
 
                     # Add to node config
@@ -418,8 +424,10 @@ class WorkflowGenerator:
             generation_config["max_tokens"] = self.config.max_tokens
 
         # Create simple LLMAgentNode configuration (no signature)
+        # #1948: resolve the provider from the environment when unset instead of
+        # hardcoding "openai" (see _build_llm_node_config above for rationale).
         node_config = {
-            "provider": self.config.llm_provider or "openai",
+            "provider": self.config.llm_provider or detect_provider_from_env(),
             "model": self.config.model or os.environ.get("DEFAULT_LLM_MODEL"),
             "generation_config": generation_config,
         }

--- a/packages/kailash-kaizen/src/kaizen/integrations/nexus/deployment_cache.py
+++ b/packages/kailash-kaizen/src/kaizen/integrations/nexus/deployment_cache.py
@@ -59,6 +59,10 @@ class DeploymentCache:
         - RESOLVED LLM provider (see FIX 8 note below)
         - Model name
         - Signature structure
+        - System prompt (#1948: two agents sharing name+provider+model+
+          signature but different prompts must NOT collide)
+        - Temperature (#1948: same-shape agents at different temperatures
+          build different workflows and must key distinctly)
 
         Args:
             agent: BaseAgent instance
@@ -98,11 +102,19 @@ class DeploymentCache:
         resolved_provider = llm_provider or detect_provider_from_env()
 
         # Build key data
+        #
+        # #1948: include system_prompt and temperature. Two agents that share
+        # name + provider + model + signature but carry different system
+        # prompts (or run at different temperatures) build DIFFERENT workflows;
+        # omitting these dimensions let the second agent collide onto the
+        # first's cached build under the module-global cache.
         key_data = {
             "name": name,
             "provider": resolved_provider,
             "model": getattr(config, "model", None),
             "signature": str(signature) if signature else None,
+            "system_prompt": getattr(config, "system_prompt", None),
+            "temperature": getattr(config, "temperature", None),
         }
 
         # Create deterministic JSON string

--- a/packages/kailash-kaizen/src/kaizen/integrations/nexus/deployment_cache.py
+++ b/packages/kailash-kaizen/src/kaizen/integrations/nexus/deployment_cache.py
@@ -14,7 +14,10 @@ Features:
 
 import hashlib
 import json
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from ...core.base_agent import BaseAgent
 
 
 class DeploymentCache:
@@ -59,8 +62,9 @@ class DeploymentCache:
         - RESOLVED LLM provider (see FIX 8 note below)
         - Model name
         - Signature structure
-        - System prompt (#1948: two agents sharing name+provider+model+
-          signature but different prompts must NOT collide)
+        - Effective system prompt (#1948: two agents sharing name+provider+
+          model+signature but different prompts — e.g. different discovered
+          MCP tools or a custom prompt override — must NOT collide)
         - Temperature (#1948: same-shape agents at different temperatures
           build different workflows and must key distinctly)
 
@@ -101,19 +105,49 @@ class DeploymentCache:
         llm_provider = getattr(config, "llm_provider", None)
         resolved_provider = llm_provider or detect_provider_from_env()
 
-        # Build key data
+        # #1948: key on the agent's REAL EFFECTIVE system prompt plus
+        # temperature. Two agents that share name + provider + model +
+        # signature but carry different prompts (or run at different
+        # temperatures) build DIFFERENT workflows; omitting these dimensions
+        # let the second agent collide onto the first's cached build under the
+        # module-global cache.
         #
-        # #1948: include system_prompt and temperature. Two agents that share
-        # name + provider + model + signature but carry different system
-        # prompts (or run at different temperatures) build DIFFERENT workflows;
-        # omitting these dimensions let the second agent collide onto the
-        # first's cached build under the module-global cache.
+        # `system_prompt` is NOT a BaseAgentConfig field, so reading it off the
+        # config was a no-op for every real agent. The effective prompt comes
+        # from `agent._generate_system_prompt()` — the same method
+        # `to_workflow()` invokes — which captures the signature, the
+        # discovered MCP tools (`_discovered_mcp_tools`), and any subclass
+        # prompt override. That is the value that actually differentiates two
+        # otherwise-identical agents. A non-BaseAgent that carries an explicit
+        # `config.system_prompt` falls back to it.
+        prompt_gen = getattr(agent, "_generate_system_prompt", None)
+        if callable(prompt_gen):
+            effective_system_prompt = prompt_gen()
+        else:
+            effective_system_prompt = getattr(config, "system_prompt", None)
+
+        # #1948: a DETERMINISTIC signature representation. `str(signature)` fell
+        # to Signature's default object repr (`<Sig object at 0x...>`), whose
+        # embedded memory address made the cache key UNIQUE PER AGENT INSTANCE —
+        # so two structurally-identical agents never shared a cache entry and
+        # the cache never hit for real agents. `to_dict()` is the stable
+        # structural form (identical across instances of the same signature).
+        if signature is None:
+            signature_repr = None
+        elif hasattr(signature, "to_dict"):
+            signature_repr = json.dumps(
+                signature.to_dict(), sort_keys=True, default=str
+            )
+        else:
+            signature_repr = str(signature)
+
+        # Build key data
         key_data = {
             "name": name,
             "provider": resolved_provider,
             "model": getattr(config, "model", None),
-            "signature": str(signature) if signature else None,
-            "system_prompt": getattr(config, "system_prompt", None),
+            "signature": signature_repr,
+            "system_prompt": effective_system_prompt,
             "temperature": getattr(config, "temperature", None),
         }
 
@@ -154,7 +188,7 @@ class DeploymentCache:
         # Store workflow
         self._cache[cache_key] = workflow
 
-    def invalidate(self, cache_key: str = None):
+    def invalidate(self, cache_key: Optional[str] = None):
         """
         Invalidate cache entry or entire cache.
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
@@ -35,6 +35,7 @@ import pytest
 from kaizen.core.config import BaseAgentConfig
 from kaizen.core.mixins.caching_mixin import CachingMixin
 from kaizen.integrations.nexus.deployment_cache import DeploymentCache
+from kaizen.signatures import InputField, OutputField, Signature
 
 
 def _fake_agent(llm_provider=None):
@@ -215,48 +216,103 @@ class TestItem3WorkflowGeneratorEnvDetection:
 
 
 # ---------------------------------------------------------------------------
-# Item 4 — DeploymentCache key includes system_prompt and temperature
+# Item 4 — DeploymentCache key includes the REAL effective prompt + temperature
+#
+# These tests use a REAL BaseAgent + BaseAgentConfig (NOT SimpleNamespace).
+# The prior SimpleNamespace-based test fabricated a `system_prompt` field that
+# no real config has, so it proved nothing about real agents (the round-1
+# redteam INVEST-NOW). The effective prompt now comes from
+# agent._generate_system_prompt() — which varies by discovered MCP tools and
+# subclass overrides — so these tests exercise the collision that actually
+# occurs in production.
 # ---------------------------------------------------------------------------
+class _QASignature(Signature):
+    question: str = InputField(description="the question")
+    answer: str = OutputField(description="the answer")
+
+
 class TestItem4DeploymentCacheKeyDimensions:
-    def _agent(self, *, system_prompt=None, temperature=0.1):
-        cfg = SimpleNamespace(
-            llm_provider="openai",  # pin provider so it isn't env-dependent
+    def _real_agent(self, *, temperature=0.1):
+        from kaizen.core.base_agent import BaseAgent
+
+        cfg = BaseAgentConfig(
+            llm_provider="openai",  # pin provider so the key isn't env-dependent
             model="test-model",
-            system_prompt=system_prompt,
             temperature=temperature,
         )
-        return SimpleNamespace(config=cfg, signature="SIG")
+        # mcp_servers=[] disables MCP auto-connect so construction is
+        # deterministic and offline (Tier-1); _discovered_mcp_tools stays {}.
+        return BaseAgent(config=cfg, signature=_QASignature(), mcp_servers=[])
 
-    def test_different_system_prompt_yields_different_key(self):
-        key_a = DeploymentCache.create_cache_key(
-            self._agent(system_prompt="You are agent A"), "wf"
-        )
-        key_b = DeploymentCache.create_cache_key(
-            self._agent(system_prompt="You are agent B"), "wf"
-        )
+    def test_different_effective_prompt_yields_different_key(self):
+        """Real agents differing ONLY in discovered MCP tools MUST key apart.
+
+        Two agents share name+provider+model+signature; the sole difference is
+        the discovered-tools set, which changes _generate_system_prompt()'s
+        output — the exact collision the fix closes. `str(signature)` does NOT
+        capture the tool difference, so this fails without the effective-prompt
+        dimension.
+        """
+        agent_a = self._real_agent()
+        agent_b = self._real_agent()
+        agent_a._discovered_mcp_tools = {}
+        agent_b._discovered_mcp_tools = {
+            "srv": [{"name": "read_file", "description": "reads a file"}]
+        }
+        # Sanity: the effective prompts genuinely differ.
+        assert agent_a._generate_system_prompt() != agent_b._generate_system_prompt()
+
+        key_a = DeploymentCache.create_cache_key(agent_a, "wf")
+        key_b = DeploymentCache.create_cache_key(agent_b, "wf")
         assert key_a != key_b, (
             "two agents sharing name+provider+model+signature but different "
-            "system prompts MUST NOT collide (#1948 item 4)"
+            "effective prompts (discovered MCP tools) MUST NOT collide "
+            "(#1948 item 4)"
         )
 
+    def test_custom_prompt_override_yields_different_key(self):
+        """A subclass override of _generate_system_prompt is keyed on."""
+        agent_a = self._real_agent()
+        agent_b = self._real_agent()
+        agent_a._generate_system_prompt = lambda: "You are agent A"
+        agent_b._generate_system_prompt = lambda: "You are agent B"
+
+        key_a = DeploymentCache.create_cache_key(agent_a, "wf")
+        key_b = DeploymentCache.create_cache_key(agent_b, "wf")
+        assert key_a != key_b
+
     def test_different_temperature_yields_different_key(self):
-        key_cold = DeploymentCache.create_cache_key(self._agent(temperature=0.0), "wf")
-        key_warm = DeploymentCache.create_cache_key(self._agent(temperature=0.9), "wf")
+        key_cold = DeploymentCache.create_cache_key(
+            self._real_agent(temperature=0.0), "wf"
+        )
+        key_warm = DeploymentCache.create_cache_key(
+            self._real_agent(temperature=0.9), "wf"
+        )
         assert key_cold != key_warm, (
             "different temperatures build different workflows and MUST key "
             "distinctly (#1948 item 4)"
         )
 
-    def test_identical_config_yields_same_key(self):
+    def test_identical_agents_yield_same_key(self):
         key_a = DeploymentCache.create_cache_key(
-            self._agent(system_prompt="same", temperature=0.3), "wf"
+            self._real_agent(temperature=0.3), "wf"
         )
         key_b = DeploymentCache.create_cache_key(
-            self._agent(system_prompt="same", temperature=0.3), "wf"
+            self._real_agent(temperature=0.3), "wf"
         )
         assert key_a == key_b
 
+    def test_config_system_prompt_field_is_a_no_op_for_real_agents(self):
+        """Guard the redteam finding: system_prompt is NOT a BaseAgentConfig
+        field, so the old getattr(config, 'system_prompt') dimension could
+        never discriminate a real agent. Pin that the field is absent so a
+        future 'fix' cannot silently reintroduce the vacuous dimension."""
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(BaseAgentConfig)}
+        assert "system_prompt" not in field_names
+
     def test_key_is_sha256_hex(self):
-        key = DeploymentCache.create_cache_key(self._agent(system_prompt="x"), "wf")
+        key = DeploymentCache.create_cache_key(self._real_agent(), "wf")
         assert len(key) == len(hashlib.sha256(b"x").hexdigest())
         assert all(c in "0123456789abcdef" for c in key)

--- a/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
@@ -249,9 +249,12 @@ class TestItem4DeploymentCacheKeyDimensions:
 
         Two agents share name+provider+model+signature; the sole difference is
         the discovered-tools set, which changes _generate_system_prompt()'s
-        output — the exact collision the fix closes. `str(signature)` does NOT
-        capture the tool difference, so this fails without the effective-prompt
-        dimension.
+        output — the exact collision the fix closes. This ISOLATES the
+        effective-prompt dimension: with the deterministic signature repr in
+        place, reverting only the effective-prompt keying makes this fail (the
+        signature no longer distinguishes the tool difference). It does NOT
+        guard the determinism fix on its own — test_identical_agents_yield_same_key
+        is that guard.
         """
         agent_a = self._real_agent()
         agent_b = self._real_agent()

--- a/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1948_provider_minor_followups.py
@@ -1,0 +1,262 @@
+"""Regression tests — issue #1948 provider-handling minor follow-ups.
+
+Four small, independent provider-handling fixes, one test class each:
+
+1. ``CachingMixin._make_cache_key`` was provider-BLIND — the response-cache
+   key omitted the resolved provider, so a response computed under one
+   provider could replay across a provider change (an agent with no explicit
+   ``llm_provider`` resolves the provider from ambient env keys, so identical
+   inputs can dispatch to different providers across calls). FIX: the resolved
+   provider is now part of the key.
+
+2. The ``CachingMixin`` docstring documented ``caching_enabled=True`` as the
+   enable flag, but the real gate BaseAgent maps to this mixin is
+   ``batch_processing_enabled``; ``caching_enabled`` is not a BaseAgentConfig
+   field, so the documented enable-path was a no-op (zero-tolerance Rule 3c).
+   FIX: the docstring now names the real gate.
+
+3. ``workflow_generator`` used the literal fallback ``llm_provider or "openai"``
+   at the LLMAgentNode-provider sites, so an agent with only ``ANTHROPIC_API_KEY``
+   set and no explicit provider was wrongly dispatched to OpenAI. FIX: the
+   sites now resolve the provider via ``detect_provider_from_env()``.
+
+4. ``DeploymentCache.create_cache_key`` omitted ``system_prompt`` and
+   ``temperature``, so two agents sharing name+provider+model+signature but
+   different prompts (or temperatures) collided under the module-global cache.
+   FIX: both dimensions are now part of the key.
+"""
+
+import dataclasses
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+
+from kaizen.core.config import BaseAgentConfig
+from kaizen.core.mixins.caching_mixin import CachingMixin
+from kaizen.integrations.nexus.deployment_cache import DeploymentCache
+
+
+def _fake_agent(llm_provider=None):
+    """Minimal stand-in for a BaseAgent as _make_cache_key consumes it.
+
+    _make_cache_key reads only ``agent.__class__.__name__`` and
+    ``agent.config.llm_provider``; SimpleNamespace supplies both without
+    dragging in the full BaseAgent construction path.
+    """
+    return SimpleNamespace(config=SimpleNamespace(llm_provider=llm_provider))
+
+
+# ---------------------------------------------------------------------------
+# Item 1 — CachingMixin cache key includes the resolved provider
+# ---------------------------------------------------------------------------
+class TestItem1CachingMixinCacheKeyProvider:
+    def test_explicit_provider_is_part_of_key(self):
+        """Same inputs, different explicit providers -> different keys."""
+        key_openai = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider="openai"), question="test"
+        )
+        key_anthropic = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider="anthropic"), question="test"
+        )
+        assert key_openai != key_anthropic, (
+            "cache key MUST differ across providers for identical inputs; "
+            "a key blind to the provider replays one provider's response "
+            "after a provider change (#1948 item 1)"
+        )
+
+    def test_same_provider_same_inputs_same_key(self):
+        """The key stays stable for the same provider + inputs (real cache hit)."""
+        key_a = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider="openai"), question="test"
+        )
+        key_b = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider="openai"), question="test"
+        )
+        assert key_a == key_b
+
+    def test_env_resolved_provider_is_part_of_key(self, monkeypatch):
+        """No explicit provider -> the env-resolved provider still keys it.
+
+        This is the exact drift the fix targets: an agent that leaves
+        ``llm_provider`` unset resolves the provider from ambient env keys,
+        so the key MUST change when that ambient resolution changes.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+        key_under_openai = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider=None), question="test"
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-anthropic")
+        key_under_anthropic = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider=None), question="test"
+        )
+
+        assert key_under_openai != key_under_anthropic
+
+    def test_key_does_not_embed_credentials(self, monkeypatch):
+        """security.md: the resolved provider is a bare name, never the key."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-do-not-leak")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        key = CachingMixin._make_cache_key(
+            _fake_agent(llm_provider=None), question="test"
+        )
+        # Key is a bare sha256 hex digest; assert it is exactly that and that
+        # the secret cannot be recovered from it.
+        assert len(key) == 64 and all(c in "0123456789abcdef" for c in key)
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — CachingMixin docstring names the REAL gate (batch_processing_enabled)
+# ---------------------------------------------------------------------------
+class TestItem2CachingMixinGateConsistency:
+    def test_docstring_names_real_gate_not_phantom_field(self):
+        doc = CachingMixin.__doc__ or ""
+        assert "batch_processing_enabled" in doc, (
+            "the docstring MUST document the real enable gate "
+            "(batch_processing_enabled)"
+        )
+        assert "caching_enabled=True" not in doc, (
+            "the docstring MUST NOT document caching_enabled — it is not a "
+            "BaseAgentConfig field and enabling via it is a no-op "
+            "(zero-tolerance Rule 3c)"
+        )
+
+    def test_documented_gate_is_a_real_config_field(self):
+        field_names = {f.name for f in dataclasses.fields(BaseAgentConfig)}
+        assert (
+            "batch_processing_enabled" in field_names
+        ), "the documented enable gate MUST be a real config field"
+
+    def test_phantom_gate_is_not_a_config_field(self):
+        field_names = {f.name for f in dataclasses.fields(BaseAgentConfig)}
+        assert "caching_enabled" not in field_names, (
+            "caching_enabled is NOT a BaseAgentConfig field; the old docstring "
+            "advertised a dead enable-path"
+        )
+
+    def test_config_rejects_the_phantom_flag(self):
+        """Passing the phantom flag is a hard error, proving it never gated."""
+        with pytest.raises(TypeError):
+            BaseAgentConfig(caching_enabled=True)  # type: ignore[call-arg]
+
+    def test_real_gate_constructs(self):
+        cfg = BaseAgentConfig(batch_processing_enabled=True)
+        assert cfg.batch_processing_enabled is True
+
+    def test_docstring_example_is_constructible(self):
+        """The docstring example MUST use only real BaseAgentConfig kwargs.
+
+        The old example passed cache_ttl (a KaizenConfig field, not a
+        BaseAgentConfig one) alongside the phantom caching_enabled — a
+        double-phantom example that raised TypeError if a user copied it.
+        """
+        assert "cache_ttl=600" not in (CachingMixin.__doc__ or ""), (
+            "the docstring example MUST NOT pass cache_ttl to BaseAgentConfig "
+            "(it is a KaizenConfig field; the constructor rejects it)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Item 3 — workflow_generator resolves provider from env, not the "openai" literal
+# ---------------------------------------------------------------------------
+class TestItem3WorkflowGeneratorEnvDetection:
+    def _provider_of(self, workflow, node_id):
+        return workflow.nodes[node_id]["config"]["provider"]
+
+    def test_fallback_workflow_uses_anthropic_when_only_anthropic_key(
+        self, monkeypatch
+    ):
+        from kaizen.core.workflow_generator import WorkflowGenerator
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-anthropic")
+
+        gen = WorkflowGenerator(config=BaseAgentConfig(llm_provider=None))
+        wf = gen.generate_fallback_workflow()
+        assert self._provider_of(wf, "agent_fallback") == "anthropic", (
+            "an agent with only ANTHROPIC_API_KEY MUST resolve to anthropic, "
+            "not the hardcoded 'openai' literal (#1948 item 3)"
+        )
+
+    def test_fallback_workflow_uses_openai_when_openai_key(self, monkeypatch):
+        from kaizen.core.workflow_generator import WorkflowGenerator
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+
+        gen = WorkflowGenerator(config=BaseAgentConfig(llm_provider=None))
+        wf = gen.generate_fallback_workflow()
+        assert self._provider_of(wf, "agent_fallback") == "openai"
+
+    def test_explicit_provider_still_wins(self, monkeypatch):
+        from kaizen.core.workflow_generator import WorkflowGenerator
+
+        # Even with an OpenAI key present, an explicit provider is honored.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+        gen = WorkflowGenerator(config=BaseAgentConfig(llm_provider="anthropic"))
+        wf = gen.generate_fallback_workflow()
+        assert self._provider_of(wf, "agent_fallback") == "anthropic"
+
+    def test_source_has_no_hardcoded_openai_provider_fallback(self):
+        """The `llm_provider or "openai"` provider literal is gone from the source."""
+        import kaizen.core.workflow_generator as wg
+
+        src = __import__("pathlib").Path(wg.__file__).read_text()
+        assert 'llm_provider or "openai"' not in src, (
+            "no provider-dispatch site may fall back to the 'openai' literal; "
+            "resolve via detect_provider_from_env() instead (#1948 item 3)"
+        )
+        assert "detect_provider_from_env" in src
+
+
+# ---------------------------------------------------------------------------
+# Item 4 — DeploymentCache key includes system_prompt and temperature
+# ---------------------------------------------------------------------------
+class TestItem4DeploymentCacheKeyDimensions:
+    def _agent(self, *, system_prompt=None, temperature=0.1):
+        cfg = SimpleNamespace(
+            llm_provider="openai",  # pin provider so it isn't env-dependent
+            model="test-model",
+            system_prompt=system_prompt,
+            temperature=temperature,
+        )
+        return SimpleNamespace(config=cfg, signature="SIG")
+
+    def test_different_system_prompt_yields_different_key(self):
+        key_a = DeploymentCache.create_cache_key(
+            self._agent(system_prompt="You are agent A"), "wf"
+        )
+        key_b = DeploymentCache.create_cache_key(
+            self._agent(system_prompt="You are agent B"), "wf"
+        )
+        assert key_a != key_b, (
+            "two agents sharing name+provider+model+signature but different "
+            "system prompts MUST NOT collide (#1948 item 4)"
+        )
+
+    def test_different_temperature_yields_different_key(self):
+        key_cold = DeploymentCache.create_cache_key(self._agent(temperature=0.0), "wf")
+        key_warm = DeploymentCache.create_cache_key(self._agent(temperature=0.9), "wf")
+        assert key_cold != key_warm, (
+            "different temperatures build different workflows and MUST key "
+            "distinctly (#1948 item 4)"
+        )
+
+    def test_identical_config_yields_same_key(self):
+        key_a = DeploymentCache.create_cache_key(
+            self._agent(system_prompt="same", temperature=0.3), "wf"
+        )
+        key_b = DeploymentCache.create_cache_key(
+            self._agent(system_prompt="same", temperature=0.3), "wf"
+        )
+        assert key_a == key_b
+
+    def test_key_is_sha256_hex(self):
+        key = DeploymentCache.create_cache_key(self._agent(system_prompt="x"), "wf")
+        assert len(key) == len(hashlib.sha256(b"x").hexdigest())
+        assert all(c in "0123456789abcdef" for c in key)


### PR DESCRIPTION
## Summary
Four provider-handling correctness fixes surfaced during the #1943/#1947 redteams:

1. `CachingMixin._make_cache_key` now includes the resolved provider (a response computed under one provider could replay across a provider change).
2. `CachingMixin` docstring corrected: the real gate is `batch_processing_enabled` (the documented `caching_enabled`/`cache_ttl` were phantom no-ops).
3. `workflow_generator.py` — 4 provider-dispatch sites now use `detect_provider_from_env()` instead of the literal `or "openai"` (an `ANTHROPIC_API_KEY`-only agent no longer wrongly attempts OpenAI).
4. `DeploymentCache.create_cache_key` now keys on the **real effective prompt** (`agent._generate_system_prompt()` — captures signature + discovered MCP tools + custom prompt override) plus `system_prompt`/`temperature`. Redteam caught that the initial `getattr(config, "system_prompt")` was a production no-op (not a `BaseAgentConfig` field) AND that `str(signature)` embedded a memory address → the deployment cache **never hit** for real agents; fixed via deterministic `signature.to_dict()`.

Item 5 (5 pre-existing `test_end_to_end_nexus.py` failures) is a distinct Nexus-lifecycle bug class exceeding this shard — filed separately.

## Testing
New regression `tests/regression/test_issue_1948_provider_minor_followups.py` (behavioral: keys actually differ across the newly-keyed dimensions; identical agents share a key — guards the determinism fix). Redteamed to convergence (reviewer + security-reviewer, 2 rounds; cache keys are SHA256-hashed and never logged).

## Related issues
Fixes #1948