### PR TITLE
fix(middleware): server-derived identity on the gateway (#2102) + JWT log-injection sanitizing (#2104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,48 @@ such as `>=2.0`.
 
 ## [Unreleased]
 
+### Changed (BREAKING) — the middleware gateway derives identity from the credential, never from the request (#2102)
+
+**Read the migration note at the end of this entry before upgrading.** If you call `POST /api/sessions`, `GET /events` or `WS /ws` on `kailash.middleware.communication.api_gateway.APIGateway` with `enable_auth` at its default, the identity those routes act under changes.
+
+- **A valid credential lost to a POST body field (HIGH).** On a default `APIGateway()`, `POST /api/sessions` created the session under the body's `user_id` even when the caller presented a verified bearer token for somebody else. **Measured on the pre-fix source**, with a token this gateway itself minted for `alice`:
+
+  ```
+  POST /api/sessions {"user_id": "attacker-chosen"}   Authorization: Bearer <alice>
+  -> 200 {"session_id": "...", "user_id": "attacker-chosen", "active": true}
+  ```
+
+  This is the identity-derivation-parity class (`security.md` § Enforcement-Surface Parity), the same defect #2047 fixed in `MultiFactorAuthNode` and the caller-controlled `user_id` #2040 traced into the log sink.
+
+- **Two defects stacked, and both had to be fixed for either to matter.** The session dependency ran `await self.auth_manager.verify_token(token)` — but `JWTAuthManager.verify_token` is **sync** while `MiddlewareAuthManager.verify_token` is **async**, so with the manager this class constructs *by default* every verification raised `TypeError: object dict can't be used in 'await' expression`, was caught, and resolved to "no principal". And the claim it read was `payload.get("user_id")`, while every token this SDK mints carries the subject as `sub` — so even with the await corrected the derived identity would have been empty, and the route's own "credential carries no usable subject" guard would have 401'd every legitimate caller. The call is now awaited **only if awaitable**, and the subject comes from the shared `kailash.trust.auth.jwt.subject_from_claims`.
+
+- **One derivation, one policy, three routes.** `APIGateway._authenticated_user_id` is the single place this gateway answers "who is calling", and `_resolve_identity` the single place it decides what to do when the answer is nobody. Both read the principal the installed gate already verified (`scope["state"]["user"]`, set by `JWTAuthMiddleware` for HTTP and `JWTWebSocketAuthMiddleware` for the handshake) before falling back to verifying a presented bearer directly — which is the path that matters on a deployment where no gate is installed here.
+
+- **The sibling sweep found two more sites, and they were not labels (`security.md` § Enforcement-Surface Parity).** `WS /ws` and `GET /events` took `user_id` from the **query string** and handed it to `EventFilter`, so it decides *whose events the stream receives*: an authenticated caller passing `?user_id=<someone else>` subscribed to that user's event stream. Both now resolve identity the same way as the session route. A websocket cannot carry a 401, so an unresolvable identity closes the handshake with **1008 (policy violation)** without `accept()`, matching `JWTWebSocketAuthMiddleware._deny`.
+
+- **Recorded per route, including the ones left alone.** Every other route on this gateway was checked. `GET /api/sessions/{id}`, `DELETE /api/sessions/{id}`, `GET /api/sessions`, the `/api/workflows` and `/api/executions` families take **no identity field** — they take a server-minted `session_id`, and whether a caller may act on *someone else's* session is a horizontal-authorization question, a different class with a different fix, deliberately **not** smuggled in here. The other server surfaces (`servers/workflow_server.py`, `servers/enterprise_workflow_server.py`, `servers/durable_workflow_server.py`, `api/gateway.py`) declare no caller-supplied identity parameter on any route, so this class is confined to this module.
+
+- **`subject_from_claims` is shared, not copied** (`security.md` § Credential Decode Helpers). `JWTValidator.create_user_from_payload` now calls it rather than carrying its own `sub` / `user_id` / `uid` precedence, so the gate's normalizer and the gateway's direct-verification path cannot drift. A numeric `sub` is rendered rather than rejected (common in the wild, and refusing it would start rejecting tokens this SDK accepted before the extraction); `bool` is excluded despite being an `int` subclass, and structural claims yield no principal rather than being coerced into one.
+
+**Migration.** With `enable_auth` at its default, the identity is now **the credential's**, and a request that carries none is refused:
+
+| Configuration | No credential | Credential presented |
+| --- | --- | --- |
+| `APIGateway()` (default) | **401** — unchanged since #2072's gate | session owned by the **token's subject** (was: the body's `user_id`) |
+| `APIGateway(external_auth_reason=...)` | **401 (new)** — the route refuses; nothing else does | session owned by the **token's subject** |
+| `APIGateway(require_auth=False)` | body/query value, unchanged | session owned by the **token's subject** |
+| `APIGateway(enable_auth=False)` | body/query value, unchanged | body/query value, unchanged |
+
+If you were relying on setting `user_id` in the body while authenticated — an admin creating a session on another user's behalf, say — that is now a 401-free but ignored field; act on it through a credential minted for that subject. To keep the old open behaviour deliberately, construct with `require_auth=False` (or `enable_auth=False`), which is the explicit opt-out `resolve_server_auth` already announces with a WARN at construction. Tests that create sessions without credentials keep working unchanged if they already pass `enable_auth=False`, which #2072 required of them.
+
+### Security — attacker-supplied JWT header `key_id` reached a log line (#2104)
+
+- **`key_id` is read before any signature is verified, by design.** `JWTAuthManager.verify_token` reads the presented token's header with `jwt.get_unverified_header` — that is how the verification key gets selected — and then logged the `kid` it found by interpolation: `logger.warning(f"Token signed with unknown key ID: {key_id}")`. The value is therefore wholly unauthenticated, attacker-chosen input reaching a `WARNING` record, on the **failure** path an attacker probing key IDs drives repeatedly, at a level that survives the production log filters which drop its `DEBUG` siblings. An embedded newline forged additional well-formed records; NUL and ANSI escapes corrupted operator consoles and downstream SIEM ingestion.
+- **Routed through the existing public sanitizer, not a second copy** (`security.md` § Credential Decode Helpers). `kailash.utils.secure_logging.sanitize_log_value` — added in #2103 for exactly this class — flattens every non-printable to a space and bounds the value, and the call sites moved to lazy `%s` arguments so the sanitized value is what the formatter receives.
+- **The five siblings in the same file are fixed in the same change**, because a per-site fix here is precisely the drift #2088 documents: `user_id` in `create_access_token` / `create_refresh_token`, `jti` in `revoke_token` / `revoke_refresh_token`, and `user_id` in `revoke_all_user_tokens`; plus the exception-text sinks in `verify_token` and `refresh_access_token`. **Measured rather than assumed for those last three:** PyJWT's own messages do *not* echo the presented bytes (`DecodeError` reports `Invalid header string: Invalid control character at: line 1 column 25`, naming a position, not content), so the taint there arrives from any *other* exception reaching the sink — a revocation-store backend reporting a remote failure being the documented case.
+- **Three sites in the file are deliberately left interpolated, recorded so a later sweep does not re-flag them:** `Failed to load RSA keys` (operator-supplied key material, where flattening a multi-line PEM error would cost the operator the diagnostic), `Generated new JWT key pair with ID` (a server-minted uuid4), and the expired-token cleanup count (an int).
+- **The regression tests measure the emitted stream, not the `LogRecord`.** A forged record is forged at *format* time, so counting records cannot tell a sanitized call from an unsanitized one; the tests attach a real `StreamHandler` with a real `Formatter` and count the lines a log collector would actually ingest.
+
 ### Security (BREAKING) — server-wide authentication now fails closed (#2072)
 
 **Read the migration note below before upgrading. Every `create_gateway()` / `WorkflowServer()` deployment that has not configured a credential source will stop booting.** That is the intended behaviour, and the reason is in the first bullet.

--- a/src/kailash/middleware/auth/jwt_auth.py
+++ b/src/kailash/middleware/auth/jwt_auth.py
@@ -22,6 +22,7 @@ except ImportError:
     jwt = None
     rsa = None
 
+from ...utils.secure_logging import sanitize_log_value
 from .exceptions import (
     InvalidTokenError,
     RefreshTokenError,
@@ -423,7 +424,9 @@ class JWTAuthManager:
                 algorithm=self.config.algorithm,
             )
 
-        logger.debug(f"Created access token for user {user_id}")
+        logger.debug(
+            "Created access token for user %s", sanitize_log_value(user_id, 128)
+        )
         return token
 
     def create_refresh_token(
@@ -486,7 +489,9 @@ class JWTAuthManager:
             "last_used": None,
         }
 
-        logger.debug(f"Created refresh token for user {user_id}")
+        logger.debug(
+            "Created refresh token for user %s", sanitize_log_value(user_id, 128)
+        )
         return token
 
     def create_token_pair(
@@ -537,7 +542,17 @@ class JWTAuthManager:
 
                 # Verify key ID matches current key (optional check)
                 if key_id and key_id != self._key_id:
-                    logger.warning(f"Token signed with unknown key ID: {key_id}")
+                    # `key_id` comes from `get_unverified_header` -- it is read
+                    # BEFORE any signature check, because reading it is how the
+                    # verification key gets selected, so it is wholly
+                    # unauthenticated attacker-chosen input. Interpolated, an
+                    # embedded newline lets an unauthenticated caller forge
+                    # additional well-formed WARNING records on the very path
+                    # a key-ID prober drives repeatedly (issue #2104).
+                    logger.warning(
+                        "Token signed with unknown key ID: %s",
+                        sanitize_log_value(key_id, 128),
+                    )
                     # In production, you might want to support multiple keys
                     # for graceful key rotation
 
@@ -580,10 +595,14 @@ class JWTAuthManager:
             logger.debug("Token has expired")
             raise
         except jwt.InvalidTokenError as e:
-            logger.warning(f"Invalid token: {e}")
+            # PyJWT builds several of these messages FROM the presented token --
+            # `DecodeError(f"Invalid header string: {e}")` is the clearest case
+            # -- so the exception text is attacker-influenced on exactly the
+            # path an unauthenticated caller drives (issue #2104).
+            logger.warning("Invalid token: %s", sanitize_log_value(e))
             raise
         except Exception as e:
-            logger.error(f"Token verification error: {e}")
+            logger.error("Token verification error: %s", sanitize_log_value(e))
             raise jwt.InvalidTokenError(f"Token verification failed: {e}")
 
     def refresh_access_token(self, refresh_token: str) -> TokenPair:
@@ -633,7 +652,7 @@ class JWTAuthManager:
             )
 
         except Exception as e:
-            logger.error(f"Token refresh failed: {e}")
+            logger.error("Token refresh failed: %s", sanitize_log_value(e))
             raise
 
     def revoke_token(self, token: str):
@@ -650,7 +669,14 @@ class JWTAuthManager:
             exp = payload.get("exp")
             expires_at = datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
             self._revocation_store.revoke(jti=jti, token=token, expires_at=expires_at)
-            logger.info(f"Revoked token {jti}" if jti else "Revoked token")
+            # `jti` is decoded from a token the CALLER presented. It verified,
+            # so it is not unauthenticated -- but a holder of any valid token
+            # still chooses this value if it minted the token elsewhere, and a
+            # verified caller is not a trusted log author (issue #2104).
+            if jti:
+                logger.info("Revoked token %s", sanitize_log_value(jti, 128))
+            else:
+                logger.info("Revoked token")
         except Exception:
             # Even if verification fails, revoke by raw token string so a
             # malformed/expired token presented for revocation is still recorded.
@@ -682,7 +708,7 @@ class JWTAuthManager:
         """Revoke specific refresh token."""
         if jti in self._refresh_tokens:
             del self._refresh_tokens[jti]
-            logger.info(f"Revoked refresh token {jti}")
+            logger.info("Revoked refresh token %s", sanitize_log_value(jti, 128))
 
     def revoke_all_user_tokens(self, user_id: str):
         """Revoke all tokens for a specific user."""
@@ -695,7 +721,7 @@ class JWTAuthManager:
         for jti in to_remove:
             del self._refresh_tokens[jti]
 
-        logger.info(f"Revoked all tokens for user {user_id}")
+        logger.info("Revoked all tokens for user %s", sanitize_log_value(user_id, 128))
 
     def cleanup_expired_tokens(self):
         """Remove expired tokens from tracking."""

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -7,6 +7,7 @@ frontend support capabilities.
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import time
@@ -319,6 +320,11 @@ class APIGateway:
         resolved_require_auth = (
             bool(enable_auth) if require_auth is None else bool(require_auth)
         )
+        # Kept, because it is also the IDENTITY policy and not only the gate
+        # policy: a deployment that authenticates its requests must never take
+        # a principal from a request field (issue #2102). Read by
+        # `_resolve_identity`.
+        self._require_auth = resolved_require_auth
         self._auth_config = resolve_server_auth(
             require_auth=resolved_require_auth,
             auth_config=(
@@ -436,6 +442,145 @@ class APIGateway:
             audience=getattr(config, "audience", None),
         )
 
+    async def _authenticated_user_id(self, connection: Any) -> Optional[str]:
+        """The SERVER-DERIVED principal for one HTTP request or WS handshake.
+
+        THE single place this gateway answers "who is calling". Every route
+        that has an identity to establish calls it -- ``POST /api/sessions``,
+        ``/ws`` and ``/events`` -- so there is one derivation and one policy
+        rather than three (``security.md`` § Credential Decode Helpers).
+
+        Two sources, in order, and NEITHER of them is a request field:
+
+        1. **The installed gate's answer.** When ``require_auth`` resolves True
+           this gateway installs
+           :class:`~kailash.trust.auth.asgi.JWTAuthMiddleware` (HTTP) and
+           :class:`~kailash.trust.auth.asgi.JWTWebSocketAuthMiddleware`
+           (websocket), each of which verifies the credential and leaves an
+           :class:`~kailash.trust.auth.models.AuthenticatedUser` on
+           ``scope["state"]["user"]``. Re-verifying it here would be a second
+           implementation of a decision already made.
+        2. **A direct verification**, for the deployments where NO gate is
+           installed -- ``require_auth=False``, or ``external_auth_reason``
+           naming an outside ASGI layer, or a path the operator exempted. A
+           presented bearer token is verified with this gateway's own auth
+           manager, which is the issuer of the tokens it accepts.
+
+        ``verify_token`` is called and its result awaited ONLY IF awaitable.
+        The two managers in this SDK disagree: ``JWTAuthManager.verify_token``
+        is SYNC and ``MiddlewareAuthManager.verify_token`` is ASYNC. The
+        previous revision awaited unconditionally, so with the manager this
+        class constructs by DEFAULT every verification raised
+        ``TypeError: object dict can't be used in 'await' expression``, was
+        caught by the handler below, and resolved to "no principal" -- which
+        is how a valid bearer token lost to a POST body field (issue #2102).
+
+        Returns:
+            The principal's id, or ``None`` when no credential could be
+            resolved. Never raises: the REFUSAL decision belongs to
+            :meth:`_resolve_identity`, which knows whether this deployment
+            authenticates at all.
+        """
+        state = getattr(connection, "state", None)
+        user = getattr(state, "user", None) if state is not None else None
+        if user is not None:
+            user_id = getattr(user, "user_id", None)
+            if isinstance(user_id, str) and user_id:
+                return user_id
+            # A gate-verified principal with no usable subject cannot happen
+            # through `create_user_from_payload` (it raises first), so this is
+            # a foreign middleware's object. Loud, and it falls through to the
+            # direct verification rather than being treated as an identity.
+            logger.warning(
+                "api_gateway.authenticated_user_without_subject",
+                extra={"user_type": type(user).__name__},
+            )
+
+        manager = getattr(self, "auth_manager", None)
+        if manager is None:
+            return None
+
+        scheme, _, token = (
+            (connection.headers.get("Authorization") or "").partition(" ")
+            if getattr(connection, "headers", None) is not None
+            else ("", "", "")
+        )
+        if scheme.lower() != "bearer" or not token:
+            return None
+
+        try:
+            payload = manager.verify_token(token)
+            if inspect.isawaitable(payload):
+                payload = await payload
+        except HTTPException:
+            # A REJECTED credential, not an absent one. Logged rather than
+            # swallowed silently (`zero-tolerance.md` Rule 3); the caller is
+            # then unauthenticated, and `_resolve_identity` decides what that
+            # means for this deployment.
+            logger.warning("api_gateway.presented_token_rejected")
+            return None
+        except Exception as exc:
+            logger.warning(
+                "api_gateway.token_verification_failed",
+                extra={"error_type": type(exc).__name__},
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            logger.warning(
+                "api_gateway.verify_token_returned_non_mapping",
+                extra={"payload_type": type(payload).__name__},
+            )
+            return None
+
+        from ...trust.auth.jwt import subject_from_claims
+
+        return subject_from_claims(payload)
+
+    async def _resolve_identity(
+        self, connection: Any, caller_supplied: Optional[str]
+    ) -> Optional[str]:
+        """Decide whose identity a request acts under, fail-closed.
+
+        The rule, one line: **a deployment that authenticates its requests
+        never takes a principal from a request field.**
+
+        * A server-derived principal ALWAYS wins, including over a body or
+          query value that disagrees with it.
+        * With no principal and ``require_auth`` resolved True, this RAISES
+          401. It does not fall back. Falling back is the whole defect: it let
+          an unauthenticated caller open a session under any name it chose, and
+          it let an authenticated one act as somebody else (issue #2102, the
+          same class as #2047).
+        * With no principal and authentication explicitly opted OUT
+          (``require_auth=False``, or ``enable_auth=False`` which is the older
+          spelling of the same statement), the caller-supplied value stands.
+          That is this route's documented contract for an open deployment, and
+          `resolve_server_auth` has already logged that exposure loudly at
+          construction.
+
+        Raises:
+            HTTPException: 401, when this deployment authenticates requests and
+                no principal could be derived for this one.
+        """
+        principal = await self._authenticated_user_id(connection)
+        if principal:
+            return principal
+
+        if self._require_auth:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Authentication required: this gateway authenticates "
+                    "requests, so the identity for this operation must come "
+                    "from a verified credential and cannot be read from the "
+                    "request. Present a bearer token, or construct the "
+                    "gateway with require_auth=False to serve openly."
+                ),
+            )
+
+        return caller_supplied
+
     def _init_sdk_nodes(self, database_url: Optional[str] = None):
         """Initialize SDK nodes for gateway operations."""
 
@@ -552,100 +697,33 @@ class APIGateway:
     def _setup_session_routes(self):
         """Setup session management routes."""
 
-        # Create auth dependency
-        async def get_optional_current_user(request: Request):
-            """Resolve the authenticated principal, or None when there is none.
-
-            This returned None unconditionally -- "For now, return None to
-            avoid complex auth setup" -- on EVERY path, including with auth
-            enabled and a valid bearer token presented. `enable_auth` defaults
-            to True, so on the default path the session identity was always
-            the caller-supplied `request.user_id` body field and the
-            server-derived principal never won (`zero-tolerance.md` Rule 2;
-            same bug class as #2047 at the HTTP surface). The auth manager's
-            `verify_token` / `verify_api_key` existed the whole time and were
-            simply not called.
-
-            Deliberately still OPTIONAL: a request with no credential resolves
-            to None rather than 401, which preserves this route's contract.
-            Whether an auth-enabled gateway should REFUSE a session create
-            that carries no credential is a separate, breaking decision and is
-            tracked as its own issue rather than smuggled in here.
-            """
-            if not (self.enable_auth and self.auth_manager):
-                return None
-
-            scheme, _, token = (request.headers.get("Authorization") or "").partition(
-                " "
-            )
-            if scheme.lower() == "bearer" and token:
-                try:
-                    payload = await self.auth_manager.verify_token(token)
-                except HTTPException:
-                    # An invalid/expired token is a REJECTED credential, not
-                    # an absent one. Logged rather than swallowed silently
-                    # (`zero-tolerance.md` Rule 3); the request continues
-                    # unauthenticated, which this route already permits.
-                    logger.warning("Session-route bearer token was rejected")
-                    return None
-                except Exception as exc:
-                    logger.warning(
-                        "Session-route token verification failed: %s",
-                        type(exc).__name__,
-                    )
-                    return None
-                return {
-                    "user_id": payload.get("user_id"),
-                    "permissions": payload.get("permissions", []),
-                    "metadata": payload.get("metadata", {}),
-                }
-
-            # NO `X-API-Key` BRANCH HERE, deliberately.
-            #
-            # A first draft of this added one, calling
-            # `auth_manager.verify_api_key`. That method CANNOT SUCCEED, which
-            # was measured rather than assumed: it calls
-            # `credential_manager.execute(operation=..., credential_name=...)`,
-            # but `CredentialManagerNode.run()` takes `**inputs` and ignores
-            # BOTH -- it reads `self.credential_name`, fixed at construction --
-            # and its return dict has no `"success"` key at all. So
-            # `result.get("success", False)` is always False and the call
-            # always raises 401. An auth path that can only ever reject is a
-            # non-functional feature presented as a working one
-            # (`zero-tolerance.md` Rule 2), so it is not shipped. The
-            # underlying `verify_api_key` defect is pre-existing and tracked
-            # separately.
-            return None
+        # NO `X-API-Key` BRANCH ON THIS ROUTE, deliberately.
+        #
+        # A first draft added one, calling `auth_manager.verify_api_key`. That
+        # method CANNOT SUCCEED, which was measured rather than assumed: it
+        # calls `credential_manager.execute(operation=..., credential_name=...)`,
+        # but `CredentialManagerNode.run()` takes `**inputs` and ignores BOTH --
+        # it reads `self.credential_name`, fixed at construction -- and its
+        # return dict has no `"success"` key at all. So
+        # `result.get("success", False)` is always False and the call always
+        # raises 401. An auth path that can only ever reject is a non-functional
+        # feature presented as a working one (`zero-tolerance.md` Rule 2), so it
+        # is not shipped. API keys DO work on this gateway, through the
+        # installed gate's own `api_key_validator`, which is a real
+        # implementation; the `verify_api_key` defect is pre-existing and
+        # tracked separately.
 
         @self.app.post("/api/sessions", response_model=SessionResponse)
         async def create_session(
             request: SessionCreateRequest,
-            current_user: Dict[str, Any] = Depends(get_optional_current_user),
+            http_request: Request,
         ):
             """Create a new session for a frontend client."""
             try:
-                # A resolved principal WINS -- and an UNUSABLE one REFUSES.
-                #
-                # `.get("user_id", user_id)` fell back to the body value only
-                # when the key was ABSENT, so a principal resolving to a None
-                # user_id silently produced a session with no owner. The first
-                # fix for that skipped the assignment instead, which is just
-                # as wrong in the other direction: it reverted to the
-                # caller-supplied body field. A credential that verified but
-                # carries no usable subject is a BROKEN credential, not an
-                # absent one, and falling back to the caller's claim there is
-                # fail-open at an identity-resolution site.
-                user_id = request.user_id
-                if self.enable_auth and current_user:
-                    principal = current_user.get("user_id")
-                    if not isinstance(principal, str) or not principal:
-                        raise HTTPException(
-                            status_code=401,
-                            detail=(
-                                "Authenticated credential carries no usable " "subject"
-                            ),
-                        )
-                    user_id = principal
+                # The identity is SERVER-DERIVED or the request is REFUSED.
+                # `request.user_id` is a POST body field and survives only on a
+                # deployment that explicitly opted out of authentication.
+                user_id = await self._resolve_identity(http_request, request.user_id)
 
                 session_id = await self.agent_ui.create_session(
                     user_id=user_id or "", metadata=request.metadata
@@ -654,11 +732,11 @@ class APIGateway:
                 session = await self.agent_ui.get_session(session_id)
                 self.requests_processed += 1
 
-                # Log session creation. ``user_id`` is caller-controlled: it
-                # comes from the POST body and is only overridden when auth is
-                # enabled AND a principal resolved, so on the default path it
-                # is the raw request value. Interpolated, an embedded newline
-                # forges a second well-formed log record (issue #2040).
+                # Log session creation. ``user_id`` is caller-controlled on an
+                # open deployment: `_resolve_identity` returns the POST body
+                # value verbatim when authentication was explicitly opted out.
+                # Interpolated, an embedded newline forges a second well-formed
+                # log record (issue #2040).
                 logger.info(
                     "Session created: %s for user %s",
                     sanitize_log_value(session_id, 128),
@@ -680,11 +758,11 @@ class APIGateway:
 
                 return SessionResponse(**transformed["result"])
             except HTTPException:
-                # A deliberate status -- the 401 raised above for a credential
-                # with no usable subject -- must reach the client as itself.
-                # The `except Exception` below would otherwise relabel every
-                # auth refusal on this route as a 500, hiding the refusal and
-                # reporting a server fault for a client error.
+                # A deliberate status -- the 401 `_resolve_identity` raises
+                # when no principal could be derived -- must reach the client
+                # as itself. The `except Exception` below would otherwise
+                # relabel every auth refusal on this route as a 500, hiding the
+                # refusal and reporting a server fault for a client error.
                 raise
             except Exception as e:
                 # The security event and the client response share one
@@ -1008,12 +1086,30 @@ class APIGateway:
             user_id: Optional[str] = None,
             event_types: Optional[str] = None,
         ):
-            """WebSocket endpoint for real-time communication."""
+            """WebSocket endpoint for real-time communication.
+
+            ``user_id`` is a SUBSCRIPTION FILTER, not a label: it is handed to
+            ``EventFilter`` and decides which users' events this socket
+            receives. Taken from the query string it let any caller subscribe
+            to another user's event stream, so it is resolved the same way the
+            session route resolves its identity (issue #2102 sibling sweep).
+            """
             # Parse event types from query parameter
             event_type_list = event_types.split(",") if event_types else None
 
+            try:
+                resolved_user_id = await self._resolve_identity(websocket, user_id)
+            except HTTPException:
+                # A websocket cannot carry a 401. 1008 is POLICY VIOLATION, and
+                # it is sent WITHOUT `accept()` so the handshake is refused
+                # outright rather than accepted and then torn down -- the same
+                # shape `JWTWebSocketAuthMiddleware._deny` uses.
+                logger.warning("api_gateway.websocket_identity_unresolved")
+                await websocket.close(code=1008)
+                return
+
             await self.realtime.handle_websocket(
-                websocket, session_id, user_id, event_type_list
+                websocket, session_id, resolved_user_id, event_type_list
             )
 
         @self.app.get("/events")
@@ -1023,11 +1119,17 @@ class APIGateway:
             user_id: Optional[str] = None,
             event_types: Optional[str] = None,
         ):
-            """Server-Sent Events endpoint."""
+            """Server-Sent Events endpoint.
+
+            ``user_id`` is the same subscription filter as on ``/ws`` and is
+            resolved the same way: from the verified credential, never from the
+            query string (issue #2102 sibling sweep).
+            """
             event_type_list = event_types.split(",") if event_types else None
+            resolved_user_id = await self._resolve_identity(request, user_id)
 
             return self.realtime.create_sse_stream(
-                request, session_id, user_id, event_type_list
+                request, session_id, resolved_user_id, event_type_list
             )
 
         @self.app.post("/api/webhooks")

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -533,6 +533,33 @@ class APIGateway:
             )
             return None
 
