### PR TITLE
chore(authz): cross-repo write receipt for esperie-enterprise/kailash-rs (2 cross-SDK issues)

### DIFF
--- a/.claude/cross-repo-authz/2026-07-25-esperie-enterprise-kailash-rs-file-2-cross-sdk-i.md
+++ b/.claude/cross-repo-authz/2026-07-25-esperie-enterprise-kailash-rs-file-2-cross-sdk-i.md
@@ -1,0 +1,41 @@
+---
+type: cross-repo-authorization-receipt
+date: 2026-07-25
+timestamp: 2026-07-25T08:27:47.584Z
+requester: jack-hong
+target: esperie-enterprise/kailash-rs
+action: file 2 cross-sdk issues: (1) error-sanitizer credential-redaction gaps (Rust equivalent of py #1960); (2) Nexus deployment lifecycle deregister + non-blocking start (Rust equivalent of py #1959) — SDK-API-surface only per upstream-issue-hygiene
+mode: write
+---
+
+# Cross-Repo Authorization Receipt
+
+cross-repo-authorized: esperie-enterprise/kailash-rs write
+
+## Bounded action
+
+- **Target repo:** esperie-enterprise/kailash-rs
+- **Action (write):** file 2 cross-sdk issues: (1) error-sanitizer credential-redaction gaps (Rust equivalent of py #1960); (2) Nexus deployment lifecycle deregister + non-blocking start (Rust equivalent of py #1959) — SDK-API-surface only per upstream-issue-hygiene
+- **Requester (display_id):** jack-hong
+- **Authorized at:** 2026-07-25T08:27:47.584Z
+
+## Verbatim user instruction
+
+> User authorized via AskUserQuestion 'Cross-SDK' selecting 'File both' — file the 2 cross-SDK issues (Rust equivalents of #1960 sanitizer gaps + #1959 Nexus lifecycle) against the Rust SDK, SDK-API-surface only.
+
+## Five-condition attestation (repo-scope-discipline.md § User-Authorized Exception)
+
+- condition_1_user_initiated: REQUIRED — a genuine user turn (see verbatim below)
+- condition_2_explicit_specific: REQUIRED — names the target repo AND the exact bounded action
+- condition_3_confirmed: REQUIRED — the ceremony restated action+target and the user confirmed yes/no BEFORE this write
+- condition_4_receipt_before_acting: SATISFIED — THIS receipt is the durable witness, written BEFORE the command runs
+- condition_5_scoped_exactly: REQUIRED — only the named action against only the named repo
+
+<!--
+  This receipt is the ONLY distinguisher between an authorized and an
+  unauthorized cross-repo action. It is written by
+  .claude/bin/cross-repo-authorize.mjs AFTER the user confirmed the restated
+  action+target in chat, and BEFORE the action runs. The hook
+  (violation-patterns.js::hasCrossRepoAuthorizationReceipt) greps this file's
+  marker line within its mtime window; commit it for durable team audit.
+-->


### PR DESCRIPTION
Durable audit record for the user-authorized cross-SDK filings rs#2131 (↔ #1960 sanitizer gaps) + rs#2132 (↔ #1959 Nexus lifecycle). Receipt only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)