### PR TITLE
fix(kaizen): restore base_agent LOC invariant by extraction; make foundry cutover test hermetic

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -41,6 +41,7 @@ from ._provider_env import detect_provider_from_env as _detect_provider
 from .a2a_mixin import A2AMixin
 from .agent_loop import AgentLoop
 from .config import BaseAgentConfig
+from .control_protocol_mixin import ControlProtocolMixin
 from .mcp_mixin import MCPMixin
 from .output_extraction_mixin import OutputExtractionMixin
 
@@ -56,11 +57,14 @@ logger = logging.getLogger(__name__)
 # correctness-relevant predicate drift.
 
 
-class BaseAgent(MCPMixin, A2AMixin, OutputExtractionMixin, Node):
+class BaseAgent(
+    MCPMixin, A2AMixin, OutputExtractionMixin, ControlProtocolMixin, Node
+):
     """Universal base agent class with strategy-based execution and mixin composition.
 
     Inherits MCP integration from MCPMixin, A2A protocol support from A2AMixin,
-    and the typed ``extract_*`` result accessors from OutputExtractionMixin.
+    the typed ``extract_*`` result accessors from OutputExtractionMixin, and the
+    ask/approve/report user-interaction helpers from ControlProtocolMixin.
     Execution is delegated to AgentLoop for both sync and async paths.
     """
 
@@ -731,94 +735,8 @@ class BaseAgent(MCPMixin, A2AMixin, OutputExtractionMixin, Node):
             raise error
 
     # =========================================================================
-    # Control Protocol helpers
-    # =========================================================================
-
-    async def ask_user_question(
-        self,
-        question: str,
-        options: Optional[List[str]] = None,
-        timeout: float = 60.0,
-    ) -> str:
-        """Ask user a question during agent execution via Control Protocol."""
-        if self.control_protocol is None:
-            raise RuntimeError(
-                "Control protocol not configured. "
-                "Pass control_protocol parameter to BaseAgent.__init__()"
-            )
-
-        from kaizen.core.autonomy.control.types import ControlRequest
-
-        data = {"question": question}
-        if options:
-            data["options"] = options
-
-        request = ControlRequest.create("question", data)
-        response = await self.control_protocol.send_request(request, timeout=timeout)
-
-        if response.is_error:
-            raise RuntimeError(f"Question error: {response.error}")
-
-        return response.data.get("answer", "")
-
-    async def request_approval(
-        self,
-        action: str,
-        details: Optional[Dict[str, Any]] = None,
-        timeout: float = 60.0,
-    ) -> bool:
-        """Request user approval for an action via Control Protocol."""
-        if self.control_protocol is None:
-            raise RuntimeError(
-                "Control protocol not configured. "
-                "Pass control_protocol parameter to BaseAgent.__init__()"
-            )
-
-        from kaizen.core.autonomy.control.types import ControlRequest
-
-        data = {"action": action}
-        if details:
-            data["details"] = details
-
-        request = ControlRequest.create("approval", data)
-        response = await self.control_protocol.send_request(request, timeout=timeout)
-
-        if response.is_error:
-            raise RuntimeError(f"Approval error: {response.error}")
-
-        return response.data.get("approved", False)
-
-    async def report_progress(
-        self,
-        message: str,
-        percentage: Optional[float] = None,
-        details: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Report progress update to user via Control Protocol."""
-        if self.control_protocol is None:
-            raise RuntimeError(
-                "Control protocol not configured. "
-                "Pass control_protocol parameter to BaseAgent.__init__() "
-                "to enable report_progress()."
-            )
-
-        from kaizen.core.autonomy.control.types import ControlRequest
-
-        data = {"message": message}
-        if percentage is not None:
-            if not (0.0 <= percentage <= 100.0):
-                raise ValueError(
-                    f"Percentage must be between 0.0 and 100.0, got {percentage}"
-                )
-            data["percentage"] = percentage
-        if details:
-            data["details"] = details
-
-        request = ControlRequest.create("progress_update", data)
-        await self.control_protocol._transport.write(request.to_json())
-
-    # =========================================================================
     # Observability (MCP tool methods inherited from MCPMixin)
+    # Control Protocol helpers are inherited from ControlProtocolMixin.
     # =========================================================================
 
     def enable_observability(

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -57,9 +57,7 @@ logger = logging.getLogger(__name__)
 # correctness-relevant predicate drift.
 
 
-class BaseAgent(
-    MCPMixin, A2AMixin, OutputExtractionMixin, ControlProtocolMixin, Node
-):
+class BaseAgent(MCPMixin, A2AMixin, OutputExtractionMixin, ControlProtocolMixin, Node):
     """Universal base agent class with strategy-based execution and mixin composition.
 
     Inherits MCP integration from MCPMixin, A2A protocol support from A2AMixin,

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -42,6 +42,7 @@ from .a2a_mixin import A2AMixin
 from .agent_loop import AgentLoop
 from .config import BaseAgentConfig
 from .mcp_mixin import MCPMixin
+from .output_extraction_mixin import OutputExtractionMixin
 
 __all__ = ["BaseAgent", "BaseAgentConfig"]
 
@@ -55,10 +56,11 @@ logger = logging.getLogger(__name__)
 # correctness-relevant predicate drift.
 
 
-class BaseAgent(MCPMixin, A2AMixin, Node):
+class BaseAgent(MCPMixin, A2AMixin, OutputExtractionMixin, Node):
     """Universal base agent class with strategy-based execution and mixin composition.
 
-    Inherits MCP integration from MCPMixin and A2A protocol support from A2AMixin.
+    Inherits MCP integration from MCPMixin, A2A protocol support from A2AMixin,
+    and the typed ``extract_*`` result accessors from OutputExtractionMixin.
     Execution is delegated to AgentLoop for both sync and async paths.
     """
 
@@ -516,72 +518,6 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         }
 
         self.shared_memory.write_insight(insight)