+        # A REFRESH token is NOT an access credential, and this path is the
+        # only place in the gateway that could have treated it as one.
+        # `JWTValidator.verify_token` — the gate's verifier — already refuses
+        # it (`trust/auth/jwt.py`, "Refresh tokens cannot be used for API
+        # authentication"), but NEITHER middleware manager does:
+        # `auth_manager.py` never mentions `token_type`, and `jwt_auth.py`
+        # only reads it in `refresh_access_token`, checking the OPPOSITE
+        # direction. So the two verification surfaces disagreed, and this one
+        # was the permissive half (`security.md` § Enforcement-Surface Parity).
+        #
+        # Reachable ONLY where this direct path IS the identity source — a
+        # deployment with no gate installed here (`external_auth_reason=`, an
+        # exempted path, `require_auth=False`). Measured before this fix:
+        #
+        #     DEFAULT (gate installed)      -> 401  (the gate refused it)
+        #     external_auth_reason          -> 200  as the refresh token's subject
+        #     require_auth=False            -> 200  as the refresh token's subject
+        #
+        # A refresh token lives for `refresh_token_expire_days` (7 by default)
+        # and is the credential most likely to sit in cookie storage or a
+        # client log, so accepting it here turns a long-lived exchange token
+        # into a session-opening one on exactly the deployments that cannot
+        # fall back on the gate.
+        if payload.get("token_type") == "refresh":
+            logger.warning("api_gateway.refresh_token_presented_as_access")
+            return None
+
         from ...trust.auth.jwt import subject_from_claims
 
         return subject_from_claims(payload)
