### PR TITLE
fix(mcp): stop capturing the raw spawn command in SpawnSecurityError

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
+++ b/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
+from kailash.utils.url_credentials import mask_error_text
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, ServiceDiscoveryError
 from kailash_mcp.security import SpawnSecurityError, validate_spawn_command
@@ -1129,8 +1130,21 @@ class HealthChecker:
                                     "status": "healthy",
                                     "response_time": response_time,
                                 }
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        # Acts: falls through to the main-endpoint probe
+                        # below. Logged rather than swallowed silently so a
+                        # persistently-failing health endpoint is diagnosable
+                        # (zero-tolerance Rule 3).
+                        logger.debug(
+                            "health_check.health_endpoint_failed",
+                            extra={
+                                "server": server.name,
+                                # The probe URL is echoed by most client
+                                # errors and may carry userinfo / credential
+                                # query parameters.
+                                "error": mask_error_text(str(exc)),
+                            },
+                        )
 
                     # Fallback to main endpoint
                     try:
@@ -1156,6 +1170,12 @@ class HealthChecker:
                     # spawn safety): a health probe MUST NOT spawn an unlisted
                     # command. server.command is untrusted (registry / discovery
                     # response). Reject before spawn; report blocked, don't run.
+                    #
+                    # The rejection text is safe to log and to return: since
+                    # #2004 SpawnSecurityError renders a
+                    # ``basename#fingerprint`` reference rather than the raw
+                    # command, which routinely carries a credential as a CLI
+                    # flag (``npx ... --token=<secret>``).
                     try:
                         validate_spawn_command(server.command)
                     except SpawnSecurityError as e:

--- a/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
+++ b/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
@@ -48,10 +48,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
-from kailash.utils.url_credentials import mask_error_text
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, ServiceDiscoveryError
 from kailash_mcp.security import SpawnSecurityError, validate_spawn_command
+
+from kailash.utils.url_credentials import mask_error_text
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-mcp/src/kailash_mcp/security.py
+++ b/packages/kailash-mcp/src/kailash_mcp/security.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import os
 from typing import Optional, Sequence
 
+from kailash.utils.command_safety import safe_command_ref
 from kailash_mcp.errors import MCPError, MCPErrorCode
 
 # Standard MCP launcher executables considered safe to spawn without an
@@ -56,13 +57,29 @@ class SpawnSecurityError(MCPError):
     Carries :data:`MCPErrorCode.AUTHORIZATION_FAILED` (``-32003``) — a spawn
     rejection is an authorization decision, not a transport or validation
     failure.
