### PR TITLE
fix(auth): resolve every collaborator call in nodes/auth; make #2035's identity binding live

### DIFF
--- a/src/kailash/nodes/auth/_http_response.py
+++ b/src/kailash/nodes/auth/_http_response.py
@@ -1,0 +1,54 @@
+"""Unwrap the HTTP node result envelope.
+
+``HTTPRequestNode`` and ``AsyncHTTPRequestNode`` both return
+
+    {"response": <HTTPResponse.model_dump()>, "status_code": ..., "success": ...}
+
+where the parsed body lives at ``response["content"]`` alongside ``headers``,
+``content_type``, ``url`` and ``response_time_ms``. Callers in this package read
+the identity out of the body, and several of them read ``result["response"]``
+directly -- one level too shallow -- so they were looking for ``email`` on the
+envelope and always found nothing.
+
+That was invisible while the calls could not execute at all: they awaited
+``async_run``/``execute_async`` on the sync ``HTTPRequestNode``, which defines
+neither, so every call raised ``AttributeError`` first (issue #2060). Switching
+to ``AsyncHTTPRequestNode`` made the calls run and exposed the shallow read
+underneath. Both halves are fixed together; fixing only the method name would
+have shipped a path that runs, fails to find an identity, and reports it as an
+invalid token.
+"""
+
+from typing import Any, Dict, Optional
+
+__all__ = ["http_body"]
+
+
+def http_body(result: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the parsed body from an HTTP node result.
+
+    Args:
+        result: The dict returned by ``HTTPRequestNode`` / ``AsyncHTTPRequestNode``.
+
+    Returns:
+        The decoded body as a dict, or ``{}`` when the request produced no
+        body, the body was not an object, or the envelope is absent. Returning
+        an empty mapping rather than raising keeps the callers' fail-closed
+        shape: no body means no identity, which every caller already treats as
+        an authentication failure.
+    """
+    if not isinstance(result, dict):
+        return {}
+
+    envelope = result.get("response")
+    if not isinstance(envelope, dict):
+        return {}
+
+    # An HTTP node envelope always carries "content" (HTTPResponse has
+    # status_code/headers/content_type/content/response_time_ms/url). There is
+    # deliberately NO fall-back to treating the envelope itself as the body: a
+    # bare-body branch fails OPEN in shape, accepting whatever a caller happens
+    # to pass, and the only thing it would have accommodated is a test double
+    # that does not match the contract it is standing in for.
+    body = envelope.get("content")
+    return body if isinstance(body, dict) else {}

--- a/src/kailash/nodes/auth/_log_hygiene.py
+++ b/src/kailash/nodes/auth/_log_hygiene.py
@@ -1,0 +1,93 @@
+"""Hygiene helpers for values that reach a security/audit log record.
+
+``SecurityEventNode.execute`` renders its record with an unescaped f-string::
+
+    log_message = f"[{severity.value}] {event_type}: {message}"
+    if user_id:
+        log_message += f" (User: {user_id})"
+
+Every node in this package supplies ``user_id`` from caller-controlled input,
+so a value containing a newline writes a SECOND well-formed record: an attacker
+can fabricate arbitrary security-log lines and bury the real ones underneath
+them (issue #2060).
+
+This was unreachable until #2060 was fixed -- each of these call sites awaited a
+method the sink does not define and raised ``AttributeError`` before reaching
+the logger. Resolving those calls is what makes the injection live, so the
+sanitizer lands with it.
+
+One helper, used at every sink call site in this package, rather than an inline
+``replace`` per site: five hand-rolled copies is how the sites drift
+(``rules/security.md`` § Multi-Site Kwarg Plumbing).
+
+The durable fix belongs one layer down, inside ``SecurityEventNode.execute``
+and ``AuditLogNode.execute``, so that EVERY caller in the SDK is covered rather
+than only this package's. That is outside this change's file scope; the helper
+here closes the exposure this change creates.
+"""
+
+from typing import Any
+
+__all__ = ["log_safe", "redact_mapping"]
+
+# Keys whose values are credential material or bulk personal data and must not
+# be copied into a log record. Matched case-insensitively as substrings, so
+# "access_token", "refresh_token" and "totp_secret" are all caught.
+_SENSITIVE_KEY_FRAGMENTS = (
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "credential",
+    "backup_code",
+    "recovery_code",
+    "private_key",
+    "api_key",
+    "qr_code",
+    "provisioning_uri",
+    "assertion",
+    "authorization",
+    "cookie",
+    "session_id",
+)
+
+
+def log_safe(value: Any, limit: int = 256) -> str:
+    """Flatten a value to one bounded, single-line token for a log record.
+
+    Non-printable characters -- newline, carriage return, and the terminal
+    escape sequences that can rewrite a console operator's screen -- are
+    replaced with a space, and the result is truncated. One call can therefore
+    only ever produce one line.
+    """
+    text = "" if value is None else str(value)
+    flattened = "".join(ch if ch.isprintable() else " " for ch in text)
+    return flattened[:limit]
+
+
+def redact_mapping(data: Any, _depth: int = 0) -> Any:
+    """Recursively replace credential-bearing values with a redaction marker.
+
+    Used for the free-form attribute bags the SSO and directory nodes attach to
+    audit records: a provisioning record carries whatever the IdP returned,
+    which routinely includes tokens and, for a directory sync, the full mapped
+    LDAP/AD entry. The record keeps its shape -- the key stays, so an auditor
+    can still see WHICH fields were present -- while the value is withheld.
+
+    Depth is bounded so a self-referential or pathologically nested attribute
+    bag cannot exhaust the stack inside a logging call.
+    """
+    if _depth >= 6:
+        return "[REDACTED_DEPTH]"
+    if isinstance(data, dict):
+        redacted = {}
+        for key, value in data.items():
+            lowered = str(key).lower()
+            if any(fragment in lowered for fragment in _SENSITIVE_KEY_FRAGMENTS):
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = redact_mapping(value, _depth + 1)
+        return redacted
+    if isinstance(data, (list, tuple)):
+        return [redact_mapping(item, _depth + 1) for item in data]
+    return data

--- a/src/kailash/nodes/auth/directory_integration.py
+++ b/src/kailash/nodes/auth/directory_integration.py
@@ -637,11 +637,31 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
         try:
             auth_result = await self._ldap_directory_auth(username, password)
 
+        # ANY exception from the bind -- including a connection an attacker can
+        # induce by taking the directory offline -- routes here. That is only
+        # acceptable because the fallback terminates FAIL-CLOSED, and it MUST
+        # stay that way:
+        #   * _fallback_directory_auth refuses outright with
+        #     reason="directory_unavailable" unless the operator explicitly set
+        #     connection_config["allow_insecure_credential_fallback"], read
+        #     through _is_enabled() so the string "false" does not enable it;
+        #   * even opted in, there is NO built-in account and NO default
+        #     password -- an empty dev_credentials authenticates nobody, and the
+        #     comparison is secrets.compare_digest against operator-supplied
+        #     values. The hardcoded table that defaulted every lookup to
+        #     "password123" is gone (issue #2026).
+        # Giving this path a permissive default would hand an attacker who can
+        # DoS the directory a login as anyone, which is exactly what #2026 fixed.
+        #
+        # This became REACHABLE in issue #2060: the audit call after the
+        # decision awaited a method the sink does not define, so the whole
+        # function previously raised AttributeError before returning. The
+        # fail-closed property was load-bearing but unexercised until then.
         except ImportError:
-            # Fall back to simulation if ldap3 not available
+            # ldap3 not installed
             auth_result = await self._simulate_directory_auth(username, password)
         except Exception:
-            # If connection fails, use simulation
+            # Bind or connection failure
             auth_result = await self._simulate_directory_auth(username, password)
 
         if auth_result["authenticated"]:

--- a/src/kailash/nodes/auth/directory_integration.py
+++ b/src/kailash/nodes/auth/directory_integration.py
@@ -23,7 +23,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from kailash.nodes.api import HTTPRequestNode
+from kailash.nodes.api import AsyncHTTPRequestNode
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
@@ -108,7 +108,12 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
 
     def _setup_supporting_nodes(self):
         """Initialize supporting Kailash nodes."""
-        self.http_client = HTTPRequestNode(name=f"{self.name}_http")
+        # AsyncHTTPRequestNode, not HTTPRequestNode: every call site here is
+        # on an async path and awaits the client. The sync HTTPRequestNode
+        # defines neither async_run nor execute_async, so those awaits
+        # raised AttributeError (issue #2060). Both return
+        # {"success": ..., "response": ...}.
+        self.http_client = AsyncHTTPRequestNode(name=f"{self.name}_http")
 
         self.json_reader = JSONReaderNode(name=f"{self.name}_json")
 
@@ -403,8 +408,19 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
             self.sync_status[self.directory_type] = sync_stats
 
             # Log sync completion
-            await self.audit_logger.execute_async(  # type: ignore[attr-defined]
-                action="directory_sync_completed", details=sync_stats
+            # AuditLogNode / SecurityEventNode are sync-only: neither defines
+            # execute_async nor async_run, so every await in this module raised
+            # AttributeError and no directory audit or security event was ever
+            # recorded (issue #2060). They are offloaded to a worker thread and
+            # given the parameters they actually read -- event_type/message/
+            # user_id/event_data for audit, event_type/severity/message/user_id/
+            # metadata for security. The action=/details=/source=/timestamp=
+            # previously passed were silently dropped by execute().
+            await asyncio.to_thread(
+                self.audit_logger.execute,
+                event_type="directory_sync_completed",
+                message=f"Directory sync completed for {self.directory_type}",
+                event_data=sync_stats,
             )
 
             return sync_stats
@@ -641,18 +657,23 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
             auth_result["user_dn"] = user_dn_template.format(username=username)
 
             # Log successful authentication
-            await self.audit_logger.execute_async(  # type: ignore[attr-defined]
-                action="directory_authentication_success",
+            await asyncio.to_thread(
+                self.audit_logger.execute,
+                event_type="directory_authentication_success",
+                message=f"Directory authentication succeeded for {username}",
                 user_id=username,
-                details={"directory_type": self.directory_type},
+                event_data={"directory_type": self.directory_type},
             )
         else:
             # Log failed authentication
-            await self.security_logger.execute_async(  # type: ignore[attr-defined]
+            await asyncio.to_thread(
+                self.security_logger.execute,
                 event_type="authentication_failure",
                 severity="HIGH",
-                source="directory_integration",
-                details={
+                message=f"Directory authentication failed for {username}",
+                user_id=username,
+                metadata={
+                    "source": "directory_integration",
                     "username": username,
                     "directory_type": self.directory_type,
                     "reason": auth_result.get("reason", "invalid_credentials"),
@@ -820,10 +841,12 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
         }
 
         # Log user provisioning
-        await self.audit_logger.execute_async(  # type: ignore[attr-defined]
-            action="user_provisioned_from_directory",
+        await asyncio.to_thread(
+            self.audit_logger.execute,
+            event_type="user_provisioned_from_directory",
+            message=f"Provisioned user {user_id} from {self.directory_type}",
             user_id=user_id,
-            details={
+            event_data={
                 "directory_type": self.directory_type,
                 "directory_data": user_data,
                 "provisioning_data": provisioning_data,
@@ -1518,12 +1541,15 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
         else:
             severity = "MEDIUM"
 
-        await self.security_logger.execute_async(  # type: ignore[attr-defined]
+        # The node stamps its own timestamp; source= and details= are not
+        # parameters of SecurityEventNode and were dropped (issue #2060).
+        await asyncio.to_thread(
+            self.security_logger.execute,
             event_type=event_type,
             severity=severity,
-            source="directory_integration_node",
-            timestamp=datetime.now(UTC).isoformat(),
-            details=event_data,
+            message=f"{event_type} via directory_integration_node",
+            user_id=event_data.get("user_id"),
+            metadata={"source": "directory_integration_node", **event_data},
         )
 
     def get_directory_statistics(self) -> Dict[str, Any]:

--- a/src/kailash/nodes/auth/directory_integration.py
+++ b/src/kailash/nodes/auth/directory_integration.py
@@ -24,6 +24,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from kailash.nodes.api import AsyncHTTPRequestNode
+from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
@@ -660,8 +661,8 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
             await asyncio.to_thread(
                 self.audit_logger.execute,
                 event_type="directory_authentication_success",
-                message=f"Directory authentication succeeded for {username}",
-                user_id=username,
+                message=f"Directory authentication succeeded for {log_safe(username, 64)}",
+                user_id=log_safe(username),
                 event_data={"directory_type": self.directory_type},
             )
         else:
@@ -670,8 +671,8 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
                 self.security_logger.execute,
                 event_type="authentication_failure",
                 severity="HIGH",
-                message=f"Directory authentication failed for {username}",
-                user_id=username,
+                message=f"Directory authentication failed for {log_safe(username, 64)}",
+                user_id=log_safe(username),
                 metadata={
                     "source": "directory_integration",
                     "username": username,
@@ -844,13 +845,18 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
         await asyncio.to_thread(
             self.audit_logger.execute,
             event_type="user_provisioned_from_directory",
-            message=f"Provisioned user {user_id} from {self.directory_type}",
-            user_id=user_id,
-            event_data={
-                "directory_type": self.directory_type,
-                "directory_data": user_data,
-                "provisioning_data": provisioning_data,
-            },
+            message=f"Provisioned user {log_safe(user_id, 64)} from {self.directory_type}",
+            user_id=log_safe(user_id),
+            # The directory record is whatever the IdP returned -- for an
+            # LDAP/AD sync that is the full mapped entry. Redacted rather than
+            # copied verbatim into a log the whole org can read (issue #2060).
+            event_data=redact_mapping(
+                {
+                    "directory_type": self.directory_type,
+                    "directory_data": user_data,
+                    "provisioning_data": provisioning_data,
+                }
+            ),
         )
 
         return {
@@ -1548,8 +1554,10 @@ class DirectoryIntegrationNode(SecurityMixin, PerformanceMixin, LoggingMixin, No
             event_type=event_type,
             severity=severity,
             message=f"{event_type} via directory_integration_node",
-            user_id=event_data.get("user_id"),
-            metadata={"source": "directory_integration_node", **event_data},
+            user_id=log_safe(event_data.get("user_id")),
+            metadata=redact_mapping(
+                {"source": "directory_integration_node", **event_data}
+            ),
         )
 
     def get_directory_statistics(self) -> Dict[str, Any]:

--- a/src/kailash/nodes/auth/enterprise_auth_provider.py
+++ b/src/kailash/nodes/auth/enterprise_auth_provider.py
@@ -25,6 +25,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 from kailash.nodes.api import AsyncHTTPRequestNode
+from kailash.nodes.auth._http_response import http_body
+from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
 from kailash.nodes.auth.directory_integration import DirectoryIntegrationNode
 from kailash.nodes.auth.mfa import MultiFactorAuthNode
 from kailash.nodes.auth.session_management import SessionManagementNode
@@ -319,11 +321,27 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             # The claim is retained alongside it, because a caller asserting a
             # subject it did not authenticate as is exactly what an auditor
             # needs to see.
+            # "auth_success" is reserved for actions that actually authenticate
+            # a principal. get_methods / assess_risk / challenge_mfa echo the
+            # caller's own user_id back and default to success=True, so emitting
+            # auth_success for them wrote a record byte-identical to a genuine
+            # login for a subject nobody authenticated -- an unauthenticated
+            # caller could forge "alice logged in" at will, and the counter
+            # agreed with it (issue #2060).
+            # "validate" is deliberately NOT here. It is a per-request session
+            # check, and counting each one as a successful authentication makes
+            # auth_statistics["successful_auths"] mean something other than
+            # "logins" -- an auditor counting auth_success would over-count by
+            # however chatty the caller is.
+            authenticating = action in {"authenticate", "authorize"}
             if result.get("success", True):
-                self.auth_statistics["successful_auths"] += 1
+                if authenticating:
+                    self.auth_statistics["successful_auths"] += 1
                 resolved_user_id = result.get("user_id") or user_id
                 await self._log_auth_event(
-                    event_type="auth_success",
+                    event_type=(
+                        "auth_success" if authenticating else f"{action}_success"
+                    ),
                     action=action,
                     auth_id=auth_id,
                     user_id=resolved_user_id,
@@ -858,7 +876,12 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             )
 
             if response.get("success"):
-                user_info = response["response"]
+                # http_body(), not response["response"]: the value under
+                # "response" is the HTTPResponse envelope and the provider's
+                # userinfo document lives at its "content" key. Reading the
+                # envelope found no email/login and reported a valid token as
+                # invalid (issue #2060).
+                user_info = http_body(response)
                 return {
                     "valid": True,
                     "user_id": user_info.get("email") or user_info.get("login"),
@@ -1545,14 +1568,20 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         # details= this used to pass were dropped on the floor by execute(), and
         # message/user_id/metadata were never supplied -- so every event would
         # have been recorded blank even once the call resolved (issue #2060).
-        # The node stamps its own timestamp.
+        # The node stamps its own timestamp. The action is named in the message
+        # so a record cannot be mistaken for one from a different action.
         await asyncio.to_thread(
             self.security_logger.execute,
             event_type=event_type,
             severity=severity,
-            message=f"{event_type} via enterprise_auth_provider",
-            user_id=event_data.get("user_id"),
-            metadata={"source": "enterprise_auth_provider", **event_data},
+            message=(
+                f"{event_type} (action={log_safe(event_data.get('action'), 64)}) "
+                f"via enterprise_auth_provider"
+            ),
+            user_id=log_safe(event_data.get("user_id")),
+            metadata=redact_mapping(
+                {"source": "enterprise_auth_provider", **event_data}
+            ),
         )
 
     def get_auth_statistics(self) -> Dict[str, Any]:

--- a/src/kailash/nodes/auth/enterprise_auth_provider.py
+++ b/src/kailash/nodes/auth/enterprise_auth_provider.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from kailash.nodes.api import HTTPRequestNode
+from kailash.nodes.api import AsyncHTTPRequestNode
 from kailash.nodes.auth.directory_integration import DirectoryIntegrationNode
 from kailash.nodes.auth.mfa import MultiFactorAuthNode
 from kailash.nodes.auth.session_management import SessionManagementNode
@@ -148,7 +148,14 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         )
 
         # Supporting nodes
-        self.http_client = HTTPRequestNode(name=f"{self.name}_http")
+        #
+        # AsyncHTTPRequestNode, not HTTPRequestNode: every caller of this node
+        # is on an async path (_validate_social_token), and the sync
+        # HTTPRequestNode has no awaitable surface at all -- the previous
+        # execute_async() call against it raised AttributeError, which the
+        # caller's except-clause then reported as "Token validation failed"
+        # (issue #2060). Both return {"success": ..., "response": ...}.
+        self.http_client = AsyncHTTPRequestNode(name=f"{self.name}_http")
 
         self.security_logger = SecurityEventNode(name=f"{self.name}_security")
 
@@ -301,14 +308,26 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 else:
                     result["success"] = True
 
-            # Log successful operation
+            # Log successful operation.
+            #
+            # The event is attributed to the principal the operation RESOLVED
+            # to, not to the user_id the caller typed. _authenticate and
+            # _authorize both discard the caller's claim in favour of the
+            # credential's / session's subject (issue #2026, PR #2035); an
+            # audit record still naming the caller's claim would attribute
+            # alice's login to "admin" and defeat the same fix one layer up.
+            # The claim is retained alongside it, because a caller asserting a
+            # subject it did not authenticate as is exactly what an auditor
+            # needs to see.
             if result.get("success", True):
                 self.auth_statistics["successful_auths"] += 1
+                resolved_user_id = result.get("user_id") or user_id
                 await self._log_auth_event(
                     event_type="auth_success",
                     action=action,
                     auth_id=auth_id,
-                    user_id=user_id,
+                    user_id=resolved_user_id,
+                    claimed_user_id=user_id,
                     auth_method=auth_method,
                     risk_context=risk_context,
                     processing_time_ms=processing_time,
@@ -456,7 +475,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
 
         # All authentication successful - create session
         self.log_info(f"Creating session for user {user_id}...")
-        session_result = await self.session_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+        session_result = await self.session_node.async_run(
             action="create",
             user_id=user_id,
             auth_method=auth_method,
@@ -493,7 +512,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
     ) -> Dict[str, Any]:
         """Perform authentication using specified method."""
         if auth_method == "sso":
-            return await self.sso_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            return await self.sso_node.async_run(
                 action="callback",
                 provider=credentials.get("provider"),
                 request_data=credentials.get("request_data"),
@@ -501,12 +520,12 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             )
 
         elif auth_method == "directory":
-            return await self.directory_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            return await self.directory_node.async_run(
                 action="authenticate", credentials=credentials
             )
 
         elif auth_method == "mfa":
-            return await self.mfa_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            return await self.mfa_node.async_run(
                 action="verify",
                 user_id=user_id,
                 code=credentials.get("mfa_code"),
@@ -832,7 +851,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
 
         try:
             # Make request to validate token
-            response = await self.http_client.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            response = await self.http_client.async_run(
                 method="GET",
                 url=url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -953,7 +972,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 }
 
             # Verify MFA
-            mfa_result = await self.mfa_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            mfa_result = await self.mfa_node.async_run(
                 action="verify",
                 user_id=user_id,
                 code=mfa_code,
@@ -1346,7 +1365,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 "reason": "session_required",
             }
 
-        session_validation = await self.session_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+        session_validation = await self.session_node.async_run(
             action="validate", session_id=session_id
         )
 
@@ -1428,13 +1447,13 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
 
         # Logout from session management
         if session_id:
-            session_result = await self.session_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+            session_result = await self.session_node.async_run(
                 action="terminate", session_id=session_id
             )
             logout_results.append({"component": "session", "result": session_result})
 
         # Logout from SSO if applicable
-        sso_result = await self.sso_node.execute_async(action="logout", user_id=user_id)  # type: ignore[reportAttributeAccessIssue]
+        sso_result = await self.sso_node.async_run(action="logout", user_id=user_id)
         logout_results.append({"component": "sso", "result": sso_result})
 
         # Clear risk scores
@@ -1442,10 +1461,18 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             del self.risk_scores[user_id]
 
         # Log logout
-        await self.audit_logger.execute_async(  # type: ignore[reportAttributeAccessIssue]
-            action="user_logout",
+        # AuditLogNode is a sync-only Node: it defines neither execute_async nor
+        # async_run, so it is offloaded to a worker thread rather than awaited.
+        # Its parameters are event_type/message/user_id/event_data -- the
+        # action=/details= this used to pass were not read by execute() at all,
+        # so a working call would still have written {"message": "", "data": {}}:
+        # an audit record that does not say what happened (issue #2060).
+        await asyncio.to_thread(
+            self.audit_logger.execute,
+            event_type="user_logout",
+            message=f"User {user_id} logged out",
             user_id=user_id,
-            details={"session_id": session_id, "logout_results": logout_results},
+            event_data={"session_id": session_id, "logout_results": logout_results},
         )
 
         return {
@@ -1457,7 +1484,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
 
     async def _validate_session(self, session_id: str, **kwargs) -> Dict[str, Any]:
         """Validate session."""
-        result = await self.session_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+        result = await self.session_node.async_run(
             action="validate", session_id=session_id
         )
 
@@ -1479,7 +1506,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
 
             if method == "mfa":
                 # Check if user has MFA configured
-                mfa_status = await self.mfa_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+                mfa_status = await self.mfa_node.async_run(
                     action="status", user_id=user_id
                 )
                 method_info["configured"] = mfa_status.get("mfa_enabled", False)
@@ -1497,7 +1524,7 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         self, user_id: str, auth_method: str, **kwargs
     ) -> Dict[str, Any]:
         """Challenge user for MFA."""
-        return await self.mfa_node.execute_async(  # type: ignore[reportAttributeAccessIssue]
+        return await self.mfa_node.async_run(
             action="challenge", user_id=user_id, method=auth_method
         )
 
@@ -1512,12 +1539,20 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         else:
             severity = "MEDIUM"
 
-        await self.security_logger.execute_async(  # type: ignore[reportAttributeAccessIssue]
+        # SecurityEventNode is a sync-only Node (neither execute_async nor
+        # async_run), so it is offloaded to a worker thread. Its parameters are
+        # event_type/severity/message/user_id/metadata; the source=/timestamp=/
+        # details= this used to pass were dropped on the floor by execute(), and
+        # message/user_id/metadata were never supplied -- so every event would
+        # have been recorded blank even once the call resolved (issue #2060).
+        # The node stamps its own timestamp.
+        await asyncio.to_thread(
+            self.security_logger.execute,
             event_type=event_type,
             severity=severity,
-            source="enterprise_auth_provider",
-            timestamp=datetime.now(UTC).isoformat(),
-            details=event_data,
+            message=f"{event_type} via enterprise_auth_provider",
+            user_id=event_data.get("user_id"),
+            metadata={"source": "enterprise_auth_provider", **event_data},
         )
 
     def get_auth_statistics(self) -> Dict[str, Any]:

--- a/src/kailash/nodes/auth/enterprise_auth_provider.py
+++ b/src/kailash/nodes/auth/enterprise_auth_provider.py
@@ -502,6 +502,31 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             ip_address=risk_context.get("ip_address"),
             device_info=risk_context.get("device_info"),
         )
+        # A credential that verifies but yields no session is NOT an
+        # authentication. This returned success=True / authenticated=True with
+        # session_id=None whenever the session step refused, took the caller's
+        # success branch, incremented successful_auths, and emitted an
+        # auth_success record for a login that minted nothing (issue #2060).
+        #
+        # Reachable today: SessionManagementNode refuses "create" without an
+        # ip_address, and _extract_risk_context only supplies a default when
+        # risk_context is FALSY. A caller passing a non-empty risk_context that
+        # omits ip_address -- device_info or user_agent only, the ordinary
+        # shape -- skips that fallback and lands here. Same class as the
+        # success-derivation fix in async_run: the verdict comes from the
+        # operation, never from a default.
+        if not session_result.get("success") or not session_result.get("session_id"):
+            return {
+                "success": False,
+                "authenticated": False,
+                "error": "session_creation_failed",
+                "reason": "session_creation_failed",
+                "user_id": user_id,
+                "auth_method": auth_method,
+                "risk_score": risk_score,
+                "session_details": session_result,
+            }
+
         self.log_info(f"Session created: {session_result.get('session_id')}")
 
         # Clear failed attempts on successful auth
@@ -1493,8 +1518,8 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         await asyncio.to_thread(
             self.audit_logger.execute,
             event_type="user_logout",
-            message=f"User {user_id} logged out",
-            user_id=user_id,
+            message=f"User {log_safe(user_id, 64)} logged out",
+            user_id=log_safe(user_id),
             event_data={"session_id": session_id, "logout_results": logout_results},
         )
 

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -14,11 +14,13 @@ import logging
 import secrets
 import threading
 import time
+from collections import deque
 from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 import qrcode
 
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
@@ -321,6 +323,16 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         # Thread lock for concurrent access
         self._data_lock = threading.Lock()
 
+        # Audit records queued by handlers running under _data_lock, flushed by
+        # the dispatcher once the lock is released (see _log_mfa_event).
+        # Bounded so a caller that never reaches a flush cannot grow it without
+        # limit; the oldest record is dropped rather than the process.
+        self._pending_audit_records: deque = deque(maxlen=10000)
+        # In-process record of emitted events. Bounded for the same reason
+        # as the queue above: an unbounded sibling list would retain every
+        # event for the node's lifetime and defeat the cap next to it.
+        self.audit_events: deque = deque(maxlen=10000)
+
         # MFA statistics
         self.mfa_stats = {
             "total_setups": 0,
@@ -560,7 +572,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             # because they are not attacker-driven probe surfaces.
             if action == "verify" and not self._check_rate_limit(user_id):
                 self.mfa_stats["rate_limited_attempts"] += 1
-                return {
+                rate_limited = {
                     "success": False,
                     "verified": False,
                     "user_id": user_id,
@@ -570,6 +582,13 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                     "processing_time_ms": 0.0,
                     "timestamp": start_time.isoformat(),
                 }
+                # Audit before returning. This early return used to skip the
+                # audit call at the end of the dispatcher, so a sustained
+                # brute-force produced records up to the rate-limit threshold
+                # and then went SILENT for the rest of the attack -- the trail
+                # stopped exactly when it became interesting (issue #2060).
+                self._audit_mfa_operation_sync(user_id, action, method, rate_limited)
+                return rate_limited
 
             # Route to appropriate action handler
             if action in ["setup", "enroll"]:  # Handle both setup and enroll
@@ -753,6 +772,13 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         except Exception as e:
             # self.log_error_with_traceback(e, "mfa_operation")
             raise
+        finally:
+            # In a finally so that the early returns above (rate limit,
+            # malformed input) and the exception paths still drain the queue.
+            # A record queued under _data_lock and never flushed would sit in
+            # the deque until some later dispatch happened to pick it up, or
+            # fall off the end of the bounded queue entirely.
+            self._flush_audit_records()
 
     async def execute_async(self, **kwargs) -> Dict[str, Any]:
         """Execute method for async compatibility."""
@@ -1642,8 +1668,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                 # Create MFA session (internal, lock-free)
                 session_id = self._create_mfa_session_internal(user_id)
 
-                # Log security event (async - disabled for sync operation)
-                # self._log_security_event(user_id, "backup_code_used", "medium")
+                self._queue_security_event(user_id, "backup_code_used", "medium")
 
                 return {
                     "success": True,
@@ -1725,8 +1750,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                 # Create MFA session (internal, lock-free)
                 session_id = self._create_mfa_session_internal(user_id)
 
-                # Log security event (async - disabled for sync operation)
-                # self._log_security_event(user_id, "mfa_verification_success", "low")
+                self._queue_security_event(user_id, "mfa_verification_success", "low")
 
                 return {
                     "success": True,
@@ -2070,8 +2094,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                 UTC
             ).isoformat()
 
-            # Log security event
-            # self._log_security_event(user_id, "backup_codes_generated", "low")
+            self._queue_security_event(user_id, "backup_codes_generated", "low")
 
             return {
                 "success": True,
@@ -2120,8 +2143,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             # already held here and is not reentrant.
             self._invalidate_user_sessions_internal(user_id)
 
-            # Log security event
-            # self._log_security_event(user_id, "mfa_revoked", "high")
+            self._queue_security_event(user_id, "mfa_revoked", "high")
 
             return {
                 "success": True,
@@ -2535,6 +2557,82 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             self._audit_mfa_operation_sync, user_id, action, method, result
         )
 
+    # Result keys that may be copied into an audit record. This is an
+    # ALLOWLIST, not a denylist, and that is deliberate: MFA results carry
+    # credential material -- the TOTP seed, the provisioning URI that embeds
+    # it, backup/recovery codes, device trust tokens, MFA session ids, and
+    # unmasked phone/email -- and an audit sink writes to whatever handler the
+    # operator attached, typically a log aggregator with far wider read access
+    # than the credential store. Copying a whole result dict here would put a
+    # user's second factor in the SIEM: strictly worse than the unwired sink
+    # this replaced. A new result key is omitted until it is reviewed and
+    # added, so the failure mode of forgetting to update this list is a
+    # thinner record rather than a leaked secret.
+    _AUDITABLE_RESULT_KEYS = frozenset(
+        {
+            "success",
+            "action",
+            "method",
+            "user_id",
+            "verified",
+            "error",
+            "reason",
+            "reset",
+            "revoked",
+            "disabled",
+            "enabled",
+            "mfa_enabled",
+            "methods",
+            "challenge_required",
+            # A trusted-device bypass is arguably the single most important
+            # fact this node can record: it means the second factor was NOT
+            # presented for this login.
+            "trusted",
+            "skip_mfa",
+            "device_id",
+            # What a destructive admin action actually destroyed.
+            "revoked_methods",
+            "disabled_methods",
+            "mfa_disabled",
+            "method_disabled",
+            "challenge_id",
+            "recovery_method",
+            "pending_verification",
+            "valid",
+            "enrolled_methods",
+            "rate_limited",
+            "too_many_attempts",
+            "locked",
+            "admin_override",
+            "codes_remaining",
+            "backup_codes_remaining",
+            "attempts_remaining",
+            "verification_sent",
+            "masked_phone",
+            "masked_email",
+            "expires_at",
+            "setup_at",
+            "processing_time_ms",
+            "timestamp",
+        }
+    )
+
+    @classmethod
+    def _audit_safe_result(cls, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Project a result down to the keys that are safe to record.
+
+        Returns the allowlisted keys plus ``omitted_keys``, so the record
+        states what it withheld rather than silently presenting a partial
+        result as a whole one.
+        """
+        if not isinstance(result, dict):
+            return {"omitted_keys": []}
+        safe = {k: v for k, v in result.items() if k in cls._AUDITABLE_RESULT_KEYS}
+        safe["omitted_keys"] = sorted(
+            k for k in result if k not in cls._AUDITABLE_RESULT_KEYS
+        )
+        return safe
+
     def _audit_mfa_operation_sync(
         self, user_id: str, action: str, method: str, result: Dict[str, Any]
     ) -> None:
@@ -2561,8 +2659,10 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                 "method": method,
                 "resource_type": "mfa",
                 "resource_id": f"{user_id}:{method}",
-                "success": result.get("success", False),
-                "result": result,
+                "success": (
+                    result.get("success", False) if isinstance(result, dict) else False
+                ),
+                "result": self._audit_safe_result(result),
                 # user_id above is the SUBJECT of the operation, never the
                 # actor: this node has no caller identity to record, and
                 # admin_override is a caller-supplied boolean rather than an
@@ -2686,7 +2786,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             # Mirrors the sync run() rate-limit dispatch.
             if action == "verify" and not self._check_rate_limit(user_id):
                 self.mfa_stats["rate_limited_attempts"] += 1
-                return {
+                rate_limited = {
                     "success": False,
                     "verified": False,
                     "user_id": user_id,
@@ -2696,6 +2796,13 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
                     "processing_time_ms": 0.0,
                     "timestamp": start_time.isoformat(),
                 }
+                # Audit before returning. This early return used to skip the
+                # audit call at the end of the dispatcher, so a sustained
+                # brute-force produced records up to the rate-limit threshold
+                # and then went SILENT for the rest of the attack -- the trail
+                # stopped exactly when it became interesting (issue #2060).
+                await self._audit_mfa_operation(user_id, action, method, rate_limited)
+                return rate_limited
 
             # Route to appropriate action handler
             if action == "setup":
@@ -2793,6 +2900,11 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         except Exception as e:
             # self.log_error_with_traceback(e, "mfa_operation")
             raise
+        finally:
+            # See the sync dispatcher: in a finally so early returns and the
+            # exception paths still drain the queue. Offloaded because this one
+            # runs on the caller's event loop.
+            await asyncio.to_thread(self._flush_audit_records)
 
     def _verify_backup_code(self, user_id: str, code: str) -> Dict[str, Any]:
         """Verify backup code for user.
@@ -2936,34 +3048,86 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             return {"success": True, "methods": methods}
 
     def _log_mfa_event(self, event_type: str, metadata: Dict[str, Any]) -> None:
-        """Log MFA-related security events."""
-        # In a real implementation, this would log to a security audit system
-        # For testing, we just store it internally
-        if not hasattr(self, "audit_events"):
-            self.audit_events = []
+        """Record an MFA event for the audit sink.
 
+        This is called from handlers that hold ``_data_lock`` (``_setup_totp``
+        runs inside ``_setup_mfa``'s ``with self._data_lock:``), so it does NOT
+        write to the sink here. ``AuditLogNode.execute`` calls whatever logging
+        handler the operator attached; a syslog/HTTP/SIEM handler blocking on
+        the network while ``_data_lock`` is held would stall every MFA
+        operation in the process behind it -- a slow log collector becoming an
+        authentication outage. The record is queued and flushed by the
+        dispatcher after the lock is released.
+        """
         event = {
+            "kind": "audit",
             "event_type": event_type,
             "metadata": metadata,
             "timestamp": datetime.now(UTC).isoformat(),
         }
         self.audit_events.append(event)
+        self._pending_audit_records.append(event)
 
-        # Also write to the audit sink. The `hasattr(...) and self.audit_log_node`
-        # guard that used to stand here is gone: __init__ always constructs the
-        # sink now, so the absent-branch was unreachable and would have silently
-        # returned success while recording nothing (issue #2060). Parameters are
-        # the ones AuditLogNode reads -- action=/metadata= were dropped.
-        try:
-            self.audit_log_node.execute(
-                event_type=event_type,
-                message=f"MFA event {event_type}",
-                user_id=metadata.get("user_id"),
-                event_data=metadata,
-            )
-        except Exception as e:
-            # Don't fail the main operation if audit logging fails
-            logger.warning(f"Audit logging failed: {e}")
+    def _queue_security_event(
+        self, user_id: str, event_type: str, severity: str
+    ) -> None:
+        """Queue a security event for the sink. Safe to call under ``_data_lock``.
+
+        The four callers of this sit inside ``_data_lock``-held handlers, which
+        is why they stood commented out as "disabled for sync operation": the
+        only surface available was the async ``_log_security_event``. So the
+        ``mfa_revoked`` HIGH-severity event -- the one that pages someone when
+        a second factor is destroyed -- has never fired (issue #2060). Queueing
+        is synchronous and lock-safe; the dispatcher flushes after release.
+        """
+        self._pending_audit_records.append(
+            {
+                "kind": "security",
+                "event_type": event_type,
+                "severity": severity,
+                "user_id": user_id,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        )
+
+    def _flush_audit_records(self) -> None:
+        """Write queued records to the sinks. MUST run outside ``_data_lock``.
+
+        The ``hasattr(...) and self.audit_log_node`` guard that used to stand
+        at the write site is gone: ``__init__`` always constructs the sink now,
+        so the absent-branch was unreachable and would have returned success
+        while recording nothing (issue #2060).
+        """
+        while True:
+            try:
+                event = self._pending_audit_records.popleft()
+            except IndexError:
+                # Empty, or drained concurrently by the other dispatcher. Both
+                # are the same non-event; popleft is checked rather than
+                # guarded by a truthiness test so a concurrent drain cannot
+                # raise out of a logging call.
+                return
+
+            try:
+                if event["kind"] == "security":
+                    self.security_event_node.execute(
+                        event_type=event["event_type"],
+                        severity=str(event["severity"] or "INFO").upper(),
+                        message=f"MFA {event['event_type']} for user {log_safe(event['user_id'], 64)}",
+                        user_id=log_safe(event["user_id"]),
+                        metadata={"mfa_operation": True, "source_ip": "unknown"},
+                    )
+                else:
+                    metadata = event["metadata"]
+                    self.audit_log_node.execute(
+                        event_type=event["event_type"],
+                        message=f"MFA event {event['event_type']}",
+                        user_id=log_safe(metadata.get("user_id")),
+                        event_data=self._audit_safe_result(metadata),
+                    )
+            except Exception as e:
+                # Don't fail the main operation if audit logging fails
+                logger.warning(f"Audit logging failed: {e}")
 
     def _initiate_recovery(
         self,

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -2531,7 +2531,9 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             method: MFA method
             result: Operation result
         """
-        await asyncio.to_thread(self._audit_mfa_operation_sync, user_id, action, method, result)
+        await asyncio.to_thread(
+            self._audit_mfa_operation_sync, user_id, action, method, result
+        )
 
     def _audit_mfa_operation_sync(
         self, user_id: str, action: str, method: str, result: Dict[str, Any]

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import qrcode
 
-from kailash.nodes.auth._log_hygiene import log_safe
+from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
@@ -2598,7 +2598,15 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         safe["omitted_keys"] = sorted(
             k for k in result if k not in cls._AUDITABLE_RESULT_KEYS
         )
-        return safe
+        # The allowlist is FLAT -- it admits a key, not the shape underneath
+        # it. "methods" is safe only because its producer happens to be a
+        # curated projection; a future change returning user_mfa_data["methods"]
+        # directly would hand this the TOTP seed and push_token nested one level
+        # down, and the allowlist would copy them straight through. Composing
+        # the same redactor used at every SSO and directory sink closes that,
+        # and puts the strongest filter where the credential material actually
+        # lives rather than only where it does not.
+        return redact_mapping(safe)
 
     def _audit_mfa_operation_sync(
         self, user_id: str, action: str, method: str, result: Dict[str, Any]
@@ -2619,8 +2627,8 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         """
         audit_entry = {
             "event_type": f"mfa_{action}",
-            "message": f"MFA {action} ({method}) for user {user_id}",
-            "user_id": user_id,
+            "message": f"MFA {action} ({method}) for user {log_safe(user_id, 64)}",
+            "user_id": log_safe(user_id),
             "event_data": {
                 "action": action,
                 "method": method,

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -5,6 +5,7 @@ This module provides comprehensive MFA capabilities including TOTP, SMS, email
 verification, backup codes, and integration with popular authenticator apps.
 """
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -227,10 +228,6 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         >>> print(f"Verified: {verify_result['verified']}")
     """
 
-    # Set once per process by __init__ so the "no audit sink" warning is stated
-    # loudly one time, rather than per operation where it reads as transient.
-    _audit_gap_warned: bool = False
-
     def __init__(
         self,
         name: str = "multi_factor_auth",
@@ -289,22 +286,28 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         # Initialize parent classes
         super().__init__(name=name, **kwargs)
 
-        # Audit logging is NOT wired. This is a real gap, not a configuration
-        # choice, and it is stated loudly here rather than surfacing as a
-        # per-operation "Failed to audit" warning that reads like a transient
-        # error (issue #2026). The nodes were disabled while debugging a
-        # deadlock and never restored; re-wiring them needs that deadlock
-        # re-investigated, which is out of scope for the #2026 stub removal.
-        self.audit_log_node = None
-        self.security_event_node = None
-        if not MultiFactorAuthNode._audit_gap_warned:
-            MultiFactorAuthNode._audit_gap_warned = True
-            logger.warning(
-                "MultiFactorAuthNode has NO audit sink: setup, verify, revoke, "
-                "disable, reset and recovery -- including the admin-gated "
-                "destructive actions -- complete with no audit record. Deploy "
-                "behind a layer that records these operations."
-            )
+        # Audit logging IS wired (issue #2060).
+        #
+        # These two sinks stood at None from this file's first commit
+        # (7dc4e6773, 2025-06-16) behind the comment "disabled for now to fix
+        # deadlock". The deadlock was re-investigated before re-wiring and
+        # there is no evidence for it:
+        #   * `git log -S "AuditLogNode(" -- src/kailash/nodes/auth/mfa.py`
+        #     returns the birth commit and nothing earlier -- the wiring was
+        #     ALREADY commented out when the file first landed, so no commit
+        #     ever wired it and no commit ever disabled it in response to a
+        #     hang. There is no repro anywhere in history.
+        #   * AuditLogNode.execute and SecurityEventNode.execute take no lock,
+        #     open no socket, and enter no event loop; each is dict
+        #     construction plus one `logger` call.
+        #   * SessionManagementNode constructs and calls these exact two nodes
+        #     today, synchronously, from inside a held non-reentrant
+        #     threading.Lock, and ships.
+        # The real MFA deadlock -- `_revoke_mfa` re-acquiring the non-reentrant
+        # `_data_lock` -- was a different defect, fixed under #2026, and had no
+        # audit-node involvement.
+        self.audit_log_node = AuditLogNode(name=f"{name}_audit_log")
+        self.security_event_node = SecurityEventNode(name=f"{name}_security_events")
 
         # User MFA data storage (in production, this would be a database)
         self.user_mfa_data: Dict[str, Dict[str, Any]] = {}
@@ -710,15 +713,23 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             result["processing_time_ms"] = processing_time
             result["timestamp"] = start_time.isoformat()
 
-            # Audit log the operation (disabled for now to fix deadlock)
-            # self._audit_mfa_operation(user_id, action, method, result)
+            # Audit the operation. This stood commented out from this file's
+            # first commit behind "disabled for now to fix deadlock", which
+            # meant every admin-gated destructive action (revoke, disable,
+            # reset) taken through the SYNC surface completed with no record.
+            # The deadlock claim was re-investigated and has no supporting
+            # evidence -- see the sink construction in __init__ (issue #2060).
+            # This is deliberately OUTSIDE any `_data_lock` held above: the
+            # action handlers acquire and release it themselves, so the sink
+            # never runs under the lock.
+            self._audit_mfa_operation_sync(user_id, action, method, result)
 
-            # self.log_node_execution(
-            #     "mfa_operation_complete",
-            #     action=action,
-            #     success=result.get("success", False),
-            #     processing_time_ms=processing_time
-            # )
+            self.log_node_execution(
+                "mfa_operation_complete",
+                action=action,
+                success=result.get("success", False),
+                processing_time_ms=processing_time,
+            )
 
             return result
 
@@ -2486,17 +2497,26 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             event_type: Type of security event
             severity: Event severity
         """
+        # SecurityEventNode is a sync-only Node: it defines neither async_run
+        # nor execute_async, so this await raised AttributeError (issue #2060).
+        # Its parameters are event_type/severity/message/user_id/metadata --
+        # description= and source_ip= were dropped and message= never supplied.
+        # severity is upper-cased because SeverityLevel() rejects lowercase.
         security_event = {
             "event_type": event_type,
-            "severity": severity,
-            "description": f"MFA {event_type} for user {user_id}",
-            "metadata": {"mfa_operation": True},
+            "severity": severity.upper(),
+            "message": f"MFA {event_type} for user {user_id}",
             "user_id": user_id,
-            "source_ip": "unknown",  # In real implementation, get from request
+            "metadata": {
+                "mfa_operation": True,
+                # No request context reaches this node -- it has no caller,
+                # session, or principal parameter. See #2047.
+                "source_ip": "unknown",
+            },
         }
 
         try:
-            await self.security_event_node.async_run(**security_event)  # type: ignore[reportAttributeAccessIssue]
+            await asyncio.to_thread(self.security_event_node.execute, **security_event)
         except Exception as e:
             self.log_with_context("WARNING", f"Failed to log security event: {e}")
 
@@ -2511,28 +2531,49 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             method: MFA method
             result: Operation result
         """
+        await asyncio.to_thread(self._audit_mfa_operation_sync, user_id, action, method, result)
+
+    def _audit_mfa_operation_sync(
+        self, user_id: str, action: str, method: str, result: Dict[str, Any]
+    ) -> None:
+        """Audit an MFA operation from a synchronous caller.
+
+        Both dispatchers audit through this: ``run()`` calls it directly and
+        ``async_run()`` offloads it to a worker thread. Previously only the
+        async dispatcher audited at all, and the sync one carried a commented
+        out call, so ``revoke`` / ``disable`` / ``reset`` through the sync
+        surface completed with no record whatsoever (issue #2060).
+
+        AuditLogNode is a sync-only Node -- see ``_log_security_event``. Its
+        parameters are event_type/message/user_id/event_data; the previous
+        action=/resource_type=/resource_id=/metadata=/ip_address= were all
+        dropped by execute(), so even a resolved call would have written
+        {"event_type": "info", "message": "", "data": {}}.
+        """
         audit_entry = {
-            "action": f"mfa_{action}",
+            "event_type": f"mfa_{action}",
+            "message": f"MFA {action} ({method}) for user {user_id}",
             "user_id": user_id,
-            "resource_type": "mfa",
-            "resource_id": f"{user_id}:{method}",
-            "metadata": {
+            "event_data": {
                 "action": action,
                 "method": method,
+                "resource_type": "mfa",
+                "resource_id": f"{user_id}:{method}",
                 "success": result.get("success", False),
                 "result": result,
+                # user_id above is the SUBJECT of the operation, never the
+                # actor: this node has no caller identity to record, and
+                # admin_override is a caller-supplied boolean rather than an
+                # authenticated principal. An auditor reading these records
+                # can see WHAT happened and TO WHOM, but not BY WHOM. That
+                # gap is #2047 and is not closed here.
+                "actor": None,
+                "ip_address": "unknown",
             },
-            "ip_address": "unknown",  # In real implementation, get from request
         }
 
-        if self.audit_log_node is None:
-            # No sink is wired at all -- already reported once at init. Do not
-            # emit a per-operation "Failed to audit", which reads like a
-            # transient fault rather than a standing gap (issue #2026).
-            return
-
         try:
-            await self.audit_log_node.async_run(**audit_entry)  # type: ignore[reportAttributeAccessIssue]
+            self.audit_log_node.execute(**audit_entry)
         except (AttributeError, TypeError, ValueError) as e:
             # Narrow: a broad `except Exception` here hid the fact that the
             # sink was None behind a warning that looked transient.
@@ -2906,17 +2947,21 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         }
         self.audit_events.append(event)
 
-        # Also use the audit log node if available
-        if hasattr(self, "audit_log_node") and self.audit_log_node:
-            try:
-                self.audit_log_node.execute(
-                    action=event_type,
-                    user_id=metadata.get("user_id"),
-                    metadata=metadata,
-                )
-            except Exception as e:
-                # Don't fail the main operation if audit logging fails
-                logger.warning(f"Audit logging failed: {e}")
+        # Also write to the audit sink. The `hasattr(...) and self.audit_log_node`
+        # guard that used to stand here is gone: __init__ always constructs the
+        # sink now, so the absent-branch was unreachable and would have silently
+        # returned success while recording nothing (issue #2060). Parameters are
+        # the ones AuditLogNode reads -- action=/metadata= were dropped.
+        try:
+            self.audit_log_node.execute(
+                event_type=event_type,
+                message=f"MFA event {event_type}",
+                user_id=metadata.get("user_id"),
+                event_data=metadata,
+            )
+        except Exception as e:
+            # Don't fail the main operation if audit logging fails
+            logger.warning(f"Audit logging failed: {e}")
 
     def _initiate_recovery(
         self,

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -2509,39 +2509,6 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         head = local[:2] if len(local) > 2 else local[:1]
         return f"{head}***@{domain}"
 
-    async def _log_security_event(
-        self, user_id: str, event_type: str, severity: str
-    ) -> None:
-        """Log security event.
-
-        Args:
-            user_id: User ID
-            event_type: Type of security event
-            severity: Event severity
-        """
-        # SecurityEventNode is a sync-only Node: it defines neither async_run
-        # nor execute_async, so this await raised AttributeError (issue #2060).
-        # Its parameters are event_type/severity/message/user_id/metadata --
-        # description= and source_ip= were dropped and message= never supplied.
-        # severity is upper-cased because SeverityLevel() rejects lowercase.
-        security_event = {
-            "event_type": event_type,
-            "severity": severity.upper(),
-            "message": f"MFA {event_type} for user {user_id}",
-            "user_id": user_id,
-            "metadata": {
-                "mfa_operation": True,
-                # No request context reaches this node -- it has no caller,
-                # session, or principal parameter. See #2047.
-                "source_ip": "unknown",
-            },
-        }
-
-        try:
-            await asyncio.to_thread(self.security_event_node.execute, **security_event)
-        except Exception as e:
-            self.log_with_context("WARNING", f"Failed to log security event: {e}")
-
     async def _audit_mfa_operation(
         self, user_id: str, action: str, method: str, result: Dict[str, Any]
     ) -> None:
@@ -2644,7 +2611,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
         out call, so ``revoke`` / ``disable`` / ``reset`` through the sync
         surface completed with no record whatsoever (issue #2060).
 
-        AuditLogNode is a sync-only Node -- see ``_log_security_event``. Its
+        AuditLogNode is a sync-only Node -- see ``_flush_audit_records``. Its
         parameters are event_type/message/user_id/event_data; the previous
         action=/resource_type=/resource_id=/metadata=/ip_address= were all
         dropped by execute(), so even a resolved call would have written
@@ -3075,7 +3042,7 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
 
         The four callers of this sit inside ``_data_lock``-held handlers, which
         is why they stood commented out as "disabled for sync operation": the
-        only surface available was the async ``_log_security_event``. So the
+        only surface available was an async ``_log_security_event``. So the
         ``mfa_revoked`` HIGH-severity event -- the one that pages someone when
         a second factor is destroyed -- has never fired (issue #2060). Queueing
         is synchronous and lock-safe; the dispatcher flushes after release.

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -6,6 +6,7 @@ concurrent session limits, device tracking, anomaly detection, and automatic
 session cleanup with security event integration.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -227,6 +228,37 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 required=False,
                 default={},
             ),
+            # Declared because EnterpriseAuthProviderNode already passes them on
+            # create. Undeclared parameters are dropped by validate_inputs(), so
+            # the session recorded login_method="password" no matter how the
+            # principal actually authenticated -- an SSO or JWT session audited
+            # as a password login (issue #2060).
+            "auth_method": NodeParameter(
+                name="auth_method",
+                type=str,
+                description=(
+                    "Authentication method that established this session "
+                    "(password, mfa, sso, jwt, directory, ...). Recorded as the "
+                    "session's login_method."
+                ),
+                required=False,
+            ),
+            "additional_factors": NodeParameter(
+                name="additional_factors",
+                type=list,
+                description="Additional authentication factors satisfied at login",
+                required=False,
+            ),
+            "risk_score": NodeParameter(
+                name="risk_score",
+                type=float,
+                description=(
+                    "Authentication-time risk score from the caller. Recorded in "
+                    "session metadata as auth_risk_score; it does NOT override "
+                    "the session risk score this node computes itself."
+                ),
+                required=False,
+            ),
         }
 
     def run(  # type: ignore[reportIncompatibleMethodOverride]
@@ -236,6 +268,9 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         user_id: Optional[str] = None,
         ip_address: Optional[str] = None,
         device_info: Optional[Dict[str, Any]] = None,
+        auth_method: Optional[str] = None,
+        additional_factors: Optional[List[str]] = None,
+        risk_score: Optional[float] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Run session management operation.
@@ -246,6 +281,9 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             user_id: User ID for session operations
             ip_address: Client IP address
             device_info: Device information
+            auth_method: Authentication method that established the session
+            additional_factors: Additional factors satisfied at login
+            risk_score: Authentication-time risk score from the caller
             **kwargs: Additional parameters
 
         Returns:
@@ -284,7 +322,14 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                         "success": False,
                         "error": "user_id and ip_address required for create",
                     }
-                result = self._create_session(user_id, ip_address, device_info)  # type: ignore[reportArgumentType]
+                result = self._create_session(  # type: ignore[reportArgumentType]
+                    user_id,
+                    ip_address,
+                    device_info,
+                    auth_method=auth_method,
+                    additional_factors=additional_factors,
+                    auth_risk_score=risk_score,
+                )
                 self.session_stats["total_sessions_created"] += 1
 
             elif action == "validate":
@@ -348,7 +393,13 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             raise
 
     def _create_session(
-        self, user_id: str, ip_address: str, device_info: Dict[str, Any]
+        self,
+        user_id: str,
+        ip_address: str,
+        device_info: Dict[str, Any],
+        auth_method: Optional[str] = None,
+        additional_factors: Optional[List[str]] = None,
+        auth_risk_score: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Create new user session.
 
@@ -356,6 +407,11 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             user_id: User ID
             ip_address: Client IP address
             device_info: Device information
+            auth_method: Method that authenticated the principal; recorded as
+                the session's login_method
+            additional_factors: Additional factors satisfied at login
+            auth_risk_score: Caller's authentication-time risk score, recorded
+                in metadata only
 
         Returns:
             Session creation result
@@ -399,13 +455,21 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 ip_address=ip_address,
                 device_info=device,
                 status=SessionStatus.ACTIVE,
-                login_method="password",  # Default, should be set by caller
+                # The caller's auth_method, not a hardcoded "password". The
+                # caller-supplied auth_risk_score is recorded as metadata and
+                # deliberately does NOT override risk_score above: that one is
+                # computed here from IP/device/history, and letting a caller
+                # supply it would let the caller declare its own session safe.
+                login_method=auth_method or "password",
                 risk_score=risk_score,
                 anomaly_flags=[],
                 page_views=0,
                 actions_performed=0,
                 data_accessed_mb=0.0,
-                metadata={},
+                metadata={
+                    "additional_factors": list(additional_factors or []),
+                    "auth_risk_score": auth_risk_score,
+                },
             )
 
             # Add geo-location if enabled
@@ -1035,19 +1099,25 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             session_data: Session data
             metadata: Additional metadata
         """
+        # AuditLogNode.execute reads event_type/message/user_id/event_data and
+        # nothing else. This previously passed action/resource_type/resource_id/
+        # metadata/ip_address -- every one of which it drops -- so the record it
+        # actually wrote was {"event_type": "info", "message": "", "data": {}}:
+        # an audit entry that names neither the operation nor the session
+        # (issue #2060). The keys below are the ones the node reads.
         audit_entry = {
-            "action": f"session_{operation}",
+            "event_type": f"session_{operation}",
+            "message": f"Session {operation} for user {session_data.user_id}",
             "user_id": session_data.user_id,
-            "resource_type": "session",
-            "resource_id": session_data.session_id,
-            "metadata": {
+            "event_data": {
                 "operation": operation,
+                "resource_type": "session",
+                "resource_id": session_data.session_id,
                 "ip_address": session_data.ip_address,
                 "device_type": session_data.device_info.device_type,
                 "risk_score": session_data.risk_score,
                 **(metadata or {}),
             },
-            "ip_address": session_data.ip_address,
         }
 
         try:
@@ -1066,13 +1136,24 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             severity: Event severity
             metadata: Event metadata
         """
+        # SecurityEventNode.execute reads event_type/severity/message/user_id/
+        # metadata. Two defects lived here (issue #2060):
+        #   1. severity was forwarded verbatim, and every caller in this module
+        #      passes it lowercase ("medium"/"high"). SeverityLevel("medium")
+        #      raises ValueError, so the except below swallowed it and NO
+        #      session security event was ever recorded -- not one, ever.
+        #   2. description=/source_ip= are not parameters of the node and were
+        #      dropped, while message= was never supplied.
         security_event = {
             "event_type": event_type,
-            "severity": severity,
-            "description": f"Session management: {event_type}",
-            "metadata": {"session_management": True, **metadata},
+            "severity": severity.upper(),
+            "message": f"Session management: {event_type}",
             "user_id": user_id,
-            "source_ip": metadata.get("ip_address", "unknown"),
+            "metadata": {
+                "session_management": True,
+                "source_ip": metadata.get("ip_address", "unknown"),
+                **metadata,
+            },
         }
 
         try:
@@ -1089,5 +1170,14 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         return self._get_session_statistics()["statistics"]
 
     async def async_run(self, **kwargs) -> Dict[str, Any]:
-        """Async execution method for enterprise integration."""
-        return self.execute(**kwargs)
+        """Async entry point for this node.
+
+        The body is genuinely synchronous -- this node performs zero awaits;
+        it manipulates in-memory session state under ``_sessions_lock`` and
+        writes an audit record through a sync ``AuditLogNode``. It is offloaded
+        to a worker thread rather than run inline so that an async caller's
+        event loop is not blocked by whatever logging handler the operator has
+        attached to the audit logger. The node is already thread-safe by
+        construction (``threading.Lock``), which is what makes the offload safe.
+        """
+        return await asyncio.to_thread(self.execute, **kwargs)

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -176,6 +176,12 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # Thread locks for concurrent access
         self._sessions_lock = threading.Lock()
+        # Statistics are mutated from paths both inside and outside
+        # _sessions_lock, so they get their own lock rather than reusing that
+        # one -- _sessions_lock is non-reentrant and several of these sites run
+        # while it is already held. async_run offloads to a worker thread, so
+        # concurrent callers genuinely race here (issue #2060).
+        self._stats_lock = threading.Lock()
 
         # Session statistics
         self.session_stats = {
@@ -190,6 +196,19 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # Last cleanup time
         self._last_cleanup = datetime.now(UTC)
+
+    def _bump_stat(self, name: str, delta: int = 1, floor: int | None = None) -> None:
+        """Adjust a counter atomically.
+
+        ``floor`` makes the check-then-act at the decrement sites a single
+        critical section; reading the value and then decrementing it as two
+        steps let two threads both observe > 0 and drive the counter negative.
+        """
+        with self._stats_lock:
+            value = self.session_stats.get(name, 0) + delta
+            if floor is not None and value < floor:
+                value = floor
+            self.session_stats[name] = value
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters for validation and documentation.
@@ -331,7 +350,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                     additional_factors=additional_factors,
                     auth_risk_score=risk_score,
                 )
-                self.session_stats["total_sessions_created"] += 1
+                self._bump_stat("total_sessions_created")
 
             elif action == "validate":
                 if not session_id:
@@ -421,7 +440,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             # Check concurrent session limit
             user_session_count = len(self.user_sessions.get(user_id, set()))
             if user_session_count >= self.max_sessions:
-                self.session_stats["concurrent_limit_hits"] += 1
+                self._bump_stat("concurrent_limit_hits")
 
                 # Terminate oldest session
                 oldest_session = self._get_oldest_user_session(user_id)
@@ -492,11 +511,11 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 device_fingerprint = device.fingerprint
                 if device_fingerprint not in self.device_sessions:
                     self.device_sessions[device_fingerprint] = set()
-                    self.session_stats["devices_tracked"] += 1
+                    self._bump_stat("devices_tracked")
                 self.device_sessions[device_fingerprint].add(session_id)
 
             # Update statistics
-            self.session_stats["active_sessions"] += 1
+            self._bump_stat("active_sessions")
 
             # Audit log session creation
             self._audit_session_operation("create", session_data)
@@ -506,7 +525,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 anomalies = self._detect_session_anomalies(session_data)
                 if anomalies:
                     session_data.anomaly_flags.extend(anomalies)
-                    self.session_stats["anomalies_detected"] += len(anomalies)
+                    self._bump_stat("anomalies_detected", len(anomalies))
                     self._log_security_event(
                         user_id,
                         "session_anomaly_detected",
@@ -623,7 +642,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 )
                 if new_anomalies:
                     session_data.anomaly_flags.extend(new_anomalies)
-                    self.session_stats["anomalies_detected"] += len(new_anomalies)
+                    self._bump_stat("anomalies_detected", len(new_anomalies))
 
                     # Mark session as suspicious if too many anomalies
                     if len(session_data.anomaly_flags) > 3:
@@ -733,7 +752,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         self._cleanup_session_internal(session_id)
 
         # Update statistics
-        self.session_stats["sessions_terminated"] += 1
+        self._bump_stat("sessions_terminated")
 
     def _cleanup_session_internal(self, session_id: str) -> None:
         """Internal session cleanup.
@@ -764,8 +783,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         del self.sessions[session_id]
 
         # Update statistics
-        if self.session_stats["active_sessions"] > 0:
-            self.session_stats["active_sessions"] -= 1
+        self._bump_stat("active_sessions", -1, floor=0)
 
     def _cleanup_expired_sessions(self) -> Dict[str, Any]:
         """Clean up expired and idle sessions.
@@ -795,7 +813,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # Update statistics
         total_cleaned = len(expired_sessions) + len(idle_sessions)
-        self.session_stats["expired_sessions_cleaned"] += total_cleaned
+        self._bump_stat("expired_sessions_cleaned", total_cleaned)
 
         # Update last cleanup time
         self._last_cleanup = current_time
@@ -1178,7 +1196,13 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         writes an audit record through a sync ``AuditLogNode``. It is offloaded
         to a worker thread rather than run inline so that an async caller's
         event loop is not blocked by whatever logging handler the operator has
-        attached to the audit logger. The node is already thread-safe by
-        construction (``threading.Lock``), which is what makes the offload safe.
+        attached to the audit logger.
+
+        The offload makes concurrent callers genuinely parallel where they were
+        previously serialized on the loop thread, so it is paired with locking
+        that actually covers the shared state: session storage under
+        ``_sessions_lock``, and the statistics counters under ``_stats_lock``
+        via :meth:`_bump_stat`. Those counters were mutated with bare ``+=``
+        outside any lock, including a check-then-act on ``active_sessions``.
         """
         return await asyncio.to_thread(self.execute, **kwargs)

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
+from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
@@ -1108,7 +1109,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         audit_entry = {
             "event_type": f"session_{operation}",
             "message": f"Session {operation} for user {session_data.user_id}",
-            "user_id": session_data.user_id,
+            "user_id": log_safe(session_data.user_id),
             "event_data": {
                 "operation": operation,
                 "resource_type": "session",
@@ -1148,7 +1149,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "event_type": event_type,
             "severity": severity.upper(),
             "message": f"Session management: {event_type}",
-            "user_id": user_id,
+            "user_id": log_safe(user_id),
             "metadata": {
                 "session_management": True,
                 "source_ip": metadata.get("ip_address", "unknown"),

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -342,10 +342,15 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                         "success": False,
                         "error": "user_id and ip_address required for create",
                     }
-                result = self._create_session(  # type: ignore[reportArgumentType]
+                # `or {}` rather than a type: ignore. device_info is narrowed
+                # to a dict at the top of this method and round-trips through
+                # validate_and_sanitize_inputs, which widens it back to
+                # Optional; asserting that at the call makes the argument
+                # provably well-typed instead of suppressing the check.
+                result = self._create_session(
                     user_id,
                     ip_address,
-                    device_info,
+                    device_info or {},
                     auth_method=auth_method,
                     additional_factors=additional_factors,
                     auth_risk_score=risk_score,

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -1131,7 +1131,7 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         # (issue #2060). The keys below are the ones the node reads.
         audit_entry = {
             "event_type": f"session_{operation}",
-            "message": f"Session {operation} for user {session_data.user_id}",
+            "message": f"Session {operation} for user {log_safe(session_data.user_id, 64)}",
             "user_id": log_safe(session_data.user_id),
             "event_data": {
                 "operation": operation,
@@ -1170,7 +1170,11 @@ class SessionManagementNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         #      dropped, while message= was never supplied.
         security_event = {
             "event_type": event_type,
-            "severity": severity.upper(),
+            # str(... or "INFO") rather than severity.upper(): this dict is
+            # built BEFORE the try below, so a None severity would raise an
+            # AttributeError that escapes the logging call entirely and
+            # aborts session creation.
+            "severity": str(severity or "INFO").upper(),
             "message": f"Session management: {event_type}",
             "user_id": log_safe(user_id),
             "metadata": {

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -27,7 +27,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from kailash.nodes.api import HTTPRequestNode
+from kailash.nodes.api import AsyncHTTPRequestNode
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
@@ -114,7 +114,12 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
     def _setup_supporting_nodes(self):
         """Initialize supporting Kailash nodes."""
-        self.http_client = HTTPRequestNode(name=f"{self.name}_http")
+        # AsyncHTTPRequestNode, not HTTPRequestNode: every call site here is
+        # on an async path and awaits the client. The sync HTTPRequestNode
+        # defines neither async_run nor execute_async, so those awaits
+        # raised AttributeError (issue #2060). Both return
+        # {"success": ..., "response": ...}.
+        self.http_client = AsyncHTTPRequestNode(name=f"{self.name}_http")
 
         self.json_reader = JSONReaderNode(name=f"{self.name}_json")
 
@@ -953,7 +958,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # Make token request using HTTPRequestNode
         try:
-            token_response = await self.http_client.async_run(  # type: ignore[reportAttributeAccessIssue]
+            token_response = await self.http_client.async_run(
                 method="POST",
                 url=token_url,
                 data=token_data,
@@ -989,7 +994,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
 
         # Make user info request
         try:
-            userinfo_response = await self.http_client.async_run(  # type: ignore[reportAttributeAccessIssue]
+            userinfo_response = await self.http_client.async_run(
                 method="GET",
                 url=userinfo_url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -1064,11 +1069,19 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "roles": self._assign_roles_from_attributes(attributes, provider),
         }
 
-        # Log user provisioning
-        await self.audit_logger.async_run(  # type: ignore[reportAttributeAccessIssue]
-            action="user_provisioned",
+        # Log user provisioning. AuditLogNode is sync-only -- it defines
+        # neither async_run nor execute_async, so awaiting async_run raised
+        # AttributeError after the provisioning had already happened, and no
+        # provisioning was ever recorded (issue #2060). It is offloaded to a
+        # worker thread, and given the parameters it actually reads
+        # (event_type/message/user_id/event_data) rather than action=/details=,
+        # which it drops.
+        await asyncio.to_thread(
+            self.audit_logger.execute,
+            event_type="user_provisioned",
+            message=f"Provisioned SSO user {email} from {provider}",
             user_id=email,
-            details={
+            event_data={
                 "provider": provider,
                 "attributes": attributes,
                 "profile": user_profile,
@@ -1217,11 +1230,14 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             del self.active_sessions[session_id]
             sessions_removed += 1
 
-        # Log logout
-        await self.audit_logger.async_run(  # type: ignore[reportAttributeAccessIssue]
-            action="sso_logout",
+        # Log logout. Sync-only sink -- see _provision_user for why this is a
+        # thread offload with event_type/message/event_data (issue #2060).
+        await asyncio.to_thread(
+            self.audit_logger.execute,
+            event_type="sso_logout",
+            message=f"SSO logout for user {user_id}",
             user_id=user_id,
-            details={"provider": provider, "sessions_removed": sessions_removed},
+            event_data={"provider": provider, "sessions_removed": sessions_removed},
         )
 
         return {

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from kailash.nodes.api import AsyncHTTPRequestNode
+from kailash.nodes.auth._http_response import http_body
+from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
@@ -378,13 +380,18 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             else:
                 result["success"] = True
 
-            # Log security event
+            # Log security event. The verdict is the operation's own, not a
+            # hardcoded True: this recorded success=True three lines after
+            # deriving result["success"] = False, so a failed SSO operation was
+            # audited as a successful one (issue #2060).
             await self._log_security_event(
-                event_type="sso_operation",
+                event_type=(
+                    "sso_operation" if result["success"] else "sso_operation_denied"
+                ),
                 action=action,
                 provider=provider,
                 user_id=user_id,
-                success=True,
+                success=result["success"],
                 processing_time_ms=processing_time,
             )
 
@@ -970,7 +977,10 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                     f"Token exchange failed: {token_response.get('error')}"
                 )
 
-            return token_response["response"]
+            # The token document lives at the envelope's "content" key;
+            # returning the envelope made the caller's
+            # token_result["access_token"] raise KeyError (issue #2060).
+            return http_body(token_response)
         except Exception as e:
             # Fail closed for every endpoint. A failed token exchange NEVER
             # yields a token: there is no URL, host, or substring for which a
@@ -1005,7 +1015,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                     f"User info request failed: {userinfo_response.get('error')}"
                 )
 
-            return userinfo_response["response"]
+            return http_body(userinfo_response)
         except Exception as e:
             # Fail closed. Deriving an identity from the *value* of a bearer
             # token let anyone presenting "test_access_token" be provisioned as
@@ -1080,12 +1090,14 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             self.audit_logger.execute,
             event_type="user_provisioned",
             message=f"Provisioned SSO user {email} from {provider}",
-            user_id=email,
-            event_data={
-                "provider": provider,
-                "attributes": attributes,
-                "profile": user_profile,
-            },
+            user_id=log_safe(email),
+            event_data=redact_mapping(
+                {
+                    "provider": provider,
+                    "attributes": attributes,
+                    "profile": user_profile,
+                }
+            ),
         )
 
         return user_profile
@@ -1236,7 +1248,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             self.audit_logger.execute,
             event_type="sso_logout",
             message=f"SSO logout for user {user_id}",
-            user_id=user_id,
+            user_id=log_safe(user_id),
             event_data={"provider": provider, "sessions_removed": sessions_removed},
         )
 
@@ -1281,24 +1293,44 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         ``async_run`` end to end; surfaced by the sync-bridge tests added for
         issue #2026.
 
-        Dispatches to whichever surface the logger actually provides, and never
-        lets a logging failure abort the authentication that already succeeded
-        -- while still reporting that the event went unrecorded.
+        The probe loop that used to stand here -- ``getattr(self.security_logger,
+        surface, None)`` over ``("async_run", "execute_async")`` -- was dead
+        code: ``SecurityEventNode`` extends the plain ``Node`` and defines
+        neither, so both probes yielded ``None`` on every call and execution
+        always fell through. That is the dead-attribute-guard shape issue #2057
+        names as BLOCKED, and it hid the second half of the defect: the payload
+        below was built from ``source``/``timestamp``/``details``, none of which
+        are parameters of the node, so they were dropped and ``severity`` /
+        ``message`` / ``user_id`` were never supplied. Every SSO security event
+        -- including authentication FAILURES -- was recorded as a blank INFO
+        line with no user, well under any alerting threshold (issue #2060).
+
+        The sink is now named statically and offloaded to a worker thread, and
+        it is given the parameters it reads.
         """
-        payload = {
-            "event_type": event_data.get("event_type", "sso_event"),
-            "source": "sso_authentication_node",
-            "timestamp": datetime.now(UTC).isoformat(),
-            "details": event_data,
-        }
+        event_type = event_data.get("event_type", "sso_event")
+        severity = str(event_data.get("severity") or "INFO").upper()
+        if severity == "INFO" and (
+            "failure" in event_type or "error" in event_type or "denied" in event_type
+        ):
+            # An authentication failure recorded at INFO sits below the default
+            # HIGH alert threshold and never pages anyone.
+            severity = "HIGH"
 
         try:
-            for surface in ("async_run", "execute_async"):
-                fn = getattr(self.security_logger, surface, None)
-                if fn is not None:
-                    await fn(**payload)
-                    return
-            self.security_logger.execute(**payload)
+            await asyncio.to_thread(
+                self.security_logger.execute,
+                event_type=event_type,
+                severity=severity,
+                message=f"{event_type} via sso_authentication_node",
+                user_id=log_safe(event_data.get("user_id")),
+                metadata=redact_mapping(
+                    {
+                        "source": "sso_authentication_node",
+                        **{k: v for k, v in event_data.items() if k != "severity"},
+                    }
+                ),
+            )
         except Exception as e:  # noqa: BLE001 - logging must not break auth
             self.log_info(
                 f"Security event was NOT recorded ({type(e).__name__}); "

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -1089,7 +1089,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         await asyncio.to_thread(
             self.audit_logger.execute,
             event_type="user_provisioned",
-            message=f"Provisioned SSO user {email} from {provider}",
+            message=f"Provisioned SSO user {log_safe(email, 64)} from {log_safe(provider, 32)}",
             user_id=log_safe(email),
             event_data=redact_mapping(
                 {
@@ -1247,7 +1247,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
         await asyncio.to_thread(
             self.audit_logger.execute,
             event_type="sso_logout",
-            message=f"SSO logout for user {user_id}",
+            message=f"SSO logout for user {log_safe(user_id, 64)}",
             user_id=log_safe(user_id),
             event_data={"provider": provider, "sessions_removed": sessions_removed},
         )

--- a/tests/regression/test_issue_2026_auth_test_stubs.py
+++ b/tests/regression/test_issue_2026_auth_test_stubs.py
@@ -1757,22 +1757,31 @@ def test_authenticate_does_not_mint_a_session_for_a_caller_chosen_user_id():
         {"sub": "alice", "exp": int(time.time()) + 3600}, secret, algorithm="HS256"
     )
 
-    # SessionManagementNode has no execute_async (a separate, pre-existing
-    # defect), so the session call is stubbed to record who the session is for.
+    # The REAL SessionManagementNode, not a stub.
+    #
+    # This test used to replace node.session_node.execute_async with a fake.
+    # SessionManagementNode never defined execute_async, so the assignment
+    # created the attribute and the fake answered a call that, in production,
+    # raised AttributeError before any session was minted. The test therefore
+    # passed for the entire lifetime of issue #2060 while the path it claims to
+    # cover could not execute at all. Driving the real collaborator is the
+    # point: the identity binding must hold through the surface that actually
+    # runs.
     created_for = {}
+    real_create = node.session_node.async_run
 
-    async def _fake_create(**kwargs):
+    async def _recording_create(**kwargs):
         created_for.update(kwargs)
-        return {"session_id": "sess-1"}
+        return await real_create(**kwargs)
 
-    node.session_node.execute_async = _fake_create
+    node.session_node.async_run = _recording_create
 
     result = asyncio.run(
         node._authenticate(
             auth_method="jwt",
             credentials={"jwt_token": alice_token},
             user_id="admin",
-            risk_context={},
+            risk_context={"ip_address": "203.0.113.7"},
             auth_id="auth-1",
         )
     )

--- a/tests/regression/test_issue_2026_auth_test_stubs.py
+++ b/tests/regression/test_issue_2026_auth_test_stubs.py
@@ -1781,7 +1781,7 @@ def test_authenticate_does_not_mint_a_session_for_a_caller_chosen_user_id():
             auth_method="jwt",
             credentials={"jwt_token": alice_token},
             user_id="admin",
-            risk_context={"ip_address": "203.0.113.7"},
+            risk_context={},
             auth_id="auth-1",
         )
     )

--- a/tests/regression/test_issue_2060_auth_async_surface.py
+++ b/tests/regression/test_issue_2060_auth_async_surface.py
@@ -23,6 +23,7 @@ source and unreachable in practice.
 import ast
 import asyncio
 import inspect
+import json
 import pathlib
 import time
 
@@ -375,10 +376,22 @@ def test_no_auth_node_calls_a_collaborator_method_that_does_not_exist():
                 and owner.value.id == "self"
             ):
                 continue
-            collaborator = getattr(instance, owner.attr, None)
-            if collaborator is None or isinstance(
+            if not hasattr(instance, owner.attr):
+                continue
+            collaborator = getattr(instance, owner.attr)
+            if isinstance(
                 collaborator, (dict, list, set, tuple, str, int, float, bool)
             ):
+                continue
+            if collaborator is None:
+                # Do NOT skip. A None collaborator is the shape that hid
+                # mfa.py's two broken sink calls from this sweep on main: the
+                # sink was None, so `hasattr(None, "async_run")` was never the
+                # question asked. Reported, not passed over.
+                broken.append(
+                    f"{filename}:{call.lineno} self.{owner.attr}.{call.func.attr}() "
+                    f"-> self.{owner.attr} is None; the call cannot resolve"
+                )
                 continue
             if not hasattr(collaborator, call.func.attr):
                 broken.append(
@@ -392,18 +405,59 @@ def test_no_auth_node_calls_a_collaborator_method_that_does_not_exist():
 
 
 def test_every_auth_collaborator_awaited_by_the_provider_is_awaitable():
-    """The provider awaits four auth collaborators. Each must expose a
-    coroutine ``async_run``; a sync callable satisfies ``hasattr`` but would
-    make ``await`` raise at runtime."""
-    node = _provider()
-    for attr in ("session_node", "sso_node", "directory_node", "mfa_node"):
-        collaborator = getattr(node, attr)
-        method = getattr(collaborator, "async_run", None)
-        assert method is not None, f"{attr} defines no async_run"
-        assert inspect.iscoroutinefunction(method), (
-            f"{attr}.async_run is not a coroutine function; awaiting it "
-            f"would raise at runtime"
-        )
+    """Every method the provider AWAITS on a collaborator must be a coroutine.
+
+    Derived from the source rather than a hardcoded attribute list: the earlier
+    version named four attributes and asserted they expose ``async_run``, which
+    was already true on the broken tree -- the collaborators always defined it,
+    the call sites named ``execute_async``. It was the one test in this module
+    that passed before the fix, so it could not have caught the defect. This
+    version reads the ``await self.<collab>.<method>(...)`` sites out of the
+    AST, so a fifth collaborator or a renamed method is covered automatically.
+    """
+    import kailash
+
+    node = _provider(name="eap_awaitable")
+    source = (
+        pathlib.Path(kailash.__file__).parent
+        / "nodes"
+        / "auth"
+        / "enterprise_auth_provider.py"
+    ).read_text()
+
+    awaited = set()
+    for await_node in ast.walk(ast.parse(source)):
+        if not isinstance(await_node, ast.Await):
+            continue
+        call = await_node.value
+        if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)):
+            continue
+        owner = call.func.value
+        if (
+            isinstance(owner, ast.Attribute)
+            and isinstance(owner.value, ast.Name)
+            and owner.value.id == "self"
+        ):
+            awaited.add((owner.attr, call.func.attr))
+
+    assert awaited, "found no awaited collaborator calls; the sweep proved nothing"
+
+    problems = []
+    for attr, method_name in sorted(awaited):
+        collaborator = getattr(node, attr, None)
+        if collaborator is None:
+            continue  # a self-method, e.g. await self._authenticate(...)
+        method = getattr(collaborator, method_name, None)
+        if method is None:
+            problems.append(f"self.{attr}.{method_name} does not exist")
+        elif not inspect.iscoroutinefunction(method):
+            problems.append(
+                f"self.{attr}.{method_name} is awaited but is not a coroutine "
+                f"function ({type(collaborator).__name__})"
+            )
+    assert not problems, "awaited collaborator methods that cannot be awaited:\n" + (
+        "\n".join(problems)
+    )
 
 
 def test_provider_http_client_exposes_an_awaitable_surface():
@@ -413,3 +467,474 @@ def test_provider_http_client_exposes_an_awaitable_surface():
     assert inspect.iscoroutinefunction(
         node.http_client.async_run
     ), f"{type(node.http_client).__name__} has no awaitable request surface"
+
+
+# ---------------------------------------------------------------------------
+# Findings from the adversarial security review of this change
+#
+# Wiring an audit sink that had never been wired, and resolving calls that had
+# never executed, made several latent defects reachable for the first time.
+# These are the tests for them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action,kwargs",
+    [
+        ("setup", {"method": "totp", "user_email": "alice@test.invalid"}),
+        ("reset", {"method": "totp", "admin_override": True}),
+        ("generate_backup_codes", {"admin_override": True}),
+    ],
+)
+def test_audit_records_never_carry_credential_material(action, kwargs, caplog):
+    """The MFA audit record must not contain the second factor itself.
+
+    Wiring the sink while copying the whole result dict put the TOTP seed, the
+    otpauth:// provisioning URI that embeds it, and the backup codes into the
+    audit log -- readable by anyone with log access, and strictly worse than
+    the unwired sink it replaced.
+    """
+    logger_name = f"audit.mfa_secret_{action}_audit_log"
+    node = MultiFactorAuthNode(name=f"mfa_secret_{action}")
+
+    # Enrol first. Without this, generate_backup_codes returns
+    # {"success": False, "error": "MFA not setup for user"} and every
+    # credential assertion below iterates over None -- the test passes without
+    # ever examining a secret.
+    node.run(action="setup", user_id="alice", method="totp", user_email="a@t.invalid")
+    caplog.clear()
+
+    with caplog.at_level("INFO", logger=logger_name):
+        result = node.run(action=action, user_id="alice", **kwargs)
+
+    assert result.get("success") is True, (
+        f"{action} did not succeed, so this test examined no credential "
+        f"material: {result}"
+    )
+
+    written = "\n".join(r.getMessage() for r in caplog.records if r.name == logger_name)
+    assert written, f"{action} wrote no audit record"
+
+    secret_keys = (
+        "secret",
+        "provisioning_uri",
+        "qr_code",
+        "qr_code_data",
+        "qr_code_uri",
+        "trust_token",
+        "session_id",
+    )
+    for key in secret_keys:
+        value = result.get(key)
+        if isinstance(value, str) and len(value) > 6:
+            assert (
+                value not in written
+            ), f"{action} wrote {key!r} into the audit log in plaintext"
+
+    for key in ("backup_codes", "recovery_codes"):
+        for code in result.get(key) or []:
+            assert (
+                str(code) not in written
+            ), f"{action} wrote a {key[:-1]} into the audit log in plaintext"
+
+    assert "otpauth://" not in written, "provisioning URI leaked to the audit log"
+
+
+def test_audit_record_declares_what_it_withheld():
+    """Redaction must be visible, not silent: a partial result presented as a
+    whole one is its own kind of false record."""
+    node = MultiFactorAuthNode(name="mfa_omit")
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    node.run(action="setup", user_id="alice", method="totp", user_email="a@t.invalid")
+
+    entries = [e for e in written if e["event_type"] == "mfa_setup"]
+    assert entries, "setup wrote no mfa_setup record"
+    omitted = entries[0]["event_data"]["result"]["omitted_keys"]
+    assert "secret" in omitted, omitted
+    assert "backup_codes" in omitted or "recovery_codes" in omitted, omitted
+
+
+def test_audit_sink_never_runs_while_the_mfa_data_lock_is_held():
+    """AuditLogNode.execute calls the operator's logging handler. Under
+    ``_data_lock`` a slow syslog/HTTP handler would stall every MFA operation
+    in the process -- a slow log collector becoming an auth outage.
+
+    Discrimination: this probe reports >= 1 when a sink write happens inside
+    the lock; it reported exactly that for ``_log_mfa_event`` before the write
+    was deferred.
+    """
+    import logging as _logging
+
+    node = MultiFactorAuthNode(name="mfa_lockprobe")
+    under_lock = []
+
+    class _LockProbe(_logging.Handler):
+        def emit(self, record):
+            acquired = node._data_lock.acquire(blocking=False)
+            under_lock.append(not acquired)
+            if acquired:
+                node._data_lock.release()
+
+    audit_logger = _logging.getLogger("audit.mfa_lockprobe_audit_log")
+    original = audit_logger.handlers
+    audit_logger.handlers = [_LockProbe()]
+    audit_logger.setLevel(_logging.INFO)
+    try:
+        node.run(
+            action="setup", user_id="alice", method="totp", user_email="a@t.invalid"
+        )
+    finally:
+        audit_logger.handlers = original
+
+    assert under_lock, "no sink write was observed; the probe proved nothing"
+    assert not any(under_lock), (
+        f"{sum(under_lock)} of {len(under_lock)} audit writes ran while "
+        "_data_lock was held"
+    )
+
+
+def test_rate_limited_verify_is_audited():
+    """A brute-force must not silence the audit trail exactly when it matters.
+
+    The rate-limit early return skipped the audit call at the end of the
+    dispatcher, so records stopped at the threshold.
+    """
+    node = MultiFactorAuthNode(name="mfa_rl", rate_limit_attempts=1)
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    for _ in range(4):
+        node.run(action="verify", user_id="alice", code="000000", method="totp")
+
+    rate_limited = [
+        e for e in written if e["event_data"]["result"].get("rate_limited") is True
+    ]
+    assert rate_limited, (
+        "rate-limited verify attempts produced no audit record: "
+        f"{[e['event_type'] for e in written]}"
+    )
+
+
+def test_non_authenticating_actions_do_not_forge_an_auth_success_record(caplog):
+    """get_methods echoes the caller's own user_id back and defaults to
+    success, so emitting "auth_success" for it let an unauthenticated caller
+    write a record indistinguishable from a genuine login for any principal."""
+    node = _provider(name="eap_forge")
+    with caplog.at_level("INFO", logger="security.eap_forge_security"):
+        asyncio.run(node.async_run(action="get_methods", user_id="ceo@corp"))
+
+    messages = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "security.eap_forge_security"
+    ]
+    assert messages, "get_methods recorded nothing at all"
+    assert not any(
+        "auth_success" in m for m in messages
+    ), f"a non-authenticating action forged an auth_success record: {messages}"
+    assert (
+        node.auth_statistics["successful_auths"] == 0
+    ), "a non-authenticating action incremented the successful-auth counter"
+
+
+def test_a_genuine_login_is_distinguishable_from_a_non_authenticating_action(caplog):
+    """The positive half of the check above: authenticate MUST still record
+    auth_success, or the test above would pass on a node that logs nothing."""
+    node = _provider(name="eap_genuine")
+    with caplog.at_level("INFO", logger="security.eap_genuine_security"):
+        asyncio.run(_authenticate(node))
+
+    messages = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "security.eap_genuine_security"
+    ]
+    assert any(
+        "auth_success" in m for m in messages
+    ), f"a real authentication did not record auth_success: {messages}"
+
+
+def test_user_id_cannot_inject_a_second_log_record(caplog):
+    """SecurityEventNode renders user_id into an f-string with no escaping and
+    this node's user_id is caller-supplied, so a newline wrote a second
+    well-formed record: fabricate logins, bury the real ones."""
+    node = _provider(name="eap_inject")
+    payload = "alice\n[INFO] auth_success: auth_success via enterprise_auth_provider (User: root)"
+
+    with caplog.at_level("INFO", logger="security.eap_inject_security"):
+        asyncio.run(node.async_run(action="get_methods", user_id=payload))
+
+    for record in caplog.records:
+        if record.name != "security.eap_inject_security":
+            continue
+        assert "\n" not in record.getMessage(), (
+            f"a caller-supplied user_id produced a multi-line record: "
+            f"{record.getMessage()!r}"
+        )
+
+
+def test_sso_security_events_are_recorded_with_severity_and_user(caplog):
+    """sso.py probed getattr(security_logger, "async_run"/"execute_async") --
+    SecurityEventNode defines neither, so the loop was dead code (issue #2057's
+    shape) and the fall-through passed source=/timestamp=/details=, none of
+    which the node reads. Every SSO event was a blank INFO line with no user,
+    including authentication FAILURES."""
+    node = SSOAuthenticationNode(name="sso_ev")
+    seen = []
+    node.security_logger.execute = lambda **kw: seen.append(kw) or {"ok": True}
+
+    asyncio.run(
+        node._log_security_event(
+            event_type="sso_failure", action="callback", user_id="alice"
+        )
+    )
+
+    assert seen, "no SSO security event was recorded"
+    event = seen[0]
+    assert event["user_id"] == "alice", event
+    assert event["message"], "SSO security event carries an empty message"
+    assert event["severity"] == "HIGH", (
+        f"an SSO authentication failure was recorded at {event['severity']}, "
+        "below the default HIGH alert threshold"
+    )
+
+
+def test_http_body_unwraps_the_response_envelope():
+    """Both HTTP nodes return {"response": <HTTPResponse envelope>}, and the
+    body lives at envelope["content"]. Callers read the envelope directly and
+    looked for "email" on it, so a valid token was reported invalid."""
+    from kailash.nodes.auth._http_response import http_body
+
+    envelope_result = {
+        "success": True,
+        "response": {
+            "status_code": 200,
+            "headers": {},
+            "content_type": "application/json",
+            "content": {"email": "alice@test.invalid"},
+        },
+    }
+    assert http_body(envelope_result) == {"email": "alice@test.invalid"}
+    assert http_body({"success": False, "response": None}) == {}
+    assert http_body(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Second review round: parity across every sink, not just the provider's
+# ---------------------------------------------------------------------------
+
+
+def _injection_payload():
+    return "alice\n[INFO] auth_success: auth_success via enterprise_auth_provider (User: root)"
+
+
+def test_no_auth_node_writes_a_multi_line_security_record():
+    """Parity sweep. The first fix sanitized user_id at the provider only,
+    while this change made four SIBLING sinks reachable for the first time --
+    each of which passes user_id straight into SecurityEventNode's unescaped
+    f-string. Fixing one site and leaving the siblings is the multi-site
+    plumbing failure `rules/security.md` names.
+    """
+    payload = _injection_payload()
+    offenders = []
+
+    def _recorder(store):
+        def _execute(**kwargs):
+            store.append(kwargs)
+            return {"ok": True}
+
+        return _execute
+
+    # SSO
+    sso = SSOAuthenticationNode(name="sso_par")
+    sso_seen = []
+    sso.security_logger.execute = _recorder(sso_seen)
+    asyncio.run(
+        sso._log_security_event(
+            event_type="sso_failure", action="callback", user_id=payload
+        )
+    )
+
+    # Session management
+    sess = SessionManagementNode(name="sess_par")
+    sess_seen = []
+    sess.security_event_node.execute = _recorder(sess_seen)
+    sess._log_security_event(payload, "session_anomaly_detected", "medium", {})
+
+    # Directory
+    directory = DirectoryIntegrationNode(name="dir_par")
+    dir_seen = []
+    directory.security_logger.execute = _recorder(dir_seen)
+    asyncio.run(
+        directory._log_security_event(
+            event_type="authentication_failure", user_id=payload
+        )
+    )
+
+    # Provider
+    provider = _provider(name="eap_par")
+    eap_seen = []
+    provider.security_logger.execute = _recorder(eap_seen)
+    asyncio.run(provider._log_auth_event(event_type="auth_failure", user_id=payload))
+
+    for label, seen in (
+        ("sso", sso_seen),
+        ("session_management", sess_seen),
+        ("directory_integration", dir_seen),
+        ("enterprise_auth_provider", eap_seen),
+    ):
+        assert seen, f"{label} recorded no security event; the sweep proved nothing"
+        for event in seen:
+            for field in ("user_id", "message"):
+                value = event.get(field)
+                if isinstance(value, str) and "\n" in value:
+                    offenders.append(f"{label}.{field}")
+
+    assert not offenders, (
+        "these sinks let a caller-supplied value write a second log record: "
+        + ", ".join(sorted(set(offenders)))
+    )
+
+
+def test_mfa_revocation_emits_the_high_severity_security_event():
+    """The four MFA security-event calls stood commented out as "disabled for
+    sync operation" because the only surface was async and they run under
+    _data_lock. So mfa_revoked -- the event that pages someone when a second
+    factor is destroyed -- had never fired."""
+    node = MultiFactorAuthNode(name="mfa_sec_evt")
+    seen = []
+    node.security_event_node.execute = lambda **kw: seen.append(kw) or {"ok": True}
+
+    node.run(action="setup", user_id="alice", method="totp", user_email="a@t.invalid")
+    seen.clear()
+    node.run(action="revoke", user_id="alice", admin_override=True)
+
+    revoked = [e for e in seen if e["event_type"] == "mfa_revoked"]
+    assert (
+        revoked
+    ), f"revoke emitted no mfa_revoked security event: {[e['event_type'] for e in seen]}"
+    assert revoked[0]["severity"] == "HIGH", (
+        f"MFA revocation recorded at {revoked[0]['severity']}, below the "
+        "default HIGH alert threshold"
+    )
+
+
+def test_queued_records_are_flushed_even_when_the_operation_fails():
+    """The flush sits in a finally. A record queued under _data_lock and never
+    flushed would linger until some later dispatch happened to drain it, or
+    fall off the end of the bounded queue."""
+    node = MultiFactorAuthNode(name="mfa_flush")
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    # An action that returns a failure result rather than succeeding.
+    node.run(action="verify", user_id="alice", code="000000", method="totp")
+
+    assert (
+        not node._pending_audit_records
+    ), f"{len(node._pending_audit_records)} records were left unflushed"
+    assert written, "a failed operation wrote no audit record at all"
+
+
+def test_bounded_in_process_event_history():
+    """audit_events sat next to a bounded deque as an UNBOUNDED list, retaining
+    every event for the node's lifetime and defeating the cap beside it."""
+    node = MultiFactorAuthNode(name="mfa_bounded")
+    assert hasattr(
+        node.audit_events, "maxlen"
+    ), "audit_events is unbounded; it grows without limit"
+    assert node.audit_events.maxlen is not None
+
+
+def test_social_token_validation_reads_the_identity_from_the_response_body():
+    """End-to-end cover for the envelope fix at the CALL SITE, not just the
+    helper. Reading result["response"] found no email on the envelope, so a
+    valid token was reported as an invalid one."""
+    node = _provider(name="eap_social")
+
+    async def _fake_request(**kwargs):
+        return {
+            "success": True,
+            "status_code": 200,
+            "response": {
+                "status_code": 200,
+                "headers": {},
+                "content_type": "application/json",
+                "content": {"email": "alice@test.invalid"},
+            },
+        }
+
+    node.http_client.async_run = _fake_request
+    result = asyncio.run(node._validate_social_token("google", "a-bearer-token"))
+
+    assert result["valid"] is True, result
+    assert (
+        result["user_id"] == "alice@test.invalid"
+    ), f"the identity was not read out of the response body: {result}"
+
+
+def test_directory_security_events_redact_credential_bearing_fields():
+    """The directory and SSO nodes attach free-form attribute bags to their
+    records -- for a directory sync that is the full mapped LDAP/AD entry, and
+    for SSO whatever the IdP returned. Those paths were unreachable before this
+    change (they awaited a method the sink does not define) and are now live.
+    """
+    node = DirectoryIntegrationNode(name="dir_redact")
+    seen = []
+    node.security_logger.execute = lambda **kw: seen.append(kw) or {"ok": True}
+
+    asyncio.run(
+        node._log_security_event(
+            event_type="authentication_failure",
+            user_id="alice",
+            directory_data={
+                "mail": "alice@test.invalid",
+                "userPassword": "hunter2",
+                "api_key": "sk-secret-value",
+                "nested": {"refresh_token": "rt-secret"},
+            },
+        )
+    )
+
+    assert seen, "the directory node recorded no security event"
+    rendered = json.dumps(seen[0], default=str)
+    for secret in ("hunter2", "sk-secret-value", "rt-secret"):
+        assert (
+            secret not in rendered
+        ), f"{secret!r} reached the directory security record"
+    # The KEY must survive so an auditor can still see which fields were
+    # present; only the value is withheld.
+    assert (
+        "userPassword" in rendered
+    ), "redaction dropped the key as well as the value, hiding what was there"
+
+
+def test_redact_mapping_withholds_values_and_keeps_shape():
+    from kailash.nodes.auth._log_hygiene import redact_mapping
+
+    out = redact_mapping(
+        {
+            "email": "alice@test.invalid",
+            "access_token": "at-secret",
+            "totp_secret": "seed",
+            "items": [{"password": "p"}, {"ok": 1}],
+        }
+    )
+    assert out["email"] == "alice@test.invalid"
+    assert out["access_token"] == "[REDACTED]"
+    assert out["totp_secret"] == "[REDACTED]"
+    assert out["items"][0]["password"] == "[REDACTED]"
+    assert out["items"][1]["ok"] == 1
+
+
+def test_redact_mapping_bounds_recursion_depth():
+    """A self-referential attribute bag must not blow the stack inside a
+    logging call."""
+    from kailash.nodes.auth._log_hygiene import redact_mapping
+
+    node: dict = {}
+    node["self"] = node
+    rendered = json.dumps(redact_mapping(node))
+    assert "REDACTED_DEPTH" in rendered

--- a/tests/regression/test_issue_2060_auth_async_surface.py
+++ b/tests/regression/test_issue_2060_auth_async_surface.py
@@ -993,3 +993,162 @@ def test_active_session_counter_cannot_go_negative():
     node._bump_stat("active_sessions", -1, floor=0)
     node._bump_stat("active_sessions", -1, floor=0)
     assert node.session_stats["active_sessions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Third review round: a verified credential that mints no session is not a login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "risk_context",
+    [
+        {"user_agent": "curl/8.4"},
+        {"device_info": {"device_type": "mobile"}},
+        {"location": "SG"},
+    ],
+)
+def test_authenticate_refuses_when_the_session_step_mints_nothing(risk_context):
+    """A credential that verifies but produces no session is NOT authenticated.
+
+    ``_authenticate`` returned ``success=True, authenticated=True`` with
+    ``session_id=None`` whenever the session step refused, took the caller's
+    success branch, incremented ``successful_auths`` and emitted an
+    ``auth_success`` record for a login that minted nothing.
+
+    The trigger is specific and worth stating, because the obvious one is
+    wrong: ``risk_context={}`` does NOT reach it. An empty dict is falsy, so
+    ``async_run`` replaces it via ``_extract_risk_context``, which supplies a
+    default ``ip_address`` of 127.0.0.1 and the session succeeds. It is a
+    NON-EMPTY risk_context that omits ``ip_address`` -- device info or a user
+    agent and nothing else, the ordinary caller shape -- that skips the
+    fallback and leaves ``SessionManagementNode`` refusing "create".
+    """
+    node = _provider(name="eap_nosession")
+    result = asyncio.run(
+        node.async_run(
+            action="authenticate",
+            auth_method="jwt",
+            credentials={"jwt_token": _token()},
+            user_id="alice",
+            risk_context=risk_context,
+        )
+    )
+
+    assert result["success"] is False, (
+        "a credential that minted no session was reported as a successful "
+        f"authentication: {result}"
+    )
+    assert result["authenticated"] is False, result
+    assert result.get("reason") == "session_creation_failed", result
+    assert node.auth_statistics["successful_auths"] == 0, (
+        "the successful-auth counter was incremented for a login that "
+        "produced no session"
+    )
+
+
+def test_no_auth_success_record_when_no_session_was_minted(caplog):
+    """The audit half of the above: the trail must not assert a successful
+    authentication that produced nothing."""
+    node = _provider(name="eap_nosession_log")
+    with caplog.at_level("INFO", logger="security.eap_nosession_log_security"):
+        asyncio.run(
+            node.async_run(
+                action="authenticate",
+                auth_method="jwt",
+                credentials={"jwt_token": _token()},
+                user_id="alice",
+                risk_context={"user_agent": "curl/8.4"},
+            )
+        )
+
+    messages = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "security.eap_nosession_log_security"
+    ]
+    assert not any("auth_success" in m for m in messages), (
+        f"an auth_success record was written for a login that minted no "
+        f"session: {messages}"
+    )
+
+
+def test_empty_risk_context_still_authenticates():
+    """The complement, so the test above cannot pass by refusing everything.
+
+    An empty risk_context is falsy and picks up _extract_risk_context's
+    defaults, so it must still authenticate end to end.
+    """
+    node = _provider(name="eap_emptyrc")
+    result = asyncio.run(
+        node.async_run(
+            action="authenticate",
+            auth_method="jwt",
+            credentials={"jwt_token": _token()},
+            user_id="alice",
+            risk_context={},
+        )
+    )
+    assert result["success"] is True, result
+    assert result["session_id"], "empty risk_context should still mint a session"
+
+
+def test_mfa_audit_redaction_reaches_nested_values():
+    """_audit_safe_result's allowlist is flat -- it admits a KEY, not the shape
+    under it. If a producer ever returns a nested credential under an
+    allowlisted key, the allowlist alone would copy it straight to the sink."""
+    node = MultiFactorAuthNode(name="mfa_nested")
+    projected = node._audit_safe_result(
+        {
+            "success": True,
+            "methods": {"totp": {"secret": "SEEDVALUE123", "verified": True}},
+        }
+    )
+    rendered = json.dumps(projected)
+    assert (
+        "SEEDVALUE123" not in rendered
+    ), f"a nested secret under an allowlisted key reached the record: {rendered}"
+    assert "verified" in rendered, "redaction flattened the whole structure away"
+
+
+def test_audit_sink_messages_are_single_line_too():
+    """The security sinks were sanitized but the AUDIT sinks interpolate the
+    same caller-supplied value into their ``message=``.
+
+    Latent rather than live: AuditLogNode defaults to output_format="json" and
+    json.dumps escapes newlines. It goes live the moment a deployment
+    constructs the node with any other format, where execute() renders
+    f"[{event_type}] {message} - User: {user_id} ...". Pinned so the two sink
+    families do not drift apart.
+    """
+    payload = _injection_payload()
+    offenders = []
+
+    sso = SSOAuthenticationNode(name="sso_audit_line")
+    sso_seen = []
+    sso.audit_logger.execute = lambda **kw: sso_seen.append(kw) or {"logged": True}
+    asyncio.run(sso._handle_logout(payload, "oauth2"))
+
+    mfa = MultiFactorAuthNode(name="mfa_audit_line")
+    mfa_seen = []
+    mfa.audit_log_node.execute = lambda **kw: mfa_seen.append(kw) or {"logged": True}
+    mfa.run(action="status", user_id=payload)
+
+    sess = SessionManagementNode(name="sess_audit_line")
+    sess_seen = []
+    sess.audit_log_node.execute = lambda **kw: sess_seen.append(kw) or {"logged": True}
+    sess.execute(action="create", user_id=payload, ip_address="203.0.113.7")
+
+    for label, seen in (("sso", sso_seen), ("mfa", mfa_seen), ("session", sess_seen)):
+        assert seen, f"{label} wrote no audit record; the sweep proved nothing"
+        for event in seen:
+            for field in ("message", "user_id"):
+                value = event.get(field)
+                if isinstance(value, str) and "\n" in value:
+                    offenders.append(f"{label}.{field}")
+
+    assert (
+        not offenders
+    ), "audit records carried a caller-supplied newline: " + ", ".join(
+        sorted(set(offenders))
+    )

--- a/tests/regression/test_issue_2060_auth_async_surface.py
+++ b/tests/regression/test_issue_2060_auth_async_surface.py
@@ -1,0 +1,415 @@
+"""Regression tests for issue #2060 — nodes/auth called methods that did not exist.
+
+``EnterpriseAuthProviderNode`` called ``execute_async`` on collaborators that
+never defined it. A correctly signed, unexpired, correct-issuer JWT raised
+``AttributeError`` in ``_log_auth_event`` before the session step, so
+``authenticate`` / ``authorize`` / ``logout`` / ``validate`` could not complete
+for any action that logs an auth event. The node was non-functional end to end,
+not merely degraded.
+
+The reason this survived is the thing these tests exist to prevent: the previous
+coverage exercised helpers directly and stubbed the missing methods. A test that
+calls ``_log_auth_event`` in isolation, or that assigns a fake onto
+``session_node.execute_async``, passes identically whether or not the real path
+can run — assigning to a missing attribute simply creates it. **Every test in
+this module drives the public surface** (``async_run(action=...)``) with real
+collaborators.
+
+The identity-binding fixes from PR #2035 (issue #2026) are re-asserted here
+through that public surface, because until #2060 was closed they were correct in
+source and unreachable in practice.
+"""
+
+import ast
+import asyncio
+import inspect
+import pathlib
+import time
+
+import pytest
+
+from kailash.nodes.auth.directory_integration import DirectoryIntegrationNode
+from kailash.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+from kailash.nodes.auth.mfa import MultiFactorAuthNode
+from kailash.nodes.auth.session_management import SessionManagementNode
+from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+SECRET = "signing-secret-for-tests"
+ISSUER = "https://idp.test.invalid"
+
+
+def _provider(**overrides):
+    """A provider wired for JWT auth with no risk/adaptive machinery."""
+    kwargs = dict(
+        name="eap_2060",
+        enabled_methods=["jwt"],
+        adaptive_auth_enabled=False,
+        risk_assessment_enabled=False,
+        jwt_config={"secret": SECRET, "issuer": ISSUER},
+        user_permissions={"alice": ["read", "write"]},
+    )
+    kwargs.update(overrides)
+    return EnterpriseAuthProviderNode(**kwargs)
+
+
+def _token(subject="alice", **claims):
+    pyjwt = pytest.importorskip("jwt")
+    payload = {"sub": subject, "exp": int(time.time()) + 3600, "iss": ISSUER}
+    payload.update(claims)
+    return pyjwt.encode(payload, SECRET, algorithm="HS256")
+
+
+async def _authenticate(node, claimed_user_id="alice"):
+    return await node.async_run(
+        action="authenticate",
+        auth_method="jwt",
+        credentials={"jwt_token": _token()},
+        user_id=claimed_user_id,
+        risk_context={"ip_address": "203.0.113.7"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# The four public actions complete end to end
+# ---------------------------------------------------------------------------
+
+
+def test_authenticate_completes_through_the_public_surface():
+    """A valid JWT authenticates. This raised AttributeError before #2060."""
+    node = _provider()
+    result = asyncio.run(_authenticate(node))
+
+    assert result["success"] is True, result
+    assert result["authenticated"] is True, result
+    assert result["session_id"], "authenticate returned no session id"
+
+
+def test_validate_completes_through_the_public_surface():
+    node = _provider()
+
+    async def scenario():
+        auth = await _authenticate(node)
+        return await node.async_run(action="validate", session_id=auth["session_id"])
+
+    result = asyncio.run(scenario())
+    assert result["valid"] is True, result
+
+
+def test_authorize_completes_through_the_public_surface():
+    node = _provider()
+
+    async def scenario():
+        auth = await _authenticate(node)
+        return await node.async_run(
+            action="authorize",
+            session_id=auth["session_id"],
+            user_id="alice",
+            permissions=["read"],
+            resource="doc/1",
+        )
+
+    result = asyncio.run(scenario())
+    assert result["authorized"] is True, result
+
+
+def test_logout_completes_and_invalidates_the_session():
+    node = _provider()
+
+    async def scenario():
+        auth = await _authenticate(node)
+        out = await node.async_run(
+            action="logout", user_id="alice", session_id=auth["session_id"]
+        )
+        after = await node.async_run(action="validate", session_id=auth["session_id"])
+        return out, after
+
+    logout, after = asyncio.run(scenario())
+    assert logout["logged_out"] is True, logout
+    assert after["valid"] is False, "session survived logout"
+
+
+# ---------------------------------------------------------------------------
+# PR #2035's identity binding, asserted through the surface that runs
+# ---------------------------------------------------------------------------
+
+
+def test_session_binds_to_the_credential_subject_not_the_caller_claim():
+    """alice's credential presented as user_id='admin' yields a session for alice.
+
+    This is PR #2035's fix. Before #2060 it could not execute.
+    """
+    node = _provider()
+    result = asyncio.run(_authenticate(node, claimed_user_id="admin"))
+
+    assert result["user_id"] == "alice", (
+        "authenticate honoured the caller-supplied identity over the "
+        f"credential's subject: {result}"
+    )
+    assert result["session_details"]["success"] is True, result["session_details"]
+
+
+def test_authorize_resolves_the_subject_from_the_session_not_the_caller():
+    """The caller claims 'admin'; authorization must evaluate alice's grants."""
+    node = _provider()
+
+    async def scenario():
+        auth = await _authenticate(node, claimed_user_id="admin")
+        allowed = await node.async_run(
+            action="authorize",
+            session_id=auth["session_id"],
+            user_id="admin",  # the caller's claim, which must be ignored
+            permissions=["read"],
+            resource="doc/1",
+        )
+        denied = await node.async_run(
+            action="authorize",
+            session_id=auth["session_id"],
+            user_id="admin",
+            permissions=["delete"],  # alice holds read+write only
+            resource="doc/1",
+        )
+        return allowed, denied
+
+    allowed, denied = asyncio.run(scenario())
+
+    assert allowed["authorized"] is True, allowed
+    assert (
+        allowed["user_id"] == "alice"
+    ), f"authorization bound to the caller's claim, not the session: {allowed}"
+    assert denied["authorized"] is False, (
+        "caller claiming admin was granted a permission the session's subject "
+        f"does not hold: {denied}"
+    )
+    assert denied["reason"] == "insufficient_permissions", denied
+
+
+def test_authorize_without_a_session_is_refused():
+    node = _provider()
+    result = asyncio.run(
+        node.async_run(
+            action="authorize", user_id="admin", permissions=["read"], resource="doc/1"
+        )
+    )
+    assert result["authorized"] is False, result
+    assert result["reason"] == "session_required", result
+
+
+# ---------------------------------------------------------------------------
+# The records the auth path writes actually say what happened
+# ---------------------------------------------------------------------------
+
+
+def test_session_records_the_authenticating_method_not_a_hardcoded_password():
+    """login_method was hardcoded to "password" and the caller could not set it."""
+    node = _provider()
+
+    async def scenario():
+        auth = await _authenticate(node)
+        session_id = auth["session_id"]
+        return node.session_node.sessions[session_id]
+
+    session = asyncio.run(scenario())
+    assert session.login_method == "jwt", (
+        "session recorded a password login for a JWT authentication: "
+        f"{session.login_method!r}"
+    )
+
+
+def test_auth_events_are_recorded_with_content(caplog):
+    """SecurityEventNode was handed parameters it does not read, so every
+    event was written with an empty message and no user."""
+    node = _provider()
+    with caplog.at_level("INFO", logger="security.eap_2060_security"):
+        asyncio.run(_authenticate(node))
+
+    records = [r for r in caplog.records if r.name == "security.eap_2060_security"]
+    assert records, "no security event was recorded for a successful authentication"
+    assert any("auth_success" in r.getMessage() for r in records), [
+        r.getMessage() for r in records
+    ]
+
+
+def test_auth_success_event_names_the_resolved_principal(caplog):
+    """The event must attribute the login to alice, not to the claimed 'admin'."""
+    node = _provider()
+    with caplog.at_level("INFO", logger="security.eap_2060_security"):
+        asyncio.run(_authenticate(node, claimed_user_id="admin"))
+
+    messages = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "security.eap_2060_security" and "auth_success" in r.getMessage()
+    ]
+    assert messages, "no auth_success event recorded"
+    assert any("User: alice" in m for m in messages), (
+        f"auth success attributed to the caller's claim rather than the "
+        f"authenticated principal: {messages}"
+    )
+
+
+def test_session_audit_record_names_the_operation():
+    """AuditLogNode was called with action=/resource_id=, which it drops, so
+    every session audit entry was {"message": "", "data": {}}."""
+    node = SessionManagementNode(name="sess_2060")
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    node.execute(action="create", user_id="alice", ip_address="203.0.113.7")
+
+    assert written, "session creation wrote no audit record"
+    entry = written[0]
+    assert entry["event_type"] == "session_create", entry
+    assert entry["message"], "audit record carries an empty message"
+    assert entry["event_data"]["resource_id"], "audit record names no session"
+
+
+def test_session_security_events_are_not_swallowed_by_a_severity_error():
+    """severity was forwarded lowercase; SeverityLevel() rejects it, and the
+    except-clause swallowed the ValueError, so no event was ever recorded."""
+    node = SessionManagementNode(name="sess_sev_2060", max_sessions=1)
+    seen = []
+    node.security_event_node.execute = lambda **kw: seen.append(kw) or {"ok": True}
+
+    # Two sessions for one user with max_sessions=1 trips session_limit_exceeded.
+    node.execute(action="create", user_id="alice", ip_address="203.0.113.7")
+    node.execute(action="create", user_id="alice", ip_address="203.0.113.7")
+
+    assert seen, "no session security event was recorded"
+    for event in seen:
+        assert event[
+            "severity"
+        ].isupper(), f"severity forwarded in a form SeverityLevel() rejects: {event['severity']!r}"
+
+
+# ---------------------------------------------------------------------------
+# MFA audit sink
+# ---------------------------------------------------------------------------
+
+
+def test_mfa_audit_sink_is_wired():
+    """The sink stood at None from this file's first commit behind a deadlock
+    claim for which no evidence exists in the repository's history."""
+    node = MultiFactorAuthNode(name="mfa_2060")
+    assert node.audit_log_node is not None, "MFA audit sink is not wired"
+    assert node.security_event_node is not None, "MFA security event sink is not wired"
+
+
+@pytest.mark.parametrize("action", ["revoke", "disable", "reset"])
+def test_admin_gated_destructive_mfa_actions_write_an_audit_record(action):
+    """revoke/disable/reset completed with no record: the sink was None AND the
+    sync dispatcher's audit call was commented out."""
+    node = MultiFactorAuthNode(name=f"mfa_{action}_2060")
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    node.run(action=action, user_id="alice", admin_override=True)
+
+    assert written, f"{action} completed with no audit record"
+    # `reset` re-enrols before resetting, so it legitimately writes an
+    # enrolment record too; the operation's own record must be among them.
+    matching = [e for e in written if e["event_type"] == f"mfa_{action}"]
+    assert matching, (
+        f"{action} wrote records but none naming the operation: "
+        f"{[e['event_type'] for e in written]}"
+    )
+    entry = matching[0]
+    assert entry["message"], "audit record carries an empty message"
+    assert entry["user_id"] == "alice", entry
+
+
+def test_mfa_audit_records_declare_the_missing_actor():
+    """#2047: this node has no caller identity. The record must not imply that
+    user_id is the actor — an auditor reading it sees the subject only."""
+    node = MultiFactorAuthNode(name="mfa_actor_2060")
+    written = []
+    node.audit_log_node.execute = lambda **kw: written.append(kw) or {"logged": True}
+
+    node.run(action="revoke", user_id="alice", admin_override=True)
+
+    assert written, "revoke wrote no audit record"
+    assert "actor" in written[0]["event_data"], written[0]
+    assert written[0]["event_data"]["actor"] is None, (
+        "the node grew a caller identity; #2047 may be closed and this "
+        "expectation should be revisited"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The mechanical sweep the issue asks for
+# ---------------------------------------------------------------------------
+
+
+def test_no_auth_node_calls_a_collaborator_method_that_does_not_exist():
+    """Acceptance criterion: a mechanical sweep, not a judgement call.
+
+    Walks the AST of every module in ``nodes/auth`` for ``self.<collab>.<m>()``
+    and asserts ``<m>`` resolves on the constructed collaborator.
+
+    Discrimination: run against ``main`` at aba8a0878 this reports 19 broken
+    call sites across ``enterprise_auth_provider.py``, ``sso.py`` and
+    ``directory_integration.py``. It is not a check that cannot fail.
+    """
+    import kailash
+
+    instances = {
+        "directory_integration.py": DirectoryIntegrationNode(name="d_sweep"),
+        "enterprise_auth_provider.py": EnterpriseAuthProviderNode(name="e_sweep"),
+        "mfa.py": MultiFactorAuthNode(name="m_sweep"),
+        "session_management.py": SessionManagementNode(name="s_sweep"),
+        "sso.py": SSOAuthenticationNode(name="o_sweep"),
+    }
+    auth_dir = pathlib.Path(kailash.__file__).parent / "nodes" / "auth"
+
+    broken = []
+    for filename, instance in instances.items():
+        tree = ast.parse((auth_dir / filename).read_text())
+        for call in ast.walk(tree):
+            if not (
+                isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+            ):
+                continue
+            owner = call.func.value
+            if not (
+                isinstance(owner, ast.Attribute)
+                and isinstance(owner.value, ast.Name)
+                and owner.value.id == "self"
+            ):
+                continue
+            collaborator = getattr(instance, owner.attr, None)
+            if collaborator is None or isinstance(
+                collaborator, (dict, list, set, tuple, str, int, float, bool)
+            ):
+                continue
+            if not hasattr(collaborator, call.func.attr):
+                broken.append(
+                    f"{filename}:{call.lineno} self.{owner.attr}.{call.func.attr}() "
+                    f"-> {type(collaborator).__name__} defines no {call.func.attr!r}"
+                )
+
+    assert not broken, "collaborator calls that cannot resolve:\n" + "\n".join(
+        sorted(set(broken))
+    )
+
+
+def test_every_auth_collaborator_awaited_by_the_provider_is_awaitable():
+    """The provider awaits four auth collaborators. Each must expose a
+    coroutine ``async_run``; a sync callable satisfies ``hasattr`` but would
+    make ``await`` raise at runtime."""
+    node = _provider()
+    for attr in ("session_node", "sso_node", "directory_node", "mfa_node"):
+        collaborator = getattr(node, attr)
+        method = getattr(collaborator, "async_run", None)
+        assert method is not None, f"{attr} defines no async_run"
+        assert inspect.iscoroutinefunction(method), (
+            f"{attr}.async_run is not a coroutine function; awaiting it "
+            f"would raise at runtime"
+        )
+
+
+def test_provider_http_client_exposes_an_awaitable_surface():
+    """HTTPRequestNode has neither async_run nor execute_async, so the OAuth
+    and social-token paths awaited a method that does not exist."""
+    node = _provider()
+    assert inspect.iscoroutinefunction(
+        node.http_client.async_run
+    ), f"{type(node.http_client).__name__} has no awaitable request surface"

--- a/tests/regression/test_issue_2060_auth_async_surface.py
+++ b/tests/regression/test_issue_2060_auth_async_surface.py
@@ -938,3 +938,58 @@ def test_redact_mapping_bounds_recursion_depth():
     node["self"] = node
     rendered = json.dumps(redact_mapping(node))
     assert "REDACTED_DEPTH" in rendered
+
+
+def test_concurrent_session_creation_does_not_lose_counter_updates():
+    """A tripwire, NOT evidence that the lock is doing anything.
+
+    Stated plainly because it was measured: this test PASSES against the
+    pre-fix bare ``+=`` (3 runs out of 3, switch interval at 1e-6). Under
+    CPython's GIL a read-modify-write on a dict value is not reliably
+    interrupted at this load, so the test cannot currently produce a
+    falsifying result and must not be cited as proof that ``_bump_stat``
+    closed a demonstrated race.
+
+    It is kept as a regression tripwire: the guarantee should not rest on a
+    GIL implementation detail, and on a free-threaded build this becomes a
+    real instrument. ``test_active_session_counter_cannot_go_negative`` is the
+    one that does discriminate today -- it fails against the pre-fix
+    check-then-act.
+    """
+    import sys
+    import threading
+
+    node = SessionManagementNode(name="sess_race", max_sessions=10_000)
+    workers, per_worker = 8, 40
+    start = threading.Barrier(workers)
+
+    def _create():
+        start.wait()
+        for i in range(per_worker):
+            node.execute(action="create", user_id=f"u{i % 7}", ip_address="203.0.113.7")
+
+    original = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=_create) for _ in range(workers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(original)
+
+    expected = workers * per_worker
+    assert node.session_stats["total_sessions_created"] == expected, (
+        "lost counter updates under concurrency: "
+        f"{node.session_stats['total_sessions_created']} of {expected}"
+    )
+
+
+def test_active_session_counter_cannot_go_negative():
+    """The decrement was a read-then-write: two threads could both observe
+    > 0 and drive the counter below zero."""
+    node = SessionManagementNode(name="sess_floor")
+    node._bump_stat("active_sessions", -1, floor=0)
+    node._bump_stat("active_sessions", -1, floor=0)
+    assert node.session_stats["active_sessions"] == 0


### PR DESCRIPTION
## Summary

`EnterpriseAuthProviderNode` could not complete `authenticate`, `authorize`, `logout` or `validate`. It called `execute_async` on collaborators that never defined it, so a correctly signed, unexpired, correct-issuer JWT raised `AttributeError` before a session was ever minted. That is what made PR #2035's identity-binding fixes unreachable — correct in source, never executed. Closing this is what makes them take effect.

## Re-measured introspection table

Measured by importing each class and checking `hasattr`, against `main` in this worktree. It **agrees with the issue's table**, with three corrections:

| node | `execute_async` | `async_run` | `execute` | notes |
|---|---|---|---|---|
| `SessionManagementNode` | False | True | True | 0 `await`s — genuinely synchronous |
| `SSOAuthenticationNode` | False | True | True | 27 `await`s — genuinely async |
| `DirectoryIntegrationNode` | False | True | True | 41 `await`s — genuinely async |
| `MultiFactorAuthNode` | **True** | True | True | defines `execute_async` **on itself**, not via `AsyncNode` |
| `SecurityEventNode` | False | False | True | sync-only |
| `AuditLogNode` | False | False | True | sync-only; exported as `AuditLogNode` from `kailash.nodes.security`, class name in `nodes/admin/audit_log.py` is `EnterpriseAuditLogNode` (a different class) |
| `HTTPRequestNode` | False | **False** | True | no awaitable surface at all |

Corrections: `MultiFactorAuthNode`'s `execute_async` is hand-rolled, not inherited. `SessionManagementNode` performs zero `await`s, so its `async_run` was decorative. And the defect is **larger than 14 sites** — a mechanical AST sweep found **19** across three files: `sso.py` awaited `async_run` on the sync `HTTPRequestNode` (OAuth token exchange and userinfo both dead) and `directory_integration.py` awaited `execute_async` on both sync-only sinks. The sweep reports 19 rather than 21 because `mfa.py`'s two broken calls sat behind a `None` sink; that blind spot is now itself fixed.

## Approach

Not a `getattr` dispatch shim — that hides the next mismatch. The collaborators split three ways and the call sites converge accordingly:

- **Four auth collaborators all define `async_run`** → all 12 auth call sites use it uniformly.
- **`AuditLogNode` / `SecurityEventNode` are sync-only** → explicit `asyncio.to_thread(node.execute, ...)`, named at each site.
- **`HTTPRequestNode` has no awaitable surface** → the provider, SSO and directory now construct `AsyncHTTPRequestNode`, a real `AsyncNode`.

`SSOAuthenticationNode` and `DirectoryIntegrationNode` were deliberately **not** reparented onto `AsyncNode`: `sso.py::run` is a purpose-built sync bridge with a bounded executor and a hard timeout, and `AsyncNode.execute` would bypass it.

## End-to-end evidence

All four public actions now complete through `async_run(action=...)`, with the #2035 binding live:

```
1 AUTHENTICATE -> True  user_id= alice  session= True     (caller claimed "admin")
2 VALIDATE     -> True  user_id= alice
3 AUTHORIZE    -> True  user_id= alice  (caller claimed admin)
3b AUTHORIZE delete -> False insufficient_permissions
4 LOGOUT       -> True
5 VALIDATE after logout -> False
```

## Fail-first

`pytest.ini` sets `pythonpath = src`, inserted **ahead of** `PYTHONPATH`. Pointing `PYTHONPATH` at another checkout does not change the tree under test — my first RED attempt was vacuous that way and reported a false 20/20 pass. Redone by restoring `main`'s `nodes/auth` into this worktree, confirmed with an in-process `kailash.__file__` print:

- Against `main`'s source: **19 of 20 fail**. The one that passed did so correctly — collaborators always had a coroutine `async_run`; the call sites named something else. That test was non-discriminating and has been rewritten to derive its targets from the AST.
- Against the fix: **39 pass**.
- The 15 tests added after review each go red against the prior commit.
- Suites: `tests/unit/` + `tests/regression/` → **6847 passed, 16 skipped**. Pre-commit green.

## What review found — and what it means for this PR

Making dead paths live exposed latent defects. The adversarial security review found one **I introduced**:

**CRITICAL — audit sink leaked the second factor.** Copying the whole MFA result into the audit record wrote the TOTP seed, the `otpauth://` URI embedding it, and the backup codes to the log in plaintext. Verified by running it; the secret appeared verbatim. Fixed with an allowlist projection that also declares its `omitted_keys`. **This was strictly worse than the unwired sink it replaced** — worth flagging as the main risk this PR carried.

Also fixed: log injection via unescaped `user_id` (a newline wrote a second well-formed record — fabricate logins, bury the real ones); forged `auth_success` records from non-authenticating actions; the audit sink running under `_data_lock` (a slow SIEM handler would stall every MFA operation — a log collector becoming an auth outage); rate-limited verify attempts going unaudited; SSO's dead `getattr` probe loop (issue #2057's shape) that hid a payload built from parameters the sink does not read, so every SSO event including **authentication failures** was a blank INFO line below the alert threshold; SSO recording `success=True` three lines after deriving `success=False`; whole IdP attribute bags and mapped LDAP entries copied into records; and sinks called with parameters they do not read, which would have written `{"message": "", "data": {}}` even once the calls resolved.

`SessionManagementNode` also hardcoded `login_method="password"` with the comment *"should be set by caller"* while the caller had no way to set it — every SSO and JWT session was audited as a password login.

## MFA audit sink — disposition

**Wired.** The deadlock it was "disabled for" is folklore, and the falsifying evidence is decisive:

- `git log -S "AuditLogNode(" -- src/kailash/nodes/auth/mfa.py` returns the file's **birth commit** (`7dc4e6773`, 2025-06-16, a 2301-line bulk add) **and nothing earlier**. The wiring was already commented out when the file first landed. No commit ever wired it; no commit ever disabled it in response to a hang. There is no repro anywhere in history.
- `AuditLogNode.execute` and `SecurityEventNode.execute` take no lock, open no socket, enter no event loop.
- `SessionManagementNode` constructs and calls these exact two nodes today, synchronously, from inside a held non-reentrant `threading.Lock`, and ships.
- The real MFA deadlock — `_revoke_mfa` re-acquiring `_data_lock` — was a different defect, fixed under #2026.

The same commit also commented out input sanitization "for debugging - causing deadlock", which reads as a blanket comment-it-out pass rather than a diagnosed deadlock.

Wiring it exposed that `revoke`/`disable`/`reset` had **no audit call at all** on the sync path, and that the four MFA security-event calls — including `mfa_revoked`, the HIGH-severity event that pages someone when a second factor is destroyed — stood commented out as "disabled for sync operation". All are now live through a lock-safe queue flushed in a `finally`.

## Second review round

A correctness review of the security fixes found more, all fixed here:

- The docstring added with the `async_run` offload claimed the node was *"already thread-safe by construction"*. **Over-claimed** — session storage is locked, but the statistics counters were mutated with a bare `+=` from paths inside and outside the lock, including a check-then-act on `active_sessions`. They now have their own lock (not `_sessions_lock`, which is non-reentrant and already held at several of those sites).
- The four MFA security-event calls that stood commented out as *"disabled for sync operation"* are re-enabled through a lock-safe queue — `mfa_revoked`, the HIGH-severity event that pages someone when a second factor is destroyed, had **never fired**.
- `audit_events` was an unbounded list sitting beside a bounded deque, defeating the cap next to it.
- The flush moved into a `finally` so early returns and exception paths drain the queue.
- Directory and SSO records redact credential-bearing fields; `redact_mapping` keeps the KEY so an auditor still sees which fields were present, and bounds recursion depth.

### Three tests were non-discriminating and were fixed or relabelled

Measured, not assumed:

1. `test_every_auth_collaborator_awaited_by_the_provider_is_awaitable` asserted a property **already true on the broken tree** — it was the one test of 31 that passed pre-fix. Rewritten to derive its targets from the AST.
2. The `generate_backup_codes` redaction case ran against an unenrolled user, so every credential assertion iterated over `None`. Now enrols first and asserts the action succeeded.
3. `test_concurrent_session_creation_does_not_lose_counter_updates` **passes against the pre-fix bare `+=`** (3 runs of 3) — CPython's GIL does not reliably interrupt a read-modify-write on a dict value at this load. Its docstring now says so plainly rather than reading as proof of a race it cannot detect; it is kept as a tripwire for a free-threaded build. `test_active_session_counter_cannot_go_negative` is the one that **does** discriminate today.

Also fixed: the collaborator sweep skipped `None`-valued attributes, which is exactly the shape that hid `mfa.py`'s two broken sink calls from it (why it reports 19 rather than 21 on main).

## Third round — static analysis follow-up

A pyright pass flagged `asyncio` as undefined in `mfa.py`. **It is not** — `import asyncio` is at line 8 and pyright on this branch reports zero `reportUndefinedVariable`. But running the check properly found a real defect one step over.

Line-tracing `async_run` through `setup` and `revoke` showed **one of the three `asyncio.` sites never executed**: `MultiFactorAuthNode._log_security_event` had **zero callers anywhere**. Its four call sites were the ones commented out as *"disabled for sync operation"*, and the previous round re-enabled them through `_queue_security_event` instead (they run under `_data_lock`, which is precisely why the async surface was unusable there). That left the method dead, carrying a call nothing reached. Removed — private, no callers. Both remaining sites now **trace as executed**, which is the check that matters; an import-only test passes whether or not the branch is reachable.

Also fixed: `_create_session` took `Dict[str, Any] | None` where `Dict[str, Any]` is declared. That was suppressed on main by a `# type: ignore` on a single-line call; expanding the call across lines in this branch moved the argument to its own line and **stopped the comment landing** — a suppression this branch broke. Fixed by passing `device_info or {}` rather than relocating the ignore, so the argument is provably well-typed instead of merely unchecked.

**pyright across all five auth modules now reports 8 diagnostics, identical to the set `main` produces — this branch introduces none.** (The 8, all pre-existing: 4x `ldap3` unresolved-source, 2x `str | None` in mfa's twilio/smtp destinations, 1x `Any | None` uri in sso, 1x `No parameter named "format"` in mfa.)

Checked and **not** changed: `from twilio.rest import Client` is a function-level import inside `try/except`, reached only when `sms_provider["service"] == "twilio"`, byte-identical on main — a correctly deferred optional dependency, not a latent hard `ImportError`.

## Fourth round — MERGE-WITH-FIXES review

**M5 (MEDIUM-HIGH) — a verified credential that mints no session is not a login.** `_authenticate` returned `success=True, authenticated=True` with `session_id=None` whenever the session step refused: it took the caller's success branch, incremented `successful_auths`, and emitted an `auth_success` record for a login that produced nothing. Same class as the success-derivation fix in `async_run`. Now refuses with `reason="session_creation_failed"`.

**The trigger is not the obvious one**, and the distinction is load-bearing because the obvious regression test would pass on the broken code. Measured across four shapes:

| `risk_context` | result |
|---|---|
| `{}` | `success=True`, real `session_id` — falsy, so `_extract_risk_context` supplies a default `ip_address` of `127.0.0.1` |
| `{"user_agent": "curl"}` | `success=True`, **`session_id=None`** — the defect |
| `{"device_info": {...}}` | `success=True`, **`session_id=None`** — the defect |
| `{"ip_address": ...}` | `success=True`, real `session_id` |

It is a **non-empty** `risk_context` omitting `ip_address` — device info or a user agent and nothing else, the ordinary caller shape — that skips the fallback. The tests pin that trigger plus a complement asserting `{}` still authenticates, so the pair cannot pass by refusing everything.

The earlier edit to `test_issue_2026`'s `risk_context` is **reverted to `{}`** — it was unnecessary (that test passes as originally written), and changing a test's input while fixing the stub beside it is how a suite stops being able to go red.

**M7 — the allowlist is flat.** `_audit_safe_result` admits a KEY, not the shape under it; `methods` is safe only because its producer happens to be a curated projection. It now composes `redact_mapping`, the same redactor already used at every SSO and directory sink — closing the asymmetry where the strongest filter sat everywhere except where the credential material lives.

**M6 — `log_safe` parity.** It covered `user_id=` at the security sinks but not the `message=` f-strings interpolating the same value, nor the audit sinks' `user_id`. Latent (AuditLogNode defaults to JSON, which escapes newlines) but live for any non-json deployment. **The sweep test written for it found two sites the manual pass had missed** — direct evidence that N-call-site sanitizing drifts, and the argument for fixing this inside `SecurityEventNode.execute` instead.

**M8 — documented, not changed.** Re-verified independently before asserting it: the LDAP-exception fallback refuses with `directory_unavailable` unless the operator opts in through `_is_enabled()`, and even then there is no built-in account and no default password, compared with `secrets.compare_digest`. It fails closed. The comment records that this branch is what made it *reachable* — the trailing audit call previously raised `AttributeError` after the decision — so the property was load-bearing but unexercised.

Also: `session_management`'s severity dict is built **before** the `try`, so a `None` would raise out of the logging call and abort session creation; `str(severity or "INFO")` closes that.

pyright across the five auth modules remains **byte-identical to main's set** — zero introduced, zero removed.

## Could NOT verify / out of scope

- **The durable log-injection fix belongs in `SecurityEventNode.execute`** (`src/kailash/nodes/security/`), so every SDK caller is covered rather than only this package's. Out of this change's file scope; a shared helper covers all `nodes/auth` sinks. **Worth a follow-up issue.**
- **Pre-existing, unrelated to this defect:** `Node.execute` merges constructor config into runtime inputs, so `SessionManagementNode` logs `[NODE] Unknown parameter(s): ['max_sessions', 'idle_timeout', ...]` on every call. Reproduced on unmodified `main`. The fix is in `nodes/base.py` — SDK-wide blast radius, another lane's file.
- `challenge_mfa` is a declared provider action, but `MultiFactorAuthNode` returns `Unknown action: challenge` for it. This PR upgrades that from `AttributeError` to a clean failure; the action is still unimplemented.
- `login_method` is now recorded correctly but is still write-only — nothing reads it, including the audit record.
- A structural `popleft` race in the flush drain is closed defensively; I could not reproduce it in 4000 x 4-thread trials, so it is closed on reading, not on a demonstrated failure.
- `#2047` (MFA has no ACTOR concept) is **not** closed here and is a genuine limitation of the new records: `user_id` is the operation's SUBJECT, never the caller. The records carry an explicit `"actor": None` so they do not imply otherwise, with a test asserting it. An auditor can see what happened and to whom, not by whom.

## Related issues

Fixes #2060
Makes the fixes in #2035 (for #2026) reachable.
Relevant to #2047 — see above.


