### PR TITLE
fix(ci): kaizen regression suite + zero-match selectors + nightly main run (#2074, #2076, #2133)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint config — declares custom self-hosted runner labels so
+# `runs-on: [self-hosted, cuda, gpu]` (test-kailash-ml.yml test-cuda /
+# test-cuda-dl, gpu-smoke.yml) does not fire actionlint's runner-label
+# false positive. See docs/ci/self-hosted-runner.md for the runner
+# registration command that assigns exactly these labels.
+self-hosted-runner:
+  labels:
+    - cuda
+    - gpu

--- a/.github/workflows/example-validation.yml
+++ b/.github/workflows/example-validation.yml
@@ -105,6 +105,17 @@ jobs:
 
       - name: Run example validation tests
         working-directory: packages/kaizen-agents
+        # #2038-class masking removed: continue-on-error swallowed this
+        # step's result unconditionally. Verified before removing it —
+        # tests/examples/ exists (packages/kaizen-agents/tests/examples/
+        # test_example_validation.py, 23 tests, structural/README/syntax
+        # checks only, no infra) and runs clean on the exact CI matrix
+        # (Python 3.11): 23 passed in 0.06s. The `if [ -d ... ]` branch
+        # below is dead in this repo's current state (the directory has
+        # existed since before this fix) but is left in place — its own
+        # else-branch warning, not a mask, is an honest "nothing to test
+        # yet" for a hypothetical future state where the directory is
+        # removed again, not a hidden failure.
         run: |
           # Run validation tests if they exist
           if [ -d "tests/examples" ]; then
@@ -113,7 +124,6 @@ jobs:
             echo "⚠️  Warning: tests/examples/ directory not found - skipping validation tests"
             echo "ℹ️  Note: Example validation tests will be created in Phase 10"
           fi
-        continue-on-error: true
 
       - name: Validate example gallery documentation
         working-directory: packages/kaizen-agents

--- a/.github/workflows/example-validation.yml
+++ b/.github/workflows/example-validation.yml
@@ -14,6 +14,9 @@ on:
       - "packages/kailash-kaizen/tests/examples/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test-kailash-align.yml
+++ b/.github/workflows/test-kailash-align.yml
@@ -12,12 +12,6 @@ on:
       - "packages/kailash-align/**"
       - ".github/workflows/test-kailash-align.yml"
   workflow_dispatch:
-    inputs:
-      run-gpu:
-        description: "Include GPU tests (requires GPU runner)"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -149,55 +143,26 @@ jobs:
             --cov-fail-under=50 \
             -q --timeout=30
 
-  test-gpu:
-    name: GPU Tests (optional)
-    needs: version-check
-    # workflow_dispatch + run-gpu opt-in only; release/v* exclusion is
-    # implicit (release branches don't carry workflow_dispatch inputs)
-    # but kept explicit per ci-runners.md MUST Rule 8.
-    if: >-
-      github.event_name == 'workflow_dispatch' && inputs.run-gpu == true && !startsWith(github.head_ref, 'release/')
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install kailash-align[dev,rlhf]
-        run: |
-          uv venv .venv
-          uv pip install -e "." --python .venv/bin/python
-          # See unit-test install step — kailash_ml.rl.align_adapter is
-          # unreleased; install editable from the source tree.
-          #
-          # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
-          # Selection: packages/kailash-align/tests/ -m 'gpu'
-          #   kailash_ml    -> 95 modules  EXERCISED -> installed editable below
-          #   dataflow      -> 0  modules  NOT exercised -> not installed
-          #   kailash_align -> 23          (package under test, editable)
-          #   kailash       -> 213         editable, this tree
-          # CAVEAT recorded at the same time: `-m 'gpu'` currently selects ZERO
-          # tests (485 deselected) because no test in packages/kailash-align/
-          # carries a `gpu` marker, so pytest exits 5 (no tests collected) and
-          # this job FAILS whenever it is dispatched. Tracked in #2076. The
-          # sibling determination above is independent of it.
-          uv pip install -e "packages/kailash-ml" --python .venv/bin/python
-          uv pip install -e "packages/kailash-align[dev,rlhf]" --python .venv/bin/python
-
-      - name: Test GPU
-        timeout-minutes: 25
-        run: |
-          .venv/bin/python -m pytest \
-            packages/kailash-align/tests/ \
-            -m 'gpu' \
-            --maxfail=5 -q --timeout=300
+  # ISSUE #2076 — the `test-gpu` job lived HERE and is REMOVED, tracked by
+  # #2135. `-m 'gpu'` selected ZERO tests (485 collected, 485 deselected,
+  # pytest exit 5) because no test in packages/kailash-align/ ever carried
+  # the `gpu` marker — it is registered in pyproject.toml's
+  # [tool.pytest.ini_options] markers ("gpu: Tests requiring GPU (slow,
+  # skipped by default)") but was declared aspirationally and never applied.
+  # `grep -rn "cuda.is_available\|skipif.*cuda\|skipif.*gpu" packages/
+  # kailash-align/tests/` returns nothing; every torch-touching test in the
+  # package is explicitly documented CPU-only (tests/test_pipeline.py:3
+  # "unit tests -- no GPU, no model loading"). A job whose selector can
+  # only ever match nothing is a stub gate — removed rather than shipped
+  # degraded, same disposition as `test-root-regression` in
+  # unified-ci.yml (#2081/#2002). Restore it, along with the `run-gpu`
+  # workflow_dispatch input, once #2135 lands real GPU-hardware tests
+  # (LoRA/DPO training step, bf16 mixed precision, device placement) —
+  # follow kailash-ml's `test-cuda` pattern (`@pytest.mark.skipif(not
+  # torch.cuda.is_available(), ...)` alongside the already-registered
+  # `@pytest.mark.gpu`) in `.github/workflows/test-kailash-ml.yml`. Do not
+  # re-derive; restore the removed job body from this file's git history
+  # (the PR that closed #2076) once tests exist to select.
 
   inter-package:
     name: Inter-Package (align + dev ML)

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -4,7 +4,8 @@ name: Test kailash-kaizen
 # runs only core + mcp + pact + dataflow), so kaizen tests — including the
 # cross_sdk_parity gate — were never exercised on PRs. This job closes that gap.
 #
-# SCOPE: two infra-free pytest invocations, run sequentially in the same step.
+# SCOPE: three infra-free pytest invocations, run sequentially as separate
+# steps.
 #
 #   1. LLM deployment layer (tests/unit/llm) + cross-SDK parity
 #      (tests/cross_sdk_parity) — the ORIGINAL scope (where the #1721 parity
@@ -19,6 +20,20 @@ name: Test kailash-kaizen
 #      docker/ollama, tier3, performance, etc. on top of the original set) is
 #      applied ONLY to this invocation — it is NOT applied to invocation 1 so
 #      as to never narrow the original gate's selection.
+#   3. `tests/regression/` (issue #2074) — SAME bug class as #2038's
+#      continue-on-error masking, one layer over: this directory appeared in
+#      NO invocation above, so every regression test written for kaizen
+#      since the package existed had never been collected in CI. Issue
+#      #2074 cited a naive `grep -c "^def test_"` estimate of 107 files /
+#      855 tests; the real pytest count, measured, is 109 files / 1654 tests
+#      collected (the grep pattern undercounts parametrized cases and
+#      nested-class methods — do not re-cite the issue's estimate).
+#      Uses the SAME broad exclusion set as invocation 2 (regression/ mixes
+#      infra-free and infra-requiring tests, same shape as tests/unit/<tier>).
+#      Baseline established BEFORE gating, per the issue's own instruction
+#      not to assume it would be clean: -m filter selects 1321/1654; actual
+#      run: 1288 passed, 342 deselected, 24 xfailed, 0 failed — genuinely
+#      clean, no fixes were required to land this step blocking.
 #
 #      Two subdirectories are deliberately EXCLUDED by directory (a third —
 #      tests/unit/strategies/ — was RESOLVED and is no longer excluded; see
@@ -214,13 +229,14 @@ jobs:
           fi
 
   test-kaizen:
-    name: Test kailash-kaizen (LLM + cross-SDK parity + expanded FAST unit tiers)
+    name: Test kailash-kaizen (LLM + cross-SDK parity + expanded FAST unit tiers + regression)
     # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 — their
     # diff is metadata-only; version-check above still runs on the release cut.
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: version-check
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 20 -> 30: the third (regression) step's own budget adds 10 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -336,4 +352,21 @@ jobs:
             -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark or requires_postgres or requires_redis or requires_ollama or requires_db or requires_llm or llm_execution or real_llm or ollama_validation or cost or landing_ai or stress or endurance or requires_infrastructure or requires_kafka or requires_mongodb or memory_intensive or requires_isolation or data_intensive or flaky or slow or load or migration or openai or anthropic or google or docker or ollama or integration_llm or tier3 or performance)' \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_basic \
             --deselect tests/unit/memory/test_semantic_memory.py::TestSemanticMemorySimilaritySearch::test_find_similar_limit \
+            --timeout=30 --maxfail=50 -q
+
+      - name: Test (regression suite, infra-free)
+        # Issue #2074: tests/regression/ (109 files / 1654 tests collected,
+        # measured — see header comment) appeared in NEITHER invocation
+        # above and had therefore never run in CI. Same broad exclusion set
+        # as the expanded-tiers step above — this directory mixes infra-free
+        # gates with integration/e2e/provider-credentialed tests, same shape
+        # as tests/unit/<tier>. Baseline established before wiring this in
+        # (per the issue's own instruction not to assume clean): 1288
+        # passed, 342 deselected, 24 xfailed, 0 failed.
+        timeout-minutes: 10
+        working-directory: packages/kailash-kaizen
+        run: |
+          ../../.venv/bin/python -m pytest \
+            tests/regression/ \
+            -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark or requires_postgres or requires_redis or requires_ollama or requires_db or requires_llm or llm_execution or real_llm or ollama_validation or cost or landing_ai or stress or endurance or requires_infrastructure or requires_kafka or requires_mongodb or memory_intensive or requires_isolation or data_intensive or flaky or slow or load or migration or openai or anthropic or google or docker or ollama or integration_llm or tier3 or performance)' \
             --timeout=30 --maxfail=50 -q

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -461,8 +461,10 @@ jobs:
         # as the expanded-tiers step above — this directory mixes infra-free
         # gates with integration/e2e/provider-credentialed tests, same shape
         # as tests/unit/<tier>. Baseline established before wiring this in