@@ -549,9 +576,17 @@ class APIGateway:
           query value that disagrees with it.
         * With no principal and ``require_auth`` resolved True, this RAISES
           401. It does not fall back. Falling back is the whole defect: it let
-          an unauthenticated caller open a session under any name it chose, and
-          it let an authenticated one act as somebody else (issue #2102, the
-          same class as #2047).
+          an unauthenticated caller open a session under any name it chose
+          (issue #2102, the same class as #2047).
+
+          SCOPED CLAIM, deliberately. This closes identity DERIVATION — who a
+          request acts AS, at the routes that MINT or FILTER by an identity.
+          It does NOT close what an authenticated principal may act ON: every
+          route taking a caller-supplied ``session_id`` still acts on it
+          without checking who owns that session, so an authenticated caller
+          can still act as somebody else THERE. That is horizontal
+          authorization, a different class with a different fix, tracked as
+          issue #2145 — do not read this docstring as closing it.
         * With no principal and authentication explicitly opted OUT
           (``require_auth=False``, or ``enable_auth=False`` which is the older
           spelling of the same statement), the caller-supplied value stands.
@@ -1100,11 +1135,28 @@ class APIGateway:
             try:
                 resolved_user_id = await self._resolve_identity(websocket, user_id)
             except HTTPException:
-                # A websocket cannot carry a 401. 1008 is POLICY VIOLATION, and
-                # it is sent WITHOUT `accept()` so the handshake is refused
-                # outright rather than accepted and then torn down -- the same
-                # shape `JWTWebSocketAuthMiddleware._deny` uses.
+                # A websocket cannot carry a 401. 1008 is POLICY VIOLATION,
+                # sent WITHOUT `accept()` so the handshake is refused outright
+                # rather than accepted and then torn down.
+                #
+                # The `receive()` mirrors `JWTWebSocketAuthMiddleware._deny`
+                # and is not decoration: the ASGI spec has the server send
+                # `websocket.connect` before the application may reply, and
+                # while uvicorn tolerates a close without it, hypercorn,
+                # daphne and the wsproto implementation are stricter -- a
+                # refusal that only fails closed on one server is not a
+                # refusal. Wrapped because the peer can vanish between the
+                # server queuing `connect` and this read; the close below is
+                # then a no-op and turning that into a 500 would convert a
+                # disconnect into a server fault.
                 logger.warning("api_gateway.websocket_identity_unresolved")
+                try:
+                    await websocket.receive()
+                except Exception:
+                    logger.debug(
+                        "api_gateway.websocket_connect_event_unavailable",
+                        exc_info=True,
+                    )
                 await websocket.close(code=1008)
                 return
 

--- a/src/kailash/middleware/communication/realtime.py
+++ b/src/kailash/middleware/communication/realtime.py
@@ -30,6 +30,7 @@ except ImportError as exc:  # pragma: no cover — covered by structural invaria
 from ...nodes.api import HTTPRequestNode
 from ...nodes.security import CredentialManagerNode
 from ...nodes.transform import DataTransformer
+from ...utils.secure_logging import sanitize_log_value
 from ..core.agent_ui import AgentUIMiddleware
 from .events import BaseEvent, EventFilter, EventPriority, EventStream, EventType
 
@@ -427,7 +428,15 @@ class WebhookManager:
             "failures": 0,
             "active": True,
         }
-        logger.info(f"Registered webhook {webhook_id} -> {url}")
+        # `url` is a caller-supplied field on `WebhookRegisterRequest`; the id
+        # is server-minted. Same class as #2104 -- an unsanitized caller value
+        # reaching a log record -- caught by a sweep whose scope was the
+        # CHANGED file rather than the taint (issue #2140 follow-up).
+        logger.info(
+            "Registered webhook %s -> %s",
+            sanitize_log_value(webhook_id, 128),
+            sanitize_log_value(url, 256),
+        )
 
     def unregister_webhook(self, webhook_id: str):
         """Unregister a webhook endpoint."""
@@ -477,9 +486,14 @@ class WebhookManager:
             "timestamp": time.time(),
         }
 
