### PR TITLE
ci(coc): gate hook registration on every PR touching .claude/hooks or settings

### DIFF
--- a/.github/workflows/coc-hook-registration.yml
+++ b/.github/workflows/coc-hook-registration.yml
@@ -1,0 +1,96 @@
+name: COC Hook Registration
+
+# Guards ONE structural invariant: every top-level hook in .claude/hooks/ is
+# either registered in .claude/settings.json OR carries an
+# `@settings-registration:` header marker documenting how it is actually
+# invoked. A hook that is neither is shipped INERT — it fails open and nothing
+# says so (#771).
+#
+# Why this needs a CI gate rather than reviewer discipline: .claude/settings.json
+# is BUILD-owned and PRESERVED verbatim across every loom Gate-2 sync. loom can
+# SHIP a hook but can never WIRE it, and when loom DELETES one the registration
+# stays behind. That asymmetry is permanent, so the drift rebuilds on its own
+# unless something asserts the invariant on every PR. It had accumulated to 18
+# blocking findings before PR #1979 — including a block-severity, rule-mandated
+# guard (analyze-completeness-guard.js) that passed 9/9 of its own fixtures and
+# had never once fired.
+#
+# SCOPE: deliberately ONE check, not the full validator. `validate-emit.mjs`
+# with no --check currently reports 6 other blocking failures (provenance-parity,
+# provenance-subagent-hooks, hook-delivery, coc-artifact-ids,
+# codex-policies-fresh, gitignore-learning-parity), all loom / multi-CLI-emission
+# concerns rather than hook-registration ones. Gating on the full run would red
+# every PR on day one, and the predictable response to that is a blanket
+# --allow= suppression, which restores exactly the silence this gate exists to
+# remove. Those 6 are tracked for triage on their own terms; widening this gate
+# is a deliberate decision, not a default.
+#
+# COST: the validator imports only node: builtins plus sibling .mjs files, so no
+# npm install is needed and the check itself runs in ~0.1s. The job is
+# effectively checkout + setup-node.
+
+on:
+  pull_request:
+    paths:
+      - ".claude/hooks/**"
+      - ".claude/settings.json"
+      - ".claude/bin/validate-emit.mjs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  hook-registration:
+    name: Hooks registered or marked
+    # Release-prep PRs are metadata-only by convention (rules/git.md
+    # § "Release-Prep PRs MUST Use release/v* Branch Convention"); they cannot
+    # change hook registration, so skip rather than burn a runner.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Assert every hook is registered or explicitly marked
+        run: node .claude/bin/validate-emit.mjs --check settings-hook-registration
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          {
+            echo "## Hook registration check failed"
+            echo ""
+            echo "A hook under \`.claude/hooks/\` is neither registered in"
+            echo "\`.claude/settings.json\` nor documented with an"
+            echo "\`@settings-registration:\` header marker. Either way it ships **inert** —"
+            echo "it fails open and nothing reports that it never runs."
+            echo ""
+            echo "Two valid fixes, and the choice is not cosmetic:"
+            echo ""
+            echo "1. **Register it** in \`.claude/settings.json\` under the event/matcher its"
+            echo "   own header documents — if the hook is genuinely meant to run here."
+            echo ""
+            echo "2. **Mark it** with \`@settings-registration: <how-it-is-invoked>\` — if it is"
+            echo "   intentionally not wired in this repo (a git hook, a consumer-registered"
+            echo "   gate, a CLI utility, or a coordination-substrate hook that belongs in a"
+            echo "   per-clone \`settings.local.json\` after \`/enroll\`)."
+            echo ""
+            echo "Do **not** silence this with \`--allow=\`. A marker that misdescribes how a"
+            echo "hook is invoked permanently hides a real finding, which is worse than the"
+            echo "failure it suppresses."
+            echo ""
+            echo "Reproduce locally:"
+            echo ""
+            echo '```'
+            echo "node .claude/bin/validate-emit.mjs --check settings-hook-registration"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -74,26 +74,43 @@ a2a.py 11 errors → 8, the 3 lost being exactly the `coroutine * float` sites.
 | F3 | #1972 nexus 3 failures | PARTIALLY SUPERSEDED — 2 of 3 are STALE TESTS asserting behavior production DELIBERATELY BLOCKS (`nexus/core.py:1512-1515`). **Fixing the product to green them RE-INTRODUCES the defect.** Port the tests | queued |
 | F6 | #1981 structured-output root cause | Found by walking a LIVE provider: `CapabilityMatchAgent`/`TextSimilarityAgent` do not enforce structured output → on a non-structured-output provider EVERY real score is 0.0 and A2A ranking is arbitrary. #1980 made it LOUD (`.degraded` WARN, uncached) but did NOT fix it. HIGH, own shard | **FILED #1981**, queued |
 
-## Awaiting user decision (carried)
+## Decisions — ALL THREE RESOLVED (user "approved", 2026-07-25)
 
-- (a) wire `settings-hook-registration` validator into CI (stops the class rebuilding; `/sync` reds until dispositioned)
-- (b) **venv rebuild** — RECOMMENDED, now a blocker not housekeeping (see Traps)
-- (c) kailash-ml release owed? Rule 1a says a CHANGELOG touch ⇒ release; the touch was a 1-line
-  scrub of a HISTORICAL entry changing no wheel byte. Orchestrator read: no release owed.
+- **(a) DONE** — `.github/workflows/coc-hook-registration.yml` gates
+  `validate-emit --check settings-hook-registration` on every PR touching `.claude/hooks/**`,
+  `.claude/settings.json`, or the validator. Proven to bite: an unregistered/unmarked hook →
+  exit 1 naming it; clean tree → exit 0. ~0.1s, no `npm install` (node: builtins only).
+  **Deliberately scoped to ONE check.** A full `validate-emit` run has 6 OTHER blocking failures
+  (provenance-parity, provenance-subagent-hooks, hook-delivery, coc-artifact-ids,
+  codex-policies-fresh, gitignore-learning-parity) — all loom/multi-CLI-emission concerns, not
+  hook-registration. Gating on the full run would red every PR day one, and the predictable
+  response is a blanket `--allow=` that restores the exact silence the gate removes.
+  **Those 6 are open for triage on their own terms — do NOT widen the gate by suppressing them.**
+- **(b) DONE** — venv rebuilt; see Traps for the outcome AND the correct recipe.
+- **(c) RESOLVED — no kailash-ml release owed.** The `CHANGELOG.md` touch that made
+  `build-repo-release-discipline.md` Rule 1a read "release required" was a 1-line scrub of a
+  HISTORICAL entry; it changes no wheel byte, and CHANGELOG.md is not in the wheel
+  (`[tool.hatch.build.targets.wheel] packages = ["src/kailash_ml"]`). Release-drift counts for
+  kailash / kailash-align / kailash-ml are accurate but all chore/test-only.
 
 ## Traps
 
-- **`kailash-ml` and `kailash-align` DO NOT IMPORT.** `_editable_impl_*.pth` still point at the
-  pre-move `/Users/esperie/repos/loom/kailash-py/packages/...`. `packages/kailash-ml/tests` →
-  `99 tests collected, 180 errors`. **An errored collection reads like "no failures"** — do not
-  mistake it for green. Fix: `uv venv --clear && uv sync`. Session-start now warns about this.
-- CORRECTED from an earlier claim: the OTHER 6 packages DO import from live SOURCE at current
-  versions (kaizen 2.45.0, pact 0.18.0, mcp 0.4.3, nexus 2.15.0, dataflow 2.19.1, kailash 2.62.0).
-  Only the `.pth`-filename dist METADATA lags. Tests DO exercise current source.
+- **RESOLVED 2026-07-25 — venv rebuilt (user-approved).** `kailash-ml` / `kailash-align` no longer
+  import-fail; `.venv/bin/pre-commit` works natively again; 0 stale shebangs (was 119); 0 dangling
+  editable pointers (was 2). All 9 packages import at current versions. **`packages/kailash-ml/tests`
+  now collects 2594 tests (was 99 + 180 ERRORS); kailash-align collects 485.** ~3079 tests were
+  previously unrunnable.
+  - **REBUILD RECIPE — get this right or you will make it worse.** `uv venv --clear` alone picks the
+    NEWEST python (3.14.3) and `uv sync` alone installs only the 13-package SLIM CORE, dropping every
+    sub-package and all dev tooling. The correct invocation is:
+    `uv venv --python 3.13 --clear && uv sync --all-extras --dev`
+    (`--all-extras` is what pulls the 8 editable sub-packages via the `all` extra; there is NO
+    `.python-version` pin and `requires-python = ">=3.11"`, so the 3.13 pin must be explicit.)
 - Tests: ALWAYS `.venv/bin/python -m pytest`. Bare python/pyenv dies at conftest with
   `ImportError: Node`. **An errored run is zero evidence, not a failure.**
-- `.venv/bin/pre-commit` is DEAD (`bad interpreter`, stale shebang — 114-119 of 135 scripts
-  affected by the repo move). Use `.venv/bin/python -m pre_commit`.
+- STILL OPEN (real, hook-reported): 7 stale pins in root `pyproject.toml` — e.g. kailash-kaizen
+  pinned `>=2.7.5` vs ACTUAL 2.45.0, kailash-ml `>=1.1.0` vs 2.2.2. Not fixed (changes the
+  dependency contract; wants a deliberate pass).
 - Clear `__pycache__` before running kaizen tests — stale bytecode renders tracebacks against the
   non-existent pre-move path and you will read `???` for source.
 - Duplicate/cancelled CI runs read as red: a `conclusion: cancelled` job with all substantive


### PR DESCRIPTION
## Why

PR #1979 cleaned up 18 blocking hook-registration findings. That cleanup was **one-time**. This is what stops the class rebuilding.

The asymmetry behind it is permanent: `.claude/settings.json` is **BUILD-owned and preserved verbatim** across every loom Gate-2 sync. loom can *ship* a hook but can never *wire* it — and when loom *deletes* one, the registration stays behind. Neither side of the sync can fix that, so without an asserted invariant the drift re-accumulates on its own.

It had reached 18 before #1979 — including `analyze-completeness-guard.js`: **block**-severity, rule-mandated, passing **9/9** of its own fixtures, and never once fired.

## Deliberately scoped to ONE check

A full `validate-emit` run currently reports **6 other blocking failures**:

```
provenance-parity · provenance-subagent-hooks · hook-delivery
coc-artifact-ids · codex-policies-fresh · gitignore-learning-parity
```

All are loom / multi-CLI-emission concerns, not hook-registration. Gating on the full run would red **every PR from day one**, and the predictable response to a permanently-red gate is a blanket `--allow=` suppression — which restores exactly the silence this gate exists to remove.

Those 6 stay open for triage on their own terms. Widening the gate should be a deliberate decision, not a side effect of this PR.

## Proven to bite, not decorate

```
add unregistered + unmarked hook  → exit 1, names the offending hook
remove it                          → exit 0
```

The `failure()` step explains both valid remediations — **register** it, or **mark** it with `@settings-registration:` — and says explicitly not to reach for `--allow=`, because a marker that misdescribes how a hook is invoked hides a real finding permanently. That's a worse outcome than the failure it suppresses.

## Cost

Near-zero. The validator imports only `node:` builtins plus sibling `.mjs` files — **no `npm install`** — and the check runs in **~0.1s**. The job is effectively checkout + setup-node.

Path-filtered to `.claude/hooks/**`, `.claude/settings.json`, and the validator itself; skipped on `release/*` branches per `rules/git.md`.

## Session notes in the same commit

The venv rebuild landed (approved), so the traps recording `kailash-ml`/`kailash-align` as unimportable and `pre-commit` as dead are now **stale and would misdirect the next session**. Replaced with the outcome and the exact recipe — because `uv venv --clear` alone selects the newest Python (3.14 here) and `uv sync` alone installs only the 13-package slim core, which is how a rebuild makes the environment *worse*. I hit both.

Result of the rebuild:

```
kailash-ml / kailash-align   import-fail → OK
stale shebangs               119 → 0
dangling editable pointers   2 → 0
kailash-ml tests             99 collected + 180 ERRORS → 2594 collected
kailash-align tests          → 485 collected
```

~3079 tests that could not run before now collect.

## Related issues

Follows #1979. Implements decision (a); decisions (b) and (c) resolved in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)