-        # (per the issue's own instruction not to assume clean): 1288
-        # passed, 342 deselected, 24 xfailed, 0 failed.
+        # (per the issue's own instruction not to assume clean; see header
+        # comment for the determinism-fix history behind this number —
+        # earlier measurements here are stale, do not re-cite): 1221
+        # passed, 425 deselected, 8 xfailed, 0 failed.
         timeout-minutes: 10
         working-directory: packages/kailash-kaizen
         run: |

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -56,6 +56,38 @@ name: Test kailash-kaizen
 #      (deterministic, matches the hook's own docstring intent "based on
 #      their location and name"); three consecutive runs now agree exactly.
 #
+#      RETROACTIVE IMPLICATION: this hook has governed marker assignment for
+#      as long as it has existed, on every kaizen CI job that filters on
+#      these markers — including the pre-existing "expanded FAST unit
+#      tiers" step, not just this new one. For that entire history, each
+#      run excluded a DIFFERENT random ~3% slice of the suite. That does
+#      not mean any historical "kaizen CI is green" claim from those jobs
+#      was WRONG — but it was never REPRODUCIBLE evidence either, because
+#      the set of tests that actually ran was never the set anyone reading
+#      the green checkmark believed ran. This fix is what makes a green
+#      from these jobs, from this point forward, mean something stable.
+#
+#      SECOND-ORDER EFFECT (this is a real behavior change, not just noise
+#      removal — do not let "the number changed because I fixed a bug"
+#      hide a second cause): `str(item.function)` never contained
+#      parametrize-case text, only the base function's own name; `item.name`
+#      DOES (`test_foo[postgres-case]`). So the fix can now match a keyword
+#      that appears ONLY in a parametrize id, which was structurally
+#      impossible before. Measured directly (a standalone analysis plugin
+#      comparing item.name against the pre-parametrize base name for every
+#      collected tests/regression/ item): of 1654 total, 264 match via the
+#      BASE function name (a match the old code could equally have produced,
+#      independent of any address), and 157 match ONLY via the parametrize-id
+#      suffix — cases the old address-based code could never have tagged
+#      by construction, regardless of which run you looked at. The pre-fix
+#      "342" figure this PR originally cited is not a valid baseline to diff
+#      against — it was itself unstable (351/353/330 across three identical
+#      runs, see above) — so an exact "342 -> 425" delta split is not
+#      well-defined. What IS well-defined: at least 157 of the 425 deselected
+#      tests/regression/ items are deselected for a reason (their
+#      parametrize case, not their base name) that the old code was
+#      structurally incapable of ever detecting.
+#
 #      RESIDUE (issue #2152): the exclusion set above is a real disposition,
 #      not an oversight — several markers in it (openai/anthropic/google,
 #      cost, requires_docker/postgres/redis) need paid API calls or real

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -33,9 +33,75 @@ name: Test kailash-kaizen
 #      Uses the SAME broad exclusion set as invocation 2 (regression/ mixes
 #      infra-free and infra-requiring tests, same shape as tests/unit/<tier>).
 #      Baseline established BEFORE gating, per the issue's own instruction
-#      not to assume it would be clean: -m filter selects 1321/1654; actual
-#      run: 1288 passed, 342 deselected, 24 xfailed, 0 failed — genuinely
-#      clean, no fixes were required to land this step blocking.
+#      not to assume it would be clean: -m filter selects 1229/1654; actual
+#      run: 1221 passed, 425 deselected, 8 xfailed, 0 failed (1221+425+8=1654,
+#      reconciles). Confirmed reproducible across repeat runs — see the
+#      pytest_collection_modifyitems fix below; do not re-cite any other
+#      number pair, several were measured before that fix and none of them
+#      reconcile with each other or with this one.
+#
+#      MARKER-ASSIGNMENT DETERMINISM FIX (found while establishing the
+#      baseline above): `tests/conftest.py::pytest_collection_modifyitems`
+#      governs marker auto-tagging for the ENTIRE kaizen tests/ tree — every
+#      invocation in this file, not just this one. It used to keyword-match
+#      infra markers against `str(item.function)`, which for a plain
+#      function is CPython's default repr INCLUDING the function object's
+#      ASLR-randomized memory address (`<function test_x at 0x7f8a2c1b3af0>`).
+#      "db" is the only keyword in that list made entirely of valid hex
+#      characters, so ~3% of ALL collected items got a spurious
+#      `requires_postgres` marker on any given process run purely by address
+#      coincidence — three consecutive identical `--collect-only` runs
+#      against invocation 3 measured 351/353/330 deselected out of the same
+#      1654 collected before the fix. Changed to `item.name.lower()`
+#      (deterministic, matches the hook's own docstring intent "based on
+#      their location and name"); three consecutive runs now agree exactly.
+#
+#      RESIDUE (issue #2152): the exclusion set above is a real disposition,
+#      not an oversight — several markers in it (openai/anthropic/google,
+#      cost, requires_docker/postgres/redis) need paid API calls or real
+#      infrastructure this infra-free step correctly does not fake. But the
+#      425 tests/regression/ tests it deselects currently run in NO
+#      workflow (same is true of invocation 2's 1067 deselected — no other
+#      job in this repo runs tests/unit/<tier>/ with a narrower filter
+#      either). Per-marker breakdown for tests/regression/ (a test may carry
+#      more than one, so these do not sum to 425): requires_ollama 342,
+#      requires_postgres 41, requires_redis 32, requires_docker 12,
+#      integration 2, performance 3, all others (e2e/requires_azure/
+#      requires_google/benchmark/requires_llm/llm_execution/real_llm/cost/
+#      stress/endurance/memory_intensive/flaky/slow/load/migration/openai/
+#      anthropic/google/tier3/requires_db) 0. The requires_ollama count is
+#      dominated by a SEPARATE, pre-existing false-positive-keyword defect
+#      in the same hook (also #2152) — `item.name.lower()` still substring-
+#      matches "ai" against ordinary English words with no infra relevance
+#      (e.g. "raises", "failure", "chained", "contains" all contain "ai"):
+#      only ~125 of the 342 requires_ollama-tagged regression tests actually
+#      mention "ollama"/"llm" in their name. NOT fixed here — auditing which
+#      of ~425 (invocation 3) / ~1067 (invocation 2) deselections are
+#      false-positive keyword matches vs. genuine infra requirements is
+#      separate, larger work; #2152 tracks it. The exclusion set also
+#      includes `flaky` and `slow` — a test marked flaky that never runs is
+#      exactly how a real failure hides behind a marker (precedent: root SDK
+#      tests/tier2_integration/api/test_workflow_api_async_runtime.py::
+#      test_async_execution_no_threading carries `xfail(reason="Flaky: async
+#      event loop pollution", strict=False)` but was found, per the
+#      sweep-cont17 management report § D3, to have actually been catching
+#      ServerAuthNotConfiguredError — a different package's tests/, same
+#      failure shape as this residue).
+#
+#      ONE test is individually quarantined (issue #2149, found while
+#      re-verifying invocation 2 after the determinism fix above changed
+#      which tests it includes): tests/unit/providers/test_ollama_
+#      availability.py::TestOllamaSpecificModels::test_vision_models_not_found
+#      depends on a SIBLING test in the same file leaving kaizen.providers
+#      reloaded with OLLAMA_AVAILABLE=True via an incomplete
+#      patch.dict+importlib.reload cleanup — it fails deterministically when
+#      run standalone or as part of the full expanded-tiers selection, and
+#      only passes when that sibling happens to run first. Pre-existing,
+#      unrelated to markers (its own name matches no exclusion keyword);
+#      the determinism fix above made it visible by stabilizing which OTHER
+#      tests run around it. See the `pytest.mark.skip` at the test itself
+#      for the full reasoning — it is a skip, not an xfail, because it is
+#      order-dependent, not intermittent.
 #
 #      Two subdirectories are deliberately EXCLUDED by directory (a third —
 #      tests/unit/strategies/ — was RESOLVED and is no longer excluded; see

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -25,9 +25,11 @@ name: Test kailash-kaizen
 #      NO invocation above, so every regression test written for kaizen
 #      since the package existed had never been collected in CI. Issue
 #      #2074 cited a naive `grep -c "^def test_"` estimate of 107 files /