-        # Log delivery attempt
+        # Log delivery attempt. `url` is the caller-registered value again --
+        # it reaches this sink on EVERY delivery, so an injected value here
+        # forges a record per event rather than once at registration.
         logger.info(
-            f"Webhook delivery attempt: {webhook_id} -> {url} (event: {event.type.value})"
+            "Webhook delivery attempt: %s -> %s (event: %s)",
+            sanitize_log_value(webhook_id, 128),
+            sanitize_log_value(url, 256),
+            sanitize_log_value(event.type.value, 64),
         )
 
         self.delivery_stats["total_attempts"] += 1
@@ -681,7 +695,11 @@ class RealtimeMiddleware:
                         json.dumps({"error": "Invalid JSON format"})
                     )
                 except Exception as e:
-                    logger.error(f"WebSocket message error: {e}")
+                    # The exception text here is derived from the attacker's
+                    # own JSON payload (a decode / handler failure on bytes
+                    # they chose), so it is the #2104 class on a socket a
+                    # caller can drive repeatedly.
+                    logger.error("WebSocket message error: %s", sanitize_log_value(e))
                     await websocket.send_text(json.dumps({"error": str(e)}))
 
         finally:

--- a/src/kailash/middleware/core/agent_ui.py
+++ b/src/kailash/middleware/core/agent_ui.py
@@ -566,16 +566,24 @@ class AgentUIMiddleware:
             # Validate the workflow using SDK validation
             workflow.validate()
 
-            # Log workflow creation
+            # Log workflow creation. `name` is `WorkflowCreateRequest.name`,
+            # a caller-supplied POST body field, and this sink sits ~110 lines
+            # BELOW the two the first #2104 sweep fixed at :452-456 -- the
+            # same-file drift that sweep's own rationale warns about.
             logger.info(
-                f"Workflow built: {config.get('name', 'unnamed')} with {len(config.get('nodes', []))} nodes"
+                "Workflow built: %s with %d nodes",
+                sanitize_log_value(config.get("name", "unnamed"), 128),
+                len(config.get("nodes", [])),
             )
 
             return workflow
 
         except Exception as e:
-            # Log error
-            logger.error(f"Workflow build failed: {str(e)}")
+            # The exception text is derived from the caller's own node graph
+            # (a build/validate failure on the config they submitted), so it
+            # carries attacker-chosen bytes on the failure path a prober
+            # drives repeatedly.
+            logger.error("Workflow build failed: %s", sanitize_log_value(e))
             raise ValueError(f"Failed to build workflow from config: {e}")
 
     # Workflow Execution

--- a/src/kailash/trust/auth/asgi.py
+++ b/src/kailash/trust/auth/asgi.py
@@ -424,8 +424,36 @@ class JWTWebSocketAuthMiddleware:
             return
 
         if token.startswith("__apikey__") and self.config.api_key_enabled:
-            if not await self._api_key_ok(token[len("__apikey__") :]):
+            api_key_result = await self._api_key_ok(token[len("__apikey__") :])
+            if not api_key_result:
                 await self._deny(scope, receive, send, "invalid_api_key")
+                return
+            # Populate the principal, exactly as the HTTP sibling does at
+            # `_dispatch_api_key`. This branch previously accepted the
+            # handshake and passed it through with NO `scope["state"]["user"]`,
+            # so a route that reads the authenticated principal saw nothing on
+            # a credential the gate had just ACCEPTED -- and a fail-closed
+            # route then refused it (close 1008). Not a bypass, but a
+            # reachability regression for a valid credential, and the exact
+            # surface-parity gap `security.md` names: two independent paths
+            # authenticating the same key, only one recording who it was.
+            scope.setdefault("state", {})
+            try:
+                if isinstance(api_key_result, dict):
+                    scope["state"]["user"] = self._validator.create_user_from_payload(
+                        api_key_result
+                    )
+                else:
+                    scope["state"]["user"] = AuthenticatedUser(
+                        user_id="apikey", roles=["api"]
+                    )
+                scope["state"]["token_payload"] = {"type": "api_key"}
+            except Exception:
+                logger.exception(
+                    "jwt_ws_auth_middleware.api_key_user_construction_failed",
+                    extra={"path": scope.get("path", "")},
+                )
+                await self._deny(scope, receive, send, "auth_error")
                 return
             await self.app(scope, receive, send)
             return
@@ -472,21 +500,33 @@ class JWTWebSocketAuthMiddleware:
 
         await self.app(scope, receive, send)
 
-    async def _api_key_ok(self, api_key: str) -> bool:
+    async def _api_key_ok(self, api_key: str) -> Any:
+        """Authenticate an API key, RETURNING the validator's own result.
+
+        Returns the validator's value rather than a bare bool so the caller
+        can build the same principal the HTTP path builds: a dict result
+        carries claims (name, roles, tenant) that `create_user_from_payload`
+        normalizes, and collapsing it to `True` discarded exactly the
+        information needed to say WHO connected. Falsy (reject) and the
+        error paths return a falsy value, so `if not result` still reads as
+        the rejection test.
+        """
         validator = self.config.api_key_validator
         if validator is None:
             logger.error(
                 "jwt_ws_auth_middleware.api_key_enabled_without_validator",
             )
-            return False
+            return None
         try:
             result = validator(api_key)
             if inspect.isawaitable(result):
                 result = await result
         except Exception:
+            # Logged with a stack trace and failing CLOSED (the caller denies
+            # on a falsy return) -- not a swallow.
             logger.exception("jwt_ws_auth_middleware.api_key_validator_failed")
