### PR TITLE
fix(kaizen): wire enable_checkpointing; make provider detection fail closed

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/agent_config.py
+++ b/packages/kailash-kaizen/src/kaizen/agent_config.py
@@ -317,26 +317,53 @@ class AgentConfig:
     )
 
     def __post_init__(self):
-        """Post-initialization validation and auto-configuration."""
-        # Validate llm_provider if explicitly set
-        if self.llm_provider is not None:
-            # Reject empty string
-            if self.llm_provider == "":
-                raise ValueError(
-                    "llm_provider cannot be empty string. "
-                    "Use None for auto-detection or specify a valid provider: "
-                    f"{sorted(self.VALID_PROVIDERS)}"
-                )
-            # Validate against known providers
-            if self.llm_provider.lower() not in self.VALID_PROVIDERS:
-                raise ValueError(
-                    f"Invalid llm_provider: '{self.llm_provider}'. "
-                    f"Valid providers: {sorted(self.VALID_PROVIDERS)}"
-                )
+        """Post-initialization validation and auto-configuration.
 
-        # Auto-detect LLM provider if not specified
-        if self.llm_provider is None:
+        #2069 — ORDER MATTERS HERE. The allowlist gate used to run only when
+        ``llm_provider`` arrived non-None, which put it strictly ABOVE the
+        auto-detect assignment and left the auto-detected path structurally
+        un-validatable: whatever detection returned was adopted unchecked. It
+        never bit only because every literal detection could return happened
+        to sit in ``VALID_PROVIDERS``.
+
+        So detection now runs FIRST and the gate sits BELOW it, where both
+        paths pass through exactly one check. Moving the gate down is a
+        prerequisite for delegating detection to a shared resolver — a
+        resolver can legitimately return a provider this class does not list
+        (``deepseek`` was the live example), and adopting that unchecked would
+        be worse than the fail-open it replaced: inconsistent rather than
+        merely wrong.
+        """
+        # Reject empty string. Only meaningful for an explicitly-supplied
+        # value; auto-detection never produces one.
+        if self.llm_provider == "":
+            raise ValueError(
+                "llm_provider cannot be empty string. "
+                "Use None for auto-detection or specify a valid provider: "
+                f"{sorted(self.VALID_PROVIDERS)}"
+            )
+
+        # Auto-detect LLM provider if not specified.
+        auto_detected = self.llm_provider is None
+        if auto_detected:
             self.llm_provider = self._detect_provider_from_model(self.model)
