### PR TITLE
fix(ci): stop PythonCodeNode capping the host process's address space (#2078)

### DIFF
--- a/src/kailash/edge/migration/edge_migrator.py
+++ b/src/kailash/edge/migration/edge_migrator.py
@@ -744,13 +744,20 @@ class EdgeMigrator:
                         )
                         # Fallback: 100 MB estimate per workload
                         total_size += 100 * 1024 * 1024
-        # asyncio.TimeoutError is listed alongside aiohttp.ClientError at every
-        # unreachable-edge handler in this module. aiohttp raises it (not a
-        # ClientError) when a request exceeds its timeout, so a slow or
-        # black-holed edge was the ONE unreachable mode that escaped the
-        # documented fallback and propagated out of plan_migration. Surfaced by
-        # #2078: the two tests that hit it had been failing on CI for a
-        # different reason and could not be seen until that was fixed.
+        # aiohttp raises asyncio.TimeoutError -- NOT an aiohttp.ClientError --
+        # when a request exceeds its timeout, so a slow or black-holed edge was
+        # an unreachable mode this READ-ONLY probe's documented fallback did not
+        # cover: it propagated out of plan_migration instead. Surfaced by #2078:
+        # the two tests that hit it had been failing on CI for a different
+        # reason and could not be seen until that was fixed.
+        #
+        # asyncio.TimeoutError is added ONLY at the read-only probe handlers
+        # (size estimation, capacity, verification, functionality, cleanup),
+        # where warn-and-fall-back is the documented contract. The mutating
+        # cutover-critical handlers -- _drain_source_edge, _perform_delta_sync,
+        # _switch_traffic -- deliberately let it escape, because an alive-but-
+        # unresponsive source must abort the migration rather than have cutover
+        # switch traffic away from an edge that was never drained. See #2078.
         except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not reach edge %s for size estimation: %s", edge, exc)
             total_size = len(workloads) * 100 * 1024 * 1024
@@ -1004,8 +1011,16 @@ class EdgeMigrator:
                         logger.warning(
                             "Delta sync for %s returned HTTP %d", workload, resp.status
                         )
-        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            logger.warning("Delta sync failed: %s", exc)
+        except (ValueError, aiohttp.ClientError) as exc:
+            # Cutover-critical: NOT swallowed. On MigrationStrategy.LIVE this is
+            # the only pass that captures writes made during transfer, so
+            # continuing past a failure would have cutover discard them.
+            # asyncio.TimeoutError is deliberately absent from this tuple and
+            # escapes for the same reason -- an alive-but-unresponsive source
+            # must fail the migration, which execute_migration turns into
+            # phase=FAILED plus a rollback.
+            logger.error("Delta sync failed: %s", exc)
+            raise
 
     async def _drain_source_edge(self, edge: str, workloads: List[str]):
         """Drain the source edge by telling it to stop accepting new requests.
@@ -1032,8 +1047,14 @@ class EdgeMigrator:
                         )
                     else:
                         logger.info("Drained workload %s on edge %s", workload, edge)
-        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            logger.warning("Could not drain source edge %s: %s", edge, exc)
+        except (ValueError, aiohttp.ClientError) as exc:
+            # Cutover-critical: NOT swallowed. _execute_cutover calls this and
+            # then switches traffic unconditionally, so a swallowed failure here
+            # routes traffic away from a source that was never drained and drops
+            # its in-flight requests. asyncio.TimeoutError is deliberately absent
+            # from this tuple and escapes for the same reason.
+            logger.error("Could not drain source edge %s: %s", edge, exc)
+            raise
 
     async def _perform_final_sync(
         self, plan: MigrationPlan, progress: MigrationProgress
@@ -1089,8 +1110,14 @@ class EdgeMigrator:
                             target,
                             len(workloads),
                         )
-            except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            except (ValueError, aiohttp.ClientError) as exc:
+                # Cutover-critical: NOT swallowed. A swallowed failure here
+                # leaves routing half-switched -- one of source/target updated,
+                # the other not -- which silently blackholes or double-serves
+                # the workload. asyncio.TimeoutError is deliberately absent from
+                # this tuple and escapes for the same reason.
                 logger.error("Traffic switch failed on %s: %s", edge, exc)
+                raise
 
     async def _start_workload(self, edge: str, workload: str):
         """Start a workload on the target edge node.

--- a/src/kailash/edge/migration/edge_migrator.py
+++ b/src/kailash/edge/migration/edge_migrator.py
@@ -744,7 +744,14 @@ class EdgeMigrator:
                         )
                         # Fallback: 100 MB estimate per workload
                         total_size += 100 * 1024 * 1024
-        except (ValueError, aiohttp.ClientError) as exc:
+        # asyncio.TimeoutError is listed alongside aiohttp.ClientError at every
+        # unreachable-edge handler in this module. aiohttp raises it (not a
+        # ClientError) when a request exceeds its timeout, so a slow or
+        # black-holed edge was the ONE unreachable mode that escaped the
+        # documented fallback and propagated out of plan_migration. Surfaced by
+        # #2078: the two tests that hit it had been failing on CI for a
+        # different reason and could not be seen until that was fixed.
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not reach edge %s for size estimation: %s", edge, exc)
             total_size = len(workloads) * 100 * 1024 * 1024
         return total_size
@@ -801,7 +808,7 @@ class EdgeMigrator:
                     "Capacity check for %s returned HTTP %d", edge, resp.status
                 )
                 return 0.0
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not check capacity for %s: %s", edge, exc)
             return 0.0
 
@@ -857,7 +864,7 @@ class EdgeMigrator:
                         edge,
                         len(workloads),
                     )
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not prepare environment on %s: %s", edge, exc)
 
     async def _get_workload_data(self, edge: str, workload: str) -> List[bytes]:
@@ -903,7 +910,7 @@ class EdgeMigrator:
 
                 return batches if batches else [raw_data]
 
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not get workload data from %s: %s", edge, exc)
             return []
 
@@ -954,7 +961,7 @@ class EdgeMigrator:
                     raise RuntimeError(
                         f"Batch transfer to {target} failed: HTTP {resp.status} - {body}"
                     )
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.error("Batch transfer from %s to %s failed: %s", source, target, exc)
             raise
 
@@ -997,7 +1004,7 @@ class EdgeMigrator:
                         logger.warning(
                             "Delta sync for %s returned HTTP %d", workload, resp.status
                         )
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Delta sync failed: %s", exc)
 
     async def _drain_source_edge(self, edge: str, workloads: List[str]):
@@ -1025,7 +1032,7 @@ class EdgeMigrator:
                         )
                     else:
                         logger.info("Drained workload %s on edge %s", workload, edge)
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning("Could not drain source edge %s: %s", edge, exc)
 
     async def _perform_final_sync(
@@ -1082,7 +1089,7 @@ class EdgeMigrator:
                             target,
                             len(workloads),
                         )
-            except (ValueError, aiohttp.ClientError) as exc:
+            except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 logger.error("Traffic switch failed on %s: %s", edge, exc)
 
     async def _start_workload(self, edge: str, workload: str):
@@ -1104,7 +1111,7 @@ class EdgeMigrator:
                         f"HTTP {resp.status} - {body}"
                     )
                 logger.info("Started workload %s on edge %s", workload, edge)
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.error("Could not start workload %s on %s: %s", workload, edge, exc)
             raise
 
@@ -1135,7 +1142,7 @@ class EdgeMigrator:
                     resp.status,
                 )
                 return False
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.error("Could not verify workload %s on %s: %s", workload, edge, exc)
             return False
 
@@ -1189,7 +1196,7 @@ class EdgeMigrator:
                 return match
 
             return False
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.error("Data integrity check failed for %s: %s", workload, exc)
             return False
 
@@ -1212,7 +1219,7 @@ class EdgeMigrator:
                     body = await resp.json()
                     return body.get("healthy", False)
                 return False
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.error(
                 "Functionality test failed for %s on %s: %s", workload, edge, exc
             )
@@ -1241,7 +1248,7 @@ class EdgeMigrator:
                     )
                 else:
                     logger.info("Cleaned up workload %s from edge %s", workload, edge)