-#      855 tests; the real pytest count, measured, is 109 files / 1654 tests
-#      collected (the grep pattern undercounts parametrized cases and
-#      nested-class methods — do not re-cite the issue's estimate).
+#      855 tests; the real pytest count, measured, is 1654 tests collected
+#      from 109 *.py files (107 test_*.py + __init__.py + one non-test
+#      helper module, _issue_2014_isolation_hooks.py — the grep pattern
+#      undercounts parametrized cases and nested-class methods regardless;
+#      do not re-cite the issue's 855 estimate).
 #      Uses the SAME broad exclusion set as invocation 2 (regression/ mixes
 #      infra-free and infra-requiring tests, same shape as tests/unit/<tier>).
 #      Baseline established BEFORE gating, per the issue's own instruction
@@ -355,8 +357,8 @@ jobs:
             --timeout=30 --maxfail=50 -q
 
       - name: Test (regression suite, infra-free)
-        # Issue #2074: tests/regression/ (109 files / 1654 tests collected,
-        # measured — see header comment) appeared in NEITHER invocation
+        # Issue #2074: tests/regression/ (1654 tests collected, measured —
+        # see header comment) appeared in NEITHER invocation
         # above and had therefore never run in CI. Same broad exclusion set
         # as the expanded-tiers step above — this directory mixes infra-free
         # gates with integration/e2e/provider-credentialed tests, same shape

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -6,6 +6,24 @@ name: Test kailash-ml
 # the `continue-on-error: true  # IT-1: non-blocking until runner live`
 # line from each CUDA job.  Grep pattern for the flip:
 #   grep -n 'continue-on-error: true.*IT-1' .github/workflows/test-kailash-ml.yml
+#
+# MEASURED (2026-08-15, issue #2155): "non-blocking until runner live"
+# currently describes a runner that has never been live. Two independent
+# instruments agree:
+#   $ gh api repos/terrene-foundation/kailash-py/actions/runners --jq '.total_count'
+#   0
+#   $ gh api orgs/terrene-foundation/actions/runners --jq '.total_count'
+#   0
+#   $ gh run list --workflow gpu-smoke.yml --limit 5 --json status,conclusion,createdAt
+#   [cancelled 2026-06-17, cancelled 2026-06-13 x2, cancelled 2026-06-12,
+#    cancelled 2026-06-07]  <- every run queues until cancelled, none dispatch
+# So `test-cuda` / `test-cuda-dl` below cannot execute at all right now (they
+# don't fail into continue-on-error, GitHub Actions never assigns them a
+# runner in the first place). Their `-m cuda` / `-m dl` selector fixes
+# (issue #2076) are correct but currently unexercised. #2155 tracks the
+# decision: provision the runner, or retire these two jobs the way #2135
+# retired kailash-align's test-gpu (which had the same "selector matches
+# nothing" defect AND, unlike these two, no runner story to begin with).
 
 on:
   push:
@@ -347,7 +365,14 @@ jobs:
   # CUDA jobs — runs on [self-hosted, cuda, gpu] runner (IT-1)
   #
   # These jobs are currently NON-BLOCKING (continue-on-error: true) because
-  # the self-hosted GPU runner has not been provisioned yet.
+  # the self-hosted GPU runner has not been provisioned yet — and, MEASURED
+  # 2026-08-15 (issue #2155), currently cannot even be DISPATCHED: 0
+  # self-hosted runners registered at the repo or org level, and every one
+  # of gpu-smoke.yml's last 5 runs (back to 2026-06-07) queued until
+  # cancelled rather than running. continue-on-error never gets exercised
+  # because the job never gets a runner in the first place. See the top-of-
+  # file header comment for the full measurement and #2155 for the
+  # provision-vs-retire decision this is filed under.
   #
   # To flip CUDA from non-blocking to blocking once the runner is live:
   #   1. Run gpu-smoke.yml manually and confirm it passes green.
@@ -533,15 +558,23 @@ jobs:
         # gate defect, one layer deeper than the missing-marker case.
         #
         # Disposition: CHANGE the selector rather than delete the job. This
-        # job's stated purpose is "torch training on GPU" — that is
+        # job's stated purpose is "torch training on GPU" — that WOULD be
         # meaningfully served by running the full `dl` suite (same 79 tests
         # as test-dl) on a runner where `torch.cuda.is_available()` is
-        # actually True, which is DIFFERENT information than test-dl's
-        # CPU-only run: any DL code path that auto-detects/branches on real
-        # GPU presence (backend resolution, device placement) is only
-        # exercised here. Verified: `-m dl` collects 79/2606 (was 0/2606).
-        # Masked today by `continue-on-error: true` (IT-1, runner not yet
-        # provisioned).
+        # actually True (DIFFERENT information than test-dl's CPU-only run:
+        # any DL code path that auto-detects/branches on real GPU presence
+        # would only be exercised here). Verified: `-m dl` collects 79/2606
+        # (was 0/2606) — the selector itself is correct and is a prerequisite
+        # either way.
+        #
+        # BUT (measured 2026-08-15, issue #2155): this job currently yields
+        # ZERO information regardless of the selector fix, because it cannot
+        # be DISPATCHED at all — 0 self-hosted runners exist (repo + org),
+        # and gpu-smoke.yml's last 5 runs all queued until cancelled, never
+        # ran. `continue-on-error: true` never even gets exercised; the job
+        # just never gets assigned a runner. See the top-of-file header and
+        # #2155 for the full measurement and the provision-vs-retire
+        # decision this is filed under.
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -235,7 +235,12 @@ jobs:
         run: |
           uv venv .venv
           # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