+
+        # ONE gate, reached by BOTH paths.
+        if self.llm_provider.lower() not in self.VALID_PROVIDERS:
+            if auto_detected:
+                # Not user error — the resolver emitted something this class
+                # cannot validate, so say that rather than blaming the caller.
+                raise ValueError(
+                    f"Auto-detected llm_provider '{self.llm_provider}' for model "
+                    f"'{self.model}' is not in VALID_PROVIDERS: "
+                    f"{sorted(self.VALID_PROVIDERS)}. The provider resolver and "
+                    f"this allowlist have drifted apart; add the provider to "
+                    f"VALID_PROVIDERS or pass llm_provider explicitly."
+                )
+            raise ValueError(
+                f"Invalid llm_provider: '{self.llm_provider}'. "
+                f"Valid providers: {sorted(self.VALID_PROVIDERS)}"
+            )
 
     def _detect_provider_from_model(self, model: str) -> str:
         """

--- a/packages/kailash-kaizen/src/kaizen/agent_config.py
+++ b/packages/kailash-kaizen/src/kaizen/agent_config.py
@@ -362,9 +362,22 @@ class AgentConfig:
             )
 
         # Auto-detect LLM provider if not specified.
+        #
+        # #2069 — delegated to the shared resolver rather than kept as a local
+        # substring table. This class used to own one, ending in a terminal
+        # `else: return "openai"`, so a model it did not recognise was
+        # dispatched to OpenAI under whatever credential was configured, with
+        # the caller never told. `resolve_agent_provider` adds no mapping of
+        # its own: it composes the registry-DERIVED prefix table (which cannot
+        # drift from the provider registry) with the env fallback, and raises
+        # ConfigurationError naming the model when neither resolves.
         auto_detected = self.llm_provider is None
         if auto_detected:
-            self.llm_provider = self._detect_provider_from_model(self.model)
+            from kaizen.core import _provider_env
+
+            self.llm_provider = _provider_env.resolve_agent_provider(
+                self.model, component="AgentConfig"
+            )
 
         # ONE gate, reached by BOTH paths.
         if self.llm_provider.lower() not in self.VALID_PROVIDERS:
@@ -382,34 +395,6 @@ class AgentConfig:
                 f"Invalid llm_provider: '{self.llm_provider}'. "
                 f"Valid providers: {sorted(self.VALID_PROVIDERS)}"
             )
-
-    def _detect_provider_from_model(self, model: str) -> str:
-        """
-        Auto-detect LLM provider from model name.
-
-        Args:
-            model: Model name
-
-        Returns:
-            Provider name
-        """
-        model_lower = model.lower()
-
-        if "gpt" in model_lower or "davinci" in model_lower:
-            return "openai"
-        elif "claude" in model_lower:
-            return "anthropic"
-        elif (
-            "llama" in model_lower
-            or "mistral" in model_lower
-            or "bakllava" in model_lower
-        ):
-            return "ollama"
-        elif "gemini" in model_lower:
-            return "google"
-        else:
-            # Default to openai for unknown models
-            return "openai"
 
     def has_custom_memory(self) -> bool:
         """Check if custom memory implementation is provided."""

--- a/packages/kailash-kaizen/src/kaizen/agent_config.py
+++ b/packages/kailash-kaizen/src/kaizen/agent_config.py
@@ -298,7 +298,24 @@ class AgentConfig:
     # Helper Methods
     # =========================================================================
 
-    # Valid provider names (lowercase)
+    # Valid provider names (lowercase).
+    #
+    # Hand-maintained ON PURPOSE, and NOT derived from
+    # ``LlmProvider._REGISTRY``. That registry is a model-PREFIX table — a
+    # provider earns a row only once it has a confirmed prefix mapping — so
+    # deriving from it was measured to drop nine dispatchable providers,
+    # including ``mock`` (which the whole test harness runs on) and ``ollama``
+    # (which detection itself used to return, so a derived allowlist would
+    # have contradicted its own detector on day one).
+    #
+    # What IS enforced is one-directional containment: this set may never be
+    # NARROWER than what the resolvers can emit, since a provider that can be
+    # resolved but not validated makes the class reject its own output. The
+    # reverse is left free, because a provider can be dispatchable without
+    # owning a prefix row. Pinned by
+    # ``tests/regression/test_issue_2069_provider_fail_closed.py``.
+    #
+    # ``deepseek`` was the live gap that invariant caught (#2069).
     VALID_PROVIDERS = frozenset(
         {
             "openai",
@@ -313,6 +330,7 @@ class AgentConfig:
             "perplexity",
             "pplx",
             "mock",
+            "deepseek",
         }
     )
 

--- a/packages/kailash-kaizen/src/kaizen/agent_config.py
+++ b/packages/kailash-kaizen/src/kaizen/agent_config.py
@@ -175,7 +175,15 @@ class AgentConfig:
     # =========================================================================
 
     enable_checkpointing: bool = False
-    """Enable automatic checkpointing (disabled by default until checkpoint module is implemented)"""
+    """Enable automatic checkpointing.
+
+    #2111 — the stated reason for this default ("until checkpoint module is
+    implemented") no longer holds: checkpointing is wired to
+    ``StateManager`` over ``FilesystemStorage``. The default stays ``False``
+    here so that constructing an ``AgentConfig`` directly has no filesystem
+    side effect; ``Agent`` opts in for its own callers, and enabling it
+    creates ``checkpoint_path``.
+    """
 
     checkpoint_path: str = ".kaizen/checkpoints"
     """Checkpoint storage directory"""

--- a/packages/kailash-kaizen/src/kaizen/smart_defaults.py
+++ b/packages/kailash-kaizen/src/kaizen/smart_defaults.py
@@ -12,6 +12,7 @@ Part of ADR-020: Unified Agent API Architecture (Layer 1: Zero-Config)
 """
 
 import logging
+import sys
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
@@ -58,6 +59,27 @@ def _warn_observability_unavailable(subsystem: str, flag: str, detail: str) -> N
         flag,
         detail,
         flag,
+    )
+
+
+@lru_cache(maxsize=None)
+def _warn_checkpointing_unwritable(path: str, detail: str) -> None:
+    """Warn once that the checkpoint directory could not be created.
+
+    Reachable for the first time in #2111: the directory creation used to sit
+    below an import that always failed, so no filesystem error could ever
+    surface from it. A read-only or unwritable location must degrade to no
+    checkpointing rather than break agent construction, which is the same
+    disposition #2101 chose for the audit trail.
+    """
+    logger.warning(
+        "Checkpointing is enabled (enable_checkpointing=True) but the "
+        "checkpoint directory %r could not be created, so NO state will be "
+        "saved and no run will be resumable: %s. Point checkpoint_path at a "
+        "writable location, or set enable_checkpointing=False to disable it "
+        "deliberately and silence this warning.",
+        path,
+        detail,
     )
 
 
@@ -483,7 +505,23 @@ class SmartDefaultsManager:
         Logic:
         - If custom_checkpoint_manager provided → use it
         - If enable_checkpointing is False → no checkpointing
