### PR TITLE
fix(tests): repair the 23 Tier-2 tests that continue-on-error was hiding

### DIFF
--- a/tests/tier2_integration/api/test_workflow_api_async_runtime.py
+++ b/tests/tier2_integration/api/test_workflow_api_async_runtime.py
@@ -4,6 +4,14 @@ Test suite for WorkflowAPI async runtime selection.
 This test validates the Docker threading fix where WorkflowAPI now uses
 AsyncLocalRuntime by default instead of LocalRuntime to avoid double-threading
 deadlocks in Docker/FastAPI deployments.
+
+Every ``WorkflowAPI`` below passes ``require_auth=False`` explicitly. These
+tests exercise RUNTIME SELECTION, not the authentication gate: ``require_auth``
+defaults to True (#2072 -- a default server executed arbitrary registered
+workflows for anonymous callers), so construction now refuses when no credential
+source is configured. Nothing here binds a socket, so the opt-out is stated
+rather than inherited -- a reader can see these servers are deliberately
+ungated instead of guessing whether the omission was an oversight.
 """
 
 import pytest
@@ -28,7 +36,7 @@ class TestWorkflowAPIRuntimeSelection:
         )
 
         # Create API without specifying runtime
-        api = WorkflowAPI(workflow)
+        api = WorkflowAPI(workflow, require_auth=False)
 
         # Verify AsyncLocalRuntime was selected by default
         assert isinstance(
@@ -47,7 +55,7 @@ class TestWorkflowAPIRuntimeSelection:
 
         # Create API with explicit LocalRuntime
         sync_runtime = LocalRuntime()
-        api = WorkflowAPI(workflow, runtime=sync_runtime)
+        api = WorkflowAPI(workflow, require_auth=False, runtime=sync_runtime)
 
         # Verify LocalRuntime was used
         assert isinstance(
@@ -71,7 +79,7 @@ class TestWorkflowAPIRuntimeSelection:
 
         # Create API with explicit AsyncLocalRuntime with custom config
         async_runtime = AsyncLocalRuntime(max_concurrent_nodes=20)
-        api = WorkflowAPI(workflow, runtime=async_runtime)
+        api = WorkflowAPI(workflow, require_auth=False, runtime=async_runtime)
 
         # Verify AsyncLocalRuntime was used
         assert isinstance(api.runtime, AsyncLocalRuntime)
@@ -107,7 +115,7 @@ class TestWorkflowAPIRuntimeSelection:
         )
 
         # Create API with default AsyncLocalRuntime
-        api = WorkflowAPI(workflow)
+        api = WorkflowAPI(workflow, require_auth=False)
 
         # Verify AsyncLocalRuntime was selected
         from kailash.runtime.async_local import AsyncLocalRuntime
@@ -219,14 +227,14 @@ class TestRuntimeValidation:
 
         # Try to pass invalid runtime (string instead of runtime object)
         with pytest.raises(TypeError, match="Runtime must have 'execute' method"):
-            WorkflowAPI(workflow, runtime="invalid_runtime")
+            WorkflowAPI(workflow, require_auth=False, runtime="invalid_runtime")
 
         # Try to pass object without execute method
         class InvalidRuntime:
             pass
 
         with pytest.raises(TypeError, match="Runtime must have 'execute' method"):
-            WorkflowAPI(workflow, runtime=InvalidRuntime())
+            WorkflowAPI(workflow, require_auth=False, runtime=InvalidRuntime())
 
     def test_valid_runtime_accepted(self):
         """Test that valid runtimes are accepted."""
@@ -238,11 +246,11 @@ class TestRuntimeValidation:
         )
 
         # LocalRuntime should work
-        api1 = WorkflowAPI(workflow, runtime=LocalRuntime())
+        api1 = WorkflowAPI(workflow, require_auth=False, runtime=LocalRuntime())
         assert api1.runtime is not None
 
         # AsyncLocalRuntime should work
-        api2 = WorkflowAPI(workflow, runtime=AsyncLocalRuntime())
+        api2 = WorkflowAPI(workflow, require_auth=False, runtime=AsyncLocalRuntime())
         assert api2.runtime is not None
 
         # Custom runtime with execute method should work
@@ -250,7 +258,7 @@ class TestRuntimeValidation:
             def execute(self, workflow, **kwargs):
                 return {}, "run_id"
 
-        api3 = WorkflowAPI(workflow, runtime=CustomRuntime())
+        api3 = WorkflowAPI(workflow, require_auth=False, runtime=CustomRuntime())
         assert api3.runtime is not None
 
 
@@ -268,7 +276,7 @@ class TestBackwardCompatibility:
         )
 
         # This should work and default to AsyncLocalRuntime
-        api = WorkflowAPI(workflow)
+        api = WorkflowAPI(workflow, require_auth=False)
 
         # Should create FastAPI app successfully
         assert api.app is not None
@@ -284,7 +292,7 @@ class TestBackwardCompatibility:
         )
 
         # Explicitly use LocalRuntime for CLI context
-        api = WorkflowAPI(workflow, runtime=LocalRuntime())
+        api = WorkflowAPI(workflow, require_auth=False, runtime=LocalRuntime())
 
         # Should work correctly
         assert isinstance(api.runtime, LocalRuntime)

--- a/tests/tier2_integration/mcp_server/test_oauth.py
+++ b/tests/tier2_integration/mcp_server/test_oauth.py
@@ -474,9 +474,20 @@ class TestAuthorizationServer:
             mock_jwt_instance = MagicMock()
             mock_jwt.return_value = mock_jwt_instance
 
+            # `allow_ephemeral_key=True`, NOT a `private_key_path`.
+            #
+            # `private_key_path="test_key.pem"` named a file that has never
+            # existed in this repo. AuthorizationServer OPENS that path itself
+            # (it does not delegate the read to JWTManager), so the `mock_jwt`
+            # patch above never intercepted it and construction raised
+            # JWTKeyNotConfiguredError -- erroring every test in this class at
+            # setup. The SDK's own message prescribes this remedy: opt in to a
+            # process-local generated key pair for self-signed test tokens.
+            # These tests mock JWTManager anyway, so no real signing happens;
+            # what is needed is a constructor that does not demand a key file.
             self.server = AuthorizationServer(
                 issuer="https://auth.example.com",
-                private_key_path="test_key.pem",
+                allow_ephemeral_key=True,
                 client_store=InMemoryClientStore(),
                 token_store=InMemoryTokenStore(),
             )

--- a/tests/tier2_integration/middleware/test_circular_imports.py
+++ b/tests/tier2_integration/middleware/test_circular_imports.py
@@ -46,8 +46,17 @@ def test_create_gateway_with_auth():
         from kailash.middleware.auth import JWTAuthManager
         from kailash.middleware.communication.api_gateway import create_gateway
 
-        # Create auth manager
-        auth = JWTAuthManager(secret_key="test-secret", algorithm="HS256")
+        # Create auth manager.
+        #
+        # The secret is 32+ bytes deliberately, NOT padded to satisfy a linter:
+        # JWTAuthManager enforces the RFC 7518 §3.2 floor (an HS256 key must be
+        # at least as long as the hash output) and refuses a short one. The
+        # previous "test-secret" was 11 bytes and raised. This test asserts auth
+        # is WIRED, so it gets a real key rather than an opt-out -- swapping in
+        # require_auth=False here would delete the only thing it checks.
+        auth = JWTAuthManager(
+            secret_key="test-secret-key-minimum-32-bytes!", algorithm="HS256"
+        )
 
         # Create gateway with auth
         gateway = create_gateway(title="Test Gateway", auth_manager=auth)

--- a/tests/tier2_integration/runtime/test_core_runtime_injection.py
+++ b/tests/tier2_integration/runtime/test_core_runtime_injection.py
@@ -350,7 +350,10 @@ class TestWorkflowAPIRuntimeInjection:
 
         builder = WorkflowBuilder()
         builder.add_node("PythonCodeNode", "test_node", {"code": "result = 'ok'"})
-        return WorkflowAPI(builder, runtime=runtime)
+        # require_auth=False: this exercises RUNTIME INJECTION, not the
+        # #2072 auth gate, which defaults to True and refuses to construct
+        # without a credential source. Stated, not inherited.
+        return WorkflowAPI(builder, require_auth=False, runtime=runtime)
 
     def test_constructor_accepts_runtime_parameter(self):
         runtime = AsyncLocalRuntime()

--- a/tests/tier2_integration/servers/test_workflow_server.py
+++ b/tests/tier2_integration/servers/test_workflow_server.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.kailash.servers import WorkflowServer
+from src.kailash.utils.server_auth import mounted_subapp_auth_kwargs
 from src.kailash.workflow import Workflow
 from src.kailash.workflow.builder import WorkflowBuilder
 
@@ -116,8 +117,22 @@ class TestWorkflowServer:
         assert registration.description == "Test workflow description"
         assert registration.tags == ["test", "demo"]
 
-        # Check that WorkflowAPI was created
-        mock_workflow_api.assert_called_once_with(workflow)
+        # Check that WorkflowAPI was created, and that the parent's auth
+        # decision was propagated to it.
+        #
+        # The mounted sub-app MUST NOT install its own gate: it is served by the
+        # parent's ASGI stack, so the parent has already accepted or rejected the
+        # request before routing hands it over, and a second layer would demand a
+        # second credential. `external_auth_reason` is how that is declared, and
+        # asserting it here is what makes the propagation a tested contract
+        # rather than an implementation detail -- if a future change stops
+        # passing it, the sub-app starts refusing to construct (require_auth
+        # defaults True) and this assertion is the first thing to say why.
+        expected_kwargs = mounted_subapp_auth_kwargs(
+            parent_label="WorkflowServer(title='Workflow Registration Test')",
+            parent_is_authenticated=False,
+        )
+        mock_workflow_api.assert_called_once_with(workflow, **expected_kwargs)
 
     def test_duplicate_workflow_registration(self):
         """Test that registering duplicate workflow names raises error."""


### PR DESCRIPTION
## What this is

Tier 2 has run under `continue-on-error: true` since #2038 was filed, so its result never reached the check surface. **Three separate fail-closed security changes each broke tests in it, and each author's only feedback was a green job.** #2124 makes the tier blocking and surfaced all of them at once.

This PR is **tests-only**. No source file is touched — the production behaviour was right; the tests had not caught up.

## Four causes, not one

The #2129 issue body attributed all 23 to #2100's fail-closed auth. Having pulled the CI log and reproduced locally, that holds for 11 of 23:

| n | cause | origin |
|---|---|---|
| 11 | `ServerAuthNotConfiguredError` — `WorkflowAPI` refuses without a credential source | #2100 / #2072 |
| 1 | `JWT secret must be at least 32 characters for HS256 (got 11)` | **#2083**, not #2100 |
| 1 | `expected call not found` — `external_auth_reason` now propagates to mounted sub-apps | #2100, assertion drift |
| 10 | `JWTKeyNotConfiguredError: OAuth signing key not found at 'test_key.pem'` | **kailash-mcp fail-closed key**, unrelated to #2100 |

## Fixed per each test's own intent, not with one blanket opt-out

- **The 11 runtime tests** exercise runtime *selection* and *injection*; none binds a socket. They state `require_auth=False` **explicitly** — stated, not inherited, so a reader can see the server is deliberately ungated rather than wondering whether the omission was an oversight.
- **`test_create_gateway_with_auth`** asserts auth is *wired*. It gets a real 32-byte key. Applying `require_auth=False` here would have deleted the only thing the test checks — this is the case where the blanket fix is the wrong fix.
- **`test_workflow_registration`** now pins the `external_auth_reason` propagation instead of ignoring it. A mounted sub-app must not install a second gate; that is a real contract and now a tested one.
- **The 10 oauth tests** use `allow_ephemeral_key=True`, the remedy the SDK's own error message prescribes.

## The oauth ones were never auth-configuration at all

`AuthorizationServer.__init__` opens `private_key_path` itself instead of delegating to `JWTManager`, so the setup's `patch("kailash_mcp.auth.oauth.JWTManager")` never intercepted it. **`test_key.pem` has never existed in this repo** — that class has been erroring at setup for as long as the file has been referenced, entirely invisibly.

## Verification

Full tier, run exactly as CI runs it (same `-m` selector, same flags):

```
2603 passed, 26 skipped, 4 deselected, 1 xpassed in 91.52s
```

Baseline on `main`: `13 failed, 2559 passed, 10 errors`.

**One thing to know about the `xpassed`:** `test_async_execution_no_threading` is marked `xfail` with reason *"Flaky: async event loop pollution from prior tests"*. That marker was in fact swallowing the `ServerAuthNotConfiguredError`. With the construction fixed the test genuinely passes. The marker is non-strict so it does not fail CI, but it is now mismarked — I left it rather than remove it, because establishing that it is stable across orderings needs repeated full-suite runs I have not done. Worth a follow-up.

**Reproducing this locally requires care.** My first local run showed a *fifth*, phantom cause — `TypeError: ResourceServer.__init__() got an unexpected keyword argument 'resource'`. That was my environment resolving `kailash_mcp` from a stale site-packages wheel (0.2.15) rather than `packages/kailash-mcp/src`. CI installs it editable and never saw it. Put the repo source ahead of the installed wheel or you will chase a defect that does not exist on this branch.

## Related issues

Closes #2129. Unblocks #2124, which completes #2038.