### PR TITLE
fix(kaizen): derive infra markers from the fixture graph, not the test name

### DIFF
--- a/packages/kailash-kaizen/tests/conftest.py
+++ b/packages/kailash-kaizen/tests/conftest.py
@@ -9,6 +9,11 @@ Provides shared fixtures and configuration for comprehensive 3-tier testing stra
 
 import os
 
+# `re` backs the whole-token keyword match in pytest_collection_modifyitems
+# (#2152) -- bare-substring matching on 2-letter fragments marked ~15% of the
+# suite as needing infrastructure it does not need.
+import re
+
 # CRITICAL: Patch MockProvider BEFORE any other imports
 # This must happen at module level to catch all provider instantiations
 import sys
@@ -865,16 +870,45 @@ def pytest_collection_modifyitems(config, items):
         # `item.name` (the test's display name string) is deterministic and
         # matches the function's docstring intent ("based on their location
         # and name") -- switching to it removes the non-determinism.
+        # SECOND BUG FIX (#2152, found when the determinism fix above made this
+        # one reproducible): the switch to `item.name` was correct, but the
+        # keyword list kept BARE SUBSTRING matching, and two of the keywords
+        # are 2-letter fragments that occur inside ordinary English words:
+        #
+        #   'ai' in 'kaizen'  -> True      'ai' in 'raises'    -> True
+        #   'ai' in 'openai'  -> True      'ai' in 'available' -> True
+        #   'db' in 'feedback' -> True     'db' in 'sandbox'   -> True
+        #
+        # Measured on 14,773 collected kaizen items: 'ai' alone marked 1,980
+        # items `requires_ollama` (13.4%) of which only 353 actually mention
+        # ollama/llm -- so ~1,627 infra-free tests were EXCLUDED from every
+        # infra-free CI step. The 342->425 deselection jump after the
+        # determinism fix WAS this: a random ~3% hole became a deterministic
+        # ~15% one. It deselected `test_azure_ai_foundry_routes_through_four_
+        # axis_path` -- the #2067 test that #2143 had just made hermetic and
+        # offline SPECIFICALLY so it needs no infrastructure.
+        #
+        # Fix, per keyword length:
+        #   * 'ai' is REMOVED outright. It is not a reliable ollama signal in
+        #     any form -- not even as a whole token, because "Azure AI Foundry"
+        #     legitimately tokenizes to 'ai' while needing no Ollama. A test
+        #     that needs Ollama says so ('ollama'/'llm') or carries an explicit
+        #     marker.
+        #   * 'db' is kept but matched as a WHOLE TOKEN, so `test_db_pool`
+        #     still marks while `feedback`/`sandbox`/`mongodb` no longer do.
+        # Long keywords keep substring matching ('cache' SHOULD match 'cached').
         if hasattr(item, "function") and item.function:
+            name = item.name.lower()
+            tokens = set(re.findall(r"[a-z0-9]+", name))
+
             # Check for database usage in test parameters or names
