### PR TITLE
ci: repair Tier-2 suite, declare per-step sibling installs (#2023); diagnose why #2002/#2038 cannot gate yet

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -112,9 +112,35 @@ jobs:
           uv venv .venv
           # Install root kailash editable first so kailash.diagnostics.protocols
           # resolves from the local tree (not yet released to PyPI).
+          #
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # This job has TWO kinds of consumer, and they differ:
+          #
+          # 1. The inline `km.doctor` / torch-CUDA scripts below. Probed by
+          #    importing exactly what they import:
+          #      `from kailash_ml.doctor import doctor`
+          #        dataflow      -> 0 modules   NOT exercised
+          #        kailash_align -> 0 modules   NOT exercised
+          #        kailash_ml    -> 95, kailash -> 207
+          #    So the canary path itself needs no sibling beyond kailash-ml.
+          #
+          # 2. The "DeviceReport populated on training call" pytest step, which
+          #    names packages/kailash-ml/tests/integration/. Probed on that
+          #    exact selection:
+          #        dataflow      -> 112 modules  EXERCISED at COLLECTION time
+          #        kailash_align -> 13  modules  EXERCISED at COLLECTION time
+          #        kailash_ml    -> 115, kailash -> 251
+          #    tests/integration/ holds the feature-store files that import
+          #    dataflow at module scope, so collection reaches them whatever the
+          #    marker filter selects. Both siblings are therefore installed
+          #    editable below — this job is the human gate before CUDA CI is
+          #    flipped to blocking, so it must not be the one place a
+          #    branch-core/PyPI-sibling pairing sneaks through.
           uv pip install -e "." --python .venv/bin/python
           # Install kailash-ml with deep-learning extras (torch + cuda deps)
           uv pip install -e "packages/kailash-ml[dl,dev]" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: Verify torch CUDA is available
         shell: bash
@@ -194,6 +220,20 @@ jobs:
           # DeviceReport.backend == "cuda" when CUDA is available.
           # Uses pytest with the integration + cuda markers to pick up only
           # the CUDA-specific wiring tests.
+          #
+          # CAVEAT (measured 2026-08-11): `-m 'cuda or gpu'` over this selection
+          # currently matches ZERO tests (593 deselected) — no `cuda` or `gpu`
+          # marker exists anywhere under packages/kailash-ml/tests/. pytest then
+          # exits 5 (no tests collected) and this step FAILS. Verified:
+          #   $ pytest packages/kailash-ml/tests/integration/ \
+          #       packages/kailash-ml/tests/unit/test_device_report.py \
+          #       -m 'cuda or gpu' --collect-only -q; echo $?
+          #   no tests collected (593 deselected)
+          #   5
+          # Tracked in #2076. This matters more here than in the dispatch-only
+          # ml jobs: gpu-smoke.yml is the canary a human runs FIRST after
+          # provisioning the runner, so today it would red for a marker reason
+          # and be read as a hardware problem.
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/integration/ \
             packages/kailash-ml/tests/unit/test_device_report.py \

--- a/.github/workflows/test-kailash-align.yml
+++ b/.github/workflows/test-kailash-align.yml
@@ -106,6 +106,22 @@ jobs:
           # milestone branch and is not yet on PyPI; align tests import it
           # directly per `rules/deployment.md` § "Sibling-Package CI
           # Installs Root SDK Editable For Unreleased Core Modules".
+          #
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-align/tests/ -m 'not (gpu or slow)'
+          #            (485 tests collected)
+          # Probe: sibling module count in sys.modules at collection finish.
+          #   kailash_ml    -> 95 modules  EXERCISED -> installed editable below
+          #   dataflow      -> 0  modules  NOT exercised -> deliberately NOT
+          #                    installed. kailash-ml eagerly imports
+          #                    kailash_ml.features, and features/ does name
+          #                    dataflow — but every one of those imports is
+          #                    either inside `if TYPE_CHECKING:` or inside a
+          #                    function body, so none fires at import time.
+          #                    Adding dataflow here would pull the DB stack into
+          #                    a 5-version matrix for zero reachable code.
+          #   kailash_align -> 23          (the package under test, editable)
+          #   kailash       -> 213         editable, this tree
           uv pip install -e "packages/kailash-ml" --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev]" --python .venv/bin/python
 
@@ -160,6 +176,18 @@ jobs:
           uv pip install -e "." --python .venv/bin/python
           # See unit-test install step — kailash_ml.rl.align_adapter is
           # unreleased; install editable from the source tree.
+          #
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-align/tests/ -m 'gpu'
+          #   kailash_ml    -> 95 modules  EXERCISED -> installed editable below
+          #   dataflow      -> 0  modules  NOT exercised -> not installed
+          #   kailash_align -> 23          (package under test, editable)
+          #   kailash       -> 213         editable, this tree
+          # CAVEAT recorded at the same time: `-m 'gpu'` currently selects ZERO
+          # tests (485 deselected) because no test in packages/kailash-align/
+          # carries a `gpu` marker, so pytest exits 5 (no tests collected) and
+          # this job FAILS whenever it is dispatched. Tracked in #2076. The
+          # sibling determination above is independent of it.
           uv pip install -e "packages/kailash-ml" --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev,rlhf]" --python .venv/bin/python
 
@@ -194,6 +222,14 @@ jobs:
       - name: Install dev kailash-ml + kailash-align
         run: |
           uv venv .venv
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-align/tests/ -m 'not (gpu or slow)'
+          #            (485 tests collected) — same selection as the `test` job.
+          #   kailash_ml    -> 95 modules  EXERCISED -> installed editable below
+          #                    (this job's whole purpose: align against DEV ml)
+          #   dataflow      -> 0  modules  NOT exercised -> not installed
+          #   kailash_align -> 23          (package under test, editable)
+          #   kailash       -> 213         editable, this tree
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dev]" --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev]" --python .venv/bin/python

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -114,6 +114,23 @@ jobs:
           # Install root kailash editable — kailash.diagnostics.protocols
           # (PR #570) is not yet on PyPI, so a transitive resolve would miss
           # the module that PR#2+ (issue #567) diagnostics adapters import.
+          #
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/unit/ -m 'not (slow or gpu or bench)'
+          #            (1924 tests collected)
+          # Probe: a pytest plugin reporting len(sys.modules) per sibling at
+          # collection finish, run against this exact selection.
+          #   dataflow      -> 0 modules  NOT exercised
+          #   kailash_align -> 0 modules  NOT exercised
+          #   kailash_ml    -> 138        (the package under test)
+          #   kailash       -> 213        editable, this tree
+          # The two files under tests/unit/rl/ that mention `kailash_align`
+          # reference it only in a mock side_effect STRING and a docstring —
+          # neither is an import. So no sibling editable install is warranted
+          # here; adding one would lengthen a 5-version matrix for no benefit.
+          # Resolution: kailash = editable (this tree); kailash-ml = editable
+          # (this tree); dataflow / kailash-align = whatever the transitive
+          # resolve produces, and that is FINE because no code path reaches them.
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dev]" --python .venv/bin/python
 
@@ -172,6 +189,16 @@ jobs:
           uv pip install -e "packages/kailash-align[dev]" --python .venv/bin/python
           # pytest-httpserver for test_drift_alerting_wiring webhook tests
           uv pip install pytest-cov pytest-httpserver --python .venv/bin/python
+          #
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/unit/ + tests/integration/
+          #            -m 'not (slow or gpu or bench)'  (2493 tests collected)
+          #   dataflow      -> 112 modules  EXERCISED -> installed editable above
+          #   kailash_align -> 13  modules  EXERCISED -> installed editable above
+          #   kailash_ml    -> 139          (the package under test, editable)
+          #   kailash       -> 251          editable, this tree
+          # This step is the ONE that already had the right answer; the two
+          # installs above are what #2023 asks every other site to justify.
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/unit/ \
             packages/kailash-ml/tests/integration/ \
@@ -207,11 +234,31 @@ jobs:
       - name: Install kailash-ml[dl,dev]
         run: |
           uv venv .venv
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/ -m 'dl or deep_learning'
+          #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
+          #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
+          #   kailash_ml    -> 139          (package under test, editable)
+          #   kailash       -> 251          editable, this tree
+          # Naming the whole tests/ dir means pytest IMPORTS every test module
+          # before the -m filter deselects anything, so a PyPI-resolved dataflow
+          # can break this step at collection — the exact #2023 trap, one layer
+          # earlier than the runtime TypeError that motivated the issue.
+          # Hence both siblings are installed editable below.
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dl,dev]" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: Test DL
         timeout-minutes: 15
+        # CAVEAT (measured 2026-08-11): `-m 'dl or deep_learning'` currently
+        # selects ZERO tests — 2602 collected, 2602 deselected — because no
+        # test under packages/kailash-ml/ carries a `dl` or `deep_learning`
+        # marker, and neither name is registered in that package's
+        # [tool.pytest.ini_options] markers list. pytest then exits 5 (no tests
+        # collected), so this workflow_dispatch-only job FAILS whenever it is
+        # dispatched. Tracked in #2076.
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \
@@ -243,11 +290,29 @@ jobs:
       - name: Install kailash-ml[rl,dev]
         run: |
           uv venv .venv
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/ -m 'rl or reinforcement_learning'
+          #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
+          #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
+          #                    (tests/integration/rl/test_rl_align_cross_sdk_wiring.py
+          #                     imports kailash_align at module scope — this is
+          #                     the RL job, so that import is squarely on-path)
+          #   kailash_ml    -> 139          (package under test, editable)
+          #   kailash       -> 251          editable, this tree
+          # Both installed editable below: naming the whole tests/ dir imports
+          # every module before -m deselects, so a PyPI-resolved sibling breaks
+          # collection.
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[rl,dev]" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: Test RL
         timeout-minutes: 15
+        # CAVEAT (measured 2026-08-11): `-m 'rl or reinforcement_learning'`
+        # selects ZERO tests (2602 deselected) — no such marker exists in the
+        # package. pytest exits 5, so this dispatch-only job fails on dispatch.
+        # Tracked in #2076.
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \
@@ -313,8 +378,20 @@ jobs:
       - name: Install kailash-ml[dl,dev] + root kailash editable
         run: |
           uv venv .venv
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/unit/ + tests/integration/
+          #            -m 'cuda or gpu'
+          #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
+          #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
+          #   kailash_ml    -> 139          (package under test, editable)
+          #   kailash       -> 251          editable, this tree
+          # tests/integration/ contains the feature-store files that import
+          # dataflow at module scope, so collection touches them regardless of
+          # the marker filter. Installed editable below.
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dl,dev]" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: km.doctor gpu — assert CUDA DeviceReport populated
         run: |
@@ -388,11 +465,26 @@ jobs:
       - name: Install kailash-ml[dl,dev] + root kailash editable
         run: |
           uv venv .venv
+          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+          # Selection: packages/kailash-ml/tests/
+          #            -m '(dl or deep_learning) and (cuda or gpu)'
+          #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
+          #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
+          #   kailash_ml    -> 139          (package under test, editable)
+          #   kailash       -> 251          editable, this tree
+          # Installed editable below — whole-tests/ collection imports them.
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dl,dev]" --python .venv/bin/python
+          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
+          uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: Test DL on CUDA (torch + GPU-backed tests)
         timeout-minutes: 35
+        # CAVEAT (measured 2026-08-11): this conjunction selects ZERO tests —
+        # neither operand's markers exist in the package. Tracked in #2076.
+        # Masked today by `continue-on-error: true` (IT-1, runner not yet
+        # provisioned); it becomes a hard failure the moment that flag is
+        # removed, so fix #2076 BEFORE flipping.
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -158,6 +158,19 @@ jobs:
             -m 'not (slow or performance or integration or e2e or requires_docker or requires_postgres or requires_mysql or requires_redis or requires_ollama)' \
             --maxfail=10 -q -p no:xdist --timeout=30
 
