### PR TITLE
fix(deps): bump 8 stale inter-package pins to their released versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,12 +140,12 @@ data = [
 # Pins are MINIMUM compatible versions — bumping to unreleased versions
 # breaks release CI which installs from PyPI before the new release publishes.
 # ─────────────────────────────────────────────────────────────────
-dataflow = ["kailash-dataflow>=2.0.12"]
-nexus    = ["kailash-nexus>=2.1.1"]
-kaizen   = ["kailash-kaizen>=2.7.5", "kaizen-agents>=0.9.3"]
-pact     = ["kailash-pact>=0.8.2"]
-ml       = ["kailash-ml>=1.1.0"]
-align    = ["kailash-align>=0.3.2"]
+dataflow = ["kailash-dataflow>=2.19.1"]
+nexus    = ["kailash-nexus>=2.15.0"]
+kaizen   = ["kailash-kaizen>=2.45.0", "kaizen-agents>=0.12.0"]
+pact     = ["kailash-pact>=0.18.0"]
+ml       = ["kailash-ml>=2.2.2"]
+align    = ["kailash-align>=0.7.4"]
 
 # Trust Vault SLIP-0039 Shamir secret-sharing wrapper — see issue #606.
 # Module import succeeds without this extra; call-site raises RuntimeError
@@ -190,8 +190,8 @@ dev = [
     # [dev] here rather than the slim core. Per #890 audit.
     "networkx>=2.7",
     # Sub-packages required for test collection (pact/mcp tests import these)
-    "kailash-pact>=0.8.2",
-    "kailash-mcp>=0.1.0",
+    "kailash-pact>=0.18.0",
+    "kailash-mcp>=0.4.3",
     # psycopg2 is imported at module scope by 3 integration/e2e tests
     # (test_mcp_resource_flow, test_docker_infrastructure_validation,
     # test_mcp_subscriptions) — required for `pytest --collect-only`
@@ -233,13 +233,13 @@ all = [
     # encryption, Ed25519 audit signing, FastAPI gateway, etc.). Heavy ML /
     # fine-tuning stacks (torch, vllm, transformers training extras) remain
     # opt-in via kailash-ml[<extra>] / kailash-align[<extra>].
-    "kailash-dataflow[security,monitoring,api]>=2.0.12",
-    "kailash-nexus>=2.1.1",
-    "kailash-kaizen[providers-azure,providers-google,observability,db,cache,rag]>=2.7.5",
-    "kaizen-agents>=0.9.3",
-    "kailash-pact[api,execution]>=0.8.2",
-    "kailash-ml>=1.1.0",
-    "kailash-align>=0.3.2",
+    "kailash-dataflow[security,monitoring,api]>=2.19.1",
+    "kailash-nexus>=2.15.0",
+    "kailash-kaizen[providers-azure,providers-google,observability,db,cache,rag]>=2.45.0",
+    "kaizen-agents>=0.12.0",
+    "kailash-pact[api,execution]>=0.18.0",
+    "kailash-ml>=2.2.2",
+    "kailash-align>=0.7.4",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1786,7 +1786,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.61.0"
+version = "2.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2187,7 +2187,7 @@ provides-extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", 
 
 [[package]]
 name = "kailash-kaizen"
-version = "2.40.0"
+version = "2.45.0"
 source = { editable = "packages/kailash-kaizen" }
 dependencies = [
     { name = "aiohttp" },
@@ -2431,7 +2431,7 @@ provides-extras = ["dl", "dl-gpu", "rl", "rl-offline", "rl-envpool", "rl-distrib
 
 [[package]]
 name = "kailash-nexus"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "packages/kailash-nexus" }
 dependencies = [
     { name = "aiofiles" },
@@ -2464,7 +2464,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "janus", specifier = ">=1.0" },
-    { name = "kailash", specifier = ">=2.50.0" },
+    { name = "kailash", specifier = ">=2.62.0" },
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20" },
     { name = "puremagic", specifier = ">=1.0" },
     { name = "pyjwt", specifier = ">=2.8" },


### PR DESCRIPTION
## Summary

Root `pyproject.toml` floors were last touched **2026-05-08** (`ea8d956e3`) and have sat through many release cycles since, so the declared contract no longer described what the monorepo actually ships.

| Package | Floor was | Now | Actual |
|---|---|---|---|
| kailash-dataflow | `>=2.0.12` | `>=2.19.1` | 2.19.1 |
| kailash-nexus | `>=2.1.1` | `>=2.15.0` | 2.15.0 |
| kailash-kaizen | `>=2.7.5` | `>=2.45.0` | 2.45.0 |
| kaizen-agents | `>=0.9.3` | `>=0.12.0` | 0.12.0 |
| kailash-pact | `>=0.8.2` | `>=0.18.0` | 0.18.0 |
| kailash-ml | `>=1.1.0` | `>=2.2.2` | 2.2.2 |
| kailash-align | `>=0.3.2` | `>=0.7.4` | 0.7.4 |
| kailash-mcp | `>=0.1.0` | `>=0.4.3` | 0.4.3 |

## Checked PyPI first, because the file says to

The comment directly above these pins is load-bearing:

> `Pins are MINIMUM compatible versions — bumping to unreleased versions breaks release CI which installs from PyPI before the new release publishes.`

Local versions are **not** automatically on PyPI, so I verified all eight before editing. Every target is published and `local == PyPI` — no floor points at anything unreleased.

## One consequence worth stating plainly

**`kailash-ml` crosses a MAJOR boundary (1.x → 2.x).** Anyone installing `kailash[ml]` or `kailash[all]` while holding `kailash-ml` 1.x will now fail to resolve, rather than silently getting a combination this repo does not test.

That is the intended effect — these packages ship in lockstep from one monorepo — but it's a real tightening, not a no-op, and shouldn't be discovered from a resolver error.

These are **floors, not caps**, so `dependencies.md`'s no-caps-on-transitives rule is untouched; every one is a package this project directly declares.

Line 305 is left alone deliberately — its `kailash-dataflow>=2.0.3` is prose inside a comment explaining the pin policy, not a live constraint.

## Lock was stale too

`uv lock` re-resolved cleanly (282 packages) and picked up three stale recorded versions along the way:

```
kailash  2.61.0 → 2.62.0
kaizen   2.40.0 → 2.45.0
nexus    2.14.0 → 2.15.0
```

## Verification

```
TOML parses; uv lock resolves (282 packages)
uv sync --all-extras --dev clean;  9/9 packages import
pre-commit green — incl. "First-party dependency-pin drift gate (#1183)"
session-start SDK-PINS: 7 stale pins → 0
```

## Related issues

Closes the stale-pin finding surfaced by the repaired `session-start.js` SDK-PINS check (#1979).

🤖 Generated with [Claude Code](https://claude.com/claude-code)