-
-    def extract_list(
-        self, result: Dict[str, Any], field_name: str, default: Optional[List] = None
-    ) -> List:
-        """Extract a list field from result with type safety."""
-        if default is None:
-            default = []
-
-        field_value = result.get(field_name, default)
-
-        if isinstance(field_value, list):
-            return field_value
-
-        if isinstance(field_value, str):
-            try:
-                parsed = json.loads(field_value) if field_value else default
-                return parsed if isinstance(parsed, list) else default
-            except Exception:
-                return default
-
-        return default
-
-    def extract_dict(
-        self, result: Dict[str, Any], field_name: str, default: Optional[Dict] = None
-    ) -> Dict:
-        """Extract a dict field from result with type safety."""
-        if default is None:
-            default = {}
-
-        field_value = result.get(field_name, default)
-
-        if isinstance(field_value, dict):
-            return field_value
-
-        if isinstance(field_value, str):
-            try:
-                parsed = json.loads(field_value) if field_value else default
-                return parsed if isinstance(parsed, dict) else default
-            except Exception:
-                return default
-
-        return default
-
-    def extract_float(
-        self, result: Dict[str, Any], field_name: str, default: float = 0.0
-    ) -> float:
-        """Extract a float field from result with type safety."""
-        field_value = result.get(field_name, default)
-
-        if isinstance(field_value, (int, float)):
-            return float(field_value)
-
-        if isinstance(field_value, str):
-            try:
-                return float(field_value)
-            except Exception:
-                return default
-
-        return default
-
-    def extract_str(
-        self, result: Dict[str, Any], field_name: str, default: str = ""
-    ) -> str:
-        """Extract a string field from result with type safety."""
-        field_value = result.get(field_name, default)
-        return str(field_value) if field_value is not None else default
 
     # =========================================================================
     # Workflow generation