-          # Selection: packages/kailash-ml/tests/ -m 'dl or deep_learning'
+          # Selection: packages/kailash-ml/tests/ -m 'dl'  (updated by #2076;
+          # was 'dl or deep_learning', which selected zero tests — see the
+          # Test DL step below. The module-import-count measurement below is
+          # UNCHANGED by that rename: naming the whole tests/ dir imports
+          # every module at collection time regardless of the -m expression's
+          # text, so the sibling counts still hold.)
           #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
           #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
           #   kailash_ml    -> 139          (package under test, editable)
@@ -399,7 +404,11 @@ jobs:
           uv venv .venv
           # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
           # Selection: packages/kailash-ml/tests/unit/ + tests/integration/
-          #            -m 'cuda or gpu'
+          #            -m 'cuda'  (updated by #2076; was 'cuda or gpu', which
+          #            selected zero tests — see the Test step below. The
+          #            module-import-count measurement is UNCHANGED: naming
+          #            the same two directories imports the same modules at
+          #            collection time regardless of the -m expression.)
           #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
           #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
           #   kailash_ml    -> 139          (package under test, editable)
@@ -497,8 +506,11 @@ jobs:
         run: |
           uv venv .venv
           # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
-          # Selection: packages/kailash-ml/tests/
-          #            -m '(dl or deep_learning) and (cuda or gpu)'
+          # Selection: packages/kailash-ml/tests/ -m 'dl'  (updated by #2076;
+          # was '(dl or deep_learning) and (cuda or gpu)', which selected
+          # zero tests — see the Test step below. The module-import-count
+          # measurement is UNCHANGED: naming the whole tests/ dir imports the
+          # same modules at collection time regardless of the -m expression.)
           #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
           #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
           #   kailash_ml    -> 139          (package under test, editable)

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -252,17 +252,25 @@ jobs:
 
       - name: Test DL
         timeout-minutes: 15
-        # CAVEAT (measured 2026-08-11): `-m 'dl or deep_learning'` currently
-        # selects ZERO tests — 2602 collected, 2602 deselected — because no
-        # test under packages/kailash-ml/ carries a `dl` or `deep_learning`
-        # marker, and neither name is registered in that package's
-        # [tool.pytest.ini_options] markers list. pytest then exits 5 (no tests
-        # collected), so this workflow_dispatch-only job FAILS whenever it is
-        # dispatched. Tracked in #2076.
+        # Issue #2076 FIX: `-m 'dl or deep_learning'` selected ZERO tests
+        # (2602 collected, 2602 deselected, pytest exit 5) because neither
+        # marker existed anywhere in the package or its
+        # [tool.pytest.ini_options] markers list — this dispatch-only job
+        # failed on every dispatch. Disposition: MARK the tests (not
+        # path-based — DL-relevant files are scattered across tests/unit/,
+        # tests/integration/, tests/integration/autolog/, and
+        # tests/regression/, not grouped under one directory). `dl` is now
+        # registered in packages/kailash-ml/pyproject.toml and applied to
+        # every torch/lightning/transformers test module (11 files).
+        # Verified: `-m dl` over packages/kailash-ml/tests/ collects
+        # 79/2606 (was 0/2602); `accelerate>=1.1.0` was ALSO added to the
+        # [dl] extra — wiring this selector in for the first time surfaced
+        # a real ImportError in transformers.Trainer's PyTorch backend,
+        # which requires accelerate but had it undeclared.
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \
-            -m 'dl or deep_learning' \
+            -m 'dl' \
             --maxfail=5 -q --timeout=120
 
   test-rl:
@@ -291,32 +299,43 @@ jobs:
         run: |
           uv venv .venv
           # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
-          # Selection: packages/kailash-ml/tests/ -m 'rl or reinforcement_learning'
-          #   dataflow      -> 112 modules  EXERCISED at COLLECTION time
-          #   kailash_align -> 13  modules  EXERCISED at COLLECTION time
-          #                    (tests/integration/rl/test_rl_align_cross_sdk_wiring.py
-          #                     imports kailash_align at module scope — this is
-          #                     the RL job, so that import is squarely on-path)
-          #   kailash_ml    -> 139          (package under test, editable)
-          #   kailash       -> 251          editable, this tree
-          # Both installed editable below: naming the whole tests/ dir imports
-          # every module before -m deselects, so a PyPI-resolved sibling breaks
-          # collection.
+          # Selection (updated by issue #2076 — was a whole-tests/-tree
+          # marker selection matching zero tests; now path-based, scoped to
+          # the two directories that actually hold the RL suite):
+          #   packages/kailash-ml/tests/unit/rl/ packages/kailash-ml/tests/integration/rl/
+          #   -m 'not (slow or gpu or bench)'  (31 tests collected)
+          #   dataflow      -> 0  modules  NOT exercised (no rl/ file imports it,
+          #                    even at whole-tree collection — this narrowed
+          #                    selection makes that legible; NOT installed)
+          #   kailash_align -> EXERCISED, but only via `importlib` INSIDE test
+          #                    bodies (test_rl_align_cross_sdk_wiring.py), not
+          #                    at module-scope import time — installing it
+          #                    editable still changes real pass/skip outcomes
+          #                    (measured: 29 passed/2 skipped absent vs.
+          #                    30 passed/1 skipped installed), so it stays.
+          #   kailash_ml    -> package under test, editable
+          #   kailash       -> editable, this tree
           uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[rl,dev]" --python .venv/bin/python
-          uv pip install -e "packages/kailash-dataflow" --python .venv/bin/python
           uv pip install -e "packages/kailash-align" --python .venv/bin/python
 
       - name: Test RL
         timeout-minutes: 15
-        # CAVEAT (measured 2026-08-11): `-m 'rl or reinforcement_learning'`
-        # selects ZERO tests (2602 deselected) — no such marker exists in the
-        # package. pytest exits 5, so this dispatch-only job fails on dispatch.
-        # Tracked in #2076.
+        # Issue #2076 FIX: `-m 'rl or reinforcement_learning'` over the whole
+        # tests/ tree selected ZERO tests (2602 deselected, pytest exit 5) —
+        # neither marker exists anywhere in the package, so this
+        # dispatch-only job failed on every dispatch. Disposition: PATH-BASED
+        # selection, not marking — the RL suite already lives entirely under
+        # two dedicated directories (tests/unit/rl/, tests/integration/rl/),
+        # so naming them directly is more precise than inventing an `rl`
+        # marker no other file needs. Verified: 31 tests collected (was 0);
+        # 30 passed, 1 skipped (an opt-in KAILASH_ML_RUN_TRL_E2E=1 test that
+        # downloads a real model — intentionally not force-enabled here).
         run: |
           .venv/bin/python -m pytest \
-            packages/kailash-ml/tests/ \
-            -m 'rl or reinforcement_learning' \
+            packages/kailash-ml/tests/unit/rl/ \
+            packages/kailash-ml/tests/integration/rl/ \
+            -m 'not (slow or gpu or bench)' \
             --maxfail=5 -q --timeout=120
 
   # ---------------------------------------------------------------------------
@@ -412,11 +431,23 @@ jobs:
 
       - name: Test CUDA-gated unit + integration tests
         timeout-minutes: 20
+        # Issue #2076 FIX: `-m 'cuda or gpu'` selected ZERO tests (2493
+        # collected, 2493 deselected, pytest exit 5) — neither marker was
+        # registered nor applied anywhere. Disposition: MARK the one test
+        # that genuinely hard-requires real CUDA hardware to exercise
+        # anything new — test_xgboost_cuda_fits_and_reports_cuda (already
+        # skipif'd on `not torch.cuda.is_available()`; every other
+        # cuda/gpu-string-matching test in the package tests CPU-only
+        # fallback/eviction LOGIC, not real hardware, so marking those would
+        # misrepresent what needs a GPU to mean anything). `cuda` is now
+        # registered in packages/kailash-ml/pyproject.toml; `gpu` dropped
+        # from the selector — no test in this package will ever carry it.
+        # Verified: `-m cuda` here collects 1/2493 (was 0/2493).
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/unit/ \
             packages/kailash-ml/tests/integration/ \
