### PR TITLE
fix(migration): identity comparison for type objects (ruff E721)

### DIFF
--- a/src/kailash/migration/configuration_validator.py
+++ b/src/kailash/migration/configuration_validator.py
@@ -263,9 +263,14 @@ class ConfigurationValidator:
             if param_name in self.valid_parameters:
                 param_def = self.valid_parameters[param_name]
 
-                # Type validation
+                # Type validation. `is not` rather than `!=`: every value in
+                # `valid_parameters[*]["type"]` is a builtin type object
+                # (`bool`, `int`, `str`, `dict`, `object`), and those are
+                # singletons, so identity is what this comparison always meant
+                # -- `!=` only differs for a metaclass overriding `__eq__`,
+                # which cannot reach this dict (ruff E721).
                 expected_type = param_def["type"]
-                if expected_type != object and not isinstance(
+                if expected_type is not object and not isinstance(
                     param_value, expected_type
                 ):
                     result.issues.append(
@@ -280,7 +285,7 @@ class ConfigurationValidator:
                     )
 
                 # Range validation for integers
-                if expected_type == int and isinstance(param_value, int):
+                if expected_type is int and isinstance(param_value, int):
                     if "min" in param_def and param_value < param_def["min"]:
                         result.issues.append(
                             ValidationIssue(

--- a/src/kailash/migration/regression_detector.py
+++ b/src/kailash/migration/regression_detector.py
@@ -692,7 +692,12 @@ result = {
         differences = []
 
         def compare_recursive(base_obj, curr_obj, path=""):
-            if type(base_obj) != type(curr_obj):
+            # `is not` rather than `!=`: `type()` returns the exact class
+            # object, and classes are singletons, so identity is what this
+            # always meant -- `!=` only differs for a metaclass overriding
+            # `__eq__`, which would make a "type changed" report meaningless
+            # anyway (ruff E721).
+            if type(base_obj) is not type(curr_obj):
                 differences.append(
                     {
                         "path": path,


### PR DESCRIPTION
## Summary

Three `ruff` **E721** findings — `==`/`!=` comparisons against type objects — in `src/kailash/migration/`. Split out of PR #2139 deliberately: they are real, but unrelated to that PR's security work and do not belong in it.

## Why these sat here

`ruff check src tests` on the whole repo reports them; the PR gate never has. The `ruff` pre-commit hook passes **filenames**, so it only ever inspects files a commit already touched — and nothing had touched these two modules since the comparisons were written. That gap is worth recording on its own: **a repo-wide lint finding is invisible to a changed-files-only gate until someone edits the file for an unrelated reason.**

## The change

| Site | Before | After |
| --- | --- | --- |
| `configuration_validator.py:268` | `expected_type != object` | `expected_type is not object` |
| `configuration_validator.py:283` | `expected_type == int` | `expected_type is int` |
| `regression_detector.py:695` | `type(base_obj) != type(curr_obj)` | `type(base_obj) is not type(curr_obj)` |

Safe because every compared value is a builtin type object: `valid_parameters[*]["type"]` is only ever `bool`, `int`, `str`, `dict` or `object` (`configuration_validator.py:71-101`), and `type(obj)` returns the exact class. Those are singletons, so identity is what each comparison always meant; `!=` would differ only for a metaclass overriding `__eq__`, which cannot reach either site.

## Verification

Behaviour checked on **both** branches rather than assumed — a wrong rewrite here would silently stop validating, which no test in the repo would catch (the only file referencing these modules is `tests/tier2_integration/test_security_pickle_redis.py`, which does not exercise them):

```
invalid config -> "Parameter 'debug' must be of type bool, got str"     (is not object path)
                  "max_concurrency value 99999 is above recommended"    (is int path)
deep compare   -> ('a', 'type_change', 'int', 'str')                    (is not type path)
```

The second line is the discrimination control: it only appears if `expected_type is int` evaluated **True**, so the rewrite cannot have silently disabled the range check.

After: `ruff check src tests` → `All checks passed!`. `black --check src tests` → 2115 files unchanged. Pre-commit clean over the commit range.

## What is NOT in this PR, and why — this needs a decision

The same pre-flight turned up isort findings. **They are not a formatting backlog; they are a config bug, and no state of those files is shippable.** Two invocations of the repo's *own* isort hook produce contradictory results on the same file:

```
pre-commit run isort --all-files          -> removes the blank line after
                                             `from kailash_mcp.client import MCPClient`
pre-commit run isort --from-ref/--to-ref  -> puts it back
```

Whichever state is committed, the other invocation rewrites it. I built the 11-file "fix" against the `--all-files` fixed point (convergent: passes 2 and 3 change nothing), then found the changed-files hook — the one every contributor and the PR gate actually runs — reverts **all eleven**. So it was dropped rather than shipped, because committing either state just hands the next contributor a phantom diff.

**Probable root cause, one line:** `kailash_mcp` is missing from `[tool.isort] known_first_party` in `pyproject.toml`, which lists `kailash, kaizen, kaizen_agents, dataflow, nexus, pact`. Its group therefore falls through to `src_paths` inference, and that inference is batch-sensitive — the exact failure `#1995` documents as the reason this repo once sat at ~2,000 permanently-modified files for four cycles. The config comment says `src_paths` was made explicit to pin this; it does not cover a package whose module name is absent from `known_first_party`.

Adding `kailash_mcp` (and auditing the list against every distribution in `packages/`) would pin it deterministically — but it rewrites every file importing `kailash_mcp` repo-wide, which is a formatting-policy decision for the repo owner, not something to slip into a lint cleanup. Flagged for a decision rather than actioned.

Separately: `ruff check` including `packages/**` reports **341** findings. Out of scope here and not triaged — recording the number so it is not rediscovered as a surprise.

## Related issues

Refs #2139, #1995
