### PR TITLE
fix(coc): repair SessionStart hook registration + drop unmatched Write() perms

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,13 +15,6 @@
       "Edit(.claude/learning/violations.jsonl.*)",
       "Edit(.claude/learning/.initialized)",
       "Edit(.claude/learning/.posture-upgrade-nonce)",
-      "Write(.claude/learning/posture.json)",
-      "Write(.claude/learning/posture.json.bak)",
-      "Write(.claude/learning/posture.json.tmp.*)",
-      "Write(.claude/learning/violations.jsonl)",
-      "Write(.claude/learning/violations.jsonl.*)",
-      "Write(.claude/learning/.initialized)",
-      "Write(.claude/learning/.posture-upgrade-nonce)",
       "Bash(rm:.claude/learning/posture*)",
       "Bash(rm:.claude/learning/violations*)",
       "Bash(rm:.claude/learning/.posture-upgrade-nonce)",
@@ -144,7 +137,7 @@
           },
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/coc-drift-warn.js\"",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/multi-operator-sessionstart.js\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary

Two independent `.claude/settings.json` defects, both surfacing as Claude Code startup errors this session.

**1. Dead SessionStart hook registration** — `settings.json` registered `.claude/hooks/coc-drift-warn.js`, which does not exist. It was deleted by loom Gate-2 sync `717c0f6e3` after being **subsumed** into `multi-operator-sessionstart.js` (F13 closure). `settings.json` is BUILD-owned and PRESERVED verbatim across every loom sync, so the registration never followed the deletion.

Evidence:
- `.claude/hooks/multi-operator-sessionstart.js:9` — `* Subsumes 'coc-drift-warn.js' (F13 closure). Drift attribution distinguishes`
- `.claude/guides/rule-extracts/coc-sync-landing.md:103` — `(this drift-warner was previously the standalone 'coc-drift-warn.js', now subsumed per F13 closure)`

Impact: `node` exited `MODULE_NOT_FOUND` on every session start, **and** the working-tree COC-drift warning that `rules/coc-sync-landing.md` MUST-1 structurally depends on had silently not fired since that sync.

**2. Unmatched permission rules** — Claude Code >= 2.1.210 matches file permission rules on `Edit(path)`/`Read(path)` only. `Write(path)`, `NotebookEdit(path)` and `Glob(path)` are parsed but never matched, and each emits a startup warning. The 7 `Write(.claude/learning/...)` deny entries were dead config duplicating the `Edit(...)` entries that already cover every file-editing tool.

## Why this is safe

- `multi-operator-sessionstart.js` is **fail-open** (header: `Failure: fail-open (any error → continue:true with minimal context)`) and passthrough-when-coordination-OFF. It is **not** one of the 6 coordination-ENFORCEMENT hooks (`integrity-guard`, `signing-mutation-guard`, `journal-write-guard`, `genesis-anchor-guard`, `adjacency-leasecheck`, `operator-gate`) that must never ship registered in this public repo — so no fork-bricking risk.
- No enforcement is lost by dropping the `Write(...)` rules: `rules/trust-posture.md`'s MUST NOT on direct `posture.json` / `violations.jsonl` mutation stays enforced by the surviving `Edit(...)` rules plus the `Bash(rm:/mv:)` rules. Per the CC permissions docs, an `Edit(path)` rule covers all file-editing tools including creation.

## Verification

```
settings.json: valid JSON
all 17 registered hooks resolve on disk    (was: 1 MISSING)
0 Write()/NotebookEdit()/Glob() path rules remain
pre-commit --files .claude/settings.json   → all green (incl. Run Tier 1 unit tests: Passed)
SessionStart chain walked: session-start.js ✓ / posture-gate.js ✓ / multi-operator-sessionstart.js ✓ (exit 0, valid JSON envelope)
```

## Related issues

None — surfaced directly from session-start hook errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)