+
+    The rejected command is untrusted input and routinely carries a
+    credential as a CLI flag (``npx ... --token=<secret>``). This exception
+    therefore NEVER stores it. ``command`` is converted at construction time
+    to a disclosure-safe ``basename#fingerprint`` reference
+    (:func:`~kailash.utils.command_safety.safe_command_ref`) and exposed as
+    ``data["command_ref"]``.
+
+    Doing the conversion here rather than at each call site is what makes the
+    guarantee hold: ``MCPError.to_dict`` copies ``data`` into the JSON-RPC
+    error payload, so the attribute, the wire form, and every message built
+    from it are all covered at once — including sinks added later.
     """
 
-    def __init__(self, message: str, command: Optional[str] = None) -> None:
+    def __init__(self, message: str, command: object = None) -> None:
         super().__init__(
             message,
             error_code=MCPErrorCode.AUTHORIZATION_FAILED,
-            data={"command": command} if command is not None else None,
+            data=(
+                {"command_ref": safe_command_ref(command)}
+                if command is not None
+                else None
+            ),
         )
 
 
@@ -94,7 +111,7 @@ def validate_spawn_command(
     if not isinstance(command, str) or not command:
         raise SpawnSecurityError(
             "spawn command must be a non-empty string",
-            command=command if isinstance(command, str) else None,
+            command=command,
         )
 
     # Reject path traversal regardless of the allowlist / opt-out — a ``..``
@@ -102,7 +119,7 @@ def validate_spawn_command(
     segments = command.replace("\\", "/").split("/")
     if ".." in segments:
         raise SpawnSecurityError(
-            f"spawn command rejected (path traversal): {command!r}",
+            f"spawn command rejected (path traversal): {safe_command_ref(command)}",
             command=command,
         )
 
@@ -119,7 +136,7 @@ def validate_spawn_command(
         return
 
     raise SpawnSecurityError(
-        f"spawn command {command!r} is not in the allowlist "
+        f"spawn command {safe_command_ref(command)} is not in the allowlist "
         f"(allowed: {sorted(allowed)}). Add it to `allowed_commands`, pass "
         f"`allow_arbitrary=True` (or set `allow_arbitrary_commands=True` in the "
         f"client/transport config) to permit arbitrary commands.",

--- a/packages/kailash-mcp/src/kailash_mcp/security.py
+++ b/packages/kailash-mcp/src/kailash_mcp/security.py
@@ -27,8 +27,9 @@ from __future__ import annotations
 import os
 from typing import Optional, Sequence
 
-from kailash.utils.command_safety import safe_command_ref
 from kailash_mcp.errors import MCPError, MCPErrorCode
+
+from kailash.utils.command_safety import safe_command_ref
 
 # Standard MCP launcher executables considered safe to spawn without an
 # explicit per-caller allowlist. Deliberately EXCLUDES shells (``sh``,

--- a/src/kailash/channels/mcp/stdio.py
+++ b/src/kailash/channels/mcp/stdio.py
@@ -38,9 +38,10 @@ from __future__ import annotations
 
 import asyncio
 import os
-import shlex
 from asyncio.subprocess import Process
 from typing import Optional, Sequence
+
+from kailash.utils.command_safety import safe_command_ref
 
 from .base import ProtocolError, Transport, TransportError
 
@@ -156,7 +157,9 @@ class StdioTransport(Transport):
                 cwd=cwd,
             )
         except (OSError, FileNotFoundError) as exc:
-            raise TransportError(f"failed to spawn {command!r}: {exc}") from exc
+            raise TransportError(
+                f"failed to spawn {safe_command_ref(command)}: {exc}"
+            ) from exc
         return cls(process)
 
     @classmethod
@@ -175,10 +178,17 @@ class StdioTransport(Transport):
         allowed: Optional[Sequence[str]],
         allow_arbitrary: bool = False,
     ) -> None:
+        # ``command`` is untrusted (agent output, registry entry, discovery
+        # response) and routinely carries a credential as a CLI flag, so no
+        # rejection path may echo it. ``safe_command_ref`` yields a
+        # ``basename#fingerprint`` reference that stays correlatable across
+        # log lines without disclosing the arguments. See issue #2004.
         if not isinstance(command, str) or not command:
             raise TransportError("command must be a non-empty string")
         if ".." in command.replace("\\", "/").split("/"):
-            raise TransportError(f"command rejected (path traversal): {command!r}")
+            raise TransportError(
+                f"command rejected (path traversal): {safe_command_ref(command)}"
+            )
         if allow_arbitrary:
             return
         # Fail closed: absent an explicit allowlist, enforce the curated
@@ -188,7 +198,8 @@ class StdioTransport(Transport):
         if basename not in effective and command not in effective:
             allowed_str = ", ".join(repr(c) for c in sorted(effective))
             raise TransportError(
-                f"command {command!r} not in the allowlist [{allowed_str}]; "
+                f"command {safe_command_ref(command)} not in the allowlist "
+                f"[{allowed_str}]; "
                 f"pass allowed_commands=[...] or allow_arbitrary_commands=True"
             )
 
@@ -348,11 +359,6 @@ async def read_framed_message(reader: asyncio.StreamReader) -> str:
         return body.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise ProtocolError(f"message body is not valid UTF-8: {exc}") from exc
-
-
-def _quote_for_log(command: str, args: Sequence[str]) -> str:
-    """Render a spawn command + args for log output (debug only)."""
-    return shlex.join([command, *args])
 
 
 def validate_spawn_command(

--- a/src/kailash/utils/command_safety.py
+++ b/src/kailash/utils/command_safety.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Terrene Foundation
+"""Disclosure-safe references for untrusted spawn commands.
+
+A local-server spawn command is untrusted input (agent output, a registry
+entry, a discovery response) and routinely carries a credential as a CLI
+flag::
+
+    npx -y @vendor/mcp-server --token=<secret>
+
+Every rejection path for such a command wants to say *which* command was
+rejected, and every naive way of saying so — ``f"{command!r}"`` in the
+message, ``data={"command": command}`` on the exception, ``shlex.join`` into
+a debug log — publishes the credential.
+
+Why a reference rather than a scrubber
+--------------------------------------
+The obvious remedy is to scrub the command at each sink with the existing
+credential masker (:func:`kailash.utils.url_credentials.mask_error_text`).
+That helper redacts URL userinfo and credential query parameters; it does
+NOT redact a CLI-flag credential, which is the shape this input actually
+takes. Routing a spawn command through it produces a change that looks like
+a fix and leaks exactly as before.
+
+Scrubbing is also the wrong shape structurally: it has to be applied at
+every sink, so it is only ever as complete as the last enumeration of sinks,
+and a sink added later inherits nothing. A secret that is never stored
+cannot leak from a sink nobody remembered.
+
+So the contract here is: convert the command ONCE, at the point where it
+would otherwise be captured, into a reference that is safe to put anywhere —
+a log record, an exception attribute, a JSON-RPC error payload.
+
+The reference
+-------------
+``<launcher>#<fingerprint>``, e.g. ``npx#3f2a91cc``.
+
+* **launcher** — the basename of the first whitespace-delimited token, i.e.
+  the executable. Arguments (where credentials live) are never included.
+  The label is a debugging *hint*: if the token does not look like a plain
+  program name it is replaced with :data:`REDACTED_LABEL`, so the failure
+  direction is disclosure-safe.
+* **fingerprint** — a truncated BLAKE2b digest of the WHOLE command via
+  :func:`~kailash.utils.url_credentials.fingerprint_secret`. It is stable
+  across calls and processes, so two log lines about the same command
+  correlate, and distinct commands do not collapse together.
+
+A fingerprint is not a secret and not a password hash; see that function's
+docstring for the collision-stability and reversibility caveats.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from kailash.utils.url_credentials import fingerprint_secret
+
+__all__ = [
+    "safe_command_ref",
+    "EMPTY_REF",
+    "NON_STRING_REF",
+    "REDACTED_LABEL",
+]
+
+# Distinct, grep-able sentinels — see ``rules/observability.md`` Rule 6.1.
+# Each names a different input defect so log triage can tell "the caller
+# passed nothing" from "the caller passed the wrong type" from "the command
+# was present but its first token did not look like a program name".
+EMPTY_REF = "<empty>"
+NON_STRING_REF = "<non-string>"
+REDACTED_LABEL = "<redacted>"
+
+# What an executable basename looks like: starts alphanumeric (or ``_``) and
+# continues with the characters real launcher names use. Deliberately
+# EXCLUDES ``=``, ``:``, ``@``, quotes and whitespace — the characters that
+# appear when the "first token" is actually a flag (``--token=...``), a URL
+# userinfo pair (``user:pw@host``), or a fused flag/value.
+#
+# The 24-character cap is a conservative upper bound on real launcher names
+# (``mcp-server-filesystem`` is 21); a credential pasted where the executable
+# belongs is typically longer and higher-entropy. The cap is defense in
+# depth, not the security boundary: the boundary is that only the FIRST
+# token is ever considered, and a credential is never the executable.
+_SAFE_LAUNCHER_NAME = re.compile(r"[A-Za-z0-9_][A-Za-z0-9._+-]{0,23}")
+
+
+def _launcher_label(command: str) -> str:
+    """Best-effort, fail-closed label for the executable in ``command``."""
+    tokens = command.split()
+    if not tokens:
+        return REDACTED_LABEL
+    basename = os.path.basename(tokens[0].replace("\\", "/"))
+    if _SAFE_LAUNCHER_NAME.fullmatch(basename):
+        return basename
+    return REDACTED_LABEL
+
+
+def safe_command_ref(command: object) -> str:
+    """Return a disclosure-safe reference to an untrusted spawn ``command``.
+
+    Use this anywhere a spawn command would otherwise be rendered, stored, or
+    serialized — log messages and ``extra=`` blocks, exception messages,
+    structured error ``data`` payloads, returned status dicts.
+
+    Args:
+        command: The spawn command. Any object is accepted, because callers
+            validate untrusted input whose type is not yet established; a
+            non-string yields :data:`NON_STRING_REF` rather than raising.
+
+    Returns:
+        ``"<launcher>#<fingerprint>"`` for a non-empty command string,
+        :data:`EMPTY_REF` for an empty string, or :data:`NON_STRING_REF` for
+        anything that is not a string. The return value never contains any
+        substring of the command's arguments.
+
+    Examples:
+        >>> safe_command_ref("npx -y @vendor/server --token=s3cret").startswith("npx#")
+        True
+        >>> safe_command_ref("/usr/local/bin/python3").startswith("python3#")
+        True
+        >>> safe_command_ref("--token=s3cret").startswith("<redacted>#")
+        True
+        >>> safe_command_ref("")
+        '<empty>'
+        >>> safe_command_ref(None)
+        '<non-string>'
+    """
+    if not isinstance(command, str):
+        return NON_STRING_REF
+    if not command:
+        return EMPTY_REF
+    return f"{_launcher_label(command)}#{fingerprint_secret(command)}"