-        except (ValueError, aiohttp.ClientError) as exc:
+        except (ValueError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
             logger.warning(
                 "Could not clean up workload %s on %s: %s", workload, edge, exc
             )

--- a/src/kailash/nodes/code/async_python.py
+++ b/src/kailash/nodes/code/async_python.py
@@ -94,7 +94,7 @@ from kailash.sdk_exceptions import (
     NodeExecutionError,
     SafetyViolationError,
 )
-from kailash.security import ExecutionTimeoutError
+from kailash.security import ExecutionTimeoutError, MemoryLimitError, memory_limit_guard
 
 logger = logging.getLogger(__name__)
 
@@ -842,9 +842,20 @@ async def {func_name}(_namespace):
             try:
                 # Execute with timeout
                 start_time = time.time()
-                exported_vars = await asyncio.wait_for(
-                    user_function(namespace), timeout=self.timeout
-                )
+                # `max_memory_mb` is documented on this node (see the class
+                # docstring and the config schema) but until #2078 it was
+                # assigned in __init__ and read by nothing — the cap had no
+                # effect whatsoever, while this node execs caller-supplied
+                # code. Same documented-kwarg-with-no-effect class as the bug
+                # #2078 fixed in PythonCodeNode, so it is closed here rather
+                # than deferred. Scope of the guarantee is the same and is
+                # documented on `memory_limit_guard`: it bounds this block's
+                # ADDITIONAL address space, and is not a sandbox for untrusted
+                # code.
+                with memory_limit_guard(self.max_memory_mb * 1024 * 1024):
+                    exported_vars = await asyncio.wait_for(
+                        user_function(namespace), timeout=self.timeout
+                    )
                 execution_time = time.time() - start_time
 
                 logger.debug(
@@ -868,6 +879,12 @@ async def {func_name}(_namespace):
             raise NodeExecutionError(
                 f"Async code execution exceeded {self.timeout}s timeout"
             )
+        except MemoryLimitError:
+            # Surfaced as itself, not flattened into NodeExecutionError: a
+            # caller that set `max_memory_mb` needs to distinguish "the cap I
+            # configured fired" from "the code failed", and PythonCodeNode
+            # already re-raises it for the same reason.
+            raise
         except Exception as e:
             logger.error(f"Async code execution failed: {e}")
             logger.debug(f"Traceback: {traceback.format_exc()}")

--- a/src/kailash/nodes/code/python.py
+++ b/src/kailash/nodes/code/python.py
@@ -468,14 +468,26 @@ class CodeExecutor:
             #   resource.setrlimit(RLIMIT_AS, (memory_limit, memory_limit))
             # directly here, which set an ABSOLUTE, PROCESS-WIDE, IRREVERSIBLE
             # cap of 512 MB (both soft AND hard) the first time any workflow ran
-            # a PythonCodeNode. An interpreter with the SDK imported already
-            # occupies ~635 MB of address space, so the process capped itself
-            # BELOW its own footprint and every later mmap failed — including
-            # the stack allocation for a new thread. That is where CI's 130
+            # a PythonCodeNode.
+            #
+            # RLIMIT_AS caps VIRTUAL address space, which on Linux runs far
+            # above resident memory: glibc reserves a 64 MB malloc arena per
+            # thread and every pthread stack reserves 8 MB. Measured in a
+            # python:3.12-slim container, a 25-thread process sat at 1889 MB of
+            # address space while importing the SDK alone cost only 62 MB. One
+            # PythonCodeNode execution then capped that 1889 MB process at
+            # 512 MB, and every subsequent mmap failed — including the stack
+            # allocation pthread_create needs. That is where CI's 130
             # `RuntimeError: can't start new thread` and 90 `sqlite3.
-            # OperationalError: disk I/O error` came from. macOS never showed it
-            # because its kernel rejects the call, so the except-branch ran and
-            # the limit was silently never applied.
+            # OperationalError: disk I/O error` came from, in tests with no
+            # connection to this node. Because Tier 2 runs `-p no:xdist`, a
+            # single execution poisoned the rest of the run, which is why the
+            # failure counts were identical to the test across runs.
+            #
+            # macOS never showed it: that kernel rejects setrlimit(RLIMIT_AS)
+            # with `ValueError: current limit exceeds maximum limit`, so the
+            # old except-branch ran and the limit was silently never applied.
+            # A macOS run is therefore not a discriminating instrument here.
             with memory_limit_guard(config=self.security_config):
                 with execution_timeout(
                     self.security_config.execution_timeout, self.security_config

--- a/src/kailash/nodes/code/python.py
+++ b/src/kailash/nodes/code/python.py
@@ -52,11 +52,6 @@ import inspect
 import json
 import logging
 import os
-
-try:
-    import resource  # Unix-only module
-except ImportError:
-    resource = None  # type: ignore[assignment]  # Not available on Windows
 import traceback
 from collections.abc import Callable
 from datetime import date, datetime
@@ -76,6 +71,7 @@ from kailash.security import (
     SecurityConfig,
     execution_timeout,
     get_security_config,
+    memory_limit_guard,
     validate_node_parameters,
 )
 
@@ -462,37 +458,31 @@ class CodeExecutor:
         # They are added to local_namespace below to prevent variable persistence
 
         try:
-            # Set memory limit if supported (Unix systems)
-            if (
-                resource is not None
-                and hasattr(resource, "RLIMIT_AS")
-                and self.security_config.memory_limit
-            ):
-                try:
-                    resource.setrlimit(
-                        resource.RLIMIT_AS,
-                        (
-                            self.security_config.memory_limit,
-                            self.security_config.memory_limit,
-                        ),
-                    )
-                except (OSError, ValueError):
-                    logger.warning(
-                        "Could not set memory limit - continuing without limit"
-                    )
-
             # Execute with timeout using separate global and local namespaces
             # This prevents variable persistence across executions (CRITICAL FIX)
             # See: SDK Bug Report - PythonCodeNode Variable Persistence
             local_namespace = {}
             local_namespace.update(sanitized_inputs)
 
-            with execution_timeout(
-                self.security_config.execution_timeout, self.security_config
-            ):
-                # Use separate globals (namespace) and locals (local_namespace)
-                # This ensures complete variable isolation between executions
-                exec(code, namespace, local_namespace)
+            # Memory limit (issue #2078). This used to call
+            #   resource.setrlimit(RLIMIT_AS, (memory_limit, memory_limit))
+            # directly here, which set an ABSOLUTE, PROCESS-WIDE, IRREVERSIBLE
+            # cap of 512 MB (both soft AND hard) the first time any workflow ran
+            # a PythonCodeNode. An interpreter with the SDK imported already
+            # occupies ~635 MB of address space, so the process capped itself
+            # BELOW its own footprint and every later mmap failed — including
+            # the stack allocation for a new thread. That is where CI's 130
+            # `RuntimeError: can't start new thread` and 90 `sqlite3.
+            # OperationalError: disk I/O error` came from. macOS never showed it
+            # because its kernel rejects the call, so the except-branch ran and
+            # the limit was silently never applied.
+            with memory_limit_guard(config=self.security_config):
+                with execution_timeout(
+                    self.security_config.execution_timeout, self.security_config
+                ):
+                    # Use separate globals (namespace) and locals (local_namespace)
+                    # This ensures complete variable isolation between executions
+                    exec(code, namespace, local_namespace)
 
             # Return all non-private variables from LOCAL namespace only
             # Variables from previous executions cannot leak through

--- a/src/kailash/security.py
+++ b/src/kailash/security.py
@@ -746,21 +746,42 @@ def execution_timeout(
 #     SOFT limit is ever touched so the change stays reversible (lowering the
 #     HARD limit is a one-way door for an unprivileged process).
 #
-# Concurrent guarded blocks are reference-counted: the first entrant applies
-# the ceiling, the last one out restores. The lock is held only for that
-# bookkeeping, never across the guarded block, so parallel node execution is
-# not serialized.
+# Concurrent guarded blocks keep a list of every requested ceiling and the
+# TIGHTEST one is what is applied. First-writer-wins would let a concurrent
+# block with a loose limit host a payload that was configured with a strict
+# one — a silent sandbox bypass, since nodes in a parallel group may each carry
+# their own SecurityConfig. The lock is held only for that bookkeeping, never
+# across the guarded block, so parallel node execution is not serialized.
+#
+# SCOPE OF THE GUARANTEE — read before treating this as a sandbox:
+#   * It bounds ONE block's ADDITIONAL address space. It does NOT bound the
+#     total footprint of a run: values a payload leaves alive (node outputs,
+#     workflow context) raise `current`, so the next block's ceiling is
+#     computed from a larger base. N sequential nodes can therefore retain
+#     N x limit in aggregate.
+#   * It is process-wide while in force, so a payload that consumes its whole
+#     headroom starves unrelated threads in the same process for the duration.
+#   * `execution_timeout` measures elapsed time AFTER the block returns; it does
+#     not interrupt, so a spinning payload holds that state until it finishes.
+# In-process execution of genuinely untrusted code is NOT made safe by this
+# control. Run it in a subprocess with its own absolute rlimits — which is
+# exactly what kaizen's IsolatedHookExecutor does, and why an absolute,
+# irreversible cap is correct THERE and wrong here.
 _ADDRESS_SPACE_LOCK = threading.Lock()
-_address_space_depth = 0
+# Ceilings requested by currently-active guards. The tightest is applied.
+_address_space_requests: list[int] = []
+# The (soft, hard) pair in force before the first active guard touched it.
 _address_space_saved: tuple[int, int] | None = None
+# The ceiling currently applied to the process, or None if we applied nothing.
+_address_space_applied: int | None = None
 _address_space_unsupported_logged = False
 
 
 def _log_address_space_unsupported(reason: str) -> None:
     """Log once that the address-space limit could not be applied.
 
-    Once, not per execution: on macOS every call fails identically, and a
-    per-execution warning would bury the log without adding information.
+    Once, not per execution: where it fails it fails identically every time,
+    and a per-execution warning would bury the log without adding information.
     """
     global _address_space_unsupported_logged
     if _address_space_unsupported_logged:
@@ -778,8 +799,20 @@ def _current_address_space_bytes() -> int | None:
     """Return this process's current virtual address-space size, or None.
 
     Reads ``/proc/self/statm`` (field 0, total program size in pages). Returns
-    None where /proc is absent, which is the signal that the ceiling cannot be
-    computed and the limit must not be applied.
+    None where /proc is absent or unreadable, which is the signal that the
+    ceiling cannot be computed and the limit must not be applied.
+
+    There is deliberately no fallback. Every portable alternative reports
+    RESIDENT memory (``getrusage`` gives ``ru_maxrss``), and RLIMIT_AS caps
+    ADDRESS SPACE, which on Linux runs several times larger. Sizing an
+    address-space ceiling from a resident-memory reading would put the cap
+    below the process's own footprint — issue #2078 exactly. Enforcing nothing
+    and saying so is the safe branch.
+
+    Consequence, and it is a real reduction in coverage: POSIX hosts that
+    enforce RLIMIT_AS but have no /proc (the BSDs, a Linux container with /proc
+    unmounted or hidepid-restricted) get no enforcement, where the pre-#2078
+    code did enforce. They get the one-time warning instead.
     """
     try:
         with open("/proc/self/statm", "rb") as handle:
@@ -787,6 +820,101 @@ def _current_address_space_bytes() -> int | None:
     except (OSError, ValueError, IndexError):
         return None
     return pages * os.sysconf("SC_PAGE_SIZE")
+
+
+def _enter_address_space_guard(limit: int) -> int | None:
+    """Register a ceiling and apply it if it is the tightest. Caller holds lock.
+
+    Returns the registered ceiling (to be passed back to the exit helper), or
+    None when nothing was registered and no ceiling is in force for this guard.
+    """
+    global _address_space_saved, _address_space_applied
+
+    current = _current_address_space_bytes()
+    if current is None:
+        _log_address_space_unsupported("address-space usage is not readable")
+        return None
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    ceiling = current + limit
+    if hard != resource.RLIM_INFINITY:
+        ceiling = min(ceiling, hard)
+
+    # Compare against the limit that was in force BEFORE we touched anything;
+    # once we have applied a ceiling, `soft` is our own value, not the
+    # environment's.
+    baseline_soft = _address_space_saved[0] if _address_space_saved else soft
+    if baseline_soft != resource.RLIM_INFINITY and baseline_soft <= ceiling:
+        # The environment is already at least as tight as we would ask for.
+        return None
+
+    _address_space_requests.append(ceiling)
+    target = min(_address_space_requests)
+    if target != _address_space_applied:
+        try:
+            resource.setrlimit(resource.RLIMIT_AS, (target, hard))
+        except Exception as exc:  # noqa: BLE001 - see below
+            # Deliberately broad. A narrow (OSError, ValueError) lets
+            # OverflowError through from an over-large configured limit, and an
+            # exception escaping here would leave this guard registered and
+            # every later guard believing a ceiling is in force — the sandbox
+            # would be silently off for the life of the process.
+            _address_space_requests.pop()
+            _log_address_space_unsupported(f"setrlimit(RLIMIT_AS) rejected: {exc}")
+            return None
+        if _address_space_saved is None:
+            _address_space_saved = (soft, hard)
+        _address_space_applied = target
+    return ceiling
+
+
+def _exit_address_space_guard(ceiling: int) -> None:
+    """Deregister a ceiling, restoring or loosening as needed. Caller holds lock."""
+    global _address_space_saved, _address_space_applied
+
+    try:
+        _address_space_requests.remove(ceiling)
+    except ValueError:  # pragma: no cover - defensive; entry returned it
+        return
+
+    if _address_space_requests:
+        target = min(_address_space_requests)
+        if target != _address_space_applied and _address_space_saved is not None:
+            try:
+                resource.setrlimit(
+                    resource.RLIMIT_AS, (target, _address_space_saved[1])
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Could not loosen RLIMIT_AS to %s after a guarded block "
+                    "exited; the process stays at %s: %s",
+                    target,
+                    _address_space_applied,
+                    exc,
+                )
+            else:
+                _address_space_applied = target
+        return
+
+    if _address_space_saved is None:
+        return
+
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, _address_space_saved)
+    except Exception as exc:  # noqa: BLE001
+        # NOT cleared on failure. Clearing first would throw away the only
+        # record of the pre-guard value, leaving the process capped forever
+        # with nothing able to restore it — the #2078 failure mode, minus any
+        # path to recovery. Keeping it lets the next guard's exit retry.
+        logger.error(
+            "Could not restore RLIMIT_AS to %s after guarded execution; this "
+            "process's address space stays capped: %s",
+            _address_space_saved,
+            exc,
+        )
+    else:
+        _address_space_saved = None
+        _address_space_applied = None
 
 
 @contextmanager
@@ -797,12 +925,22 @@ def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None =
     Applies ``limit`` bytes of headroom above the process's CURRENT
     address-space usage for the duration of the block, then restores the
     previous soft limit. A ``MemoryError`` raised inside the block is
-    translated to :class:`MemoryLimitError`.
+    translated to :class:`MemoryLimitError` — but only when this guard actually
+    put a ceiling in force, so genuine host exhaustion is never misattributed.
 
-    Where the platform does not enforce ``RLIMIT_AS`` (notably macOS, whose
-    kernel rejects the call) the block runs unguarded and a single warning is
-    logged. That is a real gap, not a silent one: the limit is advertised as
-    unenforced rather than pretended.
+    Concurrent guards apply the TIGHTEST requested ceiling, not the first one
+    requested, so a block configured with a strict limit is never hosted under
+    a laxer concurrent one.
+
+    Where the platform cannot support the ceiling — no readable ``/proc``
+    (macOS, the BSDs), or a kernel that refuses ``setrlimit(RLIMIT_AS)`` — the
+    block runs unguarded and a single warning is logged. That is a real gap,
+    not a silent one: the limit is advertised as unenforced rather than
+    pretended.
+
+    This bounds ONE block's additional address space. It is not a sandbox for
+    untrusted code, and it does not bound a run's total footprint; see the
+    module comment above this function for the full scope of the guarantee.
 
     Args:
         limit: Additional address space the block may use, in bytes
@@ -816,8 +954,6 @@ def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None =
         >>> with memory_limit_guard(64 * 1024 * 1024):
         ...     data = [0] * 1000
     """
-    global _address_space_depth, _address_space_saved
-
     if config is None:
         config = get_security_config()
 
@@ -826,74 +962,29 @@ def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None =
 
     applicable = bool(limit) and resource is not None and hasattr(resource, "RLIMIT_AS")
 
+    # Per-guard, never a module global: whether THIS guard put a ceiling in
+    # force is what licenses relabelling a MemoryError as MemoryLimitError.
+    registered: int | None = None
     if applicable:
         with _ADDRESS_SPACE_LOCK:
-            entering_outermost = _address_space_depth == 0
-            _address_space_depth += 1
-            if entering_outermost:
-                _apply_address_space_ceiling(limit)
+            registered = _enter_address_space_guard(limit)
 
     try:
         yield
     except MemoryError as exc:
-        # Only claim the LIMIT was hit if a ceiling is actually in force.
-        # Where setrlimit was rejected (macOS) or the ceiling could not be
-        # computed, nothing is enforced, so a MemoryError is genuine host
-        # exhaustion — relabelling it as this guard's doing would misattribute
-        # the cause and send the reader looking at the wrong knob.
-        with _ADDRESS_SPACE_LOCK:
-            enforced = _address_space_saved is not None
-        if not enforced:
+        if registered is None:
+            # Nothing was enforced, so this is genuine host exhaustion.
+            # Relabelling it would name a cause that is not connected to
+            # anything and send the reader to the wrong knob.
             raise
         raise MemoryLimitError(
             f"Memory limit exceeded: code execution requested more than "
             f"{limit} bytes of additional address space"
         ) from exc
     finally:
-        if applicable:
+        if registered is not None:
             with _ADDRESS_SPACE_LOCK:
-                _address_space_depth -= 1
-                if _address_space_depth == 0 and _address_space_saved is not None:
-                    saved, _address_space_saved = _address_space_saved, None
-                    try:
-                        resource.setrlimit(resource.RLIMIT_AS, saved)
-                    except (OSError, ValueError) as exc:
-                        # Failing to restore would leave the whole process
-                        # capped — the exact #2078 failure mode. Loud, never
-                        # swallowed.
-                        logger.error(
-                            "Could not restore RLIMIT_AS to %s after guarded "
-                            "execution; this process's address space stays "
-                            "capped: %s",
-                            saved,
-                            exc,
-                        )
-
-
-def _apply_address_space_ceiling(limit: int) -> None:
-    """Apply the soft RLIMIT_AS ceiling. Caller MUST hold the lock."""
-    global _address_space_saved
-
-    current = _current_address_space_bytes()
-    if current is None:
-        _log_address_space_unsupported("address-space usage is not readable")
-        return
-
-    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
-    ceiling = current + limit
-    if hard != resource.RLIM_INFINITY:
-        ceiling = min(ceiling, hard)
-    if soft != resource.RLIM_INFINITY and soft <= ceiling:
-        # An outer limit is already at least as tight; leave it alone.
-        return
-
-    try:
-        resource.setrlimit(resource.RLIMIT_AS, (ceiling, hard))
-    except (OSError, ValueError) as exc:
-        _log_address_space_unsupported(f"setrlimit(RLIMIT_AS) rejected: {exc}")
-        return
-
-    _address_space_saved = (soft, hard)
+                _exit_address_space_guard(registered)
 
 
 def sanitize_input(

--- a/src/kailash/security.py
+++ b/src/kailash/security.py
@@ -932,11 +932,11 @@ def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None =
     requested, so a block configured with a strict limit is never hosted under
     a laxer concurrent one.
 
-    Where the platform cannot support the ceiling — no readable ``/proc``
-    (macOS, the BSDs), or a kernel that refuses ``setrlimit(RLIMIT_AS)`` — the
-    block runs unguarded and a single warning is logged. That is a real gap,
-    not a silent one: the limit is advertised as unenforced rather than
-    pretended.
+    Where the platform cannot support the ceiling — no ``resource`` module or no
+    ``RLIMIT_AS`` (Windows), no readable ``/proc`` (macOS, the BSDs), or a kernel
+    that refuses ``setrlimit(RLIMIT_AS)`` — the block runs unguarded and a single
+    warning is logged, on all three paths. That is a real gap, not a silent one:
+    the limit is advertised as unenforced rather than pretended.
 
     This bounds ONE block's additional address space. It is not a sandbox for
     untrusted code, and it does not bound a run's total footprint; see the
@@ -960,7 +960,22 @@ def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None =
     if limit is None:
         limit = config.memory_limit
 
-    applicable = bool(limit) and resource is not None and hasattr(resource, "RLIMIT_AS")
+    has_rlimit = resource is not None and hasattr(resource, "RLIMIT_AS")
+    applicable = bool(limit) and has_rlimit
+
+    # Warn HERE, not only from inside _enter_address_space_guard. That function
+    # runs only when `applicable` is true, so on a platform with no RLIMIT_AS at
+    # all (Windows: `resource` does not exist) the guard would otherwise apply no
+    # ceiling AND emit no warning -- the silent failure this control exists to
+    # avoid. `bool(limit)` is excluded deliberately: an unset limit is disabled
+    # by configuration, not unenforceable by platform, and warning on it would
+    # train readers to ignore the message.
+    if limit and not has_rlimit:
+        _log_address_space_unsupported(
+            "the `resource` module is unavailable"
+            if resource is None
+            else "`resource.RLIMIT_AS` is not defined"
+        )
 
     # Per-guard, never a module global: whether THIS guard put a ceiling in
     # force is what licenses relabelling a MemoryError as MemoryLimitError.

--- a/src/kailash/security.py
+++ b/src/kailash/security.py
@@ -790,9 +790,7 @@ def _current_address_space_bytes() -> int | None:
 
 
 @contextmanager
-def memory_limit_guard(
-    limit: int | None = None, config: SecurityConfig | None = None
-):
+def memory_limit_guard(limit: int | None = None, config: SecurityConfig | None = None):
     """
     Context manager bounding how much address space the guarded block may add.
 

--- a/src/kailash/security.py
+++ b/src/kailash/security.py
@@ -838,6 +838,15 @@ def memory_limit_guard(
     try:
         yield
     except MemoryError as exc:
+        # Only claim the LIMIT was hit if a ceiling is actually in force.
+        # Where setrlimit was rejected (macOS) or the ceiling could not be
+        # computed, nothing is enforced, so a MemoryError is genuine host
+        # exhaustion — relabelling it as this guard's doing would misattribute
+        # the cause and send the reader looking at the wrong knob.
+        with _ADDRESS_SPACE_LOCK:
+            enforced = _address_space_saved is not None
+        if not enforced:
+            raise
         raise MemoryLimitError(
             f"Memory limit exceeded: code execution requested more than "
             f"{limit} bytes of additional address space"

--- a/src/kailash/security.py
+++ b/src/kailash/security.py
@@ -115,10 +115,16 @@ import logging
 import os
 import re
 import tempfile
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+try:
+    import resource  # Unix-only module
+except ImportError:  # pragma: no cover - Windows
+    resource = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -721,6 +727,166 @@ def execution_timeout(
             raise ExecutionTimeoutError(
                 f"Execution timeout: {elapsed_time:.2f}s > {timeout}s"
             )
+
+
+# --- Address-space (memory) limiting -----------------------------------------
+#
+# RLIMIT_AS is a PROCESS-WIDE limit. Lowering it to an absolute value from
+# inside a library permanently cripples the embedding process: every later
+# mmap in that process fails, including the 8 MB stack pthread_create needs,
+# which surfaces as `RuntimeError: can't start new thread` and as
+# `sqlite3.OperationalError: disk I/O error` in code that has nothing to do
+# with the node that set the limit (issue #2078).
+#
+# The guard below is therefore bounded in BOTH directions:
+#   * in VALUE  - the ceiling is (current address-space usage + limit), so the
+#     limit bounds what the guarded block may ADD, never the footprint the
+#     process already legitimately has;
+#   * in TIME   - the previous soft limit is restored on exit, and only the
+#     SOFT limit is ever touched so the change stays reversible (lowering the
+#     HARD limit is a one-way door for an unprivileged process).
+#
+# Concurrent guarded blocks are reference-counted: the first entrant applies
+# the ceiling, the last one out restores. The lock is held only for that
+# bookkeeping, never across the guarded block, so parallel node execution is
+# not serialized.
+_ADDRESS_SPACE_LOCK = threading.Lock()
+_address_space_depth = 0
+_address_space_saved: tuple[int, int] | None = None
+_address_space_unsupported_logged = False
+
+
+def _log_address_space_unsupported(reason: str) -> None:
+    """Log once that the address-space limit could not be applied.
+
+    Once, not per execution: on macOS every call fails identically, and a
+    per-execution warning would bury the log without adding information.
+    """
+    global _address_space_unsupported_logged
+    if _address_space_unsupported_logged:
+        return
+    _address_space_unsupported_logged = True
+    logger.warning(
+        "Memory limit is NOT enforced for in-process code execution on this "
+        "platform (%s). Code executed by PythonCodeNode may allocate without "
+        "bound. Run untrusted code in a subprocess if the limit must hold.",
+        reason,
+    )
+
+
+def _current_address_space_bytes() -> int | None:
+    """Return this process's current virtual address-space size, or None.
+
+    Reads ``/proc/self/statm`` (field 0, total program size in pages). Returns
+    None where /proc is absent, which is the signal that the ceiling cannot be
+    computed and the limit must not be applied.
+    """
+    try:
+        with open("/proc/self/statm", "rb") as handle:
+            pages = int(handle.read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+    return pages * os.sysconf("SC_PAGE_SIZE")
+
+
+@contextmanager
+def memory_limit_guard(
+    limit: int | None = None, config: SecurityConfig | None = None
+):
+    """
+    Context manager bounding how much address space the guarded block may add.
+
+    Applies ``limit`` bytes of headroom above the process's CURRENT
+    address-space usage for the duration of the block, then restores the
+    previous soft limit. A ``MemoryError`` raised inside the block is
+    translated to :class:`MemoryLimitError`.
+
+    Where the platform does not enforce ``RLIMIT_AS`` (notably macOS, whose
+    kernel rejects the call) the block runs unguarded and a single warning is
+    logged. That is a real gap, not a silent one: the limit is advertised as
+    unenforced rather than pretended.
+
+    Args:
+        limit: Additional address space the block may use, in bytes
+            (uses ``config.memory_limit`` if None)
+        config: Security configuration
+
+    Raises:
+        MemoryLimitError: If the guarded block exhausts the headroom
+
+    Examples:
+        >>> with memory_limit_guard(64 * 1024 * 1024):
+        ...     data = [0] * 1000
+    """
+    global _address_space_depth, _address_space_saved
+
+    if config is None:
+        config = get_security_config()
+
+    if limit is None:
+        limit = config.memory_limit
+
+    applicable = bool(limit) and resource is not None and hasattr(resource, "RLIMIT_AS")
+
+    if applicable:
+        with _ADDRESS_SPACE_LOCK:
+            entering_outermost = _address_space_depth == 0
+            _address_space_depth += 1
+            if entering_outermost:
+                _apply_address_space_ceiling(limit)
+
+    try:
+        yield
+    except MemoryError as exc:
+        raise MemoryLimitError(
+            f"Memory limit exceeded: code execution requested more than "
+            f"{limit} bytes of additional address space"
+        ) from exc
+    finally:
+        if applicable:
+            with _ADDRESS_SPACE_LOCK:
+                _address_space_depth -= 1
+                if _address_space_depth == 0 and _address_space_saved is not None:
+                    saved, _address_space_saved = _address_space_saved, None
+                    try:
+                        resource.setrlimit(resource.RLIMIT_AS, saved)
+                    except (OSError, ValueError) as exc:
+                        # Failing to restore would leave the whole process
+                        # capped — the exact #2078 failure mode. Loud, never
+                        # swallowed.
+                        logger.error(
+                            "Could not restore RLIMIT_AS to %s after guarded "
+                            "execution; this process's address space stays "
+                            "capped: %s",
+                            saved,
+                            exc,
+                        )
+
+
+def _apply_address_space_ceiling(limit: int) -> None:
+    """Apply the soft RLIMIT_AS ceiling. Caller MUST hold the lock."""
+    global _address_space_saved
+
+    current = _current_address_space_bytes()
+    if current is None:
+        _log_address_space_unsupported("address-space usage is not readable")
+        return
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    ceiling = current + limit
+    if hard != resource.RLIM_INFINITY:
+        ceiling = min(ceiling, hard)
+    if soft != resource.RLIM_INFINITY and soft <= ceiling:
+        # An outer limit is already at least as tight; leave it alone.
+        return
+
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (ceiling, hard))
+    except (OSError, ValueError) as exc:
+        _log_address_space_unsupported(f"setrlimit(RLIMIT_AS) rejected: {exc}")
+        return
+
+    _address_space_saved = (soft, hard)
 
 
 def sanitize_input(

--- a/tests/tier2_integration/runtime/test_retry_policy_engine.py
+++ b/tests/tier2_integration/runtime/test_retry_policy_engine.py
@@ -578,17 +578,29 @@ class TestRetryPolicyEngine:
         async def keyboard_interrupt_function():
             raise KeyboardInterrupt("User interrupted")
 
-        # Wrap in timeout to prevent hanging
+        # Wrap in timeout to prevent hanging.
+        #
+        # `asyncio.timeout`, NOT `asyncio.wait_for`. On Python 3.11 wait_for
+        # wraps the coroutine in a separate Task, and a BaseException raised
+        # inside that Task escapes to the event loop instead of propagating
+        # through the await — so the `except` below never sees it, pytest
+        # receives a real KeyboardInterrupt, and the whole session aborts with
+        # exit code 2 partway through the tier. Measured, same code, no deps:
+        #     py3.11: ESCAPED -> KeyboardInterrupt: User interrupted
+        #     py3.12: CAUGHT-INSIDE
+        #     py3.13: CAUGHT-INSIDE
+        # `asyncio.timeout` drives the CURRENT task rather than a child, so the
+        # exception stays inside this frame on every version. The assertions
+        # below are unchanged; only the harness differs.
         import asyncio
 
         try:
-            result = await asyncio.wait_for(
-                engine.execute_with_retry(keyboard_interrupt_function), timeout=1.0
-            )
+            async with asyncio.timeout(1.0):
+                result = await engine.execute_with_retry(keyboard_interrupt_function)
             assert not result.success
             assert result.total_attempts == 1  # Should not retry
             assert isinstance(result.final_exception, KeyboardInterrupt)
-        except (KeyboardInterrupt, asyncio.TimeoutError):
+        except (KeyboardInterrupt, TimeoutError):
             # Test passed - KeyboardInterrupt was properly handled
             pass
 

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -6,16 +6,22 @@
 
 executed inline, in the host process. ``RLIMIT_AS`` is process-wide and the
 call set the HARD limit too, so an unprivileged process could never raise it
-again. With the 512 MB default and an interpreter that already occupies
-~635 MB of address space once the SDK is imported, the first workflow to run a
-``PythonCodeNode`` capped the process BELOW its own footprint. Every later
-``mmap`` in that process then failed — including the stack allocation
-``pthread_create`` needs — which is where CI's
+again.
+
+``RLIMIT_AS`` caps VIRTUAL address space, not resident memory, and on Linux the
+two diverge sharply: glibc reserves a 64 MB malloc arena per thread and every
+pthread stack reserves 8 MB. Measured in a python:3.12-slim container, a
+25-thread process sat at 1889 MB of address space while importing the SDK alone
+cost only 62 MB. One ``PythonCodeNode`` execution then capped that 1889 MB
+process at the 512 MB default, and every later ``mmap`` failed — including the
+stack allocation ``pthread_create`` needs — which is where CI's
 
     130 x RuntimeError: can't start new thread
      90 x sqlite3.OperationalError: disk I/O error
 
-came from, in tests that had nothing to do with PythonCodeNode.
+came from, in tests that had nothing to do with PythonCodeNode. Tier 2 runs
+``-p no:xdist``, so one execution poisoned the remainder of the run; that is
+why the failure counts were identical across runs to the test.
 
 Platform note, and it is the whole reason this went unseen for so long: the
 Darwin kernel REJECTS ``setrlimit(RLIMIT_AS)``, so on macOS the old code took
@@ -203,6 +209,38 @@ def test_python_code_node_raises_memory_limit_error_for_a_hog(
     assert any(isinstance(e, MemoryLimitError) for e in chain), (
         f"expected MemoryLimitError in the cause chain, got {chain!r}"
     )
+
+
+def test_memory_error_is_not_relabelled_when_nothing_is_enforced(monkeypatch):
+    """An unenforced guard must not claim credit for a genuine MemoryError.
+
+    On a platform that rejects ``setrlimit`` (macOS) no ceiling is ever in
+    force, so a ``MemoryError`` inside the block is real host exhaustion.
+    Reporting it as ``MemoryLimitError`` would name the wrong cause and send
+    the reader to a knob that is not connected to anything.
+    """
+    import kailash.security as security_module
+
+    # Simulate the platform where the ceiling cannot be established.
+    monkeypatch.setattr(
+        security_module, "_current_address_space_bytes", lambda: None
+    )
+    monkeypatch.setattr(security_module, "_address_space_saved", None)
+
+    with pytest.raises(MemoryError) as excinfo:
+        with memory_limit_guard(64 * 1024 * 1024):
+            raise MemoryError("host is genuinely out of memory")
+
+    assert not isinstance(excinfo.value, MemoryLimitError)
+    assert "genuinely out of memory" in str(excinfo.value)
+
+
+@requires_enforced_rlimit_as
+def test_memory_error_is_relabelled_when_the_ceiling_is_in_force():
+    """The other polarity: with a ceiling applied, the relabel MUST happen."""
+    with pytest.raises(MemoryLimitError):
+        with memory_limit_guard(16 * 1024 * 1024):
+            raise MemoryError("hit the ceiling")
 
 
 @requires_rlimit_as

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -241,6 +241,107 @@ def test_memory_error_is_relabelled_when_the_ceiling_is_in_force():
             raise MemoryError("hit the ceiling")
 
 
+@requires_enforced_rlimit_as
+def test_concurrent_guards_apply_the_tightest_ceiling_not_the_first():
+    """A lax concurrent guard must not host a strictly-configured block.
+
+    Nodes in a parallel group may each carry their own SecurityConfig, so two
+    guards with different limits are live at once. First-writer-wins would run
+    the strict payload under the lax ceiling — a silent sandbox bypass.
+    """
+    outer = 4 * 1024 * 1024 * 1024  # 4 GB, deliberately lax
+    inner = 32 * 1024 * 1024  # 32 MB, the one that must win
+
+    with memory_limit_guard(outer):
+        lax, _ = resource.getrlimit(resource.RLIMIT_AS)
+        with memory_limit_guard(inner):
+            tight, _ = resource.getrlimit(resource.RLIMIT_AS)
+        assert tight < lax, (
+            f"tighter concurrent guard did not take effect: "
+            f"{tight} should be below {lax}"
+        )
+
+
+@requires_enforced_rlimit_as
+def test_tighter_ceiling_is_released_when_its_guard_exits():
+    """The tightening must be temporary, or the outer block inherits it."""
+    outer = 4 * 1024 * 1024 * 1024
+    with memory_limit_guard(outer):
+        before, _ = resource.getrlimit(resource.RLIMIT_AS)
+        with memory_limit_guard(32 * 1024 * 1024):
+            pass
+        after, _ = resource.getrlimit(resource.RLIMIT_AS)
+    assert after == before, "inner guard's tighter ceiling leaked into the outer block"
+
+
+@requires_enforced_rlimit_as
+def test_a_failing_ceiling_application_does_not_disable_later_guards(monkeypatch):
+    """An exception while applying must not leave the sandbox permanently off.
+
+    The bookkeeping used to be incremented before the apply, outside any
+    try/finally, so one raise (e.g. OverflowError from an over-large configured
+    limit) left the count stuck and every later guard concluded a ceiling was
+    already in force.
+    """
+    import kailash.security as security_module
+
+    real_setrlimit = resource.setrlimit
+    calls = {"n": 0}
+
+    def exploding_setrlimit(which, limits):
+        if which == resource.RLIMIT_AS and calls["n"] == 0:
+            calls["n"] += 1
+            raise OverflowError("Python int too large to convert to C long")
+        return real_setrlimit(which, limits)
+
+    monkeypatch.setattr(security_module.resource, "setrlimit", exploding_setrlimit)
+    with memory_limit_guard(64 * 1024 * 1024):
+        pass
+    monkeypatch.undo()
+
+    # The next guard must still be able to apply a ceiling.
+    with memory_limit_guard(32 * 1024 * 1024):
+        soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+    assert soft != resource.RLIM_INFINITY or True  # applied or cleanly skipped
+    assert (
+        security_module._address_space_requests == []
+    ), "a failed apply leaked its bookkeeping; later guards would be no-ops"
+
+
+@requires_enforced_rlimit_as
+def test_failed_restore_keeps_the_saved_value_for_a_later_retry():
+    """Clearing the saved pair before a successful restore is unrecoverable.
+
+    If the restore fails and the saved value is dropped, nothing can ever put
+    the process back — #2078 with no path out.
+    """
+    import kailash.security as security_module
+
+    real_setrlimit = resource.setrlimit
+    fail = {"on": False}
+
+    def flaky_setrlimit(which, limits):
+        if which == resource.RLIMIT_AS and fail["on"]:
+            raise OSError("simulated restore failure")
+        return real_setrlimit(which, limits)
+
+    security_module.resource.setrlimit = flaky_setrlimit
+    try:
+        with memory_limit_guard(64 * 1024 * 1024):
+            fail["on"] = True
+        assert (
+            security_module._address_space_saved is not None
+        ), "saved limit was discarded on a failed restore — unrecoverable"
+    finally:
+        fail["on"] = False
+        security_module.resource.setrlimit = real_setrlimit
+        # Drive one more guard cycle so the pending restore is retried, and
+        # leave the process exactly as this module found it (the autouse
+        # fixture asserts that).
+        with memory_limit_guard(64 * 1024 * 1024):
+            pass
+
+
 @requires_rlimit_as
 def test_nested_and_parallel_guards_restore_exactly_once():
     """Reference counting: parallel node execution must not corrupt restore."""

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -1,0 +1,239 @@
+"""Regression tests for issue #2078 — process-wide RLIMIT_AS corruption.
+
+``PythonCodeNode`` used to enforce ``SecurityConfig.memory_limit`` with
+
+    resource.setrlimit(RLIMIT_AS, (memory_limit, memory_limit))
+
+executed inline, in the host process. ``RLIMIT_AS`` is process-wide and the
+call set the HARD limit too, so an unprivileged process could never raise it
+again. With the 512 MB default and an interpreter that already occupies
+~635 MB of address space once the SDK is imported, the first workflow to run a
+``PythonCodeNode`` capped the process BELOW its own footprint. Every later
+``mmap`` in that process then failed — including the stack allocation
+``pthread_create`` needs — which is where CI's
+
+    130 x RuntimeError: can't start new thread
+     90 x sqlite3.OperationalError: disk I/O error
+
+came from, in tests that had nothing to do with PythonCodeNode.
+
+Platform note, and it is the whole reason this went unseen for so long: the
+Darwin kernel REJECTS ``setrlimit(RLIMIT_AS)``, so on macOS the old code took
+its ``except (OSError, ValueError)`` branch and the limit was never applied.
+A macOS run is therefore NOT a discriminating instrument for this bug — the
+Linux assertions below are, and CI runs Linux.
+"""
+
+import os
+import threading
+
+import pytest
+
+from kailash.nodes.code.python import PythonCodeNode
+from kailash.security import (
+    MemoryLimitError,
+    SecurityConfig,
+    get_security_config,
+    memory_limit_guard,
+    set_security_config,
+)
+
+resource = pytest.importorskip("resource", reason="POSIX-only")
+
+HAS_RLIMIT_AS = hasattr(resource, "RLIMIT_AS")
+
+# Only Linux actually enforces RLIMIT_AS. Guard the enforcement assertions on
+# the real property rather than on a platform string, so a platform that starts
+# enforcing it is covered automatically.
+ENFORCES_RLIMIT_AS = HAS_RLIMIT_AS and os.path.exists("/proc/self/statm")
+
+requires_rlimit_as = pytest.mark.skipif(
+    not HAS_RLIMIT_AS, reason="RLIMIT_AS not available on this platform"
+)
+requires_enforced_rlimit_as = pytest.mark.skipif(
+    not ENFORCES_RLIMIT_AS,
+    reason="RLIMIT_AS is not enforced on this platform (macOS rejects it)",
+)
+
+
+@pytest.fixture
+def restore_security_config():
+    """Restore the process-global SecurityConfig after the test."""
+    previous = get_security_config()
+    yield
+    set_security_config(previous)
+
+
+@pytest.fixture(autouse=True)
+def assert_rlimit_unchanged():
+    """Every test in this module must leave RLIMIT_AS exactly as it found it."""
+    if not HAS_RLIMIT_AS:
+        yield
+        return
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    yield
+    assert resource.getrlimit(resource.RLIMIT_AS) == before, (
+        "a test in this module leaked an RLIMIT_AS change into the process — "
+        "that is the #2078 failure mode itself"
+    )
+
+
+@requires_rlimit_as
+def test_python_code_node_does_not_change_process_rlimit():
+    """The regression: executing a node must not alter the process's limit.
+
+    Pre-fix on Linux this assertion reads (536870912, 536870912) against an
+    unlimited baseline.
+    """
+    before = resource.getrlimit(resource.RLIMIT_AS)
+
+    node = PythonCodeNode(name="probe", code="result = 1 + 1")
+    assert node.execute() == {"result": 2}
+
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@requires_rlimit_as
+def test_threads_still_start_after_python_code_node_runs():
+    """The observable consequence: thread creation must keep working.
+
+    Pre-fix on Linux this raises ``RuntimeError: can't start new thread`` —
+    the exact error CI reported 130 times.
+    """
+    PythonCodeNode(name="probe", code="result = 1 + 1").execute()
+
+    started = threading.Event()
+    thread = threading.Thread(target=started.set)
+    thread.start()
+    thread.join(timeout=10)
+    assert started.is_set(), "thread created after PythonCodeNode never ran"
+
+
+@requires_rlimit_as
+def test_python_code_node_run_repeatedly_does_not_accumulate_limits():
+    """Repeated executions must not ratchet the limit downwards."""
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    node = PythonCodeNode(name="probe", code="result = 1 + 1")
+    for _ in range(25):
+        node.execute()
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@requires_rlimit_as
+def test_memory_limit_guard_restores_soft_limit_on_success():
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    with memory_limit_guard(64 * 1024 * 1024):
+        pass
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@requires_rlimit_as
+def test_memory_limit_guard_restores_soft_limit_on_exception():
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    with pytest.raises(ValueError):
+        with memory_limit_guard(64 * 1024 * 1024):
+            raise ValueError("boom")
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@requires_rlimit_as
+def test_memory_limit_guard_never_lowers_the_hard_limit():
+    """The hard limit is a one-way door for an unprivileged process."""
+    _, hard_before = resource.getrlimit(resource.RLIMIT_AS)
+    with memory_limit_guard(16 * 1024 * 1024):
+        _, hard_inside = resource.getrlimit(resource.RLIMIT_AS)
+    assert hard_inside == hard_before
+
+
+@requires_enforced_rlimit_as
+def test_memory_limit_guard_applies_headroom_above_current_usage():
+    """The ceiling must sit ABOVE the process's existing footprint.
+
+    The old code set an absolute ceiling, which is what put the process below
+    its own address-space usage.
+    """
+    with open("/proc/self/statm", "rb") as handle:
+        current = int(handle.read().split()[0]) * os.sysconf("SC_PAGE_SIZE")
+
+    headroom = 32 * 1024 * 1024
+    with memory_limit_guard(headroom):
+        soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+
+    assert soft > current, "ceiling must exceed current address-space usage"
+    assert soft <= current + headroom + (8 * 1024 * 1024), (
+        "ceiling must stay close to current usage + headroom"
+    )
+
+
+@requires_enforced_rlimit_as
+def test_memory_limit_guard_enforces_the_headroom():
+    """The limit must actually bite — a hog inside a small guard raises."""
+    with pytest.raises(MemoryLimitError):
+        with memory_limit_guard(16 * 1024 * 1024):
+            bytearray(512 * 1024 * 1024)
+
+
+@requires_enforced_rlimit_as
+def test_modest_allocation_inside_the_guard_succeeds():
+    with memory_limit_guard(64 * 1024 * 1024):
+        assert len(bytearray(4 * 1024 * 1024)) == 4 * 1024 * 1024
+
+
+@requires_enforced_rlimit_as
+def test_python_code_node_raises_memory_limit_error_for_a_hog(
+    restore_security_config,
+):
+    """``memory_limit`` is a documented contract; it must have an effect.
+
+    Before the fix ``MemoryLimitError`` was imported and caught in python.py
+    but raised nowhere, so the documented kwarg's only observable behaviour was
+    to break the host process.
+    """
+    set_security_config(SecurityConfig(memory_limit=16 * 1024 * 1024))
+
+    node = PythonCodeNode(name="hog", code="result = len(bytearray(512*1024*1024))")
+    with pytest.raises(Exception) as excinfo:
+        node.execute()
+
+    chain = []
+    err = excinfo.value
+    while err is not None and err not in chain:
+        chain.append(err)
+        err = err.__cause__ or err.__context__
+    assert any(isinstance(e, MemoryLimitError) for e in chain), (
+        f"expected MemoryLimitError in the cause chain, got {chain!r}"
+    )
+
+
+@requires_rlimit_as
+def test_nested_and_parallel_guards_restore_exactly_once():
+    """Reference counting: parallel node execution must not corrupt restore."""
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(8)
+
+    def work():
+        try:
+            barrier.wait(timeout=30)
+            for _ in range(20):
+                with memory_limit_guard(64 * 1024 * 1024):
+                    with memory_limit_guard(64 * 1024 * 1024):
+                        sum(range(100))
+        except BaseException as exc:  # noqa: BLE001 - re-raised via `errors`
+            errors.append(exc)
+
+    threads = [threading.Thread(target=work) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert not errors, f"guard raised under concurrency: {errors!r}"
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+    # And the process is still usable afterwards.
+    started = threading.Event()
+    probe = threading.Thread(target=started.set)
+    probe.start()
+    probe.join(timeout=10)
+    assert started.is_set()

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -166,9 +166,9 @@ def test_memory_limit_guard_applies_headroom_above_current_usage():
         soft, _ = resource.getrlimit(resource.RLIMIT_AS)
 
     assert soft > current, "ceiling must exceed current address-space usage"
-    assert soft <= current + headroom + (8 * 1024 * 1024), (
-        "ceiling must stay close to current usage + headroom"
-    )
+    assert soft <= current + headroom + (
+        8 * 1024 * 1024
+    ), "ceiling must stay close to current usage + headroom"
 
 
 @requires_enforced_rlimit_as
@@ -206,9 +206,9 @@ def test_python_code_node_raises_memory_limit_error_for_a_hog(
     while err is not None and err not in chain:
         chain.append(err)
         err = err.__cause__ or err.__context__
-    assert any(isinstance(e, MemoryLimitError) for e in chain), (
-        f"expected MemoryLimitError in the cause chain, got {chain!r}"
-    )
+    assert any(
+        isinstance(e, MemoryLimitError) for e in chain
+    ), f"expected MemoryLimitError in the cause chain, got {chain!r}"
 
 
 def test_memory_error_is_not_relabelled_when_nothing_is_enforced(monkeypatch):
@@ -222,9 +222,7 @@ def test_memory_error_is_not_relabelled_when_nothing_is_enforced(monkeypatch):
     import kailash.security as security_module
 
     # Simulate the platform where the ceiling cannot be established.
-    monkeypatch.setattr(
-        security_module, "_current_address_space_bytes", lambda: None
-    )
+    monkeypatch.setattr(security_module, "_current_address_space_bytes", lambda: None)
     monkeypatch.setattr(security_module, "_address_space_saved", None)
 
     with pytest.raises(MemoryError) as excinfo:

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -30,6 +30,7 @@ A macOS run is therefore NOT a discriminating instrument for this bug — the
 Linux assertions below are, and CI runs Linux.
 """
 
+import mmap
 import os
 import threading
 
@@ -478,3 +479,46 @@ def test_the_unsupported_warning_is_logged_only_once(
 
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}"
+
+
+@requires_enforced_rlimit_as
+def test_inner_tighter_guard_actually_denies_an_allocation_the_outer_allows():
+    """Behavioural sibling of the tightest-ceiling test, with distinct limits.
+
+    ``test_concurrent_guards_apply_the_tightest_ceiling_not_the_first`` reads
+    the rlimit VALUE. This one reads the CONSEQUENCE: an allocation sized to
+    fit comfortably under the outer ceiling but far above the inner one must be
+    denied while the inner guard is live, and must succeed once it exits.
+
+    Equal limits cannot produce this: with both guards at the same size the
+    allocation either fits both or neither, so the run is identical whether the
+    inner ceiling was applied or ignored. The asymmetry is what makes this
+    discriminating -- under first-writer-wins the allocation SUCCEEDS and the
+    test reads "inner 1 MB ceiling did not deny a 32 MB allocation".
+
+    The payload is an anonymous ``mmap``, NOT a ``bytearray``, and that choice
+    is load-bearing. RLIMIT_AS bounds address space, so only an allocation that
+    GROWS the mapping can trip it. An earlier test in this module frees a large
+    buffer; glibc retains that arena, so a 32 MB ``bytearray`` is then served
+    from free heap without a new mapping and the ceiling never bites -- the test
+    passed in isolation and failed in file order. ``mmap`` always creates a new
+    mapping, which makes the result independent of allocation history.
+    """
+    outer = 64 * 1024 * 1024
+    inner = 1 * 1024 * 1024
+    payload = 32 * 1024 * 1024
+
+    with memory_limit_guard(outer):
+        # OSError (ENOMEM) is the mmap failure mode; the guard relabels only
+        # MemoryError, so both are accepted. Either proves the ceiling applied.
+        with pytest.raises((MemoryLimitError, MemoryError, OSError)):
+            with memory_limit_guard(inner):
+                mmap.mmap(-1, payload)
+
+        # And the outer ceiling is restored, so the same mapping now fits.
+        # Without this half, a guard that simply never released would pass.
+        mapping = mmap.mmap(-1, payload)
+        try:
+            assert len(mapping) == payload
+        finally:
+            mapping.close()

--- a/tests/unit/security/test_issue_2078_address_space_limit.py
+++ b/tests/unit/security/test_issue_2078_address_space_limit.py
@@ -374,3 +374,107 @@ def test_nested_and_parallel_guards_restore_exactly_once():
     probe.start()
     probe.join(timeout=10)
     assert started.is_set()
+
+
+# ---------------------------------------------------------------------------
+# The unenforceable-platform warning must actually fire on every path that
+# leaves the limit unenforced -- including the one where `resource` is absent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reset_unsupported_log_latch():
+    """Clear the log-once latch so a warning can be observed in this test."""
+    import kailash.security as security_module
+
+    previous = security_module._address_space_unsupported_logged
+    security_module._address_space_unsupported_logged = False
+    yield
+    security_module._address_space_unsupported_logged = previous
+
+
+def test_warning_fires_when_the_resource_module_is_unavailable(
+    monkeypatch, caplog, reset_unsupported_log_latch
+):
+    """Windows has no ``resource`` module, so `applicable` is False.
+
+    Both existing call sites of ``_log_address_space_unsupported`` live INSIDE
+    ``_enter_address_space_guard``, which runs only when `applicable` is true.
+    Pre-fix this platform therefore got no ceiling AND no warning -- the exact
+    silent failure the docstring promised it would not have. This test reddens
+    with "expected a warning ... got []" if that guard is removed again.
+    """
+    import kailash.security as security_module
+
+    monkeypatch.setattr(security_module, "resource", None)
+
+    with caplog.at_level("WARNING", logger=security_module.logger.name):
+        with memory_limit_guard(64 * 1024 * 1024):
+            sum(range(100))
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings, (
+        "expected a warning naming the unenforced memory limit on a platform "
+        f"with no `resource` module, got {warnings!r}"
+    )
+    message = warnings[0].getMessage()
+    assert "NOT enforced" in message
+    assert "`resource` module is unavailable" in message
+
+
+def test_warning_fires_when_rlimit_as_is_undefined(
+    monkeypatch, caplog, reset_unsupported_log_latch
+):
+    """The sibling path: ``resource`` exists but carries no ``RLIMIT_AS``."""
+    import kailash.security as security_module
+
+    class _NoRlimitAs:
+        pass
+
+    monkeypatch.setattr(security_module, "resource", _NoRlimitAs())
+
+    with caplog.at_level("WARNING", logger=security_module.logger.name):
+        with memory_limit_guard(64 * 1024 * 1024):
+            sum(range(100))
+
+    messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("RLIMIT_AS` is not defined" in m for m in messages), messages
+
+
+def test_no_warning_when_the_limit_is_simply_unset(
+    monkeypatch, caplog, reset_unsupported_log_latch
+):
+    """The other polarity: an unset limit is disabled by CONFIGURATION.
+
+    Warning here would fire on every unlimited guard and train readers to
+    ignore the message, so `bool(limit)` gates it. Without this test the fix
+    could be written as an unconditional warn and still look correct.
+    """
+    import kailash.security as security_module
+
+    monkeypatch.setattr(security_module, "resource", None)
+
+    with caplog.at_level("WARNING", logger=security_module.logger.name):
+        with memory_limit_guard(0):
+            sum(range(100))
+
+    assert not [
+        r for r in caplog.records if r.levelname == "WARNING"
+    ], "an unset limit is not a platform gap and must not warn"
+
+
+def test_the_unsupported_warning_is_logged_only_once(
+    monkeypatch, caplog, reset_unsupported_log_latch
+):
+    """It fails identically every time; per-execution warnings bury the log."""
+    import kailash.security as security_module
+
+    monkeypatch.setattr(security_module, "resource", None)
+
+    with caplog.at_level("WARNING", logger=security_module.logger.name):
+        for _ in range(5):
+            with memory_limit_guard(64 * 1024 * 1024):
+                sum(range(100))
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}"


### PR DESCRIPTION
## Root cause

`PythonCodeNode` enforced `SecurityConfig.memory_limit` by calling, inline in
the host process:

```python
resource.setrlimit(RLIMIT_AS, (memory_limit, memory_limit))
```

`RLIMIT_AS` is **process-wide**, the call set the **hard** limit too (so an
unprivileged process can never raise it again), and the value was **absolute**
rather than headroom. The first workflow to run a `PythonCodeNode` therefore
capped the whole interpreter at 512 MB of address space, permanently.

`RLIMIT_AS` caps *virtual* address space, which on Linux runs far above
resident memory: glibc reserves a 64 MB malloc arena per thread and every
pthread stack reserves 8 MB. Measured in `python:3.12-slim`:

```
live_threads          = 25
vsz_realistic_mb      = 1889.2
rlimit_before_node    = (-1, -1)                 <- unlimited
node_result           = {'result': 2}            <- ONE PythonCodeNode execution
rlimit_after_node     = (536870912, 536870912)   <- capped, SOFT *and* HARD
vsz_after_node_mb     = 1961.5                   <- 1961 MB process, 512 MB cap
Exception ignored in thread started by: <object repr() failed>
MemoryError:
```

Every later `mmap` in that process then fails — including the stack allocation
`pthread_create` needs. That is the origin of the reported

```
130 x RuntimeError: can't start new thread
 90 x sqlite3.OperationalError: disk I/O error
```

in tests with no connection to `PythonCodeNode`. Tier 2 runs `-p no:xdist`, so
a single execution poisons the remainder of the run — which is why the failure
counts were *identical to the test* across runs (`174 failed / 2349 passed /
58 errors` twice, seconds apart). A shared leak would drift; deterministic
process-state corruption does not.

### Why macOS never reproduced it

Measured on Darwin 25.5.0:

```
setrlimit: REJECTED -> ValueError: current limit exceeds maximum limit
rlimit_after: (9223372036854775807, 9223372036854775807)   <- unchanged
```

The old code caught exactly `except (OSError, ValueError)` and continued, so on
macOS the limit was **never applied**. That is the whole of the "2604 passed
locally / 232 failures on CI" gap. A macOS run is not a discriminating
instrument for this bug.

## The fix

`memory_limit_guard` in `kailash/security.py`, bounded in both directions:

* **value** — the ceiling is `current address-space usage + limit`, so the limit
  bounds what the guarded block may *add*, never the footprint the process
  already legitimately holds;
* **time** — the previous soft limit is restored on exit, and only the **soft**
  limit is ever touched, so the change stays reversible.

Concurrent guards are reference-counted; the lock is held only for that
bookkeeping, never across the block, so parallel node execution is not
serialized. Where the platform refuses `setrlimit` (macOS) the block runs
unguarded and logs **one** warning naming the unenforced protection — advertised,
not pretended, per `security.md` § Secure-Default.

This also repairs a documented contract: `memory_limit` previously had no
correct effect at all. Pre-fix the hog test reports
`expected MemoryLimitError in the cause chain, got [NodeExecutionError(...MemoryError...)]`.

Second, independent defect (verified separately, see below): `aiohttp` raises
`asyncio.TimeoutError`, which is **not** an `aiohttp.ClientError`, so a slow or
black-holed edge escaped the documented fallback on the **read-only probe**
handlers of `edge_migrator.py` and propagated out of `plan_migration`.

An earlier revision of this PR widened the catch **uniformly**, which was wrong
and is corrected here. On `_drain_source_edge`, `_perform_delta_sync` and
`_switch_traffic`, escaping was the CORRECT behaviour, not a gap:
`_execute_cutover` calls all three in sequence unconditionally, so swallowing a
drain timeout at WARN let cutover switch traffic away from a source that was
never drained, and on `MigrationStrategy.LIVE` discard every write made during
transfer. Those three now **re-raise**, matching `_transfer_batch` and
`_start_workload`, which already did; `execute_migration` turns that into
`phase=FAILED` plus a rollback. The re-raise also covers `ValueError` /
`ClientError`, which these three swallowed even before this PR — same bug class
in the same handler, so it is fixed here rather than deferred.

The widened `asyncio.TimeoutError` catch is therefore retained ONLY on the
read-only probes (`_estimate_data_size`, `_check_edge_capacity`,
`_verify_*`, `_test_workload_functionality`, `_cleanup_workload`), where
warn-and-fall-back is the documented contract.

## Evidence

All A/B runs are on real Linux (`python:3.12-slim`), identical inputs, only the
source tree differing.

**Tier 2, post-fix:**

```
2582 passed, 47 skipped, 4 deselected, 1 xpassed in 68.12s
```

Reconciles against the pre-fix CI figure `174 failed, 2349 passed, 47 skipped,
4 deselected, 1 xpassed, 58 errors in 175.76s` — identical skip/deselect/xpass
counts (same collection), and 2349 + 174 + 58 = 2581.

**The regression tests are not vacuous.** Reverting only the `python.py` call
site, keeping the guard importable, reddens them:

| tree | result | wall clock |
| --- | --- | --- |
| fixed | **13 passed** | 2.10 s |
| pre-fix call site | **7 failed, 6 passed, 2 errors** | 242.19 s |

The 115x slowdown is the same capped-process thrashing behind the 10-minute
step timeouts.

**Edge migrator, A/B:** pre-fix `2 failed, 118 passed`
(`aiohttp/helpers.py:759: raise asyncio.TimeoutError from exc_val`), post-fix
`120 passed`. Both fixes are required for a green Tier 2.

Re-measured on Linux after narrowing the catch to the read-only probes and
re-raising on the three cutover handlers: **`120 passed in 21.47s`**, unchanged.
The two tests that needed the widen are in the probe paths, so restoring
abort-on-unresponsive-source for cutover costs nothing on the gate. The only
tests that touch those three handlers directly (`test_switch_traffic`,
`test_drain_source_edge`) drive them through a fake session with success
responses, and `execute_migration` is only ever `AsyncMock`ed, so
`_execute_cutover` is never exercised end-to-end by the suite — the abort path
is covered by reasoning about the call graph, not by a test, and that is stated
rather than implied.

**Windows warning path:** `_log_address_space_unsupported` was called only from
inside `_enter_address_space_guard`, which runs only when `applicable` is true.
Where `resource` does not exist the guard applied no ceiling AND emitted no
warning, while the docstring promised one. The warning now fires from the guard
itself on both unenforceable paths. Four regression tests cover it, including
the negative polarity (an unset limit must NOT warn, since that is disabled by
configuration rather than by platform); removing the fix reddens three of them
with `expected a warning ... got []`.

## What this does NOT claim

* **`continue-on-error` is left ON.** #2078's own acceptance criteria require a
  complete green run **on all four interpreters** before the flag comes off.
  My evidence is local arm64 Docker, not the x86_64 runner. The flag comes off
  in a follow-up commit on this PR once the four Tier-2 jobs are read green.
* **#2075 is a different root cause and is NOT fixed here.** It reproduces
  deterministically against a local Postgres on macOS, where
  `setrlimit(RLIMIT_AS)` is a no-op, so it cannot be this bug. It is a genuine
  DataFlow pool-disposal leak.
* **#2081 is untested here.** The infra-free root regression slice runs to
  completion in my container rather than hanging, and shares the
  macOS-passes/Linux-hangs asymmetry — but my container could not collect 10
  files (missing `dataflow`/`kaizen`/`nexus`), so that is a lead, not a result.

## Related issues

Fixes #2078
Unblocks #2038 (Tier 2 as a merge gate) once the four-interpreter run is read green.
Refs #2002, #2079, #2081.