-            if any(
-                keyword in item.name.lower()
-                for keyword in ["postgres", "database", "db"]
+            if any(keyword in name for keyword in ["postgres", "database"]) or (
+                "db" in tokens
             ):
                 item.add_marker(pytest.mark.requires_postgres)
-            if any(keyword in item.name.lower() for keyword in ["redis", "cache"]):
+            if any(keyword in name for keyword in ["redis", "cache"]):
                 item.add_marker(pytest.mark.requires_redis)
-            if any(keyword in item.name.lower() for keyword in ["docker"]):
+            if "docker" in name:
                 item.add_marker(pytest.mark.requires_docker)
-            if any(keyword in item.name.lower() for keyword in ["ollama", "llm", "ai"]):
+            if any(keyword in name for keyword in ["ollama", "llm"]):
                 item.add_marker(pytest.mark.requires_ollama)

--- a/packages/kailash-kaizen/tests/conftest.py
+++ b/packages/kailash-kaizen/tests/conftest.py
@@ -9,11 +9,6 @@ Provides shared fixtures and configuration for comprehensive 3-tier testing stra
 
 import os
 
-# `re` backs the whole-token keyword match in pytest_collection_modifyitems
-# (#2152) -- bare-substring matching on 2-letter fragments marked ~15% of the
-# suite as needing infrastructure it does not need.
-import re
-
 # CRITICAL: Patch MockProvider BEFORE any other imports
 # This must happen at module level to catch all provider instantiations
 import sys
@@ -105,6 +100,49 @@ except ImportError:
 
 # Test logging configuration
 logging.basicConfig(level=logging.DEBUG)
+
+
+#: Which fixtures PROVIDE which piece of infrastructure.
+#:
+#: This map is the whole basis on which `pytest_collection_modifyitems` decides
+#: that a test needs infrastructure: a test is marked `requires_<x>` IFF its
+#: resolved fixture closure (`item.fixturenames`, which pytest expands
+#: transitively) contains one of these. See the long comment at that hook for
+#: why the previous name-keyword inference was removed outright (#2152) rather
+#: than corrected again -- measured, it disagreed with this graph on 2,248 of
+#: 14,773 items, in BOTH directions.
+#:
+#: Adding an infrastructure fixture WITHOUT adding it here is the one way this
+#: map can rot, so `tests/unit/test_infra_marker_mapping.py` fails when a new
+#: infra-shaped fixture appears in this conftest unmapped. Add the entry in the
+#: same commit as the fixture.
+#:
+#: A test that reaches infrastructure WITHOUT going through a fixture (a direct
+#: socket or subprocess call) declares `@pytest.mark.requires_<x>` on itself --
+#: the hook only ADDS markers, so an explicit declaration always survives.
+_INFRA_FIXTURES: Dict[str, frozenset] = {
+    "requires_postgres": frozenset(
+        {
+            "postgres_connection_string",
+            "postgres_connection_config",
+            # Opens a real psycopg2 connection; skips when PG is unavailable.
+            "integration_database_connection",
+            # Depends on the above (so the closure already catches it) -- listed
+            # explicitly so the mapping reads as a complete inventory.
+            "e2e_database_setup",
+        }
+    ),
+    "requires_redis": frozenset(
+        {
+            "redis_connection_config",
+            "redis_connection_params",
+            "integration_redis_connection",
+        }
+    ),
+    "requires_docker": frozenset({"docker_services"}),
+    "requires_ollama": frozenset({"ollama_connection_config"}),
+    "requires_mysql": frozenset({"mysql_connection_config"}),
+}
 
 
 @pytest.fixture
@@ -814,6 +852,14 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow: Slow running tests (timeout > 5s)")
     config.addinivalue_line("markers", "requires_postgres: Tests requiring PostgreSQL")
     config.addinivalue_line("markers", "requires_redis: Tests requiring Redis")
+    # Registered because `_INFRA_FIXTURES` maps `mysql_connection_config` to it
+    # (#2152). An unregistered marker raises PytestUnknownMarkWarning, which
+    # this repo treats as an error. NOTE: unlike its siblings this marker is
+    # not currently in unified-ci's infra-free deselect expression, so it does
+    # not yet gate CI selection -- the fixture's own `pytest.skip` when MySQL
+    # is unavailable is what keeps those tests from failing. Add it to the
+    # expression when a MySQL-backed test lands that must be deselected.
+    config.addinivalue_line("markers", "requires_mysql: Tests requiring MySQL")
     config.addinivalue_line(
         "markers", "requires_docker: Tests requiring Docker services"
     )
@@ -896,19 +942,44 @@ def pytest_collection_modifyitems(config, items):
         #     marker.
         #   * 'db' is kept but matched as a WHOLE TOKEN, so `test_db_pool`
         #     still marks while `feedback`/`sandbox`/`mongodb` no longer do.
-        # Long keywords keep substring matching ('cache' SHOULD match 'cached').
+        #
+        # ROOT-CAUSE FIX (#2152, supersedes both fixes above): the keyword list
+        # was never the defect. INFERRING A DEPENDENCY FROM A TEST'S NAME is.
+        # A name is prose; it is not a declaration, nothing keeps it in sync
+        # with what the test actually does, and the inference is wrong in BOTH
+        # directions. Measured against the real fixture graph over the same
+        # 14,773 collected items:
+        #
+        #   name-matcher agrees with the fixture graph : 12544 (84.9%)
+        #   FALSE POSITIVES (name says infra, requests no infra fixture): 2246
+        #   FALSE NEGATIVES (requests an infra fixture, name misses it)  :    2
+        #
+        # The false NEGATIVES are the sharper half and no word-list edit can
+        # ever fix them: `test_integration_multi_service` (redis) and
+        # `test_audit_hook_includes_trace_id` (postgres) genuinely request
+        # infra fixtures, went UNMARKED, and therefore RAN in infra-free CI
+        # steps where they can only fail or flake.
+        #
+        # So the name is not consulted at all any more. A test needs
+        # infrastructure IFF it REQUESTS a fixture that provides it --
+        # `item.fixturenames` is pytest's resolved TRANSITIVE fixture closure,
+        # so a test reaching infra through an intermediate fixture is caught
+        # too. This is a structural fact about the dependency graph, not a
+        # guess about English: no word can false-positive it, and a genuinely
+        # infra-bound test cannot slip through by being named tersely.
+        #
+        # An EXPLICIT marker on the test still wins on its own terms -- this
+        # block only ADDS markers, never removes them -- so a test that reaches
+        # infrastructure WITHOUT a fixture (a direct socket/subprocess call)
+        # declares `@pytest.mark.requires_<x>` itself. That is the intended
+        # escape hatch and it is a declaration, not an inference.
+        #
+        # `_INFRA_FIXTURES` is a closed, greppable map, and
+        # tests/unit/test_infra_marker_mapping.py FAILS if a new infra-shaped
+        # fixture is added to this conftest without a mapping entry -- so the
+        # map cannot silently rot the way the keyword list did.
         if hasattr(item, "function") and item.function:
-            name = item.name.lower()
-            tokens = set(re.findall(r"[a-z0-9]+", name))
-
-            # Check for database usage in test parameters or names
-            if any(keyword in name for keyword in ["postgres", "database"]) or (
-                "db" in tokens
-            ):
-                item.add_marker(pytest.mark.requires_postgres)
-            if any(keyword in name for keyword in ["redis", "cache"]):
-                item.add_marker(pytest.mark.requires_redis)
-            if "docker" in name:
-                item.add_marker(pytest.mark.requires_docker)
-            if any(keyword in name for keyword in ["ollama", "llm"]):
-                item.add_marker(pytest.mark.requires_ollama)
+            requested = set(getattr(item, "fixturenames", ()) or ())
+            for marker_name, providing_fixtures in _INFRA_FIXTURES.items():
+                if requested & providing_fixtures:
+                    item.add_marker(getattr(pytest.mark, marker_name))

--- a/packages/kailash-kaizen/tests/unit/test_infra_marker_mapping.py
+++ b/packages/kailash-kaizen/tests/unit/test_infra_marker_mapping.py
@@ -1,0 +1,202 @@
+"""Guards for the infrastructure-marker mechanism in ``tests/conftest.py`` (#2152).
+
+Infrastructure markers (``requires_postgres`` / ``requires_redis`` / ...) decide
+which tests every infra-free CI step DESELECTS. Getting that decision wrong is
+silent in both directions:
+
+* over-marking excludes a test from CI and nothing ever reports it as skipped;
+* under-marking runs an infra-bound test in an infra-free step, where it can
+  only fail or flake.
+
+The mechanism was twice inferred from the test's NAME and twice wrong. Measured
+over 14,773 collected items, name-keyword inference disagreed with the actual
+fixture graph on 2,248 of them -- 2,246 false positives and 2 false negatives
+(``test_integration_multi_service`` and ``test_audit_hook_includes_trace_id``
+genuinely request infra fixtures, went unmarked, and therefore RAN in
+infra-free CI). It is now derived from ``item.fixturenames``: a structural fact
+about the dependency graph rather than a guess about English.
+
+These tests protect the two ways that mechanism can still decay:
+
+1. the ``_INFRA_FIXTURES`` map silently falling out of sync with the fixtures
+   the conftest actually defines (a new infra fixture, or a renamed one);
+2. name-keyword inference being reintroduced alongside it.
+
+They parse the conftest with :mod:`ast` rather than importing it -- the module
+is a pytest conftest with import-order side effects, and structural
+enumeration is what this repo requires for symbol-set assertions anyway.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Dict, Set
+
+import pytest
+
+CONFTEST = Path(__file__).resolve().parent.parent / "conftest.py"
+
+#: Substrings that make a fixture name INFRA-SHAPED, i.e. a fixture a reader
+#: would expect to provide external infrastructure. Used ONLY to decide which
+#: fixtures this guard demands a mapping decision for -- never to mark a test.
+#: A fixture matching one of these must appear in ``_INFRA_FIXTURES`` or in
+#: ``_INTENTIONALLY_UNMAPPED`` below, so the decision is always explicit.
+_INFRA_SHAPED = ("postgres", "redis", "docker", "ollama", "mysql", "kafka", "mongo")
+
+#: Infra-SHAPED fixture names that deliberately map to NO marker, each with the
+#: reason it needs none. Present so "unmapped" is always a recorded decision
+#: rather than an omission.
+_INTENTIONALLY_UNMAPPED: Dict[str, str] = {}
+
+
+def _parse_conftest() -> ast.Module:
+    return ast.parse(CONFTEST.read_text(encoding="utf-8"), filename=str(CONFTEST))
+
+
+def _defined_fixtures(tree: ast.Module) -> Set[str]:
+    """Every name defined with an ``@pytest.fixture`` decorator, via AST."""
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            # Matches both `@pytest.fixture` and `@pytest.fixture(scope=...)`.
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(target, ast.Attribute) and target.attr == "fixture":
+                found.add(node.name)
+                break
+    return found
+
+
+def _mapped_fixtures(tree: ast.Module) -> Dict[str, Set[str]]:
+    """Read the ``_INFRA_FIXTURES`` literal without importing the conftest."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AnnAssign) and not isinstance(node, ast.Assign):
+            continue
+        targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets
+        if not any(
+            isinstance(t, ast.Name) and t.id == "_INFRA_FIXTURES" for t in targets
+        ):
+            continue
+        assert isinstance(
+            node.value, ast.Dict
+        ), "_INFRA_FIXTURES must be a dict literal"
+        out: Dict[str, Set[str]] = {}
+        for key, value in zip(node.value.keys, node.value.values):
+            assert isinstance(key, ast.Constant) and isinstance(key.value, str)
+            # value is `frozenset({...})`
+            assert isinstance(
+                value, ast.Call
+            ), "map values must be frozenset(...) calls"
+            names: Set[str] = set()
+            for arg in value.args:
+                for elt in getattr(arg, "elts", []):
+                    assert isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    names.add(elt.value)
+            out[key.value] = names
+        return out
+    raise AssertionError("_INFRA_FIXTURES not found in conftest.py")
+
+
+def test_every_infra_shaped_fixture_has_an_explicit_marker_decision():
+    """A new infra fixture MUST be mapped (or explicitly recorded as unmapped).
+
+    This is the failure mode that let the previous mechanism rot: the map is
+    only as good as its coverage, and an unmapped infra fixture silently
+    reverts a test to "needs nothing".
+    """
+    tree = _parse_conftest()
+    defined = _defined_fixtures(tree)
+    mapped = set().union(*_mapped_fixtures(tree).values())
+
+    infra_shaped = {f for f in defined if any(h in f.lower() for h in _INFRA_SHAPED)}
+    undecided = infra_shaped - mapped - set(_INTENTIONALLY_UNMAPPED)
+
+    assert not undecided, (
+        "Infra-shaped fixtures in tests/conftest.py with no marker decision: "
+        f"{sorted(undecided)}. Add each to _INFRA_FIXTURES so tests requesting "
+        "it are deselected from infra-free CI steps, or to "
+        "_INTENTIONALLY_UNMAPPED with the reason it needs no marker. Leaving it "
+        "undecided means tests using it RUN in infra-free CI, where they can "
+        "only fail or flake."
+    )
+
+
+def test_every_mapped_fixture_actually_exists():
+    """The map MUST NOT name a fixture that no longer exists.
+
+    A renamed or deleted fixture leaves a dead entry, and the tests that used
+    to be marked through it silently stop being marked.
+    """
+    tree = _parse_conftest()
+    defined = _defined_fixtures(tree)
+    mapped = _mapped_fixtures(tree)
+
+    dangling = {
+        marker: sorted(names - defined)
+        for marker, names in mapped.items()
+        if names - defined
+    }
+    assert not dangling, (
+        f"_INFRA_FIXTURES names fixtures that tests/conftest.py does not define: "
+        f"{dangling}. A renamed or deleted fixture leaves a dead mapping entry, "
+        "and every test that reached infrastructure through it silently stops "
+        "being marked."
+    )
+
+
+def test_marker_assignment_does_not_infer_from_the_test_name():
+    """Name-keyword inference MUST NOT come back.
+
+    Measured, it disagreed with the fixture graph on 2,248 of 14,773 items in
+    BOTH directions, so no edit to a keyword list makes it sound. The marker
+    decision reads ``item.fixturenames``; if a future change needs an escape
+    hatch, the test declares ``@pytest.mark.requires_<x>`` on itself.
+    """
+    tree = _parse_conftest()
+
+    hook = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == "pytest_collection_modifyitems"
+        ),
+        None,
+    )
+    assert hook is not None, "pytest_collection_modifyitems not found in conftest.py"
+
+    # Every `add_marker(...)` for an infra marker must be reached from a branch
+    # that consulted `fixturenames` -- never from one that consulted item.name.
+    reads_fixturenames = any(
+        isinstance(n, ast.Constant) and n.value == "fixturenames"
+        for n in ast.walk(hook)
+    ) or any(
+        isinstance(n, ast.Attribute) and n.attr == "fixturenames"
+        for n in ast.walk(hook)
+    )
+    assert reads_fixturenames, (
+        "pytest_collection_modifyitems no longer reads item.fixturenames. The "
+        "infra-marker decision MUST be derived from the resolved fixture graph, "
+        "not inferred from the test's name."
+    )
+
+    # `item.name` may still be read for non-infra markers (performance/slow),
+    # so assert on the specific defect: an infra marker added from a name test.
+    infra_markers = set(_mapped_fixtures(tree))
+    for node in ast.walk(hook):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "add_marker"):
+            continue
+        rendered = ast.dump(node)
+        for marker in infra_markers:
+            if marker in rendered:
+                pytest.fail(
+                    f"{marker} is added via a hard-coded add_marker call "
+                    f"({ast.unparse(node)}). Infra markers MUST be driven by the "
+                    "_INFRA_FIXTURES map so the mapping stays the single place "
+                    "the decision lives."
+                )

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -1,77 +1,150 @@
-# Session Notes — 2026-08-15
+# Session Notes — 2026-08-15 (wave-1 parallel, cont-18)
 
 ## Where we are
 