--- a/tests/regression/test_issue_2004_spawn_command_leak.py
+++ b/tests/regression/test_issue_2004_spawn_command_leak.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #2004 — untrusted spawn command leaked verbatim.
+
+The defect
+----------
+``HealthChecker.check_server_health`` validates an untrusted ``server.command``
+(sourced from a registry / discovery response) through ``validate_spawn_command``
+and, on rejection, put ``str(e)`` into BOTH a log ``extra`` and the returned
+dict. ``SpawnSecurityError`` embedded the raw command in its message AND in
+``.data["command"]``, so a registry entry shaped like
+``npx -y @vendor/server --token=<secret>`` leaked the credential.
+
+Three sinks, not two
+--------------------
+The issue names two (the log ``extra`` and the returned ``error``). There is a
+THIRD: ``MCPError.to_dict()`` copies ``self.data`` into the JSON-RPC error
+payload, so ``.data["command"]`` reaches the wire. A fix applied at the three
+call sites would have closed two sinks and left the wire sink open.
+
+Why the fix is at the RAISE site
+--------------------------------
+The issue prescribes routing the sinks through the package's scrubbing helper
+(``kailash.utils.url_credentials.mask_error_text``). That helper redacts URL
+userinfo and credential query parameters; it does NOT redact a CLI-flag
+credential, which is the shape this threat actually takes.
+``test_prescribed_remedy_does_not_close_the_named_threat`` below measures that
+directly rather than asserting it from a reading of the code.
+
+So the fix stores a disclosure-safe reference (``basename#fingerprint``) at
+construction time instead of scrubbing the raw command at each sink. A secret
+that is never stored cannot leak from a sink that was forgotten, and
+``SpawnSecurityError`` becomes structurally incapable of carrying the raw
+command regardless of which call site raises it.
+
+The enumeration used (issue AC #3)
+----------------------------------
+The sweep that originally closed this class matched only f-string-interpolated
+log messages::
+
+    logger\\.(error|warning|exception)\\(f?"[^"]*\\{(e|exc|error|...)[^}]*\\}
+
+That pattern structurally cannot match ``extra={"error": str(e)}`` — a keyword
+argument whose value binds the exception — nor can it match a ``return`` whose
+dict binds one, nor ``to_dict()`` serialising ``.data``. The general instrument
+is to enumerate every construction site that binds an exception object into a
+dict or ``extra=`` block, including multi-line blocks, and additionally every
+field the exception itself carries. Running the narrower pattern and reporting
+the class closed was true of the pattern, not of the code.
+
+These tests assert the invariant at the source (the exception never holds the
+raw command) rather than at the sinks, so a NEW sink added later inherits the
+protection without needing a fourth grep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+# Clearly synthetic, non-realistic credential values. These must never appear
+# in any rendered message, log record, exception payload, or wire dict.
+SYNTHETIC_TOKEN = "SYNTHETIC-TOKEN-DO-NOT-LOG-AAA111"
+CREDENTIAL_COMMAND = f"npx -y @vendor/mcp-server --token={SYNTHETIC_TOKEN}"
+
+
+# ---------------------------------------------------------------------------
+# 0. The prescribed remedy, measured against the named threat
+#    (specification-verification.md MUST-2: test the remedy before adopting it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_prescribed_remedy_does_not_close_the_named_threat():
+    """``mask_error_text`` does not redact a CLI-flag credential.
+
+    The issue prescribes routing the leaking sinks through this helper. It
+    covers URL userinfo and credential query parameters — the two control
+    cases below prove the helper ran and works on the shapes it does cover,
+    so a pass-through on the CLI-flag shapes is a real gap and not a
+    mis-invocation.
+
+    If this test ever fails because ``mask_error_text`` gained CLI-flag
+    coverage, that is an improvement: update this test. The raise-site fix
+    remains the primary defense, because not storing a secret beats redacting
+    it at every sink that might later be added.
+    """
+    from kailash.utils.url_credentials import mask_error_text
+
+    # Controls — shapes the helper DOES cover. These discriminate: if the
+    # helper were not running at all, these would leak too.
+    assert "SYNTHETIC-URLPW" not in mask_error_text(
+        "connect failed: postgres://user:SYNTHETIC-URLPW@host/db"
+    )
+    assert "SYNTHETIC-QP-DDD" not in mask_error_text(
+        "GET https://host/x?api_key=SYNTHETIC-QP-DDD failed"
+    )
+
+    # The named threat — a CLI-flag credential. Passes through verbatim.
+    leaked = mask_error_text(f"spawn command {CREDENTIAL_COMMAND!r} is not allowed")
+    assert SYNTHETIC_TOKEN in leaked, (
+        "mask_error_text unexpectedly redacted a CLI-flag credential; "
+        "re-derive whether the raise-site fix is still the right shape"
+    )
+    for variant in (
+        f"npx --api-key={SYNTHETIC_TOKEN}",
+        f"npx --password {SYNTHETIC_TOKEN}",
+        f"npx --token {SYNTHETIC_TOKEN}",
+    ):
+        assert SYNTHETIC_TOKEN in mask_error_text(variant)
+
+
+# ---------------------------------------------------------------------------
+# 1. The shared helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "command",
+    [
+        CREDENTIAL_COMMAND,
+        f"npx --api-key={SYNTHETIC_TOKEN}",
+        f"npx --password {SYNTHETIC_TOKEN}",
+        f"/opt/vendor/bin/serve--token={SYNTHETIC_TOKEN}",
+        f"../../bin/sh -c 'curl -H auth:{SYNTHETIC_TOKEN}'",
+        f"user:{SYNTHETIC_TOKEN}@host",
+        SYNTHETIC_TOKEN,
+    ],
+)
+def test_safe_command_ref_never_echoes_the_command(command):
+    """No input shape survives into the reference."""
+    from kailash.utils.command_safety import safe_command_ref
+
+    ref = safe_command_ref(command)
+    assert SYNTHETIC_TOKEN not in ref
+    # Nor any other whole-command echo.
+    assert command not in ref
+
+
+@pytest.mark.regression
+def test_safe_command_ref_preserves_debuggability():
+    """The reference stays useful: launcher basename plus a stable fingerprint."""
+    from kailash.utils.command_safety import safe_command_ref
+
+    ref = safe_command_ref(CREDENTIAL_COMMAND)
+    assert ref.startswith("npx#"), ref
+    # Stable across calls -> two log lines about the same command correlate.
+    assert ref == safe_command_ref(CREDENTIAL_COMMAND)
+    # Distinct commands do not collapse to the same reference.
+    assert ref != safe_command_ref(f"npx -y @vendor/mcp-server --token=OTHER-{'B' * 8}")
+    # A path-form launcher reduces to its basename.
+    assert safe_command_ref("/usr/local/bin/python3").startswith("python3#")
+    assert safe_command_ref("../../bin/sh").startswith("sh#")
+
+
+@pytest.mark.regression
+def test_safe_command_ref_redacts_an_unsafe_looking_launcher_token():
+    """Fail closed: a first token that is not a plain launcher name is redacted."""
+    from kailash.utils.command_safety import safe_command_ref
+
+    assert safe_command_ref(f"--token={SYNTHETIC_TOKEN}").startswith("<redacted>#")
+    assert safe_command_ref(f"user:{SYNTHETIC_TOKEN}@host").startswith("<redacted>#")
+
+
+@pytest.mark.regression
+def test_safe_command_ref_uses_distinct_sentinels_for_non_commands():
+    """Empty / non-string inputs get distinguishable sentinels, never a crash."""
+    from kailash.utils.command_safety import safe_command_ref
+
+    assert safe_command_ref("") == "<empty>"
+    assert safe_command_ref(None) == "<non-string>"
+    assert safe_command_ref(["npx"]) == "<non-string>"
+
+
+# ---------------------------------------------------------------------------
+# 2. The raise site — all three sinks
+# ---------------------------------------------------------------------------
+
+
+def _raise_spawn_error(command: str):
+    from kailash_mcp.security import SpawnSecurityError, validate_spawn_command
+
+    with pytest.raises(SpawnSecurityError) as exc_info:
+        validate_spawn_command(command)
+    return exc_info.value
+
+
+@pytest.mark.regression
+def test_spawn_error_message_does_not_carry_the_raw_command():
+    """Sink 1 of 3: the rendered message (what ``str(e)`` yields)."""
+    err = _raise_spawn_error(CREDENTIAL_COMMAND)
+    assert SYNTHETIC_TOKEN not in str(err)
+    assert SYNTHETIC_TOKEN not in err.message
+
+
+@pytest.mark.regression
+def test_spawn_error_data_does_not_carry_the_raw_command():
+    """Sink 2 of 3: the structured ``.data`` payload."""
+    err = _raise_spawn_error(CREDENTIAL_COMMAND)
+    assert SYNTHETIC_TOKEN not in json.dumps(err.data)
+    assert "command" not in err.data, "the raw-command field must be gone, not masked"
+    assert err.data["command_ref"].startswith("npx#")
+
+
+@pytest.mark.regression
+def test_spawn_error_to_dict_does_not_carry_the_raw_command():
+    """Sink 3 of 3 — the one the issue misses: the JSON-RPC wire payload."""
+    err = _raise_spawn_error(CREDENTIAL_COMMAND)
+    assert SYNTHETIC_TOKEN not in json.dumps(err.to_dict())
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "command",
+    [
+        CREDENTIAL_COMMAND,  # not in the allowlist
+        f"../../bin/sh --token={SYNTHETIC_TOKEN}",  # path traversal branch
+    ],
+)
+def test_every_raise_branch_is_covered(command):
+    """Each rejection branch, not just the allowlist one, must be safe."""
+    err = _raise_spawn_error(command)
+    blob = json.dumps(err.to_dict()) + str(err)
+    assert SYNTHETIC_TOKEN not in blob
+
+
+@pytest.mark.regression
+def test_spawn_error_remains_useful_for_debugging():
+    """zero-tolerance Rule 3: the error must still say what happened and why."""
+    err = _raise_spawn_error(CREDENTIAL_COMMAND)
+    from kailash_mcp.errors import MCPErrorCode
+
+    assert err.error_code == MCPErrorCode.AUTHORIZATION_FAILED
+    assert "npx#" in str(err), "the correlatable reference must survive"
+    assert "allowlist" in str(err)
+    assert "allow_arbitrary" in str(err), "the remediation hint must survive"
+
+
+# ---------------------------------------------------------------------------
+# 3. The reported call site — discovery health check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_health_check_leaks_nothing_to_log_or_return_value(caplog):
+    """The reported site: neither the log record nor the returned dict leaks."""
+    from kailash_mcp.discovery.discovery import HealthChecker, ServerInfo
+
+    server = ServerInfo(
+        name="vendor-mcp",
+        transport="stdio",
+        command=CREDENTIAL_COMMAND,
+    )
+    checker = HealthChecker()
+
+    with caplog.at_level(logging.WARNING):
+        result = await checker.check_server_health(server)
+
+    assert result["status"] == "blocked"
+    assert SYNTHETIC_TOKEN not in json.dumps(result)
+
+    # Every attribute of every record, not just the formatted message —
+    # the leak lived in `extra=`, which does not appear in record.message.
+    for record in caplog.records:
+        assert SYNTHETIC_TOKEN not in record.getMessage()
+        for value in vars(record).values():
+            assert SYNTHETIC_TOKEN not in str(value)
+
+
+# ---------------------------------------------------------------------------
+# 4. Sibling surface — the core stdio transport validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "command",
+    [
+        CREDENTIAL_COMMAND,
+        f"../../bin/sh --token={SYNTHETIC_TOKEN}",
+        "",
+    ],
+)
+def test_core_stdio_validator_does_not_echo_the_command(command):
+    """``security.md`` enforcement-surface parity: the core sibling validator.
+
+    ``kailash.channels.mcp.stdio.validate_spawn_command`` is an independent
+    implementation of the same fail-closed check with the same leak shape.
+    Fixing only the packaged one would leave the identical defect reachable
+    through the core stdio transport.
+    """
+    from kailash.channels.mcp.stdio import validate_spawn_command
+
+    if not command:
+        pytest.raises(Exception, validate_spawn_command, command)
+        return
+
+    with pytest.raises(Exception) as exc_info:
+        validate_spawn_command(command)
+    assert SYNTHETIC_TOKEN not in str(exc_info.value)


