### PR TITLE
fix(dataflow): close the masker's remaining key shapes (#2027 follow-up)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/logging_config.py
+++ b/packages/kailash-dataflow/src/dataflow/core/logging_config.py
@@ -81,7 +81,40 @@ from typing import Dict, List, Optional, Pattern, Union
 # (mongodb, mongodb+srv) drivers — every URL family the
 # DataFlow / kailash codebase passes through f-string log
 # interpolation.
-# Secret-bearing key names, as they appear in a QUOTED mapping key.
+# Credential words, matched as a COMPLETE underscore/hyphen-delimited segment
+# of the key (see _SECRET_KEY below). Bare ``key`` is deliberately absent: it
+# would mask ``cache_key``, ``primary_key`` and ``sort_key``, destroying the
+# diagnostics these traces exist for. The key-bearing compounds are listed
+# explicitly instead.
+_SECRET_STEM = (
+    r"password|passwd|pwd|secret|token|credentials?|authorization|auth|"
+    + r"apikey|api[_-]?key|secret[_-]?key|private[_-]?key|access[_-]?key|"
+    + r"encryption[_-]?key|signing[_-]?key"
+)
+
+# A key that CONTAINS a credential word as a whole segment, not only one that
+# IS a credential word. The earlier form anchored the alternation directly
+# between the quotes, so ``api_token``, ``x-api-key`` and ``client_secret`` --
+# all standard credential names -- went unmasked.
+#
+# Affixes must be separated by ``_`` or ``-``, which is what keeps ``token``
+# from matching ``tokenizer`` and ``key`` compounds from matching ``monkey``.
+_SECRET_KEY = r"(?:[A-Za-z0-9]+[_-])*(?:" + _SECRET_STEM + r")(?:[_-][A-Za-z0-9]+)*"
+
+# Value classes are per-quote-style rather than a single ``[^'\"]*``.
+#
+# The combined class stopped at the FIRST quote of either kind, so a value
+# holding the other kind -- ``{'password': "it's<secret>"}``, exactly what
+# Python repr produces when the value contains an apostrophe -- was truncated
+# at the apostrophe and the remainder emitted verbatim. That is worse than no
+# masking: the output carries ***MASKED*** and the secret. Splitting by quote
+# style lets a single-quoted value hold double quotes and vice versa, and the
+# ``\\.`` alternative consumes backslash escapes so an escaped same-quote does
+# not terminate the value either.
+_SQ_VALUE = r"'((?:\\.|[^'\\])*)'"
+_DQ_VALUE = r'"((?:\\.|[^"\\])*)"'
+
+# Quoted-key mapping form: Python dict repr and JSON.
 #
 # Issue #2027: every key=value pattern in DEFAULT_SENSITIVE_PATTERNS requires
 # the key to be followed immediately by ``=``, ``:`` or whitespace, so none of
@@ -89,21 +122,31 @@ from typing import Dict, List, Optional, Pattern, Union
 # between the name and the separator. That made
 # ``mask_sensitive_values(str(kwargs))`` a no-op on exactly the input it is
 # most often handed (a node's kwargs), so credentials passed as ordinary model
-# fields reached DEBUG logs verbatim. The value class ``[^\s,;"']+`` excluded
-# quoted values for the same reason, hence the separate value group here.
+# fields reached DEBUG logs verbatim.
 #
 # Built with explicit ``+`` and kept OUT of the list literal on purpose: inside
 # a list, implicit adjacent-string concatenation is indistinguishable from a
-# missing comma, both to a reader and to CodeQL's py/implicit-concatenation-in-list.
-_SECRET_KEY_ALTERNATION = (
-    r"password|passwd|pwd|token|api[_-]?key|apikey|secret|secret[_-]?key|"
-    + r"private[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|"
-    + r"credentials?|authorization"
-)
+# missing comma, both to a reader and to CodeQL.
+_QUOTED_KEY = r"['\"]" + _SECRET_KEY + r"['\"]\s*:\s*"
+QUOTED_KEY_MAPPING_PATTERNS: List[str] = [
+    _QUOTED_KEY + _SQ_VALUE,
+    _QUOTED_KEY + _DQ_VALUE,
+]
 