--- a/packages/kailash-kaizen/src/kaizen/core/control_protocol_mixin.py
+++ b/packages/kailash-kaizen/src/kaizen/core/control_protocol_mixin.py
@@ -1,0 +1,127 @@
+"""
+Control Protocol helper mixin for BaseAgent.
+
+Extracts the three bidirectional user-interaction helpers from
+``base_agent.py`` -- ``ask_user_question``, ``request_approval`` and
+``report_progress``.
+
+These are the agent's outbound half of the Control Protocol: an executing
+agent pauses to ask the operator a question, to request approval before a
+consequential action, or to stream a progress update. All three share one
+precondition (a configured ``control_protocol``), one request type
+(``ControlRequest``), and one failure mode (an error response is re-raised as
+a ``RuntimeError`` naming the interaction that failed), which is what makes
+them a unit rather than three neighbours.
+
+Extracted from ``base_agent.py`` rather than inlined there: that module carries
+two line-count guards (``tests/regression/test_loc_invariants.py`` and
+``tests/unit/core/test_base_agent_slimming.py``) protecting it against
+re-inlined code, and this cluster depends on exactly one piece of host state.
+
+``ControlRequest`` is imported lazily inside each method, exactly as it was
+inlined, so importing this module never pulls in ``kaizen.core.autonomy`` --
+an agent that never speaks the Control Protocol pays nothing for it.
+
+Uses duck typing -- the host class must provide:
+- self.control_protocol: the Control Protocol transport, or None
+
+Copyright 2026 Terrene Foundation (Singapore CLG)
+Licensed under Apache-2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+__all__ = ["ControlProtocolMixin"]
+
+
+class ControlProtocolMixin:
+    """Mixin providing Control Protocol interaction helpers for BaseAgent.
+
+    Every method requires ``self.control_protocol`` to be configured and
+    raises ``RuntimeError`` naming the missing wiring when it is not.
+    """
+
+    async def ask_user_question(
+        self,
+        question: str,
+        options: Optional[List[str]] = None,
+        timeout: float = 60.0,
+    ) -> str:
+        """Ask user a question during agent execution via Control Protocol."""
+        if self.control_protocol is None:
+            raise RuntimeError(
+                "Control protocol not configured. "
+                "Pass control_protocol parameter to BaseAgent.__init__()"
+            )
+
+        from kaizen.core.autonomy.control.types import ControlRequest
+
+        data = {"question": question}
+        if options:
+            data["options"] = options
+
+        request = ControlRequest.create("question", data)
+        response = await self.control_protocol.send_request(request, timeout=timeout)
+
+        if response.is_error:
+            raise RuntimeError(f"Question error: {response.error}")
+
+        return response.data.get("answer", "")
+
+    async def request_approval(
+        self,
+        action: str,
+        details: Optional[Dict[str, Any]] = None,
+        timeout: float = 60.0,
+    ) -> bool:
+        """Request user approval for an action via Control Protocol."""
+        if self.control_protocol is None:
+            raise RuntimeError(
+                "Control protocol not configured. "
+                "Pass control_protocol parameter to BaseAgent.__init__()"
+            )
+
+        from kaizen.core.autonomy.control.types import ControlRequest
+
+        data = {"action": action}
+        if details:
+            data["details"] = details
+
+        request = ControlRequest.create("approval", data)
+        response = await self.control_protocol.send_request(request, timeout=timeout)
+
+        if response.is_error:
+            raise RuntimeError(f"Approval error: {response.error}")
+
+        return response.data.get("approved", False)
+
+    async def report_progress(
+        self,
+        message: str,
+        percentage: Optional[float] = None,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Report progress update to user via Control Protocol."""
+        if self.control_protocol is None:
+            raise RuntimeError(
+                "Control protocol not configured. "
+                "Pass control_protocol parameter to BaseAgent.__init__() "
+                "to enable report_progress()."
+            )
+
+        from kaizen.core.autonomy.control.types import ControlRequest
+
+        data = {"message": message}
+        if percentage is not None:
+            if not (0.0 <= percentage <= 100.0):
+                raise ValueError(
+                    f"Percentage must be between 0.0 and 100.0, got {percentage}"
+                )
+            data["percentage"] = percentage
+        if details:
+            data["details"] = details
+
+        request = ControlRequest.create("progress_update", data)
+        await self.control_protocol._transport.write(request.to_json())