### PR DESCRIPTION
## Summary

The discovery health check logged and returned `str(e)` for a spawn command rejected by the fail-closed allowlist. `server.command` is untrusted registry/discovery input and routinely carries a credential as a CLI flag (`npx -y @vendor/server --token=<secret>`), so the token reached both the log record and the caller's status dict.

Fixed at the **raise site** rather than at the three call sites the issue names.

## Why the raise site, not the call sites

**1. The issue's prescribed remedy does not close the named threat.** The issue prescribes routing the sinks through `kailash.utils.url_credentials.mask_error_text`. Measured before adopting it:

```python
>>> from kailash.utils.url_credentials import mask_error_text as m
>>> m("npx some-server --token=SYNTH_SECRET_abc --url https://u:pw@h/x?api_key=SYNTH_QP")
'npx some-server --token=SYNTH_SECRET_abc --url https://***@h/x?api_key=***'
```

URL userinfo and credential query parameters are redacted; the CLI flag — the shape this input actually takes — passes through verbatim. Had the prescribed fix worked, the token would be absent. Routing through that helper would have produced a change that looks like a fix, passes a diff review, and leaks exactly as before. `tests/regression/test_issue_2004_spawn_command_leak.py::test_prescribed_remedy_does_not_close_the_named_threat` pins this measurement with two controls (URL userinfo, query param) that discriminate a real gap from a mis-invocation.