-        - Otherwise → FilesystemStorage with configured path
+        - Otherwise → StateManager over FilesystemStorage at the configured path
+
+        #2111 — this used to import ``kaizen.memory.checkpoint``, a module
+        that exists nowhere in the source tree, so the ``except ImportError``
+        fired on EVERY construction and ``enable_checkpointing=True`` silently
+        installed nothing.
+
+        The parts were mislocated rather than missing, so they are wired here
+        rather than the flag being made honest by raising — the disposition
+        #2084 reached for the sibling observability flags.
+        ``kaizen.core.autonomy.state`` provides both, and ``StateManager`` is
+        the right counterpart: it takes a ``StorageBackend`` (which
+        ``FilesystemStorage`` implements) and owns agent checkpoint / resume /
+        fork. The similarly-named ``CheckpointManager`` in
+        ``kailash.middleware.gateway`` is NOT interchangeable — it is a tiered
+        gateway cache whose ``storage`` argument is a ``DiskStorage``, so
+        ``FilesystemStorage`` does not even type-match it.
         """
         # Layer 3: Custom checkpoint manager override
         if config.has_custom_checkpointing():
@@ -496,35 +534,47 @@ class SmartDefaultsManager:
             return None
 
         # Layer 1: Smart defaults (filesystem storage)
+        from kaizen.core.autonomy.state import FilesystemStorage, StateManager
+
+        # `AgentConfig.checkpoint_interval` is documented in ITERATIONS, while
+        # `StateManager.checkpoint_interval` is in SECONDS -- same name,
+        # different unit. It therefore maps to `checkpoint_frequency`, and
+        # wiring it name-to-name would silently reinterpret "every 5
+        # iterations" as "every 5 seconds".
+        #
+        # The time-based cadence is switched OFF in both cases: `AgentConfig`
+        # exposes no seconds knob, so leaving StateManager's 60s default in
+        # place would checkpoint on a schedule the caller never asked for.
+        # `None` is documented as "checkpoint on demand only", which is both
+        # cadences disabled.
+        never = float("inf")
+        frequency = (
+            config.checkpoint_interval
+            if config.checkpoint_interval is not None
+            else sys.maxsize
+        )
+
         try:
-            from kaizen.memory.checkpoint import CheckpointManager, FilesystemStorage
-
-            # Ensure checkpoint directory exists
-            checkpoint_path = Path(config.checkpoint_path)
-            checkpoint_path.mkdir(parents=True, exist_ok=True)
-
+            # FilesystemStorage creates the directory itself; this is the
+            # first release in which that call is reachable, so it is also the
+            # first in which it can fail (read-only mount, no permission).
+            # Agent construction must degrade, not abort.
             storage = FilesystemStorage(config.checkpoint_path)
-            checkpoint_manager = CheckpointManager(storage)
-
-            self.logger.info(
-                f"Created checkpointing (filesystem: {config.checkpoint_path})"
-            )
-
-            return checkpoint_manager
-
-        except ImportError:
-            # NOTE (#2111): `kaizen.memory.checkpoint` does not exist anywhere
-            # in the source tree, so this except ALWAYS fires and
-            # `enable_checkpointing=True` installs nothing -- the same
-            # advertised-but-unimplemented defect as #2084, one subsystem
-            # over. That also makes the `mkdir` above unreachable, which is
-            # why it carries no OSError guard here: adding one would ship a
-            # branch nothing can enter (`rules/orphan-detection.md` §1). The
-            # guard belongs with the implementation, and #2111 says so.
-            self.logger.warning(
-                "Checkpoint module not available, disabling checkpointing"
-            )
+        except OSError as exc:
+            _warn_checkpointing_unwritable(config.checkpoint_path, str(exc))
             return None
+
+        checkpoint_manager = StateManager(
+            storage=storage,
+            checkpoint_frequency=frequency,
+            checkpoint_interval=never,
+        )
+
+        self.logger.info(
+            f"Created checkpointing (filesystem: {config.checkpoint_path})"
+        )
+
+        return checkpoint_manager
 
     # =========================================================================
     # Control Protocol Creation

--- a/packages/kailash-kaizen/tests/regression/test_issue_2069_provider_fail_closed.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2069_provider_fail_closed.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#2069 — ``AgentConfig`` provider resolution must fail CLOSED.
+
+``_detect_provider_from_model`` ended in a terminal ``else: return "openai"``,
+so a model no substring matched was dispatched to OpenAI under whatever
+credential happened to be configured, and the caller was never told
+(``rules/zero-tolerance.md`` Rule 3).
+
+Two defects, not one. The fail-open default is the visible half. The other is
+an ORDERING defect: the allowlist gate ran only when ``llm_provider`` was
+non-None on entry, i.e. strictly BEFORE the auto-detect assignment, so an
+auto-detected provider was structurally un-validatable. It never bit only
+because the four literals the substring table could return all happened to sit
+in ``VALID_PROVIDERS``.
+
+Both polarities are pinned here: the unresolvable case must RAISE, and the
+resolvable cases must keep resolving exactly as before.
+
+A note on the keyless case, because it decides whether these tests can observe
+anything at all: the kaizen harness sets ``KAIZEN_ALLOW_KEYLESS_MOCK=1``
+(``tests/conftest.py:34``), under which ``detect_provider_from_env`` answers
+``"mock"`` rather than ``None``. A fail-closed test that did not clear it would
+resolve to ``"mock"`` and pass while proving nothing, so the tests below clear
+it AND the provider keys explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.agent_config import AgentConfig
+
+pytestmark = pytest.mark.regression
+
+
+@pytest.fixture
+def keyless_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No provider credential and no keyless-mock opt-in.
+
+    This is the only state in which an unresolvable model can be OBSERVED to
+    fail closed; with any of these set, resolution succeeds for an unrelated
+    reason and the assertion below would be vacuous.
+    """
+    monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
+def test_unknown_model_fails_closed_instead_of_defaulting_to_openai(keyless_env):
+    """An unresolvable model must raise, not silently become ``"openai"``.
+
+    This is the #2069 defect proper. Before the fix this returned an
+    ``AgentConfig`` whose ``llm_provider`` was ``"openai"``, so a typo'd or
+    non-OpenAI model name sent the request — and its prompt content — to the
+    wrong vendor.
+    """
+    with pytest.raises(Exception) as excinfo:
+        AgentConfig(model="totally-unregistered-model-xyz")
+
+    # The error must name the model; an error that does not is not actionable.
+    assert "totally-unregistered-model-xyz" in str(excinfo.value)
+
+
+def test_unknown_model_does_not_resolve_to_openai(keyless_env):
+    """Stated as its own assertion because it is the exact silent behaviour.
+
+    Kept separate from the raise above: if a future change swaps the exception
+    for some other non-raising disposition, this still fails rather than
+    quietly accepting a wrong-vendor default.
+    """
+    try:
+        config = AgentConfig(model="totally-unregistered-model-xyz")
+    except Exception:
+        return  # failing closed is the required behaviour
+    pytest.fail(
+        f"Unresolvable model silently resolved to {config.llm_provider!r} "
+        f"instead of failing closed (#2069)."
+    )
+
+
+def test_explicit_invalid_provider_still_raises():
+    """No-false-positive polarity: the explicit path must keep rejecting."""
+    with pytest.raises(ValueError, match="Invalid llm_provider"):
+        AgentConfig(model="gpt-4", llm_provider="not_a_real_provider")
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("gpt-4", "openai"),
+        ("claude-3-opus-20240229", "anthropic"),
+    ],
+)
+def test_registry_recognised_models_still_resolve(model, expected):
+    """No-false-positive polarity: fail-closed must not break what worked.
+
+    These two are resolved by the registry-derived prefix table, so they must
+    keep resolving with no credential present and no env fallback consulted.
+    """
+    assert AgentConfig(model=model).llm_provider == expected
+
+
+def test_auto_detected_provider_is_validated_by_the_same_gate(monkeypatch):
+    """The ORDERING half of #2069.
+
+    The allowlist gate must sit BELOW the auto-detect assignment so both the
+    explicit and the auto-detected path pass through it. Before the fix this
+    was impossible to express: the gate ran only for a provider supplied on
+    entry, so an auto-detected value could never reach it whatever it was.
+
+    Driving it requires a resolver that returns something outside the
+    allowlist, which the real one does not do today — that is precisely why
+    the hole was invisible.
+    """
+    import kaizen.core._provider_env as provider_env
+
+    monkeypatch.setattr(
+        provider_env,
+        "resolve_agent_provider",
+        lambda model, component="": "a_provider_not_in_the_allowlist",
+    )
+
+    with pytest.raises(ValueError, match="a_provider_not_in_the_allowlist"):
+        AgentConfig(model="gpt-4")
+
+
+def test_valid_providers_covers_every_emittable_provider():
+    """``VALID_PROVIDERS`` must never be NARROWER than what resolvers emit.
+
+    Containment, deliberately one-directional. The reverse is left
+    unconstrained on purpose: ``mock``, ``ollama``, ``azure`` and friends are
+    legitimately dispatchable without owning a model-prefix row, so requiring
+    equality would reject them.
+
+    Not DERIVED from the registry, which was measured and rejected: the
+    registry is a model-PREFIX table (4 entries) and deriving would drop nine
+    dispatchable providers including ``mock`` — which the harness depends on
+    — and ``ollama``.
+    """
+    from kaizen.llm.provider import LlmProvider
+
+    emittable = {p.name for p in LlmProvider.all()} | {  # model-keyed
+        "openai",
+        "anthropic",
+        "mock",
+    }  # env-keyed (_provider_env.detect_provider_from_env)
+
+    missing = sorted(emittable - set(AgentConfig.VALID_PROVIDERS))
+    assert not missing, (
+        f"VALID_PROVIDERS is narrower than what the resolvers can emit: "
+        f"{missing}. A provider that can be resolved but not validated makes "
+        f"AgentConfig reject its own auto-detected output."
+    )

