### PR TITLE
docs(kaizen): README install version 2.43.0 → 2.44.0 (release-prep completion)

### DIFF
--- a/packages/kailash-kaizen/README.md
+++ b/packages/kailash-kaizen/README.md
@@ -71,11 +71,11 @@ class MyAgent(BaseAgent):
 ### Installation
 
 ```bash
-# Install Kaizen framework (latest v2.43.0)
+# Install Kaizen framework (latest v2.44.0)
 pip install kailash-kaizen
 
 # Or specific version
-pip install kailash-kaizen==2.43.0
+pip install kailash-kaizen==2.44.0
 ```
 
 ### Your First Agent (3 Steps)


### PR DESCRIPTION
## Summary

Bumps the kaizen README's hardcoded install version (`pip install kailash-kaizen==2.43.0` → `2.44.0`). The README is the PyPI long-description, so this pin must match the released version per documentation.md — missed in release-prep PR #1968, completing the version-anchor sweep before the `kaizen-v2.44.0` tag is cut.

Metadata/docs-only.

## Related issues

Release-prep for kailash-kaizen 2.44.0 (#1952/#1953/#1948).

🤖 Generated with [Claude Code](https://claude.com/claude-code)