### PR TITLE
fix(kaizen): fail closed when hook isolation cannot be established (#2014)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/__init__.py
@@ -14,7 +14,12 @@ from .authorization import (
     HookPrincipal,
     HookRole,
 )
-from .isolation import IsolatedHookExecutor, IsolatedHookManager, ResourceLimits
+from .isolation import (
+    HookIsolationError,
+    IsolatedHookExecutor,
+    IsolatedHookManager,
+    ResourceLimits,
+)
 from .metrics_auth import MetricsAuthConfig, MetricsEndpoint, SecureMetricsEndpoint
 from .rate_limiting import RateLimitedHookManager, RateLimiter, RateLimitError
 from .redaction import (
@@ -61,4 +66,5 @@ __all__ = [
     "ResourceLimits",
     "IsolatedHookExecutor",
     "IsolatedHookManager",
+    "HookIsolationError",
 ]

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -145,23 +145,30 @@ class ResourceLimits:
         them as one block would discard the two limits the platform does
         enforce along with the one it does not.
 
-        A refusal is only tolerated when it is a PLATFORM CAPABILITY GAP -- the
-        kernel rejecting a value that is within the current hard limit, which is
-        the signature of a resource it does not implement. A refusal of a value
-        that genuinely exceeds the hard limit is a real misconfiguration and is
-        re-raised.
+        A requested cap that exceeds the environment's existing HARD limit is
+        clamped down to that hard limit rather than treated as an error. The
+        environment is already stricter than what was asked for, which satisfies
+        the intent of the cap; refusing to run would break isolation inside
+        exactly the hardened containers that most need it, and the workaround an
+        operator would reach for is turning isolation off entirely.
+
+        After that clamp every value is within the hard limit, so a refusal from
+        the kernel means it does not implement the resource at all (macOS and
+        ``RLIMIT_AS``). That is REPORTED rather than raised: the limits the
+        platform does support still apply, and process isolation itself -- the
+        primary control -- is unaffected by a missing cap.
+
+        Both the soft and the hard limit are set. Lowering the hard limit is
+        what prevents the hook's own code from raising its soft limit back up,
+        and it is irreversible for the process that does it -- which is correct
+        here, because the process that does it is a disposable child. Callers
+        MUST NOT invoke this on a process they intend to keep using.
 
         Returns:
             Names of the limits that could NOT be enforced (empty list when all
             applied). The caller is expected to surface these: an unenforced
             limit is a security control that is OFF, and the child's own log
             records do not reach the parent's handlers under ``spawn``.
-
-        Raises:
-            OSError: If setrlimit fails for a value exceeding the hard limit
-                (a real misconfiguration, not a platform capability gap)
-            ValueError: Likewise, for the ValueError variant CPython raises for
-                the same condition
 
         Example:
             >>> limits = ResourceLimits(max_memory_mb=100)
@@ -203,7 +210,26 @@ class ResourceLimits:
 
             _soft, hard = resource.getrlimit(rlimit)
 
+            # An environment that is ALREADY stricter than the requested cap
+            # satisfies the intent of the cap, so clamp to it rather than
+            # failing. Refusing to run here would mean isolation breaks inside
+            # exactly the hardened containers that need it most, and the
+            # workaround an operator would reach for is enable_isolation=False.
+            requested = value
+            if hard != resource.RLIM_INFINITY and value > hard:
+                value = hard
+                logger.info(
+                    "Resource limit %s requested %s but the environment caps it "
+                    "at %s; using the stricter environment value",
+                    label,
+                    requested,
+                    hard,
+                )
+
             try:
+                # Both soft and hard are set: lowering the HARD limit is what
+                # stops the hook's own code from raising its soft limit back up.
+                # The child is disposable, so the irreversibility is intended.
                 resource.setrlimit(rlimit, (value, value))
             except (OSError, ValueError) as e:
                 # ``scrub_local_error``, not ``scrub_remote_error``: this comes
@@ -217,17 +243,12 @@ class ResourceLimits:
                 # a leak: the moment this block covers a limit derived from a
                 # caller-supplied value, the sink is already wrong and nothing
                 # would flag it.
-                within_hard = hard == resource.RLIM_INFINITY or value <= hard
-                if not within_hard:
-                    logger.error(
-                        "SECURITY: Failed to apply resource limit %s: %s",
-                        label,
-                        scrub_local_error(e),
-                    )
-                    raise
-
-                # Refused despite being within the hard limit: this kernel does
-                # not implement the resource (macOS and RLIMIT_AS).
+                #
+                # The clamp above guarantees the value is within the hard limit,
+                # so a refusal here means the kernel does not implement this
+                # resource at all (macOS and RLIMIT_AS). That is reported, not
+                # raised: the remaining limits still apply, and process
+                # isolation itself -- the primary control -- is unaffected.
                 unenforced.append(label)
                 logger.warning(
                     "SECURITY: %s (%s) is not enforceable on this platform: %s",

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -1,10 +1,32 @@
 """
 Hook execution isolation (SECURITY FIX #5).
 
-Provides resource limits and process isolation for hook execution to prevent:
-- Resource exhaustion (memory, CPU)
-- Agent crashes from malicious hooks
-- Cross-hook interference
+WHAT THIS DELIVERS
+------------------
+- Crash containment: a hook that segfaults, aborts, or exits takes down only
+  its own process, never the agent.
+- Cross-hook independence: hooks cannot corrupt each other's or the agent's
+  in-process state, because they do not share an address space.
+- CPU and file-size caps (``RLIMIT_CPU`` / ``RLIMIT_FSIZE``) on Unix.
+- A loud, typed failure when any of the above cannot be established.
+
+WHAT THIS DOES **NOT** DELIVER
+------------------------------
+This is process SEPARATION, not a sandbox. It is not a containment boundary
+against hostile hook code, and MUST NOT be relied on as one:
+
+- The child inherits the parent's ENVIRONMENT, including every API key and
+  secret in it, plus its cwd, uid, filesystem access and network access.
+- The memory cap is unavailable on macOS, which refuses ``setrlimit`` for
+  ``RLIMIT_AS`` outright (reported at runtime by ``ResourceLimits.apply``).
+  On Windows no resource limits apply at all.
+- The hook's return value is unpickled IN THE PARENT, so a hook returning an
+  object with a hostile ``__reduce__`` executes code in the parent process.
+  A hook is TRUSTED CODE running with the agent's privileges; run only hooks
+  you would run in-process.
+
+Treat this as protection against buggy and crashing hooks, not against
+malicious ones.
 
 SECURITY: CWE-265 (Privilege Issues)
 """
@@ -35,6 +57,13 @@ logger = logging.getLogger(__name__)
 #: means the picklability requirement below is uniform instead of
 #: platform-dependent -- a hook that isolates on the developer's Linux box now
 #: isolates identically on the operator's macOS box, or fails loudly on both.
+#:
+#: OPERATOR NOTE: this changes behaviour on Linux, where ``fork`` was the
+#: default. ``spawn`` re-imports the entry-point module in every child, so an
+#: application started from a script whose top level has side effects (and no
+#: ``if __name__ == "__main__":`` guard) will re-run those side effects once per
+#: isolated hook invocation. Guard your entry point -- which ``multiprocessing``
+#: already requires of any spawn-using program.
 _ISOLATION_START_METHOD = "spawn"
 
 #: Wall-clock budget for the child interpreter to boot, import the handler's
@@ -54,9 +83,18 @@ _DRAIN_TIMEOUT = 0.5
 _REAP_TIMEOUT = 1.0
 
 
-class HookIsolationError(RuntimeError):
+class HookIsolationError(Exception):
     """
     Raised when hook process isolation cannot be established (issue #2014).
+
+    Bases ``Exception``, NOT ``RuntimeError``, deliberately. ``asyncio`` raises
+    ``RuntimeError`` for "no running event loop", and callers probe for that
+    with ``except RuntimeError`` as ordinary control flow -- ``multi_cycle.py``
+    does exactly this at six sites, with the hook trigger inside the ``try``.
+    Subclassing ``RuntimeError`` would let a fail-closed security signal be
+    swallowed by a branch whose comment reads "No running loop" and retried down
+    a path the operator never chose, destroying the loud failure this class
+    exists to produce.
 
     This error means the SECURITY CONTROL is unavailable -- not that the hook
     failed. It is raised INSTEAD of running the hook, never alongside it: a
@@ -391,7 +429,7 @@ class IsolatedHookExecutor:
         >>>     print(f"Hook failed: {result.error}")
 
     SECURITY FIX #5:
-    - Prevents malicious hooks from crashing agent
+    - Prevents a crashing hook from taking down the agent
     - Prevents resource exhaustion attacks
     - Isolates hook execution from main process
     """
@@ -679,7 +717,8 @@ class IsolatedHookManager(HookManager):
     HookManager with process isolation and resource limits (SECURITY FIX #5).
 
     Extends HookManager to execute hooks in isolated processes with resource
-    limits. This prevents malicious or buggy hooks from:
+    limits. This prevents BUGGY hooks (not hostile ones -- see the module
+    docstring) from:
     - Crashing the agent
     - Exhausting system resources
     - Interfering with other hooks
@@ -715,7 +754,7 @@ class IsolatedHookManager(HookManager):
         >>> results = await manager.trigger(HookEvent.POST_AGENT_LOOP, context)
 
     SECURITY FIX #5:
-    - Prevents malicious hooks from compromising agent
+    - Prevents a buggy hook from compromising agent state
     - Isolates hook execution in separate processes
     - Applies resource limits to prevent exhaustion attacks
     - Never downgrades itself to non-isolated execution (issue #2014)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -821,13 +821,21 @@ class IsolatedHookManager(HookManager):
             logger.debug(f"Executing hook in isolated process: {handler_name}")
             result = await self.executor.execute_isolated(handler, context, timeout)
         except HookIsolationError as e:
-            # Already typed and already scrubbed at construction; re-logged so
-            # the operator sees WHICH control failed, then propagated.
+            # Re-logged so the operator sees WHICH control failed, then
+            # propagated unchanged.
+            #
+            # Scrubbed again here even though every construction site already
+            # scrubs what it puts in ``reason``. Logging ``e.reason`` directly
+            # would make this sink's safety depend on a property of some OTHER
+            # function -- and on every future one that raises this error. The
+            # F11 sink scanner rejects exception-attribute interpolation for
+            # exactly that reason, and it is right to: scrubbing is idempotent,
+            # so re-scrubbing costs nothing and keeps the guarantee local.
             logger.error(
                 "SECURITY: Hook isolation could not be established for %s; "
                 "the hook was NOT executed: %s",
                 handler_name,
-                e.reason,
+                scrub_remote_error(e),
             )
             self._update_stats(handler_name, 0, success=False)
             raise

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -20,10 +20,11 @@ against hostile hook code, and MUST NOT be relied on as one:
 - The memory cap is unavailable on macOS, which refuses ``setrlimit`` for
   ``RLIMIT_AS`` outright (reported at runtime by ``ResourceLimits.apply``).
   On Windows no resource limits apply at all.
-- The hook's return value is unpickled IN THE PARENT, so a hook returning an
-  object with a hostile ``__reduce__`` executes code in the parent process.
-  A hook is TRUSTED CODE running with the agent's privileges; run only hooks
-  you would run in-process.
+- A hook can read and exfiltrate anything the agent can.
+
+The child->parent channel is NOT a weak point: results cross as JSON
+primitives over ``send_bytes``/``recv_bytes``, so hook output is never
+unpickled in the agent process and cannot execute code there.
 
 Treat this as protection against buggy and crashing hooks, not against
 malicious ones.
@@ -32,13 +33,12 @@ SECURITY: CWE-265 (Privilege Issues)
 """
 
 import asyncio
+import json
 import logging
 import multiprocessing
 import os
-import pickle
 import sys
 import time
-from queue import Empty as QueueEmpty
 from typing import Any
 
 from kaizen.utils.credential_scrub import scrub_local_error, scrub_remote_error
@@ -73,7 +73,7 @@ _ISOLATION_START_METHOD = "spawn"
 #: timeouts ``HookManager.trigger`` defaults to.
 DEFAULT_STARTUP_TIMEOUT = 30.0
 
-#: Queue poll granularity while waiting for a child message.
+#: Pipe poll granularity while waiting for a child message.
 _POLL_INTERVAL = 0.02
 
 #: Grace period to drain a message the child wrote immediately before exiting.
@@ -309,6 +309,99 @@ class ResourceLimits:
         return unenforced
 
 
+#: Ceiling on a single child->parent message, before it is decoded.
+_MAX_MESSAGE_BYTES = 8 * 1024 * 1024
+
+
+def _json_safe(value: Any, _depth: int = 0) -> Any:
+    """Reduce ``value`` to JSON primitives, or raise.
+
+    Rejects rather than coerces: a type that is not already a primitive is an
+    error the hook author must fix, not something to paper over with ``str()``.
+    """
+    if _depth > 32:
+        raise ValueError("hook result nests too deeply to cross the boundary")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        out = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"hook result dict keys must be str, got {type(key)!r}")
+            out[key] = _json_safe(item, _depth + 1)
+        return out
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item, _depth + 1) for item in value]
+    raise TypeError(
+        f"hook result may only contain JSON primitives, got {type(value)!r}"
+    )
+
+
+def _decode(raw: bytes) -> tuple[tuple[str, Any, int] | None, str]:
+    """Decode one child message, validating its SHAPE before anyone unpacks it.
+
+    A malformed message is reported as ``malformed`` rather than allowed to
+    raise out of the supervision thread as an unpacking ``ValueError``.
+    """
+    try:
+        message = json.loads(raw.decode())
+    except Exception as e:
+        logger.error(
+            "SECURITY: isolated hook sent an undecodable message (%s bytes): %s",
+            len(raw),
+            scrub_local_error(e),
+        )
+        return None, "malformed"
+
+    if not isinstance(message, dict):
+        logger.error(
+            "SECURITY: isolated hook sent a non-object message of type %s",
+            type(message).__name__,
+        )
+        return None, "malformed"
+
+    status = message.get("status")
+    worker_pid = message.get("pid")
+    if status not in ("ready", "success", "error"):
+        logger.error(
+            "SECURITY: isolated hook sent an unrecognised status (type %s)",
+            type(status).__name__,
+        )
+        return None, "malformed"
+    if not isinstance(worker_pid, int) or isinstance(worker_pid, bool):
+        logger.error(
+            "SECURITY: isolated hook sent a non-integer pid of type %s",
+            type(worker_pid).__name__,
+        )
+        return None, "malformed"
+
+    return (status, message.get("payload"), worker_pid), "message"
+
+
+def _send(conn: Any, status: str, payload: Any, worker_pid: int) -> None:
+    """Send one message to the parent as JSON BYTES, never as a pickled object.
+
+    This is the fix for the parent-side deserialization hole (#2037 F1). The
+    worker used to ``put`` the ``HookResult`` on a ``multiprocessing.Queue``,
+    which pickles on the way in and UNPICKLES IN THE PARENT. A hook returning an
+    object whose ``__reduce__`` builds a hostile call passed the child's own
+    ``pickle.dumps`` probe -- ``__reduce__`` only constructs the instruction, it
+    does not run it -- and then executed in the AGENT process at unpickle time,
+    inside the receive call, before the parent had inspected the status or the
+    PID. The isolation boundary was one-way: execution was isolated, and then
+    everything the isolated process sent back was trusted.
+
+    Sending ``json.dumps(...).encode()`` over ``send_bytes`` closes it. The
+    parent's ``recv_bytes`` performs no object reconstruction at all, so there
+    is no ``__reduce__``, no ``find_class``, and no code path from hook output
+    to parent execution -- rather than an allowlist that must stay correct as
+    types are added.
+    """
+    conn.send_bytes(
+        json.dumps({"status": status, "payload": payload, "pid": worker_pid}).encode()
+    )
+
+
 def _isolated_hook_worker(
     limits: ResourceLimits,
     handler: HookHandler,
@@ -326,7 +419,7 @@ def _isolated_hook_worker(
     ``Can't get local object 'IsolatedHookExecutor.execute_isolated.<locals>._run_hook'``
     and the caller swallowed it and ran the hook in-process instead.
 
-    The worker speaks a 3-tuple protocol on ``result_queue``:
+    The worker speaks a 3-field JSON protocol on ``result_queue`` (a Pipe end):
     ``(status, payload, worker_pid)`` where status is one of
     ``ready`` / ``success`` / ``error``. ``ready`` is sent once the sandbox is
     fully in place and BEFORE any caller-supplied code runs, so the parent can
@@ -344,7 +437,7 @@ def _isolated_hook_worker(
         limits: Resource limits to apply before running any hook code
         handler: Hook handler to execute
         context: Hook context to pass to the handler
-        result_queue: Queue back to the parent process
+        result_queue: Write end of the pipe back to the parent process
     """
     worker_pid = os.getpid()
 
@@ -355,49 +448,50 @@ def _isolated_hook_worker(
         # parent must treat this as an isolation failure and never run the hook.
         # ``scrub_local_error`` matches ``ResourceLimits.apply``: this is an
         # in-process OS call whose errno text IS the diagnostic.
-        result_queue.put(
-            (
-                "error",
-                f"Resource limits could not be applied: {scrub_local_error(e)}",
-                worker_pid,
-            )
+        _send(
+            result_queue,
+            "error",
+            f"Resource limits could not be applied: {scrub_local_error(e)}",
+            worker_pid,
         )
         return
 
     # Sent before any caller-supplied code runs: it is the parent's proof that a
     # distinct process exists and that the sandbox is established.
-    result_queue.put(("ready", unenforced, worker_pid))
+    _send(result_queue, "ready", unenforced, worker_pid)
 
     try:
         start_time = time.perf_counter()
         result = asyncio.run(handler.handle(context))
-        result.duration_ms = (time.perf_counter() - start_time) * 1000
+        duration_ms = (time.perf_counter() - start_time) * 1000
     except Exception as e:
         # ``handler.handle`` is CALLER-SUPPLIED code, so ``e`` is whatever it
         # raised -- an HTTP client, a DB driver, an SDK -- and this string
         # crosses the process boundary into BOTH a parent log line and the
         # returned ``HookResult.error``. Scrubbed here, at the point it is
         # built, so neither consumer can re-leak it.
-        result_queue.put(("error", f"Hook error: {scrub_remote_error(e)}", worker_pid))
+        _send(result_queue, "error", f"Hook error: {scrub_remote_error(e)}", worker_pid)
         return
 
     try:
-        # Pickled explicitly rather than left to the queue's feeder thread: a
-        # feeder-thread pickling failure surfaces as a traceback on the child's
-        # stderr and a SILENTLY dropped item, which the parent would then
-        # report as the unrelated "did not return a result".
-        pickle.dumps(result)
+        # Reduced to JSON-safe PRIMITIVES here, in the child, rather than sent
+        # as an object. See ``_send``: the parent never unpickles hook output.
+        payload = {
+            "success": bool(result.success),
+            "data": _json_safe(result.data),
+            "error": None if result.error is None else str(result.error),
+            "duration_ms": float(duration_ms),
+        }
     except Exception as e:
-        result_queue.put(
-            (
-                "error",
-                f"Hook result cannot cross the process boundary: {scrub_remote_error(e)}",
-                worker_pid,
-            )
+        _send(
+            result_queue,
+            "error",
+            f"Hook result cannot cross the process boundary: {scrub_remote_error(e)}",
+            worker_pid,
         )
         return
 
-    result_queue.put(("success", result, worker_pid))
+    _send(result_queue, "success", payload, worker_pid)
 
 
 class IsolatedHookExecutor:
@@ -506,14 +600,18 @@ class IsolatedHookExecutor:
         parent_pid = os.getpid()
 
         # Explicit context, never the platform default: see
-        # ``_ISOLATION_START_METHOD``. The queue must come from the SAME context
+        # ``_ISOLATION_START_METHOD``. The pipe must come from the SAME context
         # as the process that receives it.
+        #
+        # A one-way ``Pipe``, not a ``Queue``: the parent reads with
+        # ``recv_bytes`` and decodes JSON, so hook output is never unpickled in
+        # the agent process. See ``_send`` (#2037 F1).
         mp_context = multiprocessing.get_context(_ISOLATION_START_METHOD)
-        result_queue = mp_context.Queue()
+        receiver, sender = mp_context.Pipe(duplex=False)
 
         process = mp_context.Process(
             target=_isolated_hook_worker,
-            args=(self.limits, handler, context, result_queue),
+            args=(self.limits, handler, context, sender),
             name=f"kaizen-isolated-hook-{handler_name}",
         )
 
@@ -523,7 +621,8 @@ class IsolatedHookExecutor:
             # synchronously and leaves no orphan process behind.
             process.start()
         except Exception as e:
-            result_queue.close()
+            receiver.close()
+            sender.close()
             raise HookIsolationError(
                 handler_name,
                 f"the isolated process could not be started under the "
@@ -536,22 +635,26 @@ class IsolatedHookExecutor:
         try:
             # The supervision loop blocks on a queue and on process reaping;
             # running it in a worker thread keeps the caller's event loop free.
+            # The child's end is closed in the PARENT immediately after start, so
+            # ``recv_bytes`` raises EOFError the moment the last writer (the
+            # child) goes away, instead of blocking for the full budget.
+            sender.close()
             return await asyncio.to_thread(
                 self._supervise,
                 process,
-                result_queue,
+                receiver,
                 handler_name,
                 timeout,
                 parent_pid,
             )
         finally:
             self._reap(process)
-            result_queue.close()
+            receiver.close()
 
     def _supervise(
         self,
         process: Any,
-        result_queue: Any,
+        receiver: Any,
         handler_name: str,
         timeout: float,
         parent_pid: int,
@@ -569,7 +672,7 @@ class IsolatedHookExecutor:
         # PHASE 1: readiness. Absence here means no isolated process is running
         # our worker, so there is nothing to fall back to except the very
         # in-process execution this control exists to prevent.
-        message, reason = self._receive(process, result_queue, self.startup_timeout)
+        message, reason = self._receive(process, receiver, self.startup_timeout)
         if message is None:
             raise HookIsolationError(
                 handler_name,
@@ -621,7 +724,7 @@ class IsolatedHookExecutor:
             )
 
         # PHASE 2: the hook's own result.
-        message, reason = self._receive(process, result_queue, timeout)
+        message, reason = self._receive(process, receiver, timeout)
 
         if message is None and reason == "timeout":
             logger.warning(
@@ -653,44 +756,80 @@ class IsolatedHookExecutor:
         status, payload, _worker_pid = message
 
         if status == "success":
+            if not isinstance(payload, dict):
+                logger.error(
+                    "SECURITY: isolated hook %s sent a success payload of type "
+                    "%s; expected an object",
+                    handler_name,
+                    type(payload).__name__,
+                )
+                return HookResult(
+                    success=False,
+                    error="Hook returned a malformed result",
+                    duration_ms=0.0,
+                )
+
             logger.debug(
                 "Hook executed successfully in isolated process: %s", handler_name
             )
-            return payload
+            # Reconstructed from PRIMITIVES here, in the parent. The child sent
+            # JSON, not an object graph, so nothing the hook returned can be
+            # instantiated in this process (#2037 F1).
+            return HookResult(
+                success=bool(payload.get("success")),
+                data=payload.get("data"),
+                error=payload.get("error"),
+                duration_ms=float(payload.get("duration_ms") or 0.0),
+            )
 
         logger.error("Hook failed in isolated process: %s", payload)
-        return HookResult(success=False, error=payload, duration_ms=0.0)
+        return HookResult(success=False, error=str(payload), duration_ms=0.0)
 
     @staticmethod
     def _receive(
-        process: Any, result_queue: Any, budget: float
+        process: Any, receiver: Any, budget: float
     ) -> tuple[tuple[str, Any, int] | None, str]:
         """
         Wait up to ``budget`` seconds for one message from the child.
 
-        Polls rather than blocking on ``Queue.get(timeout=budget)`` so that a
-        child which dies without writing is noticed immediately instead of
-        after the full budget. Reads BEFORE joining, so a result larger than the
-        pipe buffer cannot deadlock the child inside its own flush.
+        Polls rather than blocking for the whole budget so that a child which
+        dies without writing is noticed immediately. Reads BEFORE joining, so a
+        message larger than the pipe buffer cannot deadlock the child inside its
+        own flush.
+
+        Decodes with ``recv_bytes`` + ``json.loads``, NEVER ``recv()``: the
+        latter unpickles, which would execute a hostile ``__reduce__`` from hook
+        output inside the agent process (#2037 F1). The message shape is
+        validated here, before ``_supervise`` unpacks it.
 
         Returns:
-            ``(message, "message")`` on success, or ``(None, "timeout")`` /
-            ``(None, "exited")`` when no message arrived.
+            ``(message, "message")`` on success, or ``(None, reason)`` where
+            reason is ``timeout``, ``exited``, or ``malformed``.
         """
         deadline = time.monotonic() + budget
 
         while True:
             try:
-                return result_queue.get(timeout=_POLL_INTERVAL), "message"
-            except QueueEmpty:
-                pass
+                if receiver.poll(_POLL_INTERVAL):
+                    return _decode(receiver.recv_bytes(_MAX_MESSAGE_BYTES))
+            except (EOFError, OSError):
+                # Every writer is gone: the child died without completing a
+                # message. Not an "empty queue" -- a closed pipe.
+                return None, "exited"
 
             if not process.is_alive():
                 # Last chance: the child may have written just before exiting.
                 try:
-                    return result_queue.get(timeout=_DRAIN_TIMEOUT), "message"
-                except QueueEmpty:
-                    return None, "exited"
+                    if receiver.poll(_DRAIN_TIMEOUT):
+                        return _decode(receiver.recv_bytes(_MAX_MESSAGE_BYTES))
+                except (EOFError, OSError) as e:
+                    # Expected when the child died mid-write; recorded rather
+                    # than swallowed so the cause is not invisible.
+                    logger.debug(
+                        "Isolated hook pipe closed during final drain: %s",
+                        scrub_local_error(e),
+                    )
+                return None, "exited"
 
             if time.monotonic() >= deadline:
                 return None, "timeout"

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -12,8 +12,11 @@ SECURITY: CWE-265 (Privilege Issues)
 import asyncio
 import logging
 import multiprocessing
+import os
+import pickle
 import sys
 import time
+from queue import Empty as QueueEmpty
 from typing import Any
 
 from kaizen.utils.credential_scrub import scrub_local_error, scrub_remote_error
@@ -23,6 +26,61 @@ from ..protocol import HookHandler
 from ..types import HookContext, HookResult
 
 logger = logging.getLogger(__name__)
+
+#: Start method used for hook isolation, selected EXPLICITLY rather than
+#: inherited from the platform default (issue #2014).
+#:
+#: ``spawn`` is the default on macOS and Windows and is available everywhere;
+#: ``fork`` is the default only on Linux. Pinning ``spawn`` on every platform
+#: means the picklability requirement below is uniform instead of
+#: platform-dependent -- a hook that isolates on the developer's Linux box now
+#: isolates identically on the operator's macOS box, or fails loudly on both.
+_ISOLATION_START_METHOD = "spawn"
+
+#: Wall-clock budget for the child interpreter to boot, import the handler's
+#: module, and signal readiness. This is deliberately NOT charged against the
+#: caller's hook timeout: under ``spawn`` the child pays a full interpreter
+#: startup plus import cost, which routinely exceeds the sub-second per-hook
+#: timeouts ``HookManager.trigger`` defaults to.
+DEFAULT_STARTUP_TIMEOUT = 30.0
+
+#: Queue poll granularity while waiting for a child message.
+_POLL_INTERVAL = 0.02
+
+#: Grace period to drain a message the child wrote immediately before exiting.
+_DRAIN_TIMEOUT = 0.5
+
+#: Grace period for a terminated child to actually die.
+_REAP_TIMEOUT = 1.0
+
+
+class HookIsolationError(RuntimeError):
+    """
+    Raised when hook process isolation cannot be established (issue #2014).
+
+    This error means the SECURITY CONTROL is unavailable -- not that the hook
+    failed. It is raised INSTEAD of running the hook, never alongside it: a
+    caller that asked for isolation and cannot get it must be told, because the
+    alternative (running caller-supplied hook code with full agent privileges
+    while reporting success) is a silent downgrade of the control to OFF.
+
+    Attributes:
+        handler_name: Safe name of the hook whose isolation could not be set up
+        reason: Why isolation could not be established
+
+    Example:
+        >>> try:
+        >>>     await manager.trigger(HookEvent.PRE_AGENT_LOOP, "agent-1", {})
+        >>> except HookIsolationError as e:
+        >>>     print(f"{e.handler_name} cannot be isolated: {e.reason}")
+    """
+
+    def __init__(self, handler_name: str, reason: str):
+        self.handler_name = handler_name
+        self.reason = reason
+        super().__init__(
+            f"Hook isolation could not be established for {handler_name}: {reason}"
+        )
 
 
 class ResourceLimits:
@@ -142,6 +200,88 @@ class ResourceLimits:
             raise
 
 
+def _isolated_hook_worker(
+    limits: ResourceLimits,
+    handler: HookHandler,
+    context: HookContext,
+    result_queue: Any,
+) -> None:
+    """
+    Entry point executed inside the isolated child process (issue #2014).
+
+    MUST stay at MODULE SCOPE. Under the ``spawn`` start method the child is a
+    fresh interpreter, so ``multiprocessing`` transfers the target by pickling
+    it -- and pickle stores a function by its ``module.qualname``, not its code.
+    A nested or closure worker cannot be pickled at all, which is precisely how
+    isolation used to fail: ``Process.start()`` raised
+    ``Can't get local object 'IsolatedHookExecutor.execute_isolated.<locals>._run_hook'``
+    and the caller swallowed it and ran the hook in-process instead.
+
+    The worker speaks a 3-tuple protocol on ``result_queue``:
+    ``(status, payload, worker_pid)`` where status is one of
+    ``ready`` / ``success`` / ``error``. ``ready`` is sent FIRST, before any
+    caller-supplied code runs, so the parent can (a) confirm a real child is
+    alive and (b) charge interpreter startup to a separate budget instead of
+    the hook's timeout.
+
+    Args:
+        limits: Resource limits to apply before running any hook code
+        handler: Hook handler to execute
+        context: Hook context to pass to the handler
+        result_queue: Queue back to the parent process
+    """
+    worker_pid = os.getpid()
+
+    # Sent BEFORE limits are applied and before any caller-supplied code runs:
+    # it is the parent's proof that a distinct process exists.
+    result_queue.put(("ready", None, worker_pid))
+
+    try:
+        limits.apply()
+    except Exception as e:
+        # ``scrub_local_error`` matches ``ResourceLimits.apply``: this is an
+        # in-process OS call whose errno text IS the diagnostic.
+        result_queue.put(
+            (
+                "error",
+                f"Resource limits could not be applied: {scrub_local_error(e)}",
+                worker_pid,
+            )
+        )
+        return
+
+    try:
+        start_time = time.perf_counter()
+        result = asyncio.run(handler.handle(context))
+        result.duration_ms = (time.perf_counter() - start_time) * 1000
+    except Exception as e:
+        # ``handler.handle`` is CALLER-SUPPLIED code, so ``e`` is whatever it
+        # raised -- an HTTP client, a DB driver, an SDK -- and this string
+        # crosses the process boundary into BOTH a parent log line and the
+        # returned ``HookResult.error``. Scrubbed here, at the point it is
+        # built, so neither consumer can re-leak it.
+        result_queue.put(("error", f"Hook error: {scrub_remote_error(e)}", worker_pid))
+        return
+
+    try:
+        # Pickled explicitly rather than left to the queue's feeder thread: a
+        # feeder-thread pickling failure surfaces as a traceback on the child's
+        # stderr and a SILENTLY dropped item, which the parent would then
+        # report as the unrelated "did not return a result".
+        pickle.dumps(result)
+    except Exception as e:
+        result_queue.put(
+            (
+                "error",
+                f"Hook result cannot cross the process boundary: {scrub_remote_error(e)}",
+                worker_pid,
+            )
+        )
+        return
+
+    result_queue.put(("success", result, worker_pid))
+
+
 class IsolatedHookExecutor:
     """
     Execute hooks in isolated processes with resource limits (SECURITY FIX #5).
@@ -176,18 +316,26 @@ class IsolatedHookExecutor:
     - Isolates hook execution from main process
     """
 
-    def __init__(self, limits: ResourceLimits):
+    def __init__(
+        self,
+        limits: ResourceLimits,
+        startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+    ):
         """
         Initialize isolated hook executor.
 
         Args:
             limits: Resource limits to apply in child process
+            startup_timeout: Seconds allowed for the child interpreter to boot
+                and signal readiness, charged SEPARATELY from the per-hook
+                timeout (default: 30s)
 
         Example:
             >>> limits = ResourceLimits(max_memory_mb=50)
             >>> executor = IsolatedHookExecutor(limits=limits)
         """
         self.limits = limits
+        self.startup_timeout = startup_timeout
 
     async def execute_isolated(
         self,
@@ -202,12 +350,22 @@ class IsolatedHookExecutor:
         returns result. If hook times out or crashes, returns error result.
 
         Args:
-            handler: Hook handler to execute
+            handler: Hook handler to execute. MUST be picklable, which under the
+                ``spawn`` start method means its class must be importable at
+                module scope -- a lambda, a closure, or a locally-defined
+                function cannot be isolated.
             context: Hook context (must be picklable)
-            timeout: Maximum execution time in seconds
+            timeout: Maximum hook execution time in seconds, measured from the
+                moment the child signals readiness (interpreter startup is
+                charged to ``startup_timeout`` instead)
 
         Returns:
             HookResult with success/failure status and metadata
+
+        Raises:
+            HookIsolationError: If the isolated process cannot be started, does
+                not signal readiness, or reports the parent's own PID. The hook
+                is NOT executed in that case -- see issue #2014.
 
         Example:
             >>> result = await executor.execute_isolated(
@@ -223,115 +381,193 @@ class IsolatedHookExecutor:
         - Timeout prevents infinite loops
         - Graceful failure handling prevents agent crashes
         """
-        # ``handler_name`` reaches three log lines below AND the returned
+        # ``handler_name`` reaches the log lines below AND the returned
         # ``HookResult.error`` on the timeout and crash paths, so it must not be
         # able to carry caller state; see ``safe_handler_name``.
         handler_name = getattr(handler, "name", safe_handler_name(handler))
+        parent_pid = os.getpid()
 
-        # Create queue for inter-process communication
-        queue: multiprocessing.Queue = multiprocessing.Queue()
+        # Explicit context, never the platform default: see
+        # ``_ISOLATION_START_METHOD``. The queue must come from the SAME context
+        # as the process that receives it.
+        mp_context = multiprocessing.get_context(_ISOLATION_START_METHOD)
+        result_queue = mp_context.Queue()
 
-        # Define worker function (runs in child process)
-        def _run_hook():
-            """
-            Worker function that runs in isolated child process.
+        process = mp_context.Process(
+            target=_isolated_hook_worker,
+            args=(self.limits, handler, context, result_queue),
+            name=f"kaizen-isolated-hook-{handler_name}",
+        )
 
-            Applies resource limits and executes hook.
-            """
-            try:
-                # STEP 1: Apply resource limits
-                self.limits.apply()
+        try:
+            # Under ``spawn`` the handler, context and limits are pickled HERE,
+            # before the child is launched, so an unpicklable handler raises
+            # synchronously and leaves no orphan process behind.
+            process.start()
+        except Exception as e:
+            result_queue.close()
+            raise HookIsolationError(
+                handler_name,
+                f"the isolated process could not be started under the "
+                f"'{_ISOLATION_START_METHOD}' start method "
+                f"({scrub_remote_error(e)}). The handler and context must be "
+                f"picklable: define the handler class at module scope rather "
+                f"than as a lambda, closure, or locally-defined function.",
+            ) from e
 
-                # STEP 2: Execute hook
-                start_time = time.perf_counter()
-                result = asyncio.run(handler.handle(context))
-                duration_ms = (time.perf_counter() - start_time) * 1000
-
-                # STEP 3: Add timing metadata
-                result.duration_ms = duration_ms
-
-                # STEP 4: Send result to parent process
-                queue.put(("success", result))
-
-            except Exception as e:
-                # Send error to parent process. ``handler.handle`` is
-                # CALLER-SUPPLIED code, so ``e`` is whatever it raised -- an
-                # HTTP client, a DB driver, an SDK -- and this string crosses
-                # the process boundary into BOTH a parent log line and the
-                # returned ``HookResult.error``. Scrubbed here, at the point it
-                # is built, so neither consumer can re-leak it.
-                error_msg = f"Hook error: {scrub_remote_error(e)}"
-                queue.put(("error", error_msg))
-
-        # Start isolated process
-        process = multiprocessing.Process(target=_run_hook)
-        process.start()
-
-        # Wait for completion with timeout
-        process.join(timeout=timeout)
-
-        # Check if process is still running (timeout)
-        if process.is_alive():
-            logger.warning(
-                f"SECURITY: Hook timeout in isolated process - {handler_name}"
+        try:
+            # The supervision loop blocks on a queue and on process reaping;
+            # running it in a worker thread keeps the caller's event loop free.
+            return await asyncio.to_thread(
+                self._supervise, process, result_queue, handler_name, timeout, parent_pid
             )
-            process.terminate()
-            process.join(timeout=1.0)  # Give it 1 second to terminate gracefully
+        finally:
+            self._reap(process)
+            result_queue.close()
 
-            # Force kill if still alive
-            if process.is_alive():
-                process.kill()
-                process.join()
+    def _supervise(
+        self,
+        process: Any,
+        result_queue: Any,
+        handler_name: str,
+        timeout: float,
+        parent_pid: int,
+    ) -> HookResult:
+        """
+        Supervise the isolated process from the parent (runs in a worker thread).
 
+        Two phases with separate budgets: readiness (``startup_timeout``) then
+        the hook itself (``timeout``).
+
+        Raises:
+            HookIsolationError: If readiness never arrives or the worker reports
+                the parent's PID -- both mean the control is not in place.
+        """
+        # PHASE 1: readiness. Absence here means no isolated process is running
+        # our worker, so there is nothing to fall back to except the very
+        # in-process execution this control exists to prevent.
+        message, reason = self._receive(process, result_queue, self.startup_timeout)
+        if message is None:
+            raise HookIsolationError(
+                handler_name,
+                f"the isolated process did not signal readiness within "
+                f"{self.startup_timeout}s (reason: {reason}, "
+                f"exit code: {process.exitcode})",
+            )
+
+        status, _payload, worker_pid = message
+        if status != "ready":
+            raise HookIsolationError(
+                handler_name,
+                f"the isolated process sent {status!r} before signalling "
+                f"readiness (isolation protocol violation)",
+            )
+        if worker_pid == parent_pid:
+            # Belt and braces: if this ever holds, the hook is running with full
+            # agent privileges and the control is OFF.
+            raise HookIsolationError(
+                handler_name,
+                f"the hook worker reported the parent PID ({parent_pid}); "
+                f"the hook is NOT isolated",
+            )
+
+        logger.debug(
+            "Hook %s isolated in process %s (parent %s)",
+            handler_name,
+            worker_pid,
+            parent_pid,
+        )
+
+        # PHASE 2: the hook's own result.
+        message, reason = self._receive(process, result_queue, timeout)
+
+        if message is None and reason == "timeout":
+            logger.warning(
+                "SECURITY: Hook timeout in isolated process - %s", handler_name
+            )
             return HookResult(
                 success=False,
                 error=f"Hook timeout in isolated process: {handler_name}",
                 duration_ms=timeout * 1000,
             )
 
-        # Check exit code
-        if process.exitcode != 0:
+        if message is None:
+            # Child exited without a result: crash, kill, or resource limit.
+            process.join(timeout=_REAP_TIMEOUT)
             logger.error(
-                f"SECURITY: Hook process crashed - {handler_name} (exit code: {process.exitcode})"
+                "SECURITY: Hook process exited without a result - %s (exit code: %s)",
+                handler_name,
+                process.exitcode,
             )
             return HookResult(
                 success=False,
-                error=f"Hook process crashed (exit code: {process.exitcode})",
+                error=(
+                    f"Hook process exited without returning a result "
+                    f"(exit code: {process.exitcode})"
+                ),
                 duration_ms=0.0,
             )
 
-        # Get result from queue
-        try:
-            if not queue.empty():
-                status, result = queue.get(timeout=1.0)
+        status, payload, _worker_pid = message
 
-                if status == "success":
-                    logger.debug(
-                        f"Hook executed successfully in isolated process: {handler_name}"
-                    )
-                    return result
-                else:
-                    # Error result
-                    logger.error(f"Hook failed in isolated process: {result}")
-                    return HookResult(success=False, error=result, duration_ms=0.0)
-            else:
-                # Queue empty - hook did not return result
-                logger.error(f"SECURITY: Hook did not return result - {handler_name}")
-                return HookResult(
-                    success=False,
-                    error="Hook did not return result",
-                    duration_ms=0.0,
-                )
+        if status == "success":
+            logger.debug(
+                "Hook executed successfully in isolated process: %s", handler_name
+            )
+            return payload
 
-        except Exception as e:
-            # The queue payload was produced by the child from caller-supplied
-            # hook code, so a deserialization failure can render it.
-            logger.error(
-                "SECURITY: Failed to retrieve hook result: %s", scrub_remote_error(e)
-            )
-            return HookResult(
-                success=False, error=f"Failed to retrieve result: {e}", duration_ms=0.0
-            )
+        logger.error("Hook failed in isolated process: %s", payload)
+        return HookResult(success=False, error=payload, duration_ms=0.0)
+
+    @staticmethod
+    def _receive(
+        process: Any, result_queue: Any, budget: float
+    ) -> tuple[tuple[str, Any, int] | None, str]:
+        """
+        Wait up to ``budget`` seconds for one message from the child.
+
+        Polls rather than blocking on ``Queue.get(timeout=budget)`` so that a
+        child which dies without writing is noticed immediately instead of
+        after the full budget. Reads BEFORE joining, so a result larger than the
+        pipe buffer cannot deadlock the child inside its own flush.
+
+        Returns:
+            ``(message, "message")`` on success, or ``(None, "timeout")`` /
+            ``(None, "exited")`` when no message arrived.
+        """
+        deadline = time.monotonic() + budget
+
+        while True:
+            try:
+                return result_queue.get(timeout=_POLL_INTERVAL), "message"
+            except QueueEmpty:
+                pass
+
+            if not process.is_alive():
+                # Last chance: the child may have written just before exiting.
+                try:
+                    return result_queue.get(timeout=_DRAIN_TIMEOUT), "message"
+                except QueueEmpty:
+                    return None, "exited"
+
+            if time.monotonic() >= deadline:
+                return None, "timeout"
+
+    @staticmethod
+    def _reap(process: Any) -> None:
+        """Terminate, kill, and release the child process. Never raises."""
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=_REAP_TIMEOUT)
+
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=_REAP_TIMEOUT)
+
+        if process.exitcode is not None:
+            # ``close()`` releases the process handle/fds; it is only legal once
+            # the child has actually been reaped.
+            process.close()
 
 
 class IsolatedHookManager(HookManager):

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/isolation.py
@@ -135,69 +135,119 @@ class ResourceLimits:
         self.max_cpu_seconds = max_cpu_seconds
         self.max_file_size_mb = max_file_size_mb
 
-    def apply(self) -> None:
+    def apply(self) -> list[str]:
         """
         Apply resource limits to current process.
 
-        Uses resource.setrlimit() on Unix systems. On Windows, logs a warning
-        as resource limits are not supported.
+        Each limit is applied INDEPENDENTLY, because platform support is
+        per-resource rather than all-or-nothing: macOS accepts ``RLIMIT_CPU``
+        and ``RLIMIT_FSIZE`` but refuses ``RLIMIT_AS`` outright, so applying
+        them as one block would discard the two limits the platform does
+        enforce along with the one it does not.
+
+        A refusal is only tolerated when it is a PLATFORM CAPABILITY GAP -- the
+        kernel rejecting a value that is within the current hard limit, which is
+        the signature of a resource it does not implement. A refusal of a value
+        that genuinely exceeds the hard limit is a real misconfiguration and is
+        re-raised.
+
+        Returns:
+            Names of the limits that could NOT be enforced (empty list when all
+            applied). The caller is expected to surface these: an unenforced
+            limit is a security control that is OFF, and the child's own log
+            records do not reach the parent's handlers under ``spawn``.
 
         Raises:
-            ImportError: If resource module is not available (Windows)
-            OSError: If setrlimit fails (insufficient privileges)
+            OSError: If setrlimit fails for a value exceeding the hard limit
+                (a real misconfiguration, not a platform capability gap)
+            ValueError: Likewise, for the ValueError variant CPython raises for
+                the same condition
 
         Example:
             >>> limits = ResourceLimits(max_memory_mb=100)
-            >>> limits.apply()  # Applies limits on Unix, warns on Windows
+            >>> unenforced = limits.apply()
+            >>> if unenforced:
+            >>>     print(f"NOT enforced on this platform: {unenforced}")
         """
+        all_limits = ["max_memory_mb", "max_cpu_seconds", "max_file_size_mb"]
+
         # Check platform support
         if sys.platform == "win32":
             logger.warning(
                 "SECURITY: Resource limits not supported on Windows. "
                 "Process isolation will be used without resource limits."
             )
-            return
+            return all_limits
 
         try:
             import resource
-
-            # Memory limit (virtual address space)
-            max_memory_bytes = self.max_memory_mb * 1024 * 1024
-            resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
-            logger.debug(f"Applied memory limit: {self.max_memory_mb}MB")
-
-            # CPU time limit
-            resource.setrlimit(
-                resource.RLIMIT_CPU, (self.max_cpu_seconds, self.max_cpu_seconds)
-            )
-            logger.debug(f"Applied CPU limit: {self.max_cpu_seconds} seconds")
-
-            # File size limit
-            max_file_bytes = self.max_file_size_mb * 1024 * 1024
-            resource.setrlimit(resource.RLIMIT_FSIZE, (max_file_bytes, max_file_bytes))
-            logger.debug(f"Applied file size limit: {self.max_file_size_mb}MB")
-
         except ImportError:
             logger.warning(
                 "SECURITY: resource module not available. "
                 "Resource limits cannot be applied."
             )
-        except OSError as e:
-            # ``scrub_local_error``, not ``scrub_remote_error``: this OSError
-            # comes from ``resource.setrlimit``, an in-process OS call, so the
-            # conservative preset is right -- it keeps the shape-only rules OFF
-            # and preserves the errno text and any path, which ARE the
-            # diagnostic here.
-            #
-            # The credential risk today is nil (setrlimit takes ints, not
-            # caller strings). It is scrubbed anyway because the raw-exception-
-            # in-an-f-string SHAPE is one edit away from being a leak: the
-            # moment this block covers a limit derived from a caller-supplied
-            # value, the sink is already wrong and nothing would flag it.
-            logger.error(
-                "SECURITY: Failed to apply resource limits: %s", scrub_local_error(e)
+            return all_limits
+
+        unenforced: list[str] = []
+
+        for label, rlimit_name, value in (
+            ("max_memory_mb", "RLIMIT_AS", self.max_memory_mb * 1024 * 1024),
+            ("max_cpu_seconds", "RLIMIT_CPU", self.max_cpu_seconds),
+            ("max_file_size_mb", "RLIMIT_FSIZE", self.max_file_size_mb * 1024 * 1024),
+        ):
+            rlimit = getattr(resource, rlimit_name, None)
+            if rlimit is None:
+                # The platform's resource module does not define this resource.
+                unenforced.append(label)
+                continue
+
+            _soft, hard = resource.getrlimit(rlimit)
+
+            try:
+                resource.setrlimit(rlimit, (value, value))
+            except (OSError, ValueError) as e:
+                # ``scrub_local_error``, not ``scrub_remote_error``: this comes
+                # from ``resource.setrlimit``, an in-process OS call, so the
+                # conservative preset is right -- it keeps the shape-only rules
+                # OFF and preserves the errno text, which IS the diagnostic.
+                #
+                # The credential risk today is nil (setrlimit takes ints, not
+                # caller strings). It is scrubbed anyway because the raw-
+                # exception-in-a-log-argument SHAPE is one edit away from being
+                # a leak: the moment this block covers a limit derived from a
+                # caller-supplied value, the sink is already wrong and nothing
+                # would flag it.
+                within_hard = hard == resource.RLIM_INFINITY or value <= hard
+                if not within_hard:
+                    logger.error(
+                        "SECURITY: Failed to apply resource limit %s: %s",
+                        label,
+                        scrub_local_error(e),
+                    )
+                    raise
+
+                # Refused despite being within the hard limit: this kernel does
+                # not implement the resource (macOS and RLIMIT_AS).
+                unenforced.append(label)
+                logger.warning(
+                    "SECURITY: %s (%s) is not enforceable on this platform: %s",
+                    label,
+                    rlimit_name,
+                    scrub_local_error(e),
+                )
+            else:
+                logger.debug("Applied resource limit %s: %s", label, value)
+
+        if unenforced:
+            logger.warning(
+                "SECURITY: Hook process isolation is ACTIVE, but these resource "
+                "limits are NOT enforced on this platform: %s. The hook is "
+                "confined to its own process but is not capped on those "
+                "resources.",
+                ", ".join(unenforced),
             )
-            raise
+
+        return unenforced
 
 
 def _isolated_hook_worker(
@@ -219,10 +269,17 @@ def _isolated_hook_worker(
 
     The worker speaks a 3-tuple protocol on ``result_queue``:
     ``(status, payload, worker_pid)`` where status is one of
-    ``ready`` / ``success`` / ``error``. ``ready`` is sent FIRST, before any
-    caller-supplied code runs, so the parent can (a) confirm a real child is
-    alive and (b) charge interpreter startup to a separate budget instead of
-    the hook's timeout.
+    ``ready`` / ``success`` / ``error``. ``ready`` is sent once the sandbox is
+    fully in place and BEFORE any caller-supplied code runs, so the parent can
+    (a) confirm a real child is alive, (b) charge interpreter startup to a
+    separate budget instead of the hook's timeout, and (c) learn which resource
+    limits this platform refused to enforce.
+
+    The ``ready`` payload carries that unenforced-limit list because the child's
+    own ``logger`` records do NOT reach the parent's handlers: under ``spawn``
+    the child is a fresh interpreter with a default, unconfigured logging setup,
+    so a warning emitted here would be written to nothing. The parent re-logs
+    it against its own handlers instead.
 
     Args:
         limits: Resource limits to apply before running any hook code
@@ -232,13 +289,11 @@ def _isolated_hook_worker(
     """
     worker_pid = os.getpid()
 
-    # Sent BEFORE limits are applied and before any caller-supplied code runs:
-    # it is the parent's proof that a distinct process exists.
-    result_queue.put(("ready", None, worker_pid))
-
     try:
-        limits.apply()
+        unenforced = limits.apply()
     except Exception as e:
+        # Reported INSTEAD of ``ready``: the sandbox was not established, so the
+        # parent must treat this as an isolation failure and never run the hook.
         # ``scrub_local_error`` matches ``ResourceLimits.apply``: this is an
         # in-process OS call whose errno text IS the diagnostic.
         result_queue.put(
@@ -249,6 +304,10 @@ def _isolated_hook_worker(
             )
         )
         return
+
+    # Sent before any caller-supplied code runs: it is the parent's proof that a
+    # distinct process exists and that the sandbox is established.
+    result_queue.put(("ready", unenforced, worker_pid))
 
     try:
         start_time = time.perf_counter()
@@ -419,7 +478,12 @@ class IsolatedHookExecutor:
             # The supervision loop blocks on a queue and on process reaping;
             # running it in a worker thread keeps the caller's event loop free.
             return await asyncio.to_thread(
-                self._supervise, process, result_queue, handler_name, timeout, parent_pid
+                self._supervise,
+                process,
+                result_queue,
+                handler_name,
+                timeout,
+                parent_pid,
             )
         finally:
             self._reap(process)
@@ -455,7 +519,15 @@ class IsolatedHookExecutor:
                 f"exit code: {process.exitcode})",
             )
 
-        status, _payload, worker_pid = message
+        status, payload, worker_pid = message
+        if status == "error":
+            # The child reached its entry point but could not establish the
+            # sandbox (resource limits refused). The control is not in place, so
+            # the hook must not run.
+            raise HookIsolationError(
+                handler_name,
+                f"the isolated process could not establish its sandbox: {payload}",
+            )
         if status != "ready":
             raise HookIsolationError(
                 handler_name,
@@ -477,6 +549,17 @@ class IsolatedHookExecutor:
             worker_pid,
             parent_pid,
         )
+
+        if payload:
+            # Re-logged HERE rather than left to the child: under ``spawn`` the
+            # child's logging is unconfigured, so its own warning went nowhere.
+            logger.warning(
+                "SECURITY: Hook %s is isolated in process %s, but these resource "
+                "limits are NOT enforced on this platform: %s",
+                handler_name,
+                worker_pid,
+                ", ".join(payload),
+            )
 
         # PHASE 2: the hook's own result.
         message, reason = self._receive(process, result_queue, timeout)
@@ -581,11 +664,13 @@ class IsolatedHookManager(HookManager):
     - Interfering with other hooks
 
     Features:
-    - Process isolation via multiprocessing
-    - Configurable resource limits (memory, CPU, file size)
-    - Optional isolation (can be disabled for backward compatibility)
-    - Graceful degradation on Windows (no resource limits)
-    - Comprehensive error handling
+    - Process isolation via multiprocessing, under an explicitly-pinned
+      ``spawn`` start method on every platform
+    - Configurable resource limits (memory, CPU, file size), each applied
+      independently and each reported when the platform refuses to enforce it
+    - Optional isolation, disabled only by explicit ``enable_isolation=False``
+    - Fails CLOSED: if isolation cannot be established the hook is not run and
+      ``HookIsolationError`` is raised (issue #2014)
 
     Example:
         >>> from kaizen.core.autonomy.hooks.security import IsolatedHookManager, ResourceLimits
@@ -612,7 +697,15 @@ class IsolatedHookManager(HookManager):
     - Prevents malicious hooks from compromising agent
     - Isolates hook execution in separate processes
     - Applies resource limits to prevent exhaustion attacks
-    - Maintains backward compatibility with non-isolated mode
+    - Never downgrades itself to non-isolated execution (issue #2014)
+
+    Note:
+        Handlers registered on an isolating manager MUST be picklable, because
+        ``spawn`` transfers them to a fresh interpreter by pickle. In practice
+        that means the handler is a class or function defined at MODULE scope.
+        A lambda, a closure, or a function defined inside a test body cannot be
+        isolated and will raise ``HookIsolationError`` rather than silently
+        running unisolated.
     """
 
     def __init__(
@@ -673,10 +766,14 @@ class IsolatedHookManager(HookManager):
         Returns:
             HookResult with success/failure status
 
+        Raises:
+            HookIsolationError: If isolation was requested but could not be
+                established. The hook is NOT executed in that case.
+
         SECURITY FIX #5:
         - Executes hook in isolated process if enable_isolation=True
-        - Falls back to normal execution if isolation fails
-        - Maintains backward compatibility with non-isolated mode
+        - Fails CLOSED if isolation cannot be established (issue #2014)
+        - Non-isolated execution remains available, but only by explicit opt-out
         """
         handler_name = getattr(handler, "name", safe_handler_name(handler))
 
@@ -685,35 +782,63 @@ class IsolatedHookManager(HookManager):
             # Use parent implementation (no isolation)
             return await super()._execute_hook(handler, context, timeout)
 
-        # Execute in isolated process
+        # Execute in isolated process.
+        #
+        # There is deliberately NO fallback to ``super()._execute_hook`` here
+        # (issue #2014). Running the hook in-process when isolation fails is not
+        # a degraded mode of this control -- it is the control switched OFF,
+        # applied to the exact code the control exists to contain, while the
+        # caller is handed a successful-looking HookResult. The failure it hid
+        # was total: under the ``spawn`` start method the old closure-based
+        # worker could never be pickled, so isolation failed on EVERY call on
+        # macOS and Windows and every hook ran with full agent privileges.
+        #
+        # A caller that genuinely wants non-isolated execution asks for it by
+        # constructing the manager with ``enable_isolation=False``, which is
+        # visible at the call site and logged as a warning at construction.
         try:
             logger.debug(f"Executing hook in isolated process: {handler_name}")
             result = await self.executor.execute_isolated(handler, context, timeout)
-
-            # Update stats
-            self._update_stats(handler_name, result.duration_ms, success=result.success)
-
-            return result
-
-        except Exception as e:
-            # Isolation failed - log error and fall back to normal execution.
-            # ``e`` comes from ``execute_isolated``, which runs CALLER-SUPPLIED
-            # hook code, so it is the same credential surface as the handler
-            # repr on this line. This module imported no scrubber at all before
-            # the F11 sweep, leaving it un-swept for the exception half.
+        except HookIsolationError as e:
+            # Already typed and already scrubbed at construction; re-logged so
+            # the operator sees WHICH control failed, then propagated.
             logger.error(
-                "SECURITY: Hook isolation failed for %s, "
-                "falling back to normal execution: %s",
+                "SECURITY: Hook isolation could not be established for %s; "
+                "the hook was NOT executed: %s",
+                handler_name,
+                e.reason,
+            )
+            self._update_stats(handler_name, 0, success=False)
+            raise
+        except Exception as e:
+            # Anything else from ``execute_isolated`` is an isolation-machinery
+            # failure rather than a hook failure (hook exceptions come back as
+            # an unsuccessful HookResult, not as a raise). It is converted to
+            # the typed error so callers have ONE exception type to handle, and
+            # scrubbed because ``execute_isolated`` drives CALLER-SUPPLIED hook
+            # code and this text reaches both a log line and the raised message.
+            logger.error(
+                "SECURITY: Hook isolation failed for %s; the hook was NOT "
+                "executed: %s",
                 handler_name,
                 scrub_remote_error(e),
             )
+            self._update_stats(handler_name, 0, success=False)
+            raise HookIsolationError(
+                handler_name,
+                f"the isolation machinery failed: {scrub_remote_error(e)}",
+            ) from e
 
-            # Fall back to parent implementation
-            return await super()._execute_hook(handler, context, timeout)
+        # Update stats
+        self._update_stats(handler_name, result.duration_ms, success=result.success)
+
+        return result
 
 
 # Export public API
 __all__ = [
+    "DEFAULT_STARTUP_TIMEOUT",
+    "HookIsolationError",
     "ResourceLimits",
     "IsolatedHookExecutor",
     "IsolatedHookManager",

--- a/packages/kailash-kaizen/tests/e2e/security/_isolation_hooks.py
+++ b/packages/kailash-kaizen/tests/e2e/security/_isolation_hooks.py
@@ -1,0 +1,146 @@
+"""Module-scope hook handlers for the isolation E2E tests (issue #2014).
+
+Every handler an isolating ``IsolatedHookManager`` runs MUST be picklable,
+because the ``spawn`` start method transfers it to a fresh interpreter by
+pickle. Pickle stores a function by its ``module.qualname``, so a hook defined
+inside a test body cannot be transferred and cannot be isolated.
+
+Before #2014 that did not appear to matter: isolation failed and the manager
+silently ran the hook in the agent's own process instead, so tests that defined
+their hooks locally passed while exercising nothing. They now fail loudly, which
+is the point. Handlers therefore live here, at module scope, where the child can
+import them.
+"""
+
+import functools
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+from kaizen.core.autonomy.hooks.types import HookContext, HookResult
+
+
+@functools.lru_cache(maxsize=1)
+def unenforceable_limits() -> frozenset[str]:
+    """Which resource limits this platform refuses to enforce.
+
+    Probed in a SUBPROCESS, never in the test process. ``ResourceLimits.apply()``
+    sets the hard limit as well as the soft one, and lowering a hard limit is
+    irreversible for the process that does it -- calling it here would cap the
+    pytest process itself and make every later test in the session fail while
+    trying to set a higher limit.
+    """
+    probe = (
+        "import json, sys;"
+        "sys.path.insert(0, %r);"
+        "from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits;"
+        "print(json.dumps(ResourceLimits("
+        "max_memory_mb=64, max_cpu_seconds=3600, max_file_size_mb=1"
+        ").apply()))" % (_src_root(),)
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=120
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"resource-limit capability probe failed: {completed.stderr[-2000:]}"
+        )
+    return frozenset(json.loads(completed.stdout.strip().splitlines()[-1]))
+
+
+def _src_root() -> str:
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(here, "..", "..", "..", "src"))
+
+
+class SuccessHook:
+    """Minimal successful hook, for overhead measurement and ordering checks."""
+
+    name = "success-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        return HookResult(success=True, data={"pid": os.getpid()})
+
+
+class CrashingHook:
+    """Raises in the child, to prove a hook crash cannot take the parent down."""
+
+    name = "crashing-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        raise RuntimeError("simulated hook crash")
+
+
+class MemoryHogHook:
+    """Allocates far more memory than the configured cap allows.
+
+    Reports what actually happened rather than asserting, so the caller can hold
+    the platform-specific expectation: Linux enforces ``RLIMIT_AS`` and this
+    raises ``MemoryError``; macOS refuses to set ``RLIMIT_AS`` at all and the
+    allocation succeeds.
+    """
+
+    name = "memory-hog-hook"
+
+    def __init__(self, allocate_mb: int = 512):
+        self.allocate_mb = allocate_mb
+
+    async def handle(self, context: HookContext) -> HookResult:
+        try:
+            # bytearray allocates real address space immediately.
+            blob = bytearray(self.allocate_mb * 1024 * 1024)
+            return HookResult(success=True, data={"allocated": len(blob)})
+        except MemoryError:
+            return HookResult(success=False, error="MemoryError: allocation refused")
+
+
+class CpuHogHook:
+    """Burns CPU well past the configured CPU-seconds cap."""
+
+    name = "cpu-hog-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        total = 0
+        for i in range(1_000_000_000):
+            total += i
+        return HookResult(success=True, data={"total": total})
+
+
+class FileWriterHook:
+    """Writes far more than the configured file-size cap allows."""
+
+    name = "file-writer-hook"
+
+    def __init__(self, write_mb: int = 10):
+        self.write_mb = write_mb
+
+    async def handle(self, context: HookContext) -> HookResult:
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=True) as handle:
+                handle.write(b"0" * (self.write_mb * 1024 * 1024))
+                handle.flush()
+            return HookResult(success=True, data={"written_mb": self.write_mb})
+        except OSError as exc:
+            return HookResult(success=False, error=f"file size limit: {exc}")
+
+
+class MutatingHook:
+    """Mutates a process-global, to show the mutation cannot escape the child.
+
+    A hook that runs in the agent's own process can corrupt the agent's state.
+    One that is genuinely isolated cannot: the mutation dies with the child.
+    """
+
+    name = "mutating-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        global LEAKED_STATE
+        LEAKED_STATE = "written-by-hook"
+        return HookResult(success=True, data={"pid": os.getpid()})
+
+
+#: Stays at its import-time value in the PARENT for as long as hooks really are
+#: isolated. ``MutatingHook`` overwrites it only inside its own process.
+LEAKED_STATE = "clean"

--- a/packages/kailash-kaizen/tests/e2e/security/test_compliance_validation_e2e.py
+++ b/packages/kailash-kaizen/tests/e2e/security/test_compliance_validation_e2e.py
@@ -47,6 +47,8 @@ from kaizen.core.autonomy.hooks.security.validation import (
 )
 from kaizen.core.autonomy.hooks.types import HookContext, HookResult
 
+from . import _isolation_hooks as isolation_hooks
+
 logger = logging.getLogger(__name__)
 
 
@@ -478,35 +480,35 @@ async def test_soc2_availability():
     - Capacity management
     - Incident response
     """
-    # SOC2 Availability: System availability via isolation
+    # SOC2 Availability: System availability via isolation.
+    #
+    # The hook is defined at MODULE scope (see _isolation_hooks) because an
+    # isolating manager transfers it to a fresh interpreter by pickle. Defined
+    # inside this test body it could not be transferred, and before #2014 that
+    # silently meant the hook ran in the agent's own process -- so this test
+    # asserted availability of a control that was not engaged.
     manager = IsolatedHookManager(
-        limits=ResourceLimits(max_memory_mb=100, max_cpu_seconds=5),
+        limits=ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60),
         enable_isolation=True,
     )
 
-    async def failing_hook(context: HookContext) -> HookResult:
-        raise Exception("Simulated failure")
-
-    # Register failing hook
-    manager.register(HookEvent.PRE_AGENT_LOOP, failing_hook, HookPriority.NORMAL)
-
-    # Test system remains available despite hook failure
-    context = HookContext(
-        event_type=HookEvent.PRE_AGENT_LOOP,
-        agent_id="agent-001",
-        data={},
-        timestamp=datetime.now(),
+    manager.register(
+        HookEvent.PRE_AGENT_LOOP, isolation_hooks.CrashingHook(), HookPriority.NORMAL
     )
 
     results = await manager.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=1.0,
+        timeout=30.0,
     )
 
-    # System should remain available (graceful degradation)
-    assert isinstance(results, list), "SOC2: System should remain available"
+    # Availability means the crash was CONTAINED and reported, not that a list
+    # came back. The previous assertion (isinstance(results, list)) held for
+    # every possible outcome, including the hook taking down agent state.
+    assert len(results) == 1, "SOC2: the hook should have been executed once"
+    assert results[0].success is False, "SOC2: the failing hook should report failure"
+    assert "crash" in (results[0].error or "").lower(), results[0].error
 
     logger.info("✅ SOC2 Trust Principle (Availability): PASSED")
 

--- a/packages/kailash-kaizen/tests/e2e/security/test_platform_compatibility_e2e.py
+++ b/packages/kailash-kaizen/tests/e2e/security/test_platform_compatibility_e2e.py
@@ -11,6 +11,7 @@ Test Tier: 3 (E2E with real infrastructure, NO MOCKING)
 
 import asyncio
 import logging
+import os
 import platform
 import sys
 from datetime import datetime
@@ -21,9 +22,17 @@ from kaizen.core.autonomy.hooks import HookEvent, HookPriority
 from kaizen.core.autonomy.hooks.security import IsolatedHookManager, ResourceLimits
 from kaizen.core.autonomy.hooks.types import HookContext, HookResult
 
+from . import _isolation_hooks as hooks
+
 logger = logging.getLogger(__name__)
 
 CURRENT_PLATFORM = platform.system()  # Linux, Darwin (macOS), Windows
+
+#: Startup budget for a spawned child. Under ``spawn`` the child pays a full
+#: interpreter start plus the import of the handler's module, which is far more
+#: than the sub-second budgets these tests used while isolation was silently not
+#: happening (issue #2014).
+ISOLATION_TIMEOUT = 30.0
 
 
 # ============================================================================
@@ -76,39 +85,51 @@ async def test_unix_memory_limit():
     """
     Test memory limit enforcement on Unix/Linux/macOS.
 
-    Validates:
-    - Memory limits applied successfully
-    - Memory exhaustion prevented
-    - Graceful failure on memory exceeded
+    Asserts the OUTCOME rather than merely that a hook ran. The previous version
+    asserted ``len(results) == 1``, which is true whether the cap was applied,
+    ignored, or never reachable at all -- and it was in fact never reachable,
+    because isolation was silently failing (issue #2014).
+
+    The expectation is platform-split because the capability genuinely is:
+    Linux enforces ``RLIMIT_AS``, macOS refuses to set it at all. Both branches
+    are asserted, so neither can pass by accident on the other's platform.
     """
-    # Create manager with strict memory limit
-    limits = ResourceLimits(max_memory_mb=50, max_cpu_seconds=5, max_file_size_mb=10)
+    limits = ResourceLimits(max_memory_mb=50, max_cpu_seconds=60, max_file_size_mb=10)
+    unenforced = hooks.unenforceable_limits()
 
     manager = IsolatedHookManager(limits=limits, enable_isolation=True)
+    manager.register(
+        HookEvent.PRE_AGENT_LOOP,
+        hooks.MemoryHogHook(allocate_mb=512),
+        HookPriority.NORMAL,
+    )
 
-    # Create memory-intensive hook
-    async def memory_hog_hook(context: HookContext) -> HookResult:
-        # Try to allocate 100MB (exceeds 50MB limit)
-        try:
-            data = [0] * (100 * 1024 * 1024 // 8)  # 100MB of integers
-            return HookResult(success=True)
-        except MemoryError:
-            return HookResult(success=False, error="Memory limit exceeded")
-
-    manager.register(HookEvent.PRE_AGENT_LOOP, memory_hog_hook, HookPriority.NORMAL)
-
-    # Trigger hook (should fail due to memory limit)
     results = await manager.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=5.0,
+        timeout=ISOLATION_TIMEOUT,
     )
 
-    # Validate graceful failure
     assert len(results) == 1, "Hook should execute once"
-    # Note: Hook may fail or succeed depending on OS enforcement timing
-    logger.info("✅ Unix/Linux/macOS: Memory limit test completed")
+
+    if "max_memory_mb" in unenforced:
+        # macOS: the cap is not enforceable, and the code says so out loud.
+        assert results[0].success is True, (
+            "the allocation should succeed where the platform cannot cap it; "
+            f"got {results[0].error!r}"
+        )
+    else:
+        # Linux: a 512MB allocation under a 50MB cap must be refused.
+        assert results[0].success is False, (
+            "a 512MB allocation succeeded under a 50MB RLIMIT_AS cap: the "
+            "memory limit was not applied in the isolated process"
+        )
+    logger.info(
+        "✅ %s: memory limit outcome asserted (unenforced=%s)",
+        CURRENT_PLATFORM,
+        unenforced,
+    )
 
 
 @pytest.mark.skipif(
@@ -124,34 +145,32 @@ async def test_unix_cpu_limit():
     - Infinite loops prevented
     - Graceful failure on CPU exceeded
     """
-    # Create manager with strict CPU limit
-    limits = ResourceLimits(max_memory_mb=100, max_cpu_seconds=2, max_file_size_mb=10)
+    limits = ResourceLimits(max_memory_mb=4096, max_cpu_seconds=2, max_file_size_mb=10)
+    assert "max_cpu_seconds" not in hooks.unenforceable_limits(), (
+        "RLIMIT_CPU is expected to be enforceable on every non-Windows platform "
+        "this test runs on"
+    )
 
     manager = IsolatedHookManager(limits=limits, enable_isolation=True)
+    manager.register(HookEvent.PRE_AGENT_LOOP, hooks.CpuHogHook(), HookPriority.NORMAL)
 
-    # Create CPU-intensive hook
-    async def cpu_hog_hook(context: HookContext) -> HookResult:
-        # Infinite loop (should be killed by CPU limit)
-        count = 0
-        while True:
-            count += 1
-            if count > 1000000:
-                break
-        return HookResult(success=True)
-
-    manager.register(HookEvent.PRE_AGENT_LOOP, cpu_hog_hook, HookPriority.NORMAL)
-
-    # Trigger hook (should timeout or be killed by CPU limit)
     results = await manager.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=5.0,
+        timeout=ISOLATION_TIMEOUT,
     )
 
-    # Validate graceful failure
+    # The child burns a billion additions against a 2-second CPU cap. It is
+    # killed by SIGXCPU long before finishing, so the ONLY way this reports
+    # success is if the cap was never applied -- which is what a silently
+    # non-isolated execution looks like.
     assert len(results) == 1, "Hook should execute once"
-    logger.info("✅ Unix/Linux/macOS: CPU limit test completed")
+    assert results[0].success is False, (
+        "an unbounded CPU loop completed under a 2-second RLIMIT_CPU cap: the "
+        "CPU limit was not applied in the isolated process"
+    )
+    logger.info("✅ %s: CPU limit enforced (hook killed)", CURRENT_PLATFORM)
 
 
 @pytest.mark.skipif(
@@ -167,36 +186,32 @@ async def test_unix_file_size_limit():
     - Large file writes prevented
     - Graceful failure on file size exceeded
     """
-    import tempfile
-
-    # Create manager with strict file size limit
-    limits = ResourceLimits(max_memory_mb=100, max_cpu_seconds=5, max_file_size_mb=1)
+    limits = ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60, max_file_size_mb=1)
+    assert "max_file_size_mb" not in hooks.unenforceable_limits(), (
+        "RLIMIT_FSIZE is expected to be enforceable on every non-Windows "
+        "platform this test runs on"
+    )
 
     manager = IsolatedHookManager(limits=limits, enable_isolation=True)
+    manager.register(
+        HookEvent.PRE_AGENT_LOOP, hooks.FileWriterHook(write_mb=10), HookPriority.NORMAL
+    )
 
-    # Create file-writing hook
-    async def file_writer_hook(context: HookContext) -> HookResult:
-        # Try to write 10MB file (exceeds 1MB limit)
-        try:
-            with tempfile.NamedTemporaryFile(mode="wb", delete=True) as f:
-                f.write(b"0" * (10 * 1024 * 1024))  # 10MB
-            return HookResult(success=True)
-        except OSError as e:
-            return HookResult(success=False, error=f"File size limit: {e}")
-
-    manager.register(HookEvent.PRE_AGENT_LOOP, file_writer_hook, HookPriority.NORMAL)
-
-    # Trigger hook (should fail due to file size limit)
     results = await manager.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=5.0,
+        timeout=ISOLATION_TIMEOUT,
     )
 
-    # Validate graceful failure
+    # A 10MB write under a 1MB RLIMIT_FSIZE cap cannot complete. Success here
+    # would mean the cap was never applied.
     assert len(results) == 1, "Hook should execute once"
-    logger.info("✅ Unix/Linux/macOS: File size limit test completed")
+    assert results[0].success is False, (
+        "a 10MB write completed under a 1MB RLIMIT_FSIZE cap: the file size "
+        "limit was not applied in the isolated process"
+    )
+    logger.info("✅ %s: file size limit enforced", CURRENT_PLATFORM)
 
 
 # ============================================================================
@@ -209,38 +224,37 @@ async def test_process_isolation():
     """
     Test process isolation on all platforms.
 
-    Validates:
-    - Hooks run in separate processes
-    - Hook crashes don't affect main process
-    - Main process remains stable
+    Asserts that the hook ran SOMEWHERE ELSE, and that a mutation it made could
+    not reach this process. The previous version asserted
+    ``isinstance(results, list)``, which is true of every possible outcome --
+    including the in-process execution issue #2014 was silently doing.
     """
     manager = IsolatedHookManager(
-        limits=ResourceLimits(),  # Default limits
+        limits=ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60),
         enable_isolation=True,
     )
+    manager.register(
+        HookEvent.PRE_AGENT_LOOP, hooks.MutatingHook(), HookPriority.NORMAL
+    )
 
-    # Create crashing hook
-    async def crash_hook(context: HookContext) -> HookResult:
-        raise Exception("Simulated crash")
+    assert hooks.LEAKED_STATE == "clean"
 
-    manager.register(HookEvent.PRE_AGENT_LOOP, crash_hook, HookPriority.NORMAL)
+    results = await manager.trigger(
+        HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-001",
+        data={},
+        timeout=ISOLATION_TIMEOUT,
+    )
 
-    # Trigger hook (should crash in isolated process)
-    try:
-        results = await manager.trigger(
-            HookEvent.PRE_AGENT_LOOP,
-            agent_id="agent-001",
-            data={},
-            timeout=2.0,
-        )
-
-        # Main process should survive
-        assert isinstance(results, list), "Main process should remain stable"
-        logger.info(
-            f"✅ {CURRENT_PLATFORM}: Process isolation prevents main process crash"
-        )
-    except Exception as e:
-        pytest.fail(f"Main process crashed (isolation failed): {e}")
+    assert len(results) == 1 and results[0].success is True, results[0].error
+    assert (
+        results[0].data["pid"] != os.getpid()
+    ), "the hook ran in this process: isolation did not engage"
+    assert hooks.LEAKED_STATE == "clean", (
+        "the hook's mutation reached the parent's address space, so the hook "
+        "was not isolated and could corrupt agent state"
+    )
+    logger.info("✅ %s: hook confined to its own process", CURRENT_PLATFORM)
 
 
 @pytest.mark.asyncio
@@ -253,29 +267,31 @@ async def test_cross_hook_isolation():
     - Separate memory spaces
     - Independent execution
     """
-    manager = IsolatedHookManager(limits=ResourceLimits(), enable_isolation=True)
+    manager = IsolatedHookManager(
+        limits=ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60),
+        enable_isolation=True,
+    )
 
-    # Create two hooks: one crashes, one succeeds
-    async def crash_hook(context: HookContext) -> HookResult:
-        raise Exception("Hook A crash")
+    manager.register(HookEvent.PRE_AGENT_LOOP, hooks.CrashingHook(), HookPriority.HIGH)
+    manager.register(HookEvent.PRE_AGENT_LOOP, hooks.SuccessHook(), HookPriority.NORMAL)
 
-    async def success_hook(context: HookContext) -> HookResult:
-        return HookResult(success=True, metadata={"hook": "B"})
-
-    manager.register(HookEvent.PRE_AGENT_LOOP, crash_hook, HookPriority.HIGH)
-    manager.register(HookEvent.PRE_AGENT_LOOP, success_hook, HookPriority.NORMAL)
-
-    # Trigger both hooks
     results = await manager.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=2.0,
+        timeout=ISOLATION_TIMEOUT,
     )
 
-    # Hook B should succeed despite Hook A crash
+    # Asserts the OUTCOMES, not just the count: A must have failed, B must have
+    # succeeded despite it, and the two must have run in DIFFERENT processes
+    # from each other and from this one.
     assert len(results) == 2, "Both hooks should execute"
-    logger.info(f"✅ {CURRENT_PLATFORM}: Hooks isolated from each other")
+    assert results[0].success is False, "the crashing hook should report failure"
+    assert results[1].success is True, results[1].error
+    assert (
+        results[1].data["pid"] != os.getpid()
+    ), "the surviving hook ran in this process: isolation did not engage"
+    logger.info("✅ %s: hook crash did not affect the sibling hook", CURRENT_PLATFORM)
 
 
 # ============================================================================
@@ -350,49 +366,56 @@ async def test_performance_with_isolation():
     manager_no_isolation = IsolatedHookManager(
         limits=ResourceLimits(), enable_isolation=False
     )
-
-    async def fast_hook(context: HookContext) -> HookResult:
-        return HookResult(success=True)
-
     manager_no_isolation.register(
-        HookEvent.PRE_AGENT_LOOP, fast_hook, HookPriority.NORMAL
+        HookEvent.PRE_AGENT_LOOP, hooks.SuccessHook(), HookPriority.NORMAL
     )
 
     start = time.perf_counter()
-    results_no_isolation = await manager_no_isolation.trigger(
+    await manager_no_isolation.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=2.0,
+        timeout=ISOLATION_TIMEOUT,
     )
     duration_no_isolation = (time.perf_counter() - start) * 1000  # ms
 
     # Measure with isolation
     manager_with_isolation = IsolatedHookManager(
-        limits=ResourceLimits(), enable_isolation=True
+        limits=ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60),
+        enable_isolation=True,
     )
-
     manager_with_isolation.register(
-        HookEvent.PRE_AGENT_LOOP, fast_hook, HookPriority.NORMAL
+        HookEvent.PRE_AGENT_LOOP, hooks.SuccessHook(), HookPriority.NORMAL
     )
 
     start = time.perf_counter()
-    results_with_isolation = await manager_with_isolation.trigger(
+    await manager_with_isolation.trigger(
         HookEvent.PRE_AGENT_LOOP,
         agent_id="agent-001",
         data={},
-        timeout=2.0,
+        timeout=ISOLATION_TIMEOUT,
     )
     duration_with_isolation = (time.perf_counter() - start) * 1000  # ms
 
-    # Calculate overhead
     overhead_ms = duration_with_isolation - duration_no_isolation
     logger.info(f"Performance overhead: {overhead_ms:.2f}ms")
     logger.info(f"  Without isolation: {duration_no_isolation:.2f}ms")
     logger.info(f"  With isolation: {duration_with_isolation:.2f}ms")
 
-    # Validate acceptable overhead (< 200ms for process creation)
-    assert overhead_ms < 500, f"Isolation overhead too high: {overhead_ms:.2f}ms"
+    # LOWER bound first, and it is the load-bearing one. Isolation means a real
+    # interpreter is started, which cannot be free. The old assertion was an
+    # upper bound of 500ms, which passed comfortably for the wrong reason: no
+    # process was being created at all (issue #2014). A near-zero overhead is
+    # now a FAILURE signal rather than a good result.
+    assert overhead_ms > 50, (
+        f"isolation added only {overhead_ms:.2f}ms, which is too cheap to have "
+        f"started an interpreter -- isolation is probably not engaging"
+    )
+
+    # Upper bound calibrated against real spawn cost: a fresh interpreter plus
+    # the import of the handler's module, which is seconds rather than the
+    # sub-500ms a no-op fallback used to measure.
+    assert overhead_ms < 20000, f"Isolation overhead too high: {overhead_ms:.2f}ms"
     logger.info(f"✅ {CURRENT_PLATFORM}: Performance overhead acceptable")
 
 

--- a/packages/kailash-kaizen/tests/regression/_issue_2014_isolation_hooks.py
+++ b/packages/kailash-kaizen/tests/regression/_issue_2014_isolation_hooks.py
@@ -109,3 +109,37 @@ def build_context(data: dict[str, Any] | None = None) -> HookContext:
         timestamp=0.0,
         data=data if data is not None else {},
     )
+
+
+def _pwn(marker_path: str) -> str:
+    """Payload body. Writes the PID of whatever process reconstructs it."""
+    with open(marker_path, "w") as handle:
+        handle.write(str(os.getpid()))
+    return "pwned"
+
+
+class _Evil:
+    """Reconstructs by CALLING ``_pwn``, which is the whole attack.
+
+    ``__reduce__`` only BUILDS that instruction, so ``pickle.dumps`` succeeds --
+    which is why the child's own serializability probe could not catch it. The
+    call happens at UNPICKLE time, in whichever process deserializes.
+    """
+
+    def __init__(self, marker_path: str):
+        self.marker_path = marker_path
+
+    def __reduce__(self):
+        return (_pwn, (self.marker_path,))
+
+
+class MaliciousReduceHook:
+    """Returns a result carrying a ``__reduce__`` payload (#2037 F1)."""
+
+    name = "malicious-reduce-hook"
+
+    def __init__(self, marker_path: str):
+        self.marker_path = marker_path
+
+    async def handle(self, context: HookContext) -> HookResult:
+        return HookResult(success=True, data={"x": _Evil(self.marker_path)})

--- a/packages/kailash-kaizen/tests/regression/_issue_2014_isolation_hooks.py
+++ b/packages/kailash-kaizen/tests/regression/_issue_2014_isolation_hooks.py
@@ -1,0 +1,111 @@
+"""Module-scope hook handlers for the issue #2014 regression tests.
+
+These live in a HELPER module, not in the test module, on purpose.
+
+Under the ``spawn`` start method the child is a fresh interpreter that re-imports
+the defining module of every pickled object by name. Keeping the handlers here
+means the child imports this small, side-effect-free module rather than
+re-importing a ``test_*`` module under pytest's assertion-rewriting import hook.
+
+Everything here MUST stay importable at module scope: that is precisely the
+property issue #2014 was about.
+"""
+
+import os
+from typing import Any
+
+from kaizen.core.autonomy.hooks.types import HookContext, HookResult
+
+#: Rewritten by the PARENT process at test time, never by an importer.
+#:
+#: This is the fork-vs-spawn discriminator. Under ``fork`` the child is a copy of
+#: the parent's address space and observes the parent's mutation. Under ``spawn``
+#: the child re-imports this module from source and observes the literal below.
+#: A test that asserts on this value therefore fails on Linux (where ``fork`` is
+#: the default) if the start method is ever left to the platform.
+PARENT_ONLY_MUTATION = "not-mutated"
+
+
+class PidReportingHook:
+    """Reports the PID it actually executed in."""
+
+    name = "pid-reporting-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        return HookResult(success=True, data={"pid": os.getpid()})
+
+
+class StartMethodProbeHook:
+    """Reports whether it observed the parent's in-memory mutation.
+
+    ``"not-mutated"`` means a fresh interpreter (``spawn``).
+    ``"mutated-in-parent"`` means an inherited address space (``fork``).
+    """
+
+    name = "start-method-probe-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        return HookResult(
+            success=True,
+            data={"observed": PARENT_ONLY_MUTATION, "pid": os.getpid()},
+        )
+
+
+class CrashingHook:
+    """Raises inside the child, to prove a hook crash cannot take the parent down."""
+
+    name = "crashing-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        raise RuntimeError("simulated hook crash")
+
+
+class UnpicklableResultHook:
+    """Returns a result that cannot cross the process boundary.
+
+    A module object has no pickle representation, so this exercises the worker's
+    explicit ``pickle.dumps(result)`` probe. Without that probe the failure would
+    surface only as a queue feeder-thread traceback on the child's stderr plus a
+    silently dropped item, which the parent would misreport as "exited without a
+    result".
+    """
+
+    name = "unpicklable-result-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        import types
+
+        return HookResult(success=True, data={"mod": types})
+
+
+class EchoHook:
+    """Returns the context data it was handed, to prove the context crossed intact."""
+
+    name = "echo-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        return HookResult(success=True, data={"echoed": context.data})
+
+
+class SlowHook:
+    """Sleeps well past any test timeout, to exercise the timeout path."""
+
+    name = "slow-hook"
+
+    async def handle(self, context: HookContext) -> HookResult:
+        import asyncio
+
+        await asyncio.sleep(30)
+        return HookResult(success=True, data={"slept": True})
+
+
+def build_context(data: dict[str, Any] | None = None) -> HookContext:
+    """A picklable context for the executor-level tests."""
+    from kaizen.core.autonomy.hooks.types import HookEvent
+
+    return HookContext(
+        event_type=HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-2014",
+        timestamp=0.0,
+        data=data if data is not None else {},
+    )

--- a/packages/kailash-kaizen/tests/regression/test_f11_caller_repr_does_not_leak.py
+++ b/packages/kailash-kaizen/tests/regression/test_f11_caller_repr_does_not_leak.py
@@ -37,7 +37,10 @@ import pytest
 
 from kaizen.core.autonomy.hooks.manager import HookManager
 from kaizen.core.autonomy.hooks.protocol import BaseHook, HookHandler
-from kaizen.core.autonomy.hooks.security.isolation import IsolatedHookManager
+from kaizen.core.autonomy.hooks.security.isolation import (
+    HookIsolationError,
+    IsolatedHookManager,
+)
 from kaizen.core.autonomy.hooks.security.rate_limiting import (
     RateLimitedHookManager,
     RateLimitError,
@@ -356,6 +359,12 @@ class _FailingExecutor:
     when isolation itself fails. Spawning a real child process to force that
     would test ``multiprocessing``, not the sink; the logger under assertion is
     the real ``kaizen...isolation`` logger either way.
+
+    Since #2014 that sink fires on the way OUT: the manager logs and then
+    RAISES, rather than logging and falling back to in-process execution. The
+    leak surface is unchanged -- and in fact widened, because the scrubbed text
+    now reaches the raised exception message as well as the log line -- so both
+    are asserted below.
     """
 
     def __init__(self, message: str = "isolation unavailable") -> None:
@@ -375,38 +384,42 @@ class TestIsolatedHookManagerSinks:
 
     @pytest.mark.asyncio
     async def test_isolation_failure_does_not_log_the_handler_repr(self, capture):
-        """isolation.py:418 -- the isolation-failure fallback sink."""
+        """The isolation-failure sink, which since #2014 raises rather than falls back."""
         manager = IsolatedHookManager(enable_isolation=True)
         manager.executor = _FailingExecutor()
 
-        result = await manager._execute_hook(
-            _StructuralHandler(_SENTINEL), _context(), timeout=5.0
-        )
+        with pytest.raises(HookIsolationError):
+            await manager._execute_hook(
+                _StructuralHandler(_SENTINEL), _context(), timeout=5.0
+            )
 
-        assert result.success is False
         assert "isolation failed" in capture.text, "sink never fired; vacuous"
         assert _SENTINEL not in capture.text, capture.text
         assert "_StructuralHandler" in capture.text, capture.text
 
     @pytest.mark.asyncio
     async def test_isolation_failure_scrubs_the_exception_text(self, capture):
-        """isolation.py:437 also rendered the EXCEPTION raw, beside the repr.
+        """The same sink also rendered the EXCEPTION raw, beside the repr.
 
-        The same sink interpolates ``{e}``, and that exception comes from
-        ``executor.execute_isolated`` -- which runs the caller's hook. This
-        module imported no scrubber at all, so it was un-swept for the
-        exception-text half of the same leak class.
+        That exception comes from ``executor.execute_isolated`` -- which drives
+        the caller's hook. This module imported no scrubber at all, so it was
+        un-swept for the exception-text half of the same leak class.
+
+        Since #2014 the text reaches the RAISED message as well as the log line,
+        so both are asserted: a scrubber applied to only one of the two would
+        leave the other leaking.
         """
         manager = IsolatedHookManager(enable_isolation=True)
         manager.executor = _FailingExecutor(message=f"connect failed: {_LEAKY_URL}")
 
-        result = await manager._execute_hook(
-            _StructuralHandler("no-credential-here"), _context(), timeout=5.0
-        )
+        with pytest.raises(HookIsolationError) as excinfo:
+            await manager._execute_hook(
+                _StructuralHandler("no-credential-here"), _context(), timeout=5.0
+            )
 
-        assert result.success is False
         assert "isolation failed" in capture.text, "sink never fired; vacuous"
         assert _SENTINEL not in capture.text, capture.text
+        assert _SENTINEL not in str(excinfo.value), str(excinfo.value)
 
     def test_execute_isolated_name_is_derived_without_repr(self):
         """isolation.py:211 -- the name that reaches the RETURNED HookResult.

--- a/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
@@ -572,3 +572,58 @@ class _ExplodingExecutor:
 
     async def execute_isolated(self, handler, context, timeout):
         raise RuntimeError("multiprocessing is unavailable in this sandbox")
+
+
+class TestHookOutputCannotExecuteInTheParent:
+    """#2037 F1 -- the isolation boundary must not be one-way.
+
+    Execution was isolated, and then everything the isolated process sent back
+    was trusted: the parent received hook output through a
+    ``multiprocessing.Queue``, which UNPICKLES in the receiving process. A hook
+    returning an object whose ``__reduce__`` builds a hostile call passed the
+    child's own ``pickle.dumps`` probe -- ``__reduce__`` constructs the
+    instruction, it does not run it -- and then executed in the AGENT process
+    at unpickle time, inside the receive call, before the parent had inspected
+    status or PID. It reported ``success=True`` with no error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hostile_reduce_in_hook_output_does_not_execute_in_the_parent(
+        self, tmp_path
+    ):
+        """Falsifying result: the marker file exists and holds the PARENT's pid."""
+        marker = tmp_path / "pwned.marker"
+
+        executor = IsolatedHookExecutor(GENEROUS)
+        result = await executor.execute_isolated(
+            hooks.MaliciousReduceHook(str(marker)),
+            hooks.build_context(),
+            timeout=30.0,
+        )
+
+        assert not marker.exists(), (
+            f"the payload EXECUTED at deserialization time, writing pid "
+            f"{marker.read_text()!r} (this process is {os.getpid()}); hook "
+            f"output is being deserialized into live objects"
+        )
+        # And the hook is told its result could not cross, rather than the
+        # parent silently reporting success on a payload it could not carry.
+        assert result.success is False
+        assert "JSON primitives" in (result.error or ""), result.error
+
+    @pytest.mark.asyncio
+    async def test_ordinary_results_still_cross_intact(self):
+        """Guards the guard: the hardening must not break legitimate payloads."""
+        executor = IsolatedHookExecutor(GENEROUS)
+        result = await executor.execute_isolated(
+            hooks.EchoHook(),
+            hooks.build_context({"n": 1, "s": "x", "nested": {"a": [1, 2, None]}}),
+            timeout=30.0,
+        )
+
+        assert result.success is True, result.error
+        assert result.data["echoed"] == {
+            "n": 1,
+            "s": "x",
+            "nested": {"a": [1, 2, None]},
+        }

--- a/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
@@ -111,6 +111,30 @@ class TestWorkerIsTransferable:
         with pytest.raises((AttributeError, pickle.PicklingError)):
             pickle.dumps(_local_worker)
 
+    def test_isolation_error_is_not_caught_by_an_asyncio_loop_probe(self):
+        """The fail-closed signal must not be swallowed by unrelated control flow.
+
+        ``multi_cycle.py`` wraps hook triggers in ``except RuntimeError`` at six
+        sites to probe for "no running event loop". If HookIsolationError
+        subclassed RuntimeError, an isolation failure would be caught by a
+        branch whose comment reads "No running loop" and retried down a path the
+        operator never chose -- losing the diagnostic entirely.
+
+        Falsifying result: ``issubclass(HookIsolationError, RuntimeError)``.
+        """
+        assert not issubclass(HookIsolationError, RuntimeError), (
+            "HookIsolationError subclasses RuntimeError, so asyncio loop probes "
+            "(except RuntimeError) will swallow the fail-closed security signal"
+        )
+        assert issubclass(HookIsolationError, Exception)
+
+        # The concrete shadowing scenario, not just the class relationship.
+        with pytest.raises(HookIsolationError):
+            try:
+                raise HookIsolationError("h", "isolation unavailable")
+            except RuntimeError:  # pragma: no cover - must not catch
+                pytest.fail("an asyncio loop probe swallowed the isolation error")
+
     def test_start_method_is_pinned_not_inherited(self):
         """A platform-dependent start method is the condition that hid the bug."""
         assert _ISOLATION_START_METHOD == "spawn"

--- a/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
@@ -1,0 +1,484 @@
+"""Issue #2014 -- hook process isolation never ran under the ``spawn`` start method.
+
+WHAT WAS BROKEN
+
+``IsolatedHookExecutor.execute_isolated`` built its worker as a CLOSURE inside
+the method. ``spawn`` transfers the process target by pickling it, and pickle
+stores a function by its ``module.qualname`` rather than by its code, so a local
+object has no representation at all -- ``Process.start()`` raised
+``Can't get local object 'IsolatedHookExecutor.execute_isolated.<locals>._run_hook'``
+on every single call. ``IsolatedHookManager._execute_hook`` then caught that,
+logged it, and ran the hook through ``super()._execute_hook`` instead.
+
+``spawn`` is the default start method on macOS and Windows. On those platforms
+isolation therefore failed for EVERY hook, every time, and every hook ran in the
+agent's own process with the agent's own privileges -- while the caller was
+handed a successful-looking ``HookResult``. Only Linux, where ``fork`` is the
+default, isolated anything at all.
+
+WHY THESE TESTS ARE WRITTEN THIS WAY
+
+A test that merely calls an isolating manager and asserts the call succeeded
+passes identically whether isolation happened or not -- that is exactly how the
+pre-existing suite stayed green across the entire bug. Every test below is
+therefore pinned to an observable that DIFFERS between the isolated and the
+non-isolated execution:
+
+* the PID the hook body actually ran in,
+* whether the child observed a mutation only the parent's address space holds,
+* whether an in-process side effect fired at all.
+
+The start method is pinned to ``spawn`` explicitly rather than left to the
+platform. That matters for CI: on Linux ``fork`` is the default, a forked child
+inherits the parent's memory, and the fork/spawn discrimination test below would
+pass for the wrong reason if the pin were ever dropped.
+"""
+
+import multiprocessing
+import os
+import pickle
+import subprocess
+import sys
+
+import pytest
+
+from kaizen.core.autonomy.hooks.manager import HookManager
+from kaizen.core.autonomy.hooks.security.isolation import (
+    _ISOLATION_START_METHOD,
+    HookIsolationError,
+    IsolatedHookExecutor,
+    IsolatedHookManager,
+    ResourceLimits,
+    _isolated_hook_worker,
+)
+from kaizen.core.autonomy.hooks.types import HookEvent, HookPriority, HookResult
+
+from . import _issue_2014_isolation_hooks as hooks
+
+pytestmark = pytest.mark.regression
+
+
+#: Limits generous enough that nothing here is killed by a resource cap.
+#: The limit-enforcement behaviour has its own tests further down; the isolation
+#: tests must not be able to fail for a resource reason.
+GENEROUS = ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60, max_file_size_mb=64)
+
+#: Written by a hook that runs IN THIS PROCESS. It stays empty for as long as
+#: every hook really is isolated, which is what makes it a usable detector.
+_IN_PROCESS_SIDE_EFFECTS: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _clear_side_effects():
+    _IN_PROCESS_SIDE_EFFECTS.clear()
+    yield
+    _IN_PROCESS_SIDE_EFFECTS.clear()
+
+
+# --------------------------------------------------------------------------
+# The mechanism that could not work: a closure cannot cross a spawn boundary
+# --------------------------------------------------------------------------
+
+
+class TestWorkerIsTransferable:
+    def test_worker_lives_at_module_scope_and_survives_pickling(self):
+        """The direct regression assertion for the original defect.
+
+        Pickling the worker is precisely what ``Process.start()`` does under
+        ``spawn``. The pre-fix closure raised ``AttributeError: Can't get local
+        object ...`` here; that is the falsifying result this asserts against.
+        """
+        restored = pickle.loads(pickle.dumps(_isolated_hook_worker))
+
+        assert restored is _isolated_hook_worker
+        assert _isolated_hook_worker.__qualname__ == "_isolated_hook_worker", (
+            "the worker must stay at module scope: a nested or closure worker "
+            "has no pickle representation and cannot be spawned"
+        )
+
+    def test_a_closure_worker_would_not_have_survived(self):
+        """Pins the mechanism itself, so the test above cannot pass vacuously.
+
+        If pickling a local function ever started working, the assertion above
+        would no longer discriminate between a module-scope worker and the
+        closure that caused #2014.
+        """
+
+        def _local_worker():  # pragma: no cover - never called
+            return None
+
+        with pytest.raises((AttributeError, pickle.PicklingError)):
+            pickle.dumps(_local_worker)
+
+    def test_start_method_is_pinned_not_inherited(self):
+        """A platform-dependent start method is the condition that hid the bug."""
+        assert _ISOLATION_START_METHOD == "spawn"
+        assert _ISOLATION_START_METHOD in multiprocessing.get_all_start_methods()
+
+
+# --------------------------------------------------------------------------
+# The control actually engages
+# --------------------------------------------------------------------------
+
+
+class TestHookReallyRunsElsewhere:
+    @pytest.mark.asyncio
+    async def test_hook_body_executes_in_a_different_process(self):
+        """The PID the hook OBSERVED, not the fact that the call returned.
+
+        Falsifying result: ``data["pid"] == os.getpid()``, which is what the
+        pre-fix fallback produced on every call under spawn.
+        """
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        result = await executor.execute_isolated(
+            hooks.PidReportingHook(), hooks.build_context(), timeout=30.0
+        )
+
+        assert result.success is True, result.error
+        assert (
+            result.data["pid"] != os.getpid()
+        ), "the hook ran in the parent process: isolation did not engage"
+
+    @pytest.mark.asyncio
+    async def test_child_is_a_fresh_interpreter_not_a_fork(self, monkeypatch):
+        """Discriminates ``spawn`` from ``fork``, and so is meaningful on Linux.
+
+        The parent mutates a module global in its own address space only. A
+        ``fork``ed child inherits that mutation; a ``spawn``ed child re-imports
+        the module from source and cannot see it.
+
+        Falsifying result: ``observed == "mutated-in-parent"``, meaning the
+        start method was inherited from the platform rather than pinned -- the
+        condition under which #2014 stayed invisible on Linux.
+        """
+        monkeypatch.setattr(hooks, "PARENT_ONLY_MUTATION", "mutated-in-parent")
+        assert hooks.PARENT_ONLY_MUTATION == "mutated-in-parent"
+
+        executor = IsolatedHookExecutor(GENEROUS)
+        result = await executor.execute_isolated(
+            hooks.StartMethodProbeHook(), hooks.build_context(), timeout=30.0
+        )
+
+        assert result.success is True, result.error
+        assert result.data["observed"] == "not-mutated", (
+            "the child inherited the parent's address space: this is fork, not "
+            "spawn, and the picklability contract is not being enforced"
+        )
+        assert result.data["pid"] != os.getpid()
+
+    @pytest.mark.asyncio
+    async def test_context_crosses_the_boundary_intact(self):
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        result = await executor.execute_isolated(
+            hooks.EchoHook(), hooks.build_context({"payload": [1, 2, 3]}), timeout=30.0
+        )
+
+        assert result.success is True, result.error
+        assert result.data["echoed"] == {"payload": [1, 2, 3]}
+
+    @pytest.mark.asyncio
+    async def test_hook_crash_is_contained_and_reported(self):
+        """A crash in the child is a hook failure, never an isolation failure."""
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        result = await executor.execute_isolated(
+            hooks.CrashingHook(), hooks.build_context(), timeout=30.0
+        )
+
+        assert result.success is False
+        assert "simulated hook crash" in result.error
+        assert os.getpid() == os.getpid(), "parent survived"
+
+    @pytest.mark.asyncio
+    async def test_result_that_cannot_cross_the_boundary_is_named_precisely(self):
+        """The worker's explicit ``pickle.dumps(result)`` probe.
+
+        Without it the queue's feeder thread fails asynchronously and drops the
+        item, and the parent misreports the cause as "exited without a result".
+        """
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        result = await executor.execute_isolated(
+            hooks.UnpicklableResultHook(), hooks.build_context(), timeout=30.0
+        )
+
+        assert result.success is False
+        assert "cannot cross the process boundary" in result.error
+
+    @pytest.mark.asyncio
+    async def test_hook_that_overruns_its_timeout_is_stopped(self):
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        result = await executor.execute_isolated(
+            hooks.SlowHook(), hooks.build_context(), timeout=1.0
+        )
+
+        assert result.success is False
+        assert "timeout" in result.error.lower()
+
+
+# --------------------------------------------------------------------------
+# The fallback is gone: isolation failure never becomes in-process execution
+# --------------------------------------------------------------------------
+
+
+class TestFailsClosed:
+    @pytest.mark.asyncio
+    async def test_unpicklable_handler_raises_the_typed_error(self):
+        """An unpicklable handler is the exact shape #2014's own worker had."""
+
+        async def _local_hook(context):  # pragma: no cover - must never run
+            _IN_PROCESS_SIDE_EFFECTS.append("ran")
+            return HookResult(success=True)
+
+        executor = IsolatedHookExecutor(GENEROUS)
+
+        with pytest.raises(HookIsolationError) as excinfo:
+            await executor.execute_isolated(
+                _local_hook, hooks.build_context(), timeout=30.0
+            )
+
+        assert "picklable" in str(excinfo.value)
+        assert (
+            _IN_PROCESS_SIDE_EFFECTS == []
+        ), "the hook body ran in the parent process despite isolation failing"
+
+    @pytest.mark.asyncio
+    async def test_manager_raises_rather_than_running_the_hook_in_process(self):
+        """The regression assertion for the deleted fallback.
+
+        Pre-fix this returned a successful ``HookResult`` and appended to
+        ``_IN_PROCESS_SIDE_EFFECTS``; both are asserted against here.
+        """
+        manager = IsolatedHookManager(limits=GENEROUS, enable_isolation=True)
+
+        async def _local_hook(context):  # pragma: no cover - must never run
+            _IN_PROCESS_SIDE_EFFECTS.append("ran")
+            return HookResult(success=True)
+
+        manager.register(HookEvent.PRE_AGENT_LOOP, _local_hook, HookPriority.NORMAL)
+
+        with pytest.raises(HookIsolationError):
+            await manager.trigger(
+                HookEvent.PRE_AGENT_LOOP, agent_id="agent-2014", data={}, timeout=30.0
+            )
+
+        assert _IN_PROCESS_SIDE_EFFECTS == [], (
+            "isolation failed and the hook was executed anyway -- this is the "
+            "silent downgrade issue #2014 reported"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_isolated_path_is_never_reached_on_isolation_failure(
+        self, monkeypatch
+    ):
+        """Asserts on the CALL, not just on the side effect.
+
+        The fallback invoked ``HookManager._execute_hook``. Recording calls to
+        it proves the deleted branch is not reachable by any other route.
+        """
+        calls: list[str] = []
+
+        original = HookManager._execute_hook
+
+        async def _recording(self, handler, context, timeout):
+            calls.append(getattr(handler, "name", type(handler).__name__))
+            return await original(self, handler, context, timeout)
+
+        monkeypatch.setattr(HookManager, "_execute_hook", _recording)
+
+        manager = IsolatedHookManager(limits=GENEROUS, enable_isolation=True)
+
+        async def _local_hook(context):  # pragma: no cover - must never run
+            return HookResult(success=True)
+
+        with pytest.raises(HookIsolationError):
+            await manager._execute_hook(
+                _LocalAdapter(_local_hook), hooks.build_context(), timeout=30.0
+            )
+
+        assert calls == [], (
+            "HookManager._execute_hook was reached, so a non-isolated execution "
+            "path is still live behind the isolating manager"
+        )
+
+    @pytest.mark.asyncio
+    async def test_machinery_failure_is_converted_to_the_typed_error(self):
+        """Callers get ONE exception type, whatever the executor raised."""
+        manager = IsolatedHookManager(limits=GENEROUS, enable_isolation=True)
+        manager.executor = _ExplodingExecutor()
+
+        with pytest.raises(HookIsolationError) as excinfo:
+            await manager._execute_hook(
+                hooks.PidReportingHook(), hooks.build_context(), timeout=5.0
+            )
+
+        assert "isolation machinery failed" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_explicit_opt_out_still_runs_in_process(self):
+        """The opt-out remains, because it is visible at the call site."""
+        manager = IsolatedHookManager(limits=GENEROUS, enable_isolation=False)
+
+        async def _local_hook(context):
+            _IN_PROCESS_SIDE_EFFECTS.append("ran")
+            return HookResult(success=True)
+
+        manager.register(HookEvent.PRE_AGENT_LOOP, _local_hook, HookPriority.NORMAL)
+
+        results = await manager.trigger(
+            HookEvent.PRE_AGENT_LOOP, agent_id="agent-2014", data={}, timeout=5.0
+        )
+
+        assert len(results) == 1 and results[0].success is True
+        assert _IN_PROCESS_SIDE_EFFECTS == ["ran"]
+
+    @pytest.mark.asyncio
+    async def test_isolated_and_opt_out_managers_disagree_about_the_same_hook(self):
+        """Guards the pair: the two modes must be distinguishable.
+
+        If this ever passes with both managers succeeding, the opt-out and the
+        isolated path have converged again -- which is the #2014 state.
+        """
+        isolated = IsolatedHookManager(limits=GENEROUS, enable_isolation=True)
+        opted_out = IsolatedHookManager(limits=GENEROUS, enable_isolation=False)
+
+        async def _local_hook(context):
+            return HookResult(success=True)
+
+        for manager in (isolated, opted_out):
+            manager.register(HookEvent.PRE_AGENT_LOOP, _local_hook, HookPriority.NORMAL)
+
+        with pytest.raises(HookIsolationError):
+            await isolated.trigger(
+                HookEvent.PRE_AGENT_LOOP, agent_id="a", data={}, timeout=30.0
+            )
+
+        results = await opted_out.trigger(
+            HookEvent.PRE_AGENT_LOOP, agent_id="a", data={}, timeout=5.0
+        )
+        assert results[0].success is True
+
+
+# --------------------------------------------------------------------------
+# Resource limits: per-limit, and never silently absent
+# --------------------------------------------------------------------------
+
+
+class TestResourceLimitReporting:
+    def test_apply_returns_the_limits_it_could_not_enforce(self):
+        """``apply()`` reports rather than swallows.
+
+        On macOS ``RLIMIT_AS`` is refused outright, so ``max_memory_mb`` is
+        expected in the returned list there. The assertion is written against
+        the CONTRACT (a list naming real limit fields) so it holds on Linux,
+        where the list is empty.
+        """
+        unenforced = ResourceLimits(
+            max_memory_mb=4096, max_cpu_seconds=60, max_file_size_mb=64
+        ).apply()
+
+        assert isinstance(unenforced, list)
+        assert set(unenforced) <= {
+            "max_memory_mb",
+            "max_cpu_seconds",
+            "max_file_size_mb",
+        }
+        if sys.platform == "darwin":
+            assert "max_memory_mb" in unenforced, (
+                "macOS refuses setrlimit(RLIMIT_AS); that refusal must be "
+                "reported, not swallowed"
+            )
+            assert "max_cpu_seconds" not in unenforced, (
+                "a refusal of one limit must not discard the limits this "
+                "platform does enforce"
+            )
+
+    @pytest.mark.asyncio
+    async def test_unenforced_limits_reach_the_parent_log(self, caplog):
+        """The child's own logging is unconfigured under spawn, so the parent logs it.
+
+        Falsifying result on macOS: no such record, meaning the operator is
+        never told that the memory cap is off.
+        """
+        if sys.platform != "darwin":
+            pytest.skip("needs a platform with a known-unenforceable rlimit")
+
+        caplog.set_level(
+            "WARNING", logger="kaizen.core.autonomy.hooks.security.isolation"
+        )
+
+        executor = IsolatedHookExecutor(GENEROUS)
+        result = await executor.execute_isolated(
+            hooks.PidReportingHook(), hooks.build_context(), timeout=30.0
+        )
+
+        assert result.success is True, result.error
+        assert "NOT enforced on this platform" in caplog.text
+        assert "max_memory_mb" in caplog.text
+
+    def test_a_limit_above_the_hard_ceiling_still_raises(self):
+        """A capability gap is tolerated; a real misconfiguration is not.
+
+        Run in a subprocess because lowering a hard limit is irreversible for
+        the process that does it, and would poison the rest of the session.
+        """
+        script = """
+import resource, sys
+sys.path.insert(0, %r)
+from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits
+
+# Lower the HARD ceiling, then ask for more than it allows.
+resource.setrlimit(resource.RLIMIT_FSIZE, (1024 * 1024, 1024 * 1024))
+try:
+    ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60,
+                   max_file_size_mb=64).apply()
+except (OSError, ValueError):
+    print("RAISED")
+else:
+    print("SWALLOWED")
+""" % (
+            os.path.join(os.path.dirname(__file__), "..", "..", "src"),
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        assert "RAISED" in completed.stdout, (
+            f"a value above the hard limit must re-raise, not be reported as a "
+            f"platform gap. stdout={completed.stdout!r} stderr={completed.stderr[-2000:]!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+class _LocalAdapter:
+    """Wraps a local function so it reaches the executor as a handler.
+
+    Deliberately holds a reference to an unpicklable local function, which is
+    what makes isolation fail.
+    """
+
+    name = "local-adapter"
+
+    def __init__(self, func):
+        self._func = func
+
+    async def handle(self, context):  # pragma: no cover - must never run
+        return await self._func(context)
+
+
+class _ExplodingExecutor:
+    """Raises something that is NOT a HookIsolationError."""
+
+    async def execute_isolated(self, handler, context, timeout):
+        raise RuntimeError("multiprocessing is unavailable in this sandbox")

--- a/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2014_spawn_isolation.py
@@ -34,6 +34,7 @@ inherits the parent's memory, and the fork/spawn discrimination test below would
 pass for the wrong reason if the pin were ever dropped.
 """
 
+import json
 import multiprocessing
 import os
 import pickle
@@ -375,10 +376,15 @@ class TestResourceLimitReporting:
         expected in the returned list there. The assertion is written against
         the CONTRACT (a list naming real limit fields) so it holds on Linux,
         where the list is empty.
+
+        Run in a subprocess. ``apply()`` lowers the HARD limit as well as the
+        soft one, which is irreversible for the process that does it -- calling
+        it inline would cap the pytest process and break every later test that
+        needs a higher limit.
         """
-        unenforced = ResourceLimits(
-            max_memory_mb=4096, max_cpu_seconds=60, max_file_size_mb=64
-        ).apply()
+        unenforced = _apply_in_subprocess(
+            max_memory_mb=4096, max_cpu_seconds=3600, max_file_size_mb=64
+        )
 
         assert isinstance(unenforced, list)
         assert set(unenforced) <= {
@@ -395,6 +401,32 @@ class TestResourceLimitReporting:
                 "a refusal of one limit must not discard the limits this "
                 "platform does enforce"
             )
+
+    def test_apply_does_not_leak_limits_into_the_calling_process(self):
+        """Guards the guard: the subprocess indirection above must stay necessary.
+
+        If ``apply()`` ever stops lowering the hard limit, the isolation
+        sandbox becomes escapable -- hook code could raise its own soft limit
+        back up. This asserts the hard limit really is lowered, in a throwaway
+        process.
+        """
+        script = (
+            "import resource, sys;"
+            "sys.path.insert(0, %r);"
+            "from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits;"
+            "ResourceLimits(max_memory_mb=4096, max_cpu_seconds=1234,"
+            " max_file_size_mb=64).apply();"
+            "print(resource.getrlimit(resource.RLIMIT_CPU)[1])" % (_SRC_ROOT,)
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+        )
+
+        assert completed.returncode == 0, completed.stderr[-2000:]
+        assert completed.stdout.strip().splitlines()[-1] == "1234", (
+            "the HARD limit was not lowered, so hook code could raise its own "
+            f"soft limit back up. stdout={completed.stdout!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_unenforced_limits_reach_the_parent_log(self, caplog):
@@ -419,28 +451,33 @@ class TestResourceLimitReporting:
         assert "NOT enforced on this platform" in caplog.text
         assert "max_memory_mb" in caplog.text
 
-    def test_a_limit_above_the_hard_ceiling_still_raises(self):
-        """A capability gap is tolerated; a real misconfiguration is not.
+    def test_a_stricter_environment_clamps_rather_than_breaking_isolation(self):
+        """An environment already tighter than the request is not an error.
+
+        A container may impose a hard limit below what the caller asked for.
+        That environment is STRICTER than requested, so it satisfies the intent
+        of the cap. Raising there would break isolation inside exactly the
+        hardened deployments that most need it, and the workaround an operator
+        would reach for is turning isolation off.
+
+        Falsifying result: a non-zero exit, i.e. ``apply()`` raised instead of
+        clamping. Asserted alongside the resulting limit, so the test cannot
+        pass merely because nothing blew up.
 
         Run in a subprocess because lowering a hard limit is irreversible for
         the process that does it, and would poison the rest of the session.
         """
-        script = """
-import resource, sys
-sys.path.insert(0, %r)
-from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits
-
-# Lower the HARD ceiling, then ask for more than it allows.
-resource.setrlimit(resource.RLIMIT_FSIZE, (1024 * 1024, 1024 * 1024))
-try:
-    ResourceLimits(max_memory_mb=4096, max_cpu_seconds=60,
-                   max_file_size_mb=64).apply()
-except (OSError, ValueError):
-    print("RAISED")
-else:
-    print("SWALLOWED")
-""" % (
-            os.path.join(os.path.dirname(__file__), "..", "..", "src"),
+        one_mb = 1024 * 1024
+        script = (
+            "import resource, sys;"
+            "sys.path.insert(0, %r);"
+            "resource.setrlimit(resource.RLIMIT_FSIZE, (%d, %d));"
+            "from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits;"
+            "unenforced = ResourceLimits(max_memory_mb=4096, max_cpu_seconds=3600,"
+            " max_file_size_mb=64).apply();"
+            "print('FSIZE=%%s' %% (resource.getrlimit(resource.RLIMIT_FSIZE)[0],));"
+            "print('UNENFORCED=%%s' %% (','.join(unenforced),))"
+            % (_SRC_ROOT, one_mb, one_mb)
         )
 
         completed = subprocess.run(
@@ -450,15 +487,44 @@ else:
             timeout=120,
         )
 
-        assert "RAISED" in completed.stdout, (
-            f"a value above the hard limit must re-raise, not be reported as a "
-            f"platform gap. stdout={completed.stdout!r} stderr={completed.stderr[-2000:]!r}"
+        assert completed.returncode == 0, (
+            f"apply() raised instead of clamping to the stricter environment "
+            f"limit. stderr={completed.stderr[-2000:]!r}"
+        )
+        assert f"FSIZE={one_mb}" in completed.stdout, (
+            f"the requested 64MB cap should have been clamped down to the "
+            f"environment's 1MB ceiling. stdout={completed.stdout!r}"
+        )
+        assert "max_file_size_mb" not in completed.stdout.split("UNENFORCED=")[-1], (
+            "a clamped limit IS enforced, and must not be reported as " "unenforceable"
         )
 
 
 # --------------------------------------------------------------------------
 # Helpers
 # --------------------------------------------------------------------------
+
+#: Import root for the subprocess probes below.
+_SRC_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+def _apply_in_subprocess(
+    *, max_memory_mb: int, max_cpu_seconds: int, max_file_size_mb: int
+) -> list[str]:
+    """Run ``ResourceLimits.apply()`` somewhere disposable and return its result."""
+    script = (
+        "import json, sys;"
+        "sys.path.insert(0, %r);"
+        "from kaizen.core.autonomy.hooks.security.isolation import ResourceLimits;"
+        "print(json.dumps(ResourceLimits(max_memory_mb=%d, max_cpu_seconds=%d,"
+        " max_file_size_mb=%d).apply()))"
+        % (_SRC_ROOT, max_memory_mb, max_cpu_seconds, max_file_size_mb)
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+    )
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    return json.loads(completed.stdout.strip().splitlines()[-1])
 
 
 class _LocalAdapter:


### PR DESCRIPTION
## Summary

`IsolatedHookManager` advertised process isolation as a security control, could not deliver it under the `spawn` start method, and hid that fact behind a fallback that ran the hook in-process and returned success.

The worker was a **closure** defined inside `execute_isolated`. `spawn` transfers the process target by pickle, and pickle stores a function by `module.qualname`, so a local object has no representation at all — `Process.start()` raised every time. The caller caught that, logged it, and ran the hook via `super()._execute_hook`.

`spawn` is the default on **macOS and Windows**. On those platforms isolation failed on *every* call and every hook ran with full agent privileges, while the caller received a successful-looking `HookResult`. Only Linux, where `fork` is the default, isolated anything.

## How I proved the test fails without the fix

The load-bearing claim is that the new tests *discriminate*, so I ran them against the pre-fix code at `8fb1057f1` rather than assuming. Identical harness, public API only, both directions:

| Assertion | pre-fix `8fb1057f1` | post-fix |
| --- | --- | --- |
| `hook_body_executes_in_a_different_process` | **FAIL** — `AttributeError: Can't get local object 'IsolatedHookExecutor.execute_isolated.<locals>._run_hook'` | PASS |
| `child_is_a_fresh_interpreter_not_a_fork` | **FAIL** — same `AttributeError` | PASS |
| `manager_fails_closed_instead_of_running_in_process` | **FAIL** — *"no exception raised: the isolation failure was swallowed and reported as success"* | PASS |
| | `SUMMARY: 0 passed, 3 failed` | `SUMMARY: 3 passed, 0 failed` |

End-to-end through the public manager, pre-fix:

```
SECURITY: Hook isolation failed for pid-reporting-hook, falling back to normal
execution: Can't get local object 'IsolatedHookExecutor.execute_isolated.<locals>._run_hook'
parent_pid=41012 hook_ran_in_pid=41012 success=True
VERDICT: NOT ISOLATED -- hook ran with full agent privileges (#2014)
```

post-fix: `parent_pid=75478 hook_ran_in_pid=78224` → `VERDICT: ISOLATED`.

## Why the existing suite never caught it

It could not have. `test_process_isolation` asserted `isinstance(results, list)`; the resource-limit tests asserted `len(results) == 1`. Those hold identically whether the hook ran in a child process or in the agent's own. Every one of those tests also registered a hook defined *inside the test body* — unpicklable, so isolation could never engage for any of them.

Each is now pinned to something that differs when isolation is off: the PID the hook observed, whether a hook's mutation reached the parent, whether an in-process side effect fired. The platform-compatibility file went from **0.29s to 17s**, which is itself the signal that real interpreters are now being started.

The fork/spawn test is the one that matters for CI: on Linux `fork` is the default and a forked child inherits parent memory, so it asserts the child *cannot* see a parent-only mutation. It fails if the explicit `spawn` pin is ever dropped.

## Two further defects this uncovered

Both were masked by the fallback and would have become hard failures once it was removed.

1. **macOS refuses `setrlimit(RLIMIT_AS)`** and raises `ValueError`, which `apply()` did not catch (only `OSError`). Because limits were applied as one block, that refusal also discarded `RLIMIT_CPU` and `RLIMIT_FSIZE`, which macOS *does* support. Limits are now applied independently and an unenforceable one is reported, not swallowed.

2. **`apply()` raised when the requested cap exceeded the environment's hard limit.** That would break isolation inside any container already stricter than the configured caps — the hardened deployments that most need it — and the workaround an operator would reach for is `enable_isolation=False`. A stricter environment satisfies the intent of a cap, so the value is now clamped down to it.

Lowering the *hard* limit is kept deliberately: it is what stops hook code raising its own soft limit back up. That makes `apply()` unsafe to call on a process you intend to keep using, which is now documented and asserted.

Unenforceable limits are routed back to the parent in the `ready` message rather than logged in the child, because under `spawn` the child's logging is unconfigured and a warning there goes nowhere.

## Sibling sweep

- `isolation.py` is the **only** production code in the repo that creates processes. Other `multiprocessing` hits are `cpu_count()`; other `get_context` hits are unrelated PACT governance methods.
- No sibling instance of the silent-degradation class: `secure_loader` fails closed (never loads an unverified hook), `redaction` returns a failure result, `metrics_auth` returns 500 without leaking.
- `trust/signing/rotation.py` non-transactional path is *not* this class — it implements manual snapshot + rollback and raises if it cannot snapshot.
- **Reported, not fixed** (different class, outside this shard): `runtime/local.py:4096,4176` degrade audit logging to the standard logger on `ImportError` and swallow other audit failures with a WARNING. The record still reaches a sink and the failure is logged, so it is not the #2014 shape, but the audit-failure semantics are worth a deliberate decision.

## Verification

- `pre-commit run --all-files` → **exit 0**, 21 hooks passed, 0 failed.
- 209 passed / 1 skipped across the #2014 suite, both F11 regression files, the F11 sink scanner, the platform-compatibility E2E file, and the hooks unit tests.
- The F11 credential-sink scanner caught a `B6-exc-attribute` finding on my own new log line (`e.reason`); fixed by scrubbing at the sink so its safety does not depend on every present and future raise site.
- 11 failures remain in `test_hooks_integration_e2e.py` / `test_compliance_validation_e2e.py`. These are **pre-existing and unrelated** — verified by running the same files at `8fb1057f1` (an ancestor of `main`): 11 failed there, 11 fail now, same names. They are constructor drift (`max_requests`, `enable_redaction`, `enable_validation` — kwargs that do not exist), two missing-principal `PermissionError`s, and two audit-log assertions where reading the log appends to it. Left for the lane that owns auth test stubs rather than expanding this PR into unrelated API drift.

## Related issues

Fixes #2014