### PR TITLE
fix(nexus): deregister removes MCP resource + start(blocking=False) no spurious ERROR (#1959)

### DIFF
--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -1794,25 +1794,52 @@ Check the documentation or explore available resources.
     def _deregister_workflow_mcp(self, name: str) -> None:
         """Best-effort removal of a workflow's MCP tool + resource.
 
-        The Core SDK ``MCPServer`` keeps tools in ``_tool_registry`` and
-        resources in a resource manager; the exact shape varies by MCP backend
-        (official FastMCP, WebSocket wrapper, mock). Removal is best-effort and
-        never raises: a stale tool/resource is a soft issue, whereas a raised
-        error here would abort an otherwise-valid redeploy.
+        Reverses exactly what :meth:`_register_workflow_as_mcp_tool` and
+        :meth:`_register_workflow_as_mcp_resource` add. On the REAL
+        ``kailash_mcp.MCPServer``, register writes each artifact to TWO stores:
+        the wrapper's own registry dict AND the underlying official-FastMCP
+        manager (``server._mcp``). Both MUST be cleared or the artifact leaks:
+
+        * tool ``name`` → ``server._tool_registry`` (wrapper) AND
+          ``server._mcp._tool_manager._tools`` (FastMCP);
+        * resource ``workflow://{name}`` → ``server._resource_registry``
+          (wrapper) AND ``server._mcp._resource_manager._resources`` (FastMCP).
+
+        Clearing only the wrapper dicts (the pre-#1959 behaviour) left the
+        FastMCP managers populated, so a redeploy (deregister → re-register)
+        emitted ``Tool already exists`` / ``Resource already exists`` warnings
+        and the resource half never dropped at all — the wrapper's resource
+        store is ``_resource_registry``, NOT the ``_resources`` /
+        ``_resource_manager`` attrs the old probes looked for (those exist only
+        on the mock/shim backends). The ``_resources`` / ``_resource_manager``
+        probes below are RETAINED as defensive fallbacks for those backends.
+
+        Removal is best-effort and never raises: a stale tool/resource is a
+        soft issue, whereas a raised error here would abort an otherwise-valid
+        redeploy.
         """
         server = getattr(self, "_mcp_server", None)
         if server is None:
             return
 
         uri = f"workflow://{name}"
-        # Tool registries seen across backends: `_tool_registry` (Core SDK),
-        # `_tools` (FastMCP fallback shim).
+
+        # --- Tool stores ---------------------------------------------------
+        # Wrapper registries seen across backends: `_tool_registry` (Core SDK
+        # wrapper), `_tools` (FastMCP fallback shim / mock server).
         for attr in ("_tool_registry", "_tools"):
             registry = getattr(server, attr, None)
             if isinstance(registry, dict):
                 registry.pop(name, None)
                 registry.pop(f"workflow_{name}", None)
-        # Resource registries: a `_resources` dict, or a resource manager.
+
+        # --- Resource stores -----------------------------------------------
+        # Real Core SDK wrapper store (the store register actually writes to).
+        resource_registry = getattr(server, "_resource_registry", None)
+        if isinstance(resource_registry, dict):
+            resource_registry.pop(uri, None)
+        # Defensive fallbacks for mock/shim backends: a `_resources` dict, or a
+        # `_resource_manager._resources` dict directly on the server.
         resources = getattr(server, "_resources", None)
         if isinstance(resources, dict):
             resources.pop(uri, None)
@@ -1820,6 +1847,22 @@ Check the documentation or explore available resources.
         mgr_resources = getattr(manager, "_resources", None)
         if isinstance(mgr_resources, dict):
             mgr_resources.pop(uri, None)
+
+        # --- Underlying official-FastMCP managers (server._mcp) ------------
+        # register mirrors both artifacts here via the `tool()` / `resource()`
+        # decorators; drop them so a re-register installs a fresh handler
+        # instead of colliding with the stale one (the duplicate-warning path).
+        mcp = getattr(server, "_mcp", None)
+        if mcp is not None:
+            tool_manager = getattr(mcp, "_tool_manager", None)
+            mcp_tools = getattr(tool_manager, "_tools", None)
+            if isinstance(mcp_tools, dict):
+                mcp_tools.pop(name, None)
+                mcp_tools.pop(f"workflow_{name}", None)
+            resource_manager = getattr(mcp, "_resource_manager", None)
+            mcp_resources = getattr(resource_manager, "_resources", None)
+            if isinstance(mcp_resources, dict):
+                mcp_resources.pop(uri, None)
 
     # Multi-channel registration is handled automatically by the enterprise gateway
     # No need for custom channel registry - the gateway provides this natively

--- a/packages/kailash-nexus/src/nexus/transports/http.py
+++ b/packages/kailash-nexus/src/nexus/transports/http.py
@@ -173,17 +173,39 @@ class HTTPTransport(Transport):
             self._register_endpoint_internal(path, methods, func, **kwargs)
         self._endpoint_queue.clear()
 
-        # Register all workflows from registry
+        # Register all workflows from registry.
+        #
+        # The gateway is built once at construction, so Nexus.register() has
+        # ALREADY eagerly registered it with each workflow before start() runs
+        # (the documented ``register(wf); start()`` flow). Re-registering the
+        # same name raises ``ValueError: '<name>' already registered``. Skip
+        # names the gateway already knows rather than catching-and-logging the
+        # collision at ERROR — a false "Failed to register" on the happy path
+        # (a redeploy re-uses this same gateway, so already-present is normal,
+        # not a failure). ``register_workflow`` is still the sole registration
+        # path; the pre-check just avoids driving it into its duplicate guard.
         for wf_name, workflow in registry.list_workflows().items():
+            if wf_name in self._registered_workflow_names():
+                logger.debug(
+                    f"Workflow '{wf_name}' already registered with HTTP gateway; "
+                    f"skipping"
+                )
+                continue
             try:
                 self._gateway.register_workflow(wf_name, workflow)
             except Exception as e:
                 logger.error(f"Failed to register workflow '{wf_name}' with HTTP: {e}")
 
-        # Register handler workflows
+        # Register handler workflows (same idempotency contract as above).
         for handler_def in registry.list_handlers():
             wf = registry._handler_funcs.get(handler_def.name, {}).get("workflow")
             if wf is not None:
+                if handler_def.name in self._registered_workflow_names():
+                    logger.debug(
+                        f"Handler '{handler_def.name}' already registered with HTTP "
+                        f"gateway; skipping"
+                    )
+                    continue
                 try:
                     self._gateway.register_workflow(handler_def.name, wf)
                 except Exception as e:
@@ -193,6 +215,22 @@ class HTTPTransport(Transport):
 
         self._running = True
         logger.info(f"HTTPTransport started on port {self._port}")
+
+    def _registered_workflow_names(self) -> frozenset:
+        """Names the enterprise gateway already has a workflow registered under.
+
+        The gateway (``EnterpriseWorkflowServer``) tracks registrations in a
+        name-keyed ``workflows`` dict. Reading it is the pre-check that lets
+        :meth:`start` skip re-registering a workflow ``Nexus.register()``
+        already installed, rather than driving ``register_workflow`` into its
+        duplicate-name ``ValueError`` guard. Defensive: an unexpected gateway
+        without a mapping ``workflows`` attribute yields an empty set (the loop
+        then falls back to the try/except register path unchanged).
+        """
+        workflows = getattr(self._gateway, "workflows", None)
+        if isinstance(workflows, dict):
+            return frozenset(workflows.keys())
+        return frozenset()
 
     def _install_exception_handlers(self) -> None:
         """Install the NexusError -> HTTP exception handler on the gateway app.

--- a/packages/kailash-nexus/tests/regression/test_issue_1959_deregister_mcp_resource.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1959_deregister_mcp_resource.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1959 BUG-1 — ``Nexus.deregister`` removes the workflow's MCP
+resource from the REAL MCP server.
+
+``_deregister_workflow_mcp`` probed ``server._resources`` and
+``server._resource_manager._resources`` for the resource half — but the REAL
+``kailash_mcp.MCPServer`` stores workflow resources in ``_resource_registry``
+(and mirrors them into the underlying official FastMCP
+``server._mcp._resource_manager._resources``). Neither probed attr exists on the
+real server, so ``workflow://<name>`` was never dropped. A redeploy
+(register -> deregister -> re-register) then left the stale resource in place
+and re-register emitted ``Resource already exists: workflow://<name>`` —
+contradicting ``deregister``'s "removed from all channels" docstring and
+#1959's redeploy-idempotency goal. (The tool half's underlying FastMCP store
+leaked the same way, warning ``Tool already exists`` on re-register.)
+
+Walks the REAL documented flow (a real ``Nexus`` instance + the real MCP
+server) per rules/testing.md Tier 2 (no mocking). The 16 e2e tests missed this
+because their fixture starts an EMPTY registry then registers AFTER start,
+never exercising the redeploy path.
+"""
+
+import logging
+
+import pytest
+
+from nexus import Nexus
+
+
+def _workflow():
+    """Build a trivial real workflow (no mocking)."""
+    from kailash.workflow.builder import WorkflowBuilder
+
+    wf = WorkflowBuilder()
+    wf.add_node("PythonCodeNode", "n", {"code": "result = {'ok': True}"})
+    return wf.build()
+
+
+@pytest.mark.regression
+def test_deregister_removes_mcp_resource_from_real_server():
+    """deregister drops ``workflow://<name>`` from the REAL MCP server's
+    ``_resource_registry`` (and the underlying FastMCP store), so a re-register
+    installs a fresh handler instead of colliding."""
+    app = Nexus(auto_discovery=False)
+    server = app._mcp_server
+    # The real kailash_mcp MCPServer keeps resources in _resource_registry.
+    # Pin the store this regression is about, so a future backend swap surfaces
+    # here rather than silently passing.
+    assert isinstance(getattr(server, "_resource_registry", None), dict), (
+        "expected the real kailash_mcp.MCPServer with a _resource_registry; "
+        f"got {type(server).__name__}"
+    )
+
+    app.register("demo", _workflow())
+    uri = "workflow://demo"
+    assert uri in server._resource_registry, "register must add the MCP resource"
+
+    app.deregister("demo")
+
+    # The core assertion: the resource is GONE from the store register wrote to.
+    assert uri not in server._resource_registry, (
+        "deregister must remove the MCP resource from _resource_registry "
+        "(BUG-1: it leaked because the old probes looked at non-existent "
+        "_resources / _resource_manager attrs)"
+    )
+    # And symmetrically from the underlying official-FastMCP resource manager,
+    # so re-register does not collide.
+    mcp = getattr(server, "_mcp", None)
+    rm = getattr(mcp, "_resource_manager", None)
+    if isinstance(getattr(rm, "_resources", None), dict):
+        assert uri not in rm._resources, (
+            "deregister must also remove the resource from the underlying "
+            "FastMCP resource manager"
+        )
+
+
+@pytest.mark.regression
+def test_redeploy_reregister_emits_no_already_exists_warning(caplog):
+    """After deregister, a re-register must NOT warn ``Resource already exists``
+    / ``Tool already exists`` — the stale MCP artifacts were fully removed."""
+    app = Nexus(auto_discovery=False)
+    app.register("demo", _workflow())
+    app.deregister("demo")
+
+    with caplog.at_level(logging.WARNING):
+        app.register("demo", _workflow())
+
+    offending = [
+        r.getMessage()
+        for r in caplog.records
+        if "already exists" in r.getMessage().lower()
+    ]
+    assert not offending, (
+        "re-register after deregister must not warn about stale MCP artifacts; "
+        f"got: {offending}"
+    )

--- a/packages/kailash-nexus/tests/regression/test_issue_1959_start_nonblocking_no_error.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1959_start_nonblocking_no_error.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: #1959 BUG-2 — ``register(wf); start(blocking=False)`` emits no
+spurious "Failed to register" ERROR.
+
+The enterprise gateway is built once at construction, so the documented
+``register(wf); start()`` flow (patterns.md) eagerly registers the workflow
+with the gateway. ``HTTPTransport.start`` then re-registered EVERY registry
+workflow, driving ``gateway.register_workflow`` into its duplicate-name
+``ValueError`` — caught and logged at ERROR as
+``Failed to register workflow '<name>' with HTTP: ... already registered``.
+Functionally benign (already registered) but a false "Failed to register"
+ERROR on the happy path (observability Rule 5 / zero-tolerance Rule 1).
+
+The 16 e2e tests missed this because their fixture starts an EMPTY registry
+then registers AFTER start; the documented register-FIRST flow was never
+walked for ``blocking=False``. This test walks it (a real ``Nexus`` + the real
+gateway) per rules/testing.md Tier 2 (no mocking).
+"""
+
+import logging
+
+import pytest
+
+from nexus import Nexus
+
+
+def _workflow():
+    """Build a trivial real workflow (no mocking)."""
+    from kailash.workflow.builder import WorkflowBuilder
+
+    wf = WorkflowBuilder()
+    wf.add_node("PythonCodeNode", "n", {"code": "result = {'ok': True}"})
+    return wf.build()
+
+
+@pytest.mark.regression
+def test_register_first_then_start_nonblocking_no_failed_to_register_error(caplog):
+    """The documented ``register(wf); start(blocking=False)`` flow emits NO
+    ERROR-level "Failed to register", and the workflow is registered with the
+    gateway exactly once."""
+    app = Nexus(auto_discovery=False)
+    app.register("demo", _workflow())  # eager register with the gateway
+
+    with caplog.at_level(logging.ERROR):
+        app.start(blocking=False)
+    try:
+        failed = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Failed to register" in r.getMessage()
+        ]
+        assert not failed, (
+            "register-first + start(blocking=False) must not log a spurious "
+            f"'Failed to register' ERROR on the happy path; got: {failed}"
+        )
+
+        # Registered exactly once (no duplicate, no silent drop).
+        gateway = app._http_transport.gateway
+        names = list(gateway.workflows.keys())
+        assert names.count("demo") == 1, (
+            f"workflow 'demo' must be registered with the gateway exactly once; "
+            f"got {names}"
+        )
+    finally:
+        app.stop()


### PR DESCRIPTION
## Summary

Two same-class (Nexus MCP/lifecycle) bugs a holistic redteam surfaced in the merged #1959 lifecycle work. Both walk the REAL documented user flow (a real `Nexus` + the real MCP server + the real gateway) per Tier 2 (no mocking); the 16 e2e tests missed both because their fixture starts an EMPTY registry then registers AFTER start — the documented register-FIRST flow was never walked.

### BUG-1 (MEDIUM) — `deregister` did not remove the workflow's MCP resource
`_deregister_workflow_mcp` probed `server._resources` / `server._resource_manager._resources`, but the real `kailash_mcp.MCPServer` stores workflow resources in `_resource_registry` (mirrored into the underlying FastMCP `_mcp._resource_manager._resources`). Neither probed attr exists on the real server, so `workflow://<name>` never dropped: a redeploy re-register warned `Resource already exists` and the "removed from all channels" docstring was false. The tool half leaked the same way at the FastMCP layer (`Tool already exists`).

**Fix:** make removal exactly symmetric with the register side (which writes each artifact to two stores) — pop `workflow://<name>` from `_resource_registry` AND `_mcp._resource_manager._resources`, and the tool from `_mcp._tool_manager._tools`; keep the `_resources` / `_resource_manager` probes as defensive fallbacks for the mock/shim backends. Redeploy is now idempotent with no duplicate warnings.

### BUG-2 (LOW-MED) — `start(blocking=False)` logged a spurious `Failed to register` ERROR
The gateway is built once at construction, so the documented `register(wf); start()` flow eagerly registers the workflow; `HTTPTransport.start` then re-registered every registry workflow, driving `gateway.register_workflow` into its duplicate-name `ValueError` — caught and logged at ERROR. Benign but a false failure on the happy path (observability log-triage).

**Fix:** pre-check the gateway's name-keyed `workflows` dict and skip names it already knows (DEBUG, not ERROR), applied symmetrically to the handler-workflow loop. `cli` registers at command time (no start collision), `mcp` builds a fresh server per start, and `websocket` already guards its handler map — HTTP was the only affected transport.

## Tests
Three behavioral regression tests (`tests/regression/test_issue_1959_*`) that walk the real flows. Each **fails on current main** and **passes with the fix** (verified by reverting the src fixes with the tests in place):

```
# fail-first (src reverted, tests present):
3 failed  test_issue_1959_deregister_mcp_resource.py (x2) + test_issue_1959_start_nonblocking_no_error.py

# with fix:
3 passed in 0.53s
```

Full change-relevant scope (unit + integration + regression + kaizen e2e), parallel:
```
2322 passed, 15 skipped, 9 errors, 3-4 failed
```
The 3 failures (special-char workflow name → invalid `workflow://` URI at register; installed `mcp`/`pydantic` strictness), the 1 flaky failure (`test_issue_1285`, xdist-ordering-dependent), and the 9 errors (`kailash_ml` optional `[ml]` extra not installed) all reproduce identically on base `80141836a` — **pre-existing, different bug class, none introduced by this PR.** Full nexus `tests/` (incl. `e2e/`) binds sockets and was not run in the sandbox; the run above is the change-relevant scope.

pre-commit (Black, isort, Ruff, type-annotations, Tier-1 unit) green on all changed files.

## Related issues
#1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)