### PR TITLE
docs(notes): point the session entry-point at the launch-ledger

### DIFF
--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -8,6 +8,12 @@
 
 Four NEW security issues were filed that **outrank everything on the original list**.
 
+**UPDATE 2 (burn-down session, post-quota-reset): main is `80b465e89`.** PR #2028 AND PR
+#2032 are both merged. #1995 closed. Four implementation lanes and two CRITICAL investigations
+are IN FLIGHT — **read `02-plans/launch-ledger.md` FIRST**; it is the authoritative,
+compaction-surviving record of which lanes are running, on which branches, and which preserved
+WIP commits they resume from. Do not spawn anything before reading it.
+
 **UPDATE (burn-down session): PR #2028 MERGED as `a101c81f9` — Gate 0 is CLEARED.** #1995 closed
 with the SHA. 1,819 files changed. Parallel burn-down waves are now running; see
 `02-plans/launch-ledger.md` for the durable agent-launch table (which lanes are in flight, on


### PR DESCRIPTION
Small but load-bearing: with two PRs merged and six agents in flight, the single most important instruction for a resumed session is **read `02-plans/launch-ledger.md` before spawning anything**.

Without that pointer a resumed session re-launches lanes that are already running and races its own branches — which is exactly the failure `orchestration-launch-ledger.md` MUST-1/2/3 exists to prevent, and which working memory cannot prevent because a compaction erases it.

## Related issues

Follows #2028, #2032. Tracks the in-flight burn-down of #2026, #2027, #2015, #2014, #2025, #2024.