**2. There is a third sink the issue does not name.** `SpawnSecurityError` stored the raw command in `.data["command"]`, and `MCPError.to_dict()` copies `data` into the JSON-RPC error payload. A fix at the three named call sites would have closed two sinks and left the wire sink open.

So `SpawnSecurityError` now converts the command **at construction time** into a disclosure-safe `basename#fingerprint` reference. The message, the `.data` attribute, and the wire payload are covered by one change — and so is any sink added later. Not storing a secret beats redacting it at every sink someone remembers.

## What changed

- **`src/kailash/utils/command_safety.py`** (new) — `safe_command_ref()`, one shared helper per `security.md` § Credential Decode Helpers. Returns `<launcher>#<fingerprint>`: the basename of the first token (arguments, where credentials live, are never included) plus a truncated BLAKE2b digest of the whole command via the existing `fingerprint_secret`. The launcher label fails closed to `<redacted>` when the first token does not look like a plain program name (`--token=…`, `user:pw@host`); `<empty>` / `<non-string>` are distinct sentinels.
- **`packages/kailash-mcp/src/kailash_mcp/security.py`** — `SpawnSecurityError` scrubs at construction; all three raise branches render the reference instead of `{command!r}`.
- **`src/kailash/channels/mcp/stdio.py`** — the **core sibling validator** is an independent implementation of the same fail-closed check with the identical leak, reachable through the core stdio transport. Fixed in this PR for enforcement-surface parity (`security.md`); fixing only the packaged one would have left the defect live. Also removed `_quote_for_log`, an unused helper whose only purpose was to `shlex.join` a command and its args into a log line.
- **`packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py`** — the reported call site now needs no change beyond a comment; the adjacent silent `except Exception: pass` on the health-endpoint probe is now logged (`zero-tolerance` Rule 3) with the probe URL masked.

