### PR TITLE
chore(release): 2.45.0 wave — core 2.62.0 + nexus 2.15.0 + kaizen 2.45.0 (#1959/#1960/#1961)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.62.0] — 2026-07-25 — WorkflowServer workflow deregistration (#1959)
+
+### Added
+
+- **`WorkflowServer.deregister_workflow(name)`** — removes a previously-registered
+  workflow: unmounts its `/workflows/{name}` sub-application and releases the
+  per-workflow `WorkflowAPI` runtime (#1285). Idempotent (returns `False` when the
+  workflow is absent); route-match is symmetric with `register_workflow` (the exact
+  `/workflows/{name}` prefix, no sibling-mount collateral). Enables Nexus redeploy
+  idempotency (kailash-nexus 2.15.0, #1959).
+
 ## [2.61.0] — 2026-07-22 — Trust-plane capability subject-binding + chain-state signing (#1912)
 
 ### Security (Trust Plane — #1912 capability subject-binding + chain-state signing)

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.45.0] — 2026-07-25 — Follow-up hardening: sanitizer redaction, Nexus lifecycle, RAG log hygiene
+
+### Fixed
+
+- **Error-sanitizer credential-redaction gaps (#1960).** `sanitize_provider_error`
+  now redacts AWS access-key IDs (`AKIA…`), 40-char AWS/base64 secrets, uppercase and
+  mixed-case hex ≥32 chars (the prior rule matched lowercase hex only), and Azure
+  OpenAI endpoints (`https://<resource>.openai.azure.com` → `https://[REDACTED]…`).
+- **Nexus deployment lifecycle (#1959).** Multi-channel redeploy is now idempotent:
+  each `deploy_as_api` / `deploy_as_cli` / `deploy_as_mcp` deregisters any prior
+  registration before re-registering (via the new `Nexus.deregister`). Session
+  activity is tracked with plain `datetime`, and session creation rejects an empty
+  `user_id`. The redeploy path requires `kailash-nexus>=2.15.0`.
+- **Federated RAG cache-hit log hygiene (#1961).** The edge-RAG cache-hit line moved
+  from INFO to DEBUG and no longer implies it logs the query — the logged value is a
+  truncated sha256 digest of the query, not the query text.
+
 ## [2.44.0] — 2026-07-25 — Provider-integrity forest: keyless fail-loud completed, synthesis error-masking closed, provider follow-ups
 
 ### Changed (behavior — potentially breaking)

--- a/packages/kailash-kaizen/README.md
+++ b/packages/kailash-kaizen/README.md
@@ -71,11 +71,11 @@ class MyAgent(BaseAgent):
 ### Installation
 
 ```bash
-# Install Kaizen framework (latest v2.44.0)
+# Install Kaizen framework (latest v2.45.0)
 pip install kailash-kaizen
 
 # Or specific version
-pip install kailash-kaizen==2.44.0
+pip install kailash-kaizen==2.45.0
 ```
 
 ### Your First Agent (3 Steps)

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.44.0"
+version = "2.45.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.44.0"
+__version__ = "2.45.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Nexus Changelog
 
+## [2.15.0] — 2026-07-25 — Deployment lifecycle: deregister + non-blocking start (#1959)
+
+### Added
+
+- **`Nexus.deregister(name)`** — removes a workflow from every channel: the HTTP
+  gateway route, and the MCP server's tool + `workflow://{name}` resource across all
+  four backing stores (`_tool_registry`, `_resource_registry`, and the underlying
+  FastMCP `_tool_manager` / `_resource_manager`). Idempotent; best-effort MCP removal
+  is logged, not silently swallowed. Makes redeploy (register → deregister →
+  re-register) collision-free.
+- **`Nexus.start(blocking=False)`** — non-blocking readiness: registers workflows with
+  the gateway, marks the app running, and reports healthy WITHOUT binding a socket or
+  entering the serving loop (for in-process / test / embedding use). The blocking
+  fallback re-raises worker-thread errors rather than swallowing them.
+
+### Fixed (#1959)
+
+- Redeploy is now idempotent across the MCP surface. Deregistration previously probed
+  non-existent server attributes and left the `workflow://` resource + FastMCP tool
+  registered, so a re-register collided with an "already exists" warning.
+  Deregistration is now symmetric with registration across all four backing stores.
+- `start(blocking=False)` no longer emits a spurious `ERROR: Failed to register
+workflow '...' already registered` when a workflow was registered before start (the
+  documented `register(); start()` flow) — HTTP transport registration is now
+  idempotent (already-registered workflows are skipped at DEBUG).
+
+### Requires
+
+- `kailash>=2.62.0` (uses the new `WorkflowServer.deregister_workflow`).
+
 ## [2.14.0] — 2026-07-20 — PKCE + id_token nonce across the SSO provider suite (#1834)
 
 ### Added (Security)

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.14.0"
+version = "2.15.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -36,7 +36,7 @@ dependencies = [
     # Tag-push CI installs `kailash` from PyPI before the new release is
     # published, so `kailash[server]` would silently drop the extra.
     # Direct declaration is dialect-stable across the release boundary.
-    "kailash>=2.50.0",
+    "kailash>=2.62.0",  # WorkflowServer.deregister_workflow (nexus 2.15.0 redeploy, #1959)
     # Server middleware stack (matches kailash[server] contents).
     "fastapi>=0.104.0",
     "starlette>=0.36.0",

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -117,7 +117,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.61.0"
+version = "2.62.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.61.0"
+__version__ = "2.62.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Coordinated multi-package release-prep for the **Wave-F follow-up-hardening forest**. Metadata-only (version anchors + CHANGELOGs + the nexus→core pin + kaizen README pin).

| Package | Bump | Ships |
|---|---|---|
| **kailash** (core) | 2.61.0 → **2.62.0** | `WorkflowServer.deregister_workflow` (#1959) |
| **kailash-nexus** | 2.14.0 → **2.15.0** | `Nexus.deregister` (4-store MCP symmetry) + `start(blocking=False)` + redeploy-idempotency fixes (#1959); pins `kailash>=2.62.0` |
| **kailash-kaizen** | 2.44.0 → **2.45.0** | error-sanitizer redaction gaps (#1960), Nexus redeploy lifecycle (#1959), federated-RAG log hygiene (#1961) |

## Release order (deps before dependents)
`v2.62.0` (core) → `nexus-v2.15.0` (install-depends on core 2.62.0) → `kaizen-v2.45.0`

## Verification
- Wave-F holistic redteam **converged**: security + closure clean; correctness found 2 nexus lifecycle BUGs → fixed in PR #1975 → Round-2 verify clean (4-store register/deregister symmetry confirmed).
- Every CHANGELOG code-claim verified against ground truth; version anchors atomic per package.

## Related issues
Closes #1959, closes #1960, closes #1961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)