### PR TITLE
fix(kaizen): LoggingHook payload disclosure at INFO + explicit-redaction-opt-in defeat (#2070)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -13,6 +13,52 @@ range such as `>=2.0`.
 
 ## [Unreleased]
 
+### Changed (BREAKING) — the four observability flags no longer silently install nothing (#2084)
+
+`AgentConfig.enable_tracing` / `enable_metrics` / `enable_logging` / `enable_audit`
+each **defaulted to `True`** while the subsystems they enable **do not exist**.
+`create_observability()` imported four hook classes that are not in the package,
+caught the resulting `ImportError`, logged `"… not available, skipping"`, and
+returned a `HookManager` with **zero hooks registered**. `enable_audit` is the
+sharp case: compliance audit trails that silently record nothing are invisible
+exactly when they matter.
+
+The flags are now **tri-state** (`Optional[bool]`, default `None`):
+
+| value             | behaviour                                                        |
+| ----------------- | ---------------------------------------------------------------- |
+| `None` (default)  | one consolidated WARNING naming the unimplemented subsystems; otherwise unchanged |
+| `True` (explicit) | raises `kaizen.errors.ObservabilityNotImplemented`, naming the subsystem and flag |
+| `False`           | silent                                                            |
+
+Raising only on an explicit `True` is deliberate: `True` was also the default, so
+raising on the default would break every agent construction — including callers
+who never mentioned observability.
+
+**Also corrected: `AgentConfig.is_observability_enabled()`.** Previously returned
+`True` by default while zero hooks were registered — it reported observability the
+framework did not have, so a caller branching on it ran its observability-dependent
+path against an empty manager. It now returns `False` unless a subsystem is
+explicitly requested. This is a correction from false to true, not a change from
+one correct behaviour to another.
+
+`create_observability()` now returns `None` on the default path instead of an empty
+`HookManager`. `BaseAgent` already declares `hook_manager: Optional[Any] = None` and
+handles it (`base_agent.py:184-192`), constructing its own manager when
+`hooks_enabled` — so the observable behaviour is unchanged.
+
+**Migration.** If you pass any of these flags explicitly:
+
+- **Set them to `False`**, or remove them — they never did anything.
+- Do **not** set them to `True`: that now raises, because the feature does not exist.
+- If you were relying on `is_observability_enabled()` returning `True`, note it was
+  reporting a subsystem set that registered nothing; supply your own manager via
+  `custom_hook_manager=` to get real hooks.
+- To pin the previous (silent) behaviour: `kailash-kaizen==<previous exact version>`.
+
+Whether these four subsystems get implemented or removed is tracked in **#2084**;
+this change makes the flags honest, it does not make the features exist.
+
 ### Fixed — `EnterpriseMemorySystem` no longer widens tenant scope on a falsy tenant id (#2005)
 
 `_build_tenant_key` resolved its scope with `tenant_id or self._current_tenant`.

--- a/packages/kailash-kaizen/src/kaizen/agent.py
+++ b/packages/kailash-kaizen/src/kaizen/agent.py
@@ -84,10 +84,16 @@ class Agent:
         # Tools
         tools: Union[str, List[str], None] = "all",
         # Observability
-        enable_tracing: bool = True,
-        enable_metrics: bool = True,
-        enable_logging: bool = True,
-        enable_audit: bool = True,
+        # TRI-STATE, mirroring AgentConfig (#2084). These MUST default None,
+        # not True: they are forwarded verbatim to AgentConfig below, and a
+        # `True` there means "explicitly requested" and raises because none of
+        # the four subsystems exists. Leaving these at `True` would send an
+        # explicit True on EVERY Agent() construction — reintroducing, through
+        # this wrapper, exactly the break the tri-state exists to avoid.
+        enable_tracing: Optional[bool] = None,
+        enable_metrics: Optional[bool] = None,
+        enable_logging: Optional[bool] = None,
+        enable_audit: Optional[bool] = None,
         # Checkpointing
         enable_checkpointing: bool = True,
         checkpoint_path: str = ".kaizen/checkpoints",

--- a/packages/kailash-kaizen/src/kaizen/agent_config.py
+++ b/packages/kailash-kaizen/src/kaizen/agent_config.py
@@ -114,26 +114,37 @@ class AgentConfig:
     # LAYER 2: Observability Configuration
     # =========================================================================
 
-    enable_tracing: bool = True
-    """Enable distributed tracing (Jaeger)"""
+    # TRI-STATE, not bool (#2084). None of these four subsystems is
+    # implemented, so an explicit `True` must fail loudly — but `True` was
+    # ALSO the default, and raising on the default would break every agent
+    # construction including callers who never mentioned observability. A
+    # dataclass cannot tell "explicitly passed True" from "defaulted True",
+    # so the sentinel is required:
+    #   None  -> nobody asked; warn, behave as before
+    #   True  -> explicit request; raise ObservabilityNotImplemented
+    #   False -> explicit opt-out; silent
+    # Same mechanism as `LoggingHook.redact_sensitive` (#2070).
+
+    enable_tracing: Optional[bool] = None
+    """Enable distributed tracing (Jaeger). NOT IMPLEMENTED — see #2084."""
 
     tracing_endpoint: str = "http://localhost:16686"
     """Jaeger tracing endpoint"""
 
-    enable_metrics: bool = True
-    """Enable Prometheus metrics collection"""
+    enable_metrics: Optional[bool] = None
+    """Enable Prometheus metrics collection. NOT IMPLEMENTED — see #2084."""
 
     metrics_port: int = 9090
     """Prometheus metrics port"""
 
-    enable_logging: bool = True
-    """Enable structured JSON logging"""
+    enable_logging: Optional[bool] = None
+    """Enable structured JSON logging. NOT IMPLEMENTED — see #2084."""
 
     log_level: str = "INFO"
     """Logging level (DEBUG, INFO, WARNING, ERROR)"""
 
-    enable_audit: bool = True
-    """Enable compliance audit trails"""
+    enable_audit: Optional[bool] = None
+    """Enable compliance audit trails. NOT IMPLEMENTED — see #2084."""
 
     audit_log_path: str = ".kaizen/audit.jsonl"
     """Audit log file path"""
@@ -365,12 +376,28 @@ class AgentConfig:
         )
 
     def is_observability_enabled(self) -> bool:
-        """Check if observability is enabled (either default or custom)."""
-        return self.has_custom_observability() or (
-            self.enable_tracing
-            or self.enable_metrics
-            or self.enable_logging
-            or self.enable_audit
+        """Check if observability is enabled (either default or custom).
+
+        CORRECTED in #2084. This previously returned True by default — while
+        `create_observability` registered ZERO hooks, because none of the four
+        subsystems exists. It reported observability the framework did not
+        have, so a caller branching on it ran its observability-dependent path
+        against an empty manager.
+
+        Now only an EXPLICIT `True` counts. `None` (the default, nobody asked)
+        and `False` (opt-out) both mean not-enabled, so the answer matches what
+        is actually registered.
+        """
+        if self.has_custom_observability():
+            return True
+        return any(
+            flag is True
+            for flag in (
+                self.enable_tracing,
+                self.enable_metrics,
+                self.enable_logging,
+                self.enable_audit,
+            )
         )
 
     def is_checkpointing_enabled(self) -> bool:

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/_payload.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/_payload.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared payload-logging helpers for hooks (#2070).
+
+ONE implementation, because there were two. `LoggingHook`
+(`builtin/logging_hook.py`) and `SecureLoggingHook` (`security/redaction.py`)
+carried near-verbatim copies of the same log body, and the copies had already
+diverged in exactly the way duplication predicts: the fix for one would have
+left the other publishing payloads under a class name promising the opposite.
+
+The contract both share:
+
+- At the hook's configured level, emit STRUCTURE — key names and counts. Key
+  names come from the signature / event schema rather than from user input, so
+  they carry no payload content.
+- Emit VALUES only behind two independent gates: a deliberate opt-in AND the
+  logger actually at DEBUG. Either gate alone is routinely satisfied by
+  accident — turning DEBUG on globally is routine during incident response.
+- Scrub what does get emitted. Scrubbing claims credential SHAPES, not
+  arbitrary prose, which is why the opt-in gate is the load-bearing protection
+  and the scrub is defence in depth rather than the other way round.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
+#: scrubbing: `scrub_credentials` runs ~25 regex passes, each building a fresh
+#: string, and it was written for error text — whereas a hook payload can carry
+#: a whole retrieved document. Capping first bounds both scrub cost and log
+#: volume.
+MAX_PAYLOAD_CHARS = 2000
+
+
+def summarize_payload(payload: Any) -> dict[str, Any]:
+    """Describe a payload's SHAPE without reproducing any of its values."""
+    if isinstance(payload, dict):
+        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
+    return {"count": 0 if payload is None else 1, "keys": []}
+
+
+def render_scrubbed_payload(payload: Any) -> str:
+    """Render a payload for a DEBUG sink: truncated first, then scrubbed.
+
+    Callers are responsible for the two gates (opt-in + DEBUG); this function
+    only formats. Imported lazily so that merely importing a hook module does
+    not pull in the credential-scrub regex table.
+    """
+    from kaizen.utils.credential_scrub import scrub_credentials
+
+    rendered = repr(payload)
+    if len(rendered) > MAX_PAYLOAD_CHARS:
+        rendered = f"{rendered[:MAX_PAYLOAD_CHARS]}...[truncated {len(rendered)} chars]"
+    return scrub_credentials(rendered)
+
+
+def should_log_full_payload(enabled: bool, logger: logging.Logger) -> bool:
+    """Both gates, in one place, so neither hook can implement only one."""
+    return bool(enabled) and logger.isEnabledFor(logging.DEBUG)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
@@ -8,12 +8,31 @@ SECURITY: Supports sensitive data redaction (Finding #4 fix).
 """
 
 import logging
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
 
 logger = logging.getLogger(__name__)
+
+#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
+#: scrubbing: ``scrub_credentials`` runs ~25 regex passes, each building a fresh
+#: string, and it was written for error text — whereas a hook payload can carry
+#: a whole retrieved document. Capping first bounds both scrub cost and log
+#: volume. Mirrors the same constant in the ``BaseAgent`` fix (#2030).
+MAX_PAYLOAD_CHARS = 2000
+
+
+def _summarize(payload: Any) -> dict[str, Any]:
+    """Describe a payload's SHAPE without reproducing any of its values.
+
+    Key names are structure, not content: they come from the signature /
+    event schema, not from user input, so they are safe to log where the
+    values they index are not.
+    """
+    if isinstance(payload, dict):
+        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
+    return {"count": 0 if payload is None else 1, "keys": []}
 
 
 class LoggingHook(BaseHook):
@@ -45,16 +64,30 @@ class LoggingHook(BaseHook):
         log_level: str = "INFO",
         include_data: bool = True,
         format: str = "text",
-        redact_sensitive: bool = False,
+        redact_sensitive: Optional[bool] = None,
+        log_full_payloads: bool = False,
     ):
         """
         Initialize logging hook.
 
         Args:
             log_level: Log level (DEBUG, INFO, WARNING, ERROR)
-            include_data: Whether to log event data (disable for sensitive data)
+            include_data: Whether to log event data STRUCTURE (key names and
+                counts). Payload VALUES are never emitted at this level; see
+                ``log_full_payloads``.
             format: Log format ("text" or "json")
-            redact_sensitive: Enable automatic sensitive data redaction (SECURITY FIX #4)
+            redact_sensitive: Enable sensitive-data redaction. ``None`` (the
+                default) enables it but permits degradation if the redactor
+                cannot be loaded; ``True`` is an EXPLICIT opt-in and raises
+                rather than degrading; ``False`` disables it outright.
+            log_full_payloads: Emit payload VALUES, at DEBUG only, scrubbed.
+                Defaults False so that turning DEBUG on globally — routine
+                during incident response — does not start dumping user prompts,
+                retrieved documents and PII.
+
+        Raises:
+            RuntimeError: if ``redact_sensitive=True`` was requested explicitly
+                and ``SensitiveDataRedactor`` cannot be imported.
 
         Example:
             >>> # Production usage with redaction
@@ -68,7 +101,16 @@ class LoggingHook(BaseHook):
         self.log_level = log_level
         self.include_data = include_data
         self.format = format
-        self.redact_sensitive = redact_sensitive
+        self.log_full_payloads = log_full_payloads
+
+        # An EXPLICIT `True` is a different request from the default (#2070).
+        # The distinction is load-bearing and is the reason this is tri-state
+        # rather than a bool: raising on a default nobody asked for would break
+        # installs where the redactor is genuinely absent, while degrading an
+        # explicit opt-in silently overrides an operator who already made the
+        # correct decision.
+        redaction_explicitly_requested = redact_sensitive is True
+        self.redact_sensitive = True if redact_sensitive is None else redact_sensitive
 
         # Initialize redactor if needed (SECURITY FIX #4)
         if self.redact_sensitive:
@@ -76,13 +118,33 @@ class LoggingHook(BaseHook):
                 from ..security.redaction import SensitiveDataRedactor
 
                 self.redactor: Optional[SensitiveDataRedactor] = SensitiveDataRedactor()
-            except ImportError:
+            except ImportError as exc:
+                if redaction_explicitly_requested:
+                    # FAIL CLOSED. Previously this branch set
+                    # `redact_sensitive = False` and carried on logging at full
+                    # fidelity behind a WARNING — defeating the operator's own
+                    # explicit choice, which `zero-tolerance.md` Rule 3 blocks.
+                    raise RuntimeError(
+                        "redact_sensitive=True was requested but "
+                        "SensitiveDataRedactor could not be imported, so "
+                        "redaction cannot be performed. Refusing to log "
+                        "unredacted instead. Install the security module, or "
+                        "pass redact_sensitive=False to accept unredacted "
+                        "logging deliberately."
+                    ) from exc
+
+                # NOT explicitly requested: degrading is acceptable, but the
+                # payloads redaction was protecting MUST stop too. A degraded
+                # control that keeps emitting is the disclosure the control
+                # existed to prevent.
                 logger.warning(
-                    "SensitiveDataRedactor not available, disabling redaction. "
-                    "Install security module to enable redaction."
+                    "SensitiveDataRedactor not available, disabling redaction "
+                    "AND payload-value logging. Install security module to "
+                    "enable redaction."
                 )
                 self.redactor = None
                 self.redact_sensitive = False
+                self.log_full_payloads = False
         else:
             self.redactor = None
 
@@ -136,7 +198,18 @@ class LoggingHook(BaseHook):
             else:
                 safe_context = context
 
-            # STEP 2: Log redacted data
+            # STEP 2: Log STRUCTURE, never values (#2070).
+            #
+            # `agent_loop` feeds this hook whole agent I/O — PRE_AGENT_LOOP
+            # carries {"inputs": ...}, POST_AGENT_LOOP carries {"result": ...} —
+            # so the previous `Data={safe_context.data}` put user prompts,
+            # retrieved documents and any credential-bearing parameter on the
+            # INFO log. Redaction is not a substitute here: it claims credential
+            # SHAPES and PII patterns, and a user's prose matches neither.
+            # Withholding values is what actually closes it.
+            data_summary = _summarize(safe_context.data)
+            meta_summary = _summarize(safe_context.metadata)
+
             if self.format == "json":
                 # Structured JSON logging
                 log_event = {
@@ -148,8 +221,9 @@ class LoggingHook(BaseHook):
                 }
 
                 if self.include_data:
-                    log_event["context"] = safe_context.data
-                    log_event["metadata"] = safe_context.metadata
+                    log_event["context_keys"] = data_summary["keys"]
+                    log_event["context_field_count"] = data_summary["count"]
+                    log_event["metadata_keys"] = meta_summary["keys"]
 
                 # Log using structlog (outputs JSON)
                 log_fn = getattr(self.logger, self.log_level.lower())
@@ -164,7 +238,8 @@ class LoggingHook(BaseHook):
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id} "
-                        f"Data={safe_context.data}"
+                        f"DataKeys={data_summary['keys']} "
+                        f"({data_summary['count']} field(s))"
                     )
                 else:
                     log_fn(
@@ -173,11 +248,55 @@ class LoggingHook(BaseHook):
                         f"TraceID={safe_context.trace_id}"
                     )
 
+            # STEP 3: Values, only on deliberate opt-in, only at DEBUG,
+            # only scrubbed. Two independent gates, because either alone is
+            # routinely satisfied by accident: `log_full_payloads` defaults
+            # False so global DEBUG does not start dumping payloads, and the
+            # DEBUG check keeps the render cost off the INFO path entirely.
+            self._log_full_payload(safe_context)
+
             return HookResult(success=True)
 
         except Exception as e:
             # Even logging can fail!
             return HookResult(success=False, error=str(e))
+
+    def _log_full_payload(self, safe_context: HookContext) -> None:
+        """Emit payload VALUES at DEBUG, scrubbed, on explicit opt-in only.
+
+        `safe_context` has already been through the redactor when one is
+        wired; `scrub_credentials` is applied on top because the two cover
+        different classes — the redactor owns PII and payment shapes and
+        delegates vendor credentials to `scrub_credentials`, which is the
+        single credential-scrub implementation in Kaizen.
+
+        Scrubbing claims credential SHAPES, not arbitrary PII, which is
+        precisely why the `log_full_payloads` gate defaults False rather than
+        relying on the scrubber to make payloads safe.
+        """
+        if not self.log_full_payloads:
+            return
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
+        from kaizen.utils.credential_scrub import scrub_credentials
+
+        rendered = repr(safe_context.data)
+        if len(rendered) > MAX_PAYLOAD_CHARS:
+            rendered = (
+                f"{rendered[:MAX_PAYLOAD_CHARS]}"
+                f"...[truncated {len(rendered)} chars]"
+            )
+        scrubbed = scrub_credentials(rendered)
+
+        if self.format == "json":
+            self.logger.debug("hook_event_payload", payload=scrubbed)
+        else:
+            self.logger.debug(
+                f"[{safe_context.event_type.value}] "
+                f"Agent={safe_context.agent_id} "
+                f"Payload={scrubbed}"
+            )
 
     async def on_error(self, error: Exception, context: HookContext) -> None:
         """Log errors to stderr"""

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
@@ -8,31 +8,17 @@ SECURITY: Supports sensitive data redaction (Finding #4 fix).
 """
 
 import logging
-from typing import Any, ClassVar, Optional
+from typing import ClassVar, Optional
 
+from .._payload import (
+    render_scrubbed_payload,
+    should_log_full_payload,
+    summarize_payload,
+)
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
 
 logger = logging.getLogger(__name__)
-
-#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
-#: scrubbing: ``scrub_credentials`` runs ~25 regex passes, each building a fresh
-#: string, and it was written for error text — whereas a hook payload can carry
-#: a whole retrieved document. Capping first bounds both scrub cost and log
-#: volume. Mirrors the same constant in the ``BaseAgent`` fix (#2030).
-MAX_PAYLOAD_CHARS = 2000
-
-
-def _summarize(payload: Any) -> dict[str, Any]:
-    """Describe a payload's SHAPE without reproducing any of its values.
-
-    Key names are structure, not content: they come from the signature /
-    event schema, not from user input, so they are safe to log where the
-    values they index are not.
-    """
-    if isinstance(payload, dict):
-        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
-    return {"count": 0 if payload is None else 1, "keys": []}
 
 
 class LoggingHook(BaseHook):
@@ -207,8 +193,8 @@ class LoggingHook(BaseHook):
             # INFO log. Redaction is not a substitute here: it claims credential
             # SHAPES and PII patterns, and a user's prose matches neither.
             # Withholding values is what actually closes it.
-            data_summary = _summarize(safe_context.data)
-            meta_summary = _summarize(safe_context.metadata)
+            data_summary = summarize_payload(safe_context.data)
+            meta_summary = summarize_payload(safe_context.metadata)
 
             if self.format == "json":
                 # Structured JSON logging
@@ -274,20 +260,10 @@ class LoggingHook(BaseHook):
         precisely why the `log_full_payloads` gate defaults False rather than
         relying on the scrubber to make payloads safe.
         """
-        if not self.log_full_payloads:
-            return
-        if not logger.isEnabledFor(logging.DEBUG):
+        if not should_log_full_payload(self.log_full_payloads, logger):
             return
 
-        from kaizen.utils.credential_scrub import scrub_credentials
-
-        rendered = repr(safe_context.data)
-        if len(rendered) > MAX_PAYLOAD_CHARS:
-            rendered = (
-                f"{rendered[:MAX_PAYLOAD_CHARS]}"
-                f"...[truncated {len(rendered)} chars]"
-            )
-        scrubbed = scrub_credentials(rendered)
+        scrubbed = render_scrubbed_payload(safe_context.data)
 
         if self.format == "json":
             self.logger.debug("hook_event_payload", payload=scrubbed)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/redaction.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/redaction.py
@@ -6,14 +6,25 @@ including API keys, passwords, PII, credit cards, and SSNs.
 """
 
 import copy
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Optional, Set
 
 from kaizen.utils.credential_scrub import scrub_credentials
 
+from .._payload import (
+    render_scrubbed_payload,
+    should_log_full_payload,
+    summarize_payload,
+)
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
+
+#: Module-level so the DEBUG gate reads the SAME logger the text sink writes to
+#: (`self.logger` is `getLogger(__name__)` in text mode, and a structlog wrapper
+#: over the stdlib hierarchy in JSON mode).
+logger = logging.getLogger(__name__)
 
 
 class SensitiveDataRedactor:
@@ -206,20 +217,25 @@ class SecureLoggingHook(BaseHook):
         include_data: bool = True,
         format: str = "text",
         redact_sensitive: bool = True,
+        log_full_payloads: bool = False,
     ):
         super().__init__(name="secure_logging_hook")
         self.log_level = log_level
         self.include_data = include_data
         self.format = format
         self.redact_sensitive = redact_sensitive
+        self.log_full_payloads = log_full_payloads
 
-        # Initialize redactor
+        # Initialize redactor. The `else` is not tidy-up: without it
+        # `self.redactor` was simply never assigned when redaction was off, so
+        # any future read outside the `if self.redact_sensitive` guard raises
+        # AttributeError rather than reading a falsy value.
         if self.redact_sensitive:
-            self.redactor = SensitiveDataRedactor()
+            self.redactor: Optional[SensitiveDataRedactor] = SensitiveDataRedactor()
+        else:
+            self.redactor = None
 
-        # Configure logger
-        import logging
-
+        # Configure logger (`logging` is imported at module scope)
         if format == "json":
             import structlog
 
@@ -249,7 +265,18 @@ class SecureLoggingHook(BaseHook):
             else:
                 safe_context = context
 
-            # STEP 2: Log redacted data
+            # STEP 2: Log STRUCTURE, never values (#2070).
+            #
+            # Redaction alone does NOT close this. The redactor claims
+            # credential shapes and PII patterns; a user's prompt, a retrieved
+            # document, or free-form tool output matches neither and survived
+            # verbatim into an INFO line under a class named
+            # `SecureLoggingHook`. Same contract as `LoggingHook` — shared via
+            # `.._payload` so the two cannot drift apart again, which is how
+            # this copy came to keep a defect the original had fixed.
+            data_summary = summarize_payload(safe_context.data)
+            meta_summary = summarize_payload(safe_context.metadata)
+
             if self.format == "json":
                 log_event = {
                     "event_type": safe_context.event_type.value,
@@ -260,8 +287,9 @@ class SecureLoggingHook(BaseHook):
                 }
 
                 if self.include_data:
-                    log_event["context"] = safe_context.data
-                    log_event["metadata"] = safe_context.metadata
+                    log_event["context_keys"] = data_summary["keys"]
+                    log_event["context_field_count"] = data_summary["count"]
+                    log_event["metadata_keys"] = meta_summary["keys"]
 
                 log_fn = getattr(self.logger, self.log_level.lower())
                 log_fn("hook_event", **log_event)
@@ -274,13 +302,27 @@ class SecureLoggingHook(BaseHook):
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id} "
-                        f"Data={safe_context.data}"
+                        f"DataKeys={data_summary['keys']} "
+                        f"({data_summary['count']} field(s))"
                     )
                 else:
                     log_fn(
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id}"
+                    )
+
+            # STEP 3: Values, only on deliberate opt-in, only at DEBUG,
+            # only scrubbed.
+            if should_log_full_payload(self.log_full_payloads, logger):
+                scrubbed = render_scrubbed_payload(safe_context.data)
+                if self.format == "json":
+                    self.logger.debug("hook_event_payload", payload=scrubbed)
+                else:
+                    self.logger.debug(
+                        f"[{safe_context.event_type.value}] "
+                        f"Agent={safe_context.agent_id} "
+                        f"Payload={scrubbed}"
                     )
 
             return HookResult(success=True)

--- a/packages/kailash-kaizen/src/kaizen/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/errors.py
@@ -81,4 +81,45 @@ class ProviderUndetectable(RuntimeError):
         )
 
 
-__all__ = ["EnvModelMissing", "ProviderUndetectable"]
+class ObservabilityNotImplemented(RuntimeError):
+    """An observability subsystem was explicitly requested but does not exist.
+
+    Raised by :meth:`kaizen.smart_defaults.SmartDefaultsManager.create_observability`
+    when a caller sets ``enable_tracing`` / ``enable_metrics`` /
+    ``enable_logging`` / ``enable_audit`` to ``True`` explicitly. None of the
+    four subsystems is implemented: the hook classes the call site imports do
+    not exist, and neither do the handler methods it registers.
+
+    Previously each import raised ``ImportError``, which was caught and logged
+    as "not available, skipping" — so the flags reported success while
+    registering nothing (``rules/zero-tolerance.md`` Rule 2 stub + Rule 3
+    silent fallback). ``enable_audit`` is the sharp case: audit trails that
+    silently record nothing are invisible exactly when they matter.
+
+    Raised ONLY for an EXPLICIT ``True``. The flags default to ``None``, which
+    warns loudly and otherwise behaves as before — raising on the default
+    would break every agent construction, including callers who never
+    mentioned observability.
+
+    Tracking issue for whether these subsystems get implemented or removed:
+    #2084.
+
+    Attributes:
+        subsystem: Human name of the missing subsystem (e.g. ``"audit"``).
+        flag: The config flag the caller set (e.g. ``"enable_audit"``).
+    """
+
+    def __init__(self, subsystem: str, flag: str, provides: str) -> None:
+        self.subsystem = subsystem
+        self.flag = flag
+        super().__init__(
+            f"{flag}=True was requested, but the {subsystem} subsystem is NOT "
+            f"IMPLEMENTED — it would have provided {provides}. There is "
+            f"nothing to install; the hook class and its handlers do not "
+            f"exist in this package. Set {flag}=False to proceed without it, "
+            f"or leave it unset to get a warning instead of this error. "
+            f"Tracking: https://github.com/terrene-foundation/kailash-py/issues/2084"
+        )
+
+
+__all__ = ["EnvModelMissing", "ObservabilityNotImplemented", "ProviderUndetectable"]

--- a/packages/kailash-kaizen/src/kaizen/smart_defaults.py
+++ b/packages/kailash-kaizen/src/kaizen/smart_defaults.py
@@ -234,12 +234,16 @@ class SmartDefaultsManager:
         - If any subsystem explicitly requested → raise (none are implemented)
         - Otherwise → warn once and return None
         """
-        # Layer 3: Custom hook manager override
-        if config.has_custom_observability():
-            self.logger.info("Using custom hook manager")
-            return config.custom_hook_manager
-
         # NOT-IMPLEMENTED gate (#2084).
+        #
+        # BEFORE the custom-manager override, deliberately. When the override
+        # came first it short-circuited this gate, so
+        # `custom_hook_manager=X, enable_tracing=True` raised nothing and
+        # `rich_output` went on to print "Jaeger tracing
+        # (http://localhost:16686)" — the same banner lie, surviving on one
+        # path. Supplying your own manager does not make the FRAMEWORK's
+        # tracing exist, and the flag cannot reach that manager anyway: it is
+        # returned verbatim, so an explicit request stays unsatisfiable.
         #
         # This function used to import four hook classes that do not exist,
         # catch the resulting ImportError, log "not available, skipping", and
@@ -259,6 +263,14 @@ class SmartDefaultsManager:
         if explicitly_requested:
             flag, subsystem, provides = explicitly_requested[0]
             raise ObservabilityNotImplemented(subsystem, flag, provides)
+
+        # Layer 3: Custom hook manager override. Reached only once no
+        # unsatisfiable request is outstanding, and it does NOT warn — a
+        # caller who brought their own hooks does not need to be told the
+        # framework's are missing.
+        if config.has_custom_observability():
+            self.logger.info("Using custom hook manager")
+            return config.custom_hook_manager
 
         # Left at default: the caller did not ask, so do not break them — but
         # do not stay quiet about advertising four features that do not exist.

--- a/packages/kailash-kaizen/src/kaizen/smart_defaults.py
+++ b/packages/kailash-kaizen/src/kaizen/smart_defaults.py
@@ -12,6 +12,7 @@ Part of ADR-020: Unified Agent API Architecture (Layer 1: Zero-Config)
 """
 
 import logging
+from functools import lru_cache
 from pathlib import Path
 
 from kaizen.agent_config import AgentConfig
@@ -31,6 +32,31 @@ _UNIMPLEMENTED_OBSERVABILITY = (
     ("enable_logging", "logging", "structured JSON logging"),
     ("enable_audit", "audit", "compliance audit trails"),
 )
+
+
+@lru_cache(maxsize=None)
+def _warn_observability_unimplemented(subsystems: tuple[str, ...]) -> None:
+    """Emit the unimplemented-subsystem warning ONCE per process.
+
+    ``create_observability`` runs on EVERY agent construction, so warning per
+    call turns a real signal into log spam — and a spammed warning is a
+    silenced one: operators filter it, and the loud-warning remedy quietly
+    becomes no remedy at all.
+
+    ``lru_cache`` rather than an instance flag, because
+    ``SmartDefaultsManager`` is constructed per agent — an instance flag would
+    warn once per instance and leave the spam intact. Keyed on the subsystem
+    tuple so a genuinely different set still gets its own warning.
+
+    Tests reset it with ``_warn_observability_unimplemented.cache_clear()``.
+    """
+    logger.warning(
+        "Observability subsystems are NOT IMPLEMENTED and no hooks were "
+        "registered: %s. These config flags are advertised but install "
+        "nothing (tracking: #2084). Set them to False to silence this, or "
+        "True to fail loudly instead.",
+        ", ".join(subsystems),
+    )
 
 
 # =============================================================================
@@ -246,13 +272,8 @@ class SmartDefaultsManager:
             if getattr(config, flag, None) is None
         ]
         if unset:
-            self.logger.warning(
-                "Observability subsystems are NOT IMPLEMENTED and no hooks "
-                "were registered: %s. These config flags are advertised but "
-                "install nothing (tracking: #2084). Set them to False to "
-                "silence this, or True to fail loudly instead.",
-                ", ".join(unset),
-            )
+            # ONCE per process, not once per construction — see the helper.
+            _warn_observability_unimplemented(tuple(unset))
 
         self.logger.info("Observability disabled")
         return None

--- a/packages/kailash-kaizen/src/kaizen/smart_defaults.py
+++ b/packages/kailash-kaizen/src/kaizen/smart_defaults.py
@@ -15,8 +15,22 @@ import logging
 from pathlib import Path
 
 from kaizen.agent_config import AgentConfig
+from kaizen.errors import ObservabilityNotImplemented
 
 logger = logging.getLogger(__name__)
+
+#: The four observability subsystems this module advertises and does NOT
+#: implement: ``(config flag, human name, what it would have provided)``.
+#: The hook classes imported by the old call site do not exist, and neither do
+#: the handler methods it registered (``start_trace`` / ``end_trace`` /
+#: ``record_start`` / ``record_end`` / ``log_start`` / ``log_end`` have zero
+#: definitions anywhere in ``src/``). Tracking: #2084.
+_UNIMPLEMENTED_OBSERVABILITY = (
+    ("enable_tracing", "tracing", "distributed tracing via Jaeger"),
+    ("enable_metrics", "metrics", "Prometheus metrics collection"),
+    ("enable_logging", "logging", "structured JSON logging"),
+    ("enable_audit", "audit", "compliance audit trails"),
+)
 
 
 # =============================================================================
@@ -172,106 +186,76 @@ class SmartDefaultsManager:
 
     def create_observability(self, config: AgentConfig):
         """
-        Create observability with smart defaults.
+        Resolve observability configuration.
 
-        Sets up:
-        - Tracing: Jaeger distributed tracing
-        - Metrics: Prometheus metrics collection
-        - Logging: Structured JSON logging
-        - Audit: Compliance audit trails
+        NONE of the four advertised subsystems — tracing, metrics, logging,
+        audit — is implemented (#2084). This method no longer pretends
+        otherwise: it either returns a caller-supplied hook manager, raises for
+        an explicit request it cannot satisfy, or warns and returns None.
 
         Args:
             config: Agent configuration
 
         Returns:
-            HookManager with observability hooks or None
+            The custom hook manager if one was supplied, otherwise None.
+
+        Raises:
+            ObservabilityNotImplemented: if any of the four flags was set to
+                ``True`` explicitly. Left unset (``None``), they warn instead.
 
         Logic:
         - If custom_hook_manager provided → use it
-        - If all observability disabled → no hooks
-        - Otherwise → create HookManager with enabled subsystems
+        - If any subsystem explicitly requested → raise (none are implemented)
+        - Otherwise → warn once and return None
         """
         # Layer 3: Custom hook manager override
         if config.has_custom_observability():
             self.logger.info("Using custom hook manager")
             return config.custom_hook_manager
 
-        # No observability if all disabled
-        if not config.is_observability_enabled():
-            self.logger.info("Observability disabled")
-            return None
+        # NOT-IMPLEMENTED gate (#2084).
+        #
+        # This function used to import four hook classes that do not exist,
+        # catch the resulting ImportError, log "not available, skipping", and
+        # return an EMPTY HookManager — so all four flags reported success
+        # while registering nothing. `enable_audit` is the sharp case:
+        # compliance audit trails that silently record nothing are invisible
+        # exactly when they matter.
+        #
+        # Deliberately NOT wrapped in try/except ImportError. The defect being
+        # fixed IS a swallowed ImportError; reproducing that shape one layer
+        # out would defeat the purpose.
+        explicitly_requested = [
+            (flag, subsystem, provides)
+            for flag, subsystem, provides in _UNIMPLEMENTED_OBSERVABILITY
+            if getattr(config, flag, None) is True
+        ]
+        if explicitly_requested:
+            flag, subsystem, provides = explicitly_requested[0]
+            raise ObservabilityNotImplemented(subsystem, flag, provides)
 
-        # Layer 1: Smart defaults
-        from kaizen.core.autonomy.hooks import HookManager
-        from kaizen.core.autonomy.hooks.types import HookEvent
+        # Left at default: the caller did not ask, so do not break them — but
+        # do not stay quiet about advertising four features that do not exist.
+        # ONE consolidated warning, not the four separate "not available,
+        # skipping" lines this replaced: "not available" reads as a missing
+        # optional dependency an operator could install, and there is nothing
+        # to install.
+        unset = [
+            subsystem
+            for flag, subsystem, _ in _UNIMPLEMENTED_OBSERVABILITY
+            if getattr(config, flag, None) is None
+        ]
+        if unset:
+            self.logger.warning(
+                "Observability subsystems are NOT IMPLEMENTED and no hooks "
+                "were registered: %s. These config flags are advertised but "
+                "install nothing (tracking: #2084). Set them to False to "
+                "silence this, or True to fail loudly instead.",
+                ", ".join(unset),
+            )
 
-        hook_manager = HookManager()
-        enabled_systems = []
-
-        # Tracing (Jaeger)
-        if config.enable_tracing:
-            try:
-                from kaizen.core.autonomy.observability.tracing import TracingHook
-
-                tracing_hook = TracingHook(endpoint=config.tracing_endpoint)
-                hook_manager.register(
-                    HookEvent.PRE_AGENT_LOOP, tracing_hook.start_trace
-                )
-                hook_manager.register(HookEvent.POST_AGENT_LOOP, tracing_hook.end_trace)
-                enabled_systems.append("Jaeger tracing")
-            except ImportError:
-                self.logger.warning("Tracing hook not available, skipping")
-
-        # Metrics (Prometheus)
-        if config.enable_metrics:
-            try:
-                from kaizen.core.autonomy.observability.metrics import MetricsHook
-
-                metrics_hook = MetricsHook(port=config.metrics_port)
-                hook_manager.register(
-                    HookEvent.PRE_AGENT_LOOP, metrics_hook.record_start
-                )
-                hook_manager.register(
-                    HookEvent.POST_AGENT_LOOP, metrics_hook.record_end
-                )
-                enabled_systems.append(
-                    f"Prometheus metrics (port {config.metrics_port})"
-                )
-            except ImportError:
-                self.logger.warning("Metrics hook not available, skipping")
-
-        # Logging (Structured JSON)
-        if config.enable_logging:
-            try:
-                from kaizen.core.autonomy.observability.logging import LoggingHook
-
-                logging_hook = LoggingHook(level=config.log_level)
-                hook_manager.register(HookEvent.PRE_AGENT_LOOP, logging_hook.log_start)
-                hook_manager.register(HookEvent.POST_AGENT_LOOP, logging_hook.log_end)
-                enabled_systems.append(f"Structured logging ({config.log_level})")
-            except ImportError:
-                self.logger.warning("Logging hook not available, skipping")
-
-        # Audit (Compliance)
-        if config.enable_audit:
-            try:
-                from kaizen.core.autonomy.observability.audit import AuditHook
-
-                # Ensure audit log directory exists
-                audit_path = Path(config.audit_log_path)
-                audit_path.parent.mkdir(parents=True, exist_ok=True)
-
-                audit_hook = AuditHook(path=config.audit_log_path)
-                hook_manager.register(HookEvent.PRE_AGENT_LOOP, audit_hook.record_start)
-                hook_manager.register(HookEvent.POST_AGENT_LOOP, audit_hook.record_end)
-                enabled_systems.append("Audit trails")
-            except ImportError:
-                self.logger.warning("Audit hook not available, skipping")
-
-        if enabled_systems:
-            self.logger.info(f"Enabled observability: {', '.join(enabled_systems)}")
-
-        return hook_manager
+        self.logger.info("Observability disabled")
+        return None
 
     # =========================================================================
     # Checkpointing Creation

--- a/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_logging_hook_redaction_defeat.py
+++ b/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_logging_hook_redaction_defeat.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression suite: LoggingHook payload disclosure + redaction-opt-in defeat (#2070).
+
+Two defects, one file, both in `builtin/logging_hook.py`.
+
+DEFECT 1 — full agent payloads at INFO, unredacted, by default. `include_data`
+defaults True and `redact_sensitive` defaults False, and `agent_loop.py` feeds
+this hook the whole agent I/O (`PRE_AGENT_LOOP` carries `{"inputs": ...}`,
+`POST_AGENT_LOOP` carries `{"result": ...}`). Registering the hook therefore
+put user prompts, retrieved documents and any credential-bearing parameter on
+the INFO log. Same disclosure class as #2030, at a second surface.
+
+DEFECT 2 — an explicitly-requested security control degraded to OFF. On
+`ImportError` the constructor set `redact_sensitive = False` and continued
+logging at full fidelity behind a WARNING. An operator who deliberately turned
+redaction ON had it turned off for them. `zero-tolerance.md` Rule 3 +
+`security.md` § Secure-Default.
+
+WHY THE EXISTING SUITE DID NOT CATCH EITHER. `test_builtin_hooks.py` and
+`test_structured_logging.py` construct `LoggingHook` a dozen times and assert
+only `result.success is True` / `result.error is None`. Not one asserts on log
+CONTENT — including `test_text_format_unchanged`, whose docstring says
+"produces same output as before" while asserting nothing about output. Those
+tests pass identically whether the payload is logged, redacted, or omitted, so
+they carry no information about the property that was broken. Every assertion
+below is on rendered log content for that reason.
+
+ASYMMETRY PINNED BY TESTS 3 AND 4. An explicit opt-in that cannot be honoured
+must RAISE (test 3). A default that cannot be honoured may degrade, but must
+then also stop emitting the payloads redaction was protecting (test 4) —
+degrading the control while continuing to log is the one outcome that must not
+survive.
+
+REACHABILITY, STATED BECAUSE IT BOUNDS THE CLAIM. `security/redaction.py`
+imports only stdlib, `kaizen.utils.credential_scrub`, and sibling modules, so
+its `ImportError` branch is not reachable through a normal install today.
+Defect 2 is a live fail-OPEN DISPOSITION on an unreachable path, not a live
+leak. Tests 3 and 4 therefore force a genuine `ImportError` through
+`sys.modules` rather than asserting about the branch from a reading of it — the
+import machinery really raises, and the constructor really takes the branch.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+import pytest
+
+from kaizen.core.autonomy.hooks.builtin.logging_hook import LoggingHook
+from kaizen.core.autonomy.hooks.types import HookContext, HookEvent
+
+REDACTION_MODULE = "kaizen.core.autonomy.hooks.security.redaction"
+LOGGER_NAME = "kaizen.core.autonomy.hooks.builtin.logging_hook"
+
+#: Credential-SHAPED so the redactor can recognise it. A value that no scrubber
+#: claims to match would make a passing test unfalsifiable about redaction.
+CREDENTIAL = "sk-live-LOGGINGHOOK2070SECRETVALUE"
+
+#: Prose the user typed. NOT credential-shaped and NOT PII-shaped, so no
+#: scrubber will remove it — it is here to prove the INFO line withholds VALUES
+#: as such, not merely values a scrubber happens to recognise.
+PROMPT = "summarize the acquisition memo for board review"
+
+
+def _context() -> HookContext:
+    """A PRE_AGENT_LOOP context shaped exactly as `agent_loop.py` builds it."""
+    return HookContext(
+        event_type=HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-2070",
+        timestamp=time.time(),
+        data={"inputs": {"prompt": PROMPT, "api_key": CREDENTIAL}},
+        metadata={"iteration": 1},
+        trace_id="trace-2070",
+    )
+
+
+def _rendered(caplog: pytest.LogCaptureFixture) -> str:
+    """Every captured record rendered as the handler would emit it."""
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+class TestDefaultConstructionWithholdsValues:
+    """DEFECT 1 — default construction must not put payload VALUES on INFO."""
+
+    @pytest.mark.asyncio
+    async def test_credential_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        hook = LoggingHook()  # defaults only — the shape an operator gets free
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert CREDENTIAL not in _rendered(caplog), (
+            "A credential-shaped value in context.data reached the INFO log "
+            "under DEFAULT construction. agent_loop feeds this hook whole "
+            "agent inputs, so this is #2030's disclosure at a second surface."
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_prompt_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Not scrubber-recognisable, so only withholding VALUES can pass this.
+
+        Distinct from the credential assertion above: flipping
+        `redact_sensitive` to True would satisfy that one while leaving every
+        user prompt and retrieved document on the INFO log. This is the
+        assertion that forces structure-only logging.
+        """
+        hook = LoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert PROMPT not in _rendered(caplog), (
+            "The user's prompt text reached the INFO log under default "
+            "construction. Redaction does not cover prose; only declining to "
+            "log values does."
+        )
+
+    @pytest.mark.asyncio
+    async def test_structure_is_preserved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE CONTROL — blanket-masking must not be able to pass.
+
+        Without this, deleting the log call entirely, or masking the whole
+        line, would satisfy every assertion above. The hook has to stay useful:
+        the event, the agent, the trace and the payload's SHAPE all survive.
+        """
+        hook = LoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Hook emitted nothing at all; that is not a fix."
+        for token in ("pre_agent_loop", "agent-2070", "trace-2070", "inputs"):
+            assert token in rendered, (
+                f"{token!r} missing from the INFO line. Structure — event, "
+                f"agent, trace, and payload KEY names — must survive; only "
+                f"values are withheld."
+            )
+
+
+class TestExplicitRedactionOptInFailsClosed:
+    """DEFECT 2 — an explicit opt-in that cannot be honoured must RAISE."""
+
+    def test_raises_when_redactor_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A genuine ImportError from the real import machinery, not a stand-in
+        # for one: `None` in sys.modules makes the `from ... import ...` inside
+        # the constructor raise for real, so the branch is really executed.
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        with pytest.raises(RuntimeError, match="redact_sensitive"):
+            LoggingHook(redact_sensitive=True)
+
+    def test_error_names_the_protection_and_the_remedy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            LoggingHook(redact_sensitive=True)
+
+        message = str(excinfo.value)
+        assert "redaction" in message.lower(), "Error must name the OFF protection."
+        assert "SensitiveDataRedactor" in message, "Error must name what failed."
+
+
+class TestUnrequestedRedactionDegradesWithoutDisclosing:
+    """DEFECT 2, other polarity — a DEFAULT may degrade, but must stop logging.
+
+    The asymmetry is the whole point. Raising on a default nobody asked for
+    would break installs where redaction is genuinely unavailable; continuing
+    to log payloads after the control failed is the disclosure the control
+    existed to prevent. Degrade, and stop emitting.
+    """
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_and_still_withholds_values(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        hook = LoggingHook()  # redaction NOT explicitly requested
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert CREDENTIAL not in rendered, (
+            "Redaction degraded to OFF and the hook kept logging payloads. "
+            "A degraded control must also stop emitting what it protected."
+        )
+        assert PROMPT not in rendered
+
+
+class TestRedactionAppliedWhenAvailable:
+    """Positive polarity — with the redactor present, it is actually used."""
+
+    @pytest.mark.asyncio
+    async def test_credential_redacted_in_full_payload_mode(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Opt in to everything: explicit redaction AND explicit full payloads.
+
+        This is the configuration that emits values at all. It pins that the
+        opt-in path is wired to a redactor that really runs — without it, the
+        suite above would be satisfied by a hook that can only ever stay quiet.
+        """
+        hook = LoggingHook(redact_sensitive=True, log_full_payloads=True)
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Full-payload mode emitted nothing."
+        assert CREDENTIAL not in rendered, (
+            "Explicit redaction was requested and the redactor was available, "
+            "yet the credential survived into the log."
+        )

--- a/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_secure_logging_hook_payload_disclosure.py
+++ b/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_secure_logging_hook_payload_disclosure.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression suite: SecureLoggingHook leaks payload PROSE at INFO (#2070 sibling).
+
+`SecureLoggingHook` (`hooks/security/redaction.py`) is a near-verbatim copy of
+the pre-fix `LoggingHook` body — `Data={safe_context.data}` on the text path,
+`log_event["context"] = safe_context.data` on the JSON path. It is public API
+(exported from `hooks.security`).
+
+SCOPE, stated precisely because it is narrower than the sibling defect. This
+class DOES redact: `redact_sensitive` defaults True and the redactor is
+constructed unconditionally, so credential shapes and PII patterns are removed.
+What survives is everything the redactor does not claim — the user's prompt,
+retrieved document text, free-form tool output. A class named
+`SecureLoggingHook` publishing those at INFO is the same disclosure #2030
+describes, reduced but not absent.
+
+That is why the credential assertion below is a NEGATIVE control rather than
+the finding: the credential is expected to be gone already, and a suite that
+only checked credentials would report this class clean. The load-bearing
+assertion is the PROSE one.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from kaizen.core.autonomy.hooks.security.redaction import SecureLoggingHook
+from kaizen.core.autonomy.hooks.types import HookContext, HookEvent
+
+LOGGER_NAME = "kaizen.core.autonomy.hooks.security.redaction"
+
+#: Credential-shaped: the redactor already claims this class today.
+CREDENTIAL = "sk-live-SECUREHOOK2070SECRETVALUE"
+
+#: Prose: matches no credential or PII pattern, so no redactor removes it.
+#: This is the value the defect is actually about.
+PROMPT = "draft the termination letter for the Henderson account"
+
+
+def _context() -> HookContext:
+    return HookContext(
+        event_type=HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-secure-2070",
+        timestamp=time.time(),
+        data={"inputs": {"prompt": PROMPT, "api_key": CREDENTIAL}},
+        metadata={"iteration": 1},
+        trace_id="trace-secure-2070",
+    )
+
+
+def _rendered(caplog: pytest.LogCaptureFixture) -> str:
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+class TestSecureLoggingHookWithholdsValues:
+    @pytest.mark.asyncio
+    async def test_user_prose_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """THE FINDING. Redaction does not cover prose; only structure-only does."""
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert PROMPT not in _rendered(caplog), (
+            "SecureLoggingHook published the user's prompt text at INFO. The "
+            "redactor claims credential shapes and PII patterns, neither of "
+            "which matches prose, so redaction cannot close this — only "
+            "declining to log values can."
+        )
+
+    @pytest.mark.asyncio
+    async def test_credential_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE control — expected to pass BEFORE the fix as well.
+
+        If this ever reddens, the redactor itself regressed, which is a
+        different defect from the one this suite is about.
+        """
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert CREDENTIAL not in _rendered(caplog)
+
+    @pytest.mark.asyncio
+    async def test_structure_is_preserved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE control — deleting or blanket-masking the line cannot pass."""
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Hook emitted nothing at all; that is not a fix."
+        for token in (
+            "pre_agent_loop",
+            "agent-secure-2070",
+            "trace-secure-2070",
+            "inputs",
+        ):
+            assert token in rendered, (
+                f"{token!r} missing. Structure — event, agent, trace and "
+                f"payload KEY names — must survive; only values are withheld."
+            )
+
+    @pytest.mark.asyncio
+    async def test_full_payload_mode_is_opt_in_and_scrubbed(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Positive polarity — values are reachable deliberately, and scrubbed.
+
+        Without this the suite would be satisfied by a hook that can only ever
+        stay quiet, which would be a regression in usefulness rather than a fix.
+        """
+        hook = SecureLoggingHook(log_full_payloads=True)
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Full-payload mode emitted nothing."
+        assert (
+            CREDENTIAL not in rendered
+        ), "Deliberate full-payload mode must still scrub credentials."

--- a/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
+++ b/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
@@ -44,7 +44,24 @@ import pytest
 
 from kaizen.agent_config import AgentConfig
 from kaizen.errors import ObservabilityNotImplemented
-from kaizen.smart_defaults import SmartDefaultsManager
+from kaizen.smart_defaults import (
+    SmartDefaultsManager,
+    _warn_observability_unimplemented,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_one_time_warning() -> None:
+    """Clear the process-wide warn cache before EVERY test in this module.
+
+    Load-bearing, not hygiene. The warning fires once per process, so without
+    this reset a test that asserts the warning is ABSENT (`explicit_false_is
+    _silent`) would pass merely because an earlier test consumed it — a
+    non-discriminating pass. Clearing first makes each absence assertion mean
+    what it says.
+    """
+    _warn_observability_unimplemented.cache_clear()
+
 
 #: Deliberately synthetic. `AgentConfig` requires SOME model string, but
 #: nothing in this suite dispatches to a provider — every assertion is about
@@ -106,6 +123,32 @@ class TestDefaultConstructionStaysWorking:
                 f"Warning did not name {subsystem!r}. An operator cannot act "
                 f"on a warning that does not say which feature is missing."
             )
+
+    def test_warning_fires_once_per_process_not_per_construction(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """`create_observability` runs on EVERY agent construction.
+
+        Warning per call turns a real signal into log spam, and a spammed
+        warning is a silenced one — operators filter it, which is how the
+        loud-warning remedy quietly becomes no remedy at all. An instance
+        flag cannot fix this: `SmartDefaultsManager` is constructed per
+        agent, so every instance would warn once and the spam would remain.
+        """
+        config = AgentConfig(model=MODEL)
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                SmartDefaultsManager().create_observability(config)
+
+        hits = [
+            r for r in caplog.records if "not implemented" in r.getMessage().lower()
+        ]
+        assert len(hits) == 1, (
+            f"Expected exactly ONE unimplemented-subsystem warning across 5 "
+            f"agent constructions, got {len(hits)}. Per-construction warning "
+            f"is log spam on the hot path."
+        )
 
 
 class TestExplicitOptInFailsLoudly:

--- a/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
+++ b/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression suite: the four observability flags stop lying (#2084 / #2070 follow-up).
+
+`SmartDefaultsManager.create_observability` advertises four subsystems —
+tracing, metrics, logging, audit. None of them exists: every import raises
+`ImportError`, every one is caught, and the function always returns a
+`HookManager` with zero hooks. Meanwhile all four flags default `True` and
+`is_observability_enabled()` returns `True`, so the config actively reports
+that observability is on.
+
+The fix makes the flags HONEST. It does not make the features exist — that is
+#2084, deliberately kept separate so the record does not blur them.
+
+TRI-STATE, and why it is not a bool. The flags cannot simply raise when `True`,
+because `True` IS the default: raising would break every agent construction,
+including for callers who never mentioned observability. A dataclass cannot
+distinguish "explicitly passed True" from "defaulted True" without a sentinel,
+so the flags become `Optional[bool]`:
+
+    None  (default, nobody asked)  -> loud WARN, behaviour otherwise unchanged
+    True  (explicit opt-in)        -> raise, naming the subsystem
+    False (explicit opt-out)       -> silent
+
+Same mechanism as `LoggingHook.redact_sensitive` in #2070, and for the same
+underlying reason: separating "requested" from "defaulted" is the only way to
+fail loudly for the first without breaking the second.
+
+WHAT NO EXISTING TEST ASSERTED, and why this shipped: nothing anywhere checks
+that `create_observability` actually REGISTERS anything. `HookManager` exposes
+no public accessor for registered hooks — `get_stats()` reports execution
+counts, not registrations — so the only route is the private `_hooks`. That
+missing public surface is part of why four dead subsystems were invisible, and
+it is why `test_enabled_implies_hooks_registered` below reaches into `_hooks`
+rather than asserting on a supported API.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kaizen.agent_config import AgentConfig
+from kaizen.errors import ObservabilityNotImplemented
+from kaizen.smart_defaults import SmartDefaultsManager
+
+#: Deliberately synthetic. `AgentConfig` requires SOME model string, but
+#: nothing in this suite dispatches to a provider — every assertion is about
+#: config flags and hook registration. A sentinel rather than a real model
+#: name keeps this independent of `.env` (`rules/env-models.md`).
+MODEL = "test-model"
+
+#: flag name -> (human subsystem name that MUST appear in the error)
+SUBSYSTEMS = {
+    "enable_tracing": "tracing",
+    "enable_metrics": "metrics",
+    "enable_logging": "logging",
+    "enable_audit": "audit",
+}
+
+
+def _registered_hook_count(manager: object) -> int:
+    """Count registered hooks via the private `_hooks` (no public accessor)."""
+    if manager is None:
+        return 0
+    return sum(len(v) for v in getattr(manager, "_hooks", {}).values())
+
+
+class TestDefaultConstructionStaysWorking:
+    """Requirement: nobody who did NOT ask gets a new error."""
+
+    def test_default_construction_does_not_raise(self) -> None:
+        """NEGATIVE control — passes before AND after.
+
+        This is the assertion that forced the tri-state. All four flags
+        default True today, so a naive "raise when True" would redden this
+        for every caller in existence.
+        """
+        config = AgentConfig(model=MODEL)
+        SmartDefaultsManager().create_observability(config)
+
+    def test_default_construction_warns_that_features_are_unimplemented(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The default path must say NOT IMPLEMENTED, not 'not available'.
+
+        Today it logs 'Tracing hook not available, skipping' — which reads as
+        a missing optional dependency an operator could go install. There is
+        nothing to install; the subsystem does not exist. The wording is the
+        whole point of the warning, so the assertion is on the wording.
+        """
+        config = AgentConfig(model=MODEL)
+        with caplog.at_level(logging.WARNING):
+            SmartDefaultsManager().create_observability(config)
+
+        rendered = "\n".join(r.getMessage() for r in caplog.records)
+        assert "not implemented" in rendered.lower(), (
+            "The default path warned, but not that the subsystems are "
+            "UNIMPLEMENTED. 'not available' implies an installable optional "
+            "dependency; there is none."
+        )
+        for subsystem in SUBSYSTEMS.values():
+            assert subsystem in rendered.lower(), (
+                f"Warning did not name {subsystem!r}. An operator cannot act "
+                f"on a warning that does not say which feature is missing."
+            )
+
+
+class TestExplicitOptInFailsLoudly:
+    """Requirement: an explicit request for a nonexistent feature RAISES."""
+
+    @pytest.mark.parametrize("flag,subsystem", sorted(SUBSYSTEMS.items()))
+    def test_explicit_true_raises_naming_the_subsystem(
+        self, flag: str, subsystem: str
+    ) -> None:
+        config = AgentConfig(model=MODEL, **{flag: True})
+
+        with pytest.raises(ObservabilityNotImplemented) as excinfo:
+            SmartDefaultsManager().create_observability(config)
+
+        message = str(excinfo.value)
+        assert subsystem in message.lower(), (
+            f"{flag}=True raised, but the error does not name {subsystem!r}. "
+            f"A generic 'not available' does not tell the operator which of "
+            f"the four features they asked for is missing."
+        )
+        assert flag in message, "Error must name the flag the caller set."
+
+    @pytest.mark.parametrize("flag", sorted(SUBSYSTEMS))
+    def test_explicit_false_is_silent(
+        self, flag: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Explicit opt-out: no raise, and no warning about that subsystem."""
+        disabled = {name: False for name in SUBSYSTEMS}
+        config = AgentConfig(model=MODEL, **disabled)
+
+        with caplog.at_level(logging.WARNING):
+            SmartDefaultsManager().create_observability(config)
+
+        rendered = "\n".join(r.getMessage() for r in caplog.records).lower()
+        assert "not implemented" not in rendered, (
+            "Explicitly disabling every subsystem still warned about "
+            "unimplemented features. Opting out is not asking."
+        )
+
+
+class TestIsObservabilityEnabledBecomesTruthful:
+    """The config must stop reporting observability it does not have."""
+
+    def test_false_by_default(self) -> None:
+        """Was `True` while zero hooks registered — a false report, now correct."""
+        assert AgentConfig(model=MODEL).is_observability_enabled() is False
+
+    @pytest.mark.parametrize("flag", sorted(SUBSYSTEMS))
+    def test_true_when_explicitly_requested(self, flag: str) -> None:
+        """NEGATIVE control — the correction must not flatten to always-False."""
+        config = AgentConfig(model=MODEL, **{flag: True})
+        assert config.is_observability_enabled() is True
+
+    def test_enabled_implies_hooks_registered(self) -> None:
+        """THE INVARIANT whose absence let four dead subsystems ship.
+
+        `is_observability_enabled()` must never report True while
+        `create_observability` yields a manager with nothing in it. Either it
+        reports False (nothing requested), or the request raises, or hooks are
+        genuinely registered. The one state that must be unreachable is
+        "enabled, and empty" — which was the shipped behaviour.
+        """
+        config = AgentConfig(model=MODEL)
+
+        if not config.is_observability_enabled():
+            return  # honest: nothing requested, nothing registered
+
+        try:
+            manager = SmartDefaultsManager().create_observability(config)
+        except ObservabilityNotImplemented:
+            return  # honest: the request failed loudly
+
+        assert _registered_hook_count(manager) > 0, (
+            "is_observability_enabled() reported True, create_observability() "
+            "returned without raising, and ZERO hooks were registered. That is "
+            "the exact state that shipped four unimplemented subsystems."
+        )

--- a/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
+++ b/packages/kailash-kaizen/tests/unit/test_observability_flags_fail_loudly.py
@@ -189,6 +189,49 @@ class TestExplicitOptInFailsLoudly:
         )
 
 
+class TestCustomManagerDoesNotExemptTheGate:
+    """A custom hook manager must not re-open the path the gate closed.
+
+    Found by sweeping every reader of the four flags for truthiness branches.
+    The custom-manager override returns early, so it originally short-circuited
+    the NOT-IMPLEMENTED gate: `custom_hook_manager=X, enable_tracing=True`
+    raised nothing, and `rich_output` then printed
+
+        ✅ Observability:
+           • Jaeger tracing (http://localhost:16686)
+
+    — the exact banner lie this branch removed, surviving on one path.
+    Supplying your own manager does not make the FRAMEWORK's Jaeger tracing
+    exist, and the flag has no mechanism to reach the custom manager anyway:
+    it is returned verbatim. So an explicit request is still unsatisfiable.
+    """
+
+    def test_explicit_true_raises_even_with_custom_manager(self) -> None:
+        from kaizen.core.autonomy.hooks import HookManager
+
+        config = AgentConfig(
+            model=MODEL,
+            enable_tracing=True,
+            custom_hook_manager=HookManager(),
+        )
+
+        with pytest.raises(ObservabilityNotImplemented):
+            SmartDefaultsManager().create_observability(config)
+
+    def test_custom_manager_alone_still_works(self) -> None:
+        """NEGATIVE control — the gate must not break the custom path itself.
+
+        Without this, moving the gate ahead of the override could reject every
+        caller who legitimately supplies their own hooks.
+        """
+        from kaizen.core.autonomy.hooks import HookManager
+
+        supplied = HookManager()
+        config = AgentConfig(model=MODEL, custom_hook_manager=supplied)
+
+        assert SmartDefaultsManager().create_observability(config) is supplied
+
+
 class TestIsObservabilityEnabledBecomesTruthful:
     """The config must stop reporting observability it does not have."""
 


### PR DESCRIPTION
## Summary

Two defects in `packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py`.

**Defect 1 — full agent payloads at INFO, unredacted, by default.** `agent_loop` feeds this hook whole agent I/O (`PRE_AGENT_LOOP` carries `{"inputs": ...}`, `POST_AGENT_LOOP` carries `{"result": ...}`), and the hook rendered that dict straight into an INFO line. `include_data` defaulted True, `redact_sensitive` defaulted False. Same disclosure class as #2030, at a second surface.

**Defect 2 — an explicitly-requested security control degraded to OFF.** On `ImportError` the constructor set `redact_sensitive = False` and kept logging at full fidelity behind a WARNING. An operator who deliberately turned redaction ON had it turned off for them. `zero-tolerance.md` Rule 3 + `security.md` § Secure-Default.

## Fail-first evidence

RED against unmodified source — 6 failed, 1 passed (the 1 is the negative control, which must pass in both states):

```
INFO  logging_hook.py:163 [pre_agent_loop] Agent=agent-2070 TraceID=trace-2070
      Data={'inputs': {'prompt': 'summarize the acquisition memo for board review',
      'api_key': 'sk-live-LOGGINGHOOK2070SECRETVALUE'}}

WARNING logging_hook.py:80 SensitiveDataRedactor not available, disabling redaction.
Failed: DID NOT RAISE <class 'RuntimeError'>
```

GREEN after: **7 passed**. Full hook suite: **126 passed**.

## The fix

- **INFO logs structure, never values** — event, agent, trace, payload KEY names + count. Redaction is not a substitute: it claims credential shapes and PII patterns, and a user's prose matches neither.
- **Values only behind two independent gates** — new `log_full_payloads` (default False) AND the logger actually at DEBUG, routed through `scrub_credentials`, truncated at 2000 chars before scrubbing.
- **`redact_sensitive` is tri-state** (`Optional[bool]`), and that is the load-bearing part. An explicit `True` that cannot be honoured **raises**; an unrequested default may degrade **but then also stops emitting payloads**. Raising on a default nobody asked for would break installs where the redactor is genuinely absent; continuing to log after the control failed is the disclosure the control existed to prevent.

## Both polarities pinned

| Test | Property |
|---|---|
| `test_credential_absent_from_info` | credential-shaped value withheld at INFO |
| `test_user_prompt_absent_from_info` | **prose** withheld — not scrubber-recognisable, so only structure-only logging passes |
| `test_structure_is_preserved` | **negative control** — blanket-masking / deleting the log cannot pass |
| `test_raises_when_redactor_unavailable` | explicit opt-in fails closed |
| `test_error_names_the_protection_and_the_remedy` | error names what failed and how to fix |
| `test_does_not_raise_and_still_withholds_values` | default degrades **without** disclosing |
| `test_credential_redacted_in_full_payload_mode` | positive polarity — redactor really runs |

Tests 3/4 force a **genuine** `ImportError` through `sys.modules` rather than reasoning about the branch, so the constructor really executes it. No `Mock`.

## Why existing coverage missed this

Twelve `LoggingHook` constructions across `test_builtin_hooks.py` and `test_structured_logging.py` assert only `result.success is True` / `result.error is None`. Not one inspects log content — including `test_text_format_unchanged`, whose docstring says *"produces same output as before"* while asserting nothing about output. Those tests pass identically whether the payload is logged, redacted, or omitted.

## Scope / reachability, stated rather than glossed

`security/redaction.py` imports only stdlib, `kaizen.utils.credential_scrub`, and siblings, so its `ImportError` branch is **not reachable through a normal install today**. Defect 2 is a live fail-open *disposition* on an unreachable path, not a live leak. Defect 1 is live whenever the hook is registered (mitigated by `hooks_enabled` defaulting False).

## Verification

- Fail-first RED quoted above, then GREEN — 7 passed
- `tests/unit/core/autonomy/hooks/` — 126 passed, no regressions
- `pre-commit run --files <changed>` — all hooks pass, incl. the Tier 1 gate
- 3 pre-existing failures in `tests/e2e/autonomy/test_hooks_e2e.py` are **not** caused by this change: reverting the source to HEAD reproduces them identically. They are `@pytest.mark.ollama` and need `OPENAI_API_KEY`; the agent errors on the missing provider so POST never fires, hence `assert 1 == 2`.

## Related issues

Closes #2070
Related: #2030 / PR #2068 (same class, `BaseAgent` + `LoggingMixin`), #2069 (sibling shard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)