## Debuggability preserved

`zero-tolerance` Rule 3: the error stays useful. The reference is stable across calls and processes, so two log lines about the same command correlate; distinct commands do not collapse. The error code, the allowlist contents, and the `allow_arbitrary` remediation hint are unchanged. A fingerprint is not a secret and not a password hash — see `fingerprint_secret`'s caveats.

## Tests

`tests/regression/test_issue_2004_spawn_command_leak.py`, 21 cases, `@pytest.mark.regression`, behavioural. Asserts the synthetic token appears in **neither** the log record (every attribute, not just the formatted message — the leak lived in `extra=`), **nor** the exception `.data`, **nor** `to_dict()` output, across both raise branches and both validator implementations.

Fail-first verified against this branch's base: 19 failed / 2 passed before the fix, 21 passed after. (Both runs pinned to this worktree with `-o pythonpath=<wt>/src <wt>/packages/kailash-mcp/src` and the resolved `__file__` printed — `pytest.ini`'s `pythonpath = src` otherwise silently exercises the installed editable path.)

Suites run green: `tests/regression` + `tests/unit` (6646 passed, 16 skipped), `packages/kailash-mcp/tests` (670 passed, 1 xfailed), `pre-commit run --all-files` (exit 0).

## Disclosure: one commit used `SKIP=isort`