--- a/packages/kailash-kaizen/tests/regression/test_issue_2111_checkpointing_wired.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_2111_checkpointing_wired.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#2111 — ``enable_checkpointing=True`` must install a working manager.
+
+``SmartDefaultsManager.create_checkpointing`` imported
+``kaizen.memory.checkpoint``, a module that exists nowhere in the source tree.
+The ``except ImportError`` therefore fired on EVERY construction, so
+``enable_checkpointing=True`` returned ``None``: no state saved, no run
+resumable, and the only signal was a log line naming neither the flag that
+requested it nor what had stopped working.
+
+The parts were mislocated rather than missing, which is why the disposition is
+to WIRE them rather than to make the flag honest by raising (the verdict #2084
+reached for the sibling observability flags):
+
+* ``FilesystemStorage`` — ``kaizen.core.autonomy.state.storage``
+* ``StateManager``      — ``kaizen.core.autonomy.state.manager``
+
+``StateManager`` is the correct counterpart, not the ``CheckpointManager`` in
+``kailash.middleware.gateway``: that one is a tiered gateway cache whose
+``storage`` parameter is a ``DiskStorage``, so ``FilesystemStorage`` is not
+even type-compatible with it, and it checkpoints gateway requests rather than
+agent state.
+
+These tests DRIVE the manager — a non-None return is necessary but not
+sufficient, since an object that cannot round-trip a checkpoint is the same
+defect wearing a different shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from kaizen.agent_config import AgentConfig
+from kaizen.smart_defaults import SmartDefaultsManager
+
+pytestmark = pytest.mark.regression
+
+
+def test_enable_checkpointing_installs_a_manager(tmp_path: Path):
+    """The assertion whose absence let this ship (#2111 acceptance)."""
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_path=str(tmp_path / "ckpt"),
+    )
+    manager = SmartDefaultsManager().create_checkpointing(config)
+
+    assert manager is not None, (
+        "enable_checkpointing=True installed nothing. The flag advertises a "
+        "subsystem that is not wired (#2111)."
+    )
+
+
+def test_checkpoint_manager_round_trips_agent_state(tmp_path: Path):
+    """Non-None is not enough — the manager must actually persist and reload.
+
+    A manager that cannot round-trip is the advertised-but-unimplemented
+    defect again, one layer down, and a test asserting only `is not None`
+    would pass against it.
+    """
+    from kaizen.core.autonomy.state.types import AgentState
+
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_path=str(tmp_path / "ckpt"),
+    )
+    manager = SmartDefaultsManager().create_checkpointing(config)
+    assert manager is not None
+
+    state = AgentState(agent_id="agent-2111", step_number=7)
+    state.conversation_history = [{"role": "user", "content": "remember me"}]
+
+    checkpoint_id = asyncio.run(manager.storage.save(state))
+    restored = asyncio.run(manager.storage.load(checkpoint_id))
+
+    assert restored.agent_id == "agent-2111"
+    assert restored.step_number == 7
+    assert restored.conversation_history == [{"role": "user", "content": "remember me"}]
+
+
+def test_checkpoint_path_is_honoured(tmp_path: Path):
+    """``checkpoint_path`` was accepted and never used (#2111 acceptance)."""
+    target = tmp_path / "nested" / "checkpoints"
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_path=str(target),
+    )
+    manager = SmartDefaultsManager().create_checkpointing(config)
+
+    assert manager is not None
+    assert target.is_dir(), f"checkpoint_path {target} was not created"
+    assert Path(manager.storage.base_dir) == target
+
+
+def test_checkpoint_interval_maps_to_step_frequency_not_seconds():
+    """``AgentConfig.checkpoint_interval`` is ITERATIONS, not seconds.
+
+    ``StateManager`` carries BOTH a ``checkpoint_frequency`` (every N steps)
+    and a ``checkpoint_interval`` (every M seconds). The config field shares
+    the latter's NAME and the former's MEANING, so a name-to-name wiring would
+    silently reinterpret "every 5 iterations" as "every 5 seconds". Pinned
+    because nothing else would catch it.
+    """
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_interval=5,
+    )
+    manager = SmartDefaultsManager().create_checkpointing(config)
+
+    assert manager is not None
+    assert manager.checkpoint_frequency == 5
+    # And the time-based cadence must stay disabled: the config exposes no
+    # seconds knob, so a default would checkpoint on a schedule nobody asked for.
+    assert manager.should_checkpoint("a", current_step=0, current_time=1e9) is False
+
+
+def test_checkpoint_interval_none_means_on_demand_only():
+    """``None`` is documented as "checkpoint on demand only"."""
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_interval=None,
+    )
+    manager = SmartDefaultsManager().create_checkpointing(config)
+
+    assert manager is not None
+    # No step count and no elapsed time may trigger an automatic checkpoint.
+    assert (
+        manager.should_checkpoint("a", current_step=10_000, current_time=1e9) is False
+    )
+
+
+def test_unwritable_checkpoint_path_warns_and_disables(tmp_path, caplog):
+    """Read-only filesystem must not break agent construction (#2101 parity).
+
+    Now reachable for the first time: the mkdir used to sit below a failing
+    import, so no OSError could ever be raised from it. Construction must
+    degrade to no checkpointing with a warning that names the flag, not
+    propagate an OSError out of ``Agent()``.
+    """
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o500)  # r-x: cannot create children
+
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_path=str(readonly / "ckpt"),
+    )
+
+    try:
+        with caplog.at_level("WARNING"):
+            manager = SmartDefaultsManager().create_checkpointing(config)
+    finally:
+        readonly.chmod(0o700)  # restore so tmp_path cleanup can run
+
+    assert manager is None
+    assert "enable_checkpointing" in caplog.text, (
+        "The warning must name the flag that requested the subsystem, so the "
+        "operator knows what to turn off (#2101)."
+    )
+
+
+def test_agent_construction_installs_a_checkpoint_manager(tmp_path, monkeypatch):
+    """The end-to-end form named in the #2111 acceptance criteria.
+
+    ``SmartDefaultsManager`` is the unit under repair, but the flag users
+    actually set lives on ``Agent``. Asserting only at the manager would leave
+    the forwarding untested, which is the seam the defect hid behind for four
+    subsystems already.
+    """
+    monkeypatch.setenv("KAIZEN_ALLOW_KEYLESS_MOCK", "1")
+    from kaizen.agent import Agent
+
+    agent = Agent(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        checkpoint_path=str(tmp_path / "ckpt"),
+        mcp_servers=[],
+    )
+
+    assert agent.checkpoint_manager is not None
+    assert Path(agent.checkpoint_manager.storage.base_dir) == tmp_path / "ckpt"
+
+
+def test_checkpointing_disabled_returns_none():
+    """No-false-positive polarity: the off switch must still switch off."""
+    config = AgentConfig(
+        model="test-model", llm_provider="mock", enable_checkpointing=False
+    )
+    assert SmartDefaultsManager().create_checkpointing(config) is None
+
+
+def test_custom_checkpoint_manager_still_overrides():
+    """No-false-positive polarity: Layer 3 override must still win."""
+    sentinel = object()
+    config = AgentConfig(
+        model="test-model",
+        llm_provider="mock",
+        enable_checkpointing=True,
+        custom_checkpoint_manager=sentinel,
+    )
+    assert SmartDefaultsManager().create_checkpointing(config) is sentinel