+      # The #2023 sibling-install lint lives in tests/regression/, which the
+      # (unshipped, see #2081) test-root-regression job would have run. Named
+      # explicitly here so AC#3 of #2023 is actually enforced on every PR rather
+      # than nominally enforced by a job that does not exist. It is a pure
+      # filesystem scan over .github/workflows/*.yml — no runtime, no hang risk,
+      # under 2 seconds. Fold it back into the regression job when #2081 lands.
+      - name: Test (regression lint — workflow sibling declarations, #2023)
+        timeout-minutes: 5
+        run: |
+          .venv/bin/python -m pytest \
+            tests/regression/test_issue_2023_sibling_install_declarations.py \
+            -q -p no:xdist --timeout=60
+
       - name: Test (Tier 2 — integration runtime tests)
         id: tier2
         # Raised from 10 minutes. On PRE-CHANGE code this step TIMED OUT at 10
@@ -247,169 +260,30 @@ jobs:
             echo "**A green PR check does NOT mean Tier 2 passed.** Open the step log."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Issue #2002: root `tests/regression/` had no blanket CI coverage. Before this
-  # job, exactly TWO of its ~156 files were named by any workflow
-  # (trust-tests.yml runs test_issue_1332_rfc3161_*.py, and only on PRs whose
-  # diff matches that workflow's trust/** paths filter). The Tier-1 step in the
-  # `test` job above runs tests/unit/, tests/trust/plane/unit/ and tests/security/
-  # — not tests/regression/. The regression step in `test-dataflow` below covers
-  # the DataFlow PACKAGE's regression dir, a different directory.
+  # ISSUE #2002 — the `test-root-regression` job lived HERE and is NOT SHIPPED,
+  # pending #2081. Root tests/regression/ cannot run to completion on this
+  # repo's ubuntu-latest runner: three CI runs, each with a sharper instrument,
+  # ended in a timeout or a truncated `--maxfail`. The last one
+  # (--timeout-method=signal, --timeout=60, --maxfail=30) enumerated 30 hangs
+  # across 8 files having executed 757 of 1916 tests in 23m40s — so 30 is a
+  # floor, not a count. The identical selection is 1916 passed / 0 failed in
+  # 217s on macOS.
   #
-  # Regression tests are the never-delete tier: each one pins a bug that already
-  # shipped once. A regression test that never executes records the intent to
-  # prevent a recurrence while providing none of the prevention.
+  # A 40-minute job that cannot complete is pure cost on every PR, and making
+  # it non-blocking would only make that cost silent. So it is removed rather
+  # than shipped degraded, and #2002 stays open with #2081 as its blocker.
   #
-  # Why this is a SEPARATE job rather than a step in the `test` matrix:
-  # root tests/regression/ imports three sibling packages at MODULE level
-  # (unguarded), which the `test` job does not install:
-  #   dataflow       — 17 files (e.g. test_dataflow_pool_bridge.py, test_issue_184.py)
-  #   nexus          —  7 files (e.g. test_issue_500_router_on_startup.py: `from nexus import Nexus`)
-  #   kaizen         —  4 files (e.g. test_provider_registry_backcompat.py:
-  #                              `from kaizen.providers.registry import ...`)
-  #   kailash_mcp    —  3 files (already installed by the `test` job)
-  #   kaizen_agents  —  1 file  (test_issue_443_kaizen_mcp_dependency.py)
-  # Adding five editable sibling installs to a 4-version matrix would pay that
-  # cost 4×; this job pays it once on a single interpreter.
+  # The complete job — the extras set (note `shamir`, without which five EATP
+  # vault tests fail), the five editable sibling installs the suite needs to
+  # COLLECT at all, and the marker filter mirroring the DataFlow regression
+  # step — is preserved in PR #2077's history and referenced from #2081.
+  # Restore it from there once the hangs are fixed; do not re-derive it.
   #
-  # Per issue #2023 § sibling-install discipline — siblings exercised by this
-  # step and how each resolves: kailash (editable, this tree), kailash-dataflow
-  # (editable), kailash-kaizen (editable), kailash-nexus (editable),
-  # kailash-mcp (editable), kaizen-agents (editable). NONE resolve from PyPI.
-  test-root-regression:
-    name: Test Root Regression Suite (Python 3.12)
-    needs: check-duplicate
-    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
-    if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
-    runs-on: ubuntu-latest
-    # Must exceed the 40-minute test step plus install time.
-    timeout-minutes: 50
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Restore uv cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-py3.12-rootregr-${{ hashFiles('pyproject.toml', 'uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-py3.12-rootregr-
-
-      - name: Install dependencies
-        # Extras are the `test` job's set PLUS `shamir`. The shamir extra is
-        # REQUIRED, not optional garnish: without shamir-mnemonic, five tests
-        # (test_eatp12_vault_3way_discrimination.py ×3,
-        # test_eatp12_vault_quickstart.py ×2) fail with
-        # `RuntimeError: SLIP-0039 Shamir secret-sharing requires the 'shamir'
-        # optional extra` raised from src/kailash/trust/vault/shamir.py. Those
-        # are real assertions on a real code path, not env noise — the fix is to
-        # provision the dependency, not to skip the tests.
-        #
-        # Root kailash editable BEFORE the sub-packages, per
-        # rules/deployment.md § "Sibling-Package CI Installs Root SDK Editable".
-        #
-        # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
-        # Selection: tests/regression/ minus the infra markers (1916 collected).
-        # Determined by grepping module-level sibling imports across the
-        # directory, then confirmed by building this exact venv from scratch and
-        # running the suite in it:
-        #   dataflow      -> EXERCISED (17 files) -> editable below
-        #   nexus         -> EXERCISED  (7 files) -> editable below
-        #   kaizen        -> EXERCISED  (4 files) -> editable below
-        #   kailash_mcp   -> EXERCISED  (3 files) -> editable below
-        #   kaizen_agents -> EXERCISED  (1 file)  -> editable below
-        #   kailash_ml / kailash_align / kailash_pact -> 0 files, NOT installed
-        # Several of these imports are UNGUARDED at module scope
-        # (`from nexus import Nexus`, `from kaizen.providers.registry import ...`),
-        # so a missing sibling is a COLLECTION error, not a skip.
-        run: |
-          uv venv .venv
-          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data,shamir]" --python .venv/bin/python
-          uv pip install -e packages/kailash-mcp --python .venv/bin/python
-          uv pip install -e packages/kailash-dataflow --python .venv/bin/python
-          uv pip install -e packages/kailash-kaizen --python .venv/bin/python
-          uv pip install -e packages/kailash-nexus --python .venv/bin/python
-          # test_issue_443_kaizen_mcp_dependency.py does `from kaizen_agents
-          # import Delegate` — without this the test fails ModuleNotFoundError.
-          uv pip install -e packages/kaizen-agents --python .venv/bin/python
-
-      - name: Test root regression suite (infra-free)
-        # 15 -> 40. The first CI run of this step TIMED OUT at 15 minutes while
-        # the identical selection completes in 210s locally. `-q` printed no
-        # per-test progress, so the log could not distinguish "hung on one test"
-        # from "uniformly ~4x slower on a 2-core runner" — 210s x 4 is already
-        # 14 minutes, i.e. the old budget was marginal on arithmetic alone.
-        # Raised well clear, and `-v --durations=25` added below so the next
-        # run answers the question instead of leaving it open.
-        #
-        # It answered it: the suite HANGS on this runner. Two observed points
-        # are test_channel_parameters_envelope_behaviour.py::
-        # test_nexus_websocket_transport_invoke_handler_binds_envelope and
-        # test_create_index_identifier_safety.py, at ~8% of the run.
-        #
-        # `--timeout-method=signal` is the load-bearing change, not the larger
-        # budget. The root pytest.ini sets `timeout_method = thread`, and a
-        # thread-method timeout CANNOT kill a test blocked in a C call: pytest
-        # -timeout printed its banner repeatedly and the process carried on
-        # regardless, so the step consumed its whole budget having run 8% of the
-        # suite. That is a timeout that cannot enforce a timeout. SIGALRM can
-        # (Linux/macOS only, which is what this job runs), so a hung test now
-        # FAILS at 120s and names itself instead of taking the job down with it.
-        # If tests still hang after this, the log will list them individually
-        # and they can be quarantined; the previous instrument could not even
-        # produce that list.
-        #
-        # It did: the first SIGALRM run named 5 hangs in
-        # test_channel_parameters_envelope_behaviour.py and 5 in
-        # test_create_index_identifier_safety.py, then stopped at
-        # `--maxfail=10`. maxfail raised to 30 and the per-test timeout dropped
-        # 120s -> 60s to enumerate the rest within the step budget: 60s is still
-        # 3x the slowest healthy test in this suite (19.94s,
-        # test_issue_2015_http_exception_leak.py), so it cannot false-positive
-        # on a merely-slow test, and it halves the cost of each genuine hang.
-        timeout-minutes: 40
-        # tests/regression/ is a MIXED dir — the same shape as the DataFlow
-        # regression dir handled below. The explicit `-m` filter mirrors that
-        # step's, and is REQUIRED for the same reason: the root pytest.ini
-        # `addopts` carries NO marker filter at all (only --strict-markers and
-        # --tb=short), so nothing else deselects the infra-requiring tests.
-        #
-        # The filter deselects 22 tests across 7 files, all Postgres/DB-pool
-        # bound (test_issue_697_pool_leak.py, test_dataflow_pool_bridge.py,
-        # test_issue_953_async_sql_pool_tracking.py, test_issue_713_*.py ×2,
-        # test_issue_1248_localruntime_cross_loop_pool_disposal.py,
-        # test_w3_security_fixes.py). Those run in `test-dataflow-infra` below,
-        # which already provides Postgres + Redis service containers.
-        #
-        # Overlap with trust-tests.yml: that workflow names
-        # test_issue_1332_rfc3161_verify_fail_closed.py and
-        # test_issue_1332_rfc3161_live_binding.py explicitly (13 tests, ~0.3s
-        # collected). The overlap is deliberate and costs a fraction of a
-        # second: trust-tests.yml is path-filtered to trust/** and does NOT run
-        # on most PRs, and it emits a separate JUnit artifact for the trust
-        # surface. Deduplicating would reintroduce the gap on every non-trust PR.
-        # test_issue_1332_rfc3161_live_binding.py self-skips here (`rfc3161`
-        # extra deliberately NOT installed — the live-binding path is
-        # trust-tests.yml's to provision).
-        #
-        # Verified green before landing: 1913 passed, 3 skipped, 22 deselected,
-        # 0 failed in 207s, in a from-scratch uv venv built with exactly the
-        # install block above (Python 3.12). The same selection run in a
-        # fully-loaded dev venv reported 1917 passed / 2 skipped — which is why
-        # the clean-venv run is the one quoted: it is the only one that can
-        # surface a missing-extra failure.
-        run: |
-          .venv/bin/python -m pytest tests/regression/ \
-            -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
-            --maxfail=30 -v -p no:xdist --durations=25 \
-            --timeout=60 --timeout-method=signal
+  # One finding from that work is worth acting on independently of #2002: the
+  # root pytest.ini sets `timeout_method = thread`, and a thread-method timeout
+  # CANNOT kill a test blocked in a C call. Two of the three runs above were
+  # unreadable for exactly that reason — pytest-timeout printed its banner and
+  # the process carried on. `signal` is the enforceable method on Linux/macOS.
 
   test-pact:
     name: Test PACT (Python 3.11)

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -121,9 +121,22 @@ jobs:
           # OLD: cli/database/postgres/mysql/files/distributed/http/mfa/otel
           # NEW: db-postgres/db-mysql/db-sqlite/http-client/auth-azure/telemetry/redis/trust
           # `cli` and `files` were folded into core/server respectively.
-          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data]" --python .venv/bin/python
+          # Issue #2038: `vault` (hvac) and `aws-secrets` (boto3) added, plus
+          # matplotlib + scikit-learn below. These are NOT decoration — with the
+          # Tier-2 step no longer swallowing failures, 8 Tier-2 tests that used
+          # to die on ModuleNotFoundError now RUN and pass:
+          #   hvac         -> test_todo027_credential_manager.py TestVaultBackend (3)
+          #   boto3        -> test_todo027_credential_manager.py TestAWSSecretsBackend (2)
+          #   matplotlib   -> visualization/test_visualization_consolidated.py (2)
+          #   scikit-learn -> test_behavior_analysis_comprehensive.py::test_isolation_forest_model (1)
+          # Provisioning the dependency is the right fix here; skipping or
+          # quarantining these would have recorded a dependency gap as a test
+          # defect.
+          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data,vault,aws-secrets]" --python .venv/bin/python
           uv pip install -e packages/kailash-mcp --python .venv/bin/python
-          uv pip install numpy --python .venv/bin/python
+          # matplotlib / scikit-learn have no declared extra — they are test-only
+          # dependencies of the two Tier-2 files named above.
+          uv pip install numpy matplotlib scikit-learn --python .venv/bin/python
 
       - name: Lint (ruff)
         run: .venv/bin/ruff check src/ tests/ --select=E9,F63,F7,F82
@@ -146,12 +159,170 @@ jobs:
 
       - name: Test (Tier 2 — integration runtime tests)
         timeout-minutes: 10
-        continue-on-error: true # Tier 2 has thread/I/O tests that may fail on CI runners
+        # Issue #2038: `continue-on-error: true` REMOVED. Tier 2 now gates the
+        # merge exactly as Tier 1 does, and `gh pr checks` is once again a
+        # discriminating instrument for integration behaviour.
+        #
+        # The removed flag's comment read "Tier 2 has thread/I/O tests that may
+        # fail on CI runners". Measured against three consecutive full Tier-2
+        # runs, that was true of exactly ONE test out of 46 failures:
+        #   * 45 failed 3/3 — consistent, not flaky, and structurally invisible
+        #     for as long as this flag was set. All 45 are now FIXED:
+        #       15  test_workflow_scheduler.py — sys.modules stubbed the parent
+        #           `apscheduler` package, so the `apscheduler.events` import
+        #           added for issue #914 could not resolve
+        #        8  runtime/test_distributed_runtime.py — MagicMock(spec=TaskQueue)
+        #           does not expose the instance attr `_default_visibility_timeout`
+        #        6  mcp_server/test_oauth.py — ResourceServer now requires an
+        #           absolute RFC 9728 `resource` URL; the fixture passed a bare
+        #           audience token
+        #        7  mock_node_factory (tests/conftest.py) built Node subclasses
+        #           with no concrete `run`, so every one was abstract
+        #        1  runtime/test_docker.py — expected module path went stale
+        #           when the file moved out of tests/unit/
+        #        8  missing optional deps — fixed by the install step above
+        #   * 1 flaked (1/3): runtime/test_phase0d_optimizations.py::
+        #     test_repeated_execution_performance, an absolute wall-clock bound.
+        #     Quarantined INDIVIDUALLY at the test with a documented skip and a
+        #     reason explaining why xfail(strict=True) cannot work for a test
+        #     that passes most runs.
+        #
+        # If this step goes red, a Tier-2 test genuinely regressed. Do NOT
+        # restore continue-on-error; quarantine the individual test instead.
         run: |
           .venv/bin/python -m pytest \
             tests/tier2_integration/ \
             -m 'not (requires_docker or requires_postgres or requires_mysql or requires_redis or requires_ollama)' \
             --maxfail=20 -q -p no:xdist --timeout=60
+
+  # Issue #2002: root `tests/regression/` had no blanket CI coverage. Before this
+  # job, exactly TWO of its ~156 files were named by any workflow
+  # (trust-tests.yml runs test_issue_1332_rfc3161_*.py, and only on PRs whose
+  # diff matches that workflow's trust/** paths filter). The Tier-1 step in the
+  # `test` job above runs tests/unit/, tests/trust/plane/unit/ and tests/security/
+  # — not tests/regression/. The regression step in `test-dataflow` below covers
+  # the DataFlow PACKAGE's regression dir, a different directory.
+  #
+  # Regression tests are the never-delete tier: each one pins a bug that already
+  # shipped once. A regression test that never executes records the intent to
+  # prevent a recurrence while providing none of the prevention.
+  #
+  # Why this is a SEPARATE job rather than a step in the `test` matrix:
+  # root tests/regression/ imports three sibling packages at MODULE level
+  # (unguarded), which the `test` job does not install:
+  #   dataflow       — 17 files (e.g. test_dataflow_pool_bridge.py, test_issue_184.py)
+  #   nexus          —  7 files (e.g. test_issue_500_router_on_startup.py: `from nexus import Nexus`)
+  #   kaizen         —  4 files (e.g. test_provider_registry_backcompat.py:
+  #                              `from kaizen.providers.registry import ...`)
+  #   kailash_mcp    —  3 files (already installed by the `test` job)
+  #   kaizen_agents  —  1 file  (test_issue_443_kaizen_mcp_dependency.py)
+  # Adding five editable sibling installs to a 4-version matrix would pay that
+  # cost 4×; this job pays it once on a single interpreter.
+  #
+  # Per issue #2023 § sibling-install discipline — siblings exercised by this
+  # step and how each resolves: kailash (editable, this tree), kailash-dataflow
+  # (editable), kailash-kaizen (editable), kailash-nexus (editable),
+  # kailash-mcp (editable), kaizen-agents (editable). NONE resolve from PyPI.
+  test-root-regression:
+    name: Test Root Regression Suite (Python 3.12)
+    needs: check-duplicate
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
+    if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Restore uv cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-py3.12-rootregr-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-py3.12-rootregr-
+
+      - name: Install dependencies
+        # Extras are the `test` job's set PLUS `shamir`. The shamir extra is
+        # REQUIRED, not optional garnish: without shamir-mnemonic, five tests
+        # (test_eatp12_vault_3way_discrimination.py ×3,
+        # test_eatp12_vault_quickstart.py ×2) fail with
+        # `RuntimeError: SLIP-0039 Shamir secret-sharing requires the 'shamir'
+        # optional extra` raised from src/kailash/trust/vault/shamir.py. Those
+        # are real assertions on a real code path, not env noise — the fix is to
+        # provision the dependency, not to skip the tests.
+        #
+        # Root kailash editable BEFORE the sub-packages, per
+        # rules/deployment.md § "Sibling-Package CI Installs Root SDK Editable".
+        #
+        # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+        # Selection: tests/regression/ minus the infra markers (1916 collected).
+        # Determined by grepping module-level sibling imports across the
+        # directory, then confirmed by building this exact venv from scratch and
+        # running the suite in it:
+        #   dataflow      -> EXERCISED (17 files) -> editable below
+        #   nexus         -> EXERCISED  (7 files) -> editable below
+        #   kaizen        -> EXERCISED  (4 files) -> editable below
+        #   kailash_mcp   -> EXERCISED  (3 files) -> editable below
+        #   kaizen_agents -> EXERCISED  (1 file)  -> editable below
+        #   kailash_ml / kailash_align / kailash_pact -> 0 files, NOT installed
+        # Several of these imports are UNGUARDED at module scope
+        # (`from nexus import Nexus`, `from kaizen.providers.registry import ...`),
+        # so a missing sibling is a COLLECTION error, not a skip.
+        run: |
+          uv venv .venv
+          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data,shamir]" --python .venv/bin/python
+          uv pip install -e packages/kailash-mcp --python .venv/bin/python
+          uv pip install -e packages/kailash-dataflow --python .venv/bin/python
+          uv pip install -e packages/kailash-kaizen --python .venv/bin/python
+          uv pip install -e packages/kailash-nexus --python .venv/bin/python
+          # test_issue_443_kaizen_mcp_dependency.py does `from kaizen_agents
+          # import Delegate` — without this the test fails ModuleNotFoundError.
+          uv pip install -e packages/kaizen-agents --python .venv/bin/python
+
+      - name: Test root regression suite (infra-free)
+        timeout-minutes: 15
+        # tests/regression/ is a MIXED dir — the same shape as the DataFlow
+        # regression dir handled below. The explicit `-m` filter mirrors that
+        # step's, and is REQUIRED for the same reason: the root pytest.ini
+        # `addopts` carries NO marker filter at all (only --strict-markers and
+        # --tb=short), so nothing else deselects the infra-requiring tests.
+        #
+        # The filter deselects 22 tests across 7 files, all Postgres/DB-pool
+        # bound (test_issue_697_pool_leak.py, test_dataflow_pool_bridge.py,
+        # test_issue_953_async_sql_pool_tracking.py, test_issue_713_*.py ×2,
+        # test_issue_1248_localruntime_cross_loop_pool_disposal.py,
+        # test_w3_security_fixes.py). Those run in `test-dataflow-infra` below,
+        # which already provides Postgres + Redis service containers.
+        #
+        # Overlap with trust-tests.yml: that workflow names
+        # test_issue_1332_rfc3161_verify_fail_closed.py and
+        # test_issue_1332_rfc3161_live_binding.py explicitly (13 tests, ~0.3s
+        # collected). The overlap is deliberate and costs a fraction of a
+        # second: trust-tests.yml is path-filtered to trust/** and does NOT run
+        # on most PRs, and it emits a separate JUnit artifact for the trust
+        # surface. Deduplicating would reintroduce the gap on every non-trust PR.
+        # test_issue_1332_rfc3161_live_binding.py self-skips here (`rfc3161`
+        # extra deliberately NOT installed — the live-binding path is
+        # trust-tests.yml's to provision).
+        #
+        # Verified green before landing: 1913 passed, 3 skipped, 22 deselected,
+        # 0 failed in 207s, in a from-scratch uv venv built with exactly the
+        # install block above (Python 3.12). The same selection run in a
+        # fully-loaded dev venv reported 1917 passed / 2 skipped — which is why
+        # the clean-venv run is the one quoted: it is the only one that can
+        # surface a missing-extra failure.
+        run: |
+          .venv/bin/python -m pytest tests/regression/ \
+            -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
+            --maxfail=10 -q -p no:xdist --timeout=300
 
   test-pact:
     name: Test PACT (Python 3.11)
