### PR TITLE
fix(async-sql,runtime): root-cause the CI hang chain and restore both regression gates (#2081, #2079)

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -267,30 +267,113 @@ jobs:
             --maxfail=400 -q -p no:xdist --timeout=60 -rf
 
 
-  # ISSUE #2002 — the `test-root-regression` job lived HERE and is NOT SHIPPED,
-  # pending #2081. Root tests/regression/ cannot run to completion on this
-  # repo's ubuntu-latest runner: three CI runs, each with a sharper instrument,
-  # ended in a timeout or a truncated `--maxfail`. The last one
-  # (--timeout-method=signal, --timeout=60, --maxfail=30) enumerated 30 hangs
-  # across 8 files having executed 757 of 1916 tests in 23m40s — so 30 is a
-  # floor, not a count. The identical selection is 1916 passed / 0 failed in
-  # 217s on macOS.
+  # ISSUE #2002 / #2081 — RESTORED. This job was removed in PR #2077 because
+  # root tests/regression/ could not run to completion on this runner: three
+  # CI runs ended in a timeout or a truncated `--maxfail`, the last one
+  # enumerating 30 hangs across 8 files having executed 757 of 1916 tests.
   #
-  # A 40-minute job that cannot complete is pure cost on every PR, and making
-  # it non-blocking would only make that cost silent. So it is removed rather
-  # than shipped degraded, and #2002 stays open with #2081 as its blocker.
+  # Two causes, both now closed. The environment-level one was #2078: a
+  # PythonCodeNode set a process-wide, irreversible RLIMIT_AS cap, so every
+  # later mmap in the process failed — including the stack pthread_create
+  # needs. That is why it never reproduced on macOS, whose kernel rejects the
+  # setrlimit outright and so is not a discriminating instrument. Fixed in
+  # #2097. The disposal-level one was #2079, fixed in this PR.
   #
-  # The complete job — the extras set (note `shamir`, without which five EATP
-  # vault tests fail), the five editable sibling installs the suite needs to
-  # COLLECT at all, and the marker filter mirroring the DataFlow regression
-  # step — is preserved in PR #2077's history and referenced from #2081.
-  # Restore it from there once the hangs are fixed; do not re-derive it.
-  #
-  # One finding from that work is worth acting on independently of #2002: the
-  # root pytest.ini sets `timeout_method = thread`, and a thread-method timeout
-  # CANNOT kill a test blocked in a C call. Two of the three runs above were
-  # unreadable for exactly that reason — pytest-timeout printed its banner and
-  # the process carried on. `signal` is the enforceable method on Linux/macOS.
+  # Re-measured before restoring, in a Linux container with Postgres 16, on
+  # this branch: `2336 passed, 4 skipped, 22 deselected in 219.36s` with ZERO
+  # pytest-timeout hits, and every one of the 30 previously-enumerated hangs
+  # passing. The 40-minute budget is kept because a runner is slower than that
+  # container, not because the suite is expected to need it.
+  test-root-regression:
+    name: Test Root Regression Suite (Python 3.12)
+    needs: check-duplicate
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
+    if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    # Must exceed the 40-minute test step plus install time.
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Restore uv cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-py3.12-rootregr-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-py3.12-rootregr-
+
+      - name: Install dependencies
+        # Extras are the `test` job's set PLUS `shamir`. The shamir extra is
+        # REQUIRED, not optional garnish: without shamir-mnemonic, five tests
+        # (test_eatp12_vault_3way_discrimination.py x3,
+        # test_eatp12_vault_quickstart.py x2) fail with
+        # `RuntimeError: SLIP-0039 Shamir secret-sharing requires the 'shamir'
+        # optional extra` raised from src/kailash/trust/vault/shamir.py. Those
+        # are real assertions on a real code path, not env noise — the fix is to
+        # provision the dependency, not to skip the tests.
+        #
+        # Root kailash editable BEFORE the sub-packages, per
+        # rules/deployment.md § "Sibling-Package CI Installs Root SDK Editable".
+        #
+        # ISSUE #2023 SIBLING DECLARATION — measured, do not re-derive.
+        # Selection: tests/regression/ minus the infra markers.
+        # Determined by grepping module-level sibling imports across the
+        # directory, then confirmed by building this exact venv from scratch and
+        # running the suite in it:
+        #   dataflow      -> EXERCISED (17 files) -> editable below
+        #   nexus         -> EXERCISED  (7 files) -> editable below
+        #   kaizen        -> EXERCISED  (4 files) -> editable below
+        #   kailash_mcp   -> EXERCISED  (3 files) -> editable below
+        #   kaizen_agents -> EXERCISED  (1 file)  -> editable below
+        #   kailash_ml / kailash_align / kailash_pact -> 0 files, NOT installed
+        # Several of these imports are UNGUARDED at module scope
+        # (`from nexus import Nexus`, `from kaizen.providers.registry import ...`),
+        # so a missing sibling is a COLLECTION error, not a skip.
+        run: |
+          uv venv .venv
+          uv pip install -e ".[dev,server,http-client,db-postgres,db-mysql,db-sqlite,redis,monitoring,auth,auth-azure,trust,mcp,scheduler,telemetry,data,shamir]" --python .venv/bin/python
+          uv pip install -e packages/kailash-mcp --python .venv/bin/python
+          uv pip install -e packages/kailash-dataflow --python .venv/bin/python
+          uv pip install -e packages/kailash-kaizen --python .venv/bin/python
+          uv pip install -e packages/kailash-nexus --python .venv/bin/python
+          # test_issue_443_kaizen_mcp_dependency.py does `from kaizen_agents
+          # import Delegate` — without this the test fails ModuleNotFoundError.
+          uv pip install -e packages/kaizen-agents --python .venv/bin/python
+
+      - name: Test root regression suite (infra-free)
+        timeout-minutes: 40
+        # tests/regression/ is a MIXED dir — the same shape as the DataFlow
+        # regression dir handled below. The explicit `-m` filter mirrors that
+        # step's, and is REQUIRED for the same reason: the root pytest.ini
+        # `addopts` carries NO marker filter at all, so nothing else deselects
+        # the infra-requiring tests. Keep this expression and the infra-marked
+        # step's in sync — they are exact complements, so between the two every
+        # test in root tests/regression/ runs on every PR and none runs twice.
+        #
+        # `--maxfail=30` is deliberately KEPT rather than lifted. It cost
+        # nothing on the verification run (0 failures) and it bounds the damage
+        # if a future change reintroduces a hang class: 30 named failures is a
+        # list you can act on, where an unbounded run is another 40-minute job
+        # with no output.
+        #
+        # `--timeout-method=signal` is no longer passed here — pytest.ini now
+        # sets it globally (platform-guarded in the root conftest.py), because
+        # a thread-method timeout cannot kill a test blocked in a C call and
+        # that is what made two of the three #2081 runs unreadable.
+        run: |
+          .venv/bin/python -m pytest tests/regression/ \
+            -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
+            --maxfail=30 -v -p no:xdist --durations=25 \
+            --timeout=60
 
   test-pact:
     name: Test PACT (Python 3.11)
@@ -520,21 +603,68 @@ jobs:
             -m "requires_postgres or requires_redis" \
             --maxfail=10 -q --timeout=120
 
-      # ISSUE #2002 AC#2 — the infra-marked root regression step lived HERE and
-      # is REMOVED pending #2079. It hangs on this runner: given a 30-minute
-      # budget it executed 3 of 22 tests and consumed the rest, with
-      # pytest-timeout's stack dump naming a `dataflow_async__0` thread at
-      # cross-event-loop pool disposal. The identical selection completes in
-      # 244s against a real Postgres on macOS, so it is Linux/container
-      # specific. A step that holds a runner for 30 minutes on every PR is a
-      # real cost even when non-blocking, and a hang yields no signal in
-      # exchange — so it is removed rather than made continue-on-error.
+      # ISSUE #2002 AC#2 / #2079 — RESTORED. This step was removed in PR #2077
+      # because it hung: given a 30-minute budget it executed 3 of 22 tests and
+      # consumed the rest, with pytest-timeout's stack dump naming a
+      # `dataflow_async__0` thread at cross-event-loop pool disposal.
       #
-      # The removed block, including the `env:` wiring for the FOUR different
-      # DSN env var names those files read (TEST_DATABASE_URL,
-      # DATAFLOW_TEST_POSTGRES_URL, TEST_POSTGRES_DSN, TEST_PG_URL — each
-      # falling back to :5434, not this job's :5432), is preserved in PR #2077's
-      # history and quoted in #2079. Restore it there once the hang is fixed.
+      # Root cause, reproduced in a Linux container and fixed in this PR: every
+      # `disconnect()`/`close()` in async_sql.py read its pool handle, awaited
+      # the driver close, and nulled the handle AFTERWARDS — so N concurrent
+      # callers on a shared adapter all entered `asyncpg.Pool.close()` at once
+      # while queries were still in flight, corrupting the protocol state and
+      # stranding `PoolConnectionHolder.close()` forever. See #2079.
       #
-      # The infra-FREE gate in `test-root-regression` — the substance of #2002 —
-      # is unaffected: its marker filter excludes exactly this set.
+      # It lands HERE rather than in a new job because this job already has
+      # Postgres + Redis service containers up — a dedicated job would pay for a
+      # second pair for 22 tests. (test-with-infrastructure.yml was the other
+      # candidate and is NOT suitable: it invokes no pytest at all, it is a
+      # config validator.)
+      #
+      # The selector is the exact COMPLEMENT of the infra-free step in
+      # `test-root-regression`, so between the two, every test in root
+      # tests/regression/ runs on every PR and none runs twice. Keep the two
+      # marker expressions in sync — if one gains a marker, so must the other.
+      #
+      # The env block below is LOAD-BEARING, not decoration, and it grew in this
+      # PR. These files read FOUR DIFFERENT env var names for the same DSN, each
+      # falling back to `localhost:5434` — the port the repo's local
+      # `./test-env up` compose stack uses, NOT the 5432 this job's service
+      # container publishes:
+      #   TEST_DATABASE_URL           test_issue_713_module_import_then_async_ddl.py
+      #   DATAFLOW_TEST_POSTGRES_URL  test_issue_713_subsystems_follow_runtime_swap.py
+      #   TEST_POSTGRES_DSN           test_issue_1248_localruntime_cross_loop_pool_disposal.py
+      #   TEST_PG_URL                 test_w3_security_fixes.py
+      #
+      # REDIS_HOST / REDIS_PORT are NEW and are why this step now runs 18 tests
+      # where it used to run 7. tests/utils/docker_config.py defaults Redis to
+      # :6380 (the compose stack's port), so `ensure_docker_services()` returned
+      # False against this job's :6379 and eleven pool tests self-skipped. The
+      # step reported a green built almost entirely out of skips — a check that
+      # could not come out the other way. Two of those eleven were genuinely
+      # broken, and both are fixed in this PR.
+      #
+      # `-rs` keeps every skip visible in the log for the same reason.
+      #
+      # Measured on this branch, Linux + Postgres 16 + Redis 7:
+      # `2 failed, 18 passed, 3 skipped in 11.40s` before the two test fixes,
+      # green after — against 131.54s WITH a 120-second hang beforehand.
+      - name: Run ROOT regression infra-marked tests (issue #2002 AC#2)
+        timeout-minutes: 15
+        env:
+          TEST_DATABASE_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
+          DATAFLOW_TEST_POSTGRES_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
+          TEST_POSTGRES_DSN: postgresql://test_user:test_password@localhost:5432/kailash_test
+          TEST_PG_URL: postgresql://test_user:test_password@localhost:5432/kailash_test
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_USER: test_user
+          DB_PASSWORD: test_password
+          DB_NAME: kailash_test
+          REDIS_HOST: localhost
+          REDIS_PORT: "6379"
+          REDIS_URL: redis://localhost:6379/0
+        run: |
+          .venv/bin/python -m pytest tests/regression/ \
+            -m "requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e" \
+            --maxfail=10 -v -p no:xdist --timeout=300 -rs --durations=25

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -365,15 +365,26 @@ jobs:
         # list you can act on, where an unbounded run is another 40-minute job
         # with no output.
         #
-        # `--timeout-method=signal` is no longer passed here — pytest.ini now
-        # sets it globally (platform-guarded in the root conftest.py), because
-        # a thread-method timeout cannot kill a test blocked in a C call and
-        # that is what made two of the three #2081 runs unreadable.
+        # `--timeout-method=signal` is passed EXPLICITLY and must stay that
+        # way. A thread-method timeout CANNOT kill a test blocked in a C call
+        # — it only observes and reports, which is why two of the three #2081
+        # runs printed the banner repeatedly and carried on to the job cap
+        # with no per-test output. SIGALRM interrupts the blocked call, so a
+        # hung test fails and names itself.
+        #
+        # It is NOT set in pytest.ini, and an attempt to set it there was
+        # reverted after measurement: root `pytest.ini` carries `timeout` and
+        # `timeout_method` inside a `[pytest:local]` section, and pytest reads
+        # ONLY `[pytest]`. `config.getini("timeout")` returns `''` on main and
+        # on this branch alike, so BOTH of those settings are dead letters and
+        # editing them changes nothing. Tracked separately — activating the
+        # global 10s timeout is a large, unmeasured blast radius (several
+        # tests in this very selection exceed 10s) and does not belong here.
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "not (requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e)" \
             --maxfail=30 -v -p no:xdist --durations=25 \
-            --timeout=60
+            --timeout=60 --timeout-method=signal
 
   test-pact:
     name: Test PACT (Python 3.11)
@@ -667,4 +678,5 @@ jobs:
         run: |
           .venv/bin/python -m pytest tests/regression/ \
             -m "requires_postgres or requires_mysql or requires_redis or requires_docker or integration or e2e" \
-            --maxfail=10 -v -p no:xdist --timeout=300 -rs --durations=25
+            --maxfail=10 -v -p no:xdist --timeout=300 --timeout-method=signal \
+            -rs --durations=25

--- a/conftest.py
+++ b/conftest.py
@@ -59,14 +59,27 @@ def pytest_configure(config):
     Runs before collection, so the ``dotenv.load_dotenv`` monkeypatch is active
     before any nested conftest / test module imports and re-injects a secret.
 
-    Also degrades ``pytest.ini``'s ``timeout_method = signal`` back to
-    ``thread`` where SIGALRM does not exist (Windows). Signal is the correct
-    default everywhere it works — a thread-method timeout cannot kill a test
-    blocked in a C call, which is what made two #2081 CI runs unreadable — but
-    setting it in the ini unconditionally would hard-break a Windows
-    contributor, and pytest-timeout does not support a platform conditional.
-    An explicit ``--timeout-method=`` on the command line still wins, because
-    this only ever tightens the unsupported case.
+    Also degrades a requested ``timeout_method = signal`` back to ``thread``
+    where SIGALRM does not exist (Windows).
+
+    This guard is DEFENSIVE, and its trigger is the command line, not the ini
+    (issue #2081). Verified with ``config.getini("timeout")``: root
+    ``pytest.ini`` carries ``timeout`` and ``timeout_method`` inside a
+    ``[pytest:local]`` section, and pytest reads ONLY ``[pytest]`` — so both
+    are dead letters and neither reaches pytest-timeout. What DOES reach it is
+    ``--timeout-method=signal``, which the two root-regression CI steps pass
+    explicitly.
+
+    Why it has to exist at all: pytest-timeout has NO fallback for a missing
+    SIGALRM. Its only coercion is signal -> thread off the main thread; with
+    ``method="signal"`` and any active timeout on a platform without SIGALRM,
+    ``pytest_timeout_set_timer`` reaches ``signal.signal(signal.SIGALRM, ...)``
+    and the run dies with ``INTERNALERROR ... AttributeError: module 'signal'
+    has no attribute 'SIGALRM'`` before a single test executes. Reproduced
+    directly, not inferred.
+
+    An explicit ``--timeout-method=thread`` still wins, because this only ever
+    tightens the unsupported case.
     """
     install_cost_guard(Path(__file__).parent / ".env")
 

--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,8 @@ model rather than an expensive default.
 """
 
 import os
+import signal
+import warnings
 from pathlib import Path
 
 import pytest
@@ -56,8 +58,30 @@ def pytest_configure(config):
 
     Runs before collection, so the ``dotenv.load_dotenv`` monkeypatch is active
     before any nested conftest / test module imports and re-injects a secret.
+
+    Also degrades ``pytest.ini``'s ``timeout_method = signal`` back to
+    ``thread`` where SIGALRM does not exist (Windows). Signal is the correct
+    default everywhere it works — a thread-method timeout cannot kill a test
+    blocked in a C call, which is what made two #2081 CI runs unreadable — but
+    setting it in the ini unconditionally would hard-break a Windows
+    contributor, and pytest-timeout does not support a platform conditional.
+    An explicit ``--timeout-method=`` on the command line still wins, because
+    this only ever tightens the unsupported case.
     """
     install_cost_guard(Path(__file__).parent / ".env")
+
+    if not hasattr(signal, "SIGALRM") and (
+        getattr(config.option, "timeout_method", None) == "signal"
+    ):
+        config.option.timeout_method = "thread"
+        warnings.warn(
+            "pytest-timeout: SIGALRM is unavailable on this platform, so the "
+            "configured `timeout_method = signal` has been degraded to "
+            "`thread`. A thread-method timeout can REPORT a hung test but "
+            "cannot kill one blocked in a C call (issue #2081).",
+            RuntimeWarning,
+            stacklevel=1,
+        )
 
 
 def pytest_collection_finish(session):

--- a/pytest.ini
+++ b/pytest.ini
@@ -91,17 +91,7 @@ asyncio_default_fixture_loop_scope = function
 # Integration tests: 5 seconds max (target: 1-2 seconds)
 # E2E tests: 10 seconds max (target: 3-5 seconds)
 timeout = 10
-# signal (SIGALRM), not thread — issue #2081. A thread-method timeout CANNOT
-# kill a test blocked in a C call: it can only observe and report, so pytest-
-# timeout printed its banner repeatedly while the process carried on to the
-# job cap. Two CI runs consumed 15 and 40 minutes and produced no per-test
-# output at all because of it. SIGALRM interrupts the blocked call, so a hung
-# test FAILS and names itself. Measured cost on a healthy run: ~3% wall clock
-# (1916 tests, 210.56s thread vs 217.79s signal).
-#
-# SIGALRM is POSIX-only. The root conftest.py flips this back to `thread` on
-# platforms without it (Windows), so this line is safe to set unconditionally.
-timeout_method = signal
+timeout_method = thread
 
 # Log settings (local only)
 log_cli = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -91,7 +91,17 @@ asyncio_default_fixture_loop_scope = function
 # Integration tests: 5 seconds max (target: 1-2 seconds)
 # E2E tests: 10 seconds max (target: 3-5 seconds)
 timeout = 10
-timeout_method = thread
+# signal (SIGALRM), not thread — issue #2081. A thread-method timeout CANNOT
+# kill a test blocked in a C call: it can only observe and report, so pytest-
+# timeout printed its banner repeatedly while the process carried on to the
+# job cap. Two CI runs consumed 15 and 40 minutes and produced no per-test
+# output at all because of it. SIGALRM interrupts the blocked call, so a hung
+# test FAILS and names itself. Measured cost on a healthy run: ~3% wall clock
+# (1916 tests, 210.56s thread vs 217.79s signal).
+#
+# SIGALRM is POSIX-only. The root conftest.py flips this back to `thread` on
+# platforms without it (Windows), so this line is safe to set unconditionally.
+timeout_method = signal
 
 # Log settings (local only)
 log_cli = true

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -425,6 +425,172 @@ class HealthCheckResult:
             self.checked_at = datetime.now()
 
 
+# =============================================================================
+# Single-flight pool disposal (issue #2079)
+# =============================================================================
+#
+# Every ``disconnect()`` / ``close()`` in this module used to read its backing
+# handle, await the driver's close, and null the handle AFTERWARDS:
+#
+#     if self._pool:                 # <- N concurrent callers all pass here
+#         await self._pool.close()
+#         self._pool = None
+#
+# With a SHARED adapter (``_shared_pools`` hands one adapter to every node on
+# the same DSN + loop) N tasks enter the driver close simultaneously while the
+# other N-1 still have queries in flight. For asyncpg that is unrecoverable:
+# ``Pool._check_init`` gates on ``_closed``, which ``Pool.close()`` only sets
+# in its ``finally``, so ``acquire()`` keeps succeeding for the whole duration
+# of a close. A holder released past ``wait_until_released()`` is re-acquired
+# by another task, then ``PoolConnectionHolder.close()`` runs against a
+# connection with a live query -> ``_request_cancel()`` -> protocol state 3
+# (PROTOCOL_CANCELLED) -> ``InternalClientError: got result for unknown
+# protocol state 3``. The stranded ``await self._con.close()`` inside
+# ``PoolConnectionHolder.close()`` is then waiting on a server acknowledgement
+# that can never arrive, and the whole event loop parks forever.
+#
+# The fix is two-part and both parts are load-bearing:
+#
+#   1. CLAIM-THEN-CLOSE. Bind the handle to a local and null the attribute
+#      BEFORE awaiting, so exactly one caller ever drives the driver close.
+#      Losers wait on the winner's completion instead of starting a second one.
+#   2. BOUND THE GRACEFUL CLOSE. asyncpg's own ``Pool.close()`` docstring says
+#      "it is advisable to use asyncio.wait_for() to set a timeout"; on expiry
+#      escalate to the driver's forced, non-blocking terminate. This is the
+#      backstop for a connection already wedged by some other cause.
+#
+# Losers await a SEPARATE future rather than the winner's task: in-tree callers
+# wrap ``disconnect()`` in their own ``asyncio.wait_for(..., timeout=1.0)``, and
+# cancelling a loser must never cancel the winner's in-flight close.
+
+# Attribute holding ``(loop, future)`` for a disposal currently in flight on an
+# adapter/pool object, or None. Set on the instance, never a class attribute.
+_DISPOSAL_IN_FLIGHT_ATTR = "_kailash_disposal_in_flight"
+
+
+@contextlib.asynccontextmanager
+async def _disposal_barrier(owner: Any) -> AsyncIterator[None]:
+    """Publish a completion future for the duration of ``owner``'s disposal.
+
+    The winning caller holds this scope while it drives the driver close.
+    Concurrent callers that find the handle already claimed use
+    :func:`_await_pending_disposal` to wait for the SAME close rather than
+    returning early — which preserves the drain-barrier contract the bridge
+    teardown in ``kailash.utils.loop_pool_registry`` depends on (issue #1572).
+
+    The future is resolved in ``finally``, so a disposal that RAISES still
+    releases every waiter instead of stranding them.
+    """
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    setattr(owner, _DISPOSAL_IN_FLIGHT_ATTR, (loop, future))
+    try:
+        yield
+    finally:
+        if getattr(owner, _DISPOSAL_IN_FLIGHT_ATTR, None) == (loop, future):
+            setattr(owner, _DISPOSAL_IN_FLIGHT_ATTR, None)
+        if not future.done():
+            future.set_result(None)
+
+
+async def _await_pending_disposal(owner: Any) -> None:
+    """Wait for a disposal another task already started on ``owner``.
+
+    Returns immediately when there is nothing in flight, or when the in-flight
+    disposal belongs to a DIFFERENT event loop: a future is loop-bound, and a
+    pool owned by another live loop is not this loop's to drain (issue #1248).
+
+    ``asyncio.shield`` is required, not optional. In-tree callers bound
+    ``disconnect()`` with their own ``asyncio.wait_for(..., timeout=1.0)``;
+    without the shield, that timeout cancelling a WAITER would propagate into
+    the winner's completion future and abandon the real close half-done.
+    """
+    pending = getattr(owner, _DISPOSAL_IN_FLIGHT_ATTR, None)
+    if pending is None:
+        return
+    loop, future = pending
+    if future.done():
+        return
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    if running is not loop:
+        return
+    await asyncio.shield(future)
+
+
+def _force_close_pool(force: Optional[Callable[[], Any]], label: str) -> None:
+    """Invoke a driver's forced-close callable, never raising out of teardown.
+
+    Failure here is logged at WARNING with the reason — never swallowed. There
+    is no recovery beyond this point: the graceful close already failed and the
+    forced close is the last disposition available, so the correct action is to
+    surface it and let teardown continue rather than crash the caller's unwind.
+    """
+    if force is None:
+        return
+    try:
+        force()
+    except Exception as exc:  # noqa: BLE001 - last-resort teardown, see docstring
+        # ``Pool.terminate()`` calls ``_check_init()``, which raises
+        # ``InterfaceError('pool is not initialized')`` when ``create_pool``
+        # failed mid-init. That is a real state, not a bug — log and move on.
+        logger.warning(
+            "async_sql.pool_force_close_failed: could not terminate %s: %s",
+            label,
+            exc,
+        )
+
+
+async def _close_pool_bounded(
+    close_awaitable: Any,
+    *,
+    force: Optional[Callable[[], Any]] = None,
+    label: str,
+    timeout: Optional[float] = None,
+) -> None:
+    """Await a driver pool close under a bound, escalating to ``force``.
+
+    Args:
+        close_awaitable: The driver's graceful-close awaitable, already called.
+        force: The driver's forced, non-blocking close (``Pool.terminate``).
+        label: Human-readable pool identity for the log line. MUST NOT contain
+            a DSN or connection string (``rules/security.md`` § no secrets in
+            logs) — pass ``redact_pool_key(...)`` output or an ``id()``.
+        timeout: Seconds to allow the graceful close. Defaults to
+            ``_POOL_DEFAULTS["close_timeout"]``.
+    """
+    if timeout is None:
+        timeout = float(_POOL_DEFAULTS["close_timeout"])
+    try:
+        await asyncio.wait_for(close_awaitable, timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "async_sql.pool_close_timeout: graceful close of %s did not "
+            "complete within %.1fs; escalating to forced termination. A "
+            "connection whose protocol state was corrupted by a concurrent "
+            "close never acknowledges a graceful close (issue #2079).",
+            label,
+            timeout,
+        )
+        _force_close_pool(force, label)
+    except asyncio.CancelledError:
+        # A caller-side ``wait_for`` cancelled us. The pool handle is already
+        # claimed and unreachable, so terminating is the only disposition that
+        # does not leak the sockets. Re-raised — cancellation is never absorbed.
+        _force_close_pool(force, label)
+        raise
+    except Exception as exc:  # noqa: BLE001 - see _force_close_pool docstring
+        logger.warning(
+            "async_sql.pool_close_failed: graceful close of %s raised %s; "
+            "escalating to forced termination",
+            label,
+            exc,
+        )
+        _force_close_pool(force, label)
+
+
 class CircuitBreakerState(Enum):
     """Circuit breaker states for connection management."""
 
@@ -616,8 +782,27 @@ class EnterpriseConnectionPool:
         )
 
     async def initialize(self) -> None:
-        """Initialize the connection pool."""
+        """Initialize the connection pool.
+
+        Refuses once ``close()`` has been entered. Issue #2079: ``close()``
+        nulls ``_pool``/``_adapter`` before awaiting the driver close, and
+        ``get_connection()`` treats ``_pool is None`` as "not yet initialized"
+        — so without this gate a task racing teardown would build a BRAND NEW
+        adapter and pool during shutdown, resurrecting the very pool being
+        disposed. ``_shutdown`` was already set by ``close()`` and read by the
+        background loops; this makes it fail closed on the creation path too.
+        """
+        if self._shutdown:
+            raise ConnectionError(
+                f"Pool '{self.pool_id}' is shutting down and cannot be "
+                "re-initialized; construct a new pool instead"
+            )
         async with self._lock:
+            if self._shutdown:
+                raise ConnectionError(
+                    f"Pool '{self.pool_id}' is shutting down and cannot be "
+                    "re-initialized; construct a new pool instead"
+                )
             if self._adapter is None:
                 self._adapter = self.adapter_class(self.database_config)
                 await self._adapter.connect()
@@ -641,6 +826,14 @@ class EnterpriseConnectionPool:
         """Get a connection from the pool with circuit breaker protection."""
         if not self._circuit_breaker.can_execute():
             raise ConnectionError(f"Circuit breaker is open for pool '{self.pool_id}'")
+
+        # Fail closed once teardown has begun (issue #2079). Without this, the
+        # `_pool is None` branch below reads as "not yet initialized" during a
+        # close and silently builds a replacement pool mid-shutdown.
+        if self._shutdown:
+            raise ConnectionError(
+                f"Pool '{self.pool_id}' is shutting down; no new connections"
+            )
 
         try:
             if self._pool is None:
@@ -990,12 +1183,19 @@ class EnterpriseConnectionPool:
             except asyncio.CancelledError:
                 pass
 
-        # Close adapter and pool
-        if self._adapter:
-            await self._adapter.disconnect()
-            self._adapter = None
-
+        # Close adapter and pool. Claim BEFORE awaiting (issue #2079): this is
+        # the MIDDLE of three nested guards that all had the same
+        # check-await-null shape, and it is the one that admitted every
+        # concurrent caller into the adapter's own disconnect().
+        adapter = self._adapter
         self._pool = None
+        if adapter is None:
+            await _await_pending_disposal(self)
+            logger.info(f"Pool '{self.pool_id}' closed successfully")
+            return
+        self._adapter = None
+        async with _disposal_barrier(self):
+            await adapter.disconnect()
         logger.info(f"Pool '{self.pool_id}' closed successfully")
 
 
@@ -1328,12 +1528,32 @@ class PostgreSQLAdapter(DatabaseAdapter):
         register_pool_drain_on_current_loop(self.disconnect)
 
     async def disconnect(self) -> None:
-        """Close connection pool (idempotent)."""
-        if self._pool:
-            await self._pool.close()
-            # Null the pool so a later cleanup()/bridge-drain double-close is a
-            # guarded no-op (issue #1572).
-            self._pool = None
+        """Close connection pool (idempotent, single-flight).
+
+        Claims the pool BEFORE awaiting the driver close, so N concurrent
+        callers on a shared adapter drive exactly ONE ``asyncpg.Pool.close()``
+        instead of N overlapping ones. Overlapping closes corrupt the asyncpg
+        protocol state and strand ``PoolConnectionHolder.close()`` forever
+        (issue #2079); see § "Single-flight pool disposal" above.
+
+        Nulling BEFORE the await also keeps the double-close guard that
+        issue #1572 added — it just closes the window a concurrent caller can
+        slip through, rather than leaving it open for the whole close.
+        """
+        pool = self._pool
+        if pool is None:
+            # Either never connected, or another task is mid-disposal. Wait for
+            # that one so this call still returns a disposed pool (the bridge
+            # drain in issue #1572 relies on disconnect() being a barrier).
+            await _await_pending_disposal(self)
+            return
+        self._pool = None
+        async with _disposal_barrier(self):
+            await _close_pool_bounded(
+                pool.close(),
+                force=getattr(pool, "terminate", None),
+                label=f"postgresql pool {id(pool)}",
+            )
 
     async def execute(
         self,
@@ -1667,9 +1887,36 @@ class PostgreSQLAdapter(DatabaseAdapter):
         needs (e.g. the serialization failure it keys a retry on); asyncpg
         already terminates + reclaims the pool slot on a release error, so
         logging is the correct disposition (issue #1580 redteam LOW).
+
+        Issue #2079: the pool may already be GONE. ``disconnect()`` claims
+        ``self._pool`` before awaiting the driver close, so a task still
+        holding a connection when disposal starts finds ``self._pool is None``.
+        Reaching through it raised an opaque
+        ``AttributeError: 'NoneType' object has no attribute 'release'`` and
+        left the connection with no disposition at all. Terminate it instead:
+        the owning pool is being torn down, so returning the connection to it
+        is meaningless, and ``terminate()`` is sync and safe on an
+        already-dead connection.
         """
+        pool = self._pool
+        if pool is None:
+            logger.warning(
+                "async_sql.postgresql.pool_released_after_close: connection "
+                "returned after its pool was disposed; terminating it "
+                "directly (issue #2079)"
+            )
+            terminate = getattr(conn, "terminate", None)
+            if terminate is not None:
+                try:
+                    terminate()
+                except Exception:
+                    logger.warning(
+                        "async_sql.postgresql.orphan_terminate_failed",
+                        exc_info=True,
+                    )
+            return
         try:
-            await self._pool.release(conn)
+            await pool.release(conn)
         except Exception:
             logger.error("async_sql.postgresql.pool_release_failed", exc_info=True)
 
@@ -1759,13 +2006,26 @@ class MySQLAdapter(DatabaseAdapter):
         register_pool_drain_on_current_loop(self.disconnect)
 
     async def disconnect(self) -> None:
-        """Close connection pool (idempotent)."""
-        if self._pool:
-            self._pool.close()
-            await self._pool.wait_closed()
-            # Null the pool so a later cleanup()/bridge-drain double-close is a
-            # guarded no-op (issue #1572).
-            self._pool = None
+        """Close connection pool (idempotent, single-flight).
+
+        Same claim-then-close + bounded-graceful-close contract as
+        ``PostgreSQLAdapter.disconnect`` (issue #2079). aiomysql's
+        ``wait_closed()`` has the same unbounded-wait shape as asyncpg's
+        ``Pool.close()``, so it gets the same bound. aiomysql exposes the
+        forced variant as ``terminate()``.
+        """
+        pool = self._pool
+        if pool is None:
+            await _await_pending_disposal(self)
+            return
+        self._pool = None
+        async with _disposal_barrier(self):
+            pool.close()  # sync: marks the pool closing, does not wait
+            await _close_pool_bounded(
+                pool.wait_closed(),
+                force=getattr(pool, "terminate", None),
+                label=f"mysql pool {id(pool)}",
+            )
 
     async def execute(
         self,
@@ -2146,18 +2406,37 @@ class SQLiteAdapter(DatabaseAdapter):
         return conn
 
     async def disconnect(self) -> None:
-        """Close pool and connections."""
-        if self._pool is not None:
-            await self._pool.close()
+        """Close pool and connections (idempotent, single-flight).
+
+        Same claim-then-close + bounded-graceful-close contract as
+        ``PostgreSQLAdapter.disconnect`` (issue #2079). aiosqlite has no
+        forced-close primitive, so there is no ``force`` escalation here — the
+        bound alone converts an unbounded wait into a logged abandonment.
+        """
+        pool = self._pool
+        if pool is not None:
             self._pool = None
+            async with _disposal_barrier(self):
+                await _close_pool_bounded(
+                    pool.close(),
+                    label=f"sqlite pool {id(pool)}",
+                )
+        else:
+            await _await_pending_disposal(self)
         # Issue #1051: close the reused :memory: connection (untracked by the
         # pool path, which is None for :memory:). Without this it survives to
         # GC and aiosqlite.Connection.__del__ emits a ResourceWarning.
-        if self._connection is not None:
-            try:
-                await self._connection.close()
-            finally:
-                self._connection = None
+        connection = self._connection
+        if connection is not None:
+            # Claim before awaiting, for the same reason the pool is claimed:
+            # aiosqlite's Connection.close() joins its worker THREAD, and two
+            # concurrent joins on one connection is the same overlapping-close
+            # hazard one layer down (issue #2079).
+            self._connection = None
+            await _close_pool_bounded(
+                connection.close(),
+                label=f"sqlite connection {id(connection)}",
+            )
 
     async def execute(
         self,
@@ -2867,12 +3146,23 @@ class ProductionPostgreSQLAdapter(PostgreSQLAdapter):
         )
 
     async def disconnect(self) -> None:
-        """Disconnect enterprise pool."""
-        if self._enterprise_pool:
-            await self._enterprise_pool.close()
-            self._enterprise_pool = None
-        else:
+        """Disconnect enterprise pool (idempotent, single-flight).
+
+        This is the OUTERMOST of three nested guards that all shared the same
+        check-await-null shape, and the one that admitted every concurrent
+        caller in issue #2079's reproduction: ``_get_adapter`` hands one
+        ``ProductionPostgreSQLAdapter`` to every node on the same DSN + loop,
+        so 50 tasks calling ``disconnect()`` all saw a truthy
+        ``_enterprise_pool`` and all descended into the driver close together.
+        """
+        pool = self._enterprise_pool
+        if pool is None:
+            await _await_pending_disposal(self)
             await super().disconnect()
+            return
+        self._enterprise_pool = None
+        async with _disposal_barrier(self):
+            await pool.close()
 
 
 class ProductionMySQLAdapter(MySQLAdapter):
@@ -2949,12 +3239,21 @@ class ProductionMySQLAdapter(MySQLAdapter):
         )
 
     async def disconnect(self) -> None:
-        """Disconnect enterprise pool."""
-        if self._enterprise_pool:
-            await self._enterprise_pool.close()
-            self._enterprise_pool = None
-        else:
+        """Disconnect enterprise pool (idempotent, single-flight).
+
+        Same claim-then-close contract as
+        ``ProductionPostgreSQLAdapter.disconnect`` (issue #2079). Swept in the
+        same change because a fix applied to only the dialect that reproduced
+        leaves the identical defect shipping on every other dialect.
+        """
+        pool = self._enterprise_pool
+        if pool is None:
+            await _await_pending_disposal(self)
             await super().disconnect()
+            return
+        self._enterprise_pool = None
+        async with _disposal_barrier(self):
+            await pool.close()
 
 
 class ProductionSQLiteAdapter(SQLiteAdapter):
@@ -3051,11 +3350,19 @@ class ProductionSQLiteAdapter(SQLiteAdapter):
         )
 
     async def disconnect(self) -> None:
-        """Disconnect enterprise pool."""
+        """Disconnect enterprise pool (idempotent, single-flight).
+
+        Same claim-then-close contract as
+        ``ProductionPostgreSQLAdapter.disconnect`` (issue #2079).
+        """
         try:
-            if self._enterprise_pool:
-                await self._enterprise_pool.close()
+            pool = self._enterprise_pool
+            if pool is None:
+                await _await_pending_disposal(self)
+            else:
                 self._enterprise_pool = None
+                async with _disposal_barrier(self):
+                    await pool.close()
         finally:
             # Issue #1051: ProductionSQLiteAdapter inherits SQLiteAdapter's
             # _get_connection()/begin_transaction(), so the :memory:
@@ -3339,11 +3646,21 @@ _PROCESS_POOL_REGISTRY: "weakref.WeakValueDictionary[str, Any]" = (
 # Lifecycle defaults. ``idle_timeout`` is the seconds-of-no-activity a pool
 # may sit before the reaper closes it. ``max_pool_count_per_process`` is the
 # hard ceiling that turns the silent-fallback bug into a typed
-# ``PoolExhaustedError``. Both values are int-positive; the validator in
-# ``set_pool_defaults`` enforces this.
+# ``PoolExhaustedError``. ``close_timeout`` bounds the GRACEFUL driver close
+# in ``disconnect()`` before it escalates to a forced terminate (issue #2079).
+# All values are int-positive; the validator in ``set_pool_defaults``
+# enforces this.
+#
+# 5 s mirrors ``kailash.utils.loop_pool_registry._DRAIN_TIMEOUT_SECONDS``,
+# which bounds the same operation one layer out. It is a BACKSTOP: every
+# in-tree caller of ``disconnect()`` already wraps it in its own
+# ``asyncio.wait_for`` (1.0-2.0 s), so this bound only ever fires for the
+# UNBOUNDED callers — the bridge drain and direct user/DataFlow
+# ``adapter.disconnect()`` calls.
 _POOL_DEFAULTS: dict[str, int] = {
     "idle_timeout": 300,
     "max_pool_count_per_process": 100,
+    "close_timeout": 5,
 }
 
 # Reaper task registry — one task per event loop, keyed on
@@ -3364,6 +3681,7 @@ def set_pool_defaults(
     *,
     idle_timeout: Optional[int] = None,
     max_pool_count_per_process: Optional[int] = None,
+    close_timeout: Optional[int] = None,
 ) -> None:
     """Configure process-wide pool lifecycle defaults (DPI-B2 / issue #697).
 
@@ -3384,6 +3702,12 @@ def set_pool_defaults(
             ``_get_adapter`` fallback raises ``PoolExhaustedError``
             instead of silently creating yet another pool. Must be a
             positive int. Default 100.
+        close_timeout: Seconds ``disconnect()`` waits for the driver's
+            GRACEFUL pool close before escalating to a forced terminate
+            (issue #2079). Must be a positive int. Default 5 s. Raise it
+            for a deployment that legitimately holds connections open
+            across long-running statements; a raised value only delays the
+            escalation, it never removes the bound.
 
     Raises:
         TypeError: If an unknown keyword argument is supplied (the
@@ -3408,11 +3732,18 @@ def set_pool_defaults(
                 "max_pool_count_per_process must be a positive int "
                 f"(got {max_pool_count_per_process!r})"
             )
+    if close_timeout is not None:
+        if not isinstance(close_timeout, int) or close_timeout < 1:
+            raise ValueError(
+                f"close_timeout must be a positive int (got {close_timeout!r})"
+            )
     with _POOL_DEFAULTS_LOCK:
         if idle_timeout is not None:
             _POOL_DEFAULTS["idle_timeout"] = idle_timeout
         if max_pool_count_per_process is not None:
             _POOL_DEFAULTS["max_pool_count_per_process"] = max_pool_count_per_process
+        if close_timeout is not None:
+            _POOL_DEFAULTS["close_timeout"] = close_timeout
 
 
 def _reset_pool_defaults_for_tests() -> None:
@@ -3426,6 +3757,7 @@ def _reset_pool_defaults_for_tests() -> None:
     with _POOL_DEFAULTS_LOCK:
         _POOL_DEFAULTS["idle_timeout"] = 300
         _POOL_DEFAULTS["max_pool_count_per_process"] = 100
+        _POOL_DEFAULTS["close_timeout"] = 5
 
 
 # ============================================================================
@@ -3440,14 +3772,40 @@ def _reset_pool_defaults_for_tests() -> None:
 # ============================================================================
 
 
+def _idle_target(entry: Any) -> Any:
+    """Return the object carrying ``entry``'s idle clock, or None.
+
+    ``_PROCESS_POOL_REGISTRY`` stores ADAPTERS (``_PROCESS_POOL_REGISTRY[key]
+    = self._adapter`` at the three insertion sites), but ``is_idle()`` and the
+    ``_last_activity_at`` it reads are defined on ``EnterpriseConnectionPool``,
+    which the production adapters hold as ``_enterprise_pool``.
+
+    Issue #2079: the reaper used to test ``hasattr(entry, "is_idle")``
+    directly, which is False for EVERY adapter the registry can contain — so
+    the DPI-B3 idle-pool reaper walked the registry and skipped 100% of it.
+    It ran, logged nothing, and reaped nothing. ``test_idle_pools_reaped``
+    pins this and had never executed in CI (issue #2002).
+
+    Returns None when no idle clock is reachable — a bare fallback adapter
+    with no enterprise pool, which is genuinely not reapable on this path.
+    """
+    if callable(getattr(entry, "is_idle", None)):
+        return entry
+    enterprise = getattr(entry, "_enterprise_pool", None)
+    if enterprise is not None and callable(getattr(enterprise, "is_idle", None)):
+        return enterprise
+    return None
+
+
 async def _idle_pool_reaper_loop() -> None:
     """Background task that closes idle pools (DPI-B3).
 
     Runs forever (until cancelled). Each iteration:
         1. Sleeps for ``idle_timeout / 4`` seconds (max 75s default).
         2. Walks ``_PROCESS_POOL_REGISTRY`` keys (snapshot list).
-        3. For each pool whose ``is_idle()`` is True, calls
-           ``await pool.close()`` and pops it from the registry.
+        3. Resolves each entry's idle clock via :func:`_idle_target`, and for
+           every entry that reports idle, disposes it (``disconnect()`` where
+           available, else ``close()``) and pops it from the registry.
 
     Exits cleanly on ``CancelledError`` (event-loop shutdown). Logs
     every reap event at INFO with a structured log line per
@@ -3467,15 +3825,15 @@ async def _idle_pool_reaper_loop() -> None:
                 items = []
 
             now = time.monotonic()
-            for key, pool in items:
-                # Pools must expose is_idle()/close(); fallback adapter
-                # objects that wrap _shared_pools may not. Skip silently.
+            for key, entry in items:
+                # ``_PROCESS_POOL_REGISTRY`` stores ADAPTERS, and the idle
+                # clock lives on the adapter's EnterpriseConnectionPool —
+                # ``_idle_target`` resolves one to the other (issue #2079).
+                # A registry entry with no resolvable idle clock (a bare
+                # fallback adapter) is skipped, as before.
                 try:
-                    if not hasattr(pool, "is_idle") or not callable(
-                        getattr(pool, "is_idle", None)
-                    ):
-                        continue
-                    if not pool.is_idle(now):
+                    idle_target = _idle_target(entry)
+                    if idle_target is None or not idle_target.is_idle(now):
                         continue
                 except Exception:
                     # Defensive — never let a bad pool break the reaper.
@@ -3483,14 +3841,26 @@ async def _idle_pool_reaper_loop() -> None:
 
                 # Close + reap.
                 try:
-                    if hasattr(pool, "close") and asyncio.iscoroutinefunction(
-                        pool.close
+                    # Reap through ``disconnect()`` where the entry has one:
+                    # closing the EnterpriseConnectionPool directly leaves the
+                    # adapter holding a shut-down pool that every later
+                    # ``get_connection()`` refuses, whereas ``disconnect()``
+                    # nulls it so a subsequent ``connect()`` rebuilds cleanly.
+                    disconnect = getattr(entry, "disconnect", None)
+                    if disconnect is not None and asyncio.iscoroutinefunction(
+                        disconnect
                     ):
-                        await asyncio.wait_for(pool.close(), timeout=5.0)
-                    elif hasattr(pool, "close"):
-                        pool.close()
-                    if hasattr(pool, "_reaped_count"):
-                        pool._reaped_count += 1
+                        await asyncio.wait_for(disconnect(), timeout=5.0)
+                    elif hasattr(entry, "close") and asyncio.iscoroutinefunction(
+                        entry.close
+                    ):
+                        await asyncio.wait_for(entry.close(), timeout=5.0)
+                    elif hasattr(entry, "close"):
+                        entry.close()
+                    # ``_reaped_count`` is a test-visible counter; it lives on
+                    # whichever object carries the idle clock.
+                    if hasattr(idle_target, "_reaped_count"):
+                        idle_target._reaped_count += 1
                     # WeakValueDictionary.pop is safe on missing keys
                     # (raises KeyError; suppress).
                     try:

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -127,6 +127,97 @@ logger = logging.getLogger(__name__)
 # Stores) of ``rules/infrastructure-sql.md`` mandates the bound.
 MAX_CHECKPOINT_LOCKS = 10_000
 
+# Interval, in seconds, between progress WARNINGs while the sync->async bridge
+# thread is still running (issue #2081). This is NOT a deadline: the join keeps
+# waiting, so a legitimately long workflow is never truncated. It only makes a
+# bridge that has stopped making progress SAY SO instead of looking identical
+# to a fast one.
+SYNC_BRIDGE_WATCHDOG_INTERVAL = 60.0
+
+
+def _join_sync_bridge(
+    thread: "threading.Thread",
+    workflow: Any,
+    *,
+    timeout: Optional[float] = None,
+) -> None:
+    """Join the sync->async bridge thread, loudly and (optionally) boundedly.
+
+    ``LocalRuntime.execute()`` called from inside a running event loop routes
+    through ``_execute_sync``, which bridges to async on a worker thread and
+    joins it. That join used to be ``thread.join()`` — no timeout, no output.
+    Exceptions raised inside the thread are captured and re-raised after the
+    join, so a RAISE can never hang the caller; only a BLOCK can, and when it
+    blocked the wait was permanent and completely silent. Three CI runs on
+    issue #2081 produced 15 and 40 minutes of wall clock and zero actionable
+    output because of it.
+
+    Default behaviour is deliberately NOT a deadline. A workflow may
+    legitimately run for hours, and silently truncating one would trade a
+    visible hang for invisible data loss. Instead the join is performed in
+    ``SYNC_BRIDGE_WATCHDOG_INTERVAL`` slices and each expiry logs a WARNING
+    naming the workflow and dumping the bridge thread's stack — which is the
+    difference between an unreadable CI job and a diagnosable one.
+
+    Deployments that DO want a hard bound opt in via
+    ``LocalRuntime(sync_bridge_timeout=...)``; on expiry that raises
+    ``RuntimeExecutionError`` naming the workflow and the bound.
+
+    Args:
+        thread: The started bridge thread.
+        workflow: The workflow being executed (for the log/error message).
+        timeout: Optional hard bound in seconds. ``None`` waits indefinitely
+            while still emitting the periodic WARNING.
+
+    Raises:
+        RuntimeExecutionError: If ``timeout`` is set and elapses.
+    """
+    label = getattr(workflow, "name", None) or f"<workflow {id(workflow)}>"
+    waited = 0.0
+    while True:
+        remaining = (
+            SYNC_BRIDGE_WATCHDOG_INTERVAL
+            if timeout is None
+            else min(SYNC_BRIDGE_WATCHDOG_INTERVAL, max(0.0, timeout - waited))
+        )
+        thread.join(timeout=remaining)
+        if not thread.is_alive():
+            return
+        waited += remaining
+
+        if timeout is not None and waited >= timeout:
+            raise RuntimeExecutionError(
+                f"Workflow '{label}' did not complete within the "
+                f"sync_bridge_timeout of {timeout}s. LocalRuntime.execute() "
+                "was called from inside a running event loop, so execution "
+                "was bridged to a worker thread; that thread is still alive "
+                "and has been abandoned. Its stack is in the WARNING above. "
+                "Raise sync_bridge_timeout, or call the async API "
+                "(execute_workflow_async) to avoid the bridge entirely."
+            )
+
+        logger.warning(
+            "runtime.sync_bridge_slow: workflow %r has been running on the "
+            "sync->async bridge thread %r for %.0fs. The join is NOT bounded "
+            "by default, so this will keep waiting; the stack below says what "
+            "it is waiting on (issue #2081).\n%s",
+            label,
+            thread.name,
+            waited,
+            _format_thread_stack(thread),
+        )
+
+
+def _format_thread_stack(thread: "threading.Thread") -> str:
+    """Render ``thread``'s current stack, or say why it could not be read."""
+    frame = sys._current_frames().get(thread.ident or -1)
+    if frame is None:
+        return "  <stack unavailable: thread has no frame in sys._current_frames()>"
+    import traceback
+
+    return "".join(traceback.format_stack(frame))
+
+
 # Allowlist of exception classes that can be referenced by name in retry config.
 # This replaces the unsafe eval() that was previously used to resolve exception names.
 _EXCEPTION_ALLOWLIST: Dict[str, type] = {
@@ -374,6 +465,8 @@ class LocalRuntime(
         checkpoint_store: Optional[Any] = None,
         checkpoint_after_each_node: bool = False,
         history_store: Optional[Any] = None,
+        # Issue #2081: opt-in hard bound on the sync->async bridge join
+        sync_bridge_timeout: Optional[float] = None,
     ):
         """Initialize the unified runtime.
 
@@ -402,6 +495,20 @@ class LocalRuntime(
             enable_connection_sharing: Whether to enable connection pool sharing across runtime instances.
             max_concurrent_workflows: Maximum number of concurrent workflows in persistent mode.
             connection_pool_size: Default size for connection pools.
+            sync_bridge_timeout: Optional hard bound, in seconds, on the
+                sync->async bridge join (issue #2081). ``execute()`` called
+                from inside a running event loop runs the workflow on a worker
+                thread and waits for it. Default ``None`` waits indefinitely —
+                a workflow may legitimately run for hours, and truncating one
+                would trade a visible hang for silent data loss — but the wait
+                is sliced, so a bridge that has stopped progressing logs a
+                WARNING with its stack every
+                ``SYNC_BRIDGE_WATCHDOG_INTERVAL`` seconds instead of hanging
+                mutely. Set a value to convert that into a
+                ``RuntimeExecutionError`` naming the workflow.
+
+        Raises:
+            ValueError: If ``sync_bridge_timeout`` is set and not positive.
         """
         # Initialize parent classes (BaseRuntime + CycleExecutionMixin)
         # Pass ALL configuration to BaseRuntime for unified initialization
@@ -841,6 +948,15 @@ class LocalRuntime(
         self._checkpoint_store = checkpoint_store
         self._checkpoint_after_each_node = bool(checkpoint_after_each_node)
         self._history_store = history_store
+        # Issue #2081: None keeps the historical wait-forever semantics, but
+        # the join is now sliced so a stuck bridge emits a stack every
+        # SYNC_BRIDGE_WATCHDOG_INTERVAL instead of failing silently.
+        if sync_bridge_timeout is not None and sync_bridge_timeout <= 0:
+            raise ValueError(
+                "sync_bridge_timeout must be a positive number of seconds or "
+                f"None (got {sync_bridge_timeout!r})"
+            )
+        self._sync_bridge_timeout = sync_bridge_timeout
         self._hook_registry = NodeCompletionHookRegistry()
         # W2 auto-subscribe: when a history store is provided, register
         # its record_event coroutine as a hook subscriber so the runtime
@@ -2331,9 +2447,21 @@ class LocalRuntime(
                 if loop:
                     loop.close()
 
-        thread = threading.Thread(target=lambda: _caller_ctx.run(run_in_thread))
+        thread = threading.Thread(
+            target=lambda: _caller_ctx.run(run_in_thread),
+            name=f"kailash-sync-bridge-{getattr(workflow, 'name', None) or id(workflow)}",
+            # daemon=True is required BY the sync_bridge_timeout path, not an
+            # aside (issue #2081). Once that bound expires we abandon a thread
+            # that is still alive; a non-daemon one would then be joined by
+            # ``threading._shutdown`` at interpreter exit, re-creating the
+            # exact unbounded wait the bound exists to remove — just moved to
+            # process teardown where it is even harder to attribute. During
+            # normal execution nothing changes: the join below keeps the
+            # caller (and the process) alive until the workflow finishes.
+            daemon=True,
+        )
         thread.start()
-        thread.join()
+        _join_sync_bridge(thread, workflow, timeout=self._sync_bridge_timeout)
 
         if exception_container:
             raise exception_container[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,16 +186,28 @@ def pytest_collection_modifyitems(config, items):
 
 
 async def check_postgres_connection():
-    """Check if PostgreSQL is available."""
+    """Check if PostgreSQL is available.
+
+    Reads the SAME environment variables as ``tests/utils/docker_config.py``
+    (``DB_HOST`` / ``DB_PORT`` / ``DB_USER`` / ``DB_PASSWORD`` / ``DB_NAME``),
+    falling back to the ``./test-env up`` compose stack's :5434.
+
+    Issue #2079: this probe used to hardcode :5434, and it gates the
+    collection-time skip for EVERY ``requires_postgres`` test. A CI job that
+    publishes Postgres on :5432 — which is what a GitHub Actions service
+    container does — therefore had every one of those tests skipped no matter
+    what it set in ``env:``, and the step reported green built entirely out of
+    skips. That is a check that cannot come out the other way.
+    """
     try:
         import asyncpg
 
         conn = await asyncpg.connect(
-            host="localhost",
-            port=5434,
-            user="test_user",
-            password="test_password",
-            database="kailash_test",
+            host=os.getenv("DB_HOST", "localhost"),
+            port=int(os.getenv("DB_PORT", "5434")),
+            user=os.getenv("DB_USER", "test_user"),
+            password=os.getenv("DB_PASSWORD", "test_password"),
+            database=os.getenv("DB_NAME", "kailash_test"),
             timeout=5,
         )
         await conn.close()

--- a/tests/regression/test_dataflow_pool_bridge.py
+++ b/tests/regression/test_dataflow_pool_bridge.py
@@ -38,8 +38,23 @@ pytestmark = [
 
 @pytest.fixture(autouse=True)
 def _verify_docker_services():
-    """Ensure PostgreSQL Docker service is running before each test."""
-    asyncio.run(ensure_docker_services())
+    """Skip the test if the required services aren't running.
+
+    Issue #2079: this fixture used to call ``ensure_docker_services()`` and
+    DISCARD the result. That helper does not raise — it prints and returns
+    False — so the fixture named "verify" verified nothing, and the tests ran
+    against whatever partial environment happened to be up. On CI that made
+    ``test_failed_ddl_with_warn_mode_still_bounded`` report FAILED, which read
+    as a fixture-phase error but was actually ``[XPASS(strict)]``: the test
+    passed because its #2075 pool leak never fired without the full stack.
+
+    Both sibling files (``test_issue_697_pool_leak.py``,
+    ``test_issue_953_async_sql_pool_tracking.py``) already check the return
+    value; this brings the third into line.
+    """
+    services_ok = asyncio.run(ensure_docker_services())
+    if not services_ok:
+        pytest.skip("Required Docker services not available. Run './test-env up'")
 
 
 @pytest.fixture
@@ -142,15 +157,26 @@ async def test_failed_ddl_does_not_leak_pools_under_saturation(pg_dsn):
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(
-    strict=True,
+    strict=False,
     reason=(
         "#2075: real pool leak on the auto_migrate='warn' DDL-failure path. "
         "Observed pool_count()=9 against a cap of 5, deterministically, in 3 of "
-        "3 consecutive runs against a real Postgres. This test has never run in "
-        "CI (it is one of the files #2002 covers), so the leak shipped "
-        "unnoticed. xfail(strict=True) — NOT skip — so it self-clears LOUDLY "
-        "(XPASS becomes a failure) the moment #2075 is fixed. The assertion is "
-        "unchanged: the bound is correct, the code is wrong."
+        "3 consecutive runs against a real Postgres on macOS via './test-env "
+        "up'. The assertion is DELIBERATELY UNCHANGED: the bound is correct "
+        "and the code is what is wrong.\n\n"
+        "strict=True -> strict=False (#2079). The leak is ENVIRONMENT-"
+        "DEPENDENT, and strict=True therefore turned the environments where it "
+        "does NOT fire into hard CI failures. Measured on Linux against a "
+        "postgres:16 service container: pool_count()=1 with a pre-existing "
+        "table and 0 against a clean database, both against a cap of 5 — i.e. "
+        "the test PASSES there, and strict=True reported that pass as FAILED. "
+        "That is the '#2079 xfail-reported-as-FAILED' discrepancy; it was "
+        "never a fixture-phase error.\n\n"
+        "This trades the loud self-clearing signal for a correct one. The "
+        "signal was not actually working: it can only self-clear in the one "
+        "environment where the premise holds, and it made every other "
+        "environment red. #2075 remains open and is the tracking issue for "
+        "the leak itself."
     ),
 )
 async def test_failed_ddl_with_warn_mode_still_bounded(pg_dsn):

--- a/tests/regression/test_issue_2079_pool_disposal_single_flight.py
+++ b/tests/regression/test_issue_2079_pool_disposal_single_flight.py
@@ -1,0 +1,323 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #2079 / #2081 — pool disposal must not hang.
+
+Every ``disconnect()`` / ``close()`` in ``kailash.nodes.data.async_sql`` used
+the same check-await-null shape::
+
+    if self._pool:                 # <- N concurrent callers all pass here
+        await self._pool.close()
+        self._pool = None
+
+``_shared_pools`` hands ONE adapter to every node on the same DSN + loop, so N
+concurrent ``disconnect()`` calls all entered the driver close while the other
+N-1 tasks still had queries in flight. For asyncpg that is unrecoverable:
+``Pool._check_init`` gates on ``_closed``, which ``Pool.close()`` only sets in
+its ``finally``, so ``acquire()`` keeps succeeding for the whole duration of a
+close. A holder released past ``wait_until_released()`` is re-acquired by
+another task, ``PoolConnectionHolder.close()`` then runs against a connection
+with a live query, and the resulting ``await self._con.close()`` waits forever
+for a server acknowledgement that can never arrive.
+
+Captured from the hung process, ~10 of these pending simultaneously::
+
+    ---- TASK 'Task-633' done=False ----
+      File ".../asyncpg/pool.py", line 268, in close
+        await self._con.close()
+
+with the main thread parked in ``selectors.select``. On CI that consumed the
+whole 30-minute job budget having executed 3 of 22 tests.
+
+The fix is two-part, and each part is pinned separately below:
+
+  1. CLAIM-THEN-CLOSE — bind the handle to a local and null the attribute
+     BEFORE awaiting, so exactly one caller drives the driver close and the
+     rest wait on that same disposal.
+  2. BOUND THE GRACEFUL CLOSE — escalate to the driver's forced terminate on
+     expiry, so a connection already wedged by some other cause cannot park
+     the event loop.
+
+Tier 1 (this module's first three tests) is infra-free and deterministic, so
+it runs in the every-PR regression gate. Tier 2 reproduces the original
+50-concurrent-disposal scenario against a real Postgres.
+
+TIMEOUT MARKERS ARE LOAD-BEARING. Without the fix these tests do not fail —
+they HANG. The marker is what converts the hang into a legible failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from urllib.parse import urlparse
+
+import pytest
+
+from kailash.nodes.data.async_sql import (
+    DatabaseConfig,
+    DatabaseType,
+    PostgreSQLAdapter,
+    set_pool_defaults,
+)
+
+# ``_idle_target`` is imported INSIDE its test, deliberately. It is a symbol
+# this fix introduces, and a module-level import of it turns a pre-fix run of
+# this file into a collection ImportError — which would hide the hang the
+# other tests exist to demonstrate behind an unrelated failure.
+
+pytestmark = [pytest.mark.regression]
+
+PG_DSN = os.environ.get(
+    "TEST_POSTGRES_DSN",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+def _pg_reachable(dsn: str) -> bool:
+    parsed = urlparse(dsn)
+    host, port = parsed.hostname or "localhost", parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Deterministic stand-ins. These are protocol-satisfying objects, NOT mocks:
+# they implement the real asyncpg pool surface the adapter calls, and their
+# behaviour (a graceful close that never completes) is the exact behaviour a
+# protocol-corrupted asyncpg pool exhibits. Nothing is patched or bypassed.
+# ---------------------------------------------------------------------------
+
+
+class _WedgedPool:
+    """A pool whose GRACEFUL close never completes — the observed failure.
+
+    Mirrors ``asyncpg.pool.PoolConnectionHolder.close()`` stranded on
+    ``await self._con.close()``: the coroutine is entered and then waits on a
+    future nothing will ever resolve. ``terminate()`` is the driver's forced,
+    non-blocking variant and DOES complete.
+    """
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.terminate_calls = 0
+        self.close_entered = asyncio.Event()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.close_entered.set()
+        await asyncio.Event().wait()  # never set — waits forever
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+
+class _SlowPool:
+    """A pool whose graceful close completes, but not instantly."""
+
+    def __init__(self, delay: float = 0.25) -> None:
+        self._delay = delay
+        self.close_calls = 0
+        self.terminate_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        await asyncio.sleep(self._delay)
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+
+def _adapter_with_pool(pool: object) -> PostgreSQLAdapter:
+    """Build a real PostgreSQLAdapter around ``pool`` without connecting."""
+    adapter = PostgreSQLAdapter(
+        DatabaseConfig(type=DatabaseType.POSTGRESQL, connection_string=PG_DSN)
+    )
+    adapter._pool = pool
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — the two halves of the fix, deterministic and infra-free
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_disconnect_bounds_a_graceful_close_that_never_completes():
+    """A wedged graceful close MUST NOT park the caller forever.
+
+    PRE-FIX: ``await self._pool.close()`` is unbounded, so this test HANGS and
+    is killed by the timeout marker. POST-FIX: the close is bounded, the
+    driver's ``terminate()`` is the escalation, and ``disconnect()`` returns.
+
+    The default ``close_timeout`` (5 s) is used deliberately rather than
+    ``set_pool_defaults(close_timeout=1)``: that keyword is itself part of this
+    fix, so calling it would make a pre-fix run fail with a ``TypeError`` about
+    the signature INSTEAD of hanging — a different failure, and a much weaker
+    demonstration than the hang this test exists to pin.
+    """
+    pool = _WedgedPool()
+    adapter = _adapter_with_pool(pool)
+
+    started = time.monotonic()
+    await adapter.disconnect()
+    elapsed = time.monotonic() - started
+
+    assert pool.close_calls == 1, "the graceful close must still be attempted first"
+    assert pool.terminate_calls == 1, (
+        "an expired graceful close MUST escalate to the driver's forced "
+        "terminate — otherwise the sockets leak instead of hanging"
+    )
+    assert elapsed < 20, (
+        f"disconnect() took {elapsed:.1f}s against a 5s default close_timeout; "
+        "the bound is not being applied"
+    )
+    assert adapter._pool is None, "the pool handle must be released"
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_concurrent_disconnect_drives_exactly_one_driver_close():
+    """N concurrent ``disconnect()`` calls MUST drive ONE ``Pool.close()``.
+
+    This is the root of #2079. Overlapping ``Pool.close()`` calls are what
+    corrupt the asyncpg protocol state in the first place, so bounding the
+    close without fixing the overlap would only paper over it.
+
+    PRE-FIX: all 50 callers pass the ``if self._pool:`` guard and
+    ``close_calls == 50``. POST-FIX: the first caller claims the handle and
+    ``close_calls == 1``.
+    """
+    pool = _SlowPool(delay=0.25)
+    adapter = _adapter_with_pool(pool)
+
+    await asyncio.gather(*(adapter.disconnect() for _ in range(50)))
+
+    assert pool.close_calls == 1, (
+        f"{pool.close_calls} concurrent driver closes were started; claim-"
+        "then-close is not in effect and the overlap that corrupts the "
+        "asyncpg protocol state is still reachable"
+    )
+    assert pool.terminate_calls == 0, "a healthy close must not escalate"
+    assert adapter._pool is None
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_losing_disconnect_waits_for_the_winner_to_finish():
+    """``disconnect()`` stays a drain BARRIER for every caller, not just one.
+
+    The bridge teardown in ``kailash.utils.loop_pool_registry`` closes the
+    event loop as soon as its drain callables return, so a caller that returned
+    while the real close was still in flight would resurrect the #1572
+    "Unclosed connection" class. Single-flight MUST therefore mean "one close,
+    N waiters" — never "one close, N early returns".
+    """
+    pool = _SlowPool(delay=0.5)
+    adapter = _adapter_with_pool(pool)
+
+    winner = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0.05)  # let the winner claim the handle
+    loser_started = time.monotonic()
+    await adapter.disconnect()
+    loser_elapsed = time.monotonic() - loser_started
+
+    await winner
+    assert pool.close_calls == 1
+    assert loser_elapsed >= 0.2, (
+        f"the losing caller returned after {loser_elapsed:.3f}s while the "
+        "winner's close was still running — disconnect() is no longer a "
+        "barrier and the bridge may close the loop underneath it (#1572)"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_idle_reaper_resolves_the_idle_clock_through_the_adapter():
+    """The DPI-B3 idle reaper MUST be able to see a registered adapter's clock.
+
+    ``_PROCESS_POOL_REGISTRY`` stores ADAPTERS, but ``is_idle()`` lives on
+    ``EnterpriseConnectionPool``. The reaper tested ``hasattr(entry,
+    "is_idle")`` directly, which is False for every adapter the registry can
+    contain — so it walked the registry and skipped 100% of it. The reaper ran,
+    reaped nothing, and reported nothing.
+    """
+    from kailash.nodes.data.async_sql import _idle_target
+
+    class _Clock:
+        def is_idle(self, now=None) -> bool:
+            return True
+
+    class _AdapterWithEnterprisePool:
+        def __init__(self) -> None:
+            self._enterprise_pool = _Clock()
+
+    entry = _AdapterWithEnterprisePool()
+    assert not hasattr(entry, "is_idle"), (
+        "precondition: a registered adapter does NOT expose is_idle directly "
+        "— that is exactly why the direct hasattr() check reaped nothing"
+    )
+    assert _idle_target(entry) is entry._enterprise_pool
+
+    # A bare object with no reachable clock is still skipped, not crashed on.
+    assert _idle_target(object()) is None
+
+    # An object carrying the clock itself resolves to itself.
+    clock = _Clock()
+    assert _idle_target(clock) is clock
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — the original scenario against a real Postgres
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.requires_postgres
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _pg_reachable(PG_DSN), reason=f"Postgres unreachable at {PG_DSN}"
+)
+async def test_fifty_concurrent_disposals_against_real_postgres_complete():
+    """The #2079 reproduction: 50 shared-adapter disposals must terminate.
+
+    This is ``test_issue_697_pool_leak.py::
+    test_pool_count_stays_bounded_under_lock_contention``'s teardown shape,
+    isolated. Pre-fix it hung indefinitely against a real Postgres on Linux
+    (killed at 120s by pytest-timeout); post-fix it completes in under a
+    second.
+    """
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    set_pool_defaults(max_pool_count_per_process=10, idle_timeout=300)
+
+    async def _one_query(i: int) -> None:
+        node = AsyncSQLDatabaseNode(
+            name=f"issue_2079_q_{i}",
+            database_type="postgresql",
+            connection_string=PG_DSN,
+            query="SELECT 1 AS n",
+            validate_queries=False,
+        )
+        try:
+            await node.async_run()
+        finally:
+            # Every task disposes the SHARED adapter — the exact overlap.
+            if node._adapter is not None:
+                await node._adapter.disconnect()
+
+    started = time.monotonic()
+    await asyncio.gather(*(_one_query(i) for i in range(50)), return_exceptions=True)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 60, (
+        f"50 concurrent disposals took {elapsed:.1f}s; pre-fix this never "
+        "returned at all"
+    )
+    assert AsyncSQLDatabaseNode.pool_count() <= 10

--- a/tests/regression/test_issue_2081_sigalrm_degrade_guard.py
+++ b/tests/regression/test_issue_2081_sigalrm_degrade_guard.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #2081 — the root conftest SIGALRM degrade guard.
+
+The two restored root-regression CI steps pass ``--timeout-method=signal``
+explicitly. A thread-method timeout CANNOT kill a test blocked in a C call, so
+signal is the only method that makes a hang fail and name itself — that is what
+made two of the three #2081 CI runs unreadable.
+
+SIGALRM is POSIX-only, and **pytest-timeout has NO fallback of its own for a
+missing SIGALRM**. Its only coercion is signal -> thread when off the main
+thread; with ``method="signal"`` and any active timeout on a platform without
+SIGALRM, ``pytest_timeout_set_timer`` reaches
+``signal.signal(signal.SIGALRM, handler)`` and the run dies before a single
+test executes:
+
+    INTERNALERROR> AttributeError: module 'signal' has no attribute 'SIGALRM'
+    ============================ no tests ran in 0.02s =============================
+
+Root ``conftest.py::pytest_configure`` therefore degrades a requested
+``signal`` back to ``thread`` with a ``RuntimeWarning`` where SIGALRM is
+absent. These tests execute that branch directly rather than asserting it reads
+correctly.
+
+WHY A SUBPROCESS, NOT AN IN-PROCESS IMPORT: root ``conftest.py`` is already
+loaded as a plugin in THIS session, and its ``pytest_configure`` calls
+``install_cost_guard``, which monkeypatches ``dotenv.load_dotenv`` and scrubs
+provider secrets from ``os.environ`` process-wide. Re-driving it in-process
+would mutate the running session. The subprocess also lets us delete
+``signal.SIGALRM`` without affecting this interpreter.
+
+NOTE ON WHY NO WINDOWS JOB COVERS THIS: no workflow this PR touches runs a
+Windows matrix (`trust-plane.yml` is the repo's only `windows-latest` job and
+its `paths:` filter is `src/kailash/trust/**`). These tests are the coverage —
+they simulate the platform condition rather than requiring the platform, which
+is why they run on every Linux CI job instead of none.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.regression]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROOT_CONFTEST = REPO_ROOT / "conftest.py"
+
+
+def _drive_pytest_configure(*, delete_sigalrm: bool, requested: str) -> dict:
+    """Drive root conftest's pytest_configure in a clean subprocess.
+
+    Returns the parsed result dict: the resolved ``timeout_method`` and whether
+    a RuntimeWarning naming SIGALRM was emitted.
+    """
+    script = textwrap.dedent(
+        f"""
+        import importlib.util, json, signal, warnings
+
+        delete_sigalrm = {delete_sigalrm!r}
+        if delete_sigalrm:
+            # Simulate a platform without SIGALRM (Windows).
+            assert hasattr(signal, "SIGALRM"), "precondition: host HAS SIGALRM"
+            del signal.SIGALRM
+        assert hasattr(signal, "SIGALRM") is (not delete_sigalrm)
+
+        spec = importlib.util.spec_from_file_location(
+            "root_conftest_under_test", {str(ROOT_CONFTEST)!r}
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        class _Opt:
+            timeout_method = {requested!r}
+
+        class _Cfg:
+            option = _Opt()
+
+        cfg = _Cfg()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mod.pytest_configure(cfg)
+
+        sigalrm_warnings = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, RuntimeWarning) and "SIGALRM" in str(w.message)
+        ]
+        print(
+            "RESULT_JSON:"
+            + json.dumps(
+                {{
+                    "timeout_method": cfg.option.timeout_method,
+                    "sigalrm_warnings": sigalrm_warnings,
+                }}
+            )
+        )
+        """
+    )
+    env = dict(os.environ)
+    # The repo `src` FIRST — a stale installed wheel otherwise shadows the repo
+    # source and the conftest's own imports fail with an unrelated ImportError.
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT / "src"), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess failed (rc={proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    marker = "RESULT_JSON:"
+    line = next((ln for ln in proc.stdout.splitlines() if ln.startswith(marker)), None)
+    assert line is not None, f"no RESULT_JSON in stdout:\n{proc.stdout}"
+
+    import json as _json
+
+    return _json.loads(line[len(marker) :])
+
+
+@pytest.mark.timeout(180)
+def test_signal_degrades_to_thread_where_sigalrm_is_absent():
+    """The degrade branch EXECUTES — this is the Windows path, simulated.
+
+    Without this guard, ``--timeout-method=signal`` on a no-SIGALRM platform
+    kills the run at the first timed test with
+    ``AttributeError: module 'signal' has no attribute 'SIGALRM'`` and zero
+    tests execute.
+    """
+    result = _drive_pytest_configure(delete_sigalrm=True, requested="signal")
+
+    assert result["timeout_method"] == "thread", (
+        "the SIGALRM degrade branch did NOT fire — a --timeout-method=signal "
+        "invocation on a platform without SIGALRM would die at collection with "
+        "AttributeError before any test ran"
+    )
+    assert result["sigalrm_warnings"], (
+        "the degrade happened SILENTLY — it MUST emit a RuntimeWarning naming "
+        "SIGALRM so the operator knows a thread-method timeout can report a "
+        "hung test but cannot kill one blocked in a C call"
+    )
+    assert "thread" in result["sigalrm_warnings"][0]
+
+
+@pytest.mark.timeout(180)
+def test_signal_is_left_intact_where_sigalrm_exists():
+    """The negative control — the guard MUST NOT degrade on POSIX.
+
+    Without this, a guard that unconditionally returned ``thread`` would pass
+    the test above while silently disabling signal-method timeouts on the very
+    Linux CI runners the #2081 fix depends on.
+    """
+    result = _drive_pytest_configure(delete_sigalrm=False, requested="signal")
+
+    assert result["timeout_method"] == "signal", (
+        "the guard degraded signal -> thread on a platform that HAS SIGALRM; "
+        "that silently removes the only timeout method able to kill a test "
+        "blocked in a C call (#2081)"
+    )
+    assert not result[
+        "sigalrm_warnings"
+    ], "the guard warned on a platform where SIGALRM is available"
+
+
+@pytest.mark.timeout(180)
+def test_an_explicitly_requested_thread_method_is_untouched():
+    """``--timeout-method=thread`` is honored as-is on both platforms."""
+    for delete in (True, False):
+        result = _drive_pytest_configure(delete_sigalrm=delete, requested="thread")
+        assert result["timeout_method"] == "thread"
+        assert not result["sigalrm_warnings"], (
+            "the guard warned about SIGALRM for a request that never asked for "
+            f"the signal method (delete_sigalrm={delete})"
+        )

--- a/tests/regression/test_issue_2081_sync_bridge_join_is_legible.py
+++ b/tests/regression/test_issue_2081_sync_bridge_join_is_legible.py
@@ -1,0 +1,268 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #2081 — the sync->async bridge join must talk.
+
+``LocalRuntime.execute()`` called from inside a running event loop bridges to
+async on a worker thread and joins it. That join was ``thread.join()`` — no
+timeout, no output, ever. Exceptions raised inside the thread are captured and
+re-raised after the join, so a RAISE cannot hang the caller; only a BLOCK can,
+and when it blocked the wait was permanent and completely silent.
+
+That silence is what made #2081 undiagnosable: three CI runs produced 15 and
+40 minutes of wall clock and zero actionable output, because the instrument
+could not distinguish "hung on one test" from "uniformly slower on a small
+runner".
+
+Two properties are pinned here:
+
+  1. The join is SLICED and emits a WARNING naming the workflow and dumping the
+     stuck thread's stack. It still waits — a workflow may legitimately run for
+     hours, and truncating one would trade a visible hang for silent data loss.
+  2. ``sync_bridge_timeout`` converts that into a typed ``RuntimeExecutionError``
+     for deployments that want a hard bound.
+
+These tests drive ``_join_sync_bridge`` against a real ``threading.Thread``
+that genuinely blocks — nothing is patched, and the blocking is the same shape
+as the bridge thread wedged on pool teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+
+import pytest
+
+from kailash.runtime import local as local_runtime
+from kailash.runtime.local import LocalRuntime
+from kailash.sdk_exceptions import RuntimeExecutionError
+
+# ``_join_sync_bridge`` is imported INSIDE the tests that need it. It is a
+# symbol this fix introduces, so a module-level import would turn a pre-fix run
+# of this file into a collection ImportError and hide
+# ``test_a_slow_bridge_is_not_silent_at_the_real_call_site`` — the one test
+# here that demonstrates the DEFECT rather than the new API.
+
+pytestmark = [pytest.mark.regression]
+
+
+class _NamedWorkflow:
+    """Minimal stand-in carrying only what the join reads: a ``name``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _blocked_thread(release: threading.Event) -> threading.Thread:
+    """Start a REAL thread that blocks until ``release`` is set."""
+    thread = threading.Thread(
+        target=release.wait, name="kailash-sync-bridge-test", daemon=True
+    )
+    thread.start()
+    return thread
+
+
+@pytest.mark.timeout(60)
+def test_stuck_bridge_logs_a_warning_naming_the_workflow_and_its_stack(
+    caplog, monkeypatch
+):
+    """A bridge that stops progressing MUST say so, with a stack.
+
+    PRE-FIX: ``thread.join()`` emits nothing at all, forever. POST-FIX: every
+    watchdog interval logs the workflow name and the stuck thread's stack.
+    """
+    from kailash.runtime.local import _join_sync_bridge
+
+    monkeypatch.setattr(local_runtime, "SYNC_BRIDGE_WATCHDOG_INTERVAL", 0.3)
+    release = threading.Event()
+    thread = _blocked_thread(release)
+    workflow = _NamedWorkflow("stuck_workflow")
+
+    def _release_after(delay: float) -> None:
+        time.sleep(delay)
+        release.set()
+
+    releaser = threading.Thread(target=_release_after, args=(1.0,), daemon=True)
+    releaser.start()
+
+    with caplog.at_level(logging.WARNING, logger="kailash.runtime.local"):
+        _join_sync_bridge(thread, workflow, timeout=None)
+    releaser.join(timeout=5)
+
+    warnings = [r for r in caplog.records if "sync_bridge_slow" in r.getMessage()]
+    assert warnings, (
+        "a bridge thread stuck past the watchdog interval produced NO log "
+        "output — this is the #2081 silence that made three CI runs unreadable"
+    )
+    message = warnings[0].getMessage()
+    assert "stuck_workflow" in message, "the log MUST name the workflow"
+    assert (
+        "File " in message or "stack unavailable" in message
+    ), "the log MUST carry the stuck thread's stack, or say why it could not"
+
+
+@pytest.mark.timeout(60)
+def test_join_still_waits_by_default_rather_than_truncating(monkeypatch):
+    """The default MUST NOT be a deadline — a long workflow still completes."""
+    from kailash.runtime.local import _join_sync_bridge
+
+    monkeypatch.setattr(local_runtime, "SYNC_BRIDGE_WATCHDOG_INTERVAL", 0.2)
+    release = threading.Event()
+    thread = _blocked_thread(release)
+
+    def _release_after(delay: float) -> None:
+        time.sleep(delay)
+        release.set()
+
+    releaser = threading.Thread(target=_release_after, args=(0.9,), daemon=True)
+    releaser.start()
+
+    # Several watchdog intervals elapse; the join must still return normally
+    # rather than raising, because no hard bound was configured.
+    _join_sync_bridge(thread, _NamedWorkflow("slow_but_fine"), timeout=None)
+    releaser.join(timeout=5)
+
+    assert not thread.is_alive(), "the join must return only once the bridge is done"
+
+
+@pytest.mark.timeout(60)
+def test_sync_bridge_timeout_raises_a_typed_error_naming_the_workflow(monkeypatch):
+    """The opt-in bound MUST fail with a named, actionable error — not a hang."""
+    from kailash.runtime.local import _join_sync_bridge
+
+    monkeypatch.setattr(local_runtime, "SYNC_BRIDGE_WATCHDOG_INTERVAL", 0.2)
+    release = threading.Event()
+    thread = _blocked_thread(release)
+
+    try:
+        started = time.monotonic()
+        with pytest.raises(RuntimeExecutionError) as excinfo:
+            _join_sync_bridge(thread, _NamedWorkflow("wedged"), timeout=0.6)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert elapsed < 30, f"the bound did not apply; waited {elapsed:.1f}s"
+    text = str(excinfo.value)
+    assert "wedged" in text, "the error MUST name the workflow"
+    assert "sync_bridge_timeout" in text, "the error MUST name the knob to change"
+    assert (
+        "execute_workflow_async" in text
+    ), "the error MUST point at the async API that avoids the bridge entirely"
+
+
+@pytest.mark.timeout(90)
+@pytest.mark.asyncio
+async def test_a_slow_bridge_is_not_silent_at_the_real_call_site(caplog, monkeypatch):
+    """The DEFECT itself, at the real call site, using no new API.
+
+    Every other test in this module exercises symbols the fix introduces, so
+    against unfixed code they fail on an absent name rather than on the
+    behaviour. This one does not: it drives ``LocalRuntime.execute()`` from
+    inside a running loop with a node that outlasts the watchdog interval, and
+    asserts only that the runtime SAID SOMETHING.
+
+    PRE-FIX that assertion fails on an empty log — ``thread.join()`` is
+    completely silent no matter how long the bridge takes, which is the whole
+    reason #2081 needed three CI runs to localise. ``raising=False`` on the
+    monkeypatch is what keeps this test runnable against unfixed code, where
+    the module constant does not exist yet.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    monkeypatch.setattr(
+        local_runtime, "SYNC_BRIDGE_WATCHDOG_INTERVAL", 1.0, raising=False
+    )
+
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "slowpoke",
+        {"code": "import time\ntime.sleep(3)\nresult = {'done': True}"},
+    )
+    workflow = builder.build()
+    workflow.name = "issue_2081_slow_workflow"
+
+    runtime = LocalRuntime()
+    with caplog.at_level(logging.WARNING, logger="kailash.runtime.local"):
+        results, _run_id = runtime.execute(workflow)
+
+    assert results, "the workflow must still complete — this is not a deadline"
+    slow = [r for r in caplog.records if "sync_bridge_slow" in r.getMessage()]
+    assert slow, (
+        "a bridge that ran well past the watchdog interval emitted NOTHING. "
+        "That silence is the #2081 defect: a hung run and a merely-slow run "
+        "are indistinguishable in the log, which is why the first two CI runs "
+        "produced 15 and 40 minutes of wall clock and no actionable output"
+    )
+    assert "issue_2081_slow_workflow" in slow[0].getMessage()
+
+
+@pytest.mark.timeout(90)
+@pytest.mark.asyncio
+async def test_execute_from_inside_a_running_loop_does_not_hang_forever():
+    """The real call site: ``execute()`` from inside a running event loop.
+
+    This is the shape #2081 describes. ``LocalRuntime.execute()`` invoked with
+    a loop already running routes through ``_execute_sync``, which bridges to a
+    worker thread and joins it. With a node that blocks, PRE-FIX this call
+    NEVER RETURNS — the test hangs and is killed by the timeout marker above.
+    POST-FIX the configured bound converts it into a typed error.
+
+    The blocking node genuinely blocks: ``execution_timeout`` in
+    ``kailash.security`` measures elapsed time AFTER the guarded block returns
+    and does not interrupt, so ``time.sleep`` inside a PythonCodeNode holds the
+    bridge thread exactly as a wedged pool teardown would.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    assert asyncio.get_running_loop() is not None  # precondition for the bridge
+
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "blocker",
+        {"code": "import time\ntime.sleep(25)\nresult = {'done': True}"},
+    )
+    workflow = builder.build()
+    workflow.name = "issue_2081_blocking_workflow"
+
+    runtime = LocalRuntime(sync_bridge_timeout=2)
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeExecutionError, match="issue_2081_blocking_workflow"):
+        runtime.execute(workflow)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 20, (
+        f"execute() took {elapsed:.1f}s against a 2s sync_bridge_timeout — the "
+        "bridge join is still unbounded (#2081)"
+    )
+    # The abandoned bridge thread is a daemon, so it cannot wedge interpreter
+    # shutdown once we have given up on it. If it were not, this test would
+    # pass and then hang the whole pytest process at exit for the remaining
+    # ~23s of the node's sleep.
+    bridges = [
+        t
+        for t in threading.enumerate()
+        if t.name.startswith("kailash-sync-bridge-issue_2081")
+    ]
+    assert bridges, "precondition: the abandoned bridge thread is still running"
+    assert all(t.daemon for t in bridges), (
+        "an abandoned bridge thread MUST be a daemon; a non-daemon one is "
+        "joined by threading._shutdown at interpreter exit, which re-creates "
+        "the unbounded wait at process teardown"
+    )
+
+
+def test_sync_bridge_timeout_rejects_a_non_positive_bound():
+    """A zero/negative bound is a configuration error, not a silent no-op."""
+    with pytest.raises(ValueError, match="sync_bridge_timeout"):
+        LocalRuntime(sync_bridge_timeout=0)
+    with pytest.raises(ValueError, match="sync_bridge_timeout"):
+        LocalRuntime(sync_bridge_timeout=-5)
+    # None is the documented default and must remain accepted.
+    assert LocalRuntime(sync_bridge_timeout=None)._sync_bridge_timeout is None

--- a/tests/regression/test_issue_2081_sync_bridge_join_is_legible.py
+++ b/tests/regression/test_issue_2081_sync_bridge_join_is_legible.py
@@ -221,16 +221,23 @@ async def test_execute_from_inside_a_running_loop_does_not_hang_forever():
 
     assert asyncio.get_running_loop() is not None  # precondition for the bridge
 
+    # The sleep is kept SHORT on purpose. PythonCodeNode executes inside
+    # ``kailash.security.memory_limit_guard``, which applies a PROCESS-WIDE
+    # RLIMIT_AS ceiling for the duration of the guarded block. An abandoned
+    # bridge thread therefore holds that ceiling over every test that runs
+    # while it is still sleeping — which is #2078's failure mode, re-created
+    # by this test's own fixture. A 5s sleep against a 1s bound proves the
+    # abandonment with a window this test can then drain.
     builder = WorkflowBuilder()
     builder.add_node(
         "PythonCodeNode",
         "blocker",
-        {"code": "import time\ntime.sleep(25)\nresult = {'done': True}"},
+        {"code": "import time\ntime.sleep(5)\nresult = {'done': True}"},
     )
     workflow = builder.build()
     workflow.name = "issue_2081_blocking_workflow"
 
-    runtime = LocalRuntime(sync_bridge_timeout=2)
+    runtime = LocalRuntime(sync_bridge_timeout=1)
 
     started = time.monotonic()
     with pytest.raises(RuntimeExecutionError, match="issue_2081_blocking_workflow"):
@@ -238,13 +245,12 @@ async def test_execute_from_inside_a_running_loop_does_not_hang_forever():
     elapsed = time.monotonic() - started
 
     assert elapsed < 20, (
-        f"execute() took {elapsed:.1f}s against a 2s sync_bridge_timeout — the "
+        f"execute() took {elapsed:.1f}s against a 1s sync_bridge_timeout — the "
         "bridge join is still unbounded (#2081)"
     )
     # The abandoned bridge thread is a daemon, so it cannot wedge interpreter
-    # shutdown once we have given up on it. If it were not, this test would
-    # pass and then hang the whole pytest process at exit for the remaining
-    # ~23s of the node's sleep.
+    # shutdown once we have given up on it. If it were not, the whole pytest
+    # process would block at exit for the remainder of the node's sleep.
     bridges = [
         t
         for t in threading.enumerate()
@@ -256,6 +262,12 @@ async def test_execute_from_inside_a_running_loop_does_not_hang_forever():
         "joined by threading._shutdown at interpreter exit, which re-creates "
         "the unbounded wait at process teardown"
     )
+    # Drain before returning. The daemon assertion above is what pins the
+    # product behaviour; leaving the thread running would additionally leak
+    # this test's process-wide memory ceiling into whatever runs next.
+    for bridge in bridges:
+        bridge.join(timeout=30)
+        assert not bridge.is_alive(), "abandoned bridge thread failed to drain"
 
 
 def test_sync_bridge_timeout_rejects_a_non_positive_bound():


### PR DESCRIPTION
## Summary

The root regression suite could not complete on the CI runner. Two independent causes; both are now closed, and both removed CI gates are restored.

- **#2081** — the infra-free suite hung on `ubuntu-latest`, 30+ tests, never completing. Root cause was the process-wide `RLIMIT_AS` cap closed by #2078/#2097. **Re-measured on Linux on this branch: it no longer hangs.** All 30 previously-enumerated hangs pass.
- **#2079** — the infra-marked slice hung in DataFlow pool disposal. **Reproduced, root-caused, and fixed here.**

## #2079 — the hang, reproduced and root-caused

Reproduced in a Linux container (Postgres 16 + Redis 7) at `tests/regression/test_issue_697_pool_leak.py::test_pool_count_stays_bounded_under_lock_contention`, in isolation. Captured pending-task dump, ~10 of these at once, with the main thread parked in `selectors.select`:

```
---- TASK 'Task-633' done=False ----
  File ".../asyncpg/pool.py", line 268, in close
    await self._con.close()
Stack for <Task pending name='Task-633' coro=<PoolConnectionHolder.close() running at .../asyncpg/pool.py:268> wait_for=<Future pending ...>>
---- TASK 'Task-3' done=False ----
  File "_taskdump.py", line 38, in _one_query
    await node._adapter.disconnect()
```

Preceding log evidence from the same run:

```
asyncpg.exceptions._base.InternalClientError: got result for unknown protocol state 3
  File "src/kailash/nodes/data/async_sql.py", line 1672, in _release_quietly
    await self._pool.release(conn)
AttributeError: 'NoneType' object has no attribute 'release'
```

**Every `disconnect()`/`close()` in `async_sql.py` read its pool handle, awaited the driver close, and nulled the handle *afterwards*.** `_shared_pools` hands ONE adapter to every node on the same DSN + loop, so N concurrent callers all passed the `if self._pool:` guard and entered the driver close together while the other N−1 still had queries in flight.

For asyncpg that is unrecoverable. `Pool._check_init` gates on `_closed`, which `Pool.close()` only sets in its `finally`, so `acquire()` keeps succeeding for the whole duration of a close: a holder released past `wait_until_released()` is re-acquired by another task, `PoolConnectionHolder.close()` then runs against a connection with a live query → `_request_cancel()` → protocol state 3 → `InternalClientError`, and the stranded `await self._con.close()` waits forever for an acknowledgement that can never arrive.

**Three nested guards had the identical shape** and all had to change — `ProductionPostgreSQLAdapter.disconnect` (the outermost, and the one that actually admitted the 50 callers), `EnterpriseConnectionPool.close`, and `PostgreSQLAdapter.disconnect` — swept across every dialect.

### The fix

1. **Claim-then-close** (the root fix) — bind the handle to a local and null the attribute *before* awaiting, so exactly one caller drives the driver close.
2. **Bound the graceful close**, escalating to the driver's forced `terminate()` — the backstop for a connection already wedged by some other cause, and what asyncpg's own `Pool.close()` docstring advises. Configurable via `set_pool_defaults(close_timeout=…)`, default 5 s.

Losers wait on the winner's completion rather than returning early, so `disconnect()` stays a drain barrier and the bridge teardown cannot close the loop underneath an in-flight close (#1572). They wait on a **shielded** future, never the winner's task: in-tree callers wrap `disconnect()` in their own 1 s `wait_for`, and cancelling a waiter must not abandon the real close half-done.

Two defects the claim *widened*, so they land here too:
- `EnterpriseConnectionPool.get_connection`/`initialize` read `_pool is None` as "not yet initialized" and would have built a replacement pool mid-shutdown → both now fail closed on `_shutdown`.
- `_release_quietly` raised an opaque `AttributeError` off the nulled pool, leaving the orphaned connection with no disposition → it now terminates it and says so.

## Three checks that could not come out the other way

Found while making the infra step actually run. Each made a step green by construction.

1. **The DPI-B3 idle-pool reaper was a complete no-op.** `_PROCESS_POOL_REGISTRY` stores *adapters*; `is_idle()` lives on `EnterpriseConnectionPool`. The reaper tested `hasattr(entry, "is_idle")`, which is False for every entry it can ever hold — it walked the registry and skipped 100% of it, silently. `test_idle_pools_reaped` pins this and had never run in CI.
2. **The root conftest's Postgres probe hardcoded `:5434`.** It gates the collection-time skip for *every* `requires_postgres` test, so a runner publishing `:5432` had all of them skipped no matter what the job set in `env:`.
3. **`test_dataflow_pool_bridge.py`'s autouse `_verify_docker_services` discarded the helper's return value.** The helper prints and returns False rather than raising, so the fixture named "verify" verified nothing. **This is the whole of #2079's "xfail reported as FAILED"**: the test was `[XPASS(strict)]`, never a fixture-phase error.

On (3): the #2075 leak the `xfail(strict=True)` asserts is environment-dependent. Measured on Linux against a `postgres:16` service container: `pool_count()=1` with a pre-existing table, `0` on a clean database — both against a cap of 5. `strict=True` therefore turned every environment where the leak does *not* fire into a hard CI failure. Changed to `strict=False` with the measurements recorded at the marker; the assertion is unchanged and **#2075 stays open**.

## #2081 — the legibility defect

`thread.join()` at `local.py:2336` had no timeout and, more importantly, **no output, ever**. Exceptions inside are captured and re-raised after the join, so a raise could never hang the caller; only a block could, and then the wait was permanent and silent. That is why three CI runs produced 15 and 40 minutes of wall clock and zero actionable output.

The join is now sliced, logging a WARNING with the workflow name and the stuck thread's stack each interval. **The default stays unbounded on purpose** — a workflow may legitimately run for hours, and truncating one would trade a visible hang for invisible data loss. `LocalRuntime(sync_bridge_timeout=…)` opts into a hard bound that raises `RuntimeExecutionError`.

The bridge thread is now a **daemon**, required *by* the bound: once it expires we abandon a live thread, and a non-daemon one would be joined by `threading._shutdown` at interpreter exit — re-creating the same unbounded wait at process teardown.

`pytest.ini` now sets `timeout_method = signal` (#2081 AC#4). A thread-method timeout cannot kill a test blocked in a C call. SIGALRM is POSIX-only, so the root `conftest.py` degrades it back to `thread` with a `RuntimeWarning` where SIGALRM does not exist, rather than hard-breaking a Windows contributor.

## Measurements

All on Linux (aarch64 container, 2-CPU quota), Postgres 16 + Redis 7.

| selection | before | after |
| --- | --- | --- |
| infra-free root regression | hung on CI; 30 hangs enumerated across 8 files, 757 of 1916 executed | `1 failed, 2346 passed, 4 skipped, 23 deselected in 107.64s`, **zero** pytest-timeout hits |
| infra-marked slice | `3 failed, 17 passed` in **131.54s** incl. a 120 s hang (30 min / 3-of-22 on CI) | `20 passed, 3 skipped, 1 xpassed in 12.97s`, **exit 0** |
| `test_issue_2079_…` (new) | `5 failed in 151.21s` — two via pytest-timeout, i.e. genuine hangs | `5 passed in 6.57s` |
| `test_issue_2081_…` (new) | `6 failed` | `6 passed` |

The one remaining infra-free failure is `test_loc_invariants.py::test_base_agent_loc` (**#2119**) — red on main, reproduced identically against unmodified code, and owned by the CI-verification lane. **It will block this restored gate until #2119 lands.**

### On the new tests' discriminating power

For `test_issue_2079_…`, all five fail pre-fix on **behaviour** — `assert 50 == 1` (fifty overlapping driver closes), and two via pytest-timeout, i.e. they genuinely hang.

For `test_issue_2081_…`, five of six fail pre-fix on an **absent symbol**, which proves only that the API is new. `test_a_slow_bridge_is_not_silent_at_the_real_call_site` is the one that demonstrates the *defect*: it uses no new API, drives the real call site, and fails pre-fix on `assert []` — the empty log.

## Not fixed

- **#2075** — the warn-mode pool leak. Does not reproduce in this environment (measured above), so I cannot claim it fixed. Issue stays open; the test still asserts the bound.
- **#2119** — `base_agent.py` at 1068 lines against a 1015 limit. Red on main, out of this shard, owned by the CI-verification lane.
- **Pre-existing isort drift**, 12 files (proven pre-existing: untouched by any commit here, last modified 2026-08-12). CI does not run isort, so it is not a gate. Left alone because one of the files is `base_agent.py`, in flight in another worktree.

## Test plan

- [x] Hang reproduced off-CI in a Linux container (#2081 AC#1, #2079 AC#1) with a captured stack
- [x] Root cause identified in cross-loop pool disposal (#2079 AC#2)
- [x] `xfail`-reported-as-`FAILED` discrepancy resolved (#2079 AC#3)
- [x] Both CI jobs restored (#2081 AC#3, #2079 AC#4)
- [x] `timeout_method` → `signal`, platform-guarded (#2081 AC#4)
- [x] New regression tests fail (by hanging) before the fix and pass after
- [x] `pre-commit run --all-files` green on every file this PR touches

## Related issues

Fixes #2081
Fixes #2079
Unblocks #2002
