### PR TITLE
fix(middleware): enforce session ownership on every session-scoped route (#2145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,56 @@ such as `>=2.0`.
 
 ## [Unreleased]
 
+### Changed (BREAKING) — session-scoped gateway routes now check ownership (#2145)
+
+**Read the migration note at the end.** If you drive `APIGateway` sessions from a caller other than the one that created them, those calls now return 404.
+
+- **An authenticated caller could execute code in another user's session (CRITICAL).** Every session-scoped route took a caller-supplied `session_id` and acted on it **without comparing the session's owner against the caller** — although `WorkflowSession.user_id` has always carried that owner, and the whole gateway module contained exactly one owner-ish token. **Measured on a default (gated) `APIGateway()`, both parties holding valid tokens the gateway itself minted**, `alice` creating a session and `bob` then driving it:
+
+  ```
+  GET  /api/sessions/{alice_sid}            -> 200 {"user_id":"alice",...}
+  POST /api/workflows?session_id=alice_sid  -> 200 {"workflow_id":"e9437e7d-..."}
+  POST /api/executions?session_id=alice_sid -> 200 {"status":"started"}
+  GET  /api/sessions                        -> 200 {"sessions":[{...,"user_id":"alice"}]}
+  DELETE /api/sessions/{alice_sid}          -> 200 {"message":"Session closed"}
+  ```
+
+  The third line is the severe one: the workflow body is caller-authored `PythonCodeNode` source, so `bob` did not merely read `alice`'s session — he **injected a workflow into it and executed it**, then closed it. This is the horizontal-authorization half of #2102: that issue fixed who a request acts *as*, and this one fixes what that principal may act *on*. It survived #2072's fail-closed gate, which authenticates these requests but does not authorize them.
+
+- **`GET /api/sessions` was the attacker's target directory, and is now scoped to the caller.** It enumerated every session on the gateway — id, owner `user_id`, creation time, workflow and execution counts — to any authenticated caller, which is how an attacker obtained the `session_id` the other routes require. It now returns only the caller's own sessions. On an open deployment it still returns everything, because there are no identities to scope by.
+
+- **One predicate, twelve call sites, found by AST sweep rather than by hand.** `APIGateway._require_session_owner` is the single ownership rule; every session-scoped route calls it. The route list was enumerated mechanically from the source, and that mattered: the hand-written list in the issue **missed `GET /api/executions` and `GET /api/schemas/workflows/{workflow_id}`**, either of which left unguarded would have shipped the exact failure mode the fix closes (`security.md` § Enforcement-Surface Parity).
+
+- **`/ws` and `/events` needed it too, and #2151's fix did not cover them.** Those routes take `session_id` as well as `user_id`. Pinning `user_id` to the verified principal (#2151) does **not** close the session selector, because `ConnectionManager.send_to_session` walks `session_connections[session_id]` and calls `send_to_connection` **directly, never evaluating the `EventFilter`**. Measured on a real socket before this fix — `alice`, authenticated as herself, on `?session_id=<bob's session>`:
+
+  ```
+  send_to_session(bob) delivered to 1 connection(s)
+  ALICE'S SOCKET RECEIVED: {"type":"private","body":"bob-session-only payload"}
+  ```
+
+  Both routes now check session ownership; the websocket refuses the handshake with 1008 before `accept()`.
+
+- **`GET /api/events/recent` without a `session_id` returned every user's recent events**, which is the #2151 confidentiality defect at the REST surface rather than the websocket one. The filter is now pinned to the caller's `user_id`. That also excludes events carrying no `user_id` at all, which is the intended direction: an event the gateway cannot attribute to the caller is not one to hand them.
+
+- **Refusals are 404, not 403, and that is deliberate.** A 403 would confirm that a session id exists, turning every one of these routes into a membership oracle over session ids. A regression test asserts the response for a real-but-unowned session is **byte-identical** to the one for an id that was never issued. The single exception is an **unclaimed** session (empty or `None` owner), which answers 403 with a named condition: that is an operator-facing fact about the server's own legacy state, and reaching it requires already holding a valid session id.
+
+- **An empty owner is not a wildcard.** Since #2102 every session created through the HTTP surface carries a server-derived owner, so an ownerless session predates that fix. On a gated deployment it is refused rather than matched against every caller — treating `""` as "matches anybody" is the silent-fallback shape (`zero-tolerance.md` Rule 3) and would have quietly re-opened exactly what this closes.
+
+- **Open deployments are an explicit branch, and say so once.** With `require_auth=False` or `enable_auth=False` there are no identities, so no ownership rule can apply; the check is skipped by an explicit branch a reader can find, not as a side effect of there being no principal to compare. Construction emits a one-time WARN (`api_gateway.session_ownership_unenforced`) naming the OFF protection — *any caller may read, drive and close any session, including `POST /api/executions` which runs workflows in it* — and its wiring, separate from `resolve_server_auth`'s own `server_auth.disabled` because it names a different protection (`security.md` § Secure-Default).
+
+**Migration.** On a gated gateway (`enable_auth` at its default), a caller may act only on sessions it owns:
+
+| Call | Before | After |
+| --- | --- | --- |
+| Own session, any session-scoped route | 200 | **200** (unchanged) |
+| Another user's session, any of the twelve routes | 200 | **404** |
+| `GET /api/sessions` | every session on the gateway | **only the caller's** |
+| Session with no recorded owner | 200 | **403**, naming the condition |
+| `WS /ws?session_id=<other user's>` | connected, received that session's traffic | **1008 at the handshake** |
+| Any of the above with `enable_auth=False` / `require_auth=False` | 200 | **200** (unchanged) |
+
+If you relied on one identity administering another's sessions, there is no supported path for that today — the gateway has no operator role, and inventing one silently is what this fix exists to prevent. Use `require_auth=False` for a deliberately open deployment, or mint a credential for the subject whose session you mean to drive.
+
 ### Changed (BREAKING) — the middleware gateway derives identity from the credential, never from the request (#2102)
 
 **Read the migration note at the end of this entry before upgrading.** If you call `POST /api/sessions`, `GET /events` or `WS /ws` on `kailash.middleware.communication.api_gateway.APIGateway` with `enable_auth` at its default, the identity those routes act under changes.

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -325,6 +325,8 @@ class APIGateway:
         # a principal from a request field (issue #2102). Read by
         # `_resolve_identity`.
         self._require_auth = resolved_require_auth
+        if not resolved_require_auth:
+            self._warn_session_ownership_unenforced()
         self._auth_config = resolve_server_auth(
             require_auth=resolved_require_auth,
             auth_config=(
@@ -616,6 +618,133 @@ class APIGateway:
 
         return caller_supplied
 
+    async def _require_session_owner(
+        self, connection: Any, session_id: str
+    ) -> Optional[str]:
+        """Fail closed unless the caller OWNS ``session_id``.
+
+        THE single ownership predicate for this gateway. Every session-scoped
+        route calls it, so there is one rule rather than twelve inline
+        comparisons that drift (issue #2145; the same consolidation argument
+        as `_resolve_identity` and `subject_from_claims`).
+
+        #2102 answered "who is calling". This answers the adjacent question it
+        does NOT answer: **what may that caller act on**. Every route here
+        takes a caller-supplied ``session_id`` and acted on it without ever
+        comparing the session's owner against the caller, even though
+        ``WorkflowSession.user_id`` has always carried that owner. Measured
+        before the fix, both parties holding valid tokens this gateway
+        itself minted::
+
+            POST /api/workflows?session_id=<alice>   as bob -> 200
+            POST /api/executions?session_id=<alice>  as bob -> 200
+
+        which is authenticated arbitrary code execution inside another user's
+        session, since the workflow body is caller-authored `PythonCodeNode`
+        source.
+
+        The four outcomes, in order:
+
+        1. **Open deployment** (``require_auth`` resolved False -- i.e.
+           ``require_auth=False`` or ``enable_auth=False``). The check is
+           SKIPPED, deliberately and as an explicit branch rather than as a
+           side effect of there being no principal to compare. Such a
+           deployment has no identities at all, so there is nothing an
+           ownership rule could mean; the exposure is announced once at
+           construction by ``_warn_session_ownership_unenforced``.
+        2. **No principal** on a gated deployment -> 401, via
+           :meth:`_resolve_identity`, which owns that decision.
+        3. **Unclaimed session** -- the owner is empty or ``None`` -> 403.
+           This is legacy state: since #2102 every session created carries a
+           server-derived owner, so an ownerless one predates that fix.
+           Treating an empty owner as a wildcard that matches every caller
+           would be the silent-fallback shape (`zero-tolerance.md` Rule 3) and
+           would quietly re-open exactly what this closes.
+        4. **Someone else's session** -> 404, NOT 403, and the difference is
+           deliberate. 403 would confirm that a session id exists, turning
+           every route here into a membership oracle over session ids. The
+           unclaimed case above answers 403 because it is an operator-facing
+           condition about the server's own legacy state, and reaching it
+           requires already holding a valid session id -- it tells an attacker
+           nothing it did not already know.
+
+        Args:
+            connection: The HTTP request or WebSocket handshake.
+            session_id: The caller-supplied session identifier.
+
+        Returns:
+            The principal that owns the session, or ``None`` on an open
+            deployment where no ownership rule applies.
+
+        Raises:
+            HTTPException: 401 (no principal), 403 (unclaimed session), or 404
+                (unknown session, or one owned by somebody else).
+        """
+        if not self._require_auth:
+            return None
+
+        principal = await self._resolve_identity(connection, None)
+
+        session = await self.agent_ui.get_session(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        owner = getattr(session, "user_id", None)
+        if not isinstance(owner, str) or not owner:
+            logger.warning(
+                "api_gateway.session_without_owner",
+                extra={"session_id": sanitize_log_value(session_id, 128)},
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "This session has no recorded owner and cannot be acted "
+                    "on while the gateway authenticates requests. Sessions "
+                    "created before server-derived identity landed carry no "
+                    "owner; create a new session, or run the gateway with "
+                    "require_auth=False if it is meant to serve openly."
+                ),
+            )
+
+        if owner != principal:
+            # Logged with BOTH ids so an operator can see the attempt; the
+            # CLIENT is told only that there is no such session.
+            logger.warning(
+                "api_gateway.session_ownership_denied",
+                extra={
+                    "session_id": sanitize_log_value(session_id, 128),
+                    "principal": sanitize_log_value(principal, 128),
+                },
+            )
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        return principal
+
+    def _warn_session_ownership_unenforced(self) -> None:
+        """Announce, once per gateway, that session ownership is not enforced.
+
+        Separate from `resolve_server_auth`'s own `server_auth.disabled` WARN
+        because it names a DIFFERENT protection. That one says requests are
+        not authenticated; this one says any caller may drive any session --
+        including executing workflows in it -- which is the consequence an
+        operator actually needs to weigh (`security.md` § Secure-Default:
+        a control that is off must say so loudly and name its wiring).
+        """
+        logger.warning(
+            "api_gateway.session_ownership_unenforced",
+            extra={
+                "reason": (
+                    "require_auth resolved False, so no principal exists to "
+                    "own a session"
+                ),
+                "exposure": (
+                    "any caller may read, drive and close any session, "
+                    "including POST /api/executions which runs workflows in it"
+                ),
+                "wiring": "construct with require_auth=True to enforce ownership",
+            },
+        )
+
     def _init_sdk_nodes(self, database_url: Optional[str] = None):
         """Initialize SDK nodes for gateway operations."""
 
@@ -824,8 +953,10 @@ class APIGateway:
                 raise HTTPException(status_code=500, detail=detail) from e
 
         @self.app.get("/api/sessions/{session_id}")
-        async def get_session(session_id: str):
+        async def get_session(session_id: str, http_request: Request):
             """Get session information."""
+            await self._require_session_owner(http_request, session_id)
+
             session = await self.agent_ui.get_session(session_id)
             if not session:
                 raise HTTPException(status_code=404, detail="Session not found")
@@ -846,34 +977,64 @@ class APIGateway:
             }
 
         @self.app.delete("/api/sessions/{session_id}")
-        async def close_session(session_id: str):
+        async def close_session(session_id: str, http_request: Request):
             """Close a session."""
+            await self._require_session_owner(http_request, session_id)
+
             await self.agent_ui.close_session(session_id)
             return {"message": "Session closed"}
 
         @self.app.get("/api/sessions")
-        async def list_sessions():
-            """List all active sessions."""
+        async def list_sessions(http_request: Request):
+            """List the caller's active sessions.
+
+            SCOPED to the caller, where it used to enumerate every session on
+            the gateway with its owner's `user_id`. That listing was not merely
+            an information leak in its own right -- it was the TARGET DIRECTORY
+            for the rest of #2145: the other eleven routes need a `session_id`
+            they do not otherwise possess, and this handed out every one of
+            them, already labelled with whose it was.
+
+            On an open deployment (`require_auth` resolved False) there are no
+            identities, so the unscoped listing remains -- that is the same
+            explicit branch every other route here takes, not an oversight.
+            """
+            principal = (
+                await self._resolve_identity(http_request, None)
+                if self._require_auth
+                else None
+            )
+
             sessions = []
             for session_id, session in self.agent_ui.sessions.items():
-                if session.active:
-                    sessions.append(
-                        {
-                            "session_id": session_id,
-                            "user_id": session.user_id,
-                            "created_at": session.created_at.isoformat(),
-                            "workflow_count": len(session.workflows),
-                            "execution_count": len(session.executions),
-                        }
-                    )
+                if not session.active:
+                    continue
+                # `principal is None` ONLY on an open deployment: on a gated
+                # one `_resolve_identity` raised 401 rather than returning it.
+                if principal is not None and session.user_id != principal:
+                    continue
+                sessions.append(
+                    {
+                        "session_id": session_id,
+                        "user_id": session.user_id,
+                        "created_at": session.created_at.isoformat(),
+                        "workflow_count": len(session.workflows),
+                        "execution_count": len(session.executions),
+                    }
+                )
             return {"sessions": sessions, "total": len(sessions)}
 
     def _setup_workflow_routes(self):
         """Setup workflow management routes."""
 
         @self.app.post("/api/workflows")
-        async def create_workflow(request: WorkflowCreateRequest, session_id: str):
+        async def create_workflow(
+            request: WorkflowCreateRequest, session_id: str, http_request: Request
+        ):
             """Create a new workflow dynamically."""
+            # BEFORE the try: an ownership refusal is a deliberate status and
+            # must not be relabelled a 500 by the handler below.
+            await self._require_session_owner(http_request, session_id)
             try:
                 workflow_config = {
                     "name": request.name,
@@ -902,8 +1063,12 @@ class APIGateway:
                 ) from e
 
         @self.app.get("/api/workflows/{workflow_id}")
-        async def get_workflow(workflow_id: str, session_id: str):
+        async def get_workflow(
+            workflow_id: str, session_id: str, http_request: Request
+        ):
             """Get workflow information and schema."""
+            await self._require_session_owner(http_request, session_id)
+
             session = await self.agent_ui.get_session(session_id)
             if not session:
                 raise HTTPException(status_code=404, detail="Session not found")
@@ -926,8 +1091,20 @@ class APIGateway:
             }
 
         @self.app.get("/api/workflows")
-        async def list_workflows(session_id: Optional[str] = None):
-            """List available workflows."""
+        async def list_workflows(
+            http_request: Request, session_id: Optional[str] = None
+        ):
+            """List available workflows.
+
+            `session_id` is OPTIONAL here, so the ownership check is too --
+            but only in the sense that there is nothing to own when it is
+            absent. Supplying another user's id is refused exactly as it is on
+            the routes where it is required; without one, the caller sees only
+            the SHARED workflows, which are shared by construction.
+            """
+            if session_id:
+                await self._require_session_owner(http_request, session_id)
+
             workflows = []
 
             # Add shared workflows
@@ -963,8 +1140,15 @@ class APIGateway:
         """Setup workflow execution routes."""
 
         @self.app.post("/api/executions", response_model=ExecutionResponse)
-        async def execute_workflow(request: WorkflowExecuteRequest, session_id: str):
+        async def execute_workflow(
+            request: WorkflowExecuteRequest, session_id: str, http_request: Request
+        ):
             """Execute a workflow."""
+            # THE site the #2145 attack trace ends at: the workflow body is
+            # caller-authored `PythonCodeNode` source, so an unowned execution
+            # here is arbitrary code execution in someone else's session.
+            # Outside the try, so the refusal is not relabelled a 500.
+            await self._require_session_owner(http_request, session_id)
             try:
                 execution_id = await self.agent_ui.execute(
                     session_id=session_id,
@@ -988,8 +1172,12 @@ class APIGateway:
                 ) from e
 
         @self.app.get("/api/executions/{execution_id}")
-        async def get_execution_status(execution_id: str, session_id: str):
+        async def get_execution_status(
+            execution_id: str, session_id: str, http_request: Request
+        ):
             """Get execution status."""
+            await self._require_session_owner(http_request, session_id)
+
             status = await self.agent_ui.get_execution_status(execution_id, session_id)
             if not status:
                 raise HTTPException(status_code=404, detail="Execution not found")
@@ -1004,14 +1192,20 @@ class APIGateway:
             }
 
         @self.app.delete("/api/executions/{execution_id}")