@@ -358,3 +529,69 @@ jobs:
           ../../.venv/bin/python -m pytest tests/regression/ \
             -m "requires_postgres or requires_redis" \
             --maxfail=10 -q --timeout=120
+
+      - name: Run ROOT regression infra-marked tests (issue #2002 AC#2)
+        timeout-minutes: 10
+        # Issue #2002 AC#2: "Infra-requiring root regression tests run in the
+        # infrastructure workflow." They land HERE rather than in a new job
+        # because this job already has Postgres + Redis service containers up —
+        # a dedicated job would pay for a second pair for 22 tests.
+        # (test-with-infrastructure.yml was the other candidate and is NOT
+        # suitable: it invokes no pytest at all, it is a config validator.)
+        #
+        # The selector is the exact COMPLEMENT of the infra-free step in
+        # `test-root-regression`, so between the two, every test in root
+        # tests/regression/ runs on every PR and none runs twice. Keep the two
+        # marker expressions in sync — if one gains a marker, so must the other.
+        #
+        # The 22 tests live in 7 files, all Postgres/DB-pool bound:
+        # test_issue_697_pool_leak.py, test_dataflow_pool_bridge.py,
+        # test_issue_953_async_sql_pool_tracking.py,
+        # test_issue_713_subsystems_follow_runtime_swap.py,
+        # test_issue_713_module_import_then_async_ddl.py,
+        # test_issue_1248_localruntime_cross_loop_pool_disposal.py,
+        # test_w3_security_fixes.py.
+        #
+        # `cd` back to the repo root: the step above leaves the shell in
+        # packages/kailash-dataflow, but each `run:` block starts fresh at the
+        # workspace root, so no cd is needed — root tests/regression/ resolves
+        # from here. The root pytest.ini (pythonpath = src) applies.
+        #
+        # The env block below is LOAD-BEARING, not decoration. These files read
+        # FOUR DIFFERENT env var names for the same DSN, and each falls back to
+        # `localhost:5434` — the port the repo's local `./test-env up` compose
+        # stack uses, NOT the 5432 this job's service container publishes:
+        #   TEST_DATABASE_URL           test_issue_713_module_import_then_async_ddl.py
+        #   DATAFLOW_TEST_POSTGRES_URL  test_issue_713_subsystems_follow_runtime_swap.py
+        #   TEST_POSTGRES_DSN           test_issue_1248_localruntime_cross_loop_pool_disposal.py
+        #   TEST_PG_URL                 test_w3_security_fixes.py
+        # Six of the seven files self-skip when the DSN is unreachable, so
+        # WITHOUT these vars this step would report a green built almost
+        # entirely out of skips — a check that cannot come out the other way.
+        # `-rs` keeps every skip visible in the log for the same reason.
+        #
+        # Measured locally against a real Postgres 16 on the tests' own default
+        # DSN: 1 failed, 11 passed, 11 skipped of 23 collected. The 11 skips are
+        # the `docker_config`-gated tests in test_issue_697_pool_leak.py and
+        # test_issue_953_async_sql_pool_tracking.py, which require the repo's
+        # `./test-env up` compose stack rather than a bare service container;
+        # they will skip here too. Closing that gap needs the compose stack in
+        # CI and is out of scope for #2002 — recorded so the next reader does
+        # not mistake this step for full coverage of the infra-marked set.
+        # The 1 failure was a genuine pool leak, now #2075, marked
+        # xfail(strict=True) at the test so this step starts green and
+        # self-clears loudly when the leak is fixed.
+        env:
+          DATAFLOW_TEST_POSTGRES_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
+          TEST_POSTGRES_DSN: postgresql://test_user:test_password@localhost:5432/kailash_test
+          TEST_PG_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_USER: test_user
+          DB_PASSWORD: test_password
+          DB_NAME: kailash_test
+          REDIS_URL: redis://localhost:6379/0
+        run: |
+          .venv/bin/python -m pytest tests/regression/ \
+            -m "requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e" \
+            --maxfail=10 -q -p no:xdist --timeout=300 -rs

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -159,14 +159,41 @@ jobs:
             --maxfail=10 -q -p no:xdist --timeout=30
 
       - name: Test (Tier 2 — integration runtime tests)
+        id: tier2
         # Raised from 10 minutes. On PRE-CHANGE code this step TIMED OUT at 10
         # minutes on Python 3.11 and 3.12 in every run inspected (e.g. runs
         # 31480330313, 31478307416, 31476919718) — and every one of those jobs
         # still reported SUCCESS, because `continue-on-error: true` swallowed
-        # the timeout as well as the failures. The Tier-2 suite has therefore
+        # the timeout as well as the failures. The Tier-2 suite had therefore
         # never been observed to COMPLETE on this repo's CI on two of the four
-        # interpreters, which means nobody knows its true failure count there.
+        # interpreters. With `--maxfail` lifted it completes in under 3 minutes.
         timeout-minutes: 25
+        # HOLDING STATE — see #2078, and read the block below before touching.
+        #
+        # This is NOT the original `continue-on-error: true`, whose comment
+        # claimed "thread/I/O tests that may fail on CI runners" and which
+        # silently swallowed everything including a 10-minute timeout. The
+        # difference is the annotation step immediately below: a Tier-2 failure
+        # now produces a `::error::` annotation and a job-summary line naming
+        # the count, so the state is VISIBLE in the PR check surface. That is
+        # #2038 AC#1's "annotation, or a posted summary" branch, satisfied
+        # explicitly rather than by accident.
+        #
+        # Why it is not blocking yet: with the truncation lifted, the tier
+        # reports 174 failed / 58 errors on the runner, from ONE cause — 130
+        # `RuntimeError: can't start new thread` plus 90 `sqlite3.
+        # OperationalError: disk I/O error`, the paired signature of thread and
+        # file-descriptor exhaustion. It is pre-existing (the same errors appear
+        # in run 31478307416 against unmodified code) and it does not reproduce
+        # on macOS, where the suite is 2604 passed / 0 failed. Making the step
+        # blocking today would red every PR in the repo on a leak none of them
+        # introduced; quarantining 232 tests would gut the tier and would be
+        # quarantining symptoms of a single cause.
+        #
+        # TO COMPLETE #2038: fix the leak (#2078), confirm a complete green run
+        # on all four interpreters, then delete this flag AND the annotation
+        # step below. Do not delete the flag without doing that first.
+        continue-on-error: true
         # Issue #2038: `continue-on-error: true` REMOVED. Tier 2 now gates the
         # merge exactly as Tier 1 does, and `gh pr checks` is once again a
         # discriminating instrument for integration behaviour.
@@ -203,6 +230,23 @@ jobs:
             -m 'not (requires_docker or requires_postgres or requires_mysql or requires_redis or requires_ollama)' \
             --maxfail=400 -q -p no:xdist --timeout=60 -rf
 
+      # Makes the holding state above LOUD. Without this the check surface
+      # reports the same green whether Tier 2 passed or failed entirely, which
+      # is precisely the non-discriminating instrument #2038 was filed about.
+      - name: Tier 2 — surface the result (issue #2078)
+        if: always() && steps.tier2.outcome == 'failure'
+        run: |
+          echo "::error title=Tier 2 FAILED (non-blocking, see #2078)::Tier-2 integration tests failed on Python ${{ matrix.python-version }}. This step is non-blocking ONLY until the thread/fd exhaustion in #2078 is fixed. Read the step log before assuming your change is unaffected."
+          {
+            echo "### Tier 2 FAILED - non-blocking (issue #2078)"
+            echo ""
+            echo "Python ${{ matrix.python-version }}. This step does not gate the merge yet,"
+            echo "because the tier reports ~232 failures on the runner from a single"
+            echo "pre-existing thread/file-descriptor exhaustion cause (#2078)."
+            echo ""
+            echo "**A green PR check does NOT mean Tier 2 passed.** Open the step log."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Issue #2002: root `tests/regression/` had no blanket CI coverage. Before this
   # job, exactly TWO of its ~156 files were named by any workflow
   # (trust-tests.yml runs test_issue_1332_rfc3161_*.py, and only on PRs whose
@@ -237,7 +281,8 @@ jobs:
     # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
     if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Must exceed the 40-minute test step plus install time.
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v7
 
@@ -296,7 +341,14 @@ jobs:
           uv pip install -e packages/kaizen-agents --python .venv/bin/python
 
       - name: Test root regression suite (infra-free)
-        timeout-minutes: 15
+        # 15 -> 40. The first CI run of this step TIMED OUT at 15 minutes while
+        # the identical selection completes in 210s locally. `-q` printed no
+        # per-test progress, so the log could not distinguish "hung on one test"
+        # from "uniformly ~4x slower on a 2-core runner" — 210s x 4 is already
+        # 14 minutes, i.e. the old budget was marginal on arithmetic alone.
+        # Raised well clear, and `-v --durations=25` added below so the next
+        # run answers the question instead of leaving it open.
+        timeout-minutes: 40
         # tests/regression/ is a MIXED dir — the same shape as the DataFlow
         # regression dir handled below. The explicit `-m` filter mirrors that
         # step's, and is REQUIRED for the same reason: the root pytest.ini
@@ -330,7 +382,7 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
-            --maxfail=10 -q -p no:xdist --timeout=300
+            --maxfail=10 -v -p no:xdist --timeout=300 --durations=25
 
   test-pact:
     name: Test PACT (Python 3.11)
@@ -470,7 +522,9 @@ jobs:
     needs: check-duplicate
     if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 15 -> 45: now carries the 10-min DataFlow step plus the 30-min root
+    # regression infra step added for #2002 AC#2, plus install.
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16
@@ -559,7 +613,10 @@ jobs:
             --maxfail=10 -q --timeout=120
 
       - name: Run ROOT regression infra-marked tests (issue #2002 AC#2)
-        timeout-minutes: 10
+        # 10 -> 30, same reasoning as the infra-free step: 244s locally against
+        # a real Postgres, and the first CI run timed out at 10 minutes with no
+        # per-test output to say where. `-v` added below.
+        timeout-minutes: 30
         # Issue #2002 AC#2: "Infra-requiring root regression tests run in the
         # infrastructure workflow." They land HERE rather than in a new job
         # because this job already has Postgres + Redis service containers up —
@@ -622,4 +679,4 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e" \
-            --maxfail=10 -q -p no:xdist --timeout=300 -rs
+            --maxfail=10 -v -p no:xdist --timeout=300 -rs --durations=25

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -89,7 +89,8 @@ jobs:
     # exercised this matrix. Saves ~45 min × matrix-size per release cycle.
     if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 25 -> 40: the Tier-2 step's own budget rose to 25 minutes (see there).
+    timeout-minutes: 40
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -158,7 +159,14 @@ jobs:
             --maxfail=10 -q -p no:xdist --timeout=30
 
       - name: Test (Tier 2 — integration runtime tests)
-        timeout-minutes: 10
+        # Raised from 10 minutes. On PRE-CHANGE code this step TIMED OUT at 10
+        # minutes on Python 3.11 and 3.12 in every run inspected (e.g. runs
+        # 31480330313, 31478307416, 31476919718) — and every one of those jobs
+        # still reported SUCCESS, because `continue-on-error: true` swallowed
+        # the timeout as well as the failures. The Tier-2 suite has therefore
+        # never been observed to COMPLETE on this repo's CI on two of the four
+        # interpreters, which means nobody knows its true failure count there.
+        timeout-minutes: 25
         # Issue #2038: `continue-on-error: true` REMOVED. Tier 2 now gates the
         # merge exactly as Tier 1 does, and `gh pr checks` is once again a
         # discriminating instrument for integration behaviour.
@@ -193,7 +201,7 @@ jobs:
           .venv/bin/python -m pytest \
             tests/tier2_integration/ \
             -m 'not (requires_docker or requires_postgres or requires_mysql or requires_redis or requires_ollama)' \
-            --maxfail=20 -q -p no:xdist --timeout=60
+            --maxfail=400 -q -p no:xdist --timeout=60 -rf
 
   # Issue #2002: root `tests/regression/` had no blanket CI coverage. Before this
   # job, exactly TWO of its ~156 files were named by any workflow
@@ -517,10 +525,30 @@ jobs:
         # dataflow [postgres-sync] extra provides psycopg2-binary, REQUIRED by the
         # auto_migrate synchronous DDL path the tenant-isolation tests exercise
         # (DataFlow is async-first but creates tables via the sync DDL executor).
+        #
+        # The extras list is WIDER than this job's DataFlow step needs, because
+        # the root-regression infra step added below shares this venv and root
+        # `tests/regression/` is collected as a whole directory — pytest imports
+        # every module in it before `-m` selects anything. On the first CI run
+        # of that step, the narrow ".[db-postgres,redis]" install produced eight
+        # COLLECTION errors, none of which was a test defect:
+        #   PyNaCl    -> test_issue_1316_*.py (trust extra)
+        #   pact      -> test_issue_1510_bh5_circuit_breaker.py
+        #   qrcode    -> test_issue_1815_oidc_nonce_pkce.py, test_issue_1835_*.py (auth extra)
+        #   filelock  -> test_issue_1912_*.py, test_issue_2027_*.py
+        # Widening costs this job some install time and removes nothing.
         run: |
           uv venv .venv
-          uv pip install -e ".[db-postgres,redis]" --python .venv/bin/python
+          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data,shamir]" --python .venv/bin/python
           uv pip install -e "packages/kailash-dataflow[dev,postgres-sync]" --python .venv/bin/python
+          # Same sibling set as `test-root-regression` — root tests/regression/
+          # imports these at module level and unguarded, so a missing one is a
+          # collection error rather than a skip.
+          uv pip install -e packages/kailash-mcp --python .venv/bin/python
+          uv pip install -e packages/kailash-kaizen --python .venv/bin/python
+          uv pip install -e packages/kailash-nexus --python .venv/bin/python
+          uv pip install -e packages/kailash-pact --python .venv/bin/python
+          uv pip install -e packages/kaizen-agents --python .venv/bin/python
 
       - name: Run Postgres/Redis-marked regression tests
         timeout-minutes: 10

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -348,6 +348,23 @@ jobs:
         # 14 minutes, i.e. the old budget was marginal on arithmetic alone.
         # Raised well clear, and `-v --durations=25` added below so the next
         # run answers the question instead of leaving it open.
+        #
+        # It answered it: the suite HANGS on this runner. Two observed points
+        # are test_channel_parameters_envelope_behaviour.py::
+        # test_nexus_websocket_transport_invoke_handler_binds_envelope and
+        # test_create_index_identifier_safety.py, at ~8% of the run.
+        #
+        # `--timeout-method=signal` is the load-bearing change, not the larger
+        # budget. The root pytest.ini sets `timeout_method = thread`, and a
+        # thread-method timeout CANNOT kill a test blocked in a C call: pytest
+        # -timeout printed its banner repeatedly and the process carried on
+        # regardless, so the step consumed its whole budget having run 8% of the
+        # suite. That is a timeout that cannot enforce a timeout. SIGALRM can
+        # (Linux/macOS only, which is what this job runs), so a hung test now
+        # FAILS at 120s and names itself instead of taking the job down with it.
+        # If tests still hang after this, the log will list them individually
+        # and they can be quarantined; the previous instrument could not even
+        # produce that list.
         timeout-minutes: 40
         # tests/regression/ is a MIXED dir — the same shape as the DataFlow
         # regression dir handled below. The explicit `-m` filter mirrors that
@@ -382,7 +399,8 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
-            --maxfail=10 -v -p no:xdist --timeout=300 --durations=25
+            --maxfail=10 -v -p no:xdist --durations=25 \
+            --timeout=120 --timeout-method=signal
 
   test-pact:
     name: Test PACT (Python 3.11)
@@ -612,71 +630,21 @@ jobs:
             -m "requires_postgres or requires_redis" \
             --maxfail=10 -q --timeout=120
 
-      - name: Run ROOT regression infra-marked tests (issue #2002 AC#2)
-        # 10 -> 30, same reasoning as the infra-free step: 244s locally against
-        # a real Postgres, and the first CI run timed out at 10 minutes with no
-        # per-test output to say where. `-v` added below.
-        timeout-minutes: 30
-        # Issue #2002 AC#2: "Infra-requiring root regression tests run in the
-        # infrastructure workflow." They land HERE rather than in a new job
-        # because this job already has Postgres + Redis service containers up —
-        # a dedicated job would pay for a second pair for 22 tests.
-        # (test-with-infrastructure.yml was the other candidate and is NOT
-        # suitable: it invokes no pytest at all, it is a config validator.)
-        #
-        # The selector is the exact COMPLEMENT of the infra-free step in
-        # `test-root-regression`, so between the two, every test in root
-        # tests/regression/ runs on every PR and none runs twice. Keep the two
-        # marker expressions in sync — if one gains a marker, so must the other.
-        #
-        # The 22 tests live in 7 files, all Postgres/DB-pool bound:
-        # test_issue_697_pool_leak.py, test_dataflow_pool_bridge.py,
-        # test_issue_953_async_sql_pool_tracking.py,
-        # test_issue_713_subsystems_follow_runtime_swap.py,
-        # test_issue_713_module_import_then_async_ddl.py,
-        # test_issue_1248_localruntime_cross_loop_pool_disposal.py,
-        # test_w3_security_fixes.py.
-        #
-        # `cd` back to the repo root: the step above leaves the shell in
-        # packages/kailash-dataflow, but each `run:` block starts fresh at the
-        # workspace root, so no cd is needed — root tests/regression/ resolves
-        # from here. The root pytest.ini (pythonpath = src) applies.
-        #
-        # The env block below is LOAD-BEARING, not decoration. These files read
-        # FOUR DIFFERENT env var names for the same DSN, and each falls back to
-        # `localhost:5434` — the port the repo's local `./test-env up` compose
-        # stack uses, NOT the 5432 this job's service container publishes:
-        #   TEST_DATABASE_URL           test_issue_713_module_import_then_async_ddl.py
-        #   DATAFLOW_TEST_POSTGRES_URL  test_issue_713_subsystems_follow_runtime_swap.py
-        #   TEST_POSTGRES_DSN           test_issue_1248_localruntime_cross_loop_pool_disposal.py
-        #   TEST_PG_URL                 test_w3_security_fixes.py
-        # Six of the seven files self-skip when the DSN is unreachable, so
-        # WITHOUT these vars this step would report a green built almost
-        # entirely out of skips — a check that cannot come out the other way.
-        # `-rs` keeps every skip visible in the log for the same reason.
-        #
-        # Measured locally against a real Postgres 16 on the tests' own default
-        # DSN: 1 failed, 11 passed, 11 skipped of 23 collected. The 11 skips are
-        # the `docker_config`-gated tests in test_issue_697_pool_leak.py and
-        # test_issue_953_async_sql_pool_tracking.py, which require the repo's
-        # `./test-env up` compose stack rather than a bare service container;
-        # they will skip here too. Closing that gap needs the compose stack in
-        # CI and is out of scope for #2002 — recorded so the next reader does
-        # not mistake this step for full coverage of the infra-marked set.
-        # The 1 failure was a genuine pool leak, now #2075, marked
-        # xfail(strict=True) at the test so this step starts green and
-        # self-clears loudly when the leak is fixed.
-        env:
-          DATAFLOW_TEST_POSTGRES_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
-          TEST_POSTGRES_DSN: postgresql://test_user:test_password@localhost:5432/kailash_test
-          TEST_PG_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
-          DB_HOST: localhost
-          DB_PORT: "5432"
-          DB_USER: test_user
-          DB_PASSWORD: test_password
-          DB_NAME: kailash_test
-          REDIS_URL: redis://localhost:6379/0
-        run: |
-          .venv/bin/python -m pytest tests/regression/ \
-            -m "requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e" \
-            --maxfail=10 -v -p no:xdist --timeout=300 -rs --durations=25
+      # ISSUE #2002 AC#2 — the infra-marked root regression step lived HERE and
+      # is REMOVED pending #2079. It hangs on this runner: given a 30-minute
+      # budget it executed 3 of 22 tests and consumed the rest, with
+      # pytest-timeout's stack dump naming a `dataflow_async__0` thread at
+      # cross-event-loop pool disposal. The identical selection completes in
+      # 244s against a real Postgres on macOS, so it is Linux/container
+      # specific. A step that holds a runner for 30 minutes on every PR is a
+      # real cost even when non-blocking, and a hang yields no signal in
+      # exchange — so it is removed rather than made continue-on-error.
+      #
+      # The removed block, including the `env:` wiring for the FOUR different
+      # DSN env var names those files read (TEST_DATABASE_URL,
+      # DATAFLOW_TEST_POSTGRES_URL, TEST_POSTGRES_DSN, TEST_PG_URL — each
+      # falling back to :5434, not this job's :5432), is preserved in PR #2077's
+      # history and quoted in #2079. Restore it there once the hang is fixed.
+      #
+      # The infra-FREE gate in `test-root-regression` — the substance of #2002 —
+      # is unaffected: its marker filter excludes exactly this set.

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -365,6 +365,15 @@ jobs:
         # If tests still hang after this, the log will list them individually
         # and they can be quarantined; the previous instrument could not even
         # produce that list.
+        #
+        # It did: the first SIGALRM run named 5 hangs in
+        # test_channel_parameters_envelope_behaviour.py and 5 in
+        # test_create_index_identifier_safety.py, then stopped at
+        # `--maxfail=10`. maxfail raised to 30 and the per-test timeout dropped
+        # 120s -> 60s to enumerate the rest within the step budget: 60s is still
+        # 3x the slowest healthy test in this suite (19.94s,
+        # test_issue_2015_http_exception_leak.py), so it cannot false-positive
+        # on a merely-slow test, and it halves the cost of each genuine hang.
         timeout-minutes: 40
         # tests/regression/ is a MIXED dir — the same shape as the DataFlow
         # regression dir handled below. The explicit `-m` filter mirrors that
@@ -399,8 +408,8 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
-            --maxfail=10 -v -p no:xdist --durations=25 \
-            --timeout=120 --timeout-method=signal
+            --maxfail=30 -v -p no:xdist --durations=25 \
+            --timeout=60 --timeout-method=signal
 
   test-pact:
     name: Test PACT (Python 3.11)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ means a failure turns the check red.
 | Suite                                                        | Runs on                    | Gates a merge?                     |
 | ------------------------------------------------------------ | -------------------------- | ---------------------------------- |
 | Tier 1 — `tests/unit/`, `tests/trust/plane/unit/`, `tests/security/` | every PR, Python 3.11–3.14 | **Yes**                            |
-| Tier 2 — `tests/tier2_integration/`                          | every PR, Python 3.11–3.14 | **Yes** (since #2038)              |
+| Tier 2 — `tests/tier2_integration/`                          | every PR, Python 3.11–3.14 | **Not yet** — non-blocking, but a failure now posts a loud annotation + job summary. Blocked on #2078; see below. |
 | Root regression — `tests/regression/`, infra-free            | every PR, Python 3.12      | **Yes** (since #2002)              |
 | Root regression — infra-marked                               | every PR (Postgres+Redis)  | **Yes** (since #2002)              |
 | DataFlow unit + regression                                   | every PR                   | **Yes**                            |
@@ -96,11 +96,28 @@ Two consequences worth internalising:
   infrastructure, pass `-rs` so the skips are visible, and check that the step
   can actually come out the other way.
 
-Until #2038 the Tier-2 step carried `continue-on-error: true`, so a Tier-2
-failure reported green. It no longer does. If your PR reds on Tier 2, a real
-integration test regressed — do not restore `continue-on-error`; quarantine the
-individual test with `xfail(strict=True)` and a tracking issue, so it clears
-itself loudly when fixed.
+#### Tier 2 is visible but not yet blocking
+
+Until #2038 the Tier-2 step carried a bare `continue-on-error: true`, so a
+Tier-2 failure — and, on Python 3.11/3.12, a 10-minute step **timeout** —
+reported green with no signal at all.
+
+It is still non-blocking, but it is no longer silent: a failure now emits a
+`::error::` annotation and a job-summary block naming the count. **A green PR
+check does not mean Tier 2 passed** — open the step log.
+
+The reason it does not gate yet is #2078. Once `--maxfail=20` was lifted so the
+suite could complete on CI for the first time, it reported 174 failed / 58
+errors, dominated by 130 `RuntimeError: can't start new thread` and 90
+`sqlite3.OperationalError: disk I/O error` — the paired signature of thread and
+file-descriptor exhaustion, from one pre-existing leak rather than 232 separate
+defects. The same suite is `2604 passed / 0 failed` on macOS, so a local green
+is not evidence about the runner.
+
+When #2078 is fixed: delete `continue-on-error` **and** the annotation step from
+`unified-ci.yml`, and update this table. If a Tier-2 test fails after that, do
+not restore the flag — quarantine that individual test with `xfail(strict=True)`
+and a tracking issue, so it clears itself loudly when fixed.
 
 ## Commit Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,7 @@ Lint rules are configured in `pyproject.toml` under `[tool.ruff]`.
 
 ## Testing
 
-Kailash uses a 3-tier testing strategy. **All 5708+ tests must pass before a PR
-can be merged.**
+Kailash uses a 3-tier testing strategy.
 
 | Tier            | Scope                                 | Command                     |
 | --------------- | ------------------------------------- | --------------------------- |
@@ -68,6 +67,40 @@ pytest tests/unit/ tests/parity/ tests/shared/ \
 
 **No mocking in Tier 2 or Tier 3 tests.** Use real infrastructure.
 See [CLAUDE.md](CLAUDE.md) and `.claude/rules/testing.md` for the full testing policy.
+
+### What "CI is green" actually means
+
+Read this before treating a green `gh pr checks` as evidence about your change.
+Each row below is a suite in `.github/workflows/unified-ci.yml`; "gates a merge"
+means a failure turns the check red.
+
+| Suite                                                        | Runs on                    | Gates a merge?                     |
+| ------------------------------------------------------------ | -------------------------- | ---------------------------------- |
+| Tier 1 — `tests/unit/`, `tests/trust/plane/unit/`, `tests/security/` | every PR, Python 3.11–3.14 | **Yes**                            |
+| Tier 2 — `tests/tier2_integration/`                          | every PR, Python 3.11–3.14 | **Yes** (since #2038)              |
+| Root regression — `tests/regression/`, infra-free            | every PR, Python 3.12      | **Yes** (since #2002)              |
+| Root regression — infra-marked                               | every PR (Postgres+Redis)  | **Yes** (since #2002)              |
+| DataFlow unit + regression                                   | every PR                   | **Yes**                            |
+| PACT                                                         | every PR                   | **Yes**                            |
+| Type check (pyright)                                         | every PR                   | No — `continue-on-error`, see #73  |
+| CUDA jobs (`test-kailash-ml.yml`)                            | manual dispatch only       | No — `continue-on-error` until the GPU runner is live |
+| kailash-ml / kailash-align / trust / CodeQL                  | only when their paths change | Yes, when they run              |
+
+Two consequences worth internalising:
+
+- **A tier that is not listed is not run.** Notably `tests/integration/` and
+  `tests/e2e/` are not part of the PR gate; run them locally when your change
+  touches those paths.
+- **Skipped is not passed.** A suite can be green because every test in it
+  skipped for a missing service. When you add a step that depends on external
+  infrastructure, pass `-rs` so the skips are visible, and check that the step
+  can actually come out the other way.
+
+Until #2038 the Tier-2 step carried `continue-on-error: true`, so a Tier-2
+failure reported green. It no longer does. If your PR reds on Tier 2, a real
+integration test regressed — do not restore `continue-on-error`; quarantine the
+individual test with `xfail(strict=True)` and a tracking issue, so it clears
+itself loudly when fixed.
 
 ## Commit Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,26 @@ means a failure turns the check red.
 | ------------------------------------------------------------ | -------------------------- | ---------------------------------- |
 | Tier 1 — `tests/unit/`, `tests/trust/plane/unit/`, `tests/security/` | every PR, Python 3.11–3.14 | **Yes**                            |
 | Tier 2 — `tests/tier2_integration/`                          | every PR, Python 3.11–3.14 | **Not yet** — non-blocking, but a failure now posts a loud annotation + job summary. Blocked on #2078; see below. |
-| Root regression — `tests/regression/`, infra-free            | every PR, Python 3.12      | **Yes** (since #2002)              |
-| Root regression — infra-marked                               | every PR (Postgres+Redis)  | **Yes** (since #2002)              |
+| Root regression — `tests/regression/`                        | **not run** — see #2081    | No                                 |
+| Regression lint (`test_issue_2023_*`)                        | every PR, Python 3.11–3.14 | **Yes**                            |
 | DataFlow unit + regression                                   | every PR                   | **Yes**                            |
 | PACT                                                         | every PR                   | **Yes**                            |
 | Type check (pyright)                                         | every PR                   | No — `continue-on-error`, see #73  |
 | CUDA jobs (`test-kailash-ml.yml`)                            | manual dispatch only       | No — `continue-on-error` until the GPU runner is live |
 | kailash-ml / kailash-align / trust / CodeQL                  | only when their paths change | Yes, when they run              |
+
+#### Root `tests/regression/` is still not run
+
+#2002 asked for it and it is still open. The gate was built and could not be
+shipped: root `tests/regression/` **hangs on the ubuntu CI runner**. Three runs
+with progressively sharper instruments ended in a timeout or a truncated
+`--maxfail`; the last enumerated 30 hung tests across 8 files having executed
+757 of 1916. The same suite is `1916 passed / 0 failed in 217s` locally. Blocker
+is #2081; the complete, working job is preserved in PR #2077's history and
+should be restored from there rather than rebuilt.
+
+Practically: **run `pytest tests/regression/` locally before you push.** Nothing
+in CI does it for you.
 
 Two consequences worth internalising:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1209,6 +1209,17 @@ def mock_node_factory():
         def execute_method(self, **kwargs):
             return execute_return
 
+        # `Node.run` is ABSTRACT. Without a concrete override here, `type()`
+        # produces a class that cannot be instantiated at all — every caller
+        # got `TypeError: Can't instantiate abstract class <name> without an
+        # implementation for abstract method 'run'`, surfacing as a
+        # WorkflowValidationError from WorkflowBuilder.add_node. The factory
+        # overrides `execute` directly, so `run` is never invoked on the happy
+        # path; it exists to satisfy the ABC and returns the same payload so a
+        # caller that does reach it sees consistent data.
+        def run_method(self, **kwargs):
+            return execute_return
+
         # Handle special execute_method if provided in extra_attrs
         if "execute_method" in extra_attrs:
             execute_method = extra_attrs.pop("execute_method")
@@ -1218,6 +1229,7 @@ def mock_node_factory():
             "__init__": init_method,
             "get_parameters": get_parameters_method,
             "execute": execute_method,
+            "run": run_method,
         }
 
         # Add any extra attributes

--- a/tests/regression/test_dataflow_pool_bridge.py
+++ b/tests/regression/test_dataflow_pool_bridge.py
@@ -141,6 +141,18 @@ async def test_failed_ddl_does_not_leak_pools_under_saturation(pg_dsn):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#2075: real pool leak on the auto_migrate='warn' DDL-failure path. "
+        "Observed pool_count()=9 against a cap of 5, deterministically, in 3 of "
+        "3 consecutive runs against a real Postgres. This test has never run in "
+        "CI (it is one of the files #2002 covers), so the leak shipped "
+        "unnoticed. xfail(strict=True) — NOT skip — so it self-clears LOUDLY "
+        "(XPASS becomes a failure) the moment #2075 is fixed. The assertion is "
+        "unchanged: the bound is correct, the code is wrong."
+    ),
+)
 async def test_failed_ddl_with_warn_mode_still_bounded(pg_dsn):
     """Pool count stays bounded in legacy auto_migrate='warn' mode too.
 
@@ -178,6 +190,9 @@ async def test_failed_ddl_with_warn_mode_still_bounded(pg_dsn):
     await asyncio.gather(*[_attempt_access_warn(i) for i in range(10)])
 
     # Pool count MUST remain bounded regardless of auto_migrate mode.
+    # NOTE: currently xfail(strict=True) per #2075 — see the marker on this
+    # function. The assertion below is DELIBERATELY UNCHANGED; the bound is
+    # correct and the code is what is wrong.
     assert AsyncSQLDatabaseNode.pool_count() <= 5, (
         f"Pool leaked in warn mode: pool_count()={AsyncSQLDatabaseNode.pool_count()} > 5 "
         "after 10 DDL-failing DataFlow instances with auto_migrate='warn'"

--- a/tests/regression/test_issue_2023_sibling_install_declarations.py
+++ b/tests/regression/test_issue_2023_sibling_install_declarations.py
@@ -1,0 +1,204 @@
+"""Issue #2023 — CI lint: root-editable installs must declare their siblings.
+
+A workflow step that installs the root ``kailash`` package editable from the
+branch, but lets a sibling package (kailash-dataflow, kailash-ml,
+kailash-align, ...) resolve from PyPI, is testing a combination the monorepo
+never ships: branch-core + released-sibling. When the branch changes a
+cross-package interface, that step fails in a way no source inspection
+explains — or, worse, passes while the real shipped pairing is broken.
+
+#2023 cost one debugging cycle to that class:
+
+    TypeError: _validate_identifier() missing 1 required keyword-only
+    argument: max_length
+    .venv/lib/python3.12/site-packages/dataflow/core/nodes.py:3620
+
+Root ``kailash`` came from the branch (carrying #1971's now-required
+keyword-only ``max_length``); ``kailash-dataflow`` came from PyPI at 2.19.1,
+which still called it positionally.
+
+The fix #2023 asks for is per-step reasoning, not a blanket install: install a
+sibling editable when the step actually exercises that sibling, and RECORD the
+determination in a comment so the next reader does not re-derive it. This test
+is the enforcement half of that — AC#3 of #2023.
+
+RATCHET SEMANTICS
+-----------------
+``GRANDFATHERED`` below lists sites that predate this lint and have not yet had
+their sibling determination measured. The list may only SHRINK. Removing an
+entry means someone measured that step's real import graph (see
+``MEASUREMENT_RECIPE``) and wrote the answer into the step. Adding an entry is
+a regression and should not pass review.
+
+TRIGGER GAP (recorded deliberately)
+-----------------------------------
+This test lives in ``tests/regression/``, which unified-ci.yml gates on every
+PR as of #2002. That workflow's ``paths:`` filter covers ``src/**``,
+``packages/**``, ``tests/**``, ``pyproject.toml``, ``uv.lock`` and
+``unified-ci.yml`` — it does NOT cover ``.github/workflows/**`` generally. So a
+PR that ONLY edits, say, ``test-kailash-ml.yml`` does not run this lint. Closing
+that would mean firing the full 4-version matrix on every workflow-only edit,
+a compute trade-off that belongs to whoever owns the CI budget, not to this
+test. Documented rather than silently assumed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.regression
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+# `uv pip install -e "."` or `-e ".[extras]"` — the root package, editable.
+ROOT_EDITABLE_RE = re.compile(r'uv\s+pip\s+install\s+-e\s+"\.(\[[^"]*\])?"')
+
+# The marker a compliant step carries. Grep-able on purpose.
+DECLARATION_MARKER = "#2023 SIBLING DECLARATION"
+
+# A step begins at a `- name:` or `- uses:` list item.
+STEP_START_RE = re.compile(r"^\s*-\s+(name|uses):")
+STEP_NAME_RE = re.compile(r"^\s*-\s+name:\s*(.+?)\s*$")
+
+MEASUREMENT_RECIPE = """
+To retire a GRANDFATHERED entry, MEASURE the step rather than guessing.
+
+Write a pytest plugin that reports sibling module residency, e.g.:
+
+    # sibprobe.py
+    import sys
+    def pytest_collection_finish(session):
+        for mod in ("dataflow", "kailash_align", "kailash_ml", "kailash"):
+            hit = [k for k in sys.modules if k == mod or k.startswith(mod + ".")]
+            print(f"SIBPROBE {mod}: {len(hit)}")
+
+then run the step's EXACT pytest selection through it:
+
+    PYTHONPATH=. pytest <the step's paths> -m '<the step's marker expr>' \\
+        -p sibprobe --collect-only -q
+
+A count of 0 means the sibling is genuinely not exercised (leave it resolving
+from PyPI and say so in-comment); a non-zero count means it IS exercised and
+must be installed editable. Note that collection imports EVERY module under a
+named directory BEFORE `-m` deselects anything, so a step naming a whole tests/
+tree exercises whatever that tree imports at module scope, regardless of which
+tests the marker filter finally selects.
+"""
+
+# (workflow filename, step name) pairs whose sibling determination has NOT yet
+# been measured. MAY ONLY SHRINK.
+#
+# Note that a name is not unique within a file — "unified-ci.yml ::
+# Install dependencies" covers FIVE distinct steps. An entry is therefore
+# retired only when EVERY step sharing that name carries a declaration, which
+# is what `test_grandfather_list_only_shrinks` enforces. Renaming the steps to
+# something distinct would tighten this, and is worth doing when someone next
+# measures that file.
+GRANDFATHERED: set[tuple[str, str]] = {
+    ("cross-sdk-interop.yml", "Install dependencies"),
+    ("security-tests.yml", "Install dependencies"),
+    ("test-kailash-kaizen.yml", "Install kailash-kaizen[dev] + sibling packages"),
+    ("trust-tests.yml", "Install dependencies"),
+    ("unified-ci.yml", "Install dependencies"),
+}
+
+
+def _iter_steps(text: str):
+    """Yield (step_name, step_body) for each step block in a workflow file.
+
+    Comment-preserving: this is a TEXT scan, not a YAML parse, because the
+    declaration lives in `#` comments that any YAML loader discards.
+    """
+    lines = text.splitlines()
+    starts = [i for i, line in enumerate(lines) if STEP_START_RE.match(line)]
+    for idx, start in enumerate(starts):
+        end = starts[idx + 1] if idx + 1 < len(starts) else len(lines)
+        block = lines[start:end]
+        match = STEP_NAME_RE.match(lines[start])
+        name = match.group(1).strip("\"'") if match else "<unnamed step>"
+        yield name, "\n".join(block)
+
+
+def _root_editable_sites() -> list[tuple[str, str, str]]:
+    """Return (workflow_filename, step_name, step_body) for each install site."""
+    sites = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if not ROOT_EDITABLE_RE.search(text):
+            continue
+        for step_name, body in _iter_steps(text):
+            if ROOT_EDITABLE_RE.search(body):
+                sites.append((path.name, step_name, body))
+    return sites
+
+
+def test_workflows_dir_is_discoverable():
+    """Guard: the lint below is vacuous if the glob finds nothing."""
+    assert WORKFLOWS_DIR.is_dir(), f"workflows dir not found at {WORKFLOWS_DIR}"
+    sites = _root_editable_sites()
+    assert len(sites) >= 10, (
+        f"Only {len(sites)} root-editable install sites found under "
+        f"{WORKFLOWS_DIR}. Expected at least 10. Either the workflows moved or "
+        "ROOT_EDITABLE_RE stopped matching — in both cases the lint below is "
+        "silently passing on an empty set and must be repaired, not deleted."
+    )
+
+
+def test_every_root_editable_install_declares_its_siblings():
+    """Every step installing root kailash editable declares its siblings.
+
+    #2023 AC#3. A step that resolves a sibling from PyPI while the root package
+    comes from the branch is testing a pairing the monorepo never ships; the
+    declaration is what stops the next reader re-deriving that reasoning, or
+    (worse) not realising there was any to do.
+    """
+    undeclared = [
+        (workflow, step)
+        for workflow, step, body in _root_editable_sites()
+        if DECLARATION_MARKER not in body and (workflow, step) not in GRANDFATHERED
+    ]
+
+    assert not undeclared, (
+        "These workflow steps install root `kailash` editable without declaring "
+        "which sibling packages they exercise and how each resolves:\n\n"
+        + "\n".join(f"  {workflow} :: {step}" for workflow, step in undeclared)
+        + "\n\nAdd a comment inside the step containing the marker "
+        f"'{DECLARATION_MARKER}', naming each sibling and whether it is "
+        "exercised, with the measured evidence.\n" + MEASUREMENT_RECIPE
+    )
+
+
+def test_grandfather_list_only_shrinks():
+    """Every grandfathered entry still exists and still lacks a declaration.
+
+    Without this, the list rots: an entry whose step was renamed or which
+    quietly gained a declaration would sit there forever, and a NEW undeclared
+    step reusing that (workflow, step-name) pair would inherit the exemption.
+    """
+    # A (workflow, step-name) key can cover MORE THAN ONE step — step names are
+    # not unique within a file. Collect every body under the key, so a key is
+    # only "now declared" when all of its steps are.
+    sites: dict[tuple[str, str], list[str]] = {}
+    for workflow, step, body in _root_editable_sites():
+        sites.setdefault((workflow, step), []).append(body)
+
+    stale_missing = sorted(key for key in GRANDFATHERED if key not in sites)
+    assert not stale_missing, (
+        "GRANDFATHERED names sites that no longer install root kailash editable "
+        "(renamed or removed). Delete these entries:\n"
+        + "\n".join(f"  {workflow} :: {step}" for workflow, step in stale_missing)
+    )
+
+    now_declared = sorted(
+        key
+        for key in GRANDFATHERED
+        if all(DECLARATION_MARKER in body for body in sites[key])
+    )
+    assert not now_declared, (
+        "These sites are grandfathered but now carry a sibling declaration. "
+        "Delete them from GRANDFATHERED so the exemption cannot be reused:\n"
+        + "\n".join(f"  {workflow} :: {step}" for workflow, step in now_declared)
+    )

--- a/tests/tier2_integration/mcp_server/test_oauth.py
+++ b/tests/tier2_integration/mcp_server/test_oauth.py
@@ -6,6 +6,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.auth.oauth import (
     AccessToken,
     AuthorizationCode,
@@ -674,8 +675,21 @@ class TestResourceServer:
             mock_jwt_instance = MagicMock()
             mock_jwt.return_value = mock_jwt_instance
 
+            # `resource` is REQUIRED here, not decoration. ResourceServer
+            # derives its RFC 9728 Protected Resource Metadata from `resource`,
+            # which defaults to `audience`; a bare token like "mcp-api" is not
+            # an absolute http(s) URL, so construction raises
+            #   ValueError: ResourceServer resource identifier must be an
+            #   absolute http(s) URL for RFC 9728 PRM derivation
+            # and every test in this class errored during setup. The SDK's own
+            # error message prescribes this remedy: pass `resource` explicitly
+            # when `audience` is a bare token. `audience` is deliberately left
+            # as "mcp-api" because the tests below assert on that exact value —
+            # audience and resource are independent by design.
             self.server = ResourceServer(
-                issuer="https://auth.example.com", audience="mcp-api"
+                issuer="https://auth.example.com",
+                audience="mcp-api",
+                resource="https://mcp.example.com/mcp-api",
             )
 
     @pytest.mark.asyncio

--- a/tests/tier2_integration/middleware/test_circular_imports.py
+++ b/tests/tier2_integration/middleware/test_circular_imports.py
@@ -186,17 +186,39 @@ def test_core_sdk_import_independence():
 
     failed_imports = []
 
-    for module_name in core_modules:
-        # Clear module from cache to test fresh import
-        if module_name in sys.modules:
-            del sys.modules[module_name]
+    # Snapshot the ORIGINAL module objects so they can be restored below.
+    #
+    # Without the restore, this test corrupts every later test in the session.
+    # Deleting "kailash.nodes.base" and re-importing it creates a SECOND,
+    # distinct `Node` class object. Modules imported earlier still hold the
+    # first one, so `isinstance(<instance of new Node>, <old Node>)` is False
+    # and the workflow builder rejects a perfectly valid node with
+    # "Invalid node type: ... Expected: str, Node class, or Node instance".
+    # That is how tests/tier2_integration/runtime/test_testing.py::
+    # TestSecurityTestHelper failed in the full suite while passing in
+    # isolation. Restoring the originals keeps the independence check (a fresh
+    # import still has to succeed) without leaking split class identity.
+    original_modules = {
+        name: sys.modules[name] for name in core_modules if name in sys.modules
+    }
 
-        try:
-            importlib.import_module(module_name)
-            print(f"✅ {module_name} imported independently")
-        except ImportError as e:
-            print(f"❌ {module_name} failed: {e}")
-            failed_imports.append(f"{module_name}: {e}")
+    try:
+        for module_name in core_modules:
+            # Clear module from cache to test fresh import
+            if module_name in sys.modules:
+                del sys.modules[module_name]
+
+            try:
+                importlib.import_module(module_name)
+                print(f"✅ {module_name} imported independently")
+            except ImportError as e:
+                print(f"❌ {module_name} failed: {e}")
+                failed_imports.append(f"{module_name}: {e}")
+    finally:
+        # Put the ORIGINAL objects back, discarding the freshly-imported
+        # duplicates. Order does not matter — these are already-initialised
+        # module objects, not a re-execution.
+        sys.modules.update(original_modules)
 
     assert (
         len(failed_imports) == 0

--- a/tests/tier2_integration/runtime/test_distributed_runtime.py
+++ b/tests/tier2_integration/runtime/test_distributed_runtime.py
@@ -12,6 +12,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
 from src.kailash.runtime.distributed import (
     _HEARTBEAT_PREFIX,
     _PROCESSING_KEY,
@@ -386,6 +387,14 @@ class TestWorker:
         mock_queue.recover_stale_tasks.return_value = 0
         mock_queue.queue_length.return_value = 0
         mock_queue.processing_length.return_value = 0
+        # `_default_visibility_timeout` is set in TaskQueue.__init__, not on the
+        # class, so `MagicMock(spec=TaskQueue)` does not expose it. The worker
+        # reads it (src/kailash/runtime/distributed.py:1054) when re-queueing a
+        # task, and every test using this helper died on
+        # `AttributeError: Mock object has no attribute
+        # '_default_visibility_timeout'`. Mirror the real default
+        # (src/kailash/infrastructure/task_queue.py:202).
+        mock_queue._default_visibility_timeout = 300
 
         worker = Worker(
             redis_url="redis://test:6379",

--- a/tests/tier2_integration/runtime/test_docker.py
+++ b/tests/tier2_integration/runtime/test_docker.py
@@ -813,6 +813,12 @@ class TestDockerRuntimeIntegration:
             node_data = json.load(f)
 
         assert node_data["class"] == "MockSimpleNode"
-        assert node_data["module"] == "tests.unit.runtime.test_docker"
+        # Derive the expected module from the class rather than hardcoding it.
+        # The literal here used to read "tests.unit.runtime.test_docker" and
+        # went stale when this file moved to tests/tier2_integration/runtime/ —
+        # the assertion then pinned a path that no longer existed. Deriving it
+        # tests the real proposition (the wrapper records the node's own module)
+        # and cannot rot on the next move.
+        assert node_data["module"] == MockSimpleNode.__module__
         assert "parameters" in node_data
         assert len(node_data["parameters"]) == 2  # input_data and multiplier

--- a/tests/tier2_integration/runtime/test_phase0d_optimizations.py
+++ b/tests/tier2_integration/runtime/test_phase0d_optimizations.py
@@ -568,6 +568,31 @@ class TestP0DIntegration:
             for i in range(5):
                 assert f"node_{i}" in results
 
+    @pytest.mark.skip(
+        reason=(
+            "QUARANTINED (#2038): load-sensitive absolute wall-clock threshold. "
+            "Observed failing 1 of 3 consecutive local runs on a loaded machine "
+            "while the other 45 Tier-2 failures were consistent 3/3 — this is "
+            "the ONLY genuine runner-flake in the tier. The assertion "
+            "`avg_ms < 50` is an absolute wall-clock bound, which "
+            "`.claude/rules/testing.md` § 'Complexity Bounds Use Self-Normalizing "
+            "Ratios, Not Absolute Wall-Clock Thresholds' prohibits: under "
+            "competing load 10 trivial nodes exceed 50ms for reasons that have "
+            "nothing to do with P0D caching, and the failure message then "
+            "asserts a diagnosis ('P0D optimizations') it cannot distinguish "
+            "from 'the machine was busy'. "
+            "skip rather than xfail(strict=True) BECAUSE the test PASSES most "
+            "runs — a strict xfail would XPASS and turn this into a different "
+            "red. That is the narrow case AC#2 of #2038 allows a documented "
+            "skip. Same class as #2029. Un-skip once the assertion is "
+            "restated structurally (e.g. warm-vs-cold ratio, or a cache-hit "
+            "counter) rather than as a wall-clock bound. Do NOT simply widen "
+            "the 50ms threshold — that ratchet is how a real serialization "
+            "regression later hides. NOTE: line ~157 of this file carries a "
+            "sibling absolute bound (`per_call_us < 50`) which was NOT observed "
+            "failing in those 3 runs and is therefore left running."
+        )
+    )
     def test_repeated_execution_performance(self):
         """Repeated executions should benefit from all P0D caching."""
         builder = WorkflowBuilder()

--- a/tests/tier2_integration/runtime/test_runtime_success_detection.py
+++ b/tests/tier2_integration/runtime/test_runtime_success_detection.py
@@ -77,6 +77,10 @@ class MockMalformedNode(Node):
 
         return {"mode": NodeParameter(name="mode", type=str, default="missing_success")}
 
+    def run(self, **kwargs):
+        """Execute the node's logic (Node ABC contract)."""
+        return self.execute(**kwargs)
+
     def execute(self, mode: str = "missing_success", **kwargs) -> Dict[str, Any]:
         if mode == "missing_success":
             return {"error": "no success field"}

--- a/tests/tier2_integration/test_workflow_scheduler.py
+++ b/tests/tier2_integration/test_workflow_scheduler.py
@@ -111,10 +111,20 @@ class TestWorkflowSchedulerInit:
             mock_jobstore = MagicMock()
             mock_scheduler_instance = MagicMock()
 
+            # NOTE: the parent package `apscheduler` is deliberately NOT stubbed
+            # here. Replacing sys.modules["apscheduler"] with a MagicMock makes
+            # it a non-package, so `from apscheduler.events import ...` — which
+            # WorkflowScheduler.__init__ does for the issue #914 fire-time
+            # listeners — fails with
+            #   ModuleNotFoundError: No module named 'apscheduler.events';
+            #   'apscheduler' is not a package
+            # Leaving the real package in place lets that import resolve while
+            # the two specific submodules below stay stubbed, which is all these
+            # tests ever needed. (apscheduler is a real dependency of the
+            # `scheduler` extra and is installed in CI.)
             with patch.dict(
                 "sys.modules",
                 {
-                    "apscheduler": MagicMock(),
                     "apscheduler.schedulers.asyncio": MagicMock(
                         AsyncIOScheduler=MagicMock(return_value=mock_scheduler_instance)
                     ),
@@ -132,10 +142,11 @@ class TestWorkflowSchedulerInit:
         """WorkflowScheduler should work with in-memory storage."""
         mock_scheduler_instance = MagicMock()
 
+        # Parent `apscheduler` intentionally left unstubbed — see the note in
+        # test_init_with_defaults above.
         with patch.dict(
             "sys.modules",
             {
-                "apscheduler": MagicMock(),
                 "apscheduler.schedulers.asyncio": MagicMock(
                     AsyncIOScheduler=MagicMock(return_value=mock_scheduler_instance)
                 ),
@@ -159,10 +170,11 @@ class TestWorkflowSchedulerOperations:
         mock_scheduler.running = False
 
         with patch("kailash.runtime.scheduler._check_apscheduler", return_value=True):
+            # Parent `apscheduler` intentionally left unstubbed — see the note
+            # in test_init_with_defaults above.
             with patch.dict(
                 "sys.modules",
                 {
-                    "apscheduler": MagicMock(),
                     "apscheduler.schedulers.asyncio": MagicMock(
                         AsyncIOScheduler=MagicMock(return_value=mock_scheduler)
                     ),

--- a/tests/tier2_integration/workflows/test_node_constructor_mapping.py
+++ b/tests/tier2_integration/workflows/test_node_constructor_mapping.py
@@ -493,17 +493,29 @@ class TestCircularImportPrevention:
             "kailash.runtime.local",
         ]
 
-        # Clear modules from cache
-        for module_name in core_modules:
-            if module_name in sys.modules:
-                del sys.modules[module_name]
+        # Snapshot the ORIGINAL module objects — see the identical guard in
+        # tests/tier2_integration/middleware/test_circular_imports.py. Without
+        # restoring them, the re-import creates a SECOND `Node` class and every
+        # later test that does isinstance(node, Node) against the first one
+        # fails with "Invalid node type".
+        original_modules = {
+            name: sys.modules[name] for name in core_modules if name in sys.modules
+        }
 
-        # Import each module independently
-        for module_name in core_modules:
-            try:
-                importlib.import_module(module_name)
-            except ImportError as e:
-                pytest.fail(f"Circular import detected in {module_name}: {e}")
+        try:
+            # Clear modules from cache
+            for module_name in core_modules:
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
+
+            # Import each module independently
+            for module_name in core_modules:
+                try:
+                    importlib.import_module(module_name)
+                except ImportError as e:
+                    pytest.fail(f"Circular import detected in {module_name}: {e}")
+        finally:
+            sys.modules.update(original_modules)
 
     def test_node_registry_lazy_loading(self):
         """NodeRegistry should use lazy loading to avoid circular imports."""


### PR DESCRIPTION
> **Read this first.** This PR does **not** close #2002 or fully close #2038.
> Both were built, and both were then refuted by the CI runner. What it does
> deliver is the diagnosis, four evidence-backed blocking issues, 45 genuinely
> repaired tests, #2023 in full, and honest contributor docs. Scope changes and
> what could not be verified are enumerated at the bottom.

## Summary

Three issues, one theme: checks that reported green while carrying no
information about the thing they were named for. Investigating them uncovered
that **this repo's CI runner cannot run root `tests/regression/` or
`tests/tier2_integration/` to completion at all** — which is most likely why
neither was ever wired in.

| Issue | Status |
| --- | --- |
| **#2023** | **Fixed.** Eight sites carry measured sibling declarations; a ratcheting lint enforces it on every PR. |
| **#2038** | **Partly fixed.** AC#1 (visible, non-green state), AC#2 (individual quarantine), AC#4 (contributor docs) met. "Gates a merge" **not** met — blocked on #2078. |
| **#2002** | **Not fixed.** The gate was built and verified locally, then could not be shipped — blocked on #2081. |

New issues filed, each with reproduction and evidence:
**#2075** · **#2076** · **#2078** · **#2079** · **#2081**

---

## The central finding

| suite | local (macOS, from-scratch CI-equivalent venv, Py 3.12) | on `ubuntu-latest` |
| --- | --- | --- |
| root regression, infra-free | `1916 passed, 3 skipped, 0 failed, 217.79s` | **hangs**; 30+ hung tests across 8 files, run never completes |
| root regression, infra-marked | `11 passed, 11 skipped, 1 xfailed, 237.06s` | **hangs**; 3 of 22 tests in 30 minutes |
| Tier 2 | `2604 passed, 24 skipped, 0 failed` (stable ×2) | **174 failed + 58 errors** in 2:55 |

A local green was never evidence about the runner, and I should have said so
before claiming Tier-2 green in the first commit. macOS thread and fd limits are
far above a 2-core container.

### Two things that were structurally invisible before this PR

1. **The Tier-2 step was timing out at 10 minutes on Python 3.11 and 3.12 in
   every run inspected** (`31480330313`, `31478307416`, `31476919718`) — and
   every one of those jobs reported **SUCCESS**. `continue-on-error: true`
   swallowed the timeout exactly as it swallowed failures. The Tier-2 suite had
   never been observed to complete on CI on half the matrix.

2. **`--maxfail=20` meant every run was a truncated window, not a failure set.**
   This PR fixed 11 of the 20 tests the pre-change 3.14 run reported; the run
   then simply reached the next batch and stopped at 20 again.

---

## What is fixed

### #2023 — per-step sibling-install determinations (complete)

Measured with a pytest plugin reporting sibling module residency in
`sys.modules` at collection finish, run against each step's exact paths and
marker expression. It returns 0 when a sibling is genuinely untouched, so a 0 is
evidence rather than an absence of it.

| site | dataflow | kailash_align | determination |
| --- | --- | --- | --- |
| `test-kailash-ml.yml` test-base | 0 | 0 | nothing added |
| `test-kailash-ml.yml` Coverage | 112 | 13 | already correct |
| `test-kailash-ml.yml` test-dl / test-rl / test-cuda / test-cuda-dl | 112 | 13 | **both added** |
| `gpu-smoke.yml` inline scripts / pytest step | 0 / 112 | 0 / 13 | **both added** (pytest step) |
| `test-kailash-align.yml` ×3 | 0 | — (95 kailash_ml) | ml only, already correct |

The load-bearing finding: **naming a whole `tests/` directory makes pytest
import every module in it before `-m` deselects anything**, so a step exercises
whatever that tree imports at module scope regardless of what the filter finally
selects — the #2023 trap one layer earlier than the runtime `TypeError` that
motivated the issue. The align jobs are the mirror case and confirm the issue's
own reasoning: the `dataflow` references under `kailash_ml/features/` are all
inside `if TYPE_CHECKING:` or function bodies, so none fires at import time.

AC#3's lint landed as `tests/regression/test_issue_2023_sibling_install_declarations.py`
and is named as its own step in the matrix job, so it runs on every PR even
though the regression job could not ship. It is a **ratchet**: pre-existing
sites sit in an explicit `GRANDFATHERED` set that may only shrink, and a
companion test fails if an entry goes stale or quietly gains a declaration, so
an exemption cannot be inherited by a new step reusing the name. The docstring
carries the measurement recipe so retiring an entry means measuring, not
guessing.

### Tier-2 test repairs — 45 tests (complete, verified)

Three consecutive full local runs gave a clean split: **45 tests failed 3/3,
exactly 1 failed 1/3.** So the removed flag's stated reason ("thread/I/O tests
that may fail on CI runners") was true of 1 test out of 46 locally.

All 45 are **fixed, not quarantined**:

| n | root cause | fix |
| --- | --- | --- |
| 15 | `test_workflow_scheduler.py` stubbed `sys.modules["apscheduler"]` with a `MagicMock`, making it a non-package, so `from apscheduler.events import ...` (added for #914) raised `ModuleNotFoundError: … 'apscheduler' is not a package` | drop the parent stub; the submodule stubs the tests need are untouched |
| 8 | `MagicMock(spec=TaskQueue)` does not expose `_default_visibility_timeout` (set in `__init__`, not on the class); the worker reads it at `distributed.py:1054` | set it on the mock to the real default |
| 7 | `mock_node_factory` in `tests/conftest.py` built Node subclasses with `execute` but no `run`; `Node.run` is abstract, so every class it produced was uninstantiable | add a concrete `run` |
| 6 | `ResourceServer(audience="mcp-api")` with no `resource` — RFC 9728 PRM derivation needs an absolute http(s) URL | pass `resource`, as the SDK's own error message prescribes; `audience` unchanged because the tests assert on it |
| 8 | missing optional deps (`hvac` 3, `boto3` 2, `matplotlib` 2, `sklearn` 1) | provisioned in CI — all 8 now run and pass |
| 1 | `test_docker.py` asserted a hardcoded module path that went stale when the file moved out of `tests/unit/` | derive it from the class under test |

Plus a **test-isolation defect** worth calling out: 2 tests failed in the full
suite while passing in isolation, with `Invalid node type: <class …>. Expected:
str, Node class, or Node instance` — on an object that *is* a Node instance.
`test_circular_imports.py` and `test_node_constructor_mapping.py` delete
`"kailash.nodes.base"` from `sys.modules` to prove independent importability and
never restore it, creating a **second `Node` class**. Both now snapshot and
restore in a `finally`; the independence assertion is unchanged.

**No assertion was widened or weakened.** Verified: Tier 2 `2604 passed / 0
failed`, stable across two consecutive runs; Tier 1 unaffected by the shared
`conftest.py` change at `5084 passed / 0 failed`.

### The one genuine flake, quarantined individually

`runtime/test_phase0d_optimizations.py::test_repeated_execution_performance` —
failed 1 of 3 runs, asserts `avg_ms < 50`, an absolute wall-clock bound.
Documented `skip`, **not** `xfail(strict=True)`: it passes most runs, so a
strict xfail would XPASS into a different red. That is the narrow case #2038
AC#2 allows a skip. Threshold deliberately **not** widened, per #2029. A sibling
absolute bound at line 157 of the same file was **not** observed failing, so it
is left running and noted rather than pre-emptively quarantined.

---

## What is not fixed, and why

### #2038 — Tier 2 does not gate yet (#2078)

With `--maxfail` lifted the tier completes in 2:55 and reports **174 failed / 58
errors** of ~2,629. Two signatures cover nearly all of it: **130 `RuntimeError:
can't start new thread`** and **90 `sqlite3.OperationalError: disk I/O error`** —
the paired symptom of thread and file-descriptor exhaustion, one cause rather
than 232 defects. Pre-existing: identical errors appear in run `31478307416`
against unmodified code.

Gating today would red every PR in the repo on a leak none of them introduced.
Quarantining is equally wrong — 232 skips would gut the tier and would be
quarantining symptoms.

So the step is **non-blocking but no longer silent**: a failure emits a
`::error::` annotation and a job-summary block naming the count. That is #2038
AC#1's "annotation, or a posted summary; not a silently-swallowed step" branch,
satisfied deliberately rather than by accident, and the flag carries the
conditions for its own removal.

### #2002 — the gate could not ship (#2081)

Three CI runs, each with a sharper instrument:

1. `-q`, `--timeout=300`, `timeout_method=thread`, 15-min budget → timed out,
   no per-test output, nothing learnable.
2. `-v`, 40-min budget → timed out at 40 minutes having run **~8%**.
   pytest-timeout printed its 300s banner repeatedly while the process carried
   on — **a thread-method timeout cannot kill a test blocked in a C call**, so
   the suite had a timeout that could not enforce one.
3. `--timeout-method=signal` (SIGALRM), which can → hung tests fail and name
   themselves. With `--maxfail=30 --timeout=60`:
   `13 failed, 757 passed, 17 errors in 1420.07s`.

**30 hangs across 8 files** — `test_create_index_identifier_safety.py` (10),
`test_issue_1245_sqlite_store_per_thread_conn_leak.py` (5),
`test_channel_parameters_envelope_behaviour.py` (5),
`test_issue_1185_async_resume_short_circuit.py` (3),
`test_issue_1708_g1_pool_metrics_production_path.py` (2),
`test_eatp12_vault_quickstart.py` (2),
`test_eatp12_vault_630_clearance_wiring.py` (2),
`test_issue_1035_delegate_m4_tenant_hash_salt.py` (1) — and **still truncated**
at maxfail with 757 of 1916 executed, so 30 is a floor.

60s is 3× the slowest healthy test in the suite (19.94s), so these are hangs,
not slow tests. The job is removed rather than shipped degraded; the complete
working job is in this branch's history and referenced from #2081 to be
restored rather than rebuilt.

The infra-marked step (#2002 AC#2) is removed for the same reason and tracked
separately as **#2079** — it hangs at DataFlow cross-loop pool disposal, with
pytest-timeout's stack dump naming a `dataflow_async__0` thread.

**Worth acting on independently of all three issues:** `timeout_method = thread`
in the root `pytest.ini` is what made two of those runs unreadable.

#### Root cause of the hangs (established after the first review round)

Two hypotheses were raised: the tests are mis-marked and need infrastructure the
runner lacks, or something in the code under test waits without a bound.

**Mis-marked — refuted.** `test_channel_parameters_envelope_behaviour.py` touches
no socket, no database, no server bind, no network. It builds channels via
`__new__`, hands them an in-memory workflow registry, and runs a
`PythonCodeNode`. The `requires_*` markers are correct and the infra-free filter
is right to select them.

**Unbounded wait — established.** `APIChannel.handle_request` is `async` but
calls the **synchronous** runtime at `src/kailash/channels/api_channel.py:411`.
With a loop already running, `LocalRuntime` bridges sync→async through a thread
at `src/kailash/runtime/local.py:2334-2336`:

```python
thread = threading.Thread(target=lambda: _caller_ctx.run(run_in_thread))
thread.start()
thread.join()          # no timeout
```

Exceptions raised inside are captured and re-raised after the join, so **a raise
cannot hang the caller — only a block can**, and then `join()` waits forever.

Demonstrated with the mutation shown to reach the code under test:

```
probe 1 (confirm the bridge is taken by this call shape):
  loop running on this thread: True
  THREADS_STARTED_DURING_EXECUTE: 1 -> ['Thread-1 (<lambda>)']   # = local.py:2334

probe 2 (block that same thread, observe the caller):
  MUTATION_REACHED: True -> ['Thread-2 (<lambda>)']
  RESULT: HUNG — no return after 25s (unbounded join)
```

An earlier probe of mine reported "no hang" and was **inert** — it called
`execute()` from a thread with no running loop, so the bridge was never taken
(`THREADS_STARTED: 0`). That result proved nothing and is withdrawn rather than
carried.

**Not established:** *why* the bridge thread blocks on Linux specifically. Pool-
dispose teardown (matching #2079's `dataflow_async__0` stack) and executor
starvation under #2078 are both consistent, and consistency is not evidence.
Recorded as an open hypothesis in #2081.

This is a code defect, not a marker problem and not a timeout-budget problem.
Bounding that join and raising a typed error would have turned 30 unkillable
hangs into 30 legible failures, and would have made the first two CI runs
readable instead of producing a 40-minute timeout with no output.

---

## Two real product defects found by turning the gates on

**#2075 — DataFlow pool leak on the `auto_migrate='warn'` DDL-failure path.**
Fails 3 of 3 runs against a real Postgres:
`AssertionError: Pool leaked in warn mode: pool_count()=9 > 5 after 10
DDL-failing DataFlow instances`. Deterministic. It shipped unnoticed *precisely
because this directory never ran in CI* — #2002's thesis, demonstrated. Marked
`xfail(strict=True)` so it self-clears loudly (XPASS → failure) when fixed; the
assertion is unchanged, because the bound is correct and the code is wrong.

**#2076 — five dispatch-only jobs run pytest selectors matching zero tests.**
`-m 'dl or deep_learning'`, `'rl or reinforcement_learning'`, `'cuda or gpu'`,
`'(dl or deep_learning) and (cuda or gpu)'`, and align's `'gpu'` all select 0
tests — none of those markers exists in either package. **pytest exits 5** on an
empty selection, so each fails whenever dispatched. Invisible because all five
are `workflow_dispatch`-only and two are masked by `continue-on-error`. Recorded
in-comment at each site, with a warning at the CUDA jobs that #2076 must be
fixed **before** the IT-1 flag is removed — otherwise a brand-new GPU runner's
first signal is a red that has nothing to do with GPUs.

---

## Corrections to earlier claims in this PR's own history

- Commit 1 claimed Tier 2 green. That held on macOS and **not** on the runner.
  Corrected in a later commit and in `CONTRIBUTING.md`.
- Commit 2 claimed the root-regression gate verified green. It was — in a
  from-scratch CI-equivalent venv on macOS. It does not run on the runner.
- The infra step landed with an explicit in-comment caveat that it had never
  executed against real service containers, and that if it reddened the likely
  cause was a missing extra. It reddened, and it was a missing extra — that part
  was right; the hang underneath was not foreseen.

## Per-PR wall-clock cost

**Measured: none.** The root-regression job never completed on CI, so there is
no honest measured figure — the last run executed 757 of 1916 tests in 23m40s
and stopped at `--maxfail`. The job is removed on this branch, so its marginal
cost today is **zero**.

For a healthy-path estimate once #2081 is fixed, the runner/local ratio from
this PR's own runs:

| suite | local | CI | ratio |
| --- | --- | --- | --- |
| Tier 1 (5,084 tests) | 69.7s | 76.5s | 1.10x |
| Tier 2 (2,604 tests) | 80.5s | 176.3s | 2.19x |

Root regression is 217.8s locally, giving **~4–8 minutes**. The two ratios
disagree enough that a point estimate would be false precision, so the range is
stated as a range. It is above the 3–4 minutes assumed when the every-PR gate
was approved.

## What I could NOT verify

1. **Whether #2078 and #2081 share a cause.** Both are on the same runner and
   the exhaustion symptoms would explain the hangs, but no evidence links them.
   Stated as a hypothesis in both issues.
2. **The true Tier-2 failure count on 3.11 / 3.13 / 3.14.** Only 3.12 was read
   in full.
3. **The full root-regression hang count.** 30 is a floor from a truncated run.
4. **Why `test_failed_ddl_with_warn_mode_still_bounded` reported `FAILED` rather
   than `XFAIL` on CI** while reporting `XFAIL` locally. The step never
   completed, so there is no traceback. Recorded in #2079.
5. **Order-dependent flakes.** `pytest-randomly` is not installed, so every run
   used identical collection order. That matches CI, but an order-dependent
   flake would not have surfaced — except the one found by comparing full-suite
   against isolated runs.
6. **The pre-existing non-strict xfail** at
   `api/test_workflow_api_async_runtime.py::test_async_execution_no_threading`
   XPASSed in all 5 local runs. Its declared failure mode is event-loop
   pollution from prior tests, and I did fix a major `sys.modules` pollution
   source — but with fixed ordering I cannot distinguish "fixed" from "this
   order is clean", so I left it alone rather than act on a non-discriminating
   result.

## Related issues

Fixes #2023
Refs #2002, #2029, #2038, #2075, #2076, #2078, #2079, #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

