### PR TITLE
fix(kaizen): federated RAG cache-hit log to DEBUG + drop misleading 'query:' label (#1961)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -722,10 +722,13 @@ class EdgeRAGNode(Node):
         local_data = kwargs.get("local_data") or []
         sync_with_cloud = kwargs.get("sync_with_cloud", False)
 
-        # Check cache first
+        # Check cache first. ``cache_key`` is a truncated sha256 digest of the
+        # query, NOT the query text — it carries no user-query content, so it is
+        # safe to log. Emitted at DEBUG because a per-cache-hit line at INFO is
+        # hot-path noise for a RAG node (observability: no log-spam in hot loops).
         cache_key = hashlib.sha256(query.encode()).hexdigest()[:8]
         if cache_key in self.cache and self.power_mode != "performance":
-            logger.info(f"Cache hit for query: {cache_key}")
+            logger.debug(f"Cache hit (key: {cache_key})")
             return self.cache[cache_key]
 
         # Resource tracking


### PR DESCRIPTION
## Summary

Reconciliation of #1961 against ground truth found the raw-query-at-INFO premise **does not hold**: `nodes/rag/federated.py:726` derives the cache key as an 8-char truncated sha256 digest (`hashlib.sha256(query.encode()).hexdigest()[:8]`) — it carries **no user-query content**. Two genuine residuals remain and are fixed here:

1. **Misleading label** — the line read `Cache hit for query: {cache_key}`, implying it logged the raw query. Reworded to `Cache hit (key: {cache_key})`.
2. **Log level** — a per-cache-hit line at INFO is hot-path noise for a RAG node. Moved to DEBUG per observability (no log-spam in hot loops).

Added a code comment documenting the key is a query-derived digest with no plaintext, so the surface is safe (satisfies the issue's "confirm the key carries no user-query content" acceptance option).

## Related issues

Fixes #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)