--- a/packages/kailash-kaizen/src/kaizen/core/output_extraction_mixin.py
+++ b/packages/kailash-kaizen/src/kaizen/core/output_extraction_mixin.py
@@ -1,0 +1,106 @@
+"""
+Typed output-field extraction mixin for BaseAgent.
+
+Extracts the four type-safe result accessors from ``base_agent.py`` --
+``extract_list``, ``extract_dict``, ``extract_float`` and ``extract_str``.
+
+An LLM returns a signature's output fields as whatever the model felt like
+emitting: the declared list may arrive as a JSON string, the declared float as
+``"0.82"``, the declared dict as ``"{}"``. These helpers coerce each field to
+its declared type and fall back to a caller-supplied default rather than
+raising, so a malformed field degrades one value instead of the whole agent
+run.
+
+Extracted from ``base_agent.py`` rather than inlined there: that module carries
+two line-count guards (``tests/regression/test_loc_invariants.py`` and
+``tests/unit/core/test_base_agent_slimming.py``) protecting it against
+re-inlined helper code, and these accessors are generic dict coercion with no
+dependency on ``BaseAgent`` state -- no ``self`` attribute is read by any of
+them.
+
+Uses duck typing -- the host class need provide nothing.
+
+Copyright 2026 Terrene Foundation (Singapore CLG)
+Licensed under Apache-2.0
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+__all__ = ["OutputExtractionMixin"]
+
+
+class OutputExtractionMixin:
+    """Mixin providing type-safe output-field extraction for BaseAgent.
+
+    Every method is a pure function of its arguments; the mixin holds no state
+    and reads none from the host class.
+    """
+
+    def extract_list(
+        self, result: Dict[str, Any], field_name: str, default: Optional[List] = None
+    ) -> List:
+        """Extract a list field from result with type safety."""
+        if default is None:
+            default = []
+
+        field_value = result.get(field_name, default)
+
+        if isinstance(field_value, list):
+            return field_value
+
+        if isinstance(field_value, str):
+            try:
+                parsed = json.loads(field_value) if field_value else default
+                return parsed if isinstance(parsed, list) else default
+            except Exception:
+                return default
+
+        return default
+
+    def extract_dict(
+        self, result: Dict[str, Any], field_name: str, default: Optional[Dict] = None
+    ) -> Dict:
+        """Extract a dict field from result with type safety."""
+        if default is None:
+            default = {}
+
+        field_value = result.get(field_name, default)
+
+        if isinstance(field_value, dict):
+            return field_value
+
+        if isinstance(field_value, str):
+            try:
+                parsed = json.loads(field_value) if field_value else default
+                return parsed if isinstance(parsed, dict) else default
+            except Exception:
+                return default
+
+        return default
+
+    def extract_float(
+        self, result: Dict[str, Any], field_name: str, default: float = 0.0
+    ) -> float:
+        """Extract a float field from result with type safety."""
+        field_value = result.get(field_name, default)
+
+        if isinstance(field_value, (int, float)):
+            return float(field_value)
+
+        if isinstance(field_value, str):
+            try:
+                return float(field_value)
+            except Exception:
+                return default
+
+        return default
+
+    def extract_str(
+        self, result: Dict[str, Any], field_name: str, default: str = ""
+    ) -> str:
+        """Extract a string field from result with type safety."""
+        field_value = result.get(field_name, default)
+        return str(field_value) if field_value is not None else default

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1a_live_cutover.py
@@ -130,11 +130,17 @@ def test_azure_ai_foundry_routes_through_four_axis_path(monkeypatch):
     (wrongly) taken, this would blow up loudly."""
     canned = load_fixture("openai_response")
 
+    # Foundry is the one provider whose endpoint is neither fixed nor derivable
+    # from the model, so BOTH axes must be supplied explicitly to keep this
+    # offline test hermetic. Bound once and reused for the re-resolution below,
+    # so the two call sites cannot drift apart.
+    foundry_base_url = "https://my-foundry-resource.services.ai.azure.com"
+
     deployment = resolve_deployment_for(
         "azure_ai_foundry",
         "gpt-5-nano",
         api_key="k-b1a-foundry-placeholder",
-        base_url="https://my-foundry-resource.services.ai.azure.com",
+        base_url=foundry_base_url,
     )
     assert deployment is not None
     real_client = LlmClient.from_deployment(deployment)
@@ -167,7 +173,16 @@ def test_azure_ai_foundry_routes_through_four_axis_path(monkeypatch):
         messages=_MSGS,
         tools=[],
         generation_config={},
+        # `_provider_llm_response` RE-RESOLVES the deployment internally, so the
+        # up-front `resolve_deployment_for` above does not carry over: both BYOK
+        # overrides must be repeated here. Unlike every other provider, Foundry's
+        # endpoint is caller-supplied, so omitting `base_url` sends the resolver
+        # to `$AZURE_AI_FOUNDRY_ENDPOINT` and this offline test fails on any
+        # machine that has not exported it. Passing it per-request (the four-axis
+        # BYOK surface `_provider_llm_response` already exposes) keeps the test
+        # hermetic — no secret, and never sent, since the transport is stubbed.
         api_key="k-b1a-foundry-placeholder",
+        base_url=foundry_base_url,
     )
 
     assert response["content"] == "The capital of France is Paris."

--- a/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
@@ -44,12 +44,19 @@ class TestBaseAgentLineCount:
         # rules/refactor-invariants.md — a guard that only ever moves in the
         # direction of the code records what happened rather than what was
         # intended.
+        #
+        # The SAME ceiling is enforced from the monorepo root by
+        # tests/regression/test_loc_invariants.py. That test also asserts this
+        # number matches its own, so the two cannot silently drift again the
+        # way they did between 2026-07-24 and 2026-08-11. It reads the literal
+        # out of the `assert len(lines) <= <N>` form below — keep that shape,
+        # or update the pattern there with it.
         path = Path(__file__).parent.parent.parent.parent / (
             "src/kaizen/core/base_agent.py"
         )
         lines = path.read_text().splitlines()
