### PR TITLE
fix(test): scope the safe_http_detail sweep to first-party source

### DIFF
--- a/tests/regression/test_issue_2015_http_exception_leak.py
+++ b/tests/regression/test_issue_2015_http_exception_leak.py
@@ -605,9 +605,31 @@ def test_every_module_calling_the_helper_also_imports_it():
 
     repo_root = pathlib.Path(__file__).resolve().parents[2]
 
+    # Scope to FIRST-PARTY source. `packages/*/` carries local `.venv` /
+    # `site-packages` trees in a developer checkout, so an unscoped rglob walks
+    # ~78k files instead of ~4.8k -- 94% of them third-party. That is not just
+    # slow (6min vs seconds): this sweep asserts a property of OUR modules, so
+    # auditing a vendored dependency's source can only produce a finding no one
+    # in this repo can act on. CI checkouts have no such trees, which is exactly
+    # why the cost is invisible there and only ever bites a local full-suite run.
+    _VENDORED = {
+        ".venv",
+        "venv",
+        "site-packages",
+        "node_modules",
+        "build",
+        ".tox",
+        "dist",
+    }
+
+    def _first_party(root: pathlib.Path):
+        for p in root.rglob("*.py"):
+            if _VENDORED.isdisjoint(p.parts):
+                yield p
+
     offenders = []
-    for path in list((repo_root / "src").rglob("*.py")) + list(
-        (repo_root / "packages").rglob("*.py")
+    for path in list(_first_party(repo_root / "src")) + list(
+        _first_party(repo_root / "packages")
     ):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))


### PR DESCRIPTION
## What

The `#2015` import-omission sweep (`test_every_module_calling_the_helper_also_imports_it`) walked `src/` and `packages/` with an unscoped `rglob("*.py")`. In a developer checkout `packages/*/` carries local `.venv` / `site-packages` trees, so it AST-parsed the **entire vendored dependency set** on every run.

Measured, this checkout:

```
src:  782   packages: 77370   TOTAL: 78152
{'real source': 3999, 'VENDORED/.venv': 73371}   # 94% third-party
```

## Why it matters (two things, one not cosmetic)

1. **Speed** — 379.72s, the slowest test in the root regression suite by a wide margin, and enough to trip any per-test timeout.
2. **Correctness** — the sweep asserts a property of *our* modules ("a module calling `safe_http_detail` also imports it"). A hit inside a vendored package could only produce a finding nobody in this repo can act on.

CI checkouts have no in-tree `.venv`, so **both costs were invisible in CI** and only ever bit a local full-suite run. That is exactly why this survived.

## Evidence

Offender count is **unchanged at 0** — the fix narrows *what is walked*, not *what is guarded*; every first-party file is still swept.

```
before: 379.72s  (20 passed)
after:    8.27s  (20 passed)     # 46x
```

## How this surfaced

While measuring #2002 (root `tests/regression/` has no blanket CI coverage) I ran the suite with `--timeout=120` and this test reported FAILED. I initially read that as a live regression; it was not. The captured traceback said `Failed: Timeout (>120.0s) from pytest-timeout` — killed by my own flag, not an assertion. Run without the timeout it passes. The real finding was the 379s underneath it.

Relevant to #2002: with this fix the root regression suite is **1,928 passed / 12 skipped / 0 failures in ~3m15s**, so the blanket CI step that issue asks for starts green.

## Related issues

Refs #2015, #2002