### PR TITLE
fix(kaizen): agent payloads at INFO, and an explicit redaction opt-in silently defeated (#2070)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/_payload.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/_payload.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared payload-logging helpers for hooks (#2070).
+
+ONE implementation, because there were two. `LoggingHook`
+(`builtin/logging_hook.py`) and `SecureLoggingHook` (`security/redaction.py`)
+carried near-verbatim copies of the same log body, and the copies had already
+diverged in exactly the way duplication predicts: the fix for one would have
+left the other publishing payloads under a class name promising the opposite.
+
+The contract both share:
+
+- At the hook's configured level, emit STRUCTURE — key names and counts. Key
+  names come from the signature / event schema rather than from user input, so
+  they carry no payload content.
+- Emit VALUES only behind two independent gates: a deliberate opt-in AND the
+  logger actually at DEBUG. Either gate alone is routinely satisfied by
+  accident — turning DEBUG on globally is routine during incident response.
+- Scrub what does get emitted. Scrubbing claims credential SHAPES, not
+  arbitrary prose, which is why the opt-in gate is the load-bearing protection
+  and the scrub is defence in depth rather than the other way round.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
+#: scrubbing: `scrub_credentials` runs ~25 regex passes, each building a fresh
+#: string, and it was written for error text — whereas a hook payload can carry
+#: a whole retrieved document. Capping first bounds both scrub cost and log
+#: volume.
+MAX_PAYLOAD_CHARS = 2000
+
+
+def summarize_payload(payload: Any) -> dict[str, Any]:
+    """Describe a payload's SHAPE without reproducing any of its values."""
+    if isinstance(payload, dict):
+        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
+    return {"count": 0 if payload is None else 1, "keys": []}
+
+
+def render_scrubbed_payload(payload: Any) -> str:
+    """Render a payload for a DEBUG sink: truncated first, then scrubbed.
+
+    Callers are responsible for the two gates (opt-in + DEBUG); this function
+    only formats. Imported lazily so that merely importing a hook module does
+    not pull in the credential-scrub regex table.
+    """
+    from kaizen.utils.credential_scrub import scrub_credentials
+
+    rendered = repr(payload)
+    if len(rendered) > MAX_PAYLOAD_CHARS:
+        rendered = f"{rendered[:MAX_PAYLOAD_CHARS]}...[truncated {len(rendered)} chars]"
+    return scrub_credentials(rendered)
+
+
+def should_log_full_payload(enabled: bool, logger: logging.Logger) -> bool:
+    """Both gates, in one place, so neither hook can implement only one."""
+    return bool(enabled) and logger.isEnabledFor(logging.DEBUG)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
@@ -8,12 +8,31 @@ SECURITY: Supports sensitive data redaction (Finding #4 fix).
 """
 
 import logging
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
 
 logger = logging.getLogger(__name__)
+
+#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
+#: scrubbing: ``scrub_credentials`` runs ~25 regex passes, each building a fresh
+#: string, and it was written for error text — whereas a hook payload can carry
+#: a whole retrieved document. Capping first bounds both scrub cost and log
+#: volume. Mirrors the same constant in the ``BaseAgent`` fix (#2030).
+MAX_PAYLOAD_CHARS = 2000
+
+
+def _summarize(payload: Any) -> dict[str, Any]:
+    """Describe a payload's SHAPE without reproducing any of its values.
+
+    Key names are structure, not content: they come from the signature /
+    event schema, not from user input, so they are safe to log where the
+    values they index are not.
+    """
+    if isinstance(payload, dict):
+        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
+    return {"count": 0 if payload is None else 1, "keys": []}
 
 
 class LoggingHook(BaseHook):
@@ -45,16 +64,30 @@ class LoggingHook(BaseHook):
         log_level: str = "INFO",
         include_data: bool = True,
         format: str = "text",
-        redact_sensitive: bool = False,
+        redact_sensitive: Optional[bool] = None,
+        log_full_payloads: bool = False,
     ):
         """
         Initialize logging hook.
 
         Args:
             log_level: Log level (DEBUG, INFO, WARNING, ERROR)
-            include_data: Whether to log event data (disable for sensitive data)
+            include_data: Whether to log event data STRUCTURE (key names and
+                counts). Payload VALUES are never emitted at this level; see
+                ``log_full_payloads``.
             format: Log format ("text" or "json")
-            redact_sensitive: Enable automatic sensitive data redaction (SECURITY FIX #4)
+            redact_sensitive: Enable sensitive-data redaction. ``None`` (the
+                default) enables it but permits degradation if the redactor
+                cannot be loaded; ``True`` is an EXPLICIT opt-in and raises
+                rather than degrading; ``False`` disables it outright.
+            log_full_payloads: Emit payload VALUES, at DEBUG only, scrubbed.
+                Defaults False so that turning DEBUG on globally — routine
+                during incident response — does not start dumping user prompts,
+                retrieved documents and PII.
+
+        Raises:
+            RuntimeError: if ``redact_sensitive=True`` was requested explicitly
+                and ``SensitiveDataRedactor`` cannot be imported.
 
         Example:
             >>> # Production usage with redaction
@@ -68,7 +101,16 @@ class LoggingHook(BaseHook):
         self.log_level = log_level
         self.include_data = include_data
         self.format = format
-        self.redact_sensitive = redact_sensitive
+        self.log_full_payloads = log_full_payloads
+
+        # An EXPLICIT `True` is a different request from the default (#2070).
+        # The distinction is load-bearing and is the reason this is tri-state
+        # rather than a bool: raising on a default nobody asked for would break
+        # installs where the redactor is genuinely absent, while degrading an
+        # explicit opt-in silently overrides an operator who already made the
+        # correct decision.
+        redaction_explicitly_requested = redact_sensitive is True
+        self.redact_sensitive = True if redact_sensitive is None else redact_sensitive
 
         # Initialize redactor if needed (SECURITY FIX #4)
         if self.redact_sensitive:
@@ -76,13 +118,33 @@ class LoggingHook(BaseHook):
                 from ..security.redaction import SensitiveDataRedactor
 
                 self.redactor: Optional[SensitiveDataRedactor] = SensitiveDataRedactor()
-            except ImportError:
+            except ImportError as exc:
+                if redaction_explicitly_requested:
+                    # FAIL CLOSED. Previously this branch set
+                    # `redact_sensitive = False` and carried on logging at full
+                    # fidelity behind a WARNING — defeating the operator's own
+                    # explicit choice, which `zero-tolerance.md` Rule 3 blocks.
+                    raise RuntimeError(
+                        "redact_sensitive=True was requested but "
+                        "SensitiveDataRedactor could not be imported, so "
+                        "redaction cannot be performed. Refusing to log "
+                        "unredacted instead. Install the security module, or "
+                        "pass redact_sensitive=False to accept unredacted "
+                        "logging deliberately."
+                    ) from exc
+
+                # NOT explicitly requested: degrading is acceptable, but the
+                # payloads redaction was protecting MUST stop too. A degraded
+                # control that keeps emitting is the disclosure the control
+                # existed to prevent.
                 logger.warning(
-                    "SensitiveDataRedactor not available, disabling redaction. "
-                    "Install security module to enable redaction."
+                    "SensitiveDataRedactor not available, disabling redaction "
+                    "AND payload-value logging. Install security module to "
+                    "enable redaction."
                 )
                 self.redactor = None
                 self.redact_sensitive = False
+                self.log_full_payloads = False
         else:
             self.redactor = None
 
@@ -136,7 +198,18 @@ class LoggingHook(BaseHook):
             else:
                 safe_context = context
 
-            # STEP 2: Log redacted data
+            # STEP 2: Log STRUCTURE, never values (#2070).
+            #
+            # `agent_loop` feeds this hook whole agent I/O — PRE_AGENT_LOOP
+            # carries {"inputs": ...}, POST_AGENT_LOOP carries {"result": ...} —
+            # so the previous `Data={safe_context.data}` put user prompts,
+            # retrieved documents and any credential-bearing parameter on the
+            # INFO log. Redaction is not a substitute here: it claims credential
+            # SHAPES and PII patterns, and a user's prose matches neither.
+            # Withholding values is what actually closes it.
+            data_summary = _summarize(safe_context.data)
+            meta_summary = _summarize(safe_context.metadata)
+
             if self.format == "json":
                 # Structured JSON logging
                 log_event = {
@@ -148,8 +221,9 @@ class LoggingHook(BaseHook):
                 }
 
                 if self.include_data:
-                    log_event["context"] = safe_context.data
-                    log_event["metadata"] = safe_context.metadata
+                    log_event["context_keys"] = data_summary["keys"]
+                    log_event["context_field_count"] = data_summary["count"]
+                    log_event["metadata_keys"] = meta_summary["keys"]
 
                 # Log using structlog (outputs JSON)
                 log_fn = getattr(self.logger, self.log_level.lower())
@@ -164,7 +238,8 @@ class LoggingHook(BaseHook):
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id} "
-                        f"Data={safe_context.data}"
+                        f"DataKeys={data_summary['keys']} "
+                        f"({data_summary['count']} field(s))"
                     )
                 else:
                     log_fn(
@@ -173,11 +248,55 @@ class LoggingHook(BaseHook):
                         f"TraceID={safe_context.trace_id}"
                     )
 
+            # STEP 3: Values, only on deliberate opt-in, only at DEBUG,
+            # only scrubbed. Two independent gates, because either alone is
+            # routinely satisfied by accident: `log_full_payloads` defaults
+            # False so global DEBUG does not start dumping payloads, and the
+            # DEBUG check keeps the render cost off the INFO path entirely.
+            self._log_full_payload(safe_context)
+
             return HookResult(success=True)
 
         except Exception as e:
             # Even logging can fail!
             return HookResult(success=False, error=str(e))
+
+    def _log_full_payload(self, safe_context: HookContext) -> None:
+        """Emit payload VALUES at DEBUG, scrubbed, on explicit opt-in only.
+
+        `safe_context` has already been through the redactor when one is
+        wired; `scrub_credentials` is applied on top because the two cover
+        different classes — the redactor owns PII and payment shapes and
+        delegates vendor credentials to `scrub_credentials`, which is the
+        single credential-scrub implementation in Kaizen.
+
+        Scrubbing claims credential SHAPES, not arbitrary PII, which is
+        precisely why the `log_full_payloads` gate defaults False rather than
+        relying on the scrubber to make payloads safe.
+        """
+        if not self.log_full_payloads:
+            return
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
+        from kaizen.utils.credential_scrub import scrub_credentials
+
+        rendered = repr(safe_context.data)
+        if len(rendered) > MAX_PAYLOAD_CHARS:
+            rendered = (
+                f"{rendered[:MAX_PAYLOAD_CHARS]}"
+                f"...[truncated {len(rendered)} chars]"
+            )
+        scrubbed = scrub_credentials(rendered)
+
+        if self.format == "json":
+            self.logger.debug("hook_event_payload", payload=scrubbed)
+        else:
+            self.logger.debug(
+                f"[{safe_context.event_type.value}] "
+                f"Agent={safe_context.agent_id} "
+                f"Payload={scrubbed}"
+            )
 
     async def on_error(self, error: Exception, context: HookContext) -> None:
         """Log errors to stderr"""

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
@@ -8,31 +8,17 @@ SECURITY: Supports sensitive data redaction (Finding #4 fix).
 """
 
 import logging
-from typing import Any, ClassVar, Optional
+from typing import ClassVar, Optional
 
+from .._payload import (
+    render_scrubbed_payload,
+    should_log_full_payload,
+    summarize_payload,
+)
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
 
 logger = logging.getLogger(__name__)
-
-#: Cap on a rendered payload before it reaches the DEBUG sink. Applied BEFORE
-#: scrubbing: ``scrub_credentials`` runs ~25 regex passes, each building a fresh
-#: string, and it was written for error text — whereas a hook payload can carry
-#: a whole retrieved document. Capping first bounds both scrub cost and log
-#: volume. Mirrors the same constant in the ``BaseAgent`` fix (#2030).
-MAX_PAYLOAD_CHARS = 2000
-
-
-def _summarize(payload: Any) -> dict[str, Any]:
-    """Describe a payload's SHAPE without reproducing any of its values.
-
-    Key names are structure, not content: they come from the signature /
-    event schema, not from user input, so they are safe to log where the
-    values they index are not.
-    """
-    if isinstance(payload, dict):
-        return {"count": len(payload), "keys": sorted(str(k) for k in payload)}
-    return {"count": 0 if payload is None else 1, "keys": []}
 
 
 class LoggingHook(BaseHook):
@@ -207,8 +193,8 @@ class LoggingHook(BaseHook):
             # INFO log. Redaction is not a substitute here: it claims credential
             # SHAPES and PII patterns, and a user's prose matches neither.
             # Withholding values is what actually closes it.
-            data_summary = _summarize(safe_context.data)
-            meta_summary = _summarize(safe_context.metadata)
+            data_summary = summarize_payload(safe_context.data)
+            meta_summary = summarize_payload(safe_context.metadata)
 
             if self.format == "json":
                 # Structured JSON logging
@@ -274,20 +260,10 @@ class LoggingHook(BaseHook):
         precisely why the `log_full_payloads` gate defaults False rather than
         relying on the scrubber to make payloads safe.
         """
-        if not self.log_full_payloads:
-            return
-        if not logger.isEnabledFor(logging.DEBUG):
+        if not should_log_full_payload(self.log_full_payloads, logger):
             return
 
-        from kaizen.utils.credential_scrub import scrub_credentials
-
-        rendered = repr(safe_context.data)
-        if len(rendered) > MAX_PAYLOAD_CHARS:
-            rendered = (
-                f"{rendered[:MAX_PAYLOAD_CHARS]}"
-                f"...[truncated {len(rendered)} chars]"
-            )
-        scrubbed = scrub_credentials(rendered)
+        scrubbed = render_scrubbed_payload(safe_context.data)
 
         if self.format == "json":
             self.logger.debug("hook_event_payload", payload=scrubbed)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/redaction.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/security/redaction.py
@@ -6,14 +6,25 @@ including API keys, passwords, PII, credit cards, and SSNs.
 """
 
 import copy
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Optional, Set
 
 from kaizen.utils.credential_scrub import scrub_credentials
 
+from .._payload import (
+    render_scrubbed_payload,
+    should_log_full_payload,
+    summarize_payload,
+)
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
+
+#: Module-level so the DEBUG gate reads the SAME logger the text sink writes to
+#: (`self.logger` is `getLogger(__name__)` in text mode, and a structlog wrapper
+#: over the stdlib hierarchy in JSON mode).
+logger = logging.getLogger(__name__)
 
 
 class SensitiveDataRedactor:
@@ -206,20 +217,25 @@ class SecureLoggingHook(BaseHook):
         include_data: bool = True,
         format: str = "text",
         redact_sensitive: bool = True,
+        log_full_payloads: bool = False,
     ):
         super().__init__(name="secure_logging_hook")
         self.log_level = log_level
         self.include_data = include_data
         self.format = format
         self.redact_sensitive = redact_sensitive
+        self.log_full_payloads = log_full_payloads
 
-        # Initialize redactor
+        # Initialize redactor. The `else` is not tidy-up: without it
+        # `self.redactor` was simply never assigned when redaction was off, so
+        # any future read outside the `if self.redact_sensitive` guard raises
+        # AttributeError rather than reading a falsy value.
         if self.redact_sensitive:
-            self.redactor = SensitiveDataRedactor()
+            self.redactor: Optional[SensitiveDataRedactor] = SensitiveDataRedactor()
+        else:
+            self.redactor = None
 
-        # Configure logger
-        import logging
-
+        # Configure logger (`logging` is imported at module scope)
         if format == "json":
             import structlog
 
@@ -249,7 +265,18 @@ class SecureLoggingHook(BaseHook):
             else:
                 safe_context = context
 
-            # STEP 2: Log redacted data
+            # STEP 2: Log STRUCTURE, never values (#2070).
+            #
+            # Redaction alone does NOT close this. The redactor claims
+            # credential shapes and PII patterns; a user's prompt, a retrieved
+            # document, or free-form tool output matches neither and survived
+            # verbatim into an INFO line under a class named
+            # `SecureLoggingHook`. Same contract as `LoggingHook` — shared via
+            # `.._payload` so the two cannot drift apart again, which is how
+            # this copy came to keep a defect the original had fixed.
+            data_summary = summarize_payload(safe_context.data)
+            meta_summary = summarize_payload(safe_context.metadata)
+
             if self.format == "json":
                 log_event = {
                     "event_type": safe_context.event_type.value,
@@ -260,8 +287,9 @@ class SecureLoggingHook(BaseHook):
                 }
 
                 if self.include_data:
-                    log_event["context"] = safe_context.data
-                    log_event["metadata"] = safe_context.metadata
+                    log_event["context_keys"] = data_summary["keys"]
+                    log_event["context_field_count"] = data_summary["count"]
+                    log_event["metadata_keys"] = meta_summary["keys"]
 
                 log_fn = getattr(self.logger, self.log_level.lower())
                 log_fn("hook_event", **log_event)
@@ -274,13 +302,27 @@ class SecureLoggingHook(BaseHook):
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id} "
-                        f"Data={safe_context.data}"
+                        f"DataKeys={data_summary['keys']} "
+                        f"({data_summary['count']} field(s))"
                     )
                 else:
                     log_fn(
                         f"[{safe_context.event_type.value}] "
                         f"Agent={safe_context.agent_id} "
                         f"TraceID={safe_context.trace_id}"
+                    )
+
+            # STEP 3: Values, only on deliberate opt-in, only at DEBUG,
+            # only scrubbed.
+            if should_log_full_payload(self.log_full_payloads, logger):
+                scrubbed = render_scrubbed_payload(safe_context.data)
+                if self.format == "json":
+                    self.logger.debug("hook_event_payload", payload=scrubbed)
+                else:
+                    self.logger.debug(
+                        f"[{safe_context.event_type.value}] "
+                        f"Agent={safe_context.agent_id} "
+                        f"Payload={scrubbed}"
                     )
 
             return HookResult(success=True)

--- a/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_logging_hook_redaction_defeat.py
+++ b/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_logging_hook_redaction_defeat.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression suite: LoggingHook payload disclosure + redaction-opt-in defeat (#2070).
+
+Two defects, one file, both in `builtin/logging_hook.py`.
+
+DEFECT 1 — full agent payloads at INFO, unredacted, by default. `include_data`
+defaults True and `redact_sensitive` defaults False, and `agent_loop.py` feeds
+this hook the whole agent I/O (`PRE_AGENT_LOOP` carries `{"inputs": ...}`,
+`POST_AGENT_LOOP` carries `{"result": ...}`). Registering the hook therefore
+put user prompts, retrieved documents and any credential-bearing parameter on
+the INFO log. Same disclosure class as #2030, at a second surface.
+
+DEFECT 2 — an explicitly-requested security control degraded to OFF. On
+`ImportError` the constructor set `redact_sensitive = False` and continued
+logging at full fidelity behind a WARNING. An operator who deliberately turned
+redaction ON had it turned off for them. `zero-tolerance.md` Rule 3 +
+`security.md` § Secure-Default.
+
+WHY THE EXISTING SUITE DID NOT CATCH EITHER. `test_builtin_hooks.py` and
+`test_structured_logging.py` construct `LoggingHook` a dozen times and assert
+only `result.success is True` / `result.error is None`. Not one asserts on log
+CONTENT — including `test_text_format_unchanged`, whose docstring says
+"produces same output as before" while asserting nothing about output. Those
+tests pass identically whether the payload is logged, redacted, or omitted, so
+they carry no information about the property that was broken. Every assertion
+below is on rendered log content for that reason.
+
+ASYMMETRY PINNED BY TESTS 3 AND 4. An explicit opt-in that cannot be honoured
+must RAISE (test 3). A default that cannot be honoured may degrade, but must
+then also stop emitting the payloads redaction was protecting (test 4) —
+degrading the control while continuing to log is the one outcome that must not
+survive.
+
+REACHABILITY, STATED BECAUSE IT BOUNDS THE CLAIM. `security/redaction.py`
+imports only stdlib, `kaizen.utils.credential_scrub`, and sibling modules, so
+its `ImportError` branch is not reachable through a normal install today.
+Defect 2 is a live fail-OPEN DISPOSITION on an unreachable path, not a live
+leak. Tests 3 and 4 therefore force a genuine `ImportError` through
+`sys.modules` rather than asserting about the branch from a reading of it — the
+import machinery really raises, and the constructor really takes the branch.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+import pytest
+
+from kaizen.core.autonomy.hooks.builtin.logging_hook import LoggingHook
+from kaizen.core.autonomy.hooks.types import HookContext, HookEvent
+
+REDACTION_MODULE = "kaizen.core.autonomy.hooks.security.redaction"
+LOGGER_NAME = "kaizen.core.autonomy.hooks.builtin.logging_hook"
+
+#: Credential-SHAPED so the redactor can recognise it. A value that no scrubber
+#: claims to match would make a passing test unfalsifiable about redaction.
+CREDENTIAL = "sk-live-LOGGINGHOOK2070SECRETVALUE"
+
+#: Prose the user typed. NOT credential-shaped and NOT PII-shaped, so no
+#: scrubber will remove it — it is here to prove the INFO line withholds VALUES
+#: as such, not merely values a scrubber happens to recognise.
+PROMPT = "summarize the acquisition memo for board review"
+
+
+def _context() -> HookContext:
+    """A PRE_AGENT_LOOP context shaped exactly as `agent_loop.py` builds it."""
+    return HookContext(
+        event_type=HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-2070",
+        timestamp=time.time(),
+        data={"inputs": {"prompt": PROMPT, "api_key": CREDENTIAL}},
+        metadata={"iteration": 1},
+        trace_id="trace-2070",
+    )
+
+
+def _rendered(caplog: pytest.LogCaptureFixture) -> str:
+    """Every captured record rendered as the handler would emit it."""
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+class TestDefaultConstructionWithholdsValues:
+    """DEFECT 1 — default construction must not put payload VALUES on INFO."""
+
+    @pytest.mark.asyncio
+    async def test_credential_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        hook = LoggingHook()  # defaults only — the shape an operator gets free
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert CREDENTIAL not in _rendered(caplog), (
+            "A credential-shaped value in context.data reached the INFO log "
+            "under DEFAULT construction. agent_loop feeds this hook whole "
+            "agent inputs, so this is #2030's disclosure at a second surface."
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_prompt_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Not scrubber-recognisable, so only withholding VALUES can pass this.
+
+        Distinct from the credential assertion above: flipping
+        `redact_sensitive` to True would satisfy that one while leaving every
+        user prompt and retrieved document on the INFO log. This is the
+        assertion that forces structure-only logging.
+        """
+        hook = LoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert PROMPT not in _rendered(caplog), (
+            "The user's prompt text reached the INFO log under default "
+            "construction. Redaction does not cover prose; only declining to "
+            "log values does."
+        )
+
+    @pytest.mark.asyncio
+    async def test_structure_is_preserved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE CONTROL — blanket-masking must not be able to pass.
+
+        Without this, deleting the log call entirely, or masking the whole
+        line, would satisfy every assertion above. The hook has to stay useful:
+        the event, the agent, the trace and the payload's SHAPE all survive.
+        """
+        hook = LoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Hook emitted nothing at all; that is not a fix."
+        for token in ("pre_agent_loop", "agent-2070", "trace-2070", "inputs"):
+            assert token in rendered, (
+                f"{token!r} missing from the INFO line. Structure — event, "
+                f"agent, trace, and payload KEY names — must survive; only "
+                f"values are withheld."
+            )
+
+
+class TestExplicitRedactionOptInFailsClosed:
+    """DEFECT 2 — an explicit opt-in that cannot be honoured must RAISE."""
+
+    def test_raises_when_redactor_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A genuine ImportError from the real import machinery, not a stand-in
+        # for one: `None` in sys.modules makes the `from ... import ...` inside
+        # the constructor raise for real, so the branch is really executed.
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        with pytest.raises(RuntimeError, match="redact_sensitive"):
+            LoggingHook(redact_sensitive=True)
+
+    def test_error_names_the_protection_and_the_remedy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            LoggingHook(redact_sensitive=True)
+
+        message = str(excinfo.value)
+        assert "redaction" in message.lower(), "Error must name the OFF protection."
+        assert "SensitiveDataRedactor" in message, "Error must name what failed."
+
+
+class TestUnrequestedRedactionDegradesWithoutDisclosing:
+    """DEFECT 2, other polarity — a DEFAULT may degrade, but must stop logging.
+
+    The asymmetry is the whole point. Raising on a default nobody asked for
+    would break installs where redaction is genuinely unavailable; continuing
+    to log payloads after the control failed is the disclosure the control
+    existed to prevent. Degrade, and stop emitting.
+    """
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_and_still_withholds_values(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setitem(sys.modules, REDACTION_MODULE, None)
+
+        hook = LoggingHook()  # redaction NOT explicitly requested
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert CREDENTIAL not in rendered, (
+            "Redaction degraded to OFF and the hook kept logging payloads. "
+            "A degraded control must also stop emitting what it protected."
+        )
+        assert PROMPT not in rendered
+
+
+class TestRedactionAppliedWhenAvailable:
+    """Positive polarity — with the redactor present, it is actually used."""
+
+    @pytest.mark.asyncio
+    async def test_credential_redacted_in_full_payload_mode(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Opt in to everything: explicit redaction AND explicit full payloads.
+
+        This is the configuration that emits values at all. It pins that the
+        opt-in path is wired to a redactor that really runs — without it, the
+        suite above would be satisfied by a hook that can only ever stay quiet.
+        """
+        hook = LoggingHook(redact_sensitive=True, log_full_payloads=True)
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Full-payload mode emitted nothing."
+        assert CREDENTIAL not in rendered, (
+            "Explicit redaction was requested and the redactor was available, "
+            "yet the credential survived into the log."
+        )

--- a/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_secure_logging_hook_payload_disclosure.py
+++ b/packages/kailash-kaizen/tests/unit/core/autonomy/hooks/test_secure_logging_hook_payload_disclosure.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression suite: SecureLoggingHook leaks payload PROSE at INFO (#2070 sibling).
+
+`SecureLoggingHook` (`hooks/security/redaction.py`) is a near-verbatim copy of
+the pre-fix `LoggingHook` body — `Data={safe_context.data}` on the text path,
+`log_event["context"] = safe_context.data` on the JSON path. It is public API
+(exported from `hooks.security`).
+
+SCOPE, stated precisely because it is narrower than the sibling defect. This
+class DOES redact: `redact_sensitive` defaults True and the redactor is
+constructed unconditionally, so credential shapes and PII patterns are removed.
+What survives is everything the redactor does not claim — the user's prompt,
+retrieved document text, free-form tool output. A class named
+`SecureLoggingHook` publishing those at INFO is the same disclosure #2030
+describes, reduced but not absent.
+
+That is why the credential assertion below is a NEGATIVE control rather than
+the finding: the credential is expected to be gone already, and a suite that
+only checked credentials would report this class clean. The load-bearing
+assertion is the PROSE one.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from kaizen.core.autonomy.hooks.security.redaction import SecureLoggingHook
+from kaizen.core.autonomy.hooks.types import HookContext, HookEvent
+
+LOGGER_NAME = "kaizen.core.autonomy.hooks.security.redaction"
+
+#: Credential-shaped: the redactor already claims this class today.
+CREDENTIAL = "sk-live-SECUREHOOK2070SECRETVALUE"
+
+#: Prose: matches no credential or PII pattern, so no redactor removes it.
+#: This is the value the defect is actually about.
+PROMPT = "draft the termination letter for the Henderson account"
+
+
+def _context() -> HookContext:
+    return HookContext(
+        event_type=HookEvent.PRE_AGENT_LOOP,
+        agent_id="agent-secure-2070",
+        timestamp=time.time(),
+        data={"inputs": {"prompt": PROMPT, "api_key": CREDENTIAL}},
+        metadata={"iteration": 1},
+        trace_id="trace-secure-2070",
+    )
+
+
+def _rendered(caplog: pytest.LogCaptureFixture) -> str:
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+class TestSecureLoggingHookWithholdsValues:
+    @pytest.mark.asyncio
+    async def test_user_prose_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """THE FINDING. Redaction does not cover prose; only structure-only does."""
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert PROMPT not in _rendered(caplog), (
+            "SecureLoggingHook published the user's prompt text at INFO. The "
+            "redactor claims credential shapes and PII patterns, neither of "
+            "which matches prose, so redaction cannot close this — only "
+            "declining to log values can."
+        )
+
+    @pytest.mark.asyncio
+    async def test_credential_absent_from_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE control — expected to pass BEFORE the fix as well.
+
+        If this ever reddens, the redactor itself regressed, which is a
+        different defect from the one this suite is about.
+        """
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        assert CREDENTIAL not in _rendered(caplog)
+
+    @pytest.mark.asyncio
+    async def test_structure_is_preserved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """NEGATIVE control — deleting or blanket-masking the line cannot pass."""
+        hook = SecureLoggingHook()
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Hook emitted nothing at all; that is not a fix."
+        for token in (
+            "pre_agent_loop",
+            "agent-secure-2070",
+            "trace-secure-2070",
+            "inputs",
+        ):
+            assert token in rendered, (
+                f"{token!r} missing. Structure — event, agent, trace and "
+                f"payload KEY names — must survive; only values are withheld."
+            )
+
+    @pytest.mark.asyncio
+    async def test_full_payload_mode_is_opt_in_and_scrubbed(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Positive polarity — values are reachable deliberately, and scrubbed.
+
+        Without this the suite would be satisfied by a hook that can only ever
+        stay quiet, which would be a regression in usefulness rather than a fix.
+        """
+        hook = SecureLoggingHook(log_full_payloads=True)
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await hook.handle(_context())
+
+        rendered = _rendered(caplog)
+        assert rendered.strip(), "Full-payload mode emitted nothing."
+        assert (
+            CREDENTIAL not in rendered
+        ), "Deliberate full-payload mode must still scrub credentials."


### PR DESCRIPTION
Split from #2073 at the co-owner's direction: **these two commits are non-breaking and fix a live disclosure defect**, so they land now. The observability-flag work in #2073 carries a BREAKING change across two public constructors and is held pending a check on whether the existing `ObservabilityManager` can be wired instead of raising.

Cherry-picked clean onto current main: `8b6472aca` → `8b32a033d`, `08ce48eb3` → `68db7392c`. **No `smart_defaults.py`, no `agent.py`** — verified by file list.

## What was wrong

**`LoggingHook`** put full agent payloads on INFO, and — worse — an operator who **explicitly enabled redaction** had it silently switched off on `ImportError`, with payload logging continuing. That defeats the operator's own security choice at runtime, which is materially worse than a bad default.

**`SecureLoggingHook`** carried a reduced form of the same defect. It *does* redact, so credentials and PII were covered — but **prose values still reached the log at INFO**. A class named for security, publishing user prompts.

## Fix

INFO logs structure only (event, agent, trace, payload **key names** + count). Values move behind two independent gates — an explicit `log_full_payloads` opt-in AND the logger actually at DEBUG — routed through `scrub_credentials`, truncated before scrubbing. An explicit redaction request that cannot be honoured now **raises**; an unrequested default may degrade but then also forces `log_full_payloads=False`.

Both hooks share `hooks/_payload.py` rather than each carrying a copy, and `should_log_full_payload` puts both gates behind one call — so neither caller can implement only the opt-in or only the DEBUG check, which is the divergence that created the bug.

## Fail-first, verified on THIS branch

```
RED  (main's hook sources restored):  8 failed, 3 passed
  SecureLoggingHook published the user's prompt text at INFO
  LoggingHook.__init__() got an unexpected keyword argument 'log_full_payloads'
GREEN (branch):                      11 passed
```

Full hooks suite on this branch: **130 passed**, confirming the split stands alone without the observability commits.

## The test that matters most

`test_user_prose_absent_from_info` asserts on **prose**, which no scrubber recognises — so flipping `redact_sensitive=True` alone cannot satisfy it. That forces structure-only logging rather than the weaker credential-only fix the issue's own acceptance criteria would have accepted.

The credential-absence test is a **declared negative control** that passes before and after: a suite checking only credentials would have called `SecureLoggingHook` clean. Labelled as a control rather than presented as a detector.

## Related issues

Fixes #2070