### PR TITLE
fix(rules): scope the operator-local ci-runners files so they stop loading everywhere

### DIFF
--- a/.claude/rules/ci-runners.operator.local.example.md
+++ b/.claude/rules/ci-runners.operator.local.example.md
@@ -1,3 +1,12 @@
+---
+priority: 10
+scope: path-scoped
+paths:
+  - ".github/workflows/**"
+  - "**/ci/**"
+  - "**/.github/**"
+---
+
 # ci-runners Operator-Local Values — Schema / Template
 
 Operator-local concrete values for the kailash-py self-hosted CI runbook


### PR DESCRIPTION
Both `.claude/rules/ci-runners.operator.local.example.md` (tracked) and its gitignored sibling `ci-runners.operator.local.md` carried **no YAML frontmatter**, so neither was path-scoped and **both loaded as project instructions in every session**, whatever that session was doing.

Observed directly: two separate agent sessions this cycle found both files in their loaded context while working on unrelated code.

## Why it matters

The gitignored file exists precisely so operator/deployment identifiers — runner hostnames and an org-derived runner label — never reach a synced `.claude/` artifact (#260 / #252).

**The gitignore achieves that for the FILE. It does not constrain the file's CONTENTS**, which were resident in every session's context, where any agent could echo them into a PR body, commit message, issue, or synced artifact. The scrub rules that govern durable writes cannot help with a value nothing marked as sensitive.

Nothing is known to have leaked — **this closes a surface, not an incident.** But the gitignored file's own header claims it is *"never committed, never synced"*: accurate about the file, misleading about the exposure.

## The fix

Both files now carry the same frontmatter as the rule they serve (`ci-runners.md`):

```yaml
priority: 10
scope: path-scoped
paths:
  - ".github/workflows/**"
  - "**/ci/**"
  - "**/.github/**"
```

They load when a session is actually doing CI-runner work — which is when their values are wanted — and not otherwise.

## Second, independent effect: emit.mjs was hard-failing

`emit.mjs` validator-14 rejects a rule file with no frontmatter, so **any emit run in this repo hard-failed on the tracked file**. A session measuring rule-emission headroom had to route every measurement through a scratch tree to work around it.

**Measured after the change:**

```
$ node .claude/bin/emit.mjs --all --dry-run ; echo $?
[validator-14] rule-frontmatter: PASS
[validator-13] PASS (dry-run; policies.json not written)
0
```

The operator-local files appear **nowhere** in the emitted output, and the baseline set stays at **11 rules** — so they now cost nothing against the emission budget either.

## Scope note

Only the template is tracked. The gitignored values file was given the same frontmatter locally; the schema it documents is unchanged, and no identifier appears in this diff.

## Related issues

Fixes #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)