Commit `f22b149` (imports-only, no logic) was made with `SKIP=isort` — **not** `--no-verify`; every other hook ran and passed. Reason: the isort hook contradicts itself between its two invocation modes, so no single form satisfies both. Measured on `transports.py`, a file this PR does not touch, as committed on `main`:

```
pre-commit run isort --files .../transports.py   -> rewrites it
pre-commit run isort --all-files                 -> leaves it alone
```

Root cause is pre-existing and tracked as #1995 / #2039, but is **not yet diagnosed** — two candidate explanations have since been falsified, so do not treat either as the cause:

- *Not* an isort version skew. The hook pins 5.13.2 while the venv has 7.0.0, but both halves of the measurement above run **through pre-commit**, so both used 5.13.2. One version cannot disagree with itself.
- *Not* config-batch resolution. Three package `pyproject.toml` files (`kailash-kaizen`, `kaizen-agents`, `kailash-dataflow`) do carry their own `[tool.isort]`, but running the hook on batches differing only in composition — `transports.py` alone; plus a `packages/kailash-dataflow/` file; plus a `src/kailash/` file — produced **byte-identical** output in all three. Batch composition does not drive the classification.

What remains reproducible is the mode disagreement itself: `--all-files` passes on the committed form, while every `--files` invocation rewrites it. The committed form is the one `pre-commit run --all-files` accepts, which is also the form already in the tree, so this PR leaves the repo-wide gate at exit 0. The diagnosis belongs to #2039, not here.

## Related issues

Fixes #2004
Refs #1995 (isort mode non-determinism, disclosed above)