-        async def cancel_execution(execution_id: str, session_id: str):
+        async def cancel_execution(
+            execution_id: str, session_id: str, http_request: Request
+        ):
             """Cancel a running execution."""
+            await self._require_session_owner(http_request, session_id)
+
             await self.agent_ui.cancel_execution(execution_id, session_id)
             return {"message": "Execution cancelled"}
 
         @self.app.get("/api/executions")
-        async def list_executions(session_id: str):
+        async def list_executions(session_id: str, http_request: Request):
             """List executions for a session."""
+            await self._require_session_owner(http_request, session_id)
+
             session = await self.agent_ui.get_session(session_id)
             if not session:
                 raise HTTPException(status_code=404, detail="Session not found")
@@ -1084,8 +1278,12 @@ class APIGateway:
             return {"node_type": node_type, "schema": schema}
 
         @self.app.get("/api/schemas/workflows/{workflow_id}")
-        async def get_workflow_schema(workflow_id: str, session_id: str):
+        async def get_workflow_schema(
+            workflow_id: str, session_id: str, http_request: Request
+        ):
             """Get schema for a specific workflow."""
+            await self._require_session_owner(http_request, session_id)
+
             session = await self.agent_ui.get_session(session_id)
             if not session:
                 raise HTTPException(status_code=404, detail="Session not found")