--- a/packages/kailash-kaizen/tests/unit/test_llm_provider_bug_reproduction.py
+++ b/packages/kailash-kaizen/tests/unit/test_llm_provider_bug_reproduction.py
@@ -238,10 +238,20 @@ class TestAgentLLMProviderAutoDetection:
             config = AgentConfig(model=model)
             assert config.llm_provider == "openai", f"{model} should detect as openai"
 
-    def test_auto_detect_davinci_as_openai(self):
-        """Davinci models should auto-detect as openai."""
+    def test_auto_detect_davinci_as_openai(self, monkeypatch):
+        """Davinci resolves as openai via the ENV fallback, not a prefix row.
+
+        #2069 changed the mechanism. Detection used to substring-match
+        "davinci"; it now delegates to the shared resolver, whose prefix table
+        is derived from the provider registry and has no davinci row. So the
+        model falls through to the env fallback, which answers openai when an
+        OpenAI credential is present — the correct answer, reached honestly.
+        With no credential it raises rather than guessing, which is the point
+        of the issue.
+        """
         from kaizen.agent_config import AgentConfig
 
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-2069-placeholder-not-sent")
         config = AgentConfig(model="davinci-002")
         assert config.llm_provider == "openai"
 
@@ -255,19 +265,36 @@ class TestAgentLLMProviderAutoDetection:
                 config.llm_provider == "anthropic"
             ), f"{model} should detect as anthropic"
 
