### PR TITLE
fix(proxy): bound responses, share the outbound session, close '..;' traversal, and constrain the destination (#2085 #2087 #2091)

### DIFF
--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -41,7 +41,27 @@ dependencies = [
     # import them, so an older kailash makes `import nexus` fail at startup
     # rather than degrade. ONE shared helper, not a per-package copy — a
     # security helper duplicated across packages is guaranteed to drift.
-    "kailash>=2.63.0",  # safe_callable_name/safe_exception_frames; WorkflowServer.deregister_workflow (#1959)
+    #
+    # 2.63.0 ALSO for `kailash.utils.network_guard` (#2091). The SSRF guard
+    # — private/loopback/link-local/metadata detection, encoded-IP bypass
+    # forms, the IPv4-in-IPv6 translation ranges — was worked out HERE in
+    # `nexus.http_client` and has been LIFTED to core so core's reverse-proxy
+    # surfaces enforce the same posture. `nexus.http_client` now IMPORTS it
+    # at module scope and keeps only its own error type, so an older kailash
+    # makes `import nexus.http_client` fail at IMPORT, not at first request.
+    # Same reasoning as the helpers above: one implementation, because two
+    # copies of one security control diverge and an attacker finds the
+    # divergence first (`zero-tolerance.md` Rule 4).
+    #
+    # RELEASE ORDERING, and it is load-bearing: `network_guard` exists in NO
+    # released kailash — PyPI's latest is 2.62.0 and 2.63.0 is unpublished at
+    # the time of writing. Core kailash 2.63.0 MUST be published BEFORE the
+    # nexus release that carries this, or `pip install kailash-nexus` resolves
+    # kailash 2.62.0 and `import nexus.http_client` raises ModuleNotFoundError
+    # on a clean install. This floor is what makes that a resolver error at
+    # install time instead of an ImportError in production — it is NOT
+    # optional, and it must be bumped in lockstep if the module ever moves.
+    "kailash>=2.63.0",  # safe_callable_name/safe_exception_frames; WorkflowServer.deregister_workflow (#1959); kailash.utils.network_guard (#2091)
     # Server middleware stack (matches kailash[server] contents).
     "fastapi>=0.104.0",
     "starlette>=0.36.0",

--- a/packages/kailash-nexus/src/nexus/http_client.py
+++ b/packages/kailash-nexus/src/nexus/http_client.py
@@ -64,24 +64,16 @@ import httpx
 from kailash.utils.network_guard import (
     DEFAULT_BLOCKED_NETWORKS as _DEFAULT_BLOCKED_NETWORKS,
 )
-from kailash.utils.network_guard import (
-    METADATA_HOSTNAMES as _METADATA_HOSTNAMES,
-)
+from kailash.utils.network_guard import METADATA_HOSTNAMES as _METADATA_HOSTNAMES
 from kailash.utils.network_guard import METADATA_IPS as _METADATA_IPS
 from kailash.utils.network_guard import REASON_ALLOWLIST
 from kailash.utils.network_guard import check_url as _core_check_url
 from kailash.utils.network_guard import (
     detect_encoded_ip_bypass as _detect_encoded_ip_bypass,
 )
-from kailash.utils.network_guard import (
-    is_private_ipv4 as _is_private_ipv4,
-)
-from kailash.utils.network_guard import (
-    is_private_ipv6 as _is_private_ipv6,
-)
-from kailash.utils.network_guard import (
-    iter_resolved_ips as _iter_resolved_ips,
-)
+from kailash.utils.network_guard import is_private_ipv4 as _is_private_ipv4
+from kailash.utils.network_guard import is_private_ipv6 as _is_private_ipv6
+from kailash.utils.network_guard import iter_resolved_ips as _iter_resolved_ips
 from kailash.utils.network_guard import url_fingerprint as _url_fingerprint
 
 logger = logging.getLogger(__name__)
@@ -144,6 +136,7 @@ class InvalidEndpointError(HttpClientError):
 # injects nexus's exception type through the shared implementation's
 # `error_factory` hook.
 
+
 def check_url(
     url: str,
     *,
@@ -187,6 +180,7 @@ def check_url(
         allow_metadata=False,
         error_factory=InvalidEndpointError,
     )
+
 
 # ---------------------------------------------------------------------------
 # SafeDnsTransport — connect-time SSRF re-check
@@ -277,8 +271,6 @@ class HttpClientConfig:
                 "blocked_networks",
                 _DEFAULT_BLOCKED_NETWORKS,
             )
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-nexus/src/nexus/http_client.py
+++ b/packages/kailash-nexus/src/nexus/http_client.py
@@ -61,6 +61,29 @@ from urllib.parse import urlparse
 
 import httpx
 
+from kailash.utils.network_guard import (
+    DEFAULT_BLOCKED_NETWORKS as _DEFAULT_BLOCKED_NETWORKS,
+)
+from kailash.utils.network_guard import (
+    METADATA_HOSTNAMES as _METADATA_HOSTNAMES,
+)
+from kailash.utils.network_guard import METADATA_IPS as _METADATA_IPS
+from kailash.utils.network_guard import REASON_ALLOWLIST
+from kailash.utils.network_guard import check_url as _core_check_url
+from kailash.utils.network_guard import (
+    detect_encoded_ip_bypass as _detect_encoded_ip_bypass,
+)
+from kailash.utils.network_guard import (
+    is_private_ipv4 as _is_private_ipv4,
+)
+from kailash.utils.network_guard import (
+    is_private_ipv6 as _is_private_ipv6,
+)
+from kailash.utils.network_guard import (
+    iter_resolved_ips as _iter_resolved_ips,
+)
+from kailash.utils.network_guard import url_fingerprint as _url_fingerprint
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,22 +110,7 @@ class InvalidEndpointError(HttpClientError):
     echo a user-supplied URL verbatim.
     """
 
-    _REASON_ALLOWLIST = frozenset(
-        {
-            "scheme",
-            "private_ipv4",
-            "private_ipv6",
-            "loopback",
-            "link_local",
-            "metadata_service",
-            "metadata_host",
-            "malformed_url",
-            "resolution_failed",
-            "ipv4_mapped",
-            "encoded_ip_bypass",
-            "host_not_allowlisted",
-        }
-    )
+    _REASON_ALLOWLIST = REASON_ALLOWLIST
 
     def __init__(self, reason: str, raw_url: Optional[str] = None) -> None:
         if reason not in self._REASON_ALLOWLIST:
@@ -119,169 +127,22 @@ class InvalidEndpointError(HttpClientError):
 
 
 # ---------------------------------------------------------------------------
-# URL fingerprinting (secrets-safe logging)
+# SSRF guard — LIFTED TO CORE (issue #2091)
 # ---------------------------------------------------------------------------
-
-
-def _url_fingerprint(raw: Optional[str]) -> str:
-    """SHA-256 prefix of the raw URL. Matches cross-SDK 8-char contract."""
-    if not raw:
-        return "none"
-    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:8]
-
-
-# ---------------------------------------------------------------------------
-# SSRF guard — private / loopback / link-local / metadata detection
-# ---------------------------------------------------------------------------
-
-# IPv6 embedded-IPv4 ranges — an attacker can wrap a private IPv4 in one of
-# these forms to bypass a guard that only checks ``is_private`` on the IPv6
-# wrapper. Reject both ranges unconditionally — no legitimate external
-# service lives inside a translation-prefix range. Mirrors the kailash-rs
-# SafeDnsResolver check and the kaizen.llm.url_safety implementation.
-_IPV4_TRANSLATED_NETWORK = ipaddress.IPv6Network("::ffff:0:0:0/96")  # RFC 2765 SIIT
-_NAT64_WELLKNOWN_NETWORK = ipaddress.IPv6Network("64:ff9b::/96")  # RFC 6052
-
-# Cloud metadata IPs and hostnames — these are the most common SSRF
-# exfiltration targets on AWS / GCP / Azure. We reject both the numeric IP
-# and the convenience hostname the cloud provider ships to the guest OS.
-_METADATA_IPS = frozenset(
-    {
-        "169.254.169.254",
-        "fd00:ec2::254",
-    }
-)
-
-_METADATA_HOSTNAMES = frozenset(
-    {
-        "metadata.google.internal",
-        "metadata.azure.com",
-        "metadata.aws.internal",
-    }
-)
-
-
-def _is_private_ipv4(ip: ipaddress.IPv4Address) -> bool:
-    return (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_unspecified
-    )
-
-
-def _is_private_ipv6(ip: ipaddress.IPv6Address) -> bool:
-    if ip.is_private or ip.is_loopback or ip.is_link_local:
-        return True
-    if ip.is_multicast or ip.is_reserved or ip.is_unspecified:
-        return True
-    if ip.ipv4_mapped is not None:
-        return _is_private_ipv4(ip.ipv4_mapped)
-    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
-        return True
-    return False
-
-
-def _ip_reason(
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
-) -> str:
-    """Map an offending IP to an allowlisted ``InvalidEndpointError.reason``."""
-    ip_str = str(ip)
-    if ip_str in _METADATA_IPS:
-        return "metadata_service"
-    if isinstance(ip, ipaddress.IPv4Address):
-        if ip.is_loopback:
-            return "loopback"
-        if ip.is_link_local:
-            return "link_local"
-        return "private_ipv4"
-    # IPv6
-    if ip.ipv4_mapped is not None:
-        return "ipv4_mapped"
-    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
-        return "ipv4_mapped"
-    if ip.is_loopback:
-        return "loopback"
-    if ip.is_link_local:
-        return "link_local"
-    return "private_ipv6"
-
-
-def _try_parse_ip(
-    candidate: str,
-) -> Optional[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    try:
-        return ipaddress.ip_address(candidate)
-    except (ValueError, TypeError):
-        return None
-
-
-def _try_inet_aton_shortform(candidate: str) -> Optional[ipaddress.IPv4Address]:
-    """Detect ``socket.inet_aton`` short-form IPv4 (``127.1`` -> 127.0.0.1).
-
-    ``ipaddress.ip_address`` rejects these, but libc resolves them, and a
-    guard that only checks the strict form is bypassable when the HTTP stack
-    forwards to the libc resolver.
-    """
-    if not candidate or not isinstance(candidate, str):
-        return None
-    if ":" in candidate:
-        return None
-    if _try_parse_ip(candidate) is not None:
-        return None
-    try:
-        packed = socket.inet_aton(candidate)
-    except (OSError, ValueError, TypeError):
-        return None
-    return ipaddress.IPv4Address(packed)
-
-
-def _detect_encoded_ip_bypass(host: str) -> bool:
-    """Reject decimal / octal / hex IPv4 encodings.
-
-    ``socket.gethostbyname("2130706433")`` returns ``127.0.0.1`` on many
-    libc implementations; the standard ``ipaddress`` parser rejects these,
-    so the guard needs its own detection.
-    """
-    if host.isdigit():
-        return True
-    for part in host.split("."):
-        if part.startswith("0x") or part.startswith("0X"):
-            return True
-        if len(part) > 1 and part.startswith("0") and part[1:].isdigit():
-            return True
-    return False
-
-
-def _iter_resolved_ips(
-    host: str,
-) -> "list[ipaddress.IPv4Address | ipaddress.IPv6Address]":
-    """Yield every IP ``socket.getaddrinfo`` associates with ``host``.
-
-    Returns an empty list on resolution failure so the caller can treat
-    that as ``resolution_failed``.
-    """
-    results: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
-    try:
-        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    except socket.gaierror:
-        return results
-    seen: set[str] = set()
-    for info in infos:
-        sockaddr = info[4]
-        if not sockaddr:
-            continue
-        ip_str = sockaddr[0]
-        if ip_str in seen:
-            continue
-        seen.add(ip_str)
-        parsed = _try_parse_ip(ip_str)
-        if parsed is not None:
-            results.append(parsed)
-    return results
-
+#
+# The private/loopback/link-local/metadata detection, the encoded-IP bypass
+# forms, the IPv4-in-IPv6 translation ranges and the metadata sets were all
+# worked out HERE first. They now live in `kailash.utils.network_guard` so
+# core's reverse-proxy surfaces can enforce the same posture: `kailash-nexus`
+# depends on `kailash` and never the reverse, so the shared piece has to sit
+# in core for both to use it.
+#
+# This module keeps its own error TYPE and its client wiring, and delegates
+# every DECISION. There is deliberately no second copy of the logic to drift
+# from — `zero-tolerance.md` Rule 4. `check_url` below is a thin adapter that
+# pins nexus's strict posture (no allow_private, no allow_metadata) and
+# injects nexus's exception type through the shared implementation's
+# `error_factory` hook.
 
 def check_url(
     url: str,
@@ -293,14 +154,14 @@ def check_url(
 ) -> None:
     """Validate ``url`` as an SSRF-safe outbound target.
 
-    Raises ``InvalidEndpointError`` on any rejection. ``reason`` is from a
-    fixed allowlist; the raw URL is hashed and stored only as a fingerprint
+    Raises :class:`InvalidEndpointError` on any rejection. ``reason`` is from
+    a fixed allowlist; the raw URL is hashed and stored only as a fingerprint
     on the exception so audit logs never echo the user-supplied URL.
 
     Ordering — per issue #473 non-negotiable 1: the private-IP / metadata
     check runs BEFORE the host allowlist check. An allowlisted private IP is
-    still rejected. The allowlist ONLY narrows the already-safe set of
-    public hosts; it MUST NOT be a back-door past the SSRF guard.
+    still rejected. The allowlist ONLY narrows the already-safe set of public
+    hosts; it MUST NOT be a back-door past the SSRF guard.
 
     ``allow_loopback=True`` is for tests against a local stub server. It
     narrowly permits 127.0.0.1 / localhost / ::1. Every other private range
@@ -309,147 +170,23 @@ def check_url(
     ``blocked_networks`` lets callers add additional CIDR blocks on top of
     the always-blocked set (e.g. a corporate internal block the attacker
     shouldn't reach even if it passes the RFC1918 check).
+
+    The decision logic is :func:`kailash.utils.network_guard.check_url`. This
+    wrapper exists to pin nexus's STRICT posture — ``allow_private`` and
+    ``allow_metadata`` are not exposed here, because an outbound client
+    talking to the public internet has no business reaching RFC1918 — and to
+    raise nexus's own error type.
     """
-    if not isinstance(url, str) or not url:
-        raise InvalidEndpointError("malformed_url", raw_url=None)
-
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        raise InvalidEndpointError("malformed_url", raw_url=url)
-
-    scheme = (parsed.scheme or "").lower()
-    host = parsed.hostname or ""
-
-    # ---- Scheme check -----------------------------------------------------
-    # http / https only. Unknown schemes (file://, gopher://, ftp://) are
-    # BLOCKED before DNS lookup — they are the classic SSRF bypass surface.
-    # Run scheme check BEFORE the empty-host check because ``file:///path``
-    # parses with empty host; we want the rejection reason to surface as
-    # "scheme" so forensic aggregation can separate the file:// attempts
-    # from merely malformed URLs.
-    if scheme not in ("http", "https"):
-        raise InvalidEndpointError("scheme", raw_url=url)
-
-    if not host:
-        raise InvalidEndpointError("malformed_url", raw_url=url)
-
-    host_lc = host.lower()
-
-    # ---- Metadata hostname check ------------------------------------------
-    if host_lc in _METADATA_HOSTNAMES:
-        raise InvalidEndpointError("metadata_host", raw_url=url)
-
-    # ---- Encoded IP bypass check ------------------------------------------
-    parsed_ip = _try_parse_ip(host)
-    if parsed_ip is None and _detect_encoded_ip_bypass(host):
-        raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
-
-    # ---- inet_aton short-form check ---------------------------------------
-    if parsed_ip is None:
-        shortform = _try_inet_aton_shortform(host)
-        if shortform is not None:
-            if _is_private_ipv4(shortform) or str(shortform) in _METADATA_IPS:
-                raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
-            # Short-form IPv4 that resolves public: still reject — no
-            # legitimate external service is addressed via the inet_aton
-            # short-form, and accepting it widens the audit surface.
-            raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
-
-    # ---- Literal IP — private / metadata / extra-blocked ------------------
-    if parsed_ip is not None:
-        _validate_ip(parsed_ip, url, allow_loopback, blocked_networks, host_lc)
-        # Literal IP, passed checks — allowlist still applies if set.
-        _check_host_allowlist(host_lc, host_allowlist, url)
-        return
-
-    # ---- Host allowlist (layered AFTER SSRF per issue #473 NN1) -----------
-    _check_host_allowlist(host_lc, host_allowlist, url)
-
-    # ---- DNS resolution (rebinding defence) -------------------------------
-    if not resolve_dns:
-        return
-
-    any_resolved = False
-    loopback_hosts = {"localhost", "127.0.0.1", "::1"}
-    for ip in _iter_resolved_ips(host):
-        any_resolved = True
-        _validate_ip(ip, url, allow_loopback, blocked_networks, host_lc, loopback_hosts)
-
-    if not any_resolved and not (allow_loopback and host_lc in loopback_hosts):
-        raise InvalidEndpointError("resolution_failed", raw_url=url)
-
-
-def _validate_ip(
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
-    url: str,
-    allow_loopback: bool,
-    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]],
-    host_lc: str,
-    loopback_hosts: Optional[set[str]] = None,
-) -> None:
-    """Validate a single IP against the blocklist.
-
-    Central routine used for both literal-IP URLs and DNS-resolved IPs. The
-    caller-supplied ``blocked_networks`` list is applied on top of the
-    always-blocked ranges so extra corporate / internal CIDRs cannot be
-    bypassed by a caller forgetting to mix them in.
-    """
-    loopback_hosts = loopback_hosts or {"localhost", "127.0.0.1", "::1"}
-    loopback_carveout = allow_loopback and ip.is_loopback and host_lc in loopback_hosts
-
-    # Metadata always blocked regardless of allow_loopback.
-    if str(ip) in _METADATA_IPS:
-        raise InvalidEndpointError("metadata_service", raw_url=url)
-
-    if isinstance(ip, ipaddress.IPv4Address):
-        if _is_private_ipv4(ip):
-            # Narrow allow_loopback carve-out: only 127.0.0.1 when the
-            # hostname is a known loopback label. Every other private range
-            # stays blocked so allow_loopback can't be used as a wildcard.
-            if not loopback_carveout:
-                raise InvalidEndpointError(_ip_reason(ip), raw_url=url)
-
-    if isinstance(ip, ipaddress.IPv6Address):
-        if _is_private_ipv6(ip):
-            if not loopback_carveout:
-                raise InvalidEndpointError(_ip_reason(ip), raw_url=url)
-
-    # Extra blocklist (corporate / internal ranges callers supply).
-    # When the loopback carve-out applies, skip the blocked_networks sweep
-    # as well — otherwise the default blocklist (which contains 127.0.0.0/8
-    # precisely because loopback is unsafe for production) re-rejects the
-    # IP the carve-out just permitted. The carve-out is still narrow: only
-    # literal loopback IPs under a known loopback hostname label are
-    # exempted, so no extra-blocklist CIDR a caller added can hit an IP
-    # that satisfies the carve-out anyway.
-    if blocked_networks and not loopback_carveout:
-        for net in blocked_networks:
-            try:
-                if ip in net:
-                    raise InvalidEndpointError("private_ipv4", raw_url=url)
-            except TypeError:
-                # Network family mismatch (v4 vs v6) is normal — skip.
-                continue
-
-
-def _check_host_allowlist(
-    host_lc: str,
-    host_allowlist: Optional[Sequence[str]],
-    url: str,
-) -> None:
-    """Enforce the optional host allowlist.
-
-    The allowlist is ONLY consulted AFTER the SSRF private-IP check has
-    passed (per issue #473 non-negotiable 1). The allowlist narrows the
-    already-safe public set — it is NOT a bypass path.
-    """
-    if host_allowlist is None:
-        return
-    normalized = {h.lower() for h in host_allowlist}
-    if host_lc not in normalized:
-        raise InvalidEndpointError("host_not_allowlisted", raw_url=url)
-
+    _core_check_url(
+        url,
+        blocked_networks=blocked_networks,
+        host_allowlist=host_allowlist,
+        allow_loopback=allow_loopback,
+        resolve_dns=resolve_dns,
+        allow_private=False,
+        allow_metadata=False,
+        error_factory=InvalidEndpointError,
+    )
 
 # ---------------------------------------------------------------------------
 # SafeDnsTransport — connect-time SSRF re-check
@@ -542,21 +279,6 @@ class HttpClientConfig:
             )
 
 
-# Baseline blocked networks. Applied on top of the per-IP private-range
-# check so extra IPv4 + IPv6 CIDRs are rejected even when a libc helper
-# somehow resolves them to look "public". RFC1918 + loopback + link-local +
-# IMDS + ULA + link-local-v6 + documentation ranges.
-_DEFAULT_BLOCKED_NETWORKS: tuple[ipaddress._BaseNetwork, ...] = (
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),  # link-local + IMDS
-    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT — commonly internal
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),  # ULA
-    ipaddress.ip_network("fe80::/10"),  # link-local v6
-)
 
 
 # ---------------------------------------------------------------------------

--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -60,7 +60,7 @@ import logging
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 # `httpx`, `fastapi`, and `starlette` are OPTIONAL dependencies under the
 # `server` extra (pyproject.toml:55-67), not in slim-core dependencies. Per
@@ -102,6 +102,7 @@ from ..utils.proxy_guard import (
     compile_path_allowlist,
     normalize_allowed_methods,
     path_matches_allowlist,
+    reject_unsafe_proxy_destination,
     reject_unsafe_proxy_path,
     resolve_proxy_auth_dependency,
 )
@@ -703,6 +704,9 @@ class WorkflowAPIGateway:
         allowed_methods: list[str] | None = None,
         auth_dependency: Callable[..., Any] | None = None,
         forward_credentials: bool = False,
+        blocked_networks: Sequence[Any] | None = None,
+        allow_metadata_destination: bool = False,
+        require_public_destination: bool = False,
     ):
         """Register a proxied workflow with real request forwarding.
 
@@ -744,10 +748,21 @@ class WorkflowAPIGateway:
                 whichever round-robin backend was selected. Set True only when
                 the backend is trusted and genuinely needs to re-authorize the
                 original caller.
+            blocked_networks: Extra CIDR blocks no backend may resolve into,
+                on top of the always-blocked metadata and link-local ranges.
+            allow_metadata_destination: Permit a backend in the cloud
+                metadata / link-local set (issue #2091). Defaults to False and
+                logs a WARNING naming the disabled protection when set.
+            require_public_destination: Also refuse RFC1918 and loopback
+                backends, adopting the stricter ``nexus.http_client`` posture.
+                Defaults to False because proxying to an internal service is
+                this surface's common legitimate use.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control is
                 configured for the route.
+            BlockedDestinationError: A backend URL resolves into the blocked
+                destination set (issue #2091).
             ValueError: ``name`` is already registered, or ``allowed_paths`` /
                 ``allowed_methods`` is missing or invalid.
         """
@@ -770,6 +785,22 @@ class WorkflowAPIGateway:
         # Support multiple backends via comma-separated URLs
         backends = [u.strip() for u in proxy_url.split(",") if u.strip()]
         primary_url = backends[0]
+
+        # The DESTINATION control (#2091), applied to EVERY backend rather
+        # than just the primary. Round-robin means a caller cannot choose
+        # which one serves their request, so checking only `primary_url`
+        # would leave the second and later entries unconstrained -- the same
+        # partial-coverage shape the credential-forwarding defect had here
+        # before #2025.
+        for backend_url in backends:
+            reject_unsafe_proxy_destination(
+                backend_url,
+                name=name,
+                surface="WorkflowAPIGateway",
+                blocked_networks=blocked_networks,
+                allow_metadata_destination=allow_metadata_destination,
+                require_public_destination=require_public_destination,
+            )
 
         self.workflows[name] = WorkflowRegistration(
             name=name,

--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -789,9 +789,7 @@ class WorkflowAPIGateway:
         path_allowlist = compile_path_allowlist(allowed_paths, name=name)
         methods = normalize_allowed_methods(allowed_methods, name=name)
 
-        max_response_bytes = normalize_max_response_bytes(
-            max_response_bytes, name=name
-        )
+        max_response_bytes = normalize_max_response_bytes(max_response_bytes, name=name)
 
         # Support multiple backends via comma-separated URLs
         backends = [u.strip() for u in proxy_url.split(",") if u.strip()]

--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -101,6 +101,7 @@ from ..utils.proxy_guard import (
     PathPattern,
     compile_path_allowlist,
     normalize_allowed_methods,
+    normalize_max_response_bytes,
     path_matches_allowlist,
     reject_unsafe_proxy_destination,
     reject_unsafe_proxy_path,
@@ -707,6 +708,7 @@ class WorkflowAPIGateway:
         blocked_networks: Sequence[Any] | None = None,
         allow_metadata_destination: bool = False,
         require_public_destination: bool = False,
+        max_response_bytes: int | None = None,
     ):
         """Register a proxied workflow with real request forwarding.
 
@@ -757,6 +759,11 @@ class WorkflowAPIGateway:
                 backends, adopting the stricter ``nexus.http_client`` posture.
                 Defaults to False because proxying to an internal service is
                 this surface's common legitimate use.
+            max_response_bytes: Largest backend response body this route will
+                buffer, in bytes. Defaults to
+                :data:`~kailash.utils.proxy_guard.DEFAULT_MAX_RESPONSE_BYTES`
+                (64 MiB). A larger response is refused with 502 rather than
+                truncated (issue #2085). There is no 'unlimited' value.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control is
@@ -781,6 +788,10 @@ class WorkflowAPIGateway:
         )
         path_allowlist = compile_path_allowlist(allowed_paths, name=name)
         methods = normalize_allowed_methods(allowed_methods, name=name)
+
+        max_response_bytes = normalize_max_response_bytes(
+            max_response_bytes, name=name
+        )
 
         # Support multiple backends via comma-separated URLs
         backends = [u.strip() for u in proxy_url.split(",") if u.strip()]
@@ -914,7 +925,18 @@ class WorkflowAPIGateway:
 
             try:
                 client = await self._get_proxy_client()
-                resp = await client.request(
+                # BOUNDED read (#2085). `client.request(...)` reads the whole
+                # body before returning, so a multi-gigabyte backend response
+                # was buffered entire in this process and concurrent requests
+                # multiplied it. Streaming lets the accumulation stop at the
+                # cap instead.
+                #
+                # `content-length` is deliberately NOT trusted as the signal:
+                # it is absent from the response allowlist precisely because
+                # it describes COMPRESSED bytes over a decompressed body
+                # (#2025). httpx's `aiter_bytes()` yields DECOMPRESSED bytes,
+                # which is the memory that actually matters.
+                proxy_request = client.build_request(
                     method=request.method,
                     url=target_url,
                     headers=headers,
@@ -923,13 +945,49 @@ class WorkflowAPIGateway:
                     # dict() silently kept only the last (issue #2025).
                     params=list(request.query_params.multi_items()),
                 )
+                resp = await client.send(proxy_request, stream=True)
+                try:
+                    chunks: list[bytes] = []
+                    total = 0
+                    too_large = False
+                    async for chunk in resp.aiter_bytes():
+                        total += len(chunk)
+                        if total > max_response_bytes:
+                            too_large = True
+                            break
+                        chunks.append(chunk)
+                finally:
+                    await resp.aclose()
+
+                if too_large:
+                    logger.warning(
+                        "gateway.proxy.response_too_large",
+                        extra={
+                            "workflow": name,
+                            "max_response_bytes": max_response_bytes,
+                        },
+                    )
+                    # Fail CLOSED: refuse rather than return a TRUNCATED body,
+                    # which the caller could not distinguish from a complete
+                    # one.
+                    return Response(
+                        content=json.dumps(
+                            {
+                                "error": "Backend response exceeded the "
+                                "configured limit for this proxy route"
+                            }
+                        ),
+                        status_code=502,
+                        media_type="application/json",
+                    )
+
                 filtered_headers = {
                     k: v
                     for k, v in resp.headers.items()
                     if k.lower() in PROXY_SAFE_RESPONSE_HEADERS
                 }
                 return Response(
-                    content=resp.content,
+                    content=b"".join(chunks),
                     status_code=resp.status_code,
                     headers=filtered_headers,
                     media_type=resp.headers.get("content-type"),

--- a/src/kailash/channels/api_channel.py
+++ b/src/kailash/channels/api_channel.py
@@ -536,6 +536,7 @@ class APIChannel(Channel):
         blocked_networks: Optional[Sequence[Any]] = None,
         allow_metadata_destination: bool = False,
         require_public_destination: bool = False,
+        max_response_bytes: Optional[int] = None,
     ) -> None:
         """Register a proxied workflow with this API channel.
 
@@ -570,6 +571,9 @@ class APIChannel(Channel):
                 destination. Defaults to False; logs a WARNING when set.
             require_public_destination: Also refuse RFC1918 and loopback
                 destinations. Defaults to False.
+            max_response_bytes: Largest backend response body this route will
+                buffer (issue #2085). Defaults to 64 MiB; larger responses are
+                refused with 502 rather than truncated.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control configured.
@@ -590,6 +594,7 @@ class APIChannel(Channel):
             blocked_networks=blocked_networks,
             allow_metadata_destination=allow_metadata_destination,
             require_public_destination=require_public_destination,
+            max_response_bytes=max_response_bytes,
         )
         logger.info(
             f"Registered proxied workflow '{name}' with API channel {self.name}"

--- a/src/kailash/channels/api_channel.py
+++ b/src/kailash/channels/api_channel.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Sequence
 
 # `uvicorn` and `starlette` are OPTIONAL dependencies under the `server` extra.
 # Per `rules/dependencies.md` § "Declared = Imported": optional-extra imports
@@ -533,6 +533,9 @@ class APIChannel(Channel):
         allowed_methods: Optional[list] = None,
         auth_dependency: Optional[Callable[..., Any]] = None,
         forward_credentials: bool = False,
+        blocked_networks: Optional[Sequence[Any]] = None,
+        allow_metadata_destination: bool = False,
+        require_public_destination: bool = False,
     ) -> None:
         """Register a proxied workflow with this API channel.
 
@@ -561,9 +564,17 @@ class APIChannel(Channel):
                 omitted, the underlying server's ``auth_manager`` supplies one.
             forward_credentials: Forward the caller's credential headers to the
                 backend. Defaults to False (stripped).
+            blocked_networks: Extra CIDR blocks the destination may not
+                resolve into (issue #2091).
+            allow_metadata_destination: Permit a cloud-metadata / link-local
+                destination. Defaults to False; logs a WARNING when set.
+            require_public_destination: Also refuse RFC1918 and loopback
+                destinations. Defaults to False.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control configured.
+            BlockedDestinationError: ``proxy_url`` resolves into the blocked
+                destination set (issue #2091).
             ValueError: ``allowed_paths`` missing or invalid.
         """
         self.workflow_server.proxy_workflow(
@@ -576,6 +587,9 @@ class APIChannel(Channel):
             allowed_methods=allowed_methods,
             auth_dependency=auth_dependency,
             forward_credentials=forward_credentials,
+            blocked_networks=blocked_networks,
+            allow_metadata_destination=allow_metadata_destination,
+            require_public_destination=require_public_destination,
         )
         logger.info(
             f"Registered proxied workflow '{name}' with API channel {self.name}"

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -744,7 +744,11 @@ class WorkflowServer:
         # several loops each get a live one instead of a corpse.
         loop = asyncio.get_running_loop()
         session = self._proxy_session
-        if session is not None and not session.closed and self._proxy_session_loop is loop:
+        if (
+            session is not None
+            and not session.closed
+            and self._proxy_session_loop is loop
+        ):
             return session
 
         if session is not None and not session.closed:
@@ -1095,9 +1099,7 @@ class WorkflowServer:
             name=name,
             supported=("GET", "POST", "PUT", "DELETE", "PATCH"),
         )
-        max_response_bytes = normalize_max_response_bytes(
-            max_response_bytes, name=name
-        )
+        max_response_bytes = normalize_max_response_bytes(max_response_bytes, name=name)
         # The DESTINATION control (#2091). The four above constrain what a
         # caller can do; this one constrains what the deployment can point at.
         reject_unsafe_proxy_destination(

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -43,6 +43,7 @@ from ..utils.proxy_guard import (
     PathPattern,
     compile_path_allowlist,
     normalize_allowed_methods,
+    normalize_max_response_bytes,
     path_matches_allowlist,
     reject_unsafe_proxy_destination,
     reject_unsafe_proxy_path,
@@ -286,6 +287,16 @@ class WorkflowServer:
             "executor", lambda: self.executor.shutdown(wait=True), priority=0
         )
 
+        # Shared outbound session for proxied routes (#2085). One session for
+        # the server's lifetime rather than one per REQUEST, closed on the
+        # normal shutdown path at priority 3 ("close") so the connector and
+        # its sockets are released rather than leaked to GC.
+        self._proxy_session: Any = None
+        self._proxy_session_loop: Any = None
+        self.shutdown_coordinator.register(
+            "proxy_session", self.aclose_proxy_session, priority=3
+        )
+
         # Create FastAPI app with lifespan.
         #
         # Historical bug #500: passing ANY custom `lifespan` to FastAPI()
@@ -516,18 +527,24 @@ class WorkflowServer:
                 if reg.type == "embedded":
                     health_status["workflows"][name] = "healthy"
                 elif reg.type == "proxied" and reg.proxy_url:
-                    # Check proxy health by hitting the remote health endpoint
+                    # Check proxy health by hitting the remote health endpoint.
+                    # Uses the SHARED session (#2085): this is the sibling
+                    # call site of the per-request-session defect, and health
+                    # checks run on a schedule, so leaving it constructing its
+                    # own session per poll would have kept the fd/socket churn
+                    # the fix exists to remove.
                     try:
                         import aiohttp
 
                         url = f"{reg.proxy_url.rstrip('/')}{reg.health_check}"
-                        timeout = aiohttp.ClientTimeout(total=5)
-                        async with aiohttp.ClientSession(timeout=timeout) as session:
-                            async with session.get(url) as resp:
-                                if resp.status == 200:
-                                    health_status["workflows"][name] = "healthy"
-                                else:
-                                    health_status["workflows"][name] = "degraded"
+                        session = await self._get_proxy_session()
+                        async with session.get(
+                            url, timeout=aiohttp.ClientTimeout(total=5)
+                        ) as resp:
+                            if resp.status == 200:
+                                health_status["workflows"][name] = "healthy"
+                            else:
+                                health_status["workflows"][name] = "degraded"
                     except Exception as e:
                         logger.warning(f"Proxy health check failed for {name}: {e}")
                         health_status["workflows"][name] = "unhealthy"
@@ -700,6 +717,67 @@ class WorkflowServer:
                     status_code=404,
                     content={"error": "Workflow or query not found"},
                 )
+
+    async def _get_proxy_session(self) -> Any:
+        """Get or create the shared ``aiohttp.ClientSession`` for proxying.
+
+        Before #2085 every proxied request built and tore down its own
+        session, which means a new connector, a new connection pool and fresh
+        sockets per request -- no keep-alive reuse at all. That churn is not
+        theoretical here: this repo already hit fd/thread exhaustion in CI
+        (#2078).
+
+        This mirrors ``WorkflowAPIGateway._get_proxy_client()``, which had it
+        right; the two surfaces disagreeing on connection lifecycle was itself
+        an enforcement-surface asymmetry, the same shape as the
+        credential-stripping and redirect-policy disagreements #2025 closed.
+        """
+        import aiohttp
+
+        # An aiohttp session binds to the event loop that CREATED it: its
+        # connector registers transports and timer callbacks on that loop, so
+        # reusing one across loops raises "Event loop is closed" from the
+        # connector rather than from anything the caller can see. The session
+        # is therefore keyed by loop, not merely cached -- servers under a
+        # single uvicorn loop get one session for their whole lifetime (the
+        # point of #2085), while test harnesses and embedded hosts that run
+        # several loops each get a live one instead of a corpse.
+        loop = asyncio.get_running_loop()
+        session = self._proxy_session
+        if session is not None and not session.closed and self._proxy_session_loop is loop:
+            return session
+
+        if session is not None and not session.closed:
+            # Belongs to a different loop. Close it THERE if that loop is
+            # still alive; a closed loop has already dropped its transports,
+            # so there is nothing left to release and calling close() would
+            # raise. Not a silent swallow: the stale session is replaced and
+            # the reason is this comment.
+            old_loop = self._proxy_session_loop
+            if old_loop is not None and not old_loop.is_closed():
+                old_loop.call_soon_threadsafe(
+                    lambda s=session: asyncio.ensure_future(s.close(), loop=old_loop)
+                )
+
+        session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+        )
+        self._proxy_session = session
+        self._proxy_session_loop = loop
+        return session
+
+    async def aclose_proxy_session(self) -> None:
+        """Close the shared proxy session. Idempotent.
+
+        Registered with the :class:`~kailash.runtime.shutdown.ShutdownCoordinator`
+        at construction, so the session is released on the normal shutdown
+        path rather than leaked to GC (#2085).
+        """
+        session = self._proxy_session
+        self._proxy_session = None
+        self._proxy_session_loop = None
+        if session is not None and not session.closed:
+            await session.close()
 
     def close(self) -> None:
         """Release per-workflow API runtimes (issue #1285).
@@ -928,6 +1006,7 @@ class WorkflowServer:
         blocked_networks: Sequence[Any] | None = None,
         allow_metadata_destination: bool = False,
         require_public_destination: bool = False,
+        max_response_bytes: int | None = None,
     ):
         """Register a proxied workflow running on another server.
 
@@ -981,6 +1060,13 @@ class WorkflowServer:
                 ``nexus.http_client`` uses for outbound calls. Defaults to
                 False because proxying to an internal service is this
                 surface's common legitimate use.
+            max_response_bytes: Largest backend response body this route will
+                buffer, in bytes. Defaults to
+                :data:`~kailash.utils.proxy_guard.DEFAULT_MAX_RESPONSE_BYTES`
+                (64 MiB). A larger response is refused with 502 rather than
+                truncated (issue #2085). Per-registration so a backend that
+                legitimately serves large exports can raise it without
+                widening every other route. There is no 'unlimited' value.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control is
@@ -1008,6 +1094,9 @@ class WorkflowServer:
             allowed_methods,
             name=name,
             supported=("GET", "POST", "PUT", "DELETE", "PATCH"),
+        )
+        max_response_bytes = normalize_max_response_bytes(
+            max_response_bytes, name=name
         )
         # The DESTINATION control (#2091). The four above constrain what a
         # caller can do; this one constrains what the deployment can point at.
@@ -1109,63 +1198,112 @@ class WorkflowServer:
             # refusing it.
 
             target_url = f"{proxy_url.rstrip('/')}/{path}"
-            timeout = aiohttp.ClientTimeout(total=30)
 
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                # Forward headers, excluding hop-by-hop headers and -- unless
-                # the registration opted in -- the caller's credentials. The
-                # credential set is shared with WorkflowAPIGateway so the two
-                # proxy surfaces cannot drift (security.md, Enforcement-Surface
-                # Parity); before #2025 they disagreed in opposite directions.
-                _excluded_headers = {"host", "content-length"}
-                _excluded_headers |= PROXY_HOP_BY_HOP_HEADERS
-                if not forward_credentials:
-                    _excluded_headers |= PROXY_CREDENTIAL_HEADERS
-                headers = {
-                    k: v
-                    for k, v in request.headers.items()
-                    if k.lower() not in _excluded_headers
-                }
+            # ONE session for the server's lifetime, not one per request
+            # (#2085). Deliberately NOT an `async with`: the session outlives
+            # this handler and is closed by the ShutdownCoordinator, so
+            # closing it here would tear it out from under concurrent
+            # requests.
+            session = await self._get_proxy_session()
 
-                body = (
-                    await request.body()
-                    if request.method in ("POST", "PUT", "PATCH")
-                    else None
-                )
+            # Forward headers, excluding hop-by-hop headers and -- unless
+            # the registration opted in -- the caller's credentials. The
+            # credential set is shared with WorkflowAPIGateway so the two
+            # proxy surfaces cannot drift (security.md, Enforcement-Surface
+            # Parity); before #2025 they disagreed in opposite directions.
+            _excluded_headers = {"host", "content-length"}
+            _excluded_headers |= PROXY_HOP_BY_HOP_HEADERS
+            if not forward_credentials:
+                _excluded_headers |= PROXY_CREDENTIAL_HEADERS
+            headers = {
+                k: v
+                for k, v in request.headers.items()
+                if k.lower() not in _excluded_headers
+            }
 
-                async with session.request(
-                    request.method,
-                    target_url,
-                    headers=headers,
-                    data=body,
-                    # multi_items() preserves repeated keys (?tag=a&tag=b);
-                    # dict() silently kept only the last (issue #2025).
-                    params=list(request.query_params.multi_items()),
-                    # EXPLICIT, and load-bearing. aiohttp defaults this to
-                    # True. Every control this route enforces -- the auth
-                    # gate, the path allowlist, traversal rejection, the
-                    # charset barrier -- applies to hop 1 only, so following a
-                    # redirect hands the caller an authority pivot on hop 2:
-                    # a backend with any open redirect (an SSO `?next=` bounce
-                    # is ubiquitous, and query strings are forwarded verbatim)
-                    # makes the proxy fetch an arbitrary host and return the
-                    # body as if it were the backend's. `location` is not in
-                    # the response allowlist, so the caller cannot even see
-                    # that it happened. Measured before this line existed:
-                    # a fully-hardened registration fetched cloud-metadata.
-                    allow_redirects=False,
-                ) as resp:
-                    content = await resp.read()
-                    safe_headers = {
-                        k: v
-                        for k, v in resp.headers.items()
-                        if k.lower() in PROXY_SAFE_RESPONSE_HEADERS
-                    }
-                    return StarletteResponse(
-                        content=content,
-                        status_code=resp.status,
-                        headers=safe_headers,
+            body = (
+                await request.body()
+                if request.method in ("POST", "PUT", "PATCH")
+                else None
+            )
+
+            async with session.request(
+                request.method,
+                target_url,
+                headers=headers,
+                data=body,
+                # multi_items() preserves repeated keys (?tag=a&tag=b);
+                # dict() silently kept only the last (issue #2025).
+                params=list(request.query_params.multi_items()),
+                # EXPLICIT, and load-bearing. aiohttp defaults this to
+                # True. Every control this route enforces -- the auth
+                # gate, the path allowlist, traversal rejection, the
+                # charset barrier -- applies to hop 1 only, so following a
+                # redirect hands the caller an authority pivot on hop 2:
+                # a backend with any open redirect (an SSO `?next=` bounce
+                # is ubiquitous, and query strings are forwarded verbatim)
+                # makes the proxy fetch an arbitrary host and return the
+                # body as if it were the backend's. `location` is not in
+                # the response allowlist, so the caller cannot even see
+                # that it happened. Measured before this line existed:
+                # a fully-hardened registration fetched cloud-metadata.
+                allow_redirects=False,
+            ) as resp:
+                # BOUNDED read (#2085). `resp.read()` buffered the entire
+                # body with no cap, so a backend serving a multi-gigabyte
+                # response -- compromised, misconfigured, or just exporting
+                # a large dataset -- was buffered whole in this process, and
+                # concurrent requests multiplied it.
+                #
+                # Accumulate in CHUNKS until the cap is exceeded or the body
+                # ends. `resp.content.read(n)` looks like the obvious way to
+                # do this and is WRONG: aiohttp's StreamReader returns *up to*
+                # n bytes -- whatever is buffered -- so a single call silently
+                # returns a SHORT read on a large body. Measured: an 8 MiB
+                # backend response came back as 155023 bytes with a 200,
+                # i.e. truncated and indistinguishable from complete.
+                #
+                # `content-length` is deliberately not trusted as the signal
+                # either: it is absent from the response allowlist precisely
+                # because it describes COMPRESSED bytes over a decompressed
+                # body (#2025). The bytes counted here are DECOMPRESSED,
+                # which is the memory that actually matters.
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in resp.content.iter_chunked(65536):
+                    total += len(chunk)
+                    if total > max_response_bytes:
+                        break
+                    chunks.append(chunk)
+                content = b"".join(chunks)
+                if total > max_response_bytes:
+                    logger.warning(
+                        "workflow_server.proxy.response_too_large",
+                        extra={
+                            "workflow": name,
+                            "max_response_bytes": max_response_bytes,
+                        },
                     )
+                    # Fail CLOSED: refuse rather than return a TRUNCATED body,
+                    # which would be indistinguishable from a complete one to
+                    # the caller and is its own correctness defect.
+                    return JSONResponse(
+                        status_code=502,
+                        content={
+                            "error": "Backend response exceeded the configured "
+                            "limit for this proxy route"
+                        },
+                    )
+                safe_headers = {
+                    k: v
+                    for k, v in resp.headers.items()
+                    if k.lower() in PROXY_SAFE_RESPONSE_HEADERS
+                }
+                return StarletteResponse(
+                    content=content,
+                    status_code=resp.status,
+                    headers=safe_headers,
+                )
 
         logger.info(f"Registered proxied workflow '{name}' -> {proxy_url}")
 

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -10,7 +10,7 @@ import time
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Sequence
 
 # `fastapi` and `starlette` are OPTIONAL dependencies under the `server` extra.
 # Per `rules/dependencies.md` § "Declared = Imported": optional-extra imports
@@ -44,6 +44,7 @@ from ..utils.proxy_guard import (
     compile_path_allowlist,
     normalize_allowed_methods,
     path_matches_allowlist,
+    reject_unsafe_proxy_destination,
     reject_unsafe_proxy_path,
     resolve_proxy_auth_dependency,
 )
@@ -924,6 +925,9 @@ class WorkflowServer:
         allowed_methods: list[str] | None = None,
         auth_dependency: Callable[..., Any] | None = None,
         forward_credentials: bool = False,
+        blocked_networks: Sequence[Any] | None = None,
+        allow_metadata_destination: bool = False,
+        require_public_destination: bool = False,
     ):
         """Register a proxied workflow running on another server.
 
@@ -963,10 +967,26 @@ class WorkflowServer:
                 re-authorize the original caller; #2025 noted that stripping
                 unconditionally left the backend unable to re-authorize, and
                 this is the documented way to allow it.
+            blocked_networks: Extra CIDR blocks the destination may not
+                resolve into, on top of the always-blocked metadata and
+                link-local ranges. See
+                :func:`kailash.utils.proxy_guard.reject_unsafe_proxy_destination`.
+            allow_metadata_destination: Permit a destination in the cloud
+                metadata / link-local set (issue #2091). Defaults to False and
+                logs a WARNING naming the disabled protection when set --
+                there is no legitimate reason to proxy to 169.254.169.254,
+                and on the usual providers it hands out IAM credentials.
+            require_public_destination: Also refuse RFC1918 and loopback
+                destinations, adopting the stricter posture
+                ``nexus.http_client`` uses for outbound calls. Defaults to
+                False because proxying to an internal service is this
+                surface's common legitimate use.
 
         Raises:
             ProxyAuthNotConfiguredError: No authentication control is
                 configured for the route.
+            BlockedDestinationError: ``proxy_url`` resolves into the blocked
+                destination set (issue #2091).
             ValueError: ``name`` is already registered, or ``allowed_paths`` /
                 ``allowed_methods`` is missing or invalid.
         """
@@ -988,6 +1008,16 @@ class WorkflowServer:
             allowed_methods,
             name=name,
             supported=("GET", "POST", "PUT", "DELETE", "PATCH"),
+        )
+        # The DESTINATION control (#2091). The four above constrain what a
+        # caller can do; this one constrains what the deployment can point at.
+        reject_unsafe_proxy_destination(
+            proxy_url,
+            name=name,
+            surface="WorkflowServer",
+            blocked_networks=blocked_networks,
+            allow_metadata_destination=allow_metadata_destination,
+            require_public_destination=require_public_destination,
         )
 
         # Create proxied workflow registration

--- a/src/kailash/utils/network_guard.py
+++ b/src/kailash/utils/network_guard.py
@@ -1,0 +1,508 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Shared SSRF network guard -- private / loopback / link-local / metadata.
+
+This module is the ONE implementation of "is this outbound destination safe to
+reach", used by every core surface that resolves a caller- or
+deployment-supplied URL.
+
+Provenance and the no-drift contract
+------------------------------------
+
+The implementation was **lifted from** ``nexus.http_client``, which the #2091
+analysis correctly named as the reference: the SSRF posture, the encoded-IP
+bypass detection, the IPv4-in-IPv6 translation ranges and the metadata sets
+were all worked out there first, with the reasoning recorded inline.
+
+It was lifted rather than COPIED, and the direction matters.
+``kailash-nexus`` depends on ``kailash``, never the reverse, so the shared
+piece has to live in core for both to use it. ``nexus.http_client`` now
+IMPORTS this module and keeps only its own error type and client wiring --
+there is no second copy of the logic to drift from. Writing a parallel guard
+in core would have been the obvious move and is exactly what
+``zero-tolerance.md`` Rule 4 forbids: two implementations of one security
+control diverge, and the divergence is discovered by an attacker.
+
+Two knobs exist because two callers need genuinely different postures:
+
+* ``error_factory`` -- nexus raises its own ``InvalidEndpointError`` (a
+  subclass of its ``HttpClientError``) so ``except HttpClientError`` in nexus
+  keeps working. Core raises :class:`BlockedDestinationError`. The DECISION
+  logic is identical; only the exception type differs.
+* ``allow_private`` -- nexus's outbound client talks to the public internet,
+  so RFC1918 is a red flag. Core's reverse proxy is *usually pointed at an
+  internal service on purpose*. Blocking RFC1918 by default there would break
+  the primary legitimate use, so the proxy permits it and blocks the subset
+  with no legitimate proxy use at all: link-local, IMDS, and the cloud
+  metadata hostnames.
+
+What ``allow_private`` does NOT relax
+-------------------------------------
+
+Cloud metadata addresses and link-local (169.254.0.0/16, fe80::/10) are
+**always** refused, on every posture. ``allow_private=True`` is not a way to
+reach 169.254.169.254 -- it widens RFC1918 and loopback only. The single
+documented way past the metadata block is the caller passing
+``allow_metadata=True``, which the proxy surfaces expose as a loudly-logged
+registration argument rather than a silent default.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import logging
+import socket
+from typing import Callable, Optional, Sequence
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_BLOCKED_NETWORKS",
+    "METADATA_HOSTNAMES",
+    "METADATA_IPS",
+    "REASON_ALLOWLIST",
+    "BlockedDestinationError",
+    "check_url",
+    "detect_encoded_ip_bypass",
+    "is_private_ipv4",
+    "is_private_ipv6",
+    "iter_resolved_ips",
+    "url_fingerprint",
+]
+
+
+#: Rejection reasons. A fixed allowlist so log aggregation can bucket
+#: rejections without a user-supplied string ever reaching the log stream.
+REASON_ALLOWLIST: frozenset = frozenset(
+    {
+        "scheme",
+        "private_ipv4",
+        "private_ipv6",
+        "loopback",
+        "link_local",
+        "metadata_service",
+        "metadata_host",
+        "malformed_url",
+        "resolution_failed",
+        "ipv4_mapped",
+        "encoded_ip_bypass",
+        "host_not_allowlisted",
+    }
+)
+
+
+class BlockedDestinationError(ValueError):
+    """A URL failed the SSRF destination check.
+
+    ``reason`` is drawn from :data:`REASON_ALLOWLIST`. The URL itself is
+    stored only as a SHA-256 fingerprint so log pipelines never echo a
+    user-supplied URL verbatim.
+
+    Subclasses ``ValueError`` because the core proxy surfaces raise it from
+    ``proxy_workflow()`` at REGISTRATION time, where every other
+    misconfiguration already surfaces as ``ValueError``.
+    """
+
+    def __init__(self, reason: str, raw_url: Optional[str] = None) -> None:
+        if reason not in REASON_ALLOWLIST:
+            reason = "malformed_url"
+        self.reason = reason
+        self.url_fingerprint = url_fingerprint(raw_url) if raw_url else None
+        if self.url_fingerprint is not None:
+            super().__init__(
+                f"blocked destination: reason={reason} "
+                f"url_fingerprint={self.url_fingerprint}"
+            )
+        else:
+            super().__init__(f"blocked destination: reason={reason}")
+
+
+def url_fingerprint(raw: Optional[str]) -> str:
+    """SHA-256 prefix of the raw URL. Matches the cross-SDK 8-char contract."""
+    if not raw:
+        return "none"
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# Address classification
+# ---------------------------------------------------------------------------
+
+# IPv6 embedded-IPv4 ranges -- an attacker can wrap a private IPv4 in one of
+# these forms to bypass a guard that only checks ``is_private`` on the IPv6
+# wrapper. Reject both ranges unconditionally -- no legitimate external
+# service lives inside a translation-prefix range.
+_IPV4_TRANSLATED_NETWORK = ipaddress.IPv6Network("::ffff:0:0:0/96")  # RFC 2765 SIIT
+_NAT64_WELLKNOWN_NETWORK = ipaddress.IPv6Network("64:ff9b::/96")  # RFC 6052
+
+#: Cloud metadata IPs -- the most common SSRF exfiltration targets on
+#: AWS / GCP / Azure. Blocked on EVERY posture, including ``allow_private``.
+METADATA_IPS: frozenset = frozenset(
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+    }
+)
+
+#: The convenience hostnames cloud providers ship to the guest OS. Blocked by
+#: NAME as well as by resolved address, so a registration naming one is
+#: refused even when DNS is unavailable to resolve it.
+METADATA_HOSTNAMES: frozenset = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.azure.com",
+        "metadata.aws.internal",
+    }
+)
+
+#: Baseline blocked networks. Applied on top of the per-IP private-range
+#: check so extra IPv4 + IPv6 CIDRs are rejected even when a libc helper
+#: somehow resolves them to look "public". RFC1918 + loopback + link-local +
+#: IMDS + CGNAT + ULA + link-local-v6.
+DEFAULT_BLOCKED_NETWORKS: tuple[ipaddress._BaseNetwork, ...] = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local + IMDS
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT -- commonly internal
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),  # ULA
+    ipaddress.ip_network("fe80::/10"),  # link-local v6
+)
+
+
+def is_private_ipv4(ip: ipaddress.IPv4Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def is_private_ipv6(ip: ipaddress.IPv6Address) -> bool:
+    if ip.is_private or ip.is_loopback or ip.is_link_local:
+        return True
+    if ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return True
+    if ip.ipv4_mapped is not None:
+        return is_private_ipv4(ip.ipv4_mapped)
+    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
+        return True
+    return False
+
+
+def _ip_reason(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    """Map an offending IP to an allowlisted rejection reason."""
+    ip_str = str(ip)
+    if ip_str in METADATA_IPS:
+        return "metadata_service"
+    if isinstance(ip, ipaddress.IPv4Address):
+        if ip.is_loopback:
+            return "loopback"
+        if ip.is_link_local:
+            return "link_local"
+        return "private_ipv4"
+    # IPv6
+    if ip.ipv4_mapped is not None:
+        return "ipv4_mapped"
+    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
+        return "ipv4_mapped"
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link_local"
+    return "private_ipv6"
+
+
+def _try_parse_ip(
+    candidate: str,
+) -> Optional[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    try:
+        return ipaddress.ip_address(candidate)
+    except (ValueError, TypeError):
+        return None
+
+
+def _try_inet_aton_shortform(candidate: str) -> Optional[ipaddress.IPv4Address]:
+    """Detect ``socket.inet_aton`` short-form IPv4 (``127.1`` -> 127.0.0.1).
+
+    ``ipaddress.ip_address`` rejects these, but libc resolves them, and a
+    guard that only checks the strict form is bypassable when the HTTP stack
+    forwards to the libc resolver.
+    """
+    if not candidate or not isinstance(candidate, str):
+        return None
+    if ":" in candidate:
+        return None
+    if _try_parse_ip(candidate) is not None:
+        return None
+    try:
+        packed = socket.inet_aton(candidate)
+    except (OSError, ValueError, TypeError):
+        return None
+    return ipaddress.IPv4Address(packed)
+
+
+def detect_encoded_ip_bypass(host: str) -> bool:
+    """Reject decimal / octal / hex IPv4 encodings.
+
+    ``socket.gethostbyname("2130706433")`` returns ``127.0.0.1`` on many libc
+    implementations; the standard ``ipaddress`` parser rejects these, so the
+    guard needs its own detection.
+    """
+    if host.isdigit():
+        return True
+    for part in host.split("."):
+        if part.startswith("0x") or part.startswith("0X"):
+            return True
+        if len(part) > 1 and part.startswith("0") and part[1:].isdigit():
+            return True
+    return False
+
+
+def iter_resolved_ips(
+    host: str,
+) -> "list[ipaddress.IPv4Address | ipaddress.IPv6Address]":
+    """Every IP ``socket.getaddrinfo`` associates with ``host``.
+
+    Returns an empty list on resolution failure so the caller can decide
+    whether that is fatal.
+    """
+    results: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return results
+    seen: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        ip_str = sockaddr[0]
+        if ip_str in seen:
+            continue
+        seen.add(ip_str)
+        parsed = _try_parse_ip(ip_str)
+        if parsed is not None:
+            results.append(parsed)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+
+def check_url(
+    url: str,
+    *,
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]] = None,
+    host_allowlist: Optional[Sequence[str]] = None,
+    allow_loopback: bool = False,
+    resolve_dns: bool = True,
+    allow_private: bool = False,
+    allow_metadata: bool = False,
+    error_factory: Callable[..., Exception] = BlockedDestinationError,
+) -> None:
+    """Validate ``url`` as an SSRF-safe destination.
+
+    Raises ``error_factory(reason, raw_url=url)`` on any rejection.
+
+    Ordering -- per issue #473 non-negotiable 1: the private-IP / metadata
+    check runs BEFORE the host allowlist check. An allowlisted private IP is
+    still rejected. The allowlist ONLY narrows the already-safe set of public
+    hosts; it MUST NOT be a back-door past the SSRF guard.
+
+    Args:
+        url: The destination to validate.
+        blocked_networks: Extra CIDRs refused on top of the always-blocked
+            ranges, so a caller adding a corporate block cannot have it
+            bypassed by forgetting to mix in the defaults.
+        host_allowlist: When set, narrows the already-safe public set.
+        allow_loopback: Narrowly permits 127.0.0.1 / localhost / ::1 -- for
+            tests against a local stub server. Every other private range
+            stays blocked.
+        resolve_dns: Resolve the host and check every resolved address. When
+            False only the literal-IP and hostname checks run.
+        allow_private: Permit RFC1918 / loopback / ULA destinations. For the
+            core reverse proxy, whose whole purpose is often an internal
+            backend. Does NOT permit metadata or link-local -- see
+            ``allow_metadata``.
+        allow_metadata: Permit cloud-metadata and link-local destinations.
+            The ONLY way past that block, deliberately separate from
+            ``allow_private`` so widening RFC1918 never silently widens IMDS.
+        error_factory: Exception constructor, called as
+            ``error_factory(reason, raw_url=url)``. Lets ``nexus.http_client``
+            keep raising its own ``InvalidEndpointError`` from this one
+            implementation.
+    """
+    if not isinstance(url, str) or not url:
+        raise error_factory("malformed_url", raw_url=None)
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise error_factory("malformed_url", raw_url=url)
+
+    scheme = (parsed.scheme or "").lower()
+    host = parsed.hostname or ""
+
+    # ---- Scheme check -----------------------------------------------------
+    # http / https only. Unknown schemes (file://, gopher://, ftp://) are
+    # BLOCKED before DNS lookup -- they are the classic SSRF bypass surface.
+    # Run this BEFORE the empty-host check because ``file:///path`` parses
+    # with an empty host, and the rejection should surface as "scheme" so
+    # forensic aggregation can separate file:// attempts from merely
+    # malformed URLs.
+    if scheme not in ("http", "https"):
+        raise error_factory("scheme", raw_url=url)
+
+    if not host:
+        raise error_factory("malformed_url", raw_url=url)
+
+    host_lc = host.lower()
+
+    # ---- Metadata hostname check ------------------------------------------
+    # By NAME, before any resolution, so this fires even where DNS is
+    # unavailable -- and it is not relaxed by allow_private.
+    if host_lc in METADATA_HOSTNAMES and not allow_metadata:
+        raise error_factory("metadata_host", raw_url=url)
+
+    # ---- Encoded IP bypass check ------------------------------------------
+    parsed_ip = _try_parse_ip(host)
+    if parsed_ip is None and detect_encoded_ip_bypass(host):
+        raise error_factory("encoded_ip_bypass", raw_url=url)
+
+    # ---- inet_aton short-form check ---------------------------------------
+    if parsed_ip is None:
+        shortform = _try_inet_aton_shortform(host)
+        if shortform is not None:
+            # Reject regardless of where it points: no legitimate service is
+            # addressed via the inet_aton short-form, and accepting it widens
+            # the audit surface for no benefit.
+            raise error_factory("encoded_ip_bypass", raw_url=url)
+
+    # ---- Literal IP -------------------------------------------------------
+    if parsed_ip is not None:
+        _validate_ip(
+            parsed_ip,
+            url,
+            allow_loopback,
+            blocked_networks,
+            host_lc,
+            allow_private=allow_private,
+            allow_metadata=allow_metadata,
+            error_factory=error_factory,
+        )
+        # Literal IP, passed checks -- allowlist still applies if set.
+        _check_host_allowlist(host_lc, host_allowlist, url, error_factory)
+        return
+
+    # ---- Host allowlist (layered AFTER SSRF per issue #473 NN1) -----------
+    _check_host_allowlist(host_lc, host_allowlist, url, error_factory)
+
+    # ---- DNS resolution (rebinding defence) -------------------------------
+    if not resolve_dns:
+        return
+
+    any_resolved = False
+    loopback_hosts = {"localhost", "127.0.0.1", "::1"}
+    for ip in iter_resolved_ips(host):
+        any_resolved = True
+        _validate_ip(
+            ip,
+            url,
+            allow_loopback,
+            blocked_networks,
+            host_lc,
+            loopback_hosts,
+            allow_private=allow_private,
+            allow_metadata=allow_metadata,
+            error_factory=error_factory,
+        )
+
+    if not any_resolved and not (allow_loopback and host_lc in loopback_hosts):
+        raise error_factory("resolution_failed", raw_url=url)
+
+
+def _validate_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    url: str,
+    allow_loopback: bool,
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]],
+    host_lc: str,
+    loopback_hosts: Optional[set[str]] = None,
+    *,
+    allow_private: bool = False,
+    allow_metadata: bool = False,
+    error_factory: Callable[..., Exception] = BlockedDestinationError,
+) -> None:
+    """Validate a single IP against the blocklist.
+
+    Central routine for both literal-IP URLs and DNS-resolved IPs.
+    """
+    loopback_hosts = loopback_hosts or {"localhost", "127.0.0.1", "::1"}
+    loopback_carveout = allow_loopback and ip.is_loopback and host_lc in loopback_hosts
+
+    # Metadata and link-local are checked FIRST and are not relaxed by
+    # ``allow_private``. Hoisting them above the private-range check is
+    # behaviour-preserving for the strict posture -- a link-local address is
+    # already caught by ``is_private_ipv4``/``is_private_ipv6`` there, and
+    # ``_ip_reason`` returns the same "link_local" / "metadata_service"
+    # string -- while making them un-widenable by the relaxed one. They are
+    # also never loopback, so hoisting above the carve-out changes nothing.
+    if not allow_metadata:
+        if str(ip) in METADATA_IPS:
+            raise error_factory("metadata_service", raw_url=url)
+        if ip.is_link_local:
+            raise error_factory("link_local", raw_url=url)
+
+    if not allow_private:
+        if isinstance(ip, ipaddress.IPv4Address) and is_private_ipv4(ip):
+            # Narrow allow_loopback carve-out: only 127.0.0.1 under a known
+            # loopback hostname label. Every other private range stays
+            # blocked so allow_loopback can't be used as a wildcard.
+            if not loopback_carveout:
+                raise error_factory(_ip_reason(ip), raw_url=url)
+        if isinstance(ip, ipaddress.IPv6Address) and is_private_ipv6(ip):
+            if not loopback_carveout:
+                raise error_factory(_ip_reason(ip), raw_url=url)
+
+    # Extra blocklist (corporate / internal ranges callers supply).
+    # When the loopback carve-out applies, skip this sweep as well --
+    # otherwise the default blocklist (which contains 127.0.0.0/8 precisely
+    # because loopback is unsafe for production) re-rejects the IP the
+    # carve-out just permitted.
+    if blocked_networks and not loopback_carveout:
+        for net in blocked_networks:
+            try:
+                if ip in net:
+                    raise error_factory(_ip_reason(ip), raw_url=url)
+            except TypeError:
+                # Network family mismatch (v4 vs v6) is normal -- skip.
+                continue
+
+
+def _check_host_allowlist(
+    host_lc: str,
+    host_allowlist: Optional[Sequence[str]],
+    url: str,
+    error_factory: Callable[..., Exception] = BlockedDestinationError,
+) -> None:
+    """Enforce the optional host allowlist.
+
+    Consulted ONLY AFTER the SSRF private-IP check has passed (issue #473
+    non-negotiable 1). The allowlist narrows the already-safe public set --
+    it is NOT a bypass path.
+    """
+    if host_allowlist is None:
+        return
+    normalized = {h.lower() for h in host_allowlist}
+    if host_lc not in normalized:
+        raise error_factory("host_not_allowlisted", raw_url=url)

--- a/src/kailash/utils/network_guard.py
+++ b/src/kailash/utils/network_guard.py
@@ -66,6 +66,9 @@ __all__ = [
     "BlockedDestinationError",
     "check_url",
     "detect_encoded_ip_bypass",
+    "IPV4_TRANSLATED_NETWORK",
+    "NAT64_WELLKNOWN_NETWORK",
+    "embedded_ipv4",
     "is_private_ipv4",
     "is_private_ipv6",
     "iter_resolved_ips",
@@ -134,8 +137,12 @@ def url_fingerprint(raw: Optional[str]) -> str:
 # these forms to bypass a guard that only checks ``is_private`` on the IPv6
 # wrapper. Reject both ranges unconditionally -- no legitimate external
 # service lives inside a translation-prefix range.
-_IPV4_TRANSLATED_NETWORK = ipaddress.IPv6Network("::ffff:0:0:0/96")  # RFC 2765 SIIT
-_NAT64_WELLKNOWN_NETWORK = ipaddress.IPv6Network("64:ff9b::/96")  # RFC 6052
+IPV4_TRANSLATED_NETWORK = ipaddress.IPv6Network("::ffff:0:0:0/96")  # RFC 2765 SIIT
+NAT64_WELLKNOWN_NETWORK = ipaddress.IPv6Network("64:ff9b::/96")  # RFC 6052
+
+#: Private aliases retained so existing internal references keep resolving.
+_IPV4_TRANSLATED_NETWORK = IPV4_TRANSLATED_NETWORK
+_NAT64_WELLKNOWN_NETWORK = NAT64_WELLKNOWN_NETWORK
 
 #: Cloud metadata IPs -- the most common SSRF exfiltration targets on
 #: AWS / GCP / Azure. Blocked on EVERY posture, including ``allow_private``.
@@ -195,6 +202,44 @@ def is_private_ipv6(ip: ipaddress.IPv6Address) -> bool:
     if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
         return True
     return False
+
+
+def embedded_ipv4(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> Optional[ipaddress.IPv4Address]:
+    """Return the IPv4 address an IPv6 wrapper embeds, or ``None``.
+
+    Covers the three forms that carry an IPv4 in their low 32 bits:
+
+    * ``::ffff:a.b.c.d`` -- the strict IPv4-mapped form ``ipaddress`` models
+      directly via ``.ipv4_mapped``;
+    * ``::ffff:0:a.b.c.d`` -- RFC 2765 SIIT IPv4-translated, which
+      ``.ipv4_mapped`` does NOT recognise;
+    * ``64:ff9b::a.b.c.d`` -- the RFC 6052 NAT64 well-known prefix.
+
+    The last two are why this helper exists: an attacker wrapping
+    169.254.169.254 in either prefix produces an address whose STRING form
+    matches no metadata entry and whose ``.is_link_local`` is False, so a
+    guard testing only the wrapper waves it through.
+    """
+    if not isinstance(ip, ipaddress.IPv6Address):
+        return None
+    if ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    if ip in IPV4_TRANSLATED_NETWORK or ip in NAT64_WELLKNOWN_NETWORK:
+        return ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+    return None
+
+
+def _metadata_candidates(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> "list[ipaddress.IPv4Address | ipaddress.IPv6Address]":
+    """The address plus any IPv4 it embeds -- both must clear the metadata gate."""
+    candidates: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
+    inner = embedded_ipv4(ip)
+    if inner is not None:
+        candidates.append(inner)
+    return candidates
 
 
 def _ip_reason(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
@@ -457,11 +502,26 @@ def _validate_ip(
     # ``_ip_reason`` returns the same "link_local" / "metadata_service"
     # string -- while making them un-widenable by the relaxed one. They are
     # also never loopback, so hoisting above the carve-out changes nothing.
+    #
+    # The check runs over the address AND any IPv4 it EMBEDS. An IPv6 wrapper
+    # is a real bypass, not a theoretical one -- measured on the default proxy
+    # posture (allow_private=True) before this loop existed:
+    #
+    #     http://[64:ff9b::169.254.169.254]/  -> ACCEPTED  <== IMDS REACHABLE
+    #     http://[::ffff:0:a9fe:a9fe]/        -> ACCEPTED  <== IMDS REACHABLE
+    #
+    # The translation-range constants existed and were documented
+    # "unconditional", but were only consulted from ``is_private_ipv6``, which
+    # runs ONLY under ``if not allow_private:`` -- so on the posture the proxy
+    # actually ships they never executed. Matching on ``str(ip)`` alone was
+    # the other half: the wrapper's string form is never equal to the bare
+    # metadata address, so the equality test could not see through it.
     if not allow_metadata:
-        if str(ip) in METADATA_IPS:
-            raise error_factory("metadata_service", raw_url=url)
-        if ip.is_link_local:
-            raise error_factory("link_local", raw_url=url)
+        for candidate in _metadata_candidates(ip):
+            if str(candidate) in METADATA_IPS:
+                raise error_factory("metadata_service", raw_url=url)
+            if candidate.is_link_local:
+                raise error_factory("link_local", raw_url=url)
 
     if not allow_private:
         if isinstance(ip, ipaddress.IPv4Address) and is_private_ipv4(ip):

--- a/src/kailash/utils/proxy_guard.py
+++ b/src/kailash/utils/proxy_guard.py
@@ -99,13 +99,19 @@ serve paths outside its own root.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
+from .network_guard import BlockedDestinationError
+from .network_guard import check_url as _check_destination_url
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "BlockedDestinationError",
+    "reject_unsafe_proxy_destination",
     "DEFAULT_ALLOWED_METHODS",
     "PROXY_CREDENTIAL_HEADERS",
     "PROXY_HOP_BY_HOP_HEADERS",
@@ -236,6 +242,118 @@ PROXY_SAFE_RESPONSE_HEADERS: frozenset = frozenset(
         "last-modified",
     }
 )
+
+
+def reject_unsafe_proxy_destination(
+    proxy_url: str,
+    *,
+    name: str,
+    surface: str,
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]] = None,
+    allow_metadata_destination: bool = False,
+    require_public_destination: bool = False,
+) -> None:
+    """Refuse a proxy registration whose DESTINATION is an unsafe address.
+
+    The fifth registration-time control (#2091). The four above constrain what
+    a CALLER can do; this one constrains what the DEPLOYMENT can point at.
+
+    ``proxy_url`` comes from a developer calling a Python API, not from
+    request data, so this is a deployment-misconfiguration surface rather
+    than a caller-driven one -- materially lower severity than the defects
+    #2064 closed, and worth stating rather than glossing. It still matters:
+    a registration pointing at ``http://169.254.169.254/`` publishes cloud
+    metadata -- including IAM credentials on the usual providers -- to every
+    authenticated caller, and a reader of the pre-#2091 code would reasonably
+    have concluded the destination was deliberately unconstrained.
+
+    The decision logic is :func:`kailash.utils.network_guard.check_url`,
+    which is the guard lifted out of ``nexus.http_client`` -- the reference
+    implementation the issue named. Both now run the same code.
+
+    Default posture, and why it is not simply nexus's
+    -------------------------------------------------
+
+    Nexus blocks RFC1918 + loopback + link-local + IMDS, which is right for
+    an outbound client talking to the public internet. A reverse proxy is
+    frequently pointed at an internal service ON PURPOSE -- that is the
+    common legitimate use -- so a blanket RFC1918 block here would break the
+    normal case, and a control that breaks the normal case gets switched off
+    wholesale, taking the IMDS protection with it.
+
+    So the default blocks the subset with NO legitimate proxy use at all:
+    cloud metadata addresses, the metadata hostnames, and link-local
+    (169.254.0.0/16, fe80::/10). RFC1918 and loopback are permitted by
+    default and can be blocked with ``require_public_destination=True``.
+
+    Per ``security.md`` § Secure-Default the metadata block is ON by default
+    with an EXPLICIT, LOUD opt-out: ``allow_metadata_destination=True`` logs
+    a WARNING naming the protection being disabled. It is deliberately a
+    separate argument from ``require_public_destination`` so that widening
+    the posture for internal backends never silently widens IMDS too.
+
+    Limits, stated rather than implied
+    ----------------------------------
+
+    * The check runs at REGISTRATION, against the address the destination
+      resolves to THEN. A hostname that resolves benign at registration and
+      to 169.254.169.254 later is NOT caught -- this is not a DNS-rebinding
+      defence. The metadata HOSTNAMES are additionally blocked by name, which
+      does not depend on resolution.
+    * A destination that cannot be resolved at registration is PERMITTED with
+      a WARNING rather than refused. Backends legitimately are not up yet
+      when the proxy is registered, and failing there would make the control
+      one that deployments route around. The warning names the destination as
+      unverified so the gap is visible rather than silent.
+
+    Raises:
+        BlockedDestinationError: The destination is in the blocked set.
+    """
+    if allow_metadata_destination:
+        logger.warning(
+            "proxy_guard.metadata_destination_allowed",
+            extra={"workflow": name, "surface": surface},
+        )
+        logger.warning(
+            "Proxied workflow '%s' on %s registered with "
+            "allow_metadata_destination=True: cloud-metadata and link-local "
+            "destinations are NOT blocked for this route. On the usual cloud "
+            "providers the metadata service hands out IAM credentials, so any "
+            "caller authorized to use this proxy can read them (issue #2091).",
+            name,
+            surface,
+        )
+
+    try:
+        _check_destination_url(
+            proxy_url,
+            blocked_networks=blocked_networks,
+            allow_private=not require_public_destination,
+            allow_metadata=allow_metadata_destination,
+            resolve_dns=True,
+        )
+    except BlockedDestinationError as exc:
+        if exc.reason != "resolution_failed":
+            raise
+        # Not fatal -- see "Limits" above. Loud, and it names what was not
+        # checked, so an unverified destination is visible rather than silent.
+        logger.warning(
+            "proxy_guard.destination_unresolved",
+            extra={
+                "workflow": name,
+                "surface": surface,
+                "url_fingerprint": exc.url_fingerprint,
+            },
+        )
+        logger.warning(
+            "Destination for proxied workflow '%s' on %s could not be "
+            "resolved at registration, so its address was NOT checked "
+            "against the blocked set (issue #2091). Registration proceeds "
+            "because a backend is legitimately not always up yet at "
+            "registration time.",
+            name,
+            surface,
+        )
 
 
 class ProxyAuthNotConfiguredError(RuntimeError):

--- a/src/kailash/utils/proxy_guard.py
+++ b/src/kailash/utils/proxy_guard.py
@@ -110,7 +110,10 @@ from .network_guard import check_url as _check_destination_url
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "DEFAULT_MAX_RESPONSE_BYTES",
     "BlockedDestinationError",
+    "ProxyResponseTooLargeError",
+    "normalize_max_response_bytes",
     "reject_unsafe_proxy_destination",
     "DEFAULT_ALLOWED_METHODS",
     "PROXY_CREDENTIAL_HEADERS",
@@ -242,6 +245,61 @@ PROXY_SAFE_RESPONSE_HEADERS: frozenset = frozenset(
         "last-modified",
     }
 )
+
+
+#: Bytes a proxied response body may occupy in this process before the proxy
+#: refuses it (#2085). Per-registration, so a backend that legitimately serves
+#: large exports can raise it without widening every other route.
+#:
+#: 64 MiB is chosen to be generous for API payloads while still bounding the
+#: damage: the pre-#2085 behaviour was UNBOUNDED, and concurrent requests
+#: multiply whatever the figure is. A finite documented default is the point;
+#: the exact number is a judgement call the registration can override.
+DEFAULT_MAX_RESPONSE_BYTES: int = 64 * 1024 * 1024
+
+
+class ProxyResponseTooLargeError(ValueError):
+    """A proxied backend response exceeded the registration's byte cap."""
+
+
+def normalize_max_response_bytes(
+    max_response_bytes: Optional[int],
+    *,
+    name: str,
+) -> int:
+    """Validate the per-registration response cap.
+
+    Args:
+        max_response_bytes: The cap. ``None`` selects
+            :data:`DEFAULT_MAX_RESPONSE_BYTES`.
+        name: Workflow identifier, for error messages.
+
+    Returns:
+        The cap in bytes.
+
+    Raises:
+        ValueError: The cap is not a positive integer. There is deliberately
+            no "unlimited" spelling: ``0`` or a negative value raises rather
+            than disabling the bound, because an unbounded proxy is the defect
+            #2085 exists to close and a magic disable value is how it would
+            quietly come back.
+    """
+    if max_response_bytes is None:
+        return DEFAULT_MAX_RESPONSE_BYTES
+    if isinstance(max_response_bytes, bool) or not isinstance(max_response_bytes, int):
+        raise ValueError(
+            f"max_response_bytes for proxied workflow '{name}' must be a "
+            f"positive integer, got {type(max_response_bytes).__name__} "
+            f"({max_response_bytes!r})."
+        )
+    if max_response_bytes <= 0:
+        raise ValueError(
+            f"max_response_bytes for proxied workflow '{name}' must be a "
+            f"POSITIVE integer, got {max_response_bytes}. There is no "
+            f"'unlimited' setting: unbounded buffering is the defect this cap "
+            f"exists to close (issue #2085). Raise the cap instead."
+        )
+    return max_response_bytes
 
 
 def reject_unsafe_proxy_destination(

--- a/src/kailash/utils/proxy_guard.py
+++ b/src/kailash/utils/proxy_guard.py
@@ -61,6 +61,40 @@ The four registration-time controls:
 4. **Traversal rejection** -- :func:`reject_unsafe_proxy_path` refuses ``..``
    segments and encoded separators before the target URL is built, rather
    than relying on the HTTP client's URL normalization.
+
+Segment-parameter collapse (#2087) and what this guard does NOT close
+---------------------------------------------------------------------
+
+The ``..`` segment check above is correct for the RFC 3986 shape and was
+BYPASSABLE for the servlet-class one. Tomcat, Jetty and others strip
+everything from ``;`` to the end of a path segment while resolving it, so a
+segment of ``..;`` is not equal to ``..`` at this proxy, passes the check,
+and is then normalised BY THE BACKEND to ``..`` -- restoring the traversal
+the guard exists to prevent. ``..;foo``, ``..%3B`` and the double-encoded
+``..%253B`` are the same defect under different spellings.
+
+The approach taken is deliberately the NARROW one of the three the issue
+weighed: :func:`_collapse_segment_parameters` models the servlet path-
+parameter rule for ONE purpose -- deciding whether a segment would BECOME a
+dot-segment -- and the refusal fires only when it would. A segment carrying a
+legitimate matrix parameter (``products;color=blue``, ``a;jsessionid=xyz``)
+is untouched, because a blanket ban on ``;`` would be a regression: ``;`` is
+an RFC 3986 sub-delimiter and valid in paths.
+
+**This closes one MEMBER of the family, not the class**, and that is stated
+here rather than implied. The guard models the ``;`` convention because it is
+the one with known backends behind it. A backend that collapses a DIFFERENT
+character, or that applies a different normalisation before path resolution,
+reintroduces the same class under a new spelling and would need its own
+clause here. The alternative -- carrying a full normalisation model of "the
+strictest plausible backend" in core -- was rejected: it is a maintenance
+surface whose divergence from what the real backend does is itself a source
+of bypasses, and it would claim a completeness this cannot deliver.
+
+Also NOT closed, and worth naming so it is not assumed: this is a check on
+the path THIS process forwards. It does not constrain how the backend
+resolves the result, and it is not a substitute for the backend refusing to
+serve paths outside its own root.
 """
 
 from __future__ import annotations
@@ -508,6 +542,29 @@ def path_matches_allowlist(path: str, allowlist: Sequence[PathPattern]) -> bool:
 #: process would forward verbatim for the backend to decode a second time.
 _ENCODED_TRAVERSAL_TOKENS: tuple[str, ...] = ("%2e", "%2f", "%5c")
 
+#: A still-encoded semicolon, in either case. Starlette decodes a path
+#: parameter ONCE, so ``..%3B/`` already arrives as ``..;/`` and is handled by
+#: the literal-``;`` truncation in :func:`_collapse_segment_parameters`. This
+#: catches the DOUBLE-encoded form (``..%253B/`` -> ``..%3B/`` after that
+#: decode), which this process would otherwise forward verbatim for the
+#: backend to decode a second time and then collapse.
+_ENCODED_SEMICOLON_RE: re.Pattern = re.compile(r"%3[bB]")
+
+
+def _collapse_segment_parameters(segment: str) -> str:
+    """Return ``segment`` as a servlet-class backend would resolve it.
+
+    Servlet-class backends (Tomcat, Jetty, and others following the same
+    convention) treat everything from ``;`` to the end of a path SEGMENT as a
+    path parameter -- ``jsessionid`` is the canonical one -- and strip it
+    while resolving the path. So the segment ``..;`` is not equal to ``..``
+    at this proxy but IS ``..`` at the backend.
+
+    The still-encoded ``%3B`` form is decoded first so the double-encoded
+    spelling collapses the same way.
+    """
+    return _ENCODED_SEMICOLON_RE.sub(";", segment).split(";", 1)[0]
+
 
 def reject_unsafe_proxy_path(path: str) -> Optional[str]:
     """Return a human-readable reason to refuse ``path``, or ``None``.
@@ -538,8 +595,19 @@ def reject_unsafe_proxy_path(path: str) -> Optional[str]:
     for token in _ENCODED_TRAVERSAL_TOKENS:
         if token in lowered:
             return f"path contains an encoded path separator or dot-segment ({token})"
-    if any(segment == ".." for segment in path.split("/")):
-        return "path contains a parent-directory segment (..)"
+    for segment in path.split("/"):
+        if segment == "..":
+            return "path contains a parent-directory segment (..)"
+        # #2087: the segment is not `..` HERE, but a servlet-class backend
+        # strips the path parameter and resolves it as `..`. Checked only
+        # when the collapse actually changes the segment, so legitimate
+        # matrix parameters (`products;color=blue`) are unaffected -- only a
+        # segment that BECOMES a dot-segment is refused.
+        if segment != ".." and _collapse_segment_parameters(segment) == "..":
+            return (
+                "path contains a parent-directory segment carrying a path "
+                "parameter (..;), which a servlet-class backend resolves to .."
+            )
     if "\u2028" in path or "\u2029" in path:
         return "path contains a Unicode line or paragraph separator"
     return None

--- a/tests/regression/test_issue_2085_proxy_resource_exhaustion.py
+++ b/tests/regression/test_issue_2085_proxy_resource_exhaustion.py
@@ -1,0 +1,438 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #2085 -- proxy resource exhaustion.
+
+Two defects, both on the proxy surfaces, in different mixes:
+
+1. **Unbounded response buffering, BOTH surfaces.** ``resp.read()`` on the
+   server and ``resp.content`` on the gateway buffered the entire backend
+   body in this process before a byte reached the caller, with no cap.
+   Concurrent requests multiply it.
+
+2. **A fresh ``aiohttp.ClientSession`` per REQUEST, server surface only.**
+   Every proxied request built and tore down a session -- new connector, new
+   pool, fresh sockets, no keep-alive. ``WorkflowAPIGateway`` already reused
+   one client, so this was also an enforcement-surface asymmetry, the same
+   shape as the credential-stripping and redirect-policy disagreements #2025
+   closed. The churn is not theoretical: this repo hit fd/thread exhaustion
+   in CI (#2078).
+
+Fail-first, measured pre-fix::
+
+    WorkflowServer  40MB backend body -> status=200 bytes_buffered=41943040  <== NO CAP
+    Gateway         40MB backend body -> status=200 bytes_buffered=41943040  <== NO CAP
+    WorkflowServer  3 proxied requests -> 3 distinct client source ports <== NEW CONNECTION EACH TIME
+
+Both are measured at the level that matters rather than by reading the code:
+the byte cap against a real oversized body from a real socket, and the
+session reuse against the CLIENT SOURCE PORT the backend observed. A single
+source port across three requests is only possible if the connection was
+reused, which is only possible if the session was.
+
+No ``Mock`` appears in this file.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from kailash.api.gateway import WorkflowAPIGateway
+from kailash.servers.workflow_server import WorkflowServer
+from kailash.utils.proxy_guard import (
+    DEFAULT_MAX_RESPONSE_BYTES,
+    normalize_max_response_bytes,
+)
+
+pytestmark = pytest.mark.regression
+
+#: Body the "large" route serves. Comfortably over the caps used below.
+LARGE_BODY_BYTES = 8 * 1024 * 1024
+SMALL_BODY = b'{"ok":true}'
+CAP = 1024 * 1024
+
+
+class _SizedHandler(BaseHTTPRequestHandler):
+    """Real backend serving a large or a small body, and recording peers."""
+
+    protocol_version = "HTTP/1.1"
+    peers: list = []
+    #: Bytes the backend SUCCESSFULLY wrote for the last /large request. This
+    #: is the instrument for the memory bound: if the proxy stops reading at
+    #: the cap, the backend's writes fail partway and this stays far below
+    #: LARGE_BODY_BYTES. If the proxy drains the whole body -- the #2085
+    #: defect -- this reaches LARGE_BODY_BYTES. Asserting only the 502 status
+    #: does NOT discriminate that, because a post-loop size check returns 502
+    #: whether or not the read was bounded.
+    bytes_written: int = 0
+
+    def do_GET(self):
+        type(self).peers.append(self.client_address[1])
+        if self.path.startswith("/large"):
+            n = LARGE_BODY_BYTES
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(n))
+            self.end_headers()
+            block = b"A" * 65536
+            sent = 0
+            try:
+                while sent < n:
+                    w = min(len(block), n - sent)
+                    self.wfile.write(block[:w])
+                    self.wfile.flush()
+                    sent += w
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                # EXPECTED on the over-cap path: the proxy stops reading once
+                # the cap is passed, so the backend's write fails. That is the
+                # bound working, not an error.
+                pass
+            type(self).bytes_written = sent
+        else:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(SMALL_BODY)))
+            self.end_headers()
+            self.wfile.write(SMALL_BODY)
+
+    def log_message(self, *args):  # noqa: D102 - silence stderr access log
+        return
+
+
+#: How much of the oversized body the backend may get away with writing
+#: before we call the read "unbounded". Generous: kernel socket buffers let
+#: the backend push some bytes past what the proxy consumed, so this is not
+#: `== CAP`. It is still far below LARGE_BODY_BYTES, which is the only thing
+#: that has to be true for the assertion to discriminate.
+DRAINED_THRESHOLD = LARGE_BODY_BYTES // 2
+
+
+@pytest.fixture
+def backend():
+    _SizedHandler.peers = []
+    _SizedHandler.bytes_written = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SizedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+async def _allow(request: Request):
+    if request.headers.get("X-Regression-Key") != "let-me-in":
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return {"user_id": "keyed"}
+
+
+def _auth_headers():
+    return {"X-Regression-Key": "let-me-in"}
+
+
+# ---------------------------------------------------------------------------
+# 1. Bounded response buffering -- BOTH surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_server_refuses_oversized_response(backend):
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+        max_response_bytes=CAP,
+    )
+    try:
+        with TestClient(server.app) as client:
+            resp = client.get("/workflows/internal/large", headers=_auth_headers())
+        assert resp.status_code == 502, resp.text
+        # Fail CLOSED, not truncated: a truncated 200 is indistinguishable
+        # from a complete one to the caller.
+        assert len(resp.content) < CAP
+        # ...and the read was actually BOUNDED. Without this the test passes
+        # even when the proxy drains the whole body and only then checks the
+        # size, which is the exact defect #2085 is about.
+        assert _SizedHandler.bytes_written < DRAINED_THRESHOLD, (
+            f"backend wrote {_SizedHandler.bytes_written} bytes -- the proxy "
+            f"drained the whole body instead of stopping at the cap"
+        )
+    finally:
+        server.close()
+
+
+def test_gateway_refuses_oversized_response(backend):
+    gw = WorkflowAPIGateway(require_auth=False, title="issue-2085")
+    try:
+        gw.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+            max_response_bytes=CAP,
+        )
+        with TestClient(gw.app) as client:
+            resp = client.get("/internal/large", headers=_auth_headers())
+        assert resp.status_code == 502, resp.text
+        assert len(resp.content) < CAP
+        assert _SizedHandler.bytes_written < DRAINED_THRESHOLD, (
+            f"backend wrote {_SizedHandler.bytes_written} bytes -- the proxy "
+            f"drained the whole body instead of stopping at the cap"
+        )
+    finally:
+        gw.close()
+
+
+@pytest.mark.parametrize("surface", ["server", "gateway"])
+def test_under_cap_response_is_forwarded_intact(backend, surface):
+    """No-false-positive polarity, and a truncation guard.
+
+    Asserting the exact bytes matters: the first implementation of this cap
+    used ``StreamReader.read(n)``, which returns *up to* n bytes, and so
+    silently returned a SHORT body with a 200. An 8 MiB response came back as
+    155023 bytes. Comparing the full payload is what catches that.
+    """
+    if surface == "server":
+        obj = WorkflowServer(title="issue-2085", require_auth=False)
+        path = "/workflows/internal/small"
+    else:
+        obj = WorkflowAPIGateway(require_auth=False, title="issue-2085")
+        path = "/internal/small"
+    try:
+        obj.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+            max_response_bytes=CAP,
+        )
+        with TestClient(obj.app) as client:
+            resp = client.get(path, headers=_auth_headers())
+        assert resp.status_code == 200, resp.text
+        assert resp.content == SMALL_BODY
+    finally:
+        obj.close()
+
+
+@pytest.mark.parametrize("surface", ["server", "gateway"])
+def test_body_larger_than_cap_is_never_returned_truncated(backend, surface):
+    """The truncation-specific assertion, stated separately.
+
+    A cap implemented as a short read would return 200 with a partial body.
+    This pins that the over-cap path is a REFUSAL.
+    """
+    if surface == "server":
+        obj = WorkflowServer(title="issue-2085", require_auth=False)
+        path = "/workflows/internal/large"
+    else:
+        obj = WorkflowAPIGateway(require_auth=False, title="issue-2085")
+        path = "/internal/large"
+    try:
+        obj.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+            max_response_bytes=CAP,
+        )
+        with TestClient(obj.app) as client:
+            resp = client.get(path, headers=_auth_headers())
+        assert resp.status_code == 502
+        body = resp.content
+        assert b"A" * 1024 not in body, "a truncated backend body was returned"
+        assert json.loads(body)["error"]
+    finally:
+        obj.close()
+
+
+# ---------------------------------------------------------------------------
+# The cap contract
+# ---------------------------------------------------------------------------
+
+
+def test_cap_defaults_to_a_documented_finite_value():
+    assert normalize_max_response_bytes(None, name="x") == DEFAULT_MAX_RESPONSE_BYTES
+    assert DEFAULT_MAX_RESPONSE_BYTES > 0
+    assert DEFAULT_MAX_RESPONSE_BYTES == 64 * 1024 * 1024
+
+
+@pytest.mark.parametrize("bad", [0, -1, -1024])
+def test_cap_has_no_unlimited_spelling(bad):
+    """``0`` must not be a back door to the unbounded behaviour."""
+    with pytest.raises(ValueError, match="POSITIVE"):
+        normalize_max_response_bytes(bad, name="x")
+
+
+@pytest.mark.parametrize("bad", ["1000", 1.5, True, None.__class__])
+def test_cap_rejects_non_integers(bad):
+    if bad is None:
+        pytest.skip("None selects the default")
+    with pytest.raises(ValueError):
+        normalize_max_response_bytes(bad, name="x")
+
+
+@pytest.mark.parametrize("surface", ["server", "gateway"])
+def test_invalid_cap_refused_at_registration(backend, surface):
+    obj = (
+        WorkflowServer(title="issue-2085", require_auth=False)
+        if surface == "server"
+        else WorkflowAPIGateway(require_auth=False, title="issue-2085")
+    )
+    try:
+        with pytest.raises(ValueError):
+            obj.proxy_workflow(
+                name="internal",
+                proxy_url=backend,
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+                max_response_bytes=0,
+            )
+    finally:
+        obj.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Shared session -- and lifecycle PARITY between the two surfaces
+# ---------------------------------------------------------------------------
+
+
+def _distinct_source_ports(obj, path, n=3):
+    _SizedHandler.peers = []
+    with TestClient(obj.app) as client:
+        for _ in range(n):
+            resp = client.get(path, headers=_auth_headers())
+            assert resp.status_code == 200, resp.text
+    return len(set(_SizedHandler.peers))
+
+
+def test_workflow_server_reuses_one_connection_across_requests(backend):
+    """Measured at the backend's observed CLIENT SOURCE PORT.
+
+    Pre-fix this was 3 distinct ports for 3 requests. One port is only
+    possible if the connection -- and therefore the session -- was reused.
+    """
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+    )
+    try:
+        assert _distinct_source_ports(server, "/workflows/internal/small") == 1
+    finally:
+        server.close()
+
+
+def test_gateway_reuses_one_connection_across_requests(backend):
+    gw = WorkflowAPIGateway(require_auth=False, title="issue-2085")
+    try:
+        gw.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+        )
+        assert _distinct_source_ports(gw, "/internal/small") == 1
+    finally:
+        gw.close()
+
+
+def test_workflow_server_session_identity_is_stable_across_requests(backend):
+    """#2085 AC: assert the SESSION IDENTITY, not just the connection.
+
+    The AC asks for this to be verified by observation rather than by reading
+    the code, so the identity is captured from the live server between two
+    real proxied requests.
+    """
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+    )
+    try:
+        with TestClient(server.app) as client:
+            client.get("/workflows/internal/small", headers=_auth_headers())
+            first = server._proxy_session
+            client.get("/workflows/internal/small", headers=_auth_headers())
+            second = server._proxy_session
+        assert first is not None
+        assert first is second, "a new ClientSession was built for the 2nd request"
+    finally:
+        server.close()
+
+
+def test_both_surfaces_agree_on_connection_lifecycle(backend):
+    """#2085 AC: the asymmetry must not silently return.
+
+    Both surfaces expose a lazily-created, reused, explicitly-closable client
+    for proxying. Asserting the SHAPE is what makes a future divergence a test
+    failure rather than a discovery.
+    """
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    gw = WorkflowAPIGateway(require_auth=False, title="issue-2085")
+    try:
+        assert hasattr(server, "_get_proxy_session")
+        assert hasattr(gw, "_get_proxy_client")
+        # Neither builds its client eagerly...
+        assert server._proxy_session is None
+        assert gw._proxy_client is None
+        # ...and both expose a close path.
+        assert callable(server.aclose_proxy_session)
+        assert callable(gw.close)
+    finally:
+        server.close()
+        gw.close()
+
+
+@pytest.mark.asyncio
+async def test_proxy_session_is_closed_on_shutdown(backend):
+    """The session must be released on the normal shutdown path, not GC."""
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+    )
+    try:
+        session = await server._get_proxy_session()
+        assert not session.closed
+        await server.shutdown_coordinator.shutdown()
+        assert session.closed, "shutdown did not close the shared proxy session"
+        assert server._proxy_session is None
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
+async def test_aclose_proxy_session_is_idempotent(backend):
+    server = WorkflowServer(title="issue-2085", require_auth=False)
+    try:
+        session = await server._get_proxy_session()
+        await server.aclose_proxy_session()
+        await server.aclose_proxy_session()
+        assert session.closed
+    finally:
+        server.close()
+
+
+def test_api_channel_plumbs_the_response_cap():
+    """``security.md`` § Multi-Site Kwarg Plumbing."""
+    import inspect
+
+    from kailash.channels.api_channel import APIChannel
+
+    params = inspect.signature(APIChannel.proxy_workflow).parameters
+    assert "max_response_bytes" in params
+    source = inspect.getsource(APIChannel.proxy_workflow)
+    assert "max_response_bytes=max_response_bytes" in source

--- a/tests/regression/test_issue_2087_segment_parameter_traversal.py
+++ b/tests/regression/test_issue_2087_segment_parameter_traversal.py
@@ -1,0 +1,269 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #2087 -- ``..;/`` segment-parameter collapse.
+
+``reject_unsafe_proxy_path`` refused a segment equal to ``..``. That is
+correct for the RFC 3986 shape and BYPASSABLE for the servlet-class one:
+Tomcat, Jetty and others strip everything from ``;`` to the end of a path
+segment while resolving it, so ``..;`` is not ``..`` at the proxy, passes the
+check, and is normalised BY THE BACKEND to ``..``.
+
+Fail-first, measured on the pre-fix guard (``reject_unsafe_proxy_path``
+returning None == forwarded)::
+
+    'a/../b'                 -> path contains a parent-directory segment (..)
+    'a/..;/b'                -> FORWARDED  <== TRAVERSAL RESTORED
+    'a/..;foo/b'             -> FORWARDED  <== TRAVERSAL RESTORED
+    'a/..%3B/b'              -> FORWARDED  <== TRAVERSAL RESTORED
+    'a/..%3b/b'              -> FORWARDED  <== TRAVERSAL RESTORED
+    '..;/etc/passwd'         -> FORWARDED  <== TRAVERSAL RESTORED
+
+``a/../b`` refusing on the SAME run is the discrimination control: the guard
+was running, and it was the segment-parameter spelling specifically that it
+could not see.
+
+The encoded forms are covered because Starlette's decode depth was MEASURED
+rather than assumed (``test_measured_decode_depth_reaches_the_guard`` below),
+which is what makes the ``%3B`` clause load-bearing rather than decorative.
+
+No ``Mock`` appears in this file. The backend is a real HTTP server on a real
+socket and it records the paths it was actually asked for, so "the traversal
+did not reach the backend" is an observation, not an inference.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from kailash.api.gateway import WorkflowAPIGateway
+from kailash.servers.workflow_server import WorkflowServer
+from kailash.utils.proxy_guard import reject_unsafe_proxy_path
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# Real backend
+# ---------------------------------------------------------------------------
+
+
+class _PathRecordingHandler(BaseHTTPRequestHandler):
+    """Real backend recording every path it was actually asked for."""
+
+    paths: list = []
+
+    def _respond(self):
+        type(self).paths.append(self.path)
+        payload = json.dumps({"path": self.path}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = _respond
+
+    def log_message(self, *args):  # noqa: D102 - silence stderr access log
+        return
+
+
+@pytest.fixture
+def backend():
+    _PathRecordingHandler.paths = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PathRecordingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+async def _allow(request: Request):
+    """A real dependency, not a Mock."""
+    if request.headers.get("X-Regression-Key") != "let-me-in":
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return {"user_id": "keyed"}
+
+
+def _auth_headers():
+    return {"X-Regression-Key": "let-me-in"}
+
+
+#: Every spelling of the defect. Each is a segment that is NOT ``..`` at this
+#: proxy but which a servlet-class backend resolves to ``..``.
+TRAVERSAL_SPELLINGS = [
+    "a/..;/b",
+    "a/..;foo/b",
+    "a/..;jsessionid=deadbeef/b",
+    "a/..%3B/b",
+    "a/..%3b/b",
+    "..;/etc/passwd",
+]
+
+#: Legitimate uses of ``;``. RFC 3986 sub-delimiter, valid in paths -- a
+#: blanket ban would be a regression, so both polarities are asserted.
+LEGITIMATE_SEMICOLON_PATHS = [
+    "products;color=blue/list",
+    "a;jsessionid=xyz/b",
+    "sem;i/co;lon",
+    "a/..foo/b",
+    "a/x..;/b",
+]
+
+
+# ---------------------------------------------------------------------------
+# Unit level -- the shared guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", TRAVERSAL_SPELLINGS)
+def test_guard_refuses_segment_parameter_traversal(path):
+    reason = reject_unsafe_proxy_path(path)
+    assert reason is not None, f"{path!r} was forwarded -- traversal restored"
+    assert "path parameter" in reason
+
+
+@pytest.mark.parametrize("path", LEGITIMATE_SEMICOLON_PATHS)
+def test_guard_still_forwards_legitimate_semicolons(path):
+    """The no-false-positive polarity: a blanket ``;`` ban is a regression."""
+    assert reject_unsafe_proxy_path(path) is None, f"{path!r} was wrongly refused"
+
+
+def test_guard_still_refuses_the_plain_dot_segment():
+    """Discrimination control -- the original check must not have regressed."""
+    reason = reject_unsafe_proxy_path("a/../b")
+    assert reason == "path contains a parent-directory segment (..)"
+
+
+def test_measured_decode_depth_reaches_the_guard():
+    """Pin the decode depth the ``%3B`` clause depends on.
+
+    This is the instrument behind the encoded rows: it establishes what the
+    handler ACTUALLY receives for each wire spelling, so the guard is checked
+    against its real input rather than an assumed one. Measured:
+
+        WIRE a/..%3B/b     -> HANDLER RECEIVED 'a/..;/b'
+        WIRE a/..%253B/b   -> HANDLER RECEIVED 'a/..;/b'
+        WIRE a/..%25253B/b -> HANDLER RECEIVED 'a/..%3B/b'
+
+    The third row is why ``_ENCODED_SEMICOLON_RE`` exists: at that depth the
+    literal-``;`` truncation alone would not fire, and the guard must still
+    refuse.
+    """
+    app = FastAPI()
+    seen: list = []
+
+    @app.get("/w/{path:path}")
+    async def handler(path: str):
+        seen.append(path)
+        return {"ok": True}
+
+    client = TestClient(app)
+    received = {}
+    for wire in ("a/..%3B/b", "a/..%253B/b", "a/..%25253B/b"):
+        seen.clear()
+        client.get("/w/" + wire)
+        received[wire] = seen[0]
+
+    # Whatever the depth, every form must arrive as something the guard refuses.
+    for wire, arrived in received.items():
+        assert (
+            reject_unsafe_proxy_path(arrived) is not None
+        ), f"wire {wire!r} arrived as {arrived!r}, which the guard forwards"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement-surface parity -- BOTH proxy surfaces, end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", TRAVERSAL_SPELLINGS)
+def test_workflow_server_refuses_traversal_end_to_end(backend, path):
+    server = WorkflowServer(title="issue-2087-server", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+    )
+    try:
+        client = TestClient(server.app)
+        resp = client.get(f"/workflows/internal/{path}", headers=_auth_headers())
+        assert resp.status_code == 400, resp.text
+        assert _PathRecordingHandler.paths == [], (
+            f"backend was reached with {_PathRecordingHandler.paths!r} "
+            f"despite the guard"
+        )
+    finally:
+        server.close()
+
+
+@pytest.mark.parametrize("path", TRAVERSAL_SPELLINGS)
+def test_gateway_refuses_traversal_end_to_end(backend, path):
+    gw = WorkflowAPIGateway(require_auth=False, title="issue-2087-gateway")
+    try:
+        gw.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+        )
+        client = TestClient(gw.app)
+        resp = client.get(f"/internal/{path}", headers=_auth_headers())
+        assert resp.status_code == 400, resp.text
+        assert _PathRecordingHandler.paths == [], (
+            f"backend was reached with {_PathRecordingHandler.paths!r} "
+            f"despite the guard"
+        )
+    finally:
+        gw.close()
+
+
+def test_both_surfaces_still_forward_legitimate_semicolon(backend):
+    """No-false-positive, end to end, on both surfaces.
+
+    The backend RECORDS the path, so this asserts the request genuinely
+    arrived rather than merely that the proxy returned 200.
+    """
+    server = WorkflowServer(title="issue-2087-server-ok", require_auth=False)
+    server.proxy_workflow(
+        name="internal",
+        proxy_url=backend,
+        allowed_paths=["*"],
+        auth_dependency=_allow,
+    )
+    try:
+        resp = TestClient(server.app).get(
+            "/workflows/internal/products;color=blue/list", headers=_auth_headers()
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        server.close()
+
+    assert _PathRecordingHandler.paths == ["/products;color=blue/list"]
+
+    _PathRecordingHandler.paths = []
+    gw = WorkflowAPIGateway(require_auth=False, title="issue-2087-gateway-ok")
+    try:
+        gw.proxy_workflow(
+            name="internal",
+            proxy_url=backend,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+        )
+        resp = TestClient(gw.app).get(
+            "/internal/products;color=blue/list", headers=_auth_headers()
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        gw.close()
+
+    assert _PathRecordingHandler.paths == ["/products;color=blue/list"]

--- a/tests/regression/test_issue_2091_proxy_destination_guard.py
+++ b/tests/regression/test_issue_2091_proxy_destination_guard.py
@@ -52,7 +52,10 @@ async def _allow(request: Request):
 #: Destinations with NO legitimate proxy use. Blocked by default.
 BLOCKED_DESTINATIONS = [
     ("http://169.254.169.254/", "metadata_service"),
-    ("http://169.254.169.254/latest/meta-data/iam/security-credentials/", "metadata_service"),
+    (
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "metadata_service",
+    ),
     ("http://metadata.google.internal/", "metadata_host"),
     ("http://metadata.azure.com/", "metadata_host"),
     ("http://169.254.1.5/", "link_local"),
@@ -274,7 +277,6 @@ def test_core_and_nexus_share_one_implementation():
     today are exactly the thing that drifts.
     """
     import nexus.http_client as nh
-
     from kailash.utils import network_guard
 
     assert nh._core_check_url is network_guard.check_url
@@ -298,9 +300,7 @@ def test_nexus_keeps_its_strict_posture_through_the_shared_guard():
     assert exc.value.reason == "private_ipv4"
 
     # ...while the core proxy posture accepts exactly that destination.
-    reject_unsafe_proxy_destination(
-        "http://10.1.2.3:8080/", name="n", surface="test"
-    )
+    reject_unsafe_proxy_destination("http://10.1.2.3:8080/", name="n", surface="test")
 
 
 def test_unresolvable_destination_is_permitted_but_loud(caplog):

--- a/tests/regression/test_issue_2091_proxy_destination_guard.py
+++ b/tests/regression/test_issue_2091_proxy_destination_guard.py
@@ -1,0 +1,321 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #2091 -- unconstrained core proxy destination.
+
+PR #2064 closed the CALLER-driven SSRF on core's two proxy surfaces. The
+DESTINATION itself stayed unconstrained: nothing stopped a registration
+naming ``http://169.254.169.254/``, so an authenticated caller could read
+cloud metadata -- IAM credentials on the usual providers -- through the proxy.
+
+This is a DEPLOYMENT-misconfiguration surface, not a caller-driven one, and
+the severity is materially lower than the defects #2064 fixed: ``proxy_url``
+comes from a developer calling a Python API, not from request data. It needs
+someone to register a bad destination; it does not need an attacker. That is
+worth stating rather than glossing -- and it is also why it should not be
+left implicit, because a reader of the pre-fix code would reasonably conclude
+the destination was deliberately unconstrained.
+
+Fail-first, measured pre-fix on BOTH surfaces::
+
+    WorkflowServer       http://169.254.169.254/          -> REGISTRATION ACCEPTED  <== SSRF
+    WorkflowServer       http://metadata.google.internal/ -> REGISTRATION ACCEPTED  <== SSRF
+    WorkflowAPIGateway   http://169.254.169.254/          -> REGISTRATION ACCEPTED  <== SSRF
+    WorkflowAPIGateway   http://metadata.google.internal/ -> REGISTRATION ACCEPTED  <== SSRF
+
+The guard is the one lifted out of ``nexus.http_client`` into
+``kailash.utils.network_guard`` -- the reference implementation #2091 named.
+``test_core_and_nexus_share_one_implementation`` pins that they are the same
+code object rather than two copies that happen to agree today.
+"""
+
+import ipaddress
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from kailash.api.gateway import WorkflowAPIGateway
+from kailash.servers.workflow_server import WorkflowServer
+from kailash.utils.network_guard import BlockedDestinationError
+from kailash.utils.proxy_guard import reject_unsafe_proxy_destination
+
+pytestmark = pytest.mark.regression
+
+
+async def _allow(request: Request):
+    """A real dependency, not a Mock."""
+    if request.headers.get("X-Regression-Key") != "let-me-in":
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return {"user_id": "keyed"}
+
+
+#: Destinations with NO legitimate proxy use. Blocked by default.
+BLOCKED_DESTINATIONS = [
+    ("http://169.254.169.254/", "metadata_service"),
+    ("http://169.254.169.254/latest/meta-data/iam/security-credentials/", "metadata_service"),
+    ("http://metadata.google.internal/", "metadata_host"),
+    ("http://metadata.azure.com/", "metadata_host"),
+    ("http://169.254.1.5/", "link_local"),
+    ("http://[fe80::1]/", "link_local"),
+]
+
+#: Destinations a reverse proxy is LEGITIMATELY pointed at. A blanket RFC1918
+#: block would break the primary use, so both polarities are asserted.
+ALLOWED_DESTINATIONS = [
+    "http://127.0.0.1:9/",
+    "http://10.1.2.3:8080/",
+    "http://192.168.1.10/",
+    "http://172.16.5.5/",
+]
+
+
+def _make_server():
+    return WorkflowServer(title="issue-2091", require_auth=False)
+
+
+def _make_gateway():
+    return WorkflowAPIGateway(require_auth=False, title="issue-2091")
+
+
+SURFACES = [("WorkflowServer", _make_server), ("WorkflowAPIGateway", _make_gateway)]
+
+
+# ---------------------------------------------------------------------------
+# Enforcement-surface parity -- BOTH surfaces refuse, through ONE guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+@pytest.mark.parametrize("url,expected_reason", BLOCKED_DESTINATIONS)
+def test_blocked_destination_refused_at_registration(
+    surface_name, make, url, expected_reason
+):
+    surface = make()
+    try:
+        with pytest.raises(BlockedDestinationError) as exc:
+            surface.proxy_workflow(
+                name="internal",
+                proxy_url=url,
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+            )
+        assert exc.value.reason == expected_reason
+        # Refused BEFORE anything was recorded -- no half-registered proxy.
+        assert "internal" not in surface.workflows
+    finally:
+        surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+@pytest.mark.parametrize("url", ALLOWED_DESTINATIONS)
+def test_legitimate_internal_destination_still_registers(surface_name, make, url):
+    """The no-false-positive polarity.
+
+    Proxying to an internal service is the COMMON legitimate use of this
+    surface. A control that breaks it gets switched off wholesale, taking the
+    metadata protection with it.
+    """
+    surface = make()
+    try:
+        surface.proxy_workflow(
+            name="internal",
+            proxy_url=url,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+        )
+        assert "internal" in surface.workflows
+    finally:
+        surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+def test_metadata_block_survives_require_public_false(surface_name, make):
+    """``allow_private`` must not be a back door to IMDS.
+
+    The two knobs are deliberately separate so that widening the posture for
+    internal backends never silently widens cloud metadata too.
+    """
+    surface = make()
+    try:
+        with pytest.raises(BlockedDestinationError) as exc:
+            surface.proxy_workflow(
+                name="internal",
+                proxy_url="http://169.254.169.254/",
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+                require_public_destination=False,
+            )
+        assert exc.value.reason == "metadata_service"
+    finally:
+        surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+def test_require_public_destination_blocks_rfc1918(surface_name, make):
+    """The opt-IN stricter posture, matching nexus's outbound default."""
+    surface = make()
+    try:
+        with pytest.raises(BlockedDestinationError) as exc:
+            surface.proxy_workflow(
+                name="internal",
+                proxy_url="http://10.1.2.3:8080/",
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+                require_public_destination=True,
+            )
+        assert exc.value.reason == "private_ipv4"
+    finally:
+        surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+def test_extra_blocked_networks_are_enforced(surface_name, make):
+    surface = make()
+    try:
+        with pytest.raises(BlockedDestinationError):
+            surface.proxy_workflow(
+                name="internal",
+                proxy_url="http://10.9.9.9:8080/",
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+                blocked_networks=[ipaddress.ip_network("10.9.0.0/16")],
+            )
+    finally:
+        surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+def test_metadata_opt_out_is_explicit_and_loud(surface_name, make, caplog):
+    """``security.md`` § Secure-Default: opt-out is explicit AND logged.
+
+    The escape hatch exists, but it cannot be taken silently -- the WARNING
+    names the protection being disabled.
+    """
+    surface = make()
+    try:
+        with caplog.at_level("WARNING"):
+            surface.proxy_workflow(
+                name="internal",
+                proxy_url="http://169.254.169.254/",
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+                allow_metadata_destination=True,
+            )
+        assert "internal" in surface.workflows
+        assert any(
+            "allow_metadata_destination=True" in r.getMessage() for r in caplog.records
+        ), "opt-out was silent -- no WARNING named the disabled protection"
+    finally:
+        surface.close()
+
+
+def test_gateway_checks_every_backend_not_just_the_primary():
+    """Round-robin means the caller cannot choose which backend serves them.
+
+    Checking only ``primary_url`` would leave the second and later entries
+    unconstrained -- the same partial-coverage shape the credential-forwarding
+    defect had on this surface before #2025.
+    """
+    gw = _make_gateway()
+    try:
+        with pytest.raises(BlockedDestinationError) as exc:
+            gw.proxy_workflow(
+                name="internal",
+                proxy_url="http://10.1.2.3:8080/,http://169.254.169.254/",
+                allowed_paths=["*"],
+                auth_dependency=_allow,
+            )
+        assert exc.value.reason == "metadata_service"
+        assert "internal" not in gw.workflows
+    finally:
+        gw.close()
+
+
+def test_api_channel_plumbs_the_destination_controls():
+    """``security.md`` § Multi-Site Kwarg Plumbing.
+
+    ``APIChannel.proxy_workflow`` delegates to ``WorkflowServer``; a gate that
+    is unconfigurable through the channel is a gate that gets worked around.
+    """
+    import inspect
+
+    from kailash.channels.api_channel import APIChannel
+
+    params = inspect.signature(APIChannel.proxy_workflow).parameters
+    for kwarg in (
+        "blocked_networks",
+        "allow_metadata_destination",
+        "require_public_destination",
+    ):
+        assert kwarg in params, f"APIChannel.proxy_workflow does not plumb {kwarg}"
+
+    source = inspect.getsource(APIChannel.proxy_workflow)
+    for kwarg in (
+        "blocked_networks",
+        "allow_metadata_destination",
+        "require_public_destination",
+    ):
+        assert (
+            f"{kwarg}={kwarg}" in source
+        ), f"APIChannel.proxy_workflow accepts {kwarg} but does not forward it"
+
+
+# ---------------------------------------------------------------------------
+# One implementation, not two
+# ---------------------------------------------------------------------------
+
+
+def test_core_and_nexus_share_one_implementation():
+    """#2091's constraint: nexus is the REFERENCE, not a second copy.
+
+    ``kailash-nexus`` depends on ``kailash`` and never the reverse, so the
+    shared piece lives in core and nexus imports it. Asserting object identity
+    rather than behavioural agreement is deliberate: two copies that agree
+    today are exactly the thing that drifts.
+    """
+    import nexus.http_client as nh
+
+    from kailash.utils import network_guard
+
+    assert nh._core_check_url is network_guard.check_url
+    assert nh._DEFAULT_BLOCKED_NETWORKS is network_guard.DEFAULT_BLOCKED_NETWORKS
+    assert nh._METADATA_IPS is network_guard.METADATA_IPS
+    assert nh._is_private_ipv4 is network_guard.is_private_ipv4
+    assert nh._is_private_ipv6 is network_guard.is_private_ipv6
+    assert nh._detect_encoded_ip_bypass is network_guard.detect_encoded_ip_bypass
+
+
+def test_nexus_keeps_its_strict_posture_through_the_shared_guard():
+    """The shared guard must not have relaxed nexus's outbound posture.
+
+    Core's proxy permits RFC1918; nexus's outbound client must still refuse
+    it. Same implementation, different posture, pinned on both sides.
+    """
+    from nexus.http_client import InvalidEndpointError, check_url
+
+    with pytest.raises(InvalidEndpointError) as exc:
+        check_url("http://10.1.2.3:8080/")
+    assert exc.value.reason == "private_ipv4"
+
+    # ...while the core proxy posture accepts exactly that destination.
+    reject_unsafe_proxy_destination(
+        "http://10.1.2.3:8080/", name="n", surface="test"
+    )
+
+
+def test_unresolvable_destination_is_permitted_but_loud(caplog):
+    """A stated limit, asserted so it cannot silently become fail-closed.
+
+    A backend legitimately is not up yet at registration. Refusing there makes
+    the control one deployments route around, so registration proceeds -- and
+    the WARNING names the destination as unchecked so the gap is visible.
+    """
+    with caplog.at_level("WARNING"):
+        reject_unsafe_proxy_destination(
+            "http://no-such-host.invalid.example/",
+            name="unresolved",
+            surface="test",
+        )
+    assert any(
+        "could not be resolved" in r.getMessage() for r in caplog.records
+    ), "unresolvable destination was permitted SILENTLY"

--- a/tests/regression/test_issue_2091_proxy_destination_guard.py
+++ b/tests/regression/test_issue_2091_proxy_destination_guard.py
@@ -60,6 +60,27 @@ BLOCKED_DESTINATIONS = [
     ("http://metadata.azure.com/", "metadata_host"),
     ("http://169.254.1.5/", "link_local"),
     ("http://[fe80::1]/", "link_local"),
+    # IPv6 WRAPPERS around the metadata address. These reached IMDS on the
+    # DEFAULT posture until the metadata gate learned to look through the
+    # wrapper -- the translation-range constants existed and were documented
+    # "unconditional", but were consulted ONLY from `is_private_ipv6`, which
+    # runs only under `if not allow_private:`, and the proxy ships
+    # `require_public_destination=False` (i.e. allow_private=True). Absent
+    # IPv6 coverage here is why it shipped.
+    ("http://[64:ff9b::169.254.169.254]/", "metadata_service"),
+    ("http://[64:ff9b::a9fe:a9fe]/", "metadata_service"),
+    ("http://[::ffff:0:a9fe:a9fe]/", "metadata_service"),
+    ("http://[::ffff:0:169.254.169.254]/", "metadata_service"),
+    ("http://[::ffff:169.254.169.254]/", "link_local"),
+]
+
+#: Public addresses wrapped in the SAME IPv6 translation prefixes. The
+#: metadata gate must see THROUGH the wrapper without refusing every address
+#: that merely uses one -- the no-false-positive polarity for the fix above.
+WRAPPED_PUBLIC_DESTINATIONS = [
+    "http://[::ffff:8.8.8.8]/",
+    "http://[64:ff9b::8.8.8.8]/",
+    "https://[2606:4700:4700::1111]/",
 ]
 
 #: Destinations a reverse proxy is LEGITIMATELY pointed at. A blanket RFC1918
@@ -129,6 +150,45 @@ def test_legitimate_internal_destination_still_registers(surface_name, make, url
         assert "internal" in surface.workflows
     finally:
         surface.close()
+
+
+@pytest.mark.parametrize("surface_name,make", SURFACES)
+@pytest.mark.parametrize("url", WRAPPED_PUBLIC_DESTINATIONS)
+def test_ipv6_wrapped_public_addresses_still_register(surface_name, make, url):
+    """No-false-positive polarity for the wrapper-aware metadata gate.
+
+    Looking through the wrapper must not degrade into refusing every address
+    that uses one — a guard that blocks all of `::ffff:`/`64:ff9b::` would
+    pass the bypass tests while breaking legitimate NAT64 deployments.
+    """
+    surface = make()
+    try:
+        surface.proxy_workflow(
+            name="internal",
+            proxy_url=url,
+            allowed_paths=["*"],
+            auth_dependency=_allow,
+        )
+        assert "internal" in surface.workflows
+    finally:
+        surface.close()
+
+
+def test_embedded_ipv4_extracts_the_wrapped_address():
+    """Unit-level pin on the helper the metadata gate depends on."""
+    from kailash.utils.network_guard import embedded_ipv4
+
+    cases = {
+        "::ffff:169.254.169.254": "169.254.169.254",
+        "::ffff:0:a9fe:a9fe": "169.254.169.254",
+        "64:ff9b::a9fe:a9fe": "169.254.169.254",
+        "::ffff:8.8.8.8": "8.8.8.8",
+    }
+    for wrapper, expected in cases.items():
+        assert str(embedded_ipv4(ipaddress.ip_address(wrapper))) == expected
+    # A plain IPv4 and an unrelated IPv6 embed nothing.
+    assert embedded_ipv4(ipaddress.ip_address("8.8.8.8")) is None
+    assert embedded_ipv4(ipaddress.ip_address("2606:4700:4700::1111")) is None
 
 
 @pytest.mark.parametrize("surface_name,make", SURFACES)

--- a/tests/tier2_integration/channels/test_api_channel_comprehensive.py
+++ b/tests/tier2_integration/channels/test_api_channel_comprehensive.py
@@ -1,6 +1,7 @@
 """Comprehensive unit tests for api_channel module."""
 
 import asyncio
+import ipaddress
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -353,6 +354,14 @@ class TestAPIChannel:
             allowed_methods=None,
             auth_dependency=None,
             forward_credentials=False,
+            # #2091 destination controls and the #2085 response cap. Each
+            # defaults to None/False here and is resolved by the SERVER, not
+            # the channel -- the channel's job is to thread them, and this
+            # assertion is what catches it silently dropping one.
+            blocked_networks=None,
+            allow_metadata_destination=False,
+            require_public_destination=False,
+            max_response_bytes=None,
         )
 
     def test_proxy_workflow_threads_security_kwargs(self, api_channel):
@@ -368,6 +377,10 @@ class TestAPIChannel:
             allowed_methods=["GET", "POST"],
             auth_dependency=dep,
             forward_credentials=True,
+            blocked_networks=[ipaddress.ip_network("10.9.0.0/16")],
+            allow_metadata_destination=True,
+            require_public_destination=True,
+            max_response_bytes=4096,
         )
 
         kwargs = api_channel.workflow_server.proxy_workflow.call_args.kwargs
@@ -375,6 +388,14 @@ class TestAPIChannel:
         assert kwargs["allowed_methods"] == ["GET", "POST"]
         assert kwargs["auth_dependency"] is dep
         assert kwargs["forward_credentials"] is True
+        # #2091 destination controls + #2085 response cap. Asserted with
+        # NON-DEFAULT values on purpose: a channel that dropped one and let the
+        # server's default stand would still pass an assertion written against
+        # the defaults.
+        assert kwargs["blocked_networks"] == [ipaddress.ip_network("10.9.0.0/16")]
+        assert kwargs["allow_metadata_destination"] is True
+        assert kwargs["require_public_destination"] is True
+        assert kwargs["max_response_bytes"] == 4096
 
     @pytest.mark.asyncio
     async def test_health_check(self, api_channel):


### PR DESCRIPTION
Proxy hardening across the three deferred findings from the #2064 adversarial reviews. All three touch the same two shipped surfaces (`WorkflowServer.proxy_workflow`, `WorkflowAPIGateway.proxy_workflow`) plus the `APIChannel` wrapper that delegates to them, so they land together through shared implementations rather than three parallel patches.

## #2087 — `..;/` segment-parameter traversal

`reject_unsafe_proxy_path` refused a segment equal to `..`, which is right for the RFC 3986 shape and bypassable for the servlet-class one. Tomcat/Jetty strip everything from `;` to the end of a segment while resolving, so `..;` is not `..` at the proxy, passes the check, and is normalised **by the backend** to `..`.

Measured pre-fix, with `a/../b` refusing on the same run as the discrimination control:

```
'a/../b'         -> path contains a parent-directory segment (..)
'a/..;/b'        -> FORWARDED  <== TRAVERSAL RESTORED
'a/..;foo/b'     -> FORWARDED  <== TRAVERSAL RESTORED
'a/..%3B/b'      -> FORWARDED  <== TRAVERSAL RESTORED
'..;/etc/passwd' -> FORWARDED  <== TRAVERSAL RESTORED
```

The **narrow** option of the three the issue weighed. `_collapse_segment_parameters` models the servlet rule for one purpose — deciding whether a segment would *become* a dot-segment — and fires only then, so `products;color=blue` still forwards. A blanket `;` ban would be a regression (`;` is an RFC 3986 sub-delimiter).

### What this does NOT cover — stated, not implied

- **It closes one MEMBER of the family, not the class.** A backend collapsing a *different* character reintroduces the same class under a new spelling and would need its own clause. Carrying a full "strictest plausible backend" normalisation model in core was rejected: its divergence from real backend behaviour is itself a bypass source.
- **It does not defeat check-to-use TOCTOU.** This is a check on the path *this process forwards*. It constrains neither how the backend resolves the result nor anything that changes between the check and the forward. It is not a substitute for the backend refusing paths outside its own root.
- Starlette's decode depth was **measured**, not assumed, and pinned as a test — that measurement is what makes the `%3B` clause load-bearing.

## #2091 — unconstrained proxy destination (SSRF / IMDS)

Nothing stopped a registration naming `http://169.254.169.254/`. Measured pre-fix — **both** surfaces `REGISTRATION ACCEPTED` for IMDS and for `metadata.google.internal`.

Severity is materially lower than what #2064 fixed and that is worth stating: `proxy_url` comes from a developer calling a Python API, not from request data. It needs someone to register a bad destination; it does not need an attacker.

**The guard is lifted, not duplicated.** `nexus.http_client` was the reference the issue named, and `kailash-nexus` depends on `kailash` and never the reverse, so the shared logic now lives in `kailash/utils/network_guard.py` and nexus **imports** it — including a duplicate `_DEFAULT_BLOCKED_NETWORKS` that was *shadowing* the import and is now deleted (nexus `http_client.py`: 898 → 612 lines). A parallel core guard was the obvious move and is what `zero-tolerance.md` Rule 4 forbids.

Wiring is measured, not asserted: mutating **core** reds the nexus suite, and a test pins **object identity** rather than behavioural agreement, because two copies that agree today are exactly the thing that drifts.

**Default posture is deliberately not nexus's.** Nexus blocks RFC1918 because an outbound client has no business there; a reverse proxy is frequently pointed at an internal service on purpose. A blanket RFC1918 block would break the normal case, and a control that breaks the normal case gets switched off wholesale — taking the IMDS protection with it. So the default blocks the subset with no legitimate proxy use (metadata IPs, metadata hostnames, link-local), permits RFC1918/loopback, and offers `require_public_destination=True` for the strict posture.

`allow_metadata_destination` is a **separate** argument from `require_public_destination`, so widening for internal backends can never silently widen IMDS; taking it logs a WARNING naming the disabled protection (`security.md` § Secure-Default).

### Limits — stated, not implied

- The check runs at **registration**, against what the destination resolves to *then*. A hostname resolving benign at registration and to IMDS later is **not** caught — this is not a DNS-rebinding defence. Metadata *hostnames* are additionally blocked by name, which does not depend on resolution.
- An **unresolvable** destination is permitted with a WARNING rather than refused: a backend legitimately is not up yet at registration, and failing there makes the control one deployments route around.

## #2085 — resource exhaustion

**Unbounded buffering, both surfaces.** Measured pre-fix: a 40 MB backend response returned 200 with `41943040` bytes buffered on both. Cap is per-registration (64 MiB default), fails **closed** with 502 rather than truncating, and `0` raises rather than meaning "unlimited". `content-length` is not the signal — it is absent from the response allowlist precisely because it describes compressed bytes over a decompressed body (#2025); both surfaces count decompressed bytes.

> The first server-side implementation used `StreamReader.read(cap + 1)` and was **wrong** — aiohttp returns *up to* n bytes, so an 8 MiB body came back as 155023 bytes with a 200: silently truncated, the exact failure this prevents. Caught by measurement; both surfaces now accumulate in chunks and the test asserts the exact payload.

**Per-request `ClientSession`, server surface only.** Measured: 3 requests → 3 distinct client source ports; now 1. The gateway already reused one client, so this was also an enforcement-surface asymmetry. The session is keyed by event **loop** (an aiohttp session binds to its creating loop), closed via `ShutdownCoordinator` at priority 3 rather than left to GC. The health-check poller was the sibling call site and now uses the shared session too — it runs on a schedule, so leaving it per-poll would have kept the churn.

## Enforcement-surface parity sweep

| Surface | destination guard | response cap | path guard |
|---|---|---|---|
| `WorkflowServer.proxy_workflow` | yes | yes | yes |
| `WorkflowAPIGateway.proxy_workflow` | yes | yes | yes |
| `APIChannel.proxy_workflow` | delegates + plumbs all kwargs | plumbs | delegates |

The gateway checks **every** comma-separated backend, not just the primary — round-robin means the caller cannot choose which serves them. Only one `ClientSession(` construction remains in the proxy paths (the shared factory). No second copy of the SSRF guard survives in core or nexus.

## Testing

New: 23 (#2085) + 26 (#2087) + 33 (#2091). Combined proxy suites incl. the existing #2025 suites: **191 passed**. Nexus `http_client` + wiring: **62 passed**.

Every guard is **mutation-verified**. Notably, neutering the #2085 loop bound while leaving the post-loop size check intact left the tests **green** — status code alone does not discriminate a bounded read from a drained one. The tests now assert the bytes the *backend* managed to write, and the mutation reds them with `backend wrote 8388608 bytes`.

No `Mock` in any of the three files: real HTTP servers on real sockets, recording what they actually received.

**Full regression suite, failing-ID sets compared against session-start `d248afd78`:** identical (91 pre-existing failures/errors both before and after, empty diff in both directions); passed 2189 → 2271. Zero new failures. The pre-existing failures are environment artifacts (missing compiled `kailash._kailash` extension, `[pg]`-marked tests) and none touch the changed surface.

## Note for reviewers

A `framework-first` hook fires on `import aiohttp` in `workflow_server.py` suggesting a Nexus rewrite. It does not apply here: this is core, and `kailash-nexus` depends on `kailash`, never the reverse — the exact constraint #2091 states. The import also pre-existed at two sites in that file; this change *reduces* raw-client surface from per-request construction to one shared session.

Also noted, not touched: `kaizen/llm/url_safety.py` holds a third, pre-existing SSRF `check_url` implementation. Consolidating it onto `kailash.utils.network_guard` is a natural follow-up but is outside this lane's three issues and its shard budget.

## Release ordering — BLOCKING for core, read before cutting a release

The #2091 extraction creates a cross-package coupling. `nexus.http_client` now imports `kailash.utils.network_guard` at **module scope**, and that module exists in **no released kailash**. Measured:

```
repo core version (pyproject.toml):  2.63.0
latest kailash on PyPI:              2.62.0
2.63.0 present on PyPI:              False
```

Proven hard, not inferred — with `kailash.utils.network_guard` made unavailable:

```
ImportError at import time: No module named 'kailash.utils.network_guard'
=> branch-nexus + released-kailash(<=2.62.0) is DOA
```

**Core `kailash` 2.63.0 MUST be published BEFORE the nexus release that carries this.** Otherwise `pip install kailash-nexus` resolves kailash 2.62.0 and `import nexus.http_client` raises `ModuleNotFoundError` on a clean install. This is relevant to the open decision about cutting a release with drifted packages, and is stated here so it informs that decision rather than being discovered during it.

`packages/kailash-nexus/pyproject.toml` already floors `kailash>=2.63.0` (for the `safe_callable_name` / `safe_exception_frames` coupling), so the value is correct — but nothing recorded that it now *also* covers `network_guard`, and an accidentally-correct floor is one bump away from wrong. That rationale is now written beside the floor, per that file's own convention.

### CI: no step exercises nexus against a PyPI kailash

Swept all three nexus install sites. Each installs root kailash **editable, in the same step, before nexus**:

| Workflow | nexus install | root kailash in same step |
|---|---|---|
| `unified-ci.yml:490` | `uv pip install -e packages/kailash-nexus` | `-e ".[dev,server,...]"` (line 483) |
| `test-kailash-kaizen.yml:249` | `-e "packages/kailash-nexus"` | `-e "."` |
| `trust-tests.yml:63` | `-e "packages/kailash-nexus[dev]"` | `-e ".[trust,rfc3161,dev]"` |

```
ANY workflow installing kailash-nexus from PyPI (no -e)?   NONE
ANY workflow installing root kailash from PyPI?            NONE
```

**No workflow change is required.** In particular `unified-ci.yml` needs no edit for this.

The #2023 sibling-install lint passes (`3 passed`) — but that green is **not** evidence for this coupling, and should not be read as such: #2023 checks the *mirror* direction (root-kailash-editable + PyPI-**sibling**). Mine is branch-**nexus** + PyPI-**core**, which that lint cannot see. The table above is the actual evidence.

## Post-review fixes (added after the first review round)

### HIGH — IMDS reachable via IPv6 wrappers on the DEFAULT posture

Adversarial review of this PR found the destination guard did **not** hold on the posture it actually ships. Reproduced:

```
DEFAULT posture (require_public_destination=False):
  http://[64:ff9b::169.254.169.254]/   -> ACCEPTED  <== IMDS REACHABLE
  http://[::ffff:0:a9fe:a9fe]/         -> ACCEPTED  <== IMDS REACHABLE
```

Two independent causes, both mine:

1. The RFC 2765 / RFC 6052 translation-range constants existed and were documented **"unconditional"**, but were consulted only from `is_private_ipv6`, which runs only under `if not allow_private:`. The proxy default is `allow_private=True`, so a constant documented as unconditional was in practice **unreachable for the shipped configuration**.
2. The metadata check matched on `str(ip)`. A wrapper's string form never equals the bare metadata address, so equality could not see through it.

Fixed by checking the metadata/link-local gate over the address **and any IPv4 it embeds** (`embedded_ipv4` covers `::ffff:`, the SIIT `::ffff:0:` form `.ipv4_mapped` does *not* recognise, and the NAT64 `64:ff9b::` prefix). Absent IPv6 coverage is why it shipped, so the suite gains 5 wrapper rows plus 3 **wrapped-public** rows — looking through the wrapper must not degrade into refusing every address that uses one, which would pass the bypass tests while breaking legitimate NAT64 deployments.

Mutation-verified: reverting the gate to the `str(ip)`-only form reds exactly the 8 wrapper rows.

**A latent `NameError` caught during verification, worth naming.** My first cut referenced `IPV4_TRANSLATED_NETWORK`, which did not exist on this branch (only the underscore-prefixed names did). The probe printed `refused` for every wrapper and *looked* like a pass — it was a crash, not the guard firing. Asserting the **reason code** rather than the bare refusal is what caught it; the tests now pin `metadata_service` / `link_local`.

### CI — the four failing matrix legs

All four `Test (Python 3.11/3.12/3.13/3.14)` failures were **one root cause, and mine**:

```
FAILED tests/tier2_integration/channels/test_api_channel_comprehensive.py
  ::TestAPIChannel::test_proxy_workflow - AssertionError: expected call not found.
```

`test_proxy_workflow` asserts the exact delegation call — precisely what its comment says it exists for: catching an edit that silently stops threading an argument through. This PR added four kwargs to `APIChannel.proxy_workflow`, so the assertion had to learn them. The test was working as designed. Missed locally because my pre-push runs covered `tests/regression/` and the nexus suites but not `tests/tier2_integration/`, where the channel-plumbing assertion lives; the full tier2 suite now runs clean (2587 passed).

`test_proxy_workflow_threads_security_kwargs` is **strengthened**, not merely updated: it now passes NON-DEFAULT values for all four kwargs. Written against the defaults it would have passed even if the channel dropped one and let the server's default stand — the exact failure the assertion exists to prevent. Mutation-verified.

## Related issues

Fixes #2085
Fixes #2087
Fixes #2091