-cont-17 closed. **Tier 2 now gates the merge** (#2038, via #2124) — a green `gh pr checks`
-carries information about the integration suite for the first time in this repo's history.
-All lane PRs merged; the only open PR is loom's Gate-2 sync, which is not ours. Next queue is
-ratified: CI selectors (#2074/#2076), then the auth-surface completion set.
+Seven-lane parallel wave dispatched against the ratified cont-17 queue. **First merge landed:
+PR #2143 (`e228c5514`) — #2119 + #2067.** That merge is load-bearing: it unblocks the CI chain,
+because L6's restored root-regression gate had exactly one failure and it was #2119.
+
+Nine PRs remain open. Two adversarial security reviews have completed and BOTH produced HIGH
+findings that a correctness lens would not have caught.
 
 ## Read first
 
-1. `workspaces/issue-1720-llm-consolidation/sweep-cont17-report.md` — the decision report:
-   completion status w/ receipts, value-ranked queue, three open decision points (D1–D3)
-2. `.github/workflows/unified-ci.yml` — the tier2 step. **Do not restore `continue-on-error`**
-3. `workspaces/issue-1720-llm-consolidation/launch-ledger-cont17.md` — orchestration record
-4. `CLAUDE.md` — Absolute Directives, framework bindings
+1. `workspaces/issue-1720-llm-consolidation/sweep-cont17-report.md` — the ratified queue this wave executes
+2. This file's **Merge chain** and **Open decisions** sections
+3. `CLAUDE.md` — Absolute Directives
 
-## In-flight state
+## Merge chain (dependency-ordered — do not reorder)
 
-- Nothing uncommitted. Working tree clean on `main`.
-- **#2133 was filed this sweep** and is un-triaged: `CI Pipeline` has never run on `main`
-  (its `push:` branches omit main). Decision D1 in the sweep report proposes a disposition.
+CI lane:  **#2143 (`e228c5514`) → #2144 (`8a4dca737`) → #2147 (`decd9eb8e`) — ALL MERGED**
+Auth lane: #2139 → #2140 → (#2156 auto-retargets)
+Independent: #2136 → #2150 (stacked); **#2137 MERGED (`2e3ddd9e7`)**; **#2148 MERGED (`a94aad89a`)**
 
-## Executed this session
+**FIVE MERGED:** #2143, #2144, #2137, #2148, #2147. The CI lane is COMPLETE — root
+regression gates restored and running to completion on the real runner (2403 passed / 277s).
 
-- None — no external actions. All work is in THIS repo's `git log`; no cross-repo writes,
-  no releases cut, no upstream issues filed.
+## ⚠ START HERE — PR #2159 is open and MUST NOT merge until 2 test bugs are fixed
+
+`fix/2152-marker-substring-boundary` (`255b94031`) fixes the F1 regression below. It is
+CORRECT and verified both polarities, but it RELEASES ~1,627 previously-excluded tests
+into the infra-free CI step, which surfaces **pre-existing** failures:
+
+```
+WITH the fix : 3 failed, 1494 passed, 145 deselected, 8 xfailed, 4 errors
+BASELINE     : 1 failed, 8 passed, 5 deselected, 2 errors   (main's own conftest, same 2 files)
+```
+
+Pre-existing, NOT caused by the fix — same failures reproduce against main's conftest.
+Two distinct test-infrastructure defects to fix before merging #2159:
+
+1. `test_mcp_tool_wrapper_closure_capture.py::test_pre_fix_wrapper_shape_is_rejected_by_real_registration`
+   → `ValueError: Functions with **kwargs are not supported as tools`
+2. `test_issue_1720_b1b_embed_cutover.py` → `ScopeMismatch` on a function-scoped fixture (4 params)
+
+Measured scope of the fix (14,773 items, past the `maxfail` that truncates a naive run to 3,760):
+any-infra marker **2229 (15.1%) → 576 (3.9%)**; `requires_ollama` **1980 → 353**.
+
+## ⚠ REGRESSION ON MAIN — fixed by #2159, not yet merged (F1)
+
+**#2143 × #2144 do not compose.** #2144's marker fix switched `str(item.function)` →
+`item.name.lower()` but kept the BARE SUBSTRING list, and `"ai"` is in it:
+`'ai' in 'kaizen'` is True. Measured on merged main (`2e3ddd9e7`):
+```
+test_issue_1720_b1a_live_cutover.py --co                     -> 5 collected
+same, -m "not requires_ollama"                               -> 2/5 (3 deselected)
+```
+**`test_azure_ai_foundry_routes_through_four_axis_path` — the #2067 test #2143 made
+hermetic — is deselected from every infra-free CI step.** #2143 fixed a test; #2144
+stopped running it. L4 is fixing (word-boundary match, or drop the 2-letter fragments).
+Scope number UNRECONCILED: reviewer measured 14.4% of 12,629 items; my own run over
+`packages/kailash-kaizen/tests/` collected 3,760 with 10 collection errors and the filter
+deselected NOTHING at that scope. Both cannot be complete — re-derive before citing.
+
+- **#2144** (CI selectors) — MERGED `8a4dca737`. Carries the marker-determinism fix (#2152).
+- **#2147** (CI hang) — rebases onto #2144 after it merges. MUST confirm L4's `schedule:` block,
+  `pull-requests: read`, and the #2133 comment block survive the rebase as a POSITIVE check.
+  `git merge-tree` between the two heads = exit 0, so no conflict expected.
+- **#2139** (gateway identity) — BLOCKED on the refresh-token fix (see Findings).
+- **#2140** (API-key auth) — RED on CodeQL, not converging. See Findings.
+- **#2136** (SSRF guard) — BLOCKED on a HIGH IMDS bypass (see Findings). #2150 is stacked on it
+  and must retarget to `main` only after #2136 merges.
+- **#2137** (server gating) — HIGH + MEDIUM fixed; one pre-existing coroutine defect to close.
+- **#2148** (ruff E721 cleanup) — green, mergeable, independent.
+
+## Findings that block merges
+
+- **#2136 HIGH — IMDS reachable on the DEFAULT posture via IPv6 wrappers.** Reproduced:
+  `64:ff9b::169.254.169.254` and `::ffff:0:a9fe:a9fe` are ACCEPTED. The translation-range
+  constants exist and are documented "unconditional", but are only consulted inside
+  `is_private_ipv6`, which only runs under `if not allow_private:` — and the proxy defaults
+  `require_public_destination=False`. Fix: hoist into the `if not allow_metadata:` block, match
+  by embedded IPv4 not `str(ip)`, and ADD IPv6 rows to `test_issue_2091` (absent coverage is why
+  it shipped).
+- **#2139 HIGH — the direct-verification path accepts a REFRESH token; the gate rejects it.**
+  `trust/auth/jwt.py:352-353` refuses `token_type == "refresh"`; neither manager does
+  (`auth_manager.py` has ZERO `token_type` occurrences). This is the one defect the PR made
+  reachable.
+- **#2140 — CodeQL HIGH unresolved.** #2146 carries a sound Rule-1b proof (SHA-256 over a
+  256-bit CSPRNG token is not password hashing; a slow KDF on `verify_api_key` would be a DoS
+  amplifier on an unauthenticated path) but a proof does not turn a check green.
+  `.github/codeql/sanitizers/` already exists with precedent. **Confirm WHICH alert is live
+  first** — a later commit changed key addressing and may have moved it.
+
+## Open decisions for the human (unchanged, still blocking nothing)
+
+- **isort is misconfigured** — the repo's own hook contradicts itself (`--all-files` vs
+  `--from-ref`). Probable one-line cause: `kailash_mcp` missing from `known_first_party`.
+  Fixing it rewrites every file importing `kailash_mcp`; this repo already sat at ~2,000
+  permanently-modified files for four cycles from this exact failure (#1995). NOT actioned.
+- **GPU CI (#2155)** — no self-hosted runner exists at repo OR org level (`total_count: 0` both),
+  and `gpu-smoke.yml` has never completed successfully since at least 2026-06-07 (5× cancelled).
+  Provision or retire, like `test-gpu` was (#2135).
+- **Branch protection requires ZERO status checks** — `strict: true, checks: []`, confirmed
+  independently by two lanes. Combined with #2133 (CI never ran on main), a PR could merge with
+  nothing required to pass. L4 has the exact `gh api` command in #2144's body, unapplied.
+- **Release ordering is now core → {nexus, kaizen}.** `kailash.utils.network_guard` is new in
+  core 2.63.0 (unreleased; PyPI latest is 2.62.0), and BOTH nexus and kaizen now import it.
+  Kaizen's floor was genuinely wrong (`>=2.56.0`, seven minors low) and is raised.
+
+## Traps (measured this session — do not rediscover)
+
+- **A stale installed wheel at `~/.pyenv/.../site-packages/kailash/` shadows repo source.**
+  Bit me directly: the kaizen slimming guard failed with `ImportError: cannot import name 'Node'`
+  until I put `$root/src` FIRST on PYTHONPATH. Always verify with
+  `python3 -c "import kailash.nodes.base as b; print(b.__file__)"`.
+- **Combining root `tests/` and `packages/kailash-kaizen/tests/` in one pytest invocation raises
+  `ImportPathMismatchError`** (conftest collision). Run them separately, as CI does.
+- **Read-only reviewers (`security-reviewer`) have NO Bash.** Dispatching them with `git diff` /
+  `git rev-parse` instructions produces an EMPTY return that is indistinguishable from a clean
+  review. Materialize the diff to a file with the pinned SHA on line 1. Cost this session: two
+  wasted review cycles.
+- **Agents' plain-text output is invisible to the orchestrator.** Two reviewers completed work
+  that never arrived. Require SendMessage explicitly.
+- **`str(item.function)` embeds the ASLR memory address** — see #2152. Any keyword match against
+  it is non-deterministic.
 
 ## Wave tracker
 
-None — no waves in flight. No background agents running at wrapup.
+L1 #2140 (CodeQL, not converging) · L2 #2139 + #2145 + #2148 · L3 #2137 · L4 #2144 (DONE) ·
+L5 #2143 (MERGED) + #2111/#2069 next · L6 #2147 (awaiting #2144) · L7 #2136 + #2150 + webhooks.
+Reviewers: R1 (#2139 done), R2 (#2137 + #2136 done), R3 (#2143/#2139/#2137 correctness — never
+reported; treat as NOT run).
 
-## Outstanding ledger (forest)
+## Issues filed this session
 
-| ID  | Item                                          | Value-anchor (MUST-1 source)                                                    | Status                    |
-| --- | --------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------- |
-| F1  | CI selectors + red-on-main tests              | Co-owner "approved" this session (#2074/#2076); same blind-spot class as #2038   | queued — START HERE       |
-| F2  | Auth-surface completion                       | Co-owner "burn down the buckets"; #2108 = an auth path that cannot authenticate  | queued (highest exposure) |
-| F3  | CI hang chain #2081 → #2079 → #2002           | cont-16 report §3 — the keystone; #2002 stays blocked until it lands             | BLOCKED on #2081 diag     |
-| F4  | Proxy hardening #2085 #2087 #2091             | cont-16 report §3 — SSRF/traversal/exhaustion on a shipped surface               | queued (held 2×)          |
-| F5  | CI never runs on main (#2133)                 | Measured this sweep; same class as #2038                                        | awaiting D1 ratification  |
-| F6  | Gemini 3.x tool loops #2120 #2121             | Filed w/ measurement — a tool loop cannot terminate                             | queued                    |
-| F7  | Correctness set #2107 #2069 #2111 #2113 #2109 | #2107 is the documented deadlock class in `patterns.md`                          | queued                    |
+#2135 (GPU tests) · #2138 (rotation never fires) · #2141 (kailash-ml unauth DELETE) ·
+#2142 (kaizen un-gated surfaces) · #2145 (**session IDOR — authenticated RCE in another user's
+session; highest open severity**) · #2146 (codeql defer) · #2149 (order-dependent test) ·
+#2151 (cross-user event stream, FIXED by #2139) · #2152 (marker residue + "ai" substring) ·
+#2155 (GPU runner decision).
 
-Closed this session: `F-CI-MASK` (Tier-2 masking) → receipts PR #2124 (`8b96e07a6`) + PR #2131
-(`46c738ad4`); issues #2038 and #2129 both CLOSED.
+## The pattern worth carrying forward
 
-## Traps
-
-- **A stale installed wheel shadows the repo source.** Reproducing Tier 2 locally invents a
-  failure that does not exist on the branch. Prefix `PYTHONPATH="$PWD/packages/kailash-mcp/src:$PYTHONPATH"`.
-  Local `kailash.kaizen` import errors are the same class — CI installs sub-packages editable.
-- **`test_async_execution_no_threading`'s `xfail` says "flaky" but was swallowing a real auth
-  error.** It now XPASSes. The marker is wrong; see sweep D3 before removing it.
-- **Pre-commit runs the full Tier-1 suite on doc-only commits** — a notes commit takes minutes.
-  Budget for it; do not assume a hang.
-- **`gh issue create --body` with backticks silently no-ops.** Use `--body-file`. An empty
-  result is not confirmation — re-list to verify the issue exists.
-
-## Unreleased packages (BUILD-repo release drift — ALL NINE have drift)
-
-`kailash` 2.63.0 (tag v2.62.0) · `kailash-kaizen` 2.46.0 · `kailash-nexus` 2.16.0 ·
-`kailash-mcp` 0.5.1 · `kailash-dataflow` 2.20.0 · `kailash-ml` 2.2.3 · `kaizen-agents` 0.13.0 ·
-`kailash-pact` 0.18.0 **(version == tag — needs a bump)** · `kailash-align` 0.7.4 **(same)**.
-
-**Every security fix from this session is unreleased** — fail-closed auth (#2072), the
-key-generation fixes (#2083/#2092), the MFA actor model (#2047), sink-level log sanitizing.
-Users on PyPI do not have any of them. Re-derive with
-`node -e 'console.log(require("./.claude/hooks/lib/release-drift.js").detectUnreleasedPackages(process.cwd()))'`
-— running that file directly prints NOTHING and exits 0; it is a module, not a script.
-
-## Open questions for the human
-
-- **`/release` — the biggest open call.** Nine packages drifted; the session's security fixes
-  are all unshipped. Release is a structural human gate, so it was NOT cut unilaterally.
-- Sweep D1 (#2133): which CI-on-main fix — nightly + required checks (recommended), or per-merge?
-- Sweep D2 (#2119): confirm the LOC invariant RED on main folds into the F1 wave.
+Ten independent findings share ONE shape: **a control that reports success without doing its
+job.** `verify_api_key` that can never succeed; rotation that never fires; `--auth` that unlocks
+a 0.0.0.0 bind while installing nothing; `enable_checkpointing` with no checkpoint module; CI
+gates matching zero tests; a "signature" that is 8 chars of the secret; a marker hook keyed on
+memory addresses; an LOC guard silently raised from 1015 to 1070 to pass; a `run()` returning an
+un-awaited coroutine; and an IMDS guard documented "unconditional" that no shipped config
+executes. None are tested-path defects. All would ship green.

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -24,7 +24,56 @@ Independent: #2136 → #2150 (stacked); **#2137 MERGED (`2e3ddd9e7`)**; **#2148 
 **FIVE MERGED:** #2143, #2144, #2137, #2148, #2147. The CI lane is COMPLETE — root
 regression gates restored and running to completion on the real runner (2403 passed / 277s).
 
-## ⚠ START HERE — PR #2159 is open and MUST NOT merge until 2 test bugs are fixed
+## ROOT-CAUSE FIX — #2160 MERGED (`995d72bc4`), #2159 rebased green, awaiting CI
+
+The marker defect is fixed at the root, not patched again. **The name is no longer
+consulted at all.** A test needs infrastructure IFF its resolved fixture closure
+(`item.fixturenames`, transitive) contains a fixture that provides it — a structural fact
+about the dependency graph, not a guess about English.
+
+Why the two prior fixes were both symptom-level, measured over 14,773 items:
+```
+name-matcher agrees with the fixture graph        : 12544 (84.9%)
+FALSE POSITIVES (name says infra, no infra fixture): 2246
+FALSE NEGATIVES (uses infra fixture, name misses)  :    2
+```
+The FALSE NEGATIVES are the half no word-list edit reaches: `test_integration_multi_service`
+(redis) and `test_audit_hook_includes_trace_id` (postgres) requested infra fixtures, went
+UNMARKED, and RAN in infra-free CI where they can only fail or flake. Both correct now.
+
+`tests/unit/test_infra_marker_mapping.py` guards the three decay paths, **each
+mutation-verified to RED** (unmapped fixture / renamed fixture / name-inference
+reintroduced), conftest restored byte-identical after each.
+
+Progression on the suite CI runs (`tests/regression/`, full infra-free filter):
+```
+main (before)            : 1288 passed, 342 deselected   [342 was a random variable]
+keyword patch            : 1494 passed, 145 deselected, 3 failed, 4 errors
+fixture graph alone      : 1616 passed,   5 deselected, 3 failed, 6 errors
+fixture graph + #2160    : 1623 passed,   5 deselected, 0 failed, 0 errors
+```
+
+### What #2160 found (all three verified independently before merge)
+1. **A live product bug** — MCP auto-discovery aborted the ENTIRE server registration when
+   one method declared `**kwargs`, so auto-registration registered nothing. Fixed in
+   `mcp_mixin.py`: an explicit tool list is a demand (publish or raise); auto-discovery
+   warns past un-publishable methods.
+2. **The ScopeMismatch cause** — a fixture shadowing `pytest-base-url`'s `base_url`, not a
+   scope that needed widening.
+3. **The stale-wheel trap, second instance.** `test_issue_1973` failed because
+   `kaizen_agents` resolved to `site-packages` (old wheel) from kailash-kaizen's tree and to
+   branch source from kaizen-agents' tree. The product was fine; the test placement was wrong.
+4. **`packages/kaizen-agents/tests/` had NEVER run in CI — 812 tests.** The only
+   `packages/kaizen-agents` references were `paths:` TRIGGER filters (which workflow runs),
+   not pytest targets. Now wired into `test-kailash-kaizen.yml` with baseline
+   `812 passed, 2 deselected, 0 failed` established BEFORE wiring.
+
+**Four independent never-ran mechanisms found in one chain:** masked Tier 2 (#2038),
+unwired kaizen regression (#2074), memory-address markers (#2152), unreferenced package
+suite (#2160). Assume more exist; the pattern is "a control that reports success without
+doing its job."
+
+## (superseded) PR #2159 blocker notes
 
 `fix/2152-marker-substring-boundary` (`255b94031`) fixes the F1 regression below. It is
 CORRECT and verified both polarities, but it RELEASES ~1,627 previously-excluded tests


### PR DESCRIPTION
## Root cause

Two prior fixes treated the symptom. #2144 repaired *how* the test's NAME was matched
(it had been matching `str(item.function)`, which embeds the ASLR memory address). An
earlier commit on this branch corrected *which words* were matched. **The defect is that
the name is consulted at all.**

A test name is prose. Nothing keeps it in sync with what the test does, and the inference
it supports is wrong in **both** directions. Measured against the resolved fixture graph
over the same 14,773 collected kaizen items:

```
name-matcher agrees with the fixture graph        : 12544 (84.9%)
FALSE POSITIVES (name says infra, no infra fixture): 2246
FALSE NEGATIVES (uses infra fixture, name misses)  :    2
```

The **false negatives** are the half no word-list edit can ever reach:
`test_integration_multi_service` (redis) and `test_audit_hook_includes_trace_id`
(postgres) genuinely request infra fixtures, went **unmarked**, and therefore **ran in
infra-free CI steps where they can only fail or flake**. Both are correctly marked now.

## The fix

The name is no longer consulted. A test needs infrastructure **iff its resolved fixture
closure** (`item.fixturenames`, which pytest expands transitively) contains a fixture that
provides it — a structural fact about the dependency graph, not a guess about English. No
word can false-positive it; a terse-named infra test cannot slip through.

`_INFRA_FIXTURES` is a closed, greppable map. A test that reaches infrastructure *without*
a fixture (direct socket/subprocess) declares `@pytest.mark.requires_<x>` on itself — the
hook only **adds** markers, so an explicit declaration always survives. That is the escape
hatch, and it is a declaration rather than an inference.

## Why this cannot rot the way the keyword list did

`tests/unit/test_infra_marker_mapping.py` guards all three decay paths. **Each was
mutation-verified to go RED**, with the mutation confirmed present in the file first:

| mutation | guard |
| --- | --- |
| add an unmapped infra fixture | `test_every_infra_shaped_fixture_has_an_explicit_marker_decision` → RED |
| rename a mapped fixture | `test_every_mapped_fixture_actually_exists` → RED |
| reintroduce name inference | `test_marker_assignment_does_not_infer_from_the_test_name` → RED |

Conftest restored byte-identical after each.

## Effect on the suite CI actually runs

`tests/regression/`, full infra-free marker filter:

| | passed | deselected |
| --- | --- | --- |
| main | 1288 | 342 *(unstable — the 342 was a random variable)* |
| keyword patch | 1494 | 145 |
| **fixture graph** | **1616** | **5** |

## ⚠ Still RED — three pre-existing defects this release surfaces

Releasing the falsely-excluded tests surfaces failures that were being silently skipped.
**All three verified pre-existing by A/B against `origin/main`'s own conftest** (same file,
same command, only the conftest swapped — identical results). This PR widens exposure; it
does not create them.

1. `test_mcp_tool_wrapper_closure_capture.py::test_pre_fix_wrapper_shape_is_rejected_by_real_registration`
2. `test_issue_1720_b1b_embed_cutover.py` — `ScopeMismatch`, **6** parametrized cases
3. `test_issue_1973_a2a_capability_match.py` — 2 cases (config/correlation_id propagation)

Being fixed in a separate lane; this PR merges once they are green.

## Related issues

Fixes #2152
Refs #2067, #2143, #2144