-            -m 'cuda or gpu' \
+            -m 'cuda' \
             --maxfail=5 -q --timeout=120
 
       - name: Post-run cleanup
@@ -480,15 +511,29 @@ jobs:
 
       - name: Test DL on CUDA (torch + GPU-backed tests)
         timeout-minutes: 35
-        # CAVEAT (measured 2026-08-11): this conjunction selects ZERO tests —
-        # neither operand's markers exist in the package. Tracked in #2076.
+        # Issue #2076 FIX: `(dl or deep_learning) and (cuda or gpu)` selected
+        # ZERO tests — neither operand existed as a marker, AND (measured
+        # after registering `dl`/`cuda`, see test-dl / test-cuda above) no
+        # single test in the package is tagged BOTH `dl` and `cuda`: the one
+        # genuinely hardware-gated test is XGBoost (gradient-boosted, not a
+        # neural net), not a torch/lightning test. A conjunction of the two
+        # correct markers would therefore still select nothing — same stub-
+        # gate defect, one layer deeper than the missing-marker case.
+        #
+        # Disposition: CHANGE the selector rather than delete the job. This
+        # job's stated purpose is "torch training on GPU" — that is
+        # meaningfully served by running the full `dl` suite (same 79 tests
+        # as test-dl) on a runner where `torch.cuda.is_available()` is
+        # actually True, which is DIFFERENT information than test-dl's
+        # CPU-only run: any DL code path that auto-detects/branches on real
+        # GPU presence (backend resolution, device placement) is only
+        # exercised here. Verified: `-m dl` collects 79/2606 (was 0/2606).
         # Masked today by `continue-on-error: true` (IT-1, runner not yet
-        # provisioned); it becomes a hard failure the moment that flag is
-        # removed, so fix #2076 BEFORE flipping.
+        # provisioned).
         run: |
           .venv/bin/python -m pytest \
             packages/kailash-ml/tests/ \
-            -m '(dl or deep_learning) and (cuda or gpu)' \
+            -m 'dl' \
             --maxfail=5 -q --timeout=300
 
       - name: Post-run cleanup

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -3,7 +3,19 @@ name: CI Pipeline
 # Runs on GitHub-hosted ubuntu-latest runners.
 # Push to feature branches runs Tier 1 unit tests (fast).
 # PRs to main run the same checks. Manual dispatch allows full test suite.