-        assert len(lines) < 1015, (
-            f"base_agent.py has grown to {len(lines)} lines (budget: <1015). "
+        assert len(lines) <= 1015, (
+            f"base_agent.py has grown to {len(lines)} lines (budget: <=1015). "
             f"This likely indicates a merge regression that re-inlined mixin "
             f"code. MCP methods belong in MCPMixin, A2A in A2AMixin, the "
             f"extract_* accessors in OutputExtractionMixin, and the "

--- a/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
@@ -2,7 +2,8 @@
 Tests for SPEC-04: BaseAgent Slimming.
 
 Validates that:
-1. base_agent.py stays under 1,010 LOC (raised from 1,000 for #1779; see test)
+1. base_agent.py stays under 1,015 LOC (re-anchored to the architectural
+   invariant by #2119; see test for the budget history)
 2. Extracted modules exist and are importable
 3. AgentLoop produces identical results to the original inline code
 4. MCPMixin methods are accessible via BaseAgent
@@ -21,31 +22,38 @@ import pytest
 
 
 class TestBaseAgentLineCount:
-    """Enforce that base_agent.py stays under 1,000 lines."""
+    """Enforce that base_agent.py stays under 1,015 lines."""
 
-    def test_base_agent_under_1070_lines(self):
-        # Budget raised 1000 -> 1010 (2026-07-18, #1779: `ungoverned` opt-out
-        # threading) -> 1015 (2026-07-19, #1720 Wave-2b: cleanup() gained a lazy
-        # `sanitize_provider_error` import guarding a pre-existing NameError in
-        # its MCP-cleanup except-handlers — 3 lines of genuine bug-fix code, NOT
-        # re-inlined mixin code) -> 1070 (2026-08-11, #2030/#2022: the three
-        # extension points gained the I/O log-hygiene fix and the
-        # configuration-error re-raise).
+    def test_base_agent_under_1015_lines(self):
+        # Budget history: 1000 -> 1010 (2026-07-18, #1779) -> 1015 (2026-07-19,
+        # #1720 Wave-2b) -> 1070 (2026-08-11, #2030/#2022) -> back to 1015
+        # (2026-08-15, #2119).
         #
-        # The generic helpers from that fix were deliberately EXTRACTED to
-        # `kaizen/core/_log_hygiene.py` rather than inlined here, which is the
-        # behaviour this guard exists to enforce; what remains in base_agent.py
-        # is the extension-point logic itself, which must live where subclasses
-        # override it. The guard's purpose (catching a merge that re-inlines
-        # MCP/A2A mixins, which adds 200+ lines) is preserved at <1070.
+        # The first three raises each had a stated reason, but the cumulative
+        # effect was a guard that could no longer fail before the architectural
+        # invariant in tests/regression/test_loc_invariants.py (limit 1015) did
+        # — so it had stopped guarding anything. #2119 resolved the overshoot
+        # the way the invariant intended, by EXTRACTION rather than by another
+        # raise (extract_* -> OutputExtractionMixin, the Control Protocol trio
+        # -> ControlProtocolMixin), which brought the file to 922 and made this
+        # budget re-anchorable to the invariant it should never have drifted
+        # above.
+        #
+        # This number may be TIGHTENED freely. Raising it needs the same
+        # justification an extraction would have needed, per
+        # rules/refactor-invariants.md — a guard that only ever moves in the
+        # direction of the code records what happened rather than what was
+        # intended.
         path = Path(__file__).parent.parent.parent.parent / (
             "src/kaizen/core/base_agent.py"
         )
         lines = path.read_text().splitlines()
-        assert len(lines) < 1070, (
-            f"base_agent.py has grown to {len(lines)} lines (budget: <1070). "
+        assert len(lines) < 1015, (
+            f"base_agent.py has grown to {len(lines)} lines (budget: <1015). "
             f"This likely indicates a merge regression that re-inlined mixin "
-            f"code. MCP methods belong in MCPMixin, A2A in A2AMixin. "
+            f"code. MCP methods belong in MCPMixin, A2A in A2AMixin, the "
+            f"extract_* accessors in OutputExtractionMixin, and the "
+            f"ask/approve/report helpers in ControlProtocolMixin. "
             f"See journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md"
         )
 
@@ -58,6 +66,15 @@ class TestBaseAgentLineCount:
         # #2030 — the log-hygiene helpers must stay extracted, not drift back
         # into base_agent.py where the line-count guard would mask them.
         assert (base / "_log_hygiene.py").exists(), "_log_hygiene.py not found"
+        # #2119 — same contract for the two units extracted to restore the
+        # 1015 invariant. A merge that re-inlines either one puts ~150 lines
+        # back into base_agent.py.
+        assert (
+            base / "output_extraction_mixin.py"
+        ).exists(), "output_extraction_mixin.py not found"
+        assert (
+            base / "control_protocol_mixin.py"
+        ).exists(), "control_protocol_mixin.py not found"
 
 
 # =========================================================================
@@ -118,11 +135,53 @@ class TestBaseAgentMRO:
 
         assert issubclass(BaseAgent, A2AMixin)
 
+    def test_output_extraction_mixin_in_mro(self):
+        from kaizen.core.base_agent import BaseAgent
+        from kaizen.core.output_extraction_mixin import OutputExtractionMixin
+
+        assert issubclass(BaseAgent, OutputExtractionMixin)
+
+    def test_control_protocol_mixin_in_mro(self):
+        from kaizen.core.base_agent import BaseAgent
+        from kaizen.core.control_protocol_mixin import ControlProtocolMixin
+
+        assert issubclass(BaseAgent, ControlProtocolMixin)
+
     def test_node_in_mro(self):
         from kailash.nodes.base import Node
         from kaizen.core.base_agent import BaseAgent
 
         assert issubclass(BaseAgent, Node)
+
+    def test_extracted_methods_still_resolve_on_baseagent(self):
+        """#2119 — the extractions must be invisible at the public API.
+
+        Existence alone would pass even if a method were left behind as a
+        stub, so this also drives each accessor and asserts the coercion the
+        inline versions performed.
+        """
+        from kaizen.core.base_agent import BaseAgent, BaseAgentConfig
+
+        agent = BaseAgent(config=BaseAgentConfig(), mcp_servers=[])
+
+        for name in (
+            "extract_list",
+            "extract_dict",
+            "extract_float",
+            "extract_str",
+            "ask_user_question",
+            "request_approval",
+            "report_progress",
+        ):
+            assert hasattr(agent, name), f"{name} no longer resolves on BaseAgent"
+
+        # A JSON-string payload must still be coerced to the declared type,
+        # and a malformed one must still fall back to the default.
+        assert agent.extract_list({"a": '["x"]'}, "a") == ["x"]
+        assert agent.extract_dict({"a": '{"k": 1}'}, "a") == {"k": 1}
+        assert agent.extract_float({"a": "0.5"}, "a") == 0.5
+        assert agent.extract_str({"a": None}, "a", "dflt") == "dflt"
+        assert agent.extract_list({"a": "not json"}, "a", default=["d"]) == ["d"]
 
     def test_mcp_methods_accessible(self):
         """All MCPMixin methods must be accessible on BaseAgent instances."""

--- a/tests/regression/test_loc_invariants.py
+++ b/tests/regression/test_loc_invariants.py
@@ -5,9 +5,23 @@ MUST land a numeric invariant test. These tests ensure key files don't
 silently grow back beyond their post-refactor sizes.
 """
 
+import re
 from pathlib import Path
 
 import pytest
+
+#: Canonical ceiling for base_agent.py — 882 post-refactor + 15% margin.
+#: A SECOND guard enforces the same number from inside the kailash-kaizen
+#: package (that package is distributed on its own, so its tests must run
+#: without the monorepo root and cannot import this constant). The two are
+#: kept honest by ``test_base_agent_loc_guards_agree`` below.
+BASE_AGENT_LOC_LIMIT = 1015
+
+#: The sibling guard, and the pattern that reads its limit out of the source.
+BASE_AGENT_SIBLING_GUARD = Path(
+    "packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py"
+)
+_SIBLING_LIMIT_RE = re.compile(r"assert\s+len\(lines\)\s*<=\s*(\d+)")
 
 
 @pytest.mark.regression
@@ -15,11 +29,51 @@ def test_base_agent_loc():
     """Guard: base_agent.py must stay under 1015 LOC after convergence extraction."""
     path = Path("packages/kailash-kaizen/src/kaizen/core/base_agent.py")
     lines = len(path.read_text().splitlines())
-    limit = 1015  # 882 post-refactor + 15% margin
+    limit = BASE_AGENT_LOC_LIMIT
     assert lines <= limit, (
         f"base_agent.py: {lines} lines (limit {limit}). "
         f"Code may have been re-inlined by a merge. "
         f"Check git log for unexpected growth."
+    )
+
+
+@pytest.mark.regression
+def test_base_agent_loc_guards_agree():
+    """Guard: the two base_agent.py ceilings must not drift apart (#2119).
+
+    They already did once. On 2026-07-24 (63388e031) the file reached 1016
+    lines and BOTH guards — each at 1015 — went red by one line. On 2026-08-11
+    (24d06dee9) one of them was raised to 1070, which turned that copy green
+    again and left this one red, where it stayed unnoticed for 18 days. Two
+    ceilings for one file are only safe if widening one cannot pass while the
+    other still fails.
+
+    A shared constant is not available: kailash-kaizen is its own
+    distribution, so its tests must pass without the monorepo root on disk.
+    This runs from the root, where both files are visible, and fails closed if
+    the sibling cannot be read — an unreadable guard is not an agreeing one.
+    """
+    assert BASE_AGENT_SIBLING_GUARD.exists(), (
+        f"Sibling LOC guard not found at {BASE_AGENT_SIBLING_GUARD}. It enforces "
+        f"the same ceiling as this test; if it moved, point this test at its new "
+        f"home rather than deleting the agreement check."
+    )
+
+    match = _SIBLING_LIMIT_RE.search(BASE_AGENT_SIBLING_GUARD.read_text())
+    assert match is not None, (
+        f"Could not read the line-count ceiling out of {BASE_AGENT_SIBLING_GUARD}. "
+        f"Expected an `assert len(lines) <= <N>` form. If that guard was rewritten, "
+        f"update _SIBLING_LIMIT_RE — do not drop this check, which is the only "
+        f"thing keeping the two ceilings in step."
+    )
+
+    sibling_limit = int(match.group(1))
+    assert sibling_limit == BASE_AGENT_LOC_LIMIT, (
+        f"base_agent.py LOC guards disagree: this test allows "
+        f"{BASE_AGENT_LOC_LIMIT}, {BASE_AGENT_SIBLING_GUARD} allows "
+        f"{sibling_limit}. Raising one ceiling without the other is how #2119 "
+        f"stayed red on main for 18 days while a green guard covered for it. "
+        f"Re-anchor BOTH, or extract instead of raising."
     )
 
 


### PR DESCRIPTION
Fixes two tests that were RED on `main`.

## #2119 — root cause: two ceilings for one file, and one of them was widened

The file growing is the symptom. The cause is that `base_agent.py` has **two**
independent LOC ceilings, in different files, and nothing ever compared them:

| when | commit | what happened |
|---|---|---|
| 2026-07-24 | `63388e031` (#1952) | file reaches **1016** lines. Both guards were 1015 → **both go red, by one line** |
| 2026-08-11 | `24d06dee9` (#2030/#2022) | the unit-test guard is raised **1015 → 1070**. File is 1062, so that copy goes green. `tests/regression/test_loc_invariants.py` is **not touched** and stays 1015 — still red |
| → | | one guard green, its twin red on `main`, unnoticed for **18 days** |

So the ceiling was moved, in `24d06dee9`, and the raise silenced only the copy that
session happened to run. Verified: that commit's diff touches
`test_base_agent_slimming.py` and does **not** touch `test_loc_invariants.py`.

Reproduced on `main` (`d248afd78`, 1068 lines), same file, same moment:

```
guard A  tests/regression/test_loc_invariants.py  (limit 1015)
  AssertionError: base_agent.py: 1068 lines (limit 1015). ... assert 1068 <= 1015
  1 failed

guard B  test_base_agent_slimming.py             (limit 1070)
  2 passed
```

**The two guards must be re-anchored together, and now they cannot be re-anchored
apart.** A shared constant is not available — `kailash-kaizen` is its own
distribution (2.46.0) and its tests must pass with no monorepo root on disk, so its
guard cannot import from `tests/`. The root guard *can* see both files, so it now
owns the canonical `BASE_AGENT_LOC_LIMIT` and asserts the sibling's literal matches
it (`test_base_agent_loc_guards_agree`). It fails closed: a missing sibling or an
unreadable ceiling is a failure, not a pass. Both comparisons are now `<=`, since
they had differed by one (`<=1015` vs `<1015`).

Proven non-vacuous by replaying the original divergence — setting the sibling back
to 1070 reds it, naming the disagreeing pair:

```
AssertionError: base_agent.py LOC guards disagree: this test allows 1015,
packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py allows 1070.
Raising one ceiling without the other is how #2119 stayed red on main for 18 days
while a green guard covered for it. Re-anchor BOTH, or extract instead of raising.
```

### The fix: extraction, limit held at 1015

Two cohesive units moved out, each following the `MCPMixin` / `A2AMixin`
composition the class already uses rather than introducing a second idiom:

| unit | new module | why it is a unit |
|---|---|---|
| `extract_list` / `extract_dict` / `extract_float` / `extract_str` | `core/output_extraction_mixin.py` | pure coercion over a result dict; reads no `BaseAgent` state (callable with `self=None`) |
| `ask_user_question` / `request_approval` / `report_progress` | `core/control_protocol_mixin.py` | already fenced under one section banner; share a precondition, a request type and a failure mode |

**1068 → 1004 → 922 → 920** (the last step is black joining the bases onto one line).

The second extraction is deliberate. Stopping at 1004 would have left 11 lines of
headroom on a file that had just overshot by 53 through ordinary feature work, so
the guard would have re-reddened within a change or two and handed the next session
the same temptation. `ControlRequest` stays a lazy in-method import, so an agent
that never speaks the Control Protocol still does not pay to import
`kaizen.core.autonomy`.

## #2067 — `test_azure_ai_foundry_routes_through_four_axis_path`

The issue posed two dispositions. Resolved as **(2), the test was wrong**:
`_provider_llm_response` *does* accept a per-call `base_url` (`llm_agent.py:2406`)
and threads it into the resolver (`:2454`), so the four-axis BYOK surface has no gap.

The test resolved a deployment up front with both overrides but handed the
re-resolving call only `api_key`. Foundry is the one provider whose endpoint is
neither fixed nor derivable from the model, so the missing `base_url` sent the
resolver to `$AZURE_AI_FOUNDRY_ENDPOINT` and the test failed on any machine
without it exported.

No `skipif` and no credential: the placeholder endpoint is never dialled because
`CapturingTransport` serves the canned bytes.

## Verification

**#2119 — RED before, GREEN after (both guards).**

```
BEFORE (main d248afd78, 1068 lines)
  guard A: AssertionError: base_agent.py: 1068 lines (limit 1015)   1 failed
  guard B: 2 passed          <- at 1070; this is the bug, not a pass

BEFORE, with guard B re-anchored to 1015, against main's 1068-line file
  AssertionError: base_agent.py has grown to 1068 lines (budget: <=1015)
  1 failed                   <- the re-anchoring is load-bearing

AFTER (this branch, 920 lines)
  guard A + agreement: 4 passed
  guard B (full file):        23 passed
```

**#2067 — RED before, GREEN after.**

```
BEFORE
  RuntimeError: Provider azure_ai_foundry is not available: Azure AI Foundry
  endpoint or API key unresolved: set $AZURE_AI_FOUNDRY_ENDPOINT and
  $AZURE_AI_FOUNDRY_API_KEY (or pass base_url / api_key per request).
  1 failed, 4 passed

AFTER   5 passed
```

Third acceptance criterion (sweep the siblings) run as `env -i` — a fully scrubbed
environment — so any latent env dependency would fail: all 5 pass.

**The count came from this worktree, not the main checkout or the build artifact.**
`packages/kailash-kaizen/build/lib/` holds an untracked stale copy, so this was
resolved in-process by inode:

```
IMPORTED module __file__ : .../l5-red-tests/packages/kailash-kaizen/src/kaizen/core/base_agent.py
  inode 1405339099   920 lines
worktree src        inode=1405339099  lines=920
build/lib artifact  inode=1407415726  lines=920   <- distinct file
MAIN checkout       inode=1344060588  lines=1068
imported IS worktree src / build artifact / MAIN : True / False / False
```

A count read from the main checkout would have said 1068.

**Public API unchanged.** All seven methods resolve through the MRO from their new
modules (`fn.__module__` printed per method); a repo-wide grep found no module-path
patch target (`kaizen.core.base_agent.<method>`) and no `from kaizen.core.base_agent
import` of any moved symbol — only `BaseAgent` / `BaseAgentConfig`. Neither sibling
mixin is re-exported from `kaizen/core/__init__.py`, so the new ones follow suit.
Behaviour is pinned by 54 existing tests plus a new test that drives each accessor.

**New guards are not vacuous.** Dropping both mixins from `BaseAgent`'s bases reds
exactly the three new tests (`3 failed, 20 passed`) and nothing else; the mutation
was confirmed live in the file before the run.

**Import graph:** 495 `kaizen` + 180 `kaizen_agents` modules imported, 0 failures.

**Full kaizen suite** (`tests/unit` + `tests/regression`): `12766 passed, 156 skipped,
24 xfailed, 3 failed, 6 errors`. It is not fully green, and none of the residue is
attributable to this change:

- 2 performance benchmarks (`test_system_throughput_benchmark`,
  `test_kaizen_import_performance_target`) failed only under 8-way xdist while
  sibling lanes were also running; **both pass serially**.
- `test_pre_fix_wrapper_shape_is_rejected_by_real_registration` fails identically at
  `d248afd78` with these changes absent, so it is genuinely pre-existing. It is the
  environment-dependent condition its own docstring anticipates — standalone
  `fastmcp` 2.12.4 importable from site-packages, which rejects `**kwargs` tools —
  and is already tracked as #2086.
- 6 errors are a `ScopeMismatch` between the `pytest_base_url` plugin and tests
  parametrised on `base_url`, in files this PR does not touch.

## Related issues

Fixes #2119
Fixes #2067