@@ -1134,6 +1332,20 @@ class APIGateway:
 
             try:
                 resolved_user_id = await self._resolve_identity(websocket, user_id)
+                # `session_id` is the OTHER caller-supplied selector on this
+                # route, and #2139's `user_id` pin does not cover it:
+                # `ConnectionManager.send_to_session` walks
+                # `session_connections[session_id]` and calls
+                # `send_to_connection` DIRECTLY, never evaluating the
+                # `EventFilter`. So subscribing with another user's session id
+                # delivered that session's traffic regardless of the pinned
+                # user. Measured before this fix -- alice, authenticated as
+                # alice, on `?session_id=<bob's session>`::
+                #
+                #     send_to_session(bob) delivered to 1 connection(s)
+                #     ALICE'S SOCKET RECEIVED: {"body": "bob-session-only payload"}
+                if session_id:
+                    await self._require_session_owner(websocket, session_id)
             except HTTPException:
                 # A websocket cannot carry a 401. 1008 is POLICY VIOLATION,
                 # sent WITHOUT `accept()` so the handshake is refused outright
@@ -1179,6 +1391,10 @@ class APIGateway:
             """
             event_type_list = event_types.split(",") if event_types else None
             resolved_user_id = await self._resolve_identity(request, user_id)
+            # Same second selector as `/ws`, same reason: the SSE manager
+            # tracks streams by `session_id` independently of the filter.
+            if session_id:
+                await self._require_session_owner(request, session_id)
 
             return self.realtime.create_sse_stream(
                 request, session_id, resolved_user_id, event_type_list
@@ -1235,11 +1451,34 @@ class APIGateway:
 
         @self.app.get("/api/events/recent")
         async def get_recent_events(
+            http_request: Request,
             count: int = 100,
             event_types: Optional[str] = None,
             session_id: Optional[str] = None,
         ):
-            """Get recent events with filtering."""
+            """Get recent events with filtering.
+
+            Two changes, and the second is the one that matters. With a
+            `session_id` the ownership check applies as everywhere else.
+            WITHOUT one this returned every user's recent events to any
+            authenticated caller -- the #2151 confidentiality defect at the
+            REST surface rather than the websocket one -- so the filter is now
+            pinned to the caller's own `user_id`.
+
+            That filter also excludes events carrying NO `user_id`, and that
+            is the intended direction: an event this gateway cannot attribute
+            to the caller is not one to hand them (`EventFilter.matches`
+            rejects on `event.user_id != self.user_id`).
+            """
+            # Outside the try: an ownership refusal is a deliberate status and
+            # must reach the client rather than becoming a 500 below.
+            principal = None
+            if self._require_auth:
+                principal = (
+                    await self._require_session_owner(http_request, session_id)
+                    if session_id
+                    else await self._resolve_identity(http_request, None)
+                )
             try:
                 # Parse event types
                 event_type_list = None
@@ -1250,7 +1489,9 @@ class APIGateway:
 
                 # Create filter
                 event_filter = EventFilter(
-                    event_types=event_type_list, session_id=session_id
+                    event_types=event_type_list,
+                    session_id=session_id,
+                    user_id=principal,
                 )
 
                 # Get events

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -1401,9 +1401,34 @@ class APIGateway:
             )
 
         @self.app.post("/api/webhooks")
-        async def register_webhook(request: WebhookRegisterRequest):
-            """Register a webhook endpoint."""
+        async def register_webhook(
+            request: WebhookRegisterRequest, http_request: Request
+        ):
+            """Register a webhook endpoint.
+
+            THE THIRD SUBSCRIPTION SURFACE, and the one both prior fixes
+            missed. `/ws` and `/events` were scoped to the caller's principal
+            (#2151, #2145), but a webhook is registered once and delivered to
+            by the server forever after -- it consults no connection registry,
+            so neither fix reaches it. Registered with an all-unset
+            `EventFilter`, it matched EVERY event from EVERY user, because
+            `EventFilter.matches` skips each unset criterion.
+
+            The deferral criterion the earlier sweep used -- "does this route
+            take an identity field?" -- is exactly what let this through: this
+            route takes none. For a subscription route the question is instead
+            "does it CREATE or SERVE a subscription to other users' events."
+            """
             webhook_id = str(uuid.uuid4())
+
+            # `None` ONLY on an open deployment, where there is no principal to
+            # scope by and the unscoped filter is that configuration's
+            # documented contract.
+            principal = (
+                await self._resolve_identity(http_request, None)
+                if self._require_auth
+                else None
+            )
 
             self.realtime.register_webhook(
                 webhook_id=webhook_id,
@@ -1411,6 +1436,7 @@ class APIGateway:
                 secret=request.secret,
                 event_types=request.event_types,
                 headers=request.headers,
+                user_id=principal,
             )
 
             return {

--- a/src/kailash/middleware/communication/realtime.py
+++ b/src/kailash/middleware/communication/realtime.py
@@ -794,14 +794,26 @@ class RealtimeMiddleware:
         event_types: Optional[List[str]] = None,
         session_id: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        user_id: Optional[str] = None,
     ):
-        """Register webhook endpoint."""
+        """Register webhook endpoint.
+
+        ``user_id`` scopes the delivery filter to one subscriber. Without it
+        the filter is built with EVERY criterion unset, and
+        ``EventFilter.matches`` SKIPS each unset criterion
+        (``if self.user_id and ...``) -- so an all-unset filter matches
+        unconditionally and the webhook receives every event from every user.
+        That is the THIRD subscription surface of the same class as `/ws` and
+        `/events` (issues #2151 / #2145), and it bypassed both of their fixes
+        because delivery here never consults a connection registry.
+        """
         if not self.enable_webhooks or not self.webhook_manager:
             raise ValueError("Webhooks not enabled")
 
         event_filter = EventFilter(
             event_types=[EventType(t) for t in event_types] if event_types else None,
             session_id=session_id,
+            user_id=user_id,
         )
 
         self.webhook_manager.register_webhook(

--- a/tests/regression/test_issue_2145_session_ownership.py
+++ b/tests/regression/test_issue_2145_session_ownership.py
@@ -1,0 +1,406 @@
+"""Regression: session-scoped routes had no ownership check (#2145).
+
+#2102 answered "who is calling". This is the adjacent question it did not
+answer: **what may that caller act on**. Every session-scoped route on
+``APIGateway`` took a caller-supplied ``session_id`` and acted on it without
+ever comparing the session's owner against the caller -- even though
+``WorkflowSession.user_id`` has always carried that owner.
+
+Measured before the fix, both parties holding valid tokens the gateway itself
+minted, on a default (gated) ``APIGateway()``::
+
+    alice session: 3815fbd4-...  owner=alice
+    --- bob, authenticated as bob, acting on ALICE's session ---
+    POST /api/workflows?session_id=alice_sid  -> 200
+    POST /api/executions?session_id=alice_sid -> 200
+    DELETE /api/sessions/alice_sid            -> 200
+
+The middle line is the severe one: the workflow body is caller-authored
+``PythonCodeNode`` source, so that is authenticated arbitrary code execution
+inside another user's session. ``GET /api/sessions`` supplied the target
+directory, enumerating every session with its owner.
+
+**Every test here carries the owner-succeeds row as a discrimination
+control.** A suite that only shows ``bob`` refused cannot tell this fix from
+one that refuses everybody -- which is the failure mode a fail-closed change
+is most likely to ship.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="gateway tests require the `server` extra")
+pytest.importorskip("jwt", reason="PyJWT is required to mint the test credentials")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from kailash.middleware.communication.api_gateway import APIGateway  # noqa: E402
+
+GATEWAY_SECRET = "test-gateway-secret-" + "x" * 28
+
+#: A workflow whose body is caller-authored source. It is what makes
+#: `POST /api/executions` on someone else's session code execution rather than
+#: a data leak.
+WORKFLOW = {
+    "name": "probe",
+    "nodes": [
+        {
+            "id": "n",
+            "type": "PythonCodeNode",
+            "config": {"name": "n", "code": "result = {'ok': True}"},
+        }
+    ],
+    "connections": [],
+}
+
+
+@pytest.fixture(autouse=True)
+def gateway_secret(monkeypatch):
+    monkeypatch.setenv("KAILASH_API_GATEWAY_SECRET", GATEWAY_SECRET)
+
+
+def _bearer(gateway: APIGateway, user_id: str) -> dict:
+    return {
+        "Authorization": f"Bearer {gateway.auth_manager.create_access_token(user_id=user_id)}"
+    }
+
+
+@pytest.fixture
+def gated():
+    """A default gateway plus alice's session, her workflow and her execution.
+
+    Returns ``(gateway, client, alice_headers, bob_headers, ids)``. The state
+    is built THROUGH the API as alice, so every id below is one she legitimately
+    owns -- which is what makes the owner rows meaningful.
+    """
+    gateway = APIGateway(title="ownership-test")
+    client = TestClient(gateway.app)
+    alice = _bearer(gateway, "alice")
+    bob = _bearer(gateway, "bob")
+
+    session_id = client.post("/api/sessions", json={}, headers=alice).json()[
+        "session_id"
+    ]
+    workflow_id = client.post(
+        f"/api/workflows?session_id={session_id}", json=WORKFLOW, headers=alice
+    ).json()["workflow_id"]
+    execution_id = client.post(
+        f"/api/executions?session_id={session_id}",
+        json={"workflow_id": workflow_id, "inputs": {}},
+        headers=alice,
+    ).json()["execution_id"]
+
+    ids = {"sid": session_id, "wid": workflow_id, "eid": execution_id}
+    return gateway, client, alice, bob, ids
+
+
+#: Every session-scoped route, as (method, url template). Enumerated from the
+#: source with an AST sweep rather than by hand -- the hand-written list in the
+#: issue missed `GET /api/executions` and `GET /api/schemas/workflows/...`,
+#: which is exactly the sibling-left-unguarded failure the sweep exists to
+#: catch. Destructive routes are last so they do not invalidate the ids above.
+SESSION_SCOPED_ROUTES = [
+    ("GET", "/api/sessions/{sid}"),
+    ("GET", "/api/workflows/{wid}?session_id={sid}"),
+    ("GET", "/api/workflows?session_id={sid}"),
+    ("GET", "/api/executions/{eid}?session_id={sid}"),
+    ("GET", "/api/executions?session_id={sid}"),
+    ("GET", "/api/schemas/workflows/{wid}?session_id={sid}"),
+    ("GET", "/api/events/recent?session_id={sid}"),
+    ("DELETE", "/api/executions/{eid}?session_id={sid}"),
+    ("DELETE", "/api/sessions/{sid}"),
+]
+
+
+class TestEverySessionScopedRouteChecksOwnership:
+    """Both polarities, every route. The owner row is the discrimination control."""
+
+    @pytest.mark.parametrize("method,template", SESSION_SCOPED_ROUTES)
+    def test_non_owner_is_refused(self, gated, method, template):
+        _, client, _, bob, ids = gated
+        response = client.request(method, template.format(**ids), headers=bob)
+
+        assert response.status_code == 404, (
+            f"{method} {template} let a non-owner through: "
+            f"{response.status_code} {response.text[:200]}"
+        )
+
+    @pytest.mark.parametrize("method,template", SESSION_SCOPED_ROUTES)
+    def test_owner_still_succeeds(self, gated, method, template):
+        """THE CONTROL. Without this row, refusing everybody would look green."""
+        _, client, alice, _, ids = gated
+        response = client.request(method, template.format(**ids), headers=alice)
+
+        assert response.status_code == 200, (
+            f"{method} {template} refused the session's own owner: "
+            f"{response.status_code} {response.text[:200]}"
+        )
+
+    def test_mutating_routes_both_polarities(self, gated):
+        """The two POSTs, which the parametrized table cannot express."""
+        _, client, alice, bob, ids = gated
+        sid = ids["sid"]
+
+        assert (
+            client.post(
+                f"/api/workflows?session_id={sid}", json=WORKFLOW, headers=bob
+            ).status_code
+            == 404
+        )
+        owner = client.post(
+            f"/api/workflows?session_id={sid}", json=WORKFLOW, headers=alice
+        )
+        assert owner.status_code == 200, owner.text
+
+        wid = owner.json()["workflow_id"]
+        assert (
+            client.post(
+                f"/api/executions?session_id={sid}",
+                json={"workflow_id": wid, "inputs": {}},
+                headers=bob,
+            ).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                f"/api/executions?session_id={sid}",
+                json={"workflow_id": wid, "inputs": {}},
+                headers=alice,
+            ).status_code
+            == 200
+        )
+
+    def test_refusal_does_not_confirm_the_session_exists(self, gated):
+        """404, not 403 -- otherwise every route is a session-id oracle.
+
+        A non-owner must not be able to tell a real session id from one that
+        was never issued, so both answers must be byte-identical.
+        """
+        _, client, _, bob, ids = gated
+
+        real = client.get(f"/api/sessions/{ids['sid']}", headers=bob)
+        fake = client.get(
+            "/api/sessions/00000000-0000-0000-0000-000000000000", headers=bob
+        )
+
+        assert real.status_code == fake.status_code == 404
+        assert real.json() == fake.json(), (
+            "the two answers differ, so the route is a membership oracle: "
+            f"{real.json()} vs {fake.json()}"
+        )
+
+
+class TestTheIssueAttackTrace:
+    """The exact sequence from #2145, end to end."""
+
+    def test_bob_can_no_longer_execute_code_in_alices_session(self, gated):
+        _, client, alice, bob, ids = gated
+        sid = ids["sid"]
+
+        injected = client.post(
+            f"/api/workflows?session_id={sid}",
+            json={
+                "name": "bobs_workflow",
+                "nodes": [
+                    {
+                        "id": "n",
+                        "type": "PythonCodeNode",
+                        "config": {"name": "n", "code": "result = {'pwned': True}"},
+                    }
+                ],
+                "connections": [],
+            },
+            headers=bob,
+        )
+        assert injected.status_code == 404, injected.text
+
+        assert client.delete(f"/api/sessions/{sid}", headers=bob).status_code == 404
+        # And alice's session survived bob's attempt to close it.
+        assert client.get(f"/api/sessions/{sid}", headers=alice).status_code == 200
+
+
+class TestSessionListIsScopedToTheCaller:
+    """`GET /api/sessions` was the attacker's target directory."""
+
+    def test_each_caller_sees_only_their_own(self, gated):
+        gateway, client, alice, bob, ids = gated
+        bob_session = client.post("/api/sessions", json={}, headers=bob).json()[
+            "session_id"
+        ]
+
+        alice_view = client.get("/api/sessions", headers=alice).json()
+        bob_view = client.get("/api/sessions", headers=bob).json()
+
+        alice_ids = {s["session_id"] for s in alice_view["sessions"]}
+        bob_ids = {s["session_id"] for s in bob_view["sessions"]}
+
+        assert ids["sid"] in alice_ids
+        assert (
+            bob_session not in alice_ids
+        ), f"alice enumerated bob's session: {alice_ids}"
+        assert bob_session in bob_ids, "the control failed: bob cannot see his own"
+        assert ids["sid"] not in bob_ids
+
+    def test_owners_are_not_disclosed_to_other_users(self, gated):
+        _, client, _, bob, ids = gated
+        listing = client.get("/api/sessions", headers=bob).json()
+
+        assert all(
+            s["user_id"] == "bob" for s in listing["sessions"]
+        ), f"another user's owner leaked through the listing: {listing}"
+
+
+class TestUnclaimedSessionsAreRefused:
+    """An ownerless session is legacy state, not a wildcard."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("owner", ["", None])
+    async def test_ownerless_session_is_refused_with_a_named_condition(self, owner):
+        gateway = APIGateway(title="ownerless-test")
+        client = TestClient(gateway.app)
+        alice = _bearer(gateway, "alice")
+
+        # Created directly on the middleware: since #2102 the HTTP surface
+        # cannot produce one of these, which is precisely why it is legacy.
+        session_id = await gateway.agent_ui.create_session(user_id=owner)
+
+        response = client.get(f"/api/sessions/{session_id}", headers=alice)
+
+        assert response.status_code == 403, (
+            "an empty owner was treated as a wildcard matching every caller: "
+            f"{response.status_code} {response.text[:200]}"
+        )
+        assert "no recorded owner" in response.json()["detail"]
+
+
+class TestOpenDeploymentContractUnchanged:
+    """`enable_auth=False` / `require_auth=False` have no identities to own by."""
+
+    def test_ownership_is_not_enforced_and_says_so_once(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            gateway = APIGateway(title="open-test", enable_auth=False)
+
+        assert any(
+            "session_ownership_unenforced" in r.getMessage() for r in caplog.records
+        ), (
+            "an open deployment must announce that ownership is unenforced: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+        client = TestClient(gateway.app)
+        session_id = client.post("/api/sessions", json={"user_id": "alice"}).json()[
+            "session_id"
+        ]
+        # Anyone may drive it, which is this configuration's documented contract.
+        assert client.get(f"/api/sessions/{session_id}").status_code == 200
+        assert client.get("/api/sessions").json()["total"] == 1
+
+    def test_require_auth_false_behaves_the_same(self):
+        gateway = APIGateway(title="open-test-2", require_auth=False)
+        client = TestClient(gateway.app)
+        session_id = client.post("/api/sessions", json={"user_id": "alice"}).json()[
+            "session_id"
+        ]
+        assert client.get(f"/api/sessions/{session_id}").status_code == 200
+
+
+class TestRealtimeRoutesAreSessionScoped:
+    """`/ws` and `/events` take `session_id` too, and #2139's pin did not cover it.
+
+    ``ConnectionManager.send_to_session`` walks ``session_connections[session_id]``
+    and calls ``send_to_connection`` DIRECTLY, never evaluating the
+    ``EventFilter`` -- so pinning ``user_id`` to the principal (the #2151 fix)
+    left this path open. Measured before this fix, alice on
+    ``?session_id=<bob's session>``::
+
+        send_to_session(bob) delivered to 1 connection(s)
+        ALICE'S SOCKET RECEIVED: {"body": "bob-session-only payload"}
+    """
+
+    def test_websocket_both_polarities(self, gated):
+        from starlette.websockets import WebSocketDisconnect
+
+        _, client, alice, bob, ids = gated
+        sid = ids["sid"]
+
+        # THE CONTROL: the owner's handshake still completes.
+        with client.websocket_connect(f"/ws?session_id={sid}", headers=alice):
+            pass
+
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/ws?session_id={sid}", headers=bob):
+                pass
+        assert excinfo.value.code == 1008, "expected a POLICY VIOLATION close"
+
+    def test_sse_non_owner_is_refused(self, gated):
+        _, client, _, bob, ids = gated
+        response = client.get(f"/events?session_id={ids['sid']}", headers=bob)
+
+        assert response.status_code == 404, response.text
+
+    @pytest.mark.asyncio
+    async def test_sse_owner_still_streams(self, gated):
+        """THE CONTROL for `/events`, driven against the raw ASGI app.
+
+        The SSE generator loops forever on a heartbeat, so neither HTTP client
+        can close a successful stream; this takes the first body chunk and
+        cancels, which is what a real client disconnecting does.
+        """
+        import asyncio
+
+        gateway, _, alice, _, ids = gated
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/events",
+            "raw_path": b"/events",
+            "root_path": "",
+            "query_string": f"session_id={ids['sid']}".encode(),
+            "headers": [
+                (b"host", b"testserver"),
+                (b"authorization", alice["Authorization"].encode()),
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        }
+        started = asyncio.Event()
+        status: list[int] = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status.append(message["status"])
+            elif message["type"] == "http.response.body":
+                started.set()
+
+        task = asyncio.create_task(gateway.app(scope, receive, send))
+        try:
+            await asyncio.wait_for(started.wait(), timeout=10)
+        finally:
+            task.cancel()
+
+        assert status == [200], f"the owner's own stream was refused: {status!r}"
+
+
+class TestRecentEventsAreScopedToTheCaller:
+    """`/api/events/recent` without a `session_id` returned everyone's events."""
+
+    def test_events_are_filtered_to_the_principal(self, gated):
+        gateway, client, alice, bob, ids = gated
+
+        alice_events = client.get("/api/events/recent", headers=alice).json()
+        bob_events = client.get("/api/events/recent", headers=bob).json()
+
+        foreign = [
+            e for e in alice_events["events"] if e.get("user_id") not in (None, "alice")
+        ]
+        assert not foreign, f"alice received another user's events: {foreign[:2]}"
+        assert all(
+            e.get("user_id") in (None, "bob") for e in bob_events["events"]
+        ), "the control failed: bob's own listing is not scoped to bob"

--- a/tests/regression/test_issue_2145_session_ownership.py
+++ b/tests/regression/test_issue_2145_session_ownership.py
@@ -388,6 +388,86 @@ class TestRealtimeRoutesAreSessionScoped:
         assert status == [200], f"the owner's own stream was refused: {status!r}"
 
 
+class TestWebhookSubscriptionIsScopedToTheCaller:
+    """`POST /api/webhooks` — the THIRD subscription surface.
+
+    `/ws` and `/events` were scoped to the principal by #2151 and this issue,
+    but a webhook consults no connection registry: it is registered once and
+    delivered to forever after, so neither fix reaches it. Registered with an
+    all-unset ``EventFilter`` it matched every event from every user, because
+    ``EventFilter.matches`` SKIPS each unset criterion
+    (``events.py``: ``if self.user_id and event.user_id != self.user_id``).
+
+    Measured before the fix::
+
+        EventFilter().matches(<an event owned by bob>) = True
+    """
+
+    def test_registration_scopes_the_filter_to_the_principal(self, gated):
+        gateway, client, alice, _, _ = gated
+
+        response = client.post(
+            "/api/webhooks",
+            json={"url": "https://alice.example/hook", "event_types": []},
+            headers=alice,
+        )
+        assert response.status_code == 200, response.text
+
+        webhook_id = response.json()["webhook_id"]
+        registered = gateway.realtime.webhook_manager.webhooks[webhook_id]
+        event_filter = registered["event_filter"]
+
+        assert event_filter.user_id == "alice", (
+            "the webhook filter was left unscoped, so it matches every user's "
+            f"events: user_id={event_filter.user_id!r}"
+        )
+
+    def test_the_scoped_filter_actually_rejects_another_users_event(self, gated):
+        """The filter is only worth anything if it REJECTS — assert on matches()."""
+        gateway, client, alice, _, _ = gated
+
+        webhook_id = client.post(
+            "/api/webhooks",
+            json={"url": "https://alice.example/hook", "event_types": []},
+            headers=alice,
+        ).json()["webhook_id"]
+        event_filter = gateway.realtime.webhook_manager.webhooks[webhook_id][
+            "event_filter"
+        ]
+
+        class _Event:
+            type = None
+            priority = None
+            source = None
+            target = None
+            session_id = "bob-session"
+            user_id = "bob"
+
+        class _OwnEvent(_Event):
+            session_id = "alice-session"
+            user_id = "alice"
+
+        assert (
+            event_filter.matches(_Event()) is False
+        ), "the webhook still matches another user's event"
+        # THE CONTROL: it must still match the subscriber's OWN events, or a
+        # filter that rejects everything would look identical to a correct one.
+        assert event_filter.matches(_OwnEvent()) is True
+
+    def test_open_deployment_keeps_the_unscoped_filter(self):
+        gateway = APIGateway(title="open-webhook", enable_auth=False)
+        client = TestClient(gateway.app)
+
+        webhook_id = client.post(
+            "/api/webhooks", json={"url": "https://x.example/h", "event_types": []}
+        ).json()["webhook_id"]
+        event_filter = gateway.realtime.webhook_manager.webhooks[webhook_id][
+            "event_filter"
+        ]
+
+        assert event_filter.user_id is None
+
+
 class TestRecentEventsAreScopedToTheCaller:
     """`/api/events/recent` without a `session_id` returned everyone's events."""
 


### PR DESCRIPTION
> **Stacked on #2139.** Base is `fix/2102-2104-gateway-auth`, not `main`, so the diff shows only this work. GitHub retargets the base to `main` automatically when #2139 merges. It could not branch from `main`: the ownership check needs the server-derived principal, which lives in `_authenticated_user_id` / `_resolve_identity` — helpers that exist only on #2139. Branching from `main` would have meant a second copy of the identity resolution, the exact duplication `security.md` § Credential Decode Helpers forbids and #2139 consolidated.

## Summary

An **authenticated** caller could execute arbitrary code in another user's session. Every session-scoped route took a caller-supplied `session_id` and acted on it without comparing the session's owner against the caller — though `WorkflowSession.user_id` has always carried that owner.

Measured on a default (gated) `APIGateway()`, both parties holding valid tokens the gateway itself minted. `alice` creates a session; `bob`, authenticated as `bob`, drives it:

```
GET    /api/sessions/{alice_sid}            -> 200 {"user_id":"alice",...}
POST   /api/workflows?session_id=alice_sid  -> 200 {"workflow_id":"e9437e7d-..."}
POST   /api/executions?session_id=alice_sid -> 200 {"status":"started"}
GET    /api/sessions                        -> 200 {"sessions":[{...,"user_id":"alice"}]}
DELETE /api/sessions/{alice_sid}            -> 200 {"message":"Session closed"}
```

The third line is the severe one: the workflow body is caller-authored `PythonCodeNode` source, so `bob` did not merely *read* `alice`'s session — he **injected a workflow into it and executed it**, then closed it. `GET /api/sessions` is what supplied the target `session_id`, already labelled with whose it was.

This is the horizontal-authorization half of #2102 (which fixed who a request acts *as*), and it survived #2072's fail-closed gate, which authenticates these requests but never authorized them.

## The three design decisions, as directed

1. **Predicate lives in the gateway, not PACT.** `_require_session_owner` is a resource-ownership invariant, not policy — one shared predicate called by every session-scoped route, failing closed, with no cross-package dependency. PACT may layer policy on top; it is never required for the ownership check to fire.
2. **Open deployments skip the check through an explicit branch** (`if not self._require_auth: return None`) a reader can find, not as a side effect of there being no principal to compare — plus a one-time construction WARN, `api_gateway.session_ownership_unenforced`, naming the OFF protection and its wiring. It is separate from `resolve_server_auth`'s `server_auth.disabled` because it names a different protection.
3. **Ownerless sessions are refused** with 403 and a named condition. An empty owner is **not** treated as a wildcard matching every caller — that is the silent-fallback shape (`zero-tolerance.md` Rule 3) and would quietly re-open exactly what this closes.

## The route list came from an AST sweep, and that mattered

The hand-written list in the issue said ten routes. The sweep found **thirteen**, and two of the extras were unguarded siblings that would have shipped the exact failure mode this fix closes (`security.md` § Enforcement-Surface Parity):

- **`GET /api/executions`** — not in the issue's table
- **`GET /api/schemas/workflows/{workflow_id}`** — not in the issue's table

The sweep also caught **`WS /ws` and `GET /events`**, which take `session_id` as well as `user_id`. **#2151's user pin does not cover them**, because `ConnectionManager.send_to_session` walks `session_connections[session_id]` and calls `send_to_connection` **directly, never evaluating the `EventFilter`**. Measured on a real uvicorn socket before this fix — `alice`, authenticated as herself, on `?session_id=<bob's session>`:

```
send_to_session(bob) delivered to 1 connection(s)
ALICE'S SOCKET RECEIVED: {"type":"private","body":"bob-session-only payload"}
```

After, with the owner row as the control:

```
bob   -> BOB's session (control)   CONNECTED   send_to_session delivered to 1
alice -> BOB's session (attack)    REFUSED     HTTP 403 (pre-accept close, code 1008)
```

The final sweep reports **13 session-scoped routes, 13 guarded, 0 gaps.**

## `GET /api/sessions` — decided and stated, as asked

**Scoped to the caller.** You were right. It is not merely an information leak: it was the **target directory** for the rest of the vulnerability. The other twelve routes need a `session_id` the attacker does not otherwise possess, and this handed out every one of them already labelled with its owner. On an open deployment it still returns everything, because there are no identities to scope by.

## 404, not 403

A 403 would confirm a session id exists, turning every route into a membership oracle. A test asserts the response for a real-but-unowned session is **byte-identical** to the one for an id that was never issued. The one exception is the unclaimed-session 403: that is an operator-facing fact about the server's own legacy state, and reaching it requires already holding a valid session id.

## `GET /api/events/recent`

Without a `session_id` it returned **every user's** recent events to any authenticated caller — #2151's confidentiality defect at the REST surface rather than the websocket one. The filter is now pinned to the caller's `user_id`. That also excludes events carrying no `user_id`, which is the intended direction: an event the gateway cannot attribute to the caller is not one to hand them.

## Testing

`tests/regression/test_issue_2145_session_ownership.py` — 31 tests. **Every route carries the owner-succeeds row as a discrimination control**, because a suite that only shows `bob` refused cannot distinguish this fix from one that refuses everybody, which is the failure mode a fail-closed change is most likely to ship.

RED established against the pre-fix source (the #2139 base, `_require_session_owner` count = 0):

```
20 failed, 11 passed in 63.79s     <- pre-fix
31 passed in 4.28s                 <- post-fix
```

**The 11 that pass pre-fix are the controls**, not defect pins: the nine `test_owner_still_succeeds` rows, `test_require_auth_false_behaves_the_same`, and `test_sse_owner_still_streams`. They must be green on both sides — that is what makes them controls.

Both polarities per route class, plus: the ownerless-session 403 (`""` and `None`), the open-deployment contract with its one-time WARN, the session-list scoping in both directions, the oracle check, and `/ws` + `/events` with owner controls.

No regressions: **366 passed** across `tests/integration/gateway`, `tests/integration/middleware/test_gateway_integration.py`, `tests/unit/servers/test_gateway_creation.py`, and the #2102 / #2104 / #2072 / #636 / #2088 regression suites.

## Breaking change

`### Changed (BREAKING)` in `CHANGELOG.md` with a six-row migration table. Note stated plainly there: if you relied on one identity administering another's sessions, there is no supported path today — the gateway has no operator role, and inventing one silently is what this fix exists to prevent.

## Related issues

Fixes #2145
Refs #2102, #2139, #2151, #2072