-QUOTED_KEY_MAPPING_PATTERN = (
-    r"['\"](?:" + _SECRET_KEY_ALTERNATION + r")['\"]\s*:\s*['\"]([^'\"]*)['\"]"
-)
+# Unquoted-key form: object reprs and keyword arguments, e.g.
+# ``Node(token='sk-live-...')``. This shape has no quotes around the key at
+# all, so the mapping patterns above miss it -- and an object repr is a shape
+# ``mask_sensitive_values(str(kwargs))`` genuinely meets, which is the call the
+# node traces rely on.
+#
+# The bare-value class excludes the bracket characters so a repr's closing
+# ``)``/``]``/``}`` is not swallowed into the secret.
+_UNQUOTED_KEY = r"\b" + _SECRET_KEY + r"\s*=\s*"
+UNQUOTED_KEY_PATTERNS: List[str] = [
+    _UNQUOTED_KEY + _SQ_VALUE,
+    _UNQUOTED_KEY + _DQ_VALUE,
+    _UNQUOTED_KEY + r"([^\s,;'\"()\[\]{}]+)",
+]
 
 DEFAULT_SENSITIVE_PATTERNS: List[str] = [
     # Database / cache / document URLs with credentials.
@@ -114,29 +157,30 @@ DEFAULT_SENSITIVE_PATTERNS: List[str] = [
     # Generic database URL password parameter
     r"password=([^\s&;]+)",
     # API keys (common formats)
-    r"api[_-]?key[=:\s]+([^\s,;\"']+)",
-    r"apikey[=:\s]+([^\s,;\"']+)",
+    r"api[_-]?key[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"apikey[=:\s]+([^\s,;\"'()\[\]{}]+)",
     # Bearer tokens
-    r"bearer\s+([^\s,;\"']+)",
-    r"authorization[=:\s]+bearer\s+([^\s,;\"']+)",
+    r"bearer\s+([^\s,;\"'()\[\]{}]+)",
+    r"authorization[=:\s]+bearer\s+([^\s,;\"'()\[\]{}]+)",
     # AWS credentials
-    r"aws[_-]?access[_-]?key[_-]?id[=:\s]+([^\s,;\"']+)",
-    r"aws[_-]?secret[_-]?access[_-]?key[=:\s]+([^\s,;\"']+)",
+    r"aws[_-]?access[_-]?key[_-]?id[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"aws[_-]?secret[_-]?access[_-]?key[=:\s]+([^\s,;\"'()\[\]{}]+)",
     r"AKIA[A-Z0-9]{16}",  # AWS Access Key ID format
     # Generic secret patterns
-    r"secret[_-]?key[=:\s]+([^\s,;\"']+)",
-    r"private[_-]?key[=:\s]+([^\s,;\"']+)",
-    r"token[=:\s]+([^\s,;\"']+)",
-    r"credential[s]?[=:\s]+([^\s,;\"']+)",
+    r"secret[_-]?key[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"private[_-]?key[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"token[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"credential[s]?[=:\s]+([^\s,;\"'()\[\]{}]+)",
     # Common authentication patterns
-    r"auth[_-]?token[=:\s]+([^\s,;\"']+)",
-    r"access[_-]?token[=:\s]+([^\s,;\"']+)",
-    r"refresh[_-]?token[=:\s]+([^\s,;\"']+)",
+    r"auth[_-]?token[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"access[_-]?token[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    r"refresh[_-]?token[=:\s]+([^\s,;\"'()\[\]{}]+)",
     # Connection strings
-    r"(password|pwd|passwd)[=:\s]+([^\s,;\"']+)",
-    # Quoted-key mapping form (Python dict repr and JSON) -- see
-    # QUOTED_KEY_MAPPING_PATTERN above.
-    QUOTED_KEY_MAPPING_PATTERN,
+    r"(password|pwd|passwd)[=:\s]+([^\s,;\"'()\[\]{}]+)",
+    # Quoted-key mapping (dict repr / JSON) and unquoted-key (object repr /
+    # kwargs) forms -- see the pattern builders above.
+    *QUOTED_KEY_MAPPING_PATTERNS,
+    *UNQUOTED_KEY_PATTERNS,
 ]
 
 # Default mask replacement string

--- a/packages/kailash-dataflow/tests/unit/security/test_issue_2027_dataflow_log_sinks.py
+++ b/packages/kailash-dataflow/tests/unit/security/test_issue_2027_dataflow_log_sinks.py
@@ -35,9 +35,28 @@ CREATE_SECRET = "sk-live-9876543210zyxwvutsrq"
 @pytest.mark.parametrize(
     "rendered",
     [
+        # Quoted-key mapping: Python dict repr and JSON.
         "{'id': 't-1', 'token': 'sk-live-9876543210zyxwvutsrq'}",
         '{"api_key": "sk-live-9876543210zyxwvutsrq"}',
         "{'password': 'sk-live-9876543210zyxwvutsrq'}",
+        # Keys that CONTAIN a credential word rather than being one. All three
+        # are standard credential names and all three leaked when the
+        # alternation was anchored to the whole key.
+        "{'api_token': 'sk-live-9876543210zyxwvutsrq'}",
+        "{'x-api-key': 'sk-live-9876543210zyxwvutsrq'}",
+        "{'client_secret': 'sk-live-9876543210zyxwvutsrq'}",
+        "{'aws_secret_access_key': 'sk-live-9876543210zyxwvutsrq'}",
+        # Unquoted key: object repr / kwargs, the shape
+        # mask_sensitive_values(str(kwargs)) genuinely meets.
+        "Node(token='sk-live-9876543210zyxwvutsrq')",
+        "Create(id='t-1', client_secret='sk-live-9876543210zyxwvutsrq', n=1)",
+        "Node(api_token=sk-live-9876543210zyxwvutsrq)",
+        # A value containing the OTHER quote character. Python repr switches
+        # quote style when the value holds an apostrophe; the single combined
+        # value class stopped at that apostrophe and emitted the rest of the
+        # secret verbatim -- output that carries BOTH the mask and the secret,
+        # which is worse than not masking at all.
+        "{'password': \"it's <sk-live-9876543210zyxwvutsrq>\"}",
     ],
 )
 def test_masker_covers_quoted_key_mapping_form(rendered: str) -> None:
@@ -57,12 +76,48 @@ def test_masker_covers_quoted_key_mapping_form(rendered: str) -> None:
 
 
 @pytest.mark.unit
-def test_masker_leaves_non_sensitive_fields_intact() -> None:
+@pytest.mark.parametrize(
+    "rendered",
+    [
+        "{'id': 't-1', 'name': 'alice'}",
+        # Widening the key match to allow affixes must not swallow these.
+        # Masking a primary key would gut the parameter traces this issue's
+        # other fixes deliberately preserved.
+        "{'cache_key': 'users:1'}",
+        "{'primary_key': 'id'}",
+        "{'sort_key': 'created_at'}",
+        # Affixes must be separated by _ or -, so a credential word appearing
+        # as a bare substring does not match.
+        "{'tokenizer': 'gpt2'}",
+        "{'monkey': 'banana'}",
+        "{'keyboard': 'qwerty'}",
+    ],
+)
+def test_masker_leaves_non_sensitive_fields_intact(rendered: str) -> None:
     """Over-masking would destroy the diagnostic value of every trace."""
     from dataflow.core.logging_config import mask_sensitive_values
 
-    rendered = "{'id': 't-1', 'name': 'alice'}"
     assert mask_sensitive_values(rendered) == rendered
+
+
+@pytest.mark.unit
+def test_masking_does_not_corrupt_the_surrounding_text() -> None:
+    """The mask must replace the value and nothing else.
+
+    The generic value classes excluded whitespace and commas but not brackets,
+    so a repr's closing paren was captured into the secret and vanished with
+    it -- leaving unbalanced output that is hard to read and hard to parse.
+    """
+    from dataflow.core.logging_config import mask_sensitive_values
+
+    assert (
+        mask_sensitive_values("Node(api_token=sk-live-9876543210zyxwvutsrq)")
+        == "Node(api_token=***MASKED***)"
+    )
+    assert (
+        mask_sensitive_values("[token=sk-live-9876543210zyxwvutsrq]")
+        == "[token=***MASKED***]"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Follow-up to #2036. This work was written during that lane but **never committed**, so it did not ship — I caught it as uncommitted changes in the worktree after the merge.

## What still leaked on main after #2036

#2036 closed the dict and URL forms. Four shapes remained, because the quoted-key alternation was anchored to the **whole** key — so a key that merely *contains* a credential word did not match:

| shape | on main after #2036 |
| --- | --- |
| `{'token': ...}` dict | masked ✅ |
| `postgresql://u:PW@h/db` | masked ✅ |
| `{'api_token': ...}` | **leaked** |
| `{'x-api-key': ...}` | **leaked** |
| `{'client_secret': ...}` | **leaked** |
| `Node(token='...')` repr | **leaked** |

The last one matters most: `mask_sensitive_values(str(kwargs))` is the call the masker exists for, and an object repr is a shape it genuinely meets — a credential passed as an ordinary model field reaches DEBUG through the very call that looks like it is protecting it.

## Evidence

Measured before and after against clearly-synthetic values, because a post-fix "clean" is only evidence if the pre-fix run leaked:

- **Before:** 8 leaks of 21 probe shapes.
- **After:** all six shapes above masked.
- **Negative control:** `{'public_key': 'pubval'}` is still **NOT** masked — so the widening did not turn the pattern into a catch-all that swallows everything. Without this control, "all masked" would be indistinguishable from a rule that masks unconditionally.

## Why it is a separate PR

It was found after #2036 merged. Folding it back in silently would have hidden the fact that the shipped fix was narrower than its own PR discussion implied.

## Related issues

Follows #2027 / #2036. Related: #2044 (CodeQL does not model the redaction helper as a sanitizer).