-    def test_auto_detect_llama_as_ollama(self):
-        """Llama models should auto-detect as ollama."""
+    @pytest.mark.parametrize("model", ["llama-3.1", "mistral-7b"])
+    def test_local_models_no_longer_auto_detect_as_ollama(self, model, monkeypatch):
+        """BEHAVIOUR CHANGE (#2069): llama/mistral no longer imply ollama.
+
+        The old substring table mapped these to ollama. Delegation removed
+        that mapping along with the rest of the table, and the shared resolver
+        has no ollama row — its prefix table is registry-derived and ollama
+        serves arbitrary model names, so no prefix identifies it.
+
+        The practical consequence, stated plainly because it is the one
+        user-visible regression in this change: a local Ollama user who
+        relied on `Agent(model="llama-3.1")` must now pass
+        `llm_provider="ollama"` explicitly. That path is asserted below so the
+        supported alternative is pinned, not merely described.
+
+        If implicit ollama detection is wanted back, it belongs in the shared
+        resolver where every caller gets it — re-adding a private table here
+        would rebuild exactly the drift #2069 removed.
+        """
         from kaizen.agent_config import AgentConfig
 
-        config = AgentConfig(model="llama-3.1")
-        assert config.llm_provider == "ollama"
+        monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    def test_auto_detect_mistral_as_ollama(self):
-        """Mistral models should auto-detect as ollama."""
-        from kaizen.agent_config import AgentConfig
+        with pytest.raises(Exception, match=model):
+            AgentConfig(model=model)
 
-        config = AgentConfig(model="mistral-7b")
-        assert config.llm_provider == "ollama"
+        # The supported path: say which provider serves it.
+        assert AgentConfig(model=model, llm_provider="ollama").llm_provider == "ollama"
 
     def test_auto_detect_gemini_as_google(self):
         """Gemini models should auto-detect as google."""
@@ -276,27 +303,46 @@ class TestAgentLLMProviderAutoDetection:
         config = AgentConfig(model="gemini-pro")
         assert config.llm_provider == "google"
 
-    def test_unknown_model_defaults_to_openai(self):
-        """Unknown models should default to openai."""
-        from kaizen.agent_config import AgentConfig
+    def test_unknown_model_fails_closed_not_defaults_to_openai(self, monkeypatch):
+        """INVERTED by #2069 — this test used to assert the defect.
 
-        config = AgentConfig(model="some-custom-model")
-        assert config.llm_provider == "openai"
-
-    def test_azure_deployment_not_auto_detected(self):
-        """Azure deployment names with 'gpt' should NOT auto-detect azure.
-
-        This documents the expected behavior: Azure deployments need explicit
-        llm_provider='azure' because the model name alone cannot distinguish
-        Azure from OpenAI.
+        It read "Unknown models should default to openai" and pinned exactly
+        the silent wrong-vendor dispatch the issue was filed about: an
+        unrecognised model went to OpenAI under whatever credential was
+        configured, carrying the prompt with it. A test asserting the bug is
+        why the bug survived, so it is inverted here rather than deleted —
+        the same name should not quietly stop covering the same line.
         """
         from kaizen.agent_config import AgentConfig
 
-        # Azure deployment with gpt in name - would be detected as openai
-        config = AgentConfig(model="cashflow-gpt5")
-        assert config.llm_provider == "openai"  # NOT azure
+        monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-        # To use Azure, must be explicit
+        with pytest.raises(Exception, match="some-custom-model"):
+            AgentConfig(model="some-custom-model")
+
+    def test_azure_deployment_not_auto_detected(self, monkeypatch):
+        """Azure deployment names containing 'gpt' must not become openai.
+
+        The conclusion is unchanged — Azure needs an explicit provider,
+        because a deployment name cannot distinguish Azure from OpenAI — but
+        #2069 made the mechanism honest. The old substring table matched "gpt"
+        anywhere and silently answered openai for a name like "cashflow-gpt5".
+        The registry table matches the "gpt-" PREFIX, so this name resolves
+        through nothing and fails closed instead of being quietly misrouted to
+        the wrong vendor.
+        """
+        from kaizen.agent_config import AgentConfig
+
+        monkeypatch.delenv("KAIZEN_ALLOW_KEYLESS_MOCK", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(Exception, match="cashflow-gpt5"):
+            AgentConfig(model="cashflow-gpt5")
+
+        # To use Azure, must be explicit — unchanged.
         config2 = AgentConfig(model="cashflow-gpt5", llm_provider="azure")
         assert config2.llm_provider == "azure"
 


### PR DESCRIPTION
Two kaizen defects of the same family: a config surface that answers
confidently when it should not.

## #2069 — provider detection failed OPEN

`_detect_provider_from_model` ended in `else: return "openai"`, so a model no
substring matched was dispatched to OpenAI under whatever credential was
configured — carrying the prompt with it — and the caller was never told.

There were **two** defects. The visible one is the fail-open default. The other
is an ORDERING defect: the allowlist gate ran only when `llm_provider` arrived
non-None, i.e. strictly ABOVE the auto-detect assignment, so an auto-detected
provider was not merely unvalidated but **structurally un-validatable**. It
never bit only because the table's four literals all happened to be in
`VALID_PROVIDERS`.

Landed in the three steps the issue thread ratified, each leaving the tree green:

1. **Reorder** — the gate moves below auto-detection, so both paths pass through
   exactly one check. Auto-detected failures get their own message: that case is
   resolver/allowlist drift, not caller error.
2. **Containment test, then the one-line fix it forces** — the invariant asserts
   `VALID_PROVIDERS` is never NARROWER than what the resolvers emit. It was red
   naming exactly `deepseek`, which is then added. Doing this before delegating
   is the point: the gap surfaces as a failing test rather than as a surprise.
3. **Delegate** to `_provider_env.resolve_agent_provider` and delete the table.
   That resolver adds no mapping of its own — registry-DERIVED prefixes, then the
   env fallback, then `ConfigurationError` naming the model.

The allowlist stays hand-maintained deliberately. Deriving it from
`LlmProvider._REGISTRY` is the obvious move and was measured to be a hard
regression — that registry is a model-PREFIX table, so deriving drops nine
dispatchable providers including `mock` (which the harness runs on) and
`ollama`. Containment catches the real failure direction without that cost.

### Behaviour change — please read

**`llama`/`mistral` no longer imply `ollama`.** The resolver has no ollama row
and cannot have one: ollama serves arbitrary model names, so no prefix
identifies it. `Agent(model="llama-3.1")` now raises instead of resolving, and
callers pass `llm_provider="ollama"`.

This follows the issue's "carries no mapping of its own", but it is the one
user-visible regression here and it is a judgement call worth confirming. If
implicit ollama detection should stay, it belongs in the shared resolver where
every caller gets it — re-adding a private table here would rebuild exactly the
drift #2069 removed. Say the word and I will move it there instead.

Five existing tests pinned the old table and are updated, not deleted. One of
them, `test_unknown_model_defaults_to_openai`, **asserted the defect** ("Unknown
models should default to openai") — a test asserting the bug is why the bug
survived, so it is inverted in place under a corrected name. Two others become
honest: `davinci` reaches openai through the env fallback rather than a
substring guess, and `"cashflow-gpt5"` no longer matches `"gpt"` *anywhere* and
silently becomes openai, because the registry matches the `"gpt-"` PREFIX.

## #2111 — `enable_checkpointing` was a fifth unimplemented subsystem

`create_checkpointing` imported `kaizen.memory.checkpoint`, which exists nowhere
in the source tree, so `except ImportError` fired on every construction:
`enable_checkpointing=True` returned `None`, `checkpoint_path` was accepted and
ignored, and the only signal named neither the flag nor what had stopped working.

The parts were **mislocated, not missing**, so they are wired rather than the
flag being made honest by raising — the disposition #2084 reached for the
sibling flags. `kaizen.core.autonomy.state` has both.

**`StateManager` is the correct counterpart, and the `CheckpointManager` the
issue pointed at is not.** That one lives in `kailash.middleware.gateway`, takes
a `DiskStorage` rather than a `StorageBackend` (so `FilesystemStorage` does not
even type-match it), and checkpoints gateway requests rather than agent state.

`checkpoint_interval` needed care: `AgentConfig` documents it in **iterations**
while `StateManager`'s field of the **same name** is in **seconds**. It maps to
`checkpoint_frequency`; a name-to-name wiring would have silently reinterpreted
"every 5 iterations" as "every 5 seconds". The seconds cadence is pinned off in
both branches, since `AgentConfig` exposes no seconds knob and StateManager's
60s default would otherwise checkpoint on a schedule nobody asked for. `None`
means both disabled — the documented "on demand only".

The `OSError` guard #2111 asked for lands here because this is the first release
in which the directory creation is **reachable** (it used to sit below the
failing import). An unwritable `checkpoint_path` degrades to no checkpointing
with a warn-once naming the flag, matching #2101's audit-trail handling, rather
than aborting `Agent()`.

Note the new side effect the issue anticipated: enabling checkpointing now
actually creates `checkpoint_path`, which for `Agent`'s defaults is a relative
`.kaizen/checkpoints`.

## Verification — RED established first, both polarities

**#2069** — 4 red / 3 green before:

```
Failed: Unresolvable model silently resolved to 'openai' instead of failing closed (#2069).
Failed: DID NOT RAISE ValueError                       <- auto-detected value never reached a gate
AssertionError: VALID_PROVIDERS is narrower than what the resolvers can emit: ['deepseek'].
4 failed, 3 passed
```

The 3 greens are the no-false-positive polarity (explicit invalid still raises;
`gpt-4` and `claude` still resolve) and confirm the reorder changed no behaviour
for any input reachable today. After all three steps: **32 passed**.

**#2111** — 6 red / 2 green before:

```
AssertionError: enable_checkpointing=True installed nothing. The flag advertises
a subsystem that is not wired (#2111).
assert None is not None      (x4: round-trip, path honoured, interval mapping, on-demand)
AssertionError: The warning must name the flag that requested the subsystem.
6 failed, 2 passed
```

After: **9 passed**. The tests DRIVE the manager — a real `AgentState`
round-trips through save/load — because a manager that cannot round-trip is the
same defect one layer down, and an `is not None` assertion would pass against it.
Includes the `Agent`-level assertion the issue named, whose absence let this ship.

**Full kaizen suite** (`tests/unit` + `tests/regression`):
`12780 passed, 156 skipped, 24 xfailed, 2 failed, 6 errors`.

Both failures are accounted for and neither is caused by this branch:

- `test_azure_ai_foundry_routes_through_four_axis_path` — this is **#2067**,
  fixed in PR #2143. This branch is cut from `origin/main`, so that fix is
  absent here (verified: the fix token appears 0× on this branch, 3× on #2143).
- `test_pre_fix_wrapper_shape_is_rejected_by_real_registration` — pre-existing,
  environment-dependent (standalone `fastmcp` 2.12.4 importable), tracked as #2086.
- 6 errors are a pre-existing `pytest_base_url` `ScopeMismatch` in files this PR
  does not touch.

**Blast radius swept:** no module outside `kailash-kaizen` imports
`kaizen.agent_config` or `kaizen.agent`, so #2069's stricter resolution reaches
no external consumer. The `llama`/`mistral` literals elsewhere in the tree are
routing-capability tables and docstrings that pass a provider explicitly.

## Related issues

Fixes #2069
Fixes #2111