### PR TITLE
fix(kaizen): dead MCP auto-registration, pytest-base-url collision, stale-wheel test placement + wire 812 never-run kaizen-agents tests into CI

### DIFF
--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -278,11 +278,17 @@ on:
     branches: [feat/*, feature/*, fix/*, docs/*, session/*, session-*, chore/*]
     paths:
       - "packages/kailash-kaizen/**"
+      # kaizen-agents is built and tested by this workflow (see the
+      # kaizen-agents regression step). Without this path a PR touching ONLY
+      # kaizen-agents would run none of its tests -- the same never-ran gap
+      # #2074 closed for kailash-kaizen's own regression suite.
+      - "packages/kaizen-agents/**"
       - ".github/workflows/test-kailash-kaizen.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/kailash-kaizen/**"
+      - "packages/kaizen-agents/**"
       - ".github/workflows/test-kailash-kaizen.yml"
   workflow_dispatch:
 
@@ -467,6 +473,31 @@ jobs:
         # passed, 425 deselected, 8 xfailed, 0 failed.
         timeout-minutes: 10
         working-directory: packages/kailash-kaizen
+        run: |
+          ../../.venv/bin/python -m pytest \
+            tests/regression/ \
+            -m 'not (integration or e2e or requires_azure or requires_docker or requires_google or benchmark or requires_postgres or requires_redis or requires_ollama or requires_db or requires_llm or llm_execution or real_llm or ollama_validation or cost or landing_ai or stress or endurance or requires_infrastructure or requires_kafka or requires_mongodb or memory_intensive or requires_isolation or data_intensive or flaky or slow or load or migration or openai or anthropic or google or docker or ollama or integration_llm or tier3 or performance)' \
+            --timeout=30 --maxfail=50 -q
+
+      - name: Test (kaizen-agents regression suite, infra-free)
+        # packages/kaizen-agents/tests/ appeared in NO pytest invocation in ANY
+        # workflow -- the only `packages/kaizen-agents` matches were the
+        # `paths:` TRIGGER filters in unified-ci.yml, which decide which
+        # workflow runs, not what pytest collects. The whole suite had
+        # therefore never run in CI: the same never-ran gap as #2074 (this
+        # job's kailash-kaizen regression step above) and #2038.
+        #
+        # This job is where it belongs: it already installs kaizen-agents
+        # editable (see the install step), so `kaizen_agents` resolves to the
+        # branch rather than to whatever wheel is on the runner. That
+        # resolution is load-bearing -- against a stale INSTALLED wheel these
+        # tests red while the branch source is already correct.
+        #
+        # Same broad exclusion set as the steps above. Baseline established
+        # before wiring this in (per #2074's instruction not to assume clean):
+        # 812 passed, 2 deselected, 0 failed.
+        timeout-minutes: 10
+        working-directory: packages/kaizen-agents
         run: |
           ../../.venv/bin/python -m pytest \
             tests/regression/ \

--- a/packages/kailash-kaizen/conftest.py
+++ b/packages/kailash-kaizen/conftest.py
@@ -22,6 +22,7 @@ as the un-scrubbed-secret gap this file's cost-guard half already closes.
 import os
 import sys
 from pathlib import Path
+from typing import Iterator, Tuple
 
 import pytest
 
@@ -43,6 +44,65 @@ _REAL_LLM_MARKER = "requires_real_llm"
 def pytest_collection_finish(session):
     """Backstop: remove any provider secret re-injected during collection."""
     scrub_provider_secrets()
+
+
+def _shadowed_first_party_packages() -> Iterator[Tuple[str, Path, Path]]:
+    """Yield (module, imported_from, repo_source) for siblings resolved OUTSIDE
+    this checkout.
+
+    Only inspects modules ALREADY in ``sys.modules``, so it costs no imports and
+    reports exactly what the run actually used.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    packages_dir = repo_root / "packages"
+    if not packages_dir.is_dir():
+        return
+
+    for src_dir in sorted(packages_dir.glob("*/src")):
+        for candidate in sorted(src_dir.iterdir()):
+            if not (candidate / "__init__.py").is_file():
+                continue
+            module = sys.modules.get(candidate.name)
+            imported_from = getattr(module, "__file__", None)
+            if imported_from is None:
+                continue
+            imported_path = Path(imported_from).resolve()
+            if repo_root not in imported_path.parents:
+                yield candidate.name, imported_path, candidate
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Report first-party packages served from outside this checkout.
+
+    A sibling package installed as a NON-editable wheel shadows the repo source
+    silently, so the suite tests the wheel's code while reporting on the repo's.
+    Both failure directions are expensive and neither is self-evident from the
+    output: a stale wheel reds tests whose repo source is already correct (and
+    the fix gets misattributed to product or test code, which is how correct
+    code gets "fixed"), and a wheel NEWER than the branch greens a regression
+    the branch actually has.
+
+    Advisory rather than fatal: testing against a released wheel on purpose is
+    legitimate, and failing the run would red every suite on any machine with a
+    stale sibling. It is printed in the summary, where the reader is already
+    looking when results surprise them.
+    """
+    shadowed = sorted(_shadowed_first_party_packages())
+    if not shadowed:
+        return
+
+    terminalreporter.section("first-party packages NOT served from this checkout")
+    for module, imported_path, repo_source in shadowed:
+        package_dir = repo_source.parent.parent
+        terminalreporter.write_line(f"  {module}: imported from {imported_path}")
+        terminalreporter.write_line(f"  {' ' * len(module)}  repo source {repo_source}")
+        terminalreporter.write_line(
+            f"  {' ' * len(module)}  fix: uv pip install -e "
+            f"{package_dir.relative_to(package_dir.parent.parent)}"
+        )
+    terminalreporter.write_line(
+        "Results above describe the INSTALLED code, not this branch."
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/packages/kailash-kaizen/src/kaizen/core/mcp_mixin.py
+++ b/packages/kailash-kaizen/src/kaizen/core/mcp_mixin.py
@@ -22,6 +22,8 @@ Copyright 2025 Terrene Foundation (Singapore CLG)
 Licensed under Apache-2.0
 """
 
+import functools
+import inspect
 import json
 import logging
 import os
@@ -30,6 +32,30 @@ from typing import Any, Dict, List, Optional
 from kaizen.tools.types import DangerLevel, ToolCategory, ToolDefinition, ToolParameter
 
 logger = logging.getLogger(__name__)
+
+# Parameter kinds an auto-generated MCP tool cannot carry. The wrapper forwards
+# every argument by keyword, and the MCP server derives the tool's published
+# JSON schema from the signature -- neither is expressible for these kinds, so
+# a method declaring one cannot become a tool.
+_UNPUBLISHABLE_PARAM_KINDS = {
+    inspect.Parameter.VAR_POSITIONAL: "*args",
+    inspect.Parameter.VAR_KEYWORD: "**kwargs",
+    inspect.Parameter.POSITIONAL_ONLY: "positional-only parameters",
+}
+
+
+def _unpublishable_reason(method) -> Optional[str]:
+    """Return why ``method`` cannot be published as an MCP tool, else None."""
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError) as exc:  # builtins / C-level callables
+        return f"its signature could not be inspected ({exc})"
+
+    for parameter in signature.parameters.values():
+        kind = _UNPUBLISHABLE_PARAM_KINDS.get(parameter.kind)
+        if kind is not None:
+            return f"it declares {kind}, which MCP tools cannot express"
+    return None
 
 
 class MCPMixin:
@@ -737,7 +763,11 @@ class MCPMixin:
             **server_kwargs,
         )
 
-        if tools is None:
+        # An explicit list is a demand: a method the caller named MUST either be
+        # published or raise. Auto-discovery sweeps every public attribute, so it
+        # unavoidably meets un-publishable ones and warns past them instead.
+        auto_discovered = tools is None
+        if auto_discovered:
             tools = [
                 m
                 for m in dir(self)
@@ -751,6 +781,17 @@ class MCPMixin:
 
             method = getattr(self, tool_name)
 
+            reason = _unpublishable_reason(method)
+            if reason is not None:
+                message = f"Tool {tool_name} cannot be exposed as an MCP tool: {reason}"
+                if not auto_discovered:
+                    raise ValueError(
+                        f"{message}. It was requested explicitly via `tools=`; "
+                        "give it a concrete signature or drop it from the list."
+                    )
+                logger.warning(f"{message}, skipping")
+                continue
+
             # Bind via an enclosing scope, NOT a default argument. The default-arg
             # idiom (`_bound_method=method`) is the usual way to dodge Python's
             # late-binding-in-a-loop trap, but it is wrong here: the wrapper is
@@ -761,9 +802,19 @@ class MCPMixin:
             # method (binding by name, never reaching **kwargs). A factory closure
             # solves the late-binding problem without putting internal state in the
             # public signature.
+            #
+            # `functools.wraps` is load-bearing, not cosmetic. The server builds
+            # the published schema from the wrapper's signature and annotations,
+            # and a bare `**kwargs` wrapper carries NEITHER: FastMCP refuses to
+            # register a variadic function at all ("Functions with **kwargs are
+            # not supported as tools"), so every auto-generated tool raised and
+            # the feature was dead for every agent. `wraps` copies the method's
+            # signature (via `__wrapped__`) and its annotations onto the wrapper,
+            # so the tool registers AND advertises the method's real parameters
+            # instead of an empty schema no client could call correctly.
             def _make_tool_wrapper(bound_method):
+                @functools.wraps(bound_method)
                 async def tool_wrapper(**kwargs):
-                    """Auto-generated MCP tool from agent method."""
                     result = bound_method(**kwargs)
                     if hasattr(result, "__await__"):
                         result = await result
@@ -773,7 +824,25 @@ class MCPMixin:
 
             tool_wrapper = _make_tool_wrapper(method)
             tool_wrapper.__name__ = tool_name
-            server.tool()(tool_wrapper)
+
+            # The server is the authority on publishability: beyond the variadic
+            # kinds rejected above it also refuses annotations it cannot render
+            # as JSON schema, and that set is not enumerable from here. One
+            # un-publishable method must not abort the whole server -- which is
+            # exactly how this feature died -- so an auto-discovered method warns
+            # and is skipped, while an explicitly requested one still raises.
+            try:
+                server.tool()(tool_wrapper)
+            except Exception as exc:
+                if not auto_discovered:
+                    raise ValueError(
+                        f"Tool {tool_name} was requested explicitly via `tools=` "
+                        f"but the MCP server refused to register it: {exc}"
+                    ) from exc
+                logger.warning(
+                    f"Tool {tool_name} could not be registered as an MCP tool "
+                    f"({exc}), skipping"
+                )
 
         self._mcp_server = server
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_1720_b1b_embed_cutover.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1720_b1b_embed_cutover.py
@@ -102,6 +102,15 @@ class _CannedEmbedTransport:
 # Per-wire (provider, model, api_key, base_url, body-builder) matrix. api_key /
 # base_url are passed EXPLICITLY to resolve_deployment_for so no env var is read
 # (no env-mutation, no lock needed per rules/testing.md § env serialization).
+#
+# The parametrize argname is ``wire_base_url``, NOT ``base_url``. Do not rename
+# it back: ``pytest-base-url`` ships a SESSION-scoped ``base_url`` fixture plus a
+# session-scoped autouse ``_verify_url(request, base_url)`` that consumes it.
+# Parametrizing on ``base_url`` overrides that fixture with a FUNCTION-scoped
+# one, and the session-scoped consumer then fails every case in this file with
+# ``ScopeMismatch: You tried to access the function scoped fixture base_url with
+# a session scoped request object``. The name is ours and local, so renaming it
+# is the fix; widening or narrowing a third-party plugin's fixture is not.
 _WIRES = [
     ("openai", _OPENAI_MODEL, "sk-fixture", None, _openai_body),
     ("ollama", _OLLAMA_MODEL, None, "http://localhost:11434", _ollama_body),
@@ -127,13 +136,13 @@ def _client_for(provider: str, api_key, base_url, model: str) -> LlmClient:
 
 @pytest.mark.regression
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider,model,api_key,base_url,body_fn", _WIRES)
+@pytest.mark.parametrize("provider,model,api_key,wire_base_url,body_fn", _WIRES)
 async def test_embed_normalize_true_unit_vectors_every_wire(
-    provider, model, api_key, base_url, body_fn
+    provider, model, api_key, wire_base_url, body_fn
 ):
     """``EmbedOptions(normalize=True)`` L2-unit-normalizes the returned vector
     for EVERY wire (uniform client-side, not HF-only). [3, 4] -> [0.6, 0.8]."""
-    client = _client_for(provider, api_key, base_url, model)
+    client = _client_for(provider, api_key, wire_base_url, model)
     transport = _CannedEmbedTransport(body_fn([3.0, 4.0]))
 
     vectors = await client.embed(
@@ -153,13 +162,13 @@ async def test_embed_normalize_true_unit_vectors_every_wire(
 
 @pytest.mark.regression
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider,model,api_key,base_url,body_fn", _WIRES)
+@pytest.mark.parametrize("provider,model,api_key,wire_base_url,body_fn", _WIRES)
 async def test_embed_normalize_none_byte_identical_raw(
-    provider, model, api_key, base_url, body_fn
+    provider, model, api_key, wire_base_url, body_fn
 ):
     """No options AND ``EmbedOptions(normalize=None)`` both leave the raw wire
     vector untouched (additive-neutrality)."""
-    client = _client_for(provider, api_key, base_url, model)
+    client = _client_for(provider, api_key, wire_base_url, model)
 
     no_opts = await client.embed(
         ["x"], model=model, http_client=_CannedEmbedTransport(body_fn([3.0, 4.0]))

--- a/packages/kailash-kaizen/tests/regression/test_issue_1973_a2a_capability_match.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1973_a2a_capability_match.py
@@ -41,10 +41,17 @@ These tests pin:
 (b) the three tier weights (1.0 / 0.7 / 0.4) survive and differentiate;
 (c) ``matches_requirement`` is NOT a coroutine function (shape pin — the
     ``24dcc4bb5`` regression re-lands the moment this flips);
-(d) the ``kaizen_agents`` sync/async bridges still propagate ``config`` and
-    ``correlation_id`` to the now-sync matcher (guards the fix's own blast
-    radius — the bridges dispatch on ``inspect.iscoroutinefunction``);
-(e) the summarization fallback emits a WARN record instead of swallowing.
+(d) the summarization fallback emits a WARN record instead of swallowing.
+
+Deliverable (d) of the original shard — the ``kaizen_agents`` sync/async bridges
+still propagating ``config`` / ``correlation_id`` to the now-sync matcher — now
+lives in ``packages/kaizen-agents/tests/regression/``
+``test_issue_1973_reasoning_bridge_config_propagation.py``, the package that
+ships the bridges. It was unrunnable here: ``kaizen-agents`` depends on
+``kailash-kaizen``, so importing it from this suite inverts the dependency, and
+this package's ``pytest.ini`` exposes only its own ``src`` — ``kaizen_agents``
+resolved to whatever wheel was INSTALLED rather than to the branch. See that
+file's docstring for the full rationale.
 
 Scoring is stubbed at ``kaizen.llm.reasoning.llm_capability_match`` so the
 arithmetic is deterministic. That is a STRUCTURAL assertion (tier-weight
@@ -220,93 +227,6 @@ class TestFindBestAgentsForTask:
         task = A2ATask(description="d", requirements=["python"])
         for _agent_id, score in node._find_best_agents_for_task(task):
             assert isinstance(score, float)
-
-
-class TestReasoningBridgesPreserveConfigPropagation:
-    """Deliverable (d): the sync flip must not silently drop judge config.
-
-    Both ``kaizen_agents`` bridges dispatch on
-    ``inspect.iscoroutinefunction(matcher)`` and previously passed ``config`` /
-    ``correlation_id`` on the async branch ONLY. With ``matches_requirement``
-    now sync, the sync branch MUST carry the same kwargs — otherwise the judge
-    silently falls back to ``.env`` defaults instead of the host agent's model.
-    """
-
-    def test_score_capability_sync_propagates_config_and_correlation_id(
-        self, monkeypatch
-    ):
-        pytest.importorskip("kaizen_agents")
-        import kaizen.llm.reasoning as reasoning
-        from kaizen_agents.patterns._reasoning_bridge import score_capability_sync
-
-        seen = {}
-
-        def judge(**kw):
-            seen.update(kw)
-            return 1.0
-
-        monkeypatch.setattr(reasoning, "llm_capability_match", judge)
-
-        from kaizen.core.base_agent import BaseAgentConfig
-
-        config = BaseAgentConfig(llm_provider="mock", model="mock-model")
-        score = score_capability_sync(
-            _cap("python"),
-            "write python",
-            reasoning_config=config,
-            correlation_id="cid-1973",
-        )
-
-        assert score == 1.0
-        assert seen.get("config") is config, (
-            "the reasoning config was dropped on the sync matcher branch; the "
-            "judge model silently falls back to .env defaults."
-        )
-        assert seen.get("correlation_id") == "cid-1973"
-
-    def test_runtime_score_capability_propagates_config_and_correlation_id(
-        self, monkeypatch
-    ):
-        pytest.importorskip("kaizen_agents")
-        import asyncio
-
-        import kaizen.llm.reasoning as reasoning
-        from kaizen_agents.patterns.runtime import OrchestrationRuntime
-
-        seen = {}
-
-        def judge(**kw):
-            seen.update(kw)
-            return 1.0
-
-        monkeypatch.setattr(reasoning, "llm_capability_match", judge)
-
-        from kaizen.core.base_agent import BaseAgentConfig
-
-        config = BaseAgentConfig(llm_provider="mock", model="mock-model")
-        runtime = OrchestrationRuntime()
-        score = asyncio.run(
-            runtime._score_capability(
-                _cap("python"), "write python", config, agent_id="a1"
-            )
-        )
-
-        assert score == 1.0
-        assert seen.get("config") is config
-        assert seen.get("correlation_id") == "route_a1"
-
-    def test_legacy_single_arg_sync_mocks_still_score(self, monkeypatch):
-        # The bridges' TypeError fallback exists for legacy mocks with a
-        # single-positional matcher. Passing kwargs on the sync branch must not
-        # break them.
-        pytest.importorskip("kaizen_agents")
-        from kaizen_agents.patterns._reasoning_bridge import score_capability_sync
-
-        class LegacyCap:
-            def matches_requirement(self, requirement: str) -> float:
-                return 0.42
-
-        assert score_capability_sync(LegacyCap(), "anything") == pytest.approx(0.42)
 
 
 class TestReasoningHelpersDoNotReportDegradedAsOk:

--- a/packages/kailash-kaizen/tests/regression/test_mcp_tool_wrapper_closure_capture.py
+++ b/packages/kailash-kaizen/tests/regression/test_mcp_tool_wrapper_closure_capture.py
@@ -30,21 +30,41 @@ that could not observe the rejection it needed to see. The tie to #2025 is a
 shared ROOT CAUSE (internal closure state in a framework-introspected signature),
 NOT shared exploitability.
 
-VERSION-DEPENDENT, and two observations disagree. A reviewer with the standalone
-`fastmcp` 2.12.4 importable saw BOTH shapes rejected, on a different rule
-(``Functions with **kwargs are not supported as tools``). Here, with the official
-FastMCP reached via `kailash_mcp.server` and the standalone module absent, only
-the pre-fix shape is rejected and the post-fix shape registers. The fix is right
-either way -- it strictly removes one rejection cause -- but under the stack that
-reviewer measured, ``**kwargs`` is a SECOND, independent reason auto-registration
-cannot work. That is tracked separately; this change does not claim to fix it.
+SECOND DEFECT, same root cause, fixed here. An earlier version of this file
+recorded that a reviewer with `fastmcp` 2.12.4 saw BOTH shapes rejected on a
+different rule (``Functions with **kwargs are not supported as tools``) and
+concluded it was "tracked separately; this change does not claim to fix it".
+That deferral is now closed, because the second rejection is not version-noise
+-- it is the SAME defect one layer down. Driving the real path against FastMCP
+2.12.4::
 
-These tests assert the internal name is gone from the signature AND that the two
-behaviours the default-arg idiom provided still hold -- correct dispatch and
-correct per-iteration binding. A fix dropping either would be worse than the bug.
+    a.expose_as_mcp_server("probe", tools=["greet"])
+    -> ValueError: Functions with **kwargs are not supported as tools
+
+Removing ``_bound_method`` from the signature was necessary but not sufficient:
+a bare ``**kwargs`` wrapper carries NO signature and NO annotations, and the
+server builds the tool's published schema from exactly those. FastMCP refuses to
+register a variadic function at all, so ``expose_as_mcp_server`` still raised for
+every auto-generated tool and the feature was still dead for every agent.
+
+The repair is ``functools.wraps(bound_method)`` on the wrapper: it copies the
+method's signature (via ``__wrapped__``) and its annotations onto the wrapper, so
+the tool registers AND advertises the method's REAL parameters. Without it the
+published schema would have been empty even where registration succeeded -- a
+tool no client could call correctly. Un-publishable methods (variadic, or an
+annotation the server cannot render as JSON schema) no longer abort the whole
+server: auto-discovered ones warn and are skipped, explicitly requested ones
+still raise.
+
+These tests assert the internal name is gone from the signature, that real
+registration now succeeds and publishes the method's own parameters, AND that
+the two behaviours the default-arg idiom provided still hold -- correct dispatch
+and correct per-iteration binding. A fix dropping either would be worse than the
+bug.
 """
 
 import asyncio
+import functools
 import inspect
 
 import pytest
@@ -58,6 +78,7 @@ def _make_tool_wrapper(bound_method):
     this against the real source, so the mirror cannot silently drift from it.
     """
 
+    @functools.wraps(bound_method)
     async def tool_wrapper(**kwargs):
         result = bound_method(**kwargs)
         if hasattr(result, "__await__"):
@@ -75,16 +96,31 @@ def test_wrapper_does_not_advertise_internal_state_as_a_tool_parameter():
     and is NOT a detector. It documents the intended shape and would catch a
     regression in the mirror itself. The discriminating tests are
     ``test_real_source_binds_via_enclosing_scope_not_a_default_argument`` and
-    ``test_pre_fix_wrapper_shape_is_rejected_by_real_registration``.
+    ``test_expose_as_mcp_server_publishes_the_agent_methods_own_schema``.
     """
-    wrapper = _make_tool_wrapper(lambda x=1: x)
-    params = list(inspect.signature(wrapper).parameters)
 
-    assert params == ["kwargs"], (
-        f"tool wrapper advertises {params!r}; anything beyond **kwargs is "
-        "published to MCP clients as a callable tool argument"
+    def method(x: int = 1) -> int:
+        return x
+
+    wrapper = _make_tool_wrapper(method)
+
+    # DECLARED parameters -- what the wrapper itself accepts. `follow_wrapped`
+    # is off because `functools.wraps` makes the default resolve to the wrapped
+    # method's signature, which is the *published* view asserted below.
+    declared = list(inspect.signature(wrapper, follow_wrapped=False).parameters)
+    assert declared == ["kwargs"], (
+        f"tool wrapper declares {declared!r}; internal state in the declared "
+        "signature is what the original defect published to clients"
     )
-    assert "_bound_method" not in params
+    assert "_bound_method" not in declared
+
+    # PUBLISHED parameters -- what the server derives the tool schema from. It
+    # must be the METHOD's own signature, not an empty one.
+    published = list(inspect.signature(wrapper).parameters)
+    assert published == ["x"], (
+        f"tool wrapper publishes {published!r}; the schema must carry the "
+        "method's real parameters or no client can call the tool correctly"
+    )
 
 
 @pytest.mark.regression
@@ -150,45 +186,92 @@ def test_each_wrapper_binds_its_own_method_across_a_loop():
 
 
 @pytest.mark.regression
-def test_pre_fix_wrapper_shape_is_rejected_by_real_registration():
-    """EVIDENCE for the harm claim -- NOT a source-regression detector.
+def test_expose_as_mcp_server_publishes_the_agent_methods_own_schema():
+    """The detector for the dead-feature defect: drives the REAL path.
 
-    Pins the FRAMEWORK's behaviour, using probe functions defined here, so it
-    passes against both broken and fixed source. It does not red if the source
-    regresses; ``test_real_source_binds_via_enclosing_scope_not_a_default_argument``
-    is the only test that does.
+    Reds against broken source rather than pinning framework behaviour with
+    local probes -- the weakness of the version this replaces, which asserted
+    that a bare ``**kwargs`` probe registers. It does not: FastMCP 2.12.4
+    refuses variadic functions outright, so that assertion described a shape the
+    server rejects, and the shipped wrapper it stood in for was equally
+    unregistrable. ``expose_as_mcp_server`` raised for every agent.
 
-    It earns its place by substantiating the claim the rest of the file makes.
-    The absence of exactly this check is what let the wrong story be told about
-    this bug: inspecting ``inspect.signature`` on a mirror shows ``_bound_method``
-    present and invites the conclusion that it is published to clients. Driving
-    real registration shows it is REJECTED before any schema exists -- a
-    different defect (dead feature) with a different severity (no exploitable
-    surface). A harm claim with no instrument behind it is how the first version
-    of this file overstated its own finding.
+    Asserting the PUBLISHED SCHEMA, not just that registration returned, is what
+    makes this discriminating twice over: a wrapper that registered but carried
+    no signature would advertise an empty schema, and a client would have no way
+    to call the tool. The old internal name must be absent from that schema.
     """
     pytest.importorskip("kailash_mcp", reason="MCP server package not installed")
-    from kailash_mcp.server import MCPServer
+    from kaizen.core.mcp_mixin import MCPMixin
 
-    server = MCPServer("regression-probe")
+    class _ProbeAgent(MCPMixin):
+        agent_id = "regression-probe"
 
-    async def post_fix(**kwargs):
-        return kwargs
+        def greet(self, name: str, excited: bool = False) -> str:
+            """Greet someone."""
+            return f"hi {name}{'!' if excited else ''}"
 
-    async def pre_fix(_bound_method=None, **kwargs):
-        return kwargs
-
-    # POSITIVE: the shipped shape must register.
-    server.tool()(post_fix)
-
-    # NEGATIVE: the pre-fix shape must be refused, and the error must name the
-    # offending parameter -- otherwise this passes on an unrelated failure.
-    with pytest.raises(Exception) as exc:
-        server.tool()(pre_fix)
-    assert "_bound_method" in str(exc.value), (
-        "registration failed for a reason unrelated to the internal parameter; "
-        f"this test would then be non-discriminating. Got: {exc.value!r}"
+    server = _ProbeAgent().expose_as_mcp_server(
+        "regression-probe", tools=["greet"], enable_auto_discovery=False
     )
+
+    entry = server.get_tool_by_name("greet")
+    assert entry is not None, (
+        "expose_as_mcp_server registered no tool for an ordinary agent method; "
+        "auto-registration is dead"
+    )
+
+    schema = entry["function"].parameters
+    assert set(schema["properties"]) == {"name", "excited"}, (
+        f"published tool schema is {schema['properties']!r}; it must carry the "
+        "method's real parameters, otherwise no client can call the tool"
+    )
+    assert (
+        "_bound_method" not in schema["properties"]
+    ), "internal closure state is published to clients as a tool argument"
+    assert schema["required"] == ["name"]
+
+    result = asyncio.run(entry["function"].run({"name": "bob", "excited": True}))
+    assert result.content[0].text == "hi bob!", "the registered tool did not dispatch"
+
+
+@pytest.mark.regression
+def test_unpublishable_method_does_not_abort_the_whole_server():
+    """One un-publishable method must not kill every other tool.
+
+    A variadic method cannot become an MCP tool. Before the fix ANY such method
+    on the agent raised out of ``expose_as_mcp_server``, so a single one took
+    down the entire server -- the failure mode that made this feature dead.
+    Auto-discovery sweeps every public attribute and so always meets one.
+    """
+    pytest.importorskip("kailash_mcp", reason="MCP server package not installed")
+    from kaizen.core.mcp_mixin import MCPMixin
+
+    class _ProbeAgent(MCPMixin):
+        agent_id = "regression-probe"
+
+        def greet(self, name: str) -> str:
+            """Greet someone."""
+            return f"hi {name}"
+
+        def variadic(self, **kwargs):
+            """Cannot be expressed as an MCP tool."""
+            return kwargs
+
+    agent = _ProbeAgent()
+
+    server = agent.expose_as_mcp_server("regression-probe", enable_auto_discovery=False)
+    assert (
+        server.get_tool_by_name("greet") is not None
+    ), "a publishable method was dropped because a sibling was un-publishable"
+    assert server.get_tool_by_name("variadic") is None
+
+    # An EXPLICIT request is a demand, not a sweep: it must fail loudly rather
+    # than hand back a server silently missing the tool the caller named.
+    with pytest.raises(ValueError, match="variadic"):
+        agent.expose_as_mcp_server(
+            "regression-probe", tools=["variadic"], enable_auto_discovery=False
+        )
 
 
 @pytest.mark.regression

--- a/packages/kailash-kaizen/tests/regression/test_mcp_tool_wrapper_closure_capture.py
+++ b/packages/kailash-kaizen/tests/regression/test_mcp_tool_wrapper_closure_capture.py
@@ -185,6 +185,54 @@ def test_each_wrapper_binds_its_own_method_across_a_loop():
     ], f"wrappers do not bind per-iteration methods: {results!r}"
 
 
+def _published_input_schema(server, tool_name):
+    """Return *tool_name*'s published JSON input schema, whichever backend won.
+
+    ``kailash_mcp`` prefers the standalone ``fastmcp`` distribution and falls
+    back to the official MCP SDK's FastMCP when it is absent. NEITHER package
+    declares standalone ``fastmcp`` as a dependency, so CI runs the OFFICIAL
+    fallback and a developer who happens to have ``fastmcp`` installed runs the
+    other -- the two disagree about what the server hands back:
+
+        standalone : registry entry is a FunctionTool (has ``.parameters``),
+                     listing via ``get_tools()``
+        official   : registry entry is a PLAIN FUNCTION (no ``.parameters``),
+                     listing via ``list_tools()``
+
+    Reading ``.parameters`` off the registry entry therefore only works on one
+    of them; doing so passed locally and raised ``AttributeError: 'function'
+    object has no attribute 'parameters'`` on the runner.
+
+    Raises rather than returning None when neither shape is present: a schema
+    lookup that silently yielded nothing would make every assertion built on it
+    vacuous, which is the failure this whole file exists to avoid.
+    """
+    mcp = server._mcp
+
+    if hasattr(mcp, "list_tools"):  # official MCP SDK FastMCP
+        for tool in asyncio.run(mcp.list_tools()):
+            if tool.name == tool_name:
+                return tool.inputSchema
+        raise AssertionError(
+            f"{tool_name!r} was not published by {type(mcp).__name__}; "
+            "registration did not reach the server's tool listing"
+        )
+
+    if hasattr(mcp, "get_tools"):  # standalone fastmcp
+        tool = asyncio.run(mcp.get_tools()).get(tool_name)
+        if tool is None:
+            raise AssertionError(
+                f"{tool_name!r} was not published by {type(mcp).__name__}; "
+                "registration did not reach the server's tool listing"
+            )
+        return tool.to_mcp_tool().inputSchema
+
+    raise AssertionError(
+        f"no known tool-listing API on {type(mcp).__name__}; this helper must be "
+        "taught the new backend rather than silently asserting nothing"
+    )
+
+
 @pytest.mark.regression
 def test_expose_as_mcp_server_publishes_the_agent_methods_own_schema():
     """The detector for the dead-feature defect: drives the REAL path.
@@ -221,7 +269,7 @@ def test_expose_as_mcp_server_publishes_the_agent_methods_own_schema():
         "auto-registration is dead"
     )
 
-    schema = entry["function"].parameters
+    schema = _published_input_schema(server, "greet")
     assert set(schema["properties"]) == {"name", "excited"}, (
         f"published tool schema is {schema['properties']!r}; it must carry the "
         "method's real parameters, otherwise no client can call the tool"
@@ -231,8 +279,19 @@ def test_expose_as_mcp_server_publishes_the_agent_methods_own_schema():
     ), "internal closure state is published to clients as a tool argument"
     assert schema["required"] == ["name"]
 
-    result = asyncio.run(entry["function"].run({"name": "bob", "excited": True}))
-    assert result.content[0].text == "hi bob!", "the registered tool did not dispatch"
+    # End-to-end dispatch through the server, on the backend that can be driven
+    # without a live MCP session. Standalone fastmcp's equivalent is private and
+    # raises "No active context found" outside a real session, so it is exercised
+    # at the wrapper level instead (test_normal_dispatch_and_await_still_work).
+    # The schema assertions above are unconditional, so this branch narrows what
+    # the test proves on one backend -- it never makes the test vacuous.
+    if hasattr(server._mcp, "call_tool"):
+        content, _ = asyncio.run(
+            server._mcp.call_tool("greet", {"name": "bob", "excited": True})
+        )
+        assert (
+            content[0].text == "hi bob!"
+        ), f"the registered tool did not dispatch; got {content!r}"
 
 
 @pytest.mark.regression

--- a/packages/kaizen-agents/tests/regression/test_issue_1973_reasoning_bridge_config_propagation.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_1973_reasoning_bridge_config_propagation.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""#1973 — the reasoning bridges must propagate judge config on the SYNC branch.
+
+``kaizen.nodes.ai.a2a.Capability.matches_requirement`` was flipped from ``async
+def`` back to ``def`` (#1973). Both bridges here dispatch on
+``inspect.iscoroutinefunction(matcher)`` and previously passed ``config`` /
+``correlation_id`` on the async branch ONLY. With the matcher now sync, the sync
+branch MUST carry the same kwargs — otherwise the bridge's legacy
+``except TypeError`` fallback re-calls ``matcher(task)`` positionally, ``config``
+arrives as ``None``, and the judge silently falls back to ``.env`` defaults
+instead of the host agent's model. A dropped ``correlation_id`` additionally
+breaks multi-capability loop tracing (``observability.md`` § correlation ID on
+every log line).
+
+WHY THIS LIVES IN ``kaizen-agents`` AND NOT ``kailash-kaizen``.
+It was originally written in
+``packages/kailash-kaizen/tests/regression/test_issue_1973_a2a_capability_match.py``
+as that file's deliverable (d), guarding the sync flip's blast radius. But the
+code under test — ``kaizen_agents.patterns._reasoning_bridge`` and
+``kaizen_agents.patterns.runtime`` — ships in THIS package, and
+``kaizen-agents`` depends on ``kailash-kaizen``, not the reverse. A test in the
+depended-UPON package that imports its own dependent inverts that direction, and
+``packages/kailash-kaizen/pytest.ini`` exposes only its own ``src``, so
+``kaizen_agents`` there resolves to whatever wheel happens to be INSTALLED.
+Against a stale wheel the test reds while the repo source is already correct —
+it reported a live config-propagation bug for source that propagates config
+fine, which is how correct code gets "fixed" to satisfy an old wheel. The
+reverse is quieter: a wheel NEWER than the branch greens a regression the branch
+actually has.
+
+Here, ``packages/kaizen-agents/conftest.py`` puts this package's ``src`` at the
+front of ``sys.path``, so these assertions always describe the branch under
+test. Its sibling ``test_issue_1981_degraded_judgment.py`` covers the same
+module for the same reason.
+
+Tier-1 offline: the judge is stubbed at ``kaizen.llm.reasoning``, so no network
+and no credentials. That is a STRUCTURAL assertion (kwarg plumbing across a
+sync/async dispatch), not a semantic one — no probe is required per
+``probe-driven-verification.md`` Rule 3.
+"""
+
+import asyncio
+
+import pytest
+
+from kaizen.nodes.ai.a2a import Capability, CapabilityLevel
+
+pytestmark = pytest.mark.regression
+
+
+def _cap(name: str) -> Capability:
+    return Capability(
+        name=name,
+        domain="engineering",
+        level=CapabilityLevel.EXPERT,
+        description=f"can do {name}",
+        keywords=[name],
+    )
+
+
+class TestReasoningBridgesPreserveConfigPropagation:
+    """The sync flip must not silently drop judge config."""
+
+    def test_score_capability_sync_propagates_config_and_correlation_id(
+        self, monkeypatch
+    ):
+        import kaizen.llm.reasoning as reasoning
+        from kaizen_agents.patterns._reasoning_bridge import score_capability_sync
+
+        seen = {}
+
+        def judge(**kw):
+            seen.update(kw)
+            return 1.0
+
+        monkeypatch.setattr(reasoning, "llm_capability_match", judge)
+
+        from kaizen.core.base_agent import BaseAgentConfig
+
+        config = BaseAgentConfig(llm_provider="mock", model="mock-model")
+        score = score_capability_sync(
+            _cap("python"),
+            "write python",
+            reasoning_config=config,
+            correlation_id="cid-1973",
+        )
+
+        assert score == 1.0
+        assert seen.get("config") is config, (
+            "the reasoning config was dropped on the sync matcher branch; the "
+            "judge model silently falls back to .env defaults."
+        )
+        assert seen.get("correlation_id") == "cid-1973"
+
+    def test_runtime_score_capability_propagates_config_and_correlation_id(
+        self, monkeypatch
+    ):
+        import kaizen.llm.reasoning as reasoning
+        from kaizen_agents.patterns.runtime import OrchestrationRuntime
+
+        seen = {}
+
+        def judge(**kw):
+            seen.update(kw)
+            return 1.0
+
+        monkeypatch.setattr(reasoning, "llm_capability_match", judge)
+
+        from kaizen.core.base_agent import BaseAgentConfig
+
+        config = BaseAgentConfig(llm_provider="mock", model="mock-model")
+        runtime = OrchestrationRuntime()
+        score = asyncio.run(
+            runtime._score_capability(
+                _cap("python"), "write python", config, agent_id="a1"
+            )
+        )
+
+        assert score == 1.0
+        assert seen.get("config") is config
+        assert seen.get("correlation_id") == "route_a1"
+
+    def test_legacy_single_arg_sync_mocks_still_score(self):
+        # The bridges' TypeError fallback exists for legacy mocks with a
+        # single-positional matcher. Passing kwargs on the sync branch must not
+        # break them.
+        from kaizen_agents.patterns._reasoning_bridge import score_capability_sync
+
+        class LegacyCap:
+            def matches_requirement(self, requirement: str) -> float:
+                return 0.42
+
+        assert score_capability_sync(LegacyCap(), "anything") == pytest.approx(0.42)


### PR DESCRIPTION
Two pre-existing kaizen test failures that **block #2159 from merging**. A conftest bug was auto-marking ~15% of the kaizen suite as needing infrastructure it does not need, so these were silently deselected from every infra-free CI step. Fixing that marker bug releases them, and they fail. They are pre-existing, not caused by the marker fix.

## 1. MCP tool auto-registration was dead (product bug)

`test_mcp_tool_wrapper_closure_capture.py::test_pre_fix_wrapper_shape_is_rejected_by_real_registration` failed with `ValueError: Functions with **kwargs are not supported as tools`.

The test's name suggested it might merely be asserting a rejection wrongly. It is not — driving the real path shows the **product** is broken:

```
a.expose_as_mcp_server("probe", tools=["greet"])
-> ValueError: Functions with **kwargs are not supported as tools
```

`expose_as_mcp_server` raised for **every** agent method under FastMCP 2.12.4, so agent-as-MCP-server was dead for every agent. A prior fix removed `_bound_method` from the wrapper signature and filed this second rejection as version-noise "tracked separately"; it is the same defect one layer down. The server builds a tool's published schema from the wrapper's signature and annotations, and a bare `**kwargs` wrapper carries neither.

Fix: `functools.wraps(bound_method)` on the wrapper, so it carries the method's signature (via `__wrapped__`) and annotations. Registration now succeeds **and** the tool advertises the method's real parameters — without it the schema would have been empty even where registration passed, leaving a tool no client could call correctly.

Also: one un-publishable method no longer takes the whole server down. Auto-discovery sweeps every public attribute so it always meets one — those warn and are skipped; an explicit `tools=[...]` entry still raises rather than returning a server silently missing what the caller named.

The test that stood in for this asserted a bare `**kwargs` probe registers — a shape the server rejects — so it pinned framework behaviour that does not hold and could not red against broken source. It now drives `expose_as_mcp_server` and asserts the published schema.

## 2. `pytest-base-url` fixture collision (test bug)

`test_issue_1720_b1b_embed_cutover.py` — every parametrized case errored at setup with `ScopeMismatch: You tried to access the function scoped fixture base_url with a session scoped request object`.

`pytest-base-url` ships a session-scoped `base_url` fixture plus a session-scoped autouse `_verify_url(request, base_url)`. The parametrize argname `base_url` overrode it with a function-scoped one, so the session-scoped consumer could no longer request it.

Fix: renamed the argname to `wire_base_url`. The colliding name is ours and local. Widening the parametrized value to session scope would leak one wire's value across the others, and narrowing a third-party plugin's fixture is not ours to do. A comment records the collision so a later cleanup does not rename it back.

## 3. `kaizen-agents` regression suite wired into CI — 812 tests that had NEVER run

**This is the most consequential change in the PR.**

`packages/kaizen-agents/tests/` appeared in **no pytest invocation in any workflow**. The only `packages/kaizen-agents` matches anywhere in `.github/workflows/` were `paths:` **trigger** filters in `unified-ci.yml` — those decide which workflow runs, not what pytest collects. The entire suite had never executed in CI. Same never-ran class as #2074 and #2038, in a package nobody had checked.

Baseline measured **before** wiring it in, per #2074's instruction not to assume clean:

```
812 passed, 2 deselected, 0 failed
```

Wired into the existing `test-kaizen` job in `test-kailash-kaizen.yml` (no new workflow file). That job already installs `kaizen-agents` editable, so `kaizen_agents` resolves to the branch rather than to whatever wheel is on the runner — load-bearing, see below. `packages/kaizen-agents/**` added to both `paths:` filters; without it a PR touching only that package would still run none of its tests. Job name left unchanged so no required status check is renamed.

Scope: the `regression` tier only, which is verified green. `tests/unit/`, `integration/`, and `e2e/` in that package remain unrun — not baselined here, and not wired blind. That is a separate shard in the #2074 family.

## 4. The two `test_issue_1973_a2a_capability_match` failures — stale wheel, not a product bug

Reported as a third blocker. The propagation was never broken. The tests sat in `packages/kailash-kaizen/`, whose `pytest.ini` sets `pythonpath = src` (its own only), so `kaizen_agents` fell through to an installed wheel:

```
kailash-kaizen ctx : ~/.pyenv/.../site-packages/kaizen_agents/__init__.py   [0.9.11, STALE]
kaizen-agents  ctx : packages/kaizen-agents/src/kaizen_agents/__init__.py   [0.13.0, branch]

0.9.11 : result = matcher(task)
branch : result = matcher(task, config=reasoning_config, correlation_id=correlation_id)
```

The bridge's legacy `except TypeError` fallback then re-calls positionally and `config` arrives `None` — reported as a live config-propagation bug against source that propagates config fine.

Fix: moved `TestReasoningBridgesPreserveConfigPropagation` (3 tests) to `packages/kaizen-agents/tests/regression/`, beside `test_issue_1981_degraded_judgment.py`, which covers the same module for the same reason. `kaizen-agents` depends on `kailash-kaizen`, so a test in the depended-upon package importing its own dependent inverted the dependency. That package's `conftest.py` puts its own `src` at `sys.path[0]`, so the assertions always describe the branch. **No production code changed — both sides were already correct.**

These would have passed in CI in either location (CI installs the sibling editable); the failure was local-only. The relocation is what makes the outcome independent of install mode — and it is only safe because of the CI wiring in section 3.

A related guard was added in `packages/kailash-kaizen/conftest.py`: an advisory terminal-summary report naming any first-party package served from outside the checkout, with the fix command. Advisory, not fatal — testing against a released wheel on purpose is legitimate, and failing would red every suite on any machine with a stale sibling.


## Evidence

RED (before):
```
1 failed, 9 passed, 6 errors in 0.74s
```

GREEN (after):
```
17 passed in 1.84s
```

Both new tests were mutation-checked: removing `functools.wraps` reds both new MCP tests; removing the un-publishable guard alone reds `test_unpublishable_method_does_not_abort_the_whole_server`.

Wider suites: `packages/kailash-kaizen/tests/regression/` 1627 passed, `tests/unit/core/` 1096 passed, `packages/kaizen-agents/tests/regression/` 812 passed / 0 failed under the new CI step's exact command and marker filter.

No `skip`/`xfail` was used, and no test was deleted.

## Related issues

Refs #2160
Unblocks #2159