-
+#
+# Issue #2133 (Option 2 of the co-owner-ratified D1 disposition, Option 3
+# tracked separately as a branch-protection change requiring owner action —
+# see the PR body): `push:` intentionally does NOT include `main` — adding
+# it would cost one full 4-version matrix (~45 min) on every merge, and this
+# repo has an active CI-spend concern. Instead this `schedule:` trigger runs
+# the identical matrix against `main` nightly, so a main regression from two
+# independently-green PRs merging together (#2038's failure mode, one layer
+# over) is caught within a day instead of by the next unrelated PR that
+# happens to touch the same code. `schedule` events check out the DEFAULT
+# branch (main) with no `paths:` filtering — every job below runs in full
+# regardless of what changed, which is the point: it verifies what actually
+# ships, not what one PR's diff touched.
 on:
   push:
     branches: [feat/*, feature/*, fix/*, docs/*, session/*, session-*]
@@ -24,6 +36,11 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/unified-ci.yml"
+  schedule:
+    # 02:23 UTC nightly — off-the-hour to avoid GitHub Actions' top-of-hour
+    # scheduling congestion. Verifies main independent of any PR's path
+    # filters (issue #2133).
+    - cron: "23 2 * * *"
   workflow_dispatch:
     inputs:
       test-mode:

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -55,7 +55,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  # Security review (this PR): downgraded from `write`. The only
+  # pull-requests API call in this file is `github.rest.pulls.list` in
+  # check-duplicate (read-only); nothing here creates/updates a PR,
+  # comment, or review, so `write` was unused scope.
+  pull-requests: read
 
 concurrency:
   # Improved concurrency: Group by PR number for PR events, unique run_id for push events

--- a/packages/kailash-kaizen/tests/conftest.py
+++ b/packages/kailash-kaizen/tests/conftest.py
@@ -843,22 +843,38 @@ def pytest_collection_modifyitems(config, items):
         if "e2e" in str(item.fspath) or "slow" in item.name:
             item.add_marker(pytest.mark.slow)
 
-        # Add infrastructure requirement markers based on test content
+        # Add infrastructure requirement markers based on test content.
+        #
+        # BUG FIX (found while wiring tests/regression/ into CI, #2074):
+        # this block used to keyword-match against `str(item.function)`,
+        # which for a plain function is CPython's default repr --
+        # `<function test_name at 0x7f8a2c1b3af0>` -- i.e. it includes the
+        # function OBJECT'S MEMORY ADDRESS, ASLR-randomized fresh on every
+        # process start. Of the keyword list below, "db" is the only
+        # substring made entirely of valid hex characters (0-9a-f), so
+        # roughly ~3% of ALL collected items got a SPURIOUS
+        # `requires_postgres` marker on any given run purely because their
+        # function object's address happened to contain "db" -- silently
+        # and non-reproducibly excluding a different random ~3% of the
+        # suite from every infra-free CI step (this one and the pre-existing
+        # "expanded FAST unit tiers" step both use the SAME conftest.py)
+        # every time it ran. Measured: three consecutive
+        # `--collect-only -m 'not (... requires_postgres ...)'` runs against
+        # this same code produced 351/353/330 deselected out of the same
+        # 1654 collected -- three different numbers for the same command.
+        # `item.name` (the test's display name string) is deterministic and
+        # matches the function's docstring intent ("based on their location
+        # and name") -- switching to it removes the non-determinism.
         if hasattr(item, "function") and item.function:
             # Check for database usage in test parameters or names
             if any(
-                keyword in str(item.function).lower()
+                keyword in item.name.lower()
                 for keyword in ["postgres", "database", "db"]
             ):
                 item.add_marker(pytest.mark.requires_postgres)
-            if any(
-                keyword in str(item.function).lower() for keyword in ["redis", "cache"]
-            ):
+            if any(keyword in item.name.lower() for keyword in ["redis", "cache"]):
                 item.add_marker(pytest.mark.requires_redis)
-            if any(keyword in str(item.function).lower() for keyword in ["docker"]):
+            if any(keyword in item.name.lower() for keyword in ["docker"]):
                 item.add_marker(pytest.mark.requires_docker)
-            if any(
-                keyword in str(item.function).lower()
-                for keyword in ["ollama", "llm", "ai"]
-            ):
+            if any(keyword in item.name.lower() for keyword in ["ollama", "llm", "ai"]):
                 item.add_marker(pytest.mark.requires_ollama)

--- a/packages/kailash-kaizen/tests/unit/providers/test_ollama_availability.py
+++ b/packages/kailash-kaizen/tests/unit/providers/test_ollama_availability.py
@@ -231,6 +231,24 @@ class TestOllamaSpecificModels:
             result = manager.model_exists("bakllava")
             assert isinstance(result, bool)
 
+    @pytest.mark.skip(
+        reason=(
+            "Issue #2149: depends on cross-test module-reload pollution to "
+            "pass, not a real intermittent flake. FAILS deterministically "
+            "when run alone or in the full kaizen 'expanded FAST unit tiers' "
+            "selection (ImportError: cannot import name 'OllamaModelManager' "
+            "from 'kaizen.providers'); only PASSES when a sibling test in "
+            "this same file (test_ollama_available_true_when_installed) "
+            "happens to have already run first and left kaizen.providers "
+            "reloaded with OLLAMA_AVAILABLE=True via an incomplete "
+            "with-patch.dict(...)+importlib.reload() cleanup. Surfaced by "
+            "the tests/conftest.py::pytest_collection_modifyitems "
+            "determinism fix in #2144 (a stable test order made this "
+            "reliably visible instead of randomly hidden). Do not xfail "
+            "(strict or non-strict) -- it is not intermittent, it is "
+            "order-dependent. Remove this skip only once #2149 is fixed."
+        )
+    )
     def test_vision_models_not_found(self):
         """Test when vision models are not available."""
         from kaizen.providers import OllamaModelManager

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -98,6 +98,11 @@ dl = [
     "torchaudio>=2.2",
     "timm>=1.0",
     "transformers>=4.40",
+    # transformers.Trainer hard-requires accelerate>=1.1.0 for its PyTorch
+    # backend (raises ImportError at _setup_devices otherwise) — surfaced
+    # by wiring the test-dl CI selector in for the first time (issue
+    # #2076); transformers itself does not declare it as a hard dep.
+    "accelerate>=1.1.0",
     # Plotly is ALSO pinned here so the kailash_ml.diagnostics.DLDiagnostics
     # plot_*() methods install cleanly under `pip install kailash-ml[dl]`
     # regardless of any future decision to demote plotly from base deps.
@@ -248,6 +253,8 @@ markers = [
     "regression: Permanent regression tests (never delete; see rules/testing.md)",
     "invariant: Numeric/structural invariant guards (per rules/refactor-invariants.md)",
     "online_store: Online feature-store (Redis) tests — live path needs REDIS_URL (FM2 Wave-3 Shard C)",
+    "dl: Deep-learning tests (torch/lightning/transformers) — selected by the test-dl CI job (issue #2076)",
+    "cuda: Tests that hard-require real CUDA hardware (skipped when unavailable) — selected by the test-cuda CI job (issue #2076)",
 ]
 # Scoped warning filters — each entry has a documented origin + disposition
 # per rules/observability.md MUST Rule 5. Unfiltered suite emits ~240

--- a/packages/kailash-ml/tests/integration/autolog/test_autolog_ddp_rank0_only_emission.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_autolog_ddp_rank0_only_emission.py
@@ -28,10 +28,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from kailash_ml.autolog import _distribution, autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 
-pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio, pytest.mark.dl]
 
 
 @pytest.fixture

--- a/packages/kailash-ml/tests/integration/autolog/test_lightning_autolog_wiring.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_lightning_autolog_wiring.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from kailash_ml.autolog import autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 
-pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio, pytest.mark.dl]
 
 
 @pytest.fixture

--- a/packages/kailash-ml/tests/integration/autolog/test_transformers_autolog_wiring.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_transformers_autolog_wiring.py
@@ -26,10 +26,11 @@ from pathlib import Path
 
 import pytest
 import torch
+
 from kailash_ml.autolog import autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 
-pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio, pytest.mark.dl]
 
 
 # Silence transformers/hf noise that leaks into the test log pipeline.

--- a/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
@@ -21,12 +21,16 @@ import pytest
 torch = pytest.importorskip("torch")
 nn = pytest.importorskip("torch.nn")
 
+from kailash.diagnostics.protocols import Diagnostic  # noqa: E402
+
 # Import through the facade — NOT `from kailash_ml.diagnostics.dl import ...`
 # per orphan-detection §1 (downstream consumers see the public attribute,
 # so the wiring test MUST exercise the same surface).
 from kailash_ml.diagnostics import DLDiagnostics  # noqa: E402
 
-from kailash.diagnostics.protocols import Diagnostic  # noqa: E402
+# Issue #2076: this file is the deep-learning diagnostics wiring test —
+# tags it into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
 
 
 @pytest.mark.integration

--- a/packages/kailash-ml/tests/integration/test_onnx_roundtrip_lightning.py
+++ b/packages/kailash-ml/tests/integration/test_onnx_roundtrip_lightning.py
@@ -20,6 +20,10 @@ pytest.importorskip("torch")
 pytest.importorskip("pytorch_lightning")
 pytest.importorskip("onnxruntime")
 
+# Issue #2076: Lightning/torch ONNX round-trip is a deep-learning test —
+# tags it into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 
 @pytest.mark.integration
 def test_lightning_onnx_roundtrip_prediction_parity(tmp_path: Path) -> None:
@@ -34,6 +38,7 @@ def test_lightning_onnx_roundtrip_prediction_parity(tmp_path: Path) -> None:
     import pytorch_lightning as pl
     import torch
     import torch.nn as nn
+
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)

--- a/packages/kailash-ml/tests/integration/test_onnx_roundtrip_torch.py
+++ b/packages/kailash-ml/tests/integration/test_onnx_roundtrip_torch.py
@@ -20,6 +20,10 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("onnxruntime")
 
+# Issue #2076: torch ONNX round-trip is a deep-learning test — tags it
+# into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 
 class _TinyMLP:
     """Placeholder to satisfy naming rules — real class defined in test body."""
@@ -31,6 +35,7 @@ def test_torch_onnx_roundtrip_prediction_parity(tmp_path: Path) -> None:
     import onnxruntime as ort
     import torch
     import torch.nn as nn
+
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)
@@ -114,6 +119,7 @@ def test_torch_onnx_roundtrip_dynamic_batch_size(tmp_path: Path) -> None:
     import onnxruntime as ort
     import torch
     import torch.nn as nn
+
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)

--- a/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
+++ b/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
@@ -35,6 +35,7 @@ import numpy as np
 import polars as pl
 import pytest
 import torch
+
 from kailash_ml._device_report import DeviceReport
 from kailash_ml.trainable import (
     HDBSCANTrainable,
@@ -255,6 +256,7 @@ def test_xgboost_cpu_fits_and_reports_cpu(
 
 @requires_cuda
 @xgboost_stable_only
+@pytest.mark.cuda  # Issue #2076: selected by the test-cuda CI job (-m cuda).
 def test_xgboost_cuda_fits_and_reports_cuda(
     classification_frame: pl.DataFrame,
 ) -> None:

--- a/packages/kailash-ml/tests/integration/test_w22b_autoattach_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_w22b_autoattach_wiring.py
@@ -53,6 +53,10 @@ from kailash_ml.engines.model_registry import ModelRegistry
 from kailash_ml.engines.training_pipeline import ModelSpec, TrainingPipeline
 from kailash_ml.tracking.runner import _current_run
 
+# Issue #2076: Lightning auto-attach wiring is a deep-learning test —
+# tags it into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 # ----------------------------------------------------------------------
 # Tiny Lightning module wired into kailash_ml._w22b_tiny via sys.modules
 # ----------------------------------------------------------------------

--- a/packages/kailash-ml/tests/regression/test_issue_701_diagnose_dl_pytorch_dataloader_end_to_end.py
+++ b/packages/kailash-ml/tests/regression/test_issue_701_diagnose_dl_pytorch_dataloader_end_to_end.py
@@ -37,6 +37,7 @@ import pytest
 
 @pytest.mark.regression
 @pytest.mark.integration
+@pytest.mark.dl  # Issue #2076: tags into the `test-dl` CI job's selection.
 def test_diagnose_dl_pytorch_dataloader_end_to_end() -> None:
     """DOCS-EXACT: diagnose(model, kind='dl', data=loader) consumes the loader.
 
@@ -47,8 +48,9 @@ def test_diagnose_dl_pytorch_dataloader_end_to_end() -> None:
     (``n_batches > 0``, ``n_samples == 64``).
     """
     torch = pytest.importorskip("torch")
-    from kailash_ml import diagnose
     from torch.utils.data import DataLoader, TensorDataset
+
+    from kailash_ml import diagnose
 
     # Deterministic seed — rules/testing.md § Rules: no random data
     # without seeds. The DataLoader's `shuffle=False` default plus a

--- a/packages/kailash-ml/tests/unit/test_dl_diagnostics_unit.py
+++ b/packages/kailash-ml/tests/unit/test_dl_diagnostics_unit.py
@@ -16,6 +16,10 @@ nn = pytest.importorskip("torch.nn")
 from kailash_ml.diagnostics import DLDiagnostics  # noqa: E402
 from kailash_ml.diagnostics import dl as dl_mod  # noqa: E402
 
+# Issue #2076: DLDiagnostics unit tests are deep-learning tests — tags
+# this module into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 # ---------------------------------------------------------------------------
 # __init__ validation
 # ---------------------------------------------------------------------------

--- a/packages/kailash-ml/tests/unit/test_w22_lightning_callback.py
+++ b/packages/kailash-ml/tests/unit/test_w22_lightning_callback.py
@@ -45,6 +45,10 @@ except ImportError:  # pragma: no cover — [dl] extra missing on CI
 
 from kailash_ml.diagnostics.dl import DLDiagnostics
 
+# Issue #2076: Lightning callback tests are deep-learning tests — tags
+# this module into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 # ----------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------

--- a/packages/kailash-ml/tests/unit/test_w22b_train_lightning_autoattach.py
+++ b/packages/kailash-ml/tests/unit/test_w22b_train_lightning_autoattach.py
@@ -49,6 +49,10 @@ from kailash_ml.engines.training_pipeline import (  # noqa: F401 — reserved fo
     TrainingPipeline,
 )
 
+# Issue #2076: Lightning auto-attach tests are deep-learning tests —
+# tags this module into the `test-dl` CI job's selection (`-m dl`).
+pytestmark = pytest.mark.dl
+
 # ----------------------------------------------------------------------
 # Fixtures
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the same CI blind-spot class as #2038 (green signal ≠ what actually ran), in three places:

- **#2074** — `packages/kailash-kaizen/tests/regression/` was never invoked by any CI job (109 `.py` files, 1654 tests collected, measured). Wired into `test-kailash-kaizen.yml` as a new blocking step. Baseline established before gating (per the issue's instruction not to assume clean): **1221 passed, 425 deselected, 8 xfailed, 0 failed** — genuinely clean and, after the determinism fix below, reproducibly stable (not true of the first two numbers this PR reported for this line).
- **#2076** — five `pytest -m <expr>` selectors matched zero tests (pytest exit 5) because the markers never existed or were never applied. Fixed per-job with evidence (see details below); one job (`test-gpu` in kailash-align) had no real GPU-hardware test to select at all, so it's removed rather than faked (**#2135**). Two others (`test-cuda`/`test-cuda-dl` in kailash-ml) turned out to target a self-hosted runner that does not exist (**#2155**, see below) — their selector fixes are correct and shipped, but neither job can currently execute at all.
- **#2133** — `unified-ci.yml` never ran against `main` (confirmed via the API: no `CI Pipeline` run had ever executed on `main`). Adds a nightly `schedule:` cron per the co-owner-ratified D1 disposition (Option 2 + Option 3; sweep cont-17 report). Option 1 (add `main` to `push:`) is deliberately NOT done — see cost note below.

## ⚠️ Most consequential thing measured in this PR — read before merging

`gh api repos/terrene-foundation/kailash-py/branches/main/protection` returns `strict: true` **and `checks: []`** (zero required status checks). Combined with #2133's finding (CI has never run against `main` at all until this PR), this means: **a PR can merge into `main` today with no CI check required to pass at all.** `strict: true` only enforces "branch is up to date" — it enforces nothing about what passed. This is a stronger argument for applying Option 3 (below, under "Requires owner action") than anything in the original issue text, and is the reason that section is not optional follow-up color — it is the actual fix for the exposure #2133 describes.

## Per-issue detail

### #2074 — kaizen regression suite wired in, plus a real determinism bug found, fixed, and quantified along the way

New step "Test (regression suite, infra-free)" in `test-kailash-kaizen.yml`, same broad infra-free marker-exclusion set as the existing "expanded FAST unit tiers" step.

**A redteam pass caught that this step's first-draft comment did not arithmetically reconcile.** Re-deriving it (rather than patching the number) surfaced a real bug: `tests/conftest.py::pytest_collection_modifyitems` (governs marker auto-tagging for the **entire** kaizen `tests/` tree, every CI job, not just `tests/regression/`) keyword-matched infra markers against `str(item.function)` — CPython's default function repr, which embeds the function object's **ASLR-randomized memory address**. `"db"` is the only keyword in the list made entirely of valid hex characters, so ~3% of all collected items got a spurious `requires_postgres` marker on any given process run purely by address coincidence. Three consecutive identical `--collect-only` runs measured three different deselected counts (351/353/330 out of the same 1654 collected) — the number was never stable to begin with; it wasn't a typo, it was a moving target.

Fixed: keyword match now targets `item.name.lower()` (deterministic, matches the hook's own docstring intent). Verified stable across repeat runs: `1229/1654` selected, run result `1221 passed, 425 deselected, 8 xfailed, 0 failed`.

**Retroactive implication (this is bigger than this PR):** this hook has governed marker assignment for as long as it has existed, on every kaizen CI job filtering on these markers. Every historical run excluded a *different random ~3% slice* of the suite — not necessarily wrong, but never reproducible evidence, because the set that actually ran was never the set a reader of the green checkmark believed ran. This fix is what makes a green from these jobs, going forward, mean something stable.

**Second-order effect, measured (not just noise removal):** `item.name` includes parametrize-case text that `str(item.function)` structurally never could. Measured directly with a standalone analysis plugin: of 1654 `tests/regression/` items, 264 match a keyword via the base function name (a match the old code could equally have produced), and **157 match ONLY via the parametrize-id suffix** — cases the old address-based code could never detect, by construction, regardless of which run you looked at. The pre-fix "342" this PR originally cited is not a valid baseline to diff against (it was itself unstable), so an exact "342→425" split isn't well-defined — but the 157-item structural floor is.

This conftest.py is shared by the **pre-existing** "expanded FAST unit tiers" step too (not otherwise touched by this PR). Re-verified it end-to-end after the fix and it surfaced one new, real, pre-existing failure the old non-determinism had been randomly hiding — `tests/unit/providers/test_ollama_availability.py::TestOllamaSpecificModels::test_vision_models_not_found` depends on a sibling test in the same file leaving `kaizen.providers` reloaded with `OLLAMA_AVAILABLE=True` via an incomplete `patch.dict`+`importlib.reload` cleanup; A/B-confirmed against the old buggy conftest (same selection, 0 failed) that this was already latent, just randomly masked. Quarantined with `pytest.mark.skip` (not `xfail` — it's order-dependent, not intermittent) with the full diagnosis inline at the test; tracked in **#2149**. Expanded-tiers step re-verified green after the quarantine: 7263 passed, 89 skipped, 1067 deselected, 0 failed. Invocation 1 (LLM + cross-SDK parity) re-verified unaffected: 1639 passed, 12 deselected, 1 xfailed, 0 failed.

**A note on process — an apparent 5-minute hang while re-verifying the expanded-tiers step, resolved with evidence, not speculation.** The first attempt to run the full expanded-tiers selection synchronously hit a 5-minute tool-side ceiling without completing. Rather than guess, I re-ran the identical command three more times to completion in the background: 229s, 402s, 253s — all under `pytest-timeout` (`--timeout=30`, method=thread) actively enforced, which would surface any single stuck test as an explicit `Failed: Timeout >30.0s` entry. None occurred in any of the three completed runs. Conclusion: the first attempt was contended machine load (this session's own environment; other unrelated processes were observed running concurrently at that time), not a genuine test hang — no test in this suite takes anywhere near 30s.

**Residue, measured and documented, not fixed (separate, larger scope):** both infra-free kaizen steps correctly-but-silently exclude tests that need paid API keys or real infra — 425 in `tests/regression/`, 1067 in the expanded-tiers step — and none of that residue currently runs in **any** workflow. Per-marker breakdown for `tests/regression/`: `requires_ollama` 342, `requires_postgres` 41, `requires_redis` 32, `requires_docker` 12, `performance` 3, `integration` 2, everything else 0. Spot-checking the dominant `requires_ollama` count found a **second**, separate pre-existing defect in the same hook: the bare `"ai"` substring keyword matches ordinary English words with zero infra relevance (`"raises"`, `"failure"`, `"chained"`, `"contains"`, ...) — only ~125 of the 342 actually mention ollama/llm. Tracked in **#2152**, which also flags that the exclusion set includes `flaky`/`slow` and should be audited against the same swallowed-real-error shape as the sweep-cont17 D3 finding, and that `item.name`'s inclusion of parametrize IDs (per a follow-up security review) extends this same false-positive risk to parametrize cases, not just base test names.

### #2076 — per-job disposition (fix vs delete vs blocked-on-infra), with evidence

| job | file | old selector | old collect | disposition | new selector | new collect |
|---|---|---|---|---|---|---|
| `test-dl` | kailash-ml | `-m 'dl or deep_learning'` | 0/2602 | **MARKED** 11 torch/lightning/transformers test modules with a newly-registered `dl` marker | `-m 'dl'` | 79/2606 |
| `test-rl` | kailash-ml | `-m 'rl or reinforcement_learning'` | 0/2602 | **PATH-BASED** — the RL suite already lives entirely under two dedicated dirs | `tests/unit/rl/ tests/integration/rl/` | 31 collected |
| `test-cuda` | kailash-ml | `-m 'cuda or gpu'` | 0/2493 | **MARKED** the one test that genuinely hard-requires real CUDA hardware — **but see below: this job cannot currently execute at all**, independent of the selector | `-m 'cuda'` | 1/2493 |
| `test-cuda-dl` | kailash-ml | `-m '(dl or deep_learning) and (cuda or gpu)'` | 0/2606 | **SELECTOR CHANGED** — no test is tagged both `dl` and `cuda`, so the conjunction would still select nothing — **same runner caveat as test-cuda** | `-m 'dl'` | 79/2606 |
| `test-gpu` | kailash-align | `-m 'gpu'` | 0/485 | **DELETED** — zero GPU-hardware tests exist in the package at all (#2135) | — | — |

Wiring `-m dl` in surfaced a real dependency gap: `transformers.Trainer`'s PyTorch backend hard-requires `accelerate>=1.1.0`, undeclared in the `[dl]` extra. Added; `test-dl` now runs clean (78 passed, 10 skipped).

**`test-cuda` / `test-cuda-dl` cannot execute, measured — this is bigger than a selector bug.** Both target `runs-on: [self-hosted, cuda, gpu]` with `continue-on-error: true # IT-1: non-blocking until runner live`. Measured 2026-08-15:
```
gh api repos/terrene-foundation/kailash-py/actions/runners --jq .total_count -> 0
gh api orgs/terrene-foundation/actions/runners --jq .total_count           -> 0
gh run list --workflow gpu-smoke.yml --limit 5  ->  cancelled x5, back to 2026-06-07
```
Zero self-hosted runners exist at repo or org level, and every one of `gpu-smoke.yml`'s last five runs (over two months of history) queued until cancelled — the runner has never been live. `continue-on-error` never even gets exercised: GitHub Actions never assigns these jobs a runner in the first place, so they yield **zero information** regardless of how correct their selectors are. This PR's selector fixes for both jobs are correct and are shipped as a prerequisite, but they do not currently change anything observable. Filed **#2155** as a provision-vs-retire decision (same shape as #2135) rather than resolving it unilaterally, and replaced the stale "non-blocking until runner live" workflow comments with this measurement.

**Also fixed in this PR (found live #2038-class masking while working the file grant):** `example-validation.yml`'s "Run example validation tests" step wrapped a real pytest invocation in `continue-on-error: true` unconditionally. Verified before removing it: `packages/kaizen-agents/tests/examples/test_example_validation.py` exists (23 structural/README/syntax tests, no infra) and runs clean on the exact CI matrix (Python 3.11): 23 passed in 0.06s. `continue-on-error` removed; the step now genuinely gates.

Also adds `.github/actionlint.yaml` (declares the `cuda`/`gpu` self-hosted runner labels) — found via local actionlint validation, a pre-existing false positive unrelated to any logic change.

### #2133 — nightly main verification

`schedule: cron: "23 2 * * *"` (02:23 UTC, off-the-hour) added to `unified-ci.yml`. `schedule` events check out the default branch with no `paths:` filtering, so the full matrix runs against `main` regardless of what any prior PR's diff touched.

**Deliberately NOT done:** adding `main` to `push:` (Option 1) — costs one full 4-version matrix (~45 min) on every merge, disproportionate given this repo's active CI-spend concern.

A security review of this branch flagged `permissions.pull-requests: write` in `unified-ci.yml` as unused scope (the only PR API call in the file is a read-only `pulls.list`) — downgraded to `read` in a follow-up commit. A second security review flagged `example-validation.yml` had no explicit `permissions:` block (inherits repo default) unlike its siblings — added `permissions: contents: read` for parity.

## Requires owner action

**1. Branch protection (Option 3 of #2133).** Not applied by this PR. `strict: true` is already set; `checks: []` is currently **empty**:
```bash
gh api --method PUT -H "Accept: application/vnd.github+json" \
  repos/terrene-foundation/kailash-py/branches/main/protection/required_status_checks \
  --input - <<'EOF'
{
  "strict": true,
  "checks": [
    {"context": "Test (Python 3.11)"},
    {"context": "Test (Python 3.12)"},
    {"context": "Test (Python 3.13)"},
    {"context": "Test (Python 3.14)"},
    {"context": "Test PACT (Python 3.11)"},
    {"context": "Test DataFlow Unit Suite (Tier 1)"},
    {"context": "Test DataFlow Infra Regression (Postgres/Redis)"}
  ]
}
EOF
```
This changes the admin-merge workflow: merges will be blocked until these checks pass on an up-to-date branch, rather than the current "no required checks at all" state.

**2. GPU CI decision (#2155).** Provision the self-hosted `[self-hosted, cuda, gpu]` runner (see `docs/ci/self-hosted-runner.md`), or retire `test-cuda`/`test-cuda-dl` the way #2135 retired kailash-align's `test-gpu`. Not this session's call.

## Not fixed / follow-up filed

- **#2135** — kailash-align has no GPU-hardware test coverage; `test-gpu` deleted rather than faked.
- **#2149** — one kaizen test depends on cross-test module-reload pollution to pass; quarantined, not fixed.
- **#2152** — 425/1067 kaizen tests deselected by infra-free steps run in NO workflow (legitimate but silent); `requires_ollama` over-matches on a bare `"ai"` substring, including in parametrize IDs.
- **#2155** — `test-cuda`/`test-cuda-dl` target a self-hosted runner that has never existed.

## Related issues

Fixes #2074
Fixes #2076
Fixes #2133

## Test plan

- [x] All new/changed selectors verified locally with real `pytest --collect-only` counts.
- [x] Full `packages/kailash-ml/tests/unit/` suite re-run after all marker changes: 1911 passed, 19 skipped, 0 failed (1928 collected, unchanged — confirmed via `git stash`).
- [x] `packages/kailash-kaizen/tests/regression/` baseline confirmed stable across repeat runs after the determinism fix: 1221 passed, 425 deselected, 8 xfailed, 0 failed.
- [x] `packages/kailash-kaizen` full "expanded FAST unit tiers" step (pre-existing) re-verified green after the conftest.py fix + quarantine, across 3 completed background runs (229s/402s/253s, no timeout-triggered failures in any): 7263 passed, 89 skipped, 1067 deselected, 0 failed.
- [x] `packages/kailash-kaizen` invocation 1 (LLM + cross-SDK parity) re-verified unaffected: 1639 passed, 12 deselected, 1 xfailed, 0 failed.
- [x] A/B-confirmed the quarantined test (#2149) was already latent-red under the OLD (pre-fix) conftest, not introduced by this PR.
- [x] `example-validation.yml`'s newly-unmasked step verified clean before removing `continue-on-error`: 23 passed in 0.06s on the exact CI matrix.
- [x] YAML syntax + `actionlint` clean on all five touched workflow files.
- [x] `ruff check --select=E9,F63,F7,F82` clean on all touched Python files.
- [x] `tomllib` parse clean on `packages/kailash-ml/pyproject.toml`.
- [x] Security review: PASS across three rounds; findings (unused `pull-requests: write`, stale re-cited number, missing `permissions:` block) fixed in follow-up commits each time, not left open.
- [x] Correctness review: PASS; two comment-accuracy findings fixed in a follow-up commit.
- [x] Redteam: caught a non-reconciling comment number, whose re-derivation surfaced the determinism bug, a real pre-existing latent failure (#2149), a residue-visibility gap (#2152), and a second class of masking (`example-validation.yml`) outside the original grant — all fixed or tracked, none left silent.
- [ ] Owner: apply the branch-protection command above.
- [ ] Owner: decide GPU CI (#2155) — provision or retire.