-            return False
-        return bool(result)
+            return None
+        return result
 
     async def _deny(
         self, scope: Dict[str, Any], receive: Any, send: Any, error: str

--- a/src/kailash/trust/auth/jwt.py
+++ b/src/kailash/trust/auth/jwt.py
@@ -87,11 +87,25 @@ def subject_from_claims(claims: Dict[str, Any]) -> Optional[str]:
         that never existed.
     """
     for claim in ("sub", "user_id", "uid"):
-        value = claims.get(claim)
+        if claim not in claims:
+            continue
+        value = claims[claim]
         if isinstance(value, str) and value:
             return value
         if isinstance(value, int) and not isinstance(value, bool):
             return str(value)
+        # PRESENT but wrong-shape -> hard None, never fall through.
+        #
+        # Falling through let a malformed registered claim be OVERRIDDEN by a
+        # lower-precedence one: `{"sub": "", "user_id": "mallory"}` resolved to
+        # `"mallory"`. `sub` is the RFC 7519 registered claim and the one an
+        # issuer controls; `user_id`/`uid` are the accommodation spellings and
+        # are NOT in the minter's reserved-claim guard, so a caller who can
+        # influence extra claims but not `sub` could be promoted by the
+        # fallback. Latent today (no in-tree caller forwards untrusted kwargs
+        # into the minter) and closed here rather than left to become
+        # reachable (`security.md` § Secure-Default: fail closed).
+        return None
     return None
 
 

--- a/src/kailash/trust/auth/jwt.py
+++ b/src/kailash/trust/auth/jwt.py
@@ -45,7 +45,54 @@ _ASYMMETRIC_ALGORITHMS = {"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"}
 __all__ = [
     "JWTConfig",
     "JWTValidator",
+    "subject_from_claims",
 ]
+
+
+def subject_from_claims(claims: Dict[str, Any]) -> Optional[str]:
+    """The subject identifier a set of verified JWT claims names, or ``None``.
+
+    THE one place the claim precedence for "who is this token about" is
+    written. ``sub`` is the RFC 7519 §4.1.2 registered claim and wins; the two
+    fallbacks are the spellings this SDK's own issuers and common external
+    providers emit.
+
+    Extracted from :meth:`JWTValidator.create_user_from_payload`, which now
+    calls it, because a SECOND caller appeared:
+    :class:`~kailash.middleware.communication.api_gateway.APIGateway` verifies
+    a bearer token directly on the deployments where no gate middleware is
+    installed, and needs the same answer. Two copies of a precedence rule is
+    how one of them silently starts disagreeing -- the gateway's own first
+    attempt read ``payload.get("user_id")`` alone, which is ``None`` for every
+    token this SDK mints, so the identity it derived was always empty
+    (``security.md`` § Credential Decode Helpers: one shared helper, never
+    per-site copies).
+
+    Args:
+        claims: A decoded, ALREADY-VERIFIED JWT payload. This function performs
+            no verification of any kind and must never be handed the output of
+            an unverified decode.
+
+    Returns:
+        The subject as a non-empty ``str``, or ``None`` when no claim carries
+        one.
+
+        An integer subject is accepted and rendered -- RFC 7519 calls for a
+        StringOrURI, but numeric ``sub`` claims are common enough in the wild
+        that refusing them here would start rejecting tokens this SDK accepted
+        before the extraction. ``bool`` is excluded explicitly despite being an
+        ``int`` subclass, because ``"True"`` is not an identity. Every other
+        type -- a nested object, a list, ``None`` -- returns ``None`` rather
+        than being coerced: ``str()`` of a dict would manufacture a principal
+        that never existed.
+    """
+    for claim in ("sub", "user_id", "uid"):
+        value = claims.get(claim)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+    return None
 
 
 @dataclass
@@ -366,8 +413,9 @@ class JWTValidator:
         Raises:
             InvalidTokenError: If required claims are missing
         """
-        # Extract user_id
-        user_id = payload.get("sub") or payload.get("user_id") or payload.get("uid")
+        # Extract user_id. The precedence lives in `subject_from_claims` so the
+        # gateway's direct-verification path cannot drift from this one.
+        user_id = subject_from_claims(payload)
         if not user_id:
             raise InvalidTokenError("Token missing user identifier (sub)")
 

--- a/tests/integration/middleware/test_gateway_integration.py
+++ b/tests/integration/middleware/test_gateway_integration.py
@@ -135,7 +135,13 @@ result = {
         """Test complete end-to-end workflow execution through middleware stack."""
         # Create middleware stack
         agent_ui = AgentUIMiddleware(max_sessions=10, session_timeout_minutes=5)
-        gateway = create_gateway(require_auth=False, title="E2E Test Gateway")
+        # `enable_auth=False` as well as `require_auth=False`: the two are
+        # different knobs. `require_auth` is the request GATE; `enable_auth`
+        # holds a token ISSUER, defaults True, and raises without
+        # KAILASH_API_GATEWAY_SECRET (#636). This test wants neither.
+        gateway = create_gateway(
+            enable_auth=False, require_auth=False, title="E2E Test Gateway"
+        )
         gateway.agent_ui = agent_ui
 
         # Create session
@@ -164,7 +170,7 @@ result = {
         assert workflow_id is not None
 
         # Execute workflow through middleware
-        execution_id = await agent_ui.execute_workflow(
+        execution_id = await agent_ui.execute(
             session_id,
             workflow_id,
             inputs={"processor": {"input_data": [1, 2, 3, 4, 5]}},
@@ -235,11 +241,11 @@ result = {
         # Execute workflows in sequence
         test_data = [{"value": 10}, {"value": 20}, {"value": 30}]
 
-        exec1_id = await agent_ui.execute_workflow(
+        exec1_id = await agent_ui.execute(
             session_id, workflow1_id, inputs={"validate": {"data": test_data}}
         )
 
-        exec2_id = await agent_ui.execute_workflow(
+        exec2_id = await agent_ui.execute(
             session_id, workflow2_id, inputs={"analyze": {"data": test_data}}
         )
 
@@ -301,7 +307,7 @@ result = {
         )
 
         # Execute workflow and monitor events
-        execution_id = await agent_ui.execute_workflow(
+        execution_id = await agent_ui.execute(
             session_id, workflow_id, inputs={"emitter": {}}
         )
 
@@ -351,13 +357,13 @@ result = {
         )
 
         # Execute workflows with different data
-        exec1_id = await agent_ui.execute_workflow(
+        exec1_id = await agent_ui.execute(
             session1_id,
             workflow1_id,
             inputs={"identifier": {"session_id": "session_1_data"}},
         )
 
-        exec2_id = await agent_ui.execute_workflow(
+        exec2_id = await agent_ui.execute(
             session2_id,
             workflow2_id,
             inputs={"identifier": {"session_id": "session_2_data"}},
@@ -394,6 +400,7 @@ result = {
         # Create complete middleware stack
         agent_ui = AgentUIMiddleware(max_sessions=100, session_timeout_minutes=30)
         gateway = create_gateway(
+            enable_auth=False,
             require_auth=False,
             title="Health Monitor Test",
             description="Testing health monitoring",
@@ -451,7 +458,7 @@ result = {
             workflow_id = await agent_ui.create_dynamic_workflow(
                 session_id, workflow_config
             )
-            execution_id = await agent_ui.execute_workflow(
+            execution_id = await agent_ui.execute(
                 session_id,
                 workflow_id,
                 inputs={"processor": {"input_data": f"data_for_user_{user_id}"}},
@@ -537,12 +544,12 @@ result = {
             )
 
             # Execute error workflow
-            error_execution_id = await agent_ui.execute_workflow(
+            error_execution_id = await agent_ui.execute(
                 session_id, error_workflow_id, inputs={"error_node": {}}
             )
 
             # Execute success workflow (should still work despite error in other workflow)
-            success_execution_id = await agent_ui.execute_workflow(
+            success_execution_id = await agent_ui.execute(
                 session_id, success_workflow_id, inputs={"success_node": {}}
             )
 
@@ -602,7 +609,7 @@ result = {
             workflow_id = await agent_ui.create_dynamic_workflow(
                 session_id, workflow_config
             )
-            execution_id = await agent_ui.execute_workflow(
+            execution_id = await agent_ui.execute(
                 session_id, workflow_id, inputs={"calculator": {"input_id": op_id}}
             )
 

--- a/tests/regression/test_issue_2102_gateway_identity_derivation.py
+++ b/tests/regression/test_issue_2102_gateway_identity_derivation.py
@@ -257,6 +257,130 @@ class TestSiblingSweepRealtimeRoutes:
         assert response.status_code == 401, response.text
 
 
+class TestRefreshTokensAreNotAccessCredentials:
+    """A refresh token MUST NOT open a session (#2139 adversarial review, H2).
+
+    ``JWTValidator.verify_token`` — the GATE's verifier — refuses
+    ``token_type == "refresh"``. Neither middleware manager does:
+    ``auth_manager.py`` never mentions ``token_type`` and ``jwt_auth.py``
+    reads it only in ``refresh_access_token``, checking the OPPOSITE
+    direction. So the two verification surfaces disagreed and the direct
+    path — the one this PR brought to life — was the permissive half.
+
+    Measured before the fix, presenting a refresh token as a bearer::
+
+        DEFAULT (gate installed)  -> 401   (the gate refused it)
+        external_auth_reason      -> 200   as the refresh token's subject
+        require_auth=False        -> 200   as the refresh token's subject
+
+    Both polarities per deployment: an ACCESS token must still be accepted
+    on the same route, or "refuses everything" would look identical to
+    "refuses refresh tokens".
+    """
+
+    @pytest.mark.parametrize(
+        "label,kwargs",
+        [
+            ("delegated gate", {"external_auth_reason": "fronted by istio"}),
+            ("open deployment", {"require_auth": False}),
+        ],
+    )
+    def test_refresh_token_is_refused_where_the_direct_path_is_the_source(
+        self, label, kwargs
+    ):
+        gateway = APIGateway(title="test", **kwargs)
+        refresh = gateway.auth_manager.create_refresh_token(user_id="alice")
+
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={"user_id": "body-value"},
+            headers={"Authorization": f"Bearer {refresh}"},
+        )
+
+        assert response.json().get("user_id") != "alice", (
+            f"[{label}] a refresh token opened a session as its subject: "
+            f"{response.status_code} {response.text[:200]}"
+        )
+
+    @pytest.mark.parametrize(
+        "label,kwargs",
+        [
+            ("delegated gate", {"external_auth_reason": "fronted by istio"}),
+            ("open deployment", {"require_auth": False}),
+        ],
+    )
+    def test_access_token_still_works_on_the_same_route(self, label, kwargs):
+        """THE CONTROL — without it, refusing every token would look green."""
+        gateway = APIGateway(title="test", **kwargs)
+
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={"user_id": "body-value"},
+            headers=_bearer(gateway, "alice"),
+        )
+
+        assert response.status_code == 200, response.text
+        assert (
+            response.json()["user_id"] == "alice"
+        ), f"[{label}] the access-token path regressed: {response.text[:200]}"
+
+    def test_the_gate_refuses_it_too_on_a_default_deployment(self):
+        """The surface that was already correct, pinned so parity cannot drift."""
+        gateway = APIGateway(title="test")
+        refresh = gateway.auth_manager.create_refresh_token(user_id="alice")
+
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={},
+            headers={"Authorization": f"Bearer {refresh}"},
+        )
+
+        assert response.status_code == 401, response.text
+
+
+class TestApiKeyWebsocketResolvesAPrincipal:
+    """An API-key-authenticated handshake must carry a principal (M1).
+
+    ``JWTWebSocketAuthMiddleware`` accepted a valid API key and passed the
+    scope through with NO ``scope["state"]["user"]``, while its own bearer
+    branch and the HTTP sibling both populate it. A fail-closed route then
+    refused the credential the gate had just accepted.
+    """
+
+    def test_api_key_handshake_carries_a_principal(self):
+        import secrets
+
+        from starlette.websockets import WebSocketDisconnect
+
+        from kailash.trust.auth.jwt import JWTConfig as TrustJWTConfig
+
+        api_key = "k" * 40
+        config = TrustJWTConfig(
+            secret=GATEWAY_SECRET,
+            algorithm="HS256",
+            api_key_enabled=True,
+            api_key_validator=lambda k: (
+                {"sub": "apikey-alice", "roles": ["api"]}
+                if secrets.compare_digest(k, api_key)
+                else False
+            ),
+        )
+        gateway = APIGateway(title="test", auth_config=config)
+        client = _client(gateway)
+
+        with client.websocket_connect("/ws", headers={"X-API-Key": api_key}):
+            registry = gateway.realtime.connection_manager.user_connections
+            assert "apikey-alice" in registry, (
+                "the API-key handshake resolved no principal: " f"{registry!r}"
+            )
+
+        # THE CONTROL: a wrong key is still refused, so the assertion above
+        # cannot be satisfied by an unconditionally-accepting gate.
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws", headers={"X-API-Key": "wrong"}):
+                pass
+
+
 class TestSubjectClaimPrecedenceIsShared:
     """The identity comes from ``sub``, through ONE helper.
 
@@ -276,6 +400,24 @@ class TestSubjectClaimPrecedenceIsShared:
         from kailash.trust.auth.jwt import subject_from_claims
 
         assert subject_from_claims({"sub": 12345}) == "12345"
+
+    def test_a_present_but_malformed_sub_does_not_fall_through(self):
+        """M2 — a wrong-shape registered claim must not be overridden.
+
+        ``{"sub": "", "user_id": "mallory"}`` resolved to ``"mallory"``:
+        the RFC 7519 registered claim was present-but-malformed and the
+        accommodation spelling — which is NOT in the minter's reserved-claim
+        guard — won. Latent (no in-tree caller forwards untrusted kwargs into
+        the minter) and closed rather than left to become reachable.
+        """
+        from kailash.trust.auth.jwt import subject_from_claims
+
+        assert subject_from_claims({"sub": "", "user_id": "mallory"}) is None
+        assert subject_from_claims({"sub": {}, "uid": "mallory"}) is None
+        assert subject_from_claims({"sub": None, "user_id": "mallory"}) is None
+        # ABSENT (not present-but-malformed) still falls through — that is the
+        # accommodation the precedence exists for.
+        assert subject_from_claims({"user_id": "bob"}) == "bob"
 
     def test_structural_and_empty_claims_yield_no_principal(self):
         from kailash.trust.auth.jwt import subject_from_claims

--- a/tests/regression/test_issue_2102_gateway_identity_derivation.py
+++ b/tests/regression/test_issue_2102_gateway_identity_derivation.py
@@ -1,0 +1,356 @@
+"""Regression: the gateway took a principal from a request field (#2102).
+
+``POST /api/sessions`` read its session owner from the POST body's ``user_id``.
+``GET /events`` and ``WS /ws`` read their subscription identity from a
+``user_id`` QUERY parameter -- and that value is not a label, it is handed to
+``EventFilter``, so it decides whose events the stream receives.
+
+Measured on the pre-fix source, with a VALID bearer token for ``alice``
+presented on a default ``APIGateway()``::
+
+    POST /api/sessions  {"user_id": "attacker-chosen"}   Authorization: Bearer <alice>
+    -> 200 {"user_id": "attacker-chosen", ...}
+
+Two defects stacked to produce that. The dependency ran
+``await self.auth_manager.verify_token(token)``, but ``JWTAuthManager``'s
+``verify_token`` is SYNC while ``MiddlewareAuthManager``'s is ASYNC, so with
+the manager this class constructs BY DEFAULT every verification raised
+``TypeError: object dict can't be used in 'await' expression`` and resolved to
+"no principal". And the claim it then read was ``payload.get("user_id")``,
+while every token this SDK mints carries the subject as ``sub`` -- so even with
+the await fixed the derived identity would have been empty.
+
+The tests below pin BOTH polarities per route, through the HTTP and WebSocket
+surfaces rather than by calling the dependency directly, because the defect
+lived in how the route WIRED the dependency, which a direct call cannot see.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="gateway tests require the `server` extra")
+pytest.importorskip("jwt", reason="PyJWT is required to mint the test credentials")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from kailash.middleware.communication.api_gateway import APIGateway  # noqa: E402
+
+#: 48 bytes, over the 32-byte floor `APIGateway` enforces on this variable.
+GATEWAY_SECRET = "test-gateway-secret-" + "x" * 28
+
+
+@pytest.fixture(autouse=True)
+def gateway_secret(monkeypatch):
+    """Every auth-enabled gateway below needs a signing secret to construct."""
+    monkeypatch.setenv("KAILASH_API_GATEWAY_SECRET", GATEWAY_SECRET)
+
+
+def _client(gateway: APIGateway) -> TestClient:
+    return TestClient(gateway.app)
+
+
+def _bearer(gateway: APIGateway, user_id: str) -> dict:
+    """A credential this gateway itself minted, for ``user_id``."""
+    token = gateway.auth_manager.create_access_token(user_id=user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestSessionRouteIdentityIsServerDerived:
+    """``POST /api/sessions`` -- the site the issue named."""
+
+    def test_verified_principal_beats_the_body_field(self):
+        """The headline case: alice's token, attacker's body, alice's session."""
+        gateway = APIGateway(title="test")
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={"user_id": "attacker-chosen"},
+            headers=_bearer(gateway, "alice"),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "alice", (
+            "the session owner came from the request body, not the credential: "
+            f"{response.text}"
+        )
+
+    def test_no_credential_is_refused_rather_than_trusted(self):
+        """The other polarity: with auth required, absence is a 401, not a fallback."""
+        gateway = APIGateway(title="test")
+        response = _client(gateway).post(
+            "/api/sessions", json={"user_id": "attacker-chosen"}
+        )
+
+        assert response.status_code == 401, response.text
+
+    def test_route_refuses_even_when_the_gate_is_delegated_outside(self):
+        """``external_auth_reason`` installs NO gate here, so the ROUTE must refuse.
+
+        This is the case that proves the refusal lives at the identity site and
+        not only in the middleware: nothing rejects the request before the
+        handler runs, and the handler still must not read the body.
+        """
+        gateway = APIGateway(title="test", external_auth_reason="fronted by istio")
+        response = _client(gateway).post(
+            "/api/sessions", json={"user_id": "attacker-chosen"}
+        )
+
+        assert response.status_code == 401, response.text
+        assert "verified credential" in response.json()["detail"]
+
+    def test_delegated_gate_still_derives_the_identity_from_the_token(self):
+        gateway = APIGateway(title="test", external_auth_reason="fronted by istio")
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={"user_id": "attacker-chosen"},
+            headers=_bearer(gateway, "alice"),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "alice"
+
+
+class TestOpenDeploymentContractIsUnchanged:
+    """``enable_auth=False`` and ``require_auth=False`` are EXPLICIT opt-outs.
+
+    They are the documented way to run this gateway open, and
+    ``resolve_server_auth`` already announces that exposure loudly at
+    construction. Refusing here would break an operator who said what they
+    wanted in the words available to them -- the same reasoning that makes
+    ``require_auth`` tri-state (issue #636's contract, #2072's resolution).
+    """
+
+    def test_enable_auth_false_keeps_the_body_value_as_the_identity(self):
+        gateway = APIGateway(title="test", enable_auth=False)
+        response = _client(gateway).post("/api/sessions", json={"user_id": "whoever"})
+
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "whoever"
+
+    def test_require_auth_false_keeps_the_body_value_as_the_identity(self):
+        gateway = APIGateway(title="test", require_auth=False)
+        response = _client(gateway).post("/api/sessions", json={"user_id": "whoever"})
+
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "whoever"
+
+    def test_a_presented_credential_still_wins_on_an_open_deployment(self):
+        """Open does not mean "ignore credentials": a verified one is still the truth."""
+        gateway = APIGateway(title="test", require_auth=False)
+        response = _client(gateway).post(
+            "/api/sessions",
+            json={"user_id": "attacker-chosen"},
+            headers=_bearer(gateway, "alice"),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "alice"
+
+
+class TestSiblingSweepRealtimeRoutes:
+    """``/ws`` and ``/events``: the same field, reached through the query string.
+
+    ``user_id`` there is a SUBSCRIPTION FILTER. An authenticated caller passing
+    ``?user_id=<somebody else>`` subscribed to that user's event stream, which
+    is the same identity-derivation defect with a confidentiality consequence.
+    """
+
+    def test_websocket_ignores_the_query_user_id_in_favour_of_the_principal(self):
+        gateway = APIGateway(title="test")
+        client = _client(gateway)
+
+        with client.websocket_connect(
+            "/ws?user_id=victim", headers=_bearer(gateway, "alice")
+        ):
+            registry = gateway.realtime.connection_manager.user_connections
+            assert (
+                "alice" in registry
+            ), f"the socket was not registered under the principal: {registry!r}"
+            assert "victim" not in registry, (
+                "the socket subscribed to another user's events from a query "
+                f"parameter: {registry!r}"
+            )
+
+    def test_websocket_without_a_credential_is_refused(self):
+        """The gate refuses the handshake; the route never runs."""
+        from starlette.websockets import WebSocketDisconnect
+
+        gateway = APIGateway(title="test")
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with _client(gateway).websocket_connect("/ws?user_id=victim"):
+                pass
+
+        assert excinfo.value.code == 1008, "expected a POLICY VIOLATION close"
+
+    def test_websocket_query_user_id_survives_on_an_open_deployment(self):
+        gateway = APIGateway(title="test", require_auth=False)
+        client = _client(gateway)
+
+        with client.websocket_connect("/ws?user_id=anonymous-picked"):
+            registry = gateway.realtime.connection_manager.user_connections
+            assert "anonymous-picked" in registry
+
+    @pytest.mark.asyncio
+    async def test_sse_stream_is_filtered_by_the_principal_not_the_query(self):
+        """Driven against the raw ASGI app, and cancelled by this test.
+
+        Neither HTTP client works here, and the reason is in the route rather
+        than in the test: the SSE generator loops forever on a 30-second
+        heartbeat and never completes, so both ``TestClient`` and
+        ``httpx.ASGITransport`` block waiting for an app task that has no end.
+        Calling ``gateway.app`` directly lets this test take the first body
+        chunk -- which is emitted AFTER the stream registers itself, so it is
+        proof of registration -- and then cancel, which is what a real client
+        disconnecting does.
+        """
+        import asyncio
+
+        gateway = APIGateway(title="test")
+        headers = _bearer(gateway, "alice")
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/events",
+            "raw_path": b"/events",
+            "root_path": "",
+            "query_string": b"user_id=victim",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", headers["Authorization"].encode()),
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        }
+
+        first_body_chunk = asyncio.Event()
+        status: list[int] = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status.append(message["status"])
+            elif message["type"] == "http.response.body":
+                first_body_chunk.set()
+
+        task = asyncio.create_task(gateway.app(scope, receive, send))
+        try:
+            await asyncio.wait_for(first_body_chunk.wait(), timeout=10)
+            registered = [
+                stream["user_id"]
+                for stream in gateway.realtime.sse_manager.streams.values()
+            ]
+        finally:
+            task.cancel()
+
+        assert status == [200], f"the stream never started: {status!r}"
+        assert registered == [
+            "alice"
+        ], f"the SSE stream was filtered by a query parameter: {registered!r}"
+
+    def test_sse_without_a_credential_is_refused(self):
+        gateway = APIGateway(title="test")
+        response = _client(gateway).get("/events?user_id=victim")
+
+        assert response.status_code == 401, response.text
+
+
+class TestSubjectClaimPrecedenceIsShared:
+    """The identity comes from ``sub``, through ONE helper.
+
+    The gateway's own first attempt read ``payload.get("user_id")`` alone,
+    which is ``None`` for every token this SDK mints. Both callers now share
+    ``kailash.trust.auth.jwt.subject_from_claims``.
+    """
+
+    def test_sub_is_preferred_and_alternatives_are_accepted(self):
+        from kailash.trust.auth.jwt import subject_from_claims
+
+        assert subject_from_claims({"sub": "alice", "user_id": "bob"}) == "alice"
+        assert subject_from_claims({"user_id": "bob"}) == "bob"
+        assert subject_from_claims({"uid": "carol"}) == "carol"
+
+    def test_a_numeric_subject_is_rendered_not_rejected(self):
+        from kailash.trust.auth.jwt import subject_from_claims
+
+        assert subject_from_claims({"sub": 12345}) == "12345"
+
+    def test_structural_and_empty_claims_yield_no_principal(self):
+        from kailash.trust.auth.jwt import subject_from_claims
+
+        assert subject_from_claims({}) is None
+        assert subject_from_claims({"sub": ""}) is None
+        assert subject_from_claims({"sub": {"nested": "object"}}) is None
+        assert subject_from_claims({"sub": ["alice"]}) is None
+        assert (
+            subject_from_claims({"sub": True}) is None
+        ), "`True` is an int subclass but it is not an identity"
+
+    def test_the_gateway_derives_the_subject_the_validator_would(self):
+        """One precedence, two callers -- pinned against drift.
+
+        The gate's normalizer and the gateway's direct-verification path must
+        agree on the same token, which is exactly what a second copy of the
+        precedence would silently stop doing.
+        """
+        from kailash.trust.auth.jwt import JWTConfig as TrustJWTConfig
+        from kailash.trust.auth.jwt import JWTValidator
+
+        gateway = APIGateway(title="test")
+        token = gateway.auth_manager.create_access_token(user_id="alice")
+        claims = gateway.auth_manager.verify_token(token)
+
+        validator = JWTValidator(
+            TrustJWTConfig(
+                secret=GATEWAY_SECRET,
+                algorithm="HS256",
+                issuer="kailash-gateway",
+                audience="kailash-api",
+            )
+        )
+        assert validator.create_user_from_payload(claims).user_id == "alice"
+
+        response = _client(gateway).post(
+            "/api/sessions", json={}, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["user_id"] == "alice"
+
+
+class TestVerifyTokenIsAwaitedOnlyWhenAwaitable:
+    """The sync/async split between the two managers in this SDK.
+
+    ``JWTAuthManager.verify_token`` is sync, ``MiddlewareAuthManager``'s is
+    async. Awaiting unconditionally is what made the DEFAULT manager's every
+    verification raise ``TypeError`` and silently resolve to "no principal".
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_sync_manager_resolves_a_principal(self):
+        gateway = APIGateway(title="test")
+        token = gateway.auth_manager.create_access_token(user_id="alice")
+
+        class _Connection:
+            state = None
+            headers = {"Authorization": f"Bearer {token}"}
+
+        assert await gateway._authenticated_user_id(_Connection()) == "alice"
+
+    @pytest.mark.asyncio
+    async def test_an_async_manager_resolves_a_principal(self):
+        """`MiddlewareAuthManager` is the async shape, and is a real one."""
+        from kailash.middleware.auth.auth_manager import MiddlewareAuthManager
+
+        manager = MiddlewareAuthManager(
+            secret_key=GATEWAY_SECRET, enable_audit=False, database_url=None
+        )
+        gateway = APIGateway(title="test", auth_manager=manager, require_auth=False)
+        token = await manager.create_access_token("alice")
+
+        class _Connection:
+            state = None
+            headers = {"Authorization": f"Bearer {token}"}
+
+        assert await gateway._authenticated_user_id(_Connection()) == "alice"

--- a/tests/regression/test_issue_2104_jwt_log_injection.py
+++ b/tests/regression/test_issue_2104_jwt_log_injection.py
@@ -214,6 +214,68 @@ class TestSiblingSitesInTheSameFile:
             manager.revoke_all_user_tokens(INJECTION)
         _assert_single_clean_line(probe, "kid-a")
 
+    def test_sinks_outside_jwt_auth_are_covered_too(self):
+        """The #2104 sweep was scoped to the CHANGED FILE, not to the taint.
+
+        An adversarial re-review of #2139 found five reachable sinks the
+        original sweep never reached, all OUTSIDE ``jwt_auth.py`` -- and one
+        of them (``agent_ui.py`` "Workflow built") sits ~110 lines BELOW two
+        sinks that sweep DID fix, which is the same-file drift its own
+        rationale warns about. Scope, not quality: the file it did sweep was
+        complete.
+        """
+        import asyncio
+
+        from kailash.middleware.communication.realtime import RealtimeMiddleware
+        from kailash.middleware.core.agent_ui import AgentUIMiddleware
+
+        agent_ui = AgentUIMiddleware(max_sessions=5)
+        realtime = RealtimeMiddleware(agent_ui)
+
+        # `url` is a caller-supplied field on WebhookRegisterRequest.
+        with _StreamProbe(
+            "kailash.middleware.communication.realtime", logging.INFO
+        ) as probe:
+            realtime.register_webhook(webhook_id="w1", url=INJECTION)
+        _assert_single_clean_line(probe, "kid-a")
+
+        # `name` is a caller-supplied field on WorkflowCreateRequest.
+        with _StreamProbe("kailash.middleware.core.agent_ui", logging.INFO) as probe:
+            asyncio.run(
+                agent_ui._build_workflow_from_config(
+                    {
+                        "name": INJECTION,
+                        "nodes": [
+                            {
+                                "id": "n",
+                                "type": "PythonCodeNode",
+                                "config": {"name": "n", "code": "result = {}"},
+                            }
+                        ],
+                        "connections": [],
+                    }
+                )
+            )
+        _assert_single_clean_line(probe, "kid-a")
+
+        # The build-FAILURE sink: the exception text is derived from the
+        # caller's own node graph, on the path a prober drives repeatedly.
+        with _StreamProbe("kailash.middleware.core.agent_ui", logging.ERROR) as probe:
+            with pytest.raises(ValueError):
+                asyncio.run(
+                    agent_ui._build_workflow_from_config(
+                        {
+                            "name": "x",
+                            "nodes": [{"id": INJECTION, "type": INJECTION}],
+                            "connections": [],
+                        }
+                    )
+                )
+        assert probe.lines, "the build failure must still be logged"
+        assert len(probe.lines) == 1, f"expected one line, got {probe.lines!r}"
+        for byte in CONTROL_BYTES:
+            assert byte not in probe.lines[0], f"{byte!r} survived: {probe.lines[0]!r}"
+
     def test_verification_error_text_cannot_forge_records(self):
         """The ``except Exception`` sink at ``verify_token`` renders foreign text.
 

--- a/tests/regression/test_issue_2104_jwt_log_injection.py
+++ b/tests/regression/test_issue_2104_jwt_log_injection.py
@@ -1,0 +1,257 @@
+"""Regression: attacker-supplied JWT header ``kid`` reaching a log line (#2104).
+
+``JWTAuthManager.verify_token`` reads the presented token's header with
+``jwt.get_unverified_header`` -- BEFORE any signature check, because reading it
+is how the verification key gets selected -- and logged the ``kid`` it found by
+interpolation::
+
+    logger.warning(f"Token signed with unknown key ID: {key_id}")
+
+So an unauthenticated caller chose the bytes of a ``WARNING`` record. An
+embedded newline forges a second well-formed record; a NUL and an ANSI escape
+corrupt a console operator's view and downstream SIEM ingestion. It fires on
+the FAILURE path, which is the path a key-ID prober drives repeatedly.
+
+**The instrument is the emitted STREAM, not the LogRecord.** A forged record is
+forged at FORMAT time: ``caplog`` would show one ``LogRecord`` either way, so
+counting records cannot tell a sanitized call from an unsanitized one. These
+tests attach a real ``StreamHandler`` with a real ``Formatter`` and count LINES
+in what the handler wrote, which is what a log collector actually ingests. If
+the value were unsanitized the stream would carry three lines and the control
+bytes -- that is the result that would falsify each assertion below.
+"""
+
+import io
+import logging
+
+import pytest
+
+from kailash.middleware.auth.jwt_auth import JWTAuthManager
+from kailash.middleware.auth.models import JWTConfig
+
+# Imported AFTER the module-level imports on purpose: `jwt_auth` guards its own
+# PyJWT import (`jwt = None` on ImportError), so importing it is safe without
+# the optional dependency, while every test below needs the real library.
+jwt = pytest.importorskip("jwt", reason="PyJWT is required for JWT log-injection tests")
+pytest.importorskip(
+    "cryptography", reason="cryptography is required for the RSA key-id path"
+)
+
+#: One value carrying every structural threat the sanitizer must neutralize:
+#: a CRLF pair (forges a record), a bare LF (forges another), a NUL (truncates
+#: C-string consumers), and an ANSI CSI sequence (rewrites a terminal).
+INJECTION = (
+    "kid-a\r\n2026-01-01 ERROR forged: admin login succeeded\n"
+    "\x00\x1b[31mred\x1b[0m tail"
+)
+
+#: Every byte that must not survive INSIDE an emitted line. ``\n`` is not in
+#: this list because a ``StreamHandler`` appends its own terminator to every
+#: record: a newline the ATTACKER injected shows up as a SECOND line, which is
+#: what the line count below asserts on, while the handler's own trailing
+#: terminator is not a finding.
+CONTROL_BYTES = ("\r", "\x00", "\x1b")
+
+
+class _StreamProbe:
+    """Capture what a real ``Formatter`` writes for one logger."""
+
+    def __init__(self, logger_name: str, level: int = logging.DEBUG):
+        self._logger = logging.getLogger(logger_name)
+        self._buffer = io.StringIO()
+        self._handler = logging.StreamHandler(self._buffer)
+        self._handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        self._handler.setLevel(level)
+        self._level = level
+
+    def __enter__(self) -> "_StreamProbe":
+        self._prior_level = self._logger.level
+        self._prior_propagate = self._logger.propagate
+        self._logger.setLevel(self._level)
+        self._logger.addHandler(self._handler)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._prior_level)
+        self._logger.propagate = self._prior_propagate
+
+    @property
+    def text(self) -> str:
+        self._handler.flush()
+        return self._buffer.getvalue()
+
+    @property
+    def lines(self) -> list[str]:
+        """Non-empty lines the handler emitted, one per un-forged record."""
+        return [line for line in self.text.split("\n") if line]
+
+
+def _assert_single_clean_line(probe: _StreamProbe, expect_substring: str) -> None:
+    """One emitted line, no control bytes, and the value still diagnosable."""
+    assert probe.lines, "no record was emitted at all -- the probe missed the call"
+    assert len(probe.lines) == 1, (
+        "an injected newline forged an extra log line: expected exactly ONE, got "
+        f"{len(probe.lines)}: {probe.lines!r}"
+    )
+    for byte in CONTROL_BYTES:
+        assert (
+            byte not in probe.lines[0]
+        ), f"control byte {byte!r} survived into the record: {probe.lines[0]!r}"
+    assert expect_substring in probe.text, (
+        "the sanitizer redacted the diagnostic instead of neutralizing it: "
+        f"{probe.text!r}"
+    )
+
+
+@pytest.fixture
+def rsa_manager() -> JWTAuthManager:
+    """An RSA manager: the ``kid`` check only runs on the RSA verification path."""
+    return JWTAuthManager(
+        config=JWTConfig(
+            algorithm="RS256",
+            use_rsa=True,
+            auto_generate_keys=True,
+            issuer="test-issuer",
+            audience="test-audience",
+        )
+    )
+
+
+class TestUnknownKeyIdIsSanitized:
+    """The headline site: ``jwt_auth.py`` ``verify_token`` unknown-``kid`` warning."""
+
+    def test_attacker_chosen_kid_yields_one_clean_record(self, rsa_manager):
+        """A forged ``kid`` cannot forge a log record.
+
+        The token is signed with the manager's OWN private key so that
+        ``jwt.decode`` succeeds and the run reaches the revocation check --
+        proving the warning fired on a token that verified, not on a decode
+        error that would have taken a different branch.
+        """
+        token = jwt.encode(
+            {
+                "sub": "alice",
+                "iss": "test-issuer",
+                "aud": "test-audience",
+                "exp": 2**31 - 1,
+            },
+            rsa_manager._private_key,
+            algorithm="RS256",
+            headers={"kid": INJECTION},
+        )
+
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.WARNING) as probe:
+            payload = rsa_manager.verify_token(token)
+
+        assert payload["sub"] == "alice", "the token must still verify"
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_oversized_kid_is_bounded(self, rsa_manager):
+        """A megabyte ``kid`` cannot drive log volume."""
+        token = jwt.encode(
+            {
+                "sub": "alice",
+                "iss": "test-issuer",
+                "aud": "test-audience",
+                "exp": 2**31 - 1,
+            },
+            rsa_manager._private_key,
+            algorithm="RS256",
+            headers={"kid": "A" * 100_000},
+        )
+
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.WARNING) as probe:
+            rsa_manager.verify_token(token)
+
+        assert (
+            len(probe.text) < 1_000
+        ), f"the record grew with the attacker's input: {len(probe.text)} chars"
+
+
+class TestSiblingSitesInTheSameFile:
+    """The five siblings #2104 named. A per-site fix here is the drift #2088 documents."""
+
+    @pytest.fixture
+    def manager(self) -> JWTAuthManager:
+        return JWTAuthManager(secret_key="s" * 48, issuer="iss", audience="aud")
+
+    def test_create_access_token_user_id(self, manager):
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.DEBUG) as probe:
+            manager.create_access_token(user_id=INJECTION)
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_create_refresh_token_user_id(self, manager):
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.DEBUG) as probe:
+            manager.create_refresh_token(user_id=INJECTION)
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_revoke_token_jti(self, manager):
+        """``jti`` is decoded from a token the caller presented."""
+        token = jwt.encode(
+            {
+                "sub": "alice",
+                "iss": "iss",
+                "aud": "aud",
+                "exp": 2**31 - 1,
+                "jti": INJECTION,
+            },
+            "s" * 48,
+            algorithm="HS256",
+        )
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.INFO) as probe:
+            manager.revoke_token(token)
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_revoke_refresh_token_jti(self, manager):
+        manager._refresh_tokens[INJECTION] = {"user_id": "alice"}
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.INFO) as probe:
+            manager.revoke_refresh_token(INJECTION)
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_revoke_all_user_tokens_user_id(self, manager):
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.INFO) as probe:
+            manager.revoke_all_user_tokens(INJECTION)
+        _assert_single_clean_line(probe, "kid-a")
+
+    def test_verification_error_text_cannot_forge_records(self):
+        """The ``except Exception`` sink at ``verify_token`` renders foreign text.
+
+        Measured first, rather than assumed: PyJWT's OWN messages do not echo
+        the presented bytes -- ``DecodeError`` reports ``'Invalid header
+        string: Invalid control character at: line 1 column 25'``, naming a
+        POSITION and not the content. So the taint on this sink does not come
+        from PyJWT; it comes from any OTHER exception that reaches it, and the
+        documented extension point that can raise one is the revocation store
+        (``revocation_store=``, a public constructor argument whose contract
+        invites third-party Redis/database backends).
+
+        The store below is a REAL implementation of the public
+        :class:`TokenRevocationStore` contract, not a mock of the unit under
+        test: it is the collaborator, and a backend that fails with a message
+        it read from a remote system is the ordinary case.
+        """
+        from kailash.middleware.auth.revocation import TokenRevocationStore
+
+        class RaisingStore(TokenRevocationStore):
+            """A backend whose failure text carries bytes it did not author."""
+
+            def revoke(self, *, jti=None, token=None, expires_at=None) -> None:
+                return None
+
+            def is_revoked(self, *, jti=None, token=None) -> bool:
+                raise RuntimeError(f"backend refused: {INJECTION}")
+
+        manager = JWTAuthManager(
+            secret_key="s" * 48,
+            issuer="iss",
+            audience="aud",
+            revocation_store=RaisingStore(),
+        )
+        token = manager.create_access_token(user_id="alice")
+
+        with _StreamProbe("kailash.middleware.auth.jwt_auth", logging.ERROR) as probe:
+            with pytest.raises(Exception):
+                manager.verify_token(token)
+
+        _assert_single_clean_line(probe, "backend refused")


### PR DESCRIPTION
## Summary

Two filed security issues in the middleware auth surface, each with a same-PR sibling sweep — plus a **third, previously-unfiled** defect the sweep turned up (cross-user event-stream subscription on `/ws` and `/events`), which has its own section below.

**#2102 — the gateway took a principal from a request field.** `POST /api/sessions` created the session under the POST body's `user_id` **even when the caller presented a verified bearer token for somebody else.** Measured on the pre-fix source, with a token the gateway itself minted for `alice`:

```
POST /api/sessions {"user_id": "attacker-chosen"}   Authorization: Bearer <alice token>
-> 200 {"session_id": "...", "user_id": "attacker-chosen", "active": true}
```

**#2104 — attacker-supplied JWT header `key_id` reached a log line.** `verify_token` reads the presented token's header with `jwt.get_unverified_header` *before any signature check* — that is how the verification key gets selected — then logged it by interpolation, so an unauthenticated caller chose the bytes of a `WARNING` record on the failure path a key-ID prober drives repeatedly.

## Root causes (quoted)

**#2102 — two defects stacked, and both had to go for either fix to matter.**

1. The dependency ran `await self.auth_manager.verify_token(token)`, but `JWTAuthManager.verify_token` is **sync** (`src/kailash/middleware/auth/jwt_auth.py:520` — `def verify_token`) while `MiddlewareAuthManager.verify_token` is **async** (`src/kailash/middleware/auth/auth_manager.py:244` — `async def verify_token`). With the manager `APIGateway` constructs *by default*, every verification raised `TypeError: object dict can't be used in 'await' expression`, was caught by the handler below it, and resolved to "no principal". Observed directly in the probe output: `Session-route token verification failed: TypeError`.
2. The claim it then read was `payload.get("user_id")`, but every token this SDK mints carries the subject as `sub`. Decoded from a real gateway-issued token: `{'sub': 'alice', 'iss': 'kailash-gateway', 'aud': 'kailash-api', ...}` — no `user_id` key at all. So even with the await corrected, the derived identity would have been empty and the route's own "credential carries no usable subject" guard would have 401'd every legitimate caller.

**#2104** — `src/kailash/middleware/auth/jwt_auth.py:540` (pre-fix): `logger.warning(f"Token signed with unknown key ID: {key_id}")`, where `key_id = unverified_header.get("kid")`.

## The fix

- **One derivation, one policy, three routes.** `APIGateway._authenticated_user_id` is the single place the gateway answers "who is calling"; `_resolve_identity` the single place it decides what to do when the answer is nobody. Both read the principal the installed gate already verified (`scope["state"]["user"]`, set by `JWTAuthMiddleware` / `JWTWebSocketAuthMiddleware`) before falling back to verifying a presented bearer directly — the path that matters where no gate is installed here. `verify_token` is awaited **only if awaitable**.
- **Fail-closed.** A deployment that authenticates its requests never reads an identity from a request field: with no derivable principal, 401 (or WS close 1008 without `accept()`).
- **`subject_from_claims` extracted to `kailash.trust.auth.jwt`** and called by BOTH `JWTValidator.create_user_from_payload` and the gateway, so the claim precedence cannot drift — a second copy is exactly how the `user_id`-only read came to disagree (`security.md` § Credential Decode Helpers).
- **#2104 routed through the existing public sanitizer** `kailash.utils.secure_logging.sanitize_log_value` (added in #2103 for this class), with lazy `%s` arguments so the sanitized value is what the formatter receives. All five siblings the issue named fixed in the same change, plus three exception-text sinks.

## A THIRD defect this PR closes, found by the sweep: cross-user event-stream subscription (#2151)

Neither #2102 nor #2104 names this one. It is now filed as **#2151** so it is greppable after this PR merges, and it is stated separately here because it is a **live confidentiality bug with its own attack, its own consequence, and its own polarity**, not a tidy-up of the session route.

`WS /ws` and `GET /events` took `user_id` from the **query string**. That value is not a display label — it is passed straight into `EventFilter` (`api_gateway.py` -> `realtime.handle_websocket` / `create_sse_stream` -> `EventFilter(session_id=..., user_id=...)`), which is what decides **which users' events the stream receives**:

```
WS /ws?user_id=victim     Authorization: Bearer <alice>   # authenticated AS alice
-> socket registered under "victim" in connection_manager.user_connections
-> alice now receives victim's event stream
```

So any caller who could authenticate at all — including a legitimate low-privilege user on a correctly-gated deployment — could subscribe to **another user's** event stream simply by naming them in the query string. The server-derived principal was available the whole time and ignored: the websocket gate `JWTWebSocketAuthMiddleware` had already verified the handshake and left an `AuthenticatedUser` on `scope["state"]["user"]`.

Measured end-to-end on a real uvicorn socket with a real `websockets` client — `alice`, authenticated as herself, connecting to `/ws?user_id=victim` while the server addresses a message to **victim**:

```
BEFORE  registered under: ['victim']   send_to_user('victim') delivered to 1 connection(s)
        ALICE'S SOCKET RECEIVED: {"type": "private", "body": "victim-only payload"}
AFTER   registered under: ['alice']    send_to_user('victim') delivered to 0 connection(s)
        alice received nothing
```

The `delivered to 1` vs `delivered to 0` line is the discrimination control: it separates "the fix works" from "the probe never delivered anything", which a receive-side assertion alone could not.

Both routes now resolve identity through the same `_resolve_identity` as the session route. The regression test asserts both directions — `"alice" in user_connections` **and** `"victim" not in user_connections` — because asserting only the first would pass on a route that registered under both.

## Sibling sweep (`security.md` § Enforcement-Surface Parity)

Every route on this gateway checked; every other HTTP surface in `src/` checked.

| Site | Verdict |
| --- | --- |
| `POST /api/sessions` (body `user_id`) | **FIXED** — the named site |
| `WS /ws` (query `user_id`) | **FIXED** — the previously-unfiled cross-user subscription bug; see the section above |
| `GET /events` (query `user_id`) | **FIXED** — same filter, same consequence; see the section above |
| `GET/DELETE /api/sessions/{id}`, `GET /api/sessions`, `/api/workflows/*`, `/api/executions/*` | **Left as-is, recorded**: no identity field — they take a server-minted `session_id`. Whether a caller may act on *someone else's* session is horizontal authorization, a different class with a different fix, deliberately not smuggled in here. **Filed as #2145** with the full route table and a measurement showing an authenticated `bob` injecting and executing a workflow inside `alice`'s session |
| `servers/workflow_server.py`, `servers/enterprise_workflow_server.py`, `servers/durable_workflow_server.py`, `api/gateway.py` | **Clean** — no route declares a caller-supplied identity parameter; their `/ws` endpoints take only `websocket: WebSocket` |
| `jwt_auth.py` `:307` RSA-load error, `:321` generated key id, `:725` cleanup count | **Left interpolated, recorded**: operator-supplied key material (flattening a multi-line PEM error would cost the operator the diagnostic), a server-minted uuid4, and an int |

## Testing

`tests/regression/test_issue_2102_gateway_identity_derivation.py` (18) and `tests/regression/test_issue_2104_jwt_log_injection.py` (8), both driven through the HTTP / WebSocket surface rather than by calling the dependency directly — the defect lived in how the route *wired* the dependency, which a direct call cannot see.

RED established by reverting the source to `d248afd78` with the tests in place:

- #2104: **8 failed** pre-fix → **8 passed** post-fix (all eight discriminate).
- #2102: **12 failed, 6 passed** pre-fix → **18 passed** post-fix. The 6 that already passed are non-regression pins, not defect pins: the `enable_auth=False` / `require_auth=False` open-deployment contract (AC#2, "behaves exactly as today") and the no-credential 401s #2072's gate already delivered.

The #2104 tests measure the **emitted stream**, not the `LogRecord`: a forged record is forged at *format* time, so counting records cannot tell a sanitized call from an unsanitized one.

Also repaired: `tests/integration/middleware/test_gateway_integration.py`, whose 8 tests failed **identically at `d248afd78`** (`zero-tolerance.md` Rule 1) — `AgentUIMiddleware.execute_workflow` has been `execute` since v1.0.0, and two `create_gateway(require_auth=False)` calls needed `enable_auth=False` too since #636. Now 8/8 green.

Suites run green: `tests/regression` gateway/auth set + `tests/unit/servers` (215), `tests/regression/test_issue_2072_fail_closed_server_auth.py` (101), `tests/integration/gateway` (157), `tests/unit/middleware` + #2083/#2088 (127), `tests/integration/middleware` non-infra (42).

## Breaking change

`### Changed (BREAKING)` in `CHANGELOG.md` with a migration table. With `enable_auth` at its default the identity is now the credential's; a request carrying none is refused. `enable_auth=False` and `require_auth=False` remain explicit, WARN-announced opt-outs and behave exactly as before — which is why the existing gateway tests, which #2072 already forced onto `enable_auth=False`, needed no changes.

## Related issues

Fixes #2102
Fixes #2104


