### PR TITLE
chore(proposals): drop the seed-org token this entry quotes while narrating its removal

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -387,7 +387,7 @@ changes:
 
       REDTEAM: reviewer + security-reviewer + cc-architect (parallel) → MERGE-WITH-FIXES;
 
-      all fixes applied (README scrub + removed a leaked private seed-org token `rrps-mtu`
+      all fixes applied (README scrub + removed a leaked private seed-org token
 
       from the clause''s own detection grep). NOT a self-referential-codify Rule-1 round —
 


### PR DESCRIPTION
## Summary

`.claude/.proposals/latest.yaml` records that a leaked private seed-org token was removed
from a rule's own detection grep — and quotes the token inline while saying so.

That re-introduces the exact disclosure the original fix was for, into a proposal file that
rides the Gate-1 ingest path to loom. It survived review because the surrounding prose reads
as remediation rather than exposure, which is what makes this shape worth naming: **a
sentence describing a scrub is not itself scrubbed.**

## The change

One occurrence, one file. The sentence keeps its meaning — *what* was removed and *from
where* are both still stated. Only the literal is gone.

## Scope, and where it deliberately stops

The same token appears elsewhere in this repo, under `workspaces/**` and
`workspaces/_archive/**`. Those are **not** in scope here, for a stated reason rather than an
oversight:

- several are **cross-repo authorization records** where naming the target org is the entire
  point of the entry;
- one is the **discovery journal** documenting the original leak.

Those are historical records on a different surface with a different tradeoff, and rewriting
them is a separate decision that has not been taken. This PR does not pre-empt it.

## Verification

- Token count in the file: **1 → 0**, with a control (`seed-org`, still 1 hit) proving the
  matcher fires on this file — so the zero is a true negative, not a dead matcher.
- YAML still parses.
- Landed from a scratch worktree cut from `origin/main`, not from a live clone.

## Authorization

Cross-repo write, explicitly authorized by the co-owner. Receipt committed at loom under
`.claude/cross-repo-authz/`, naming this repo, this bounded action, and mode `write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
