### PR TITLE
chore(isort): fix self-contradicting import grouping for kailash_mcp

### DIFF
--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -238,7 +238,7 @@ profile = "black"
 line_length = 88
 # MUST match the root pyproject.toml list exactly — see the note in
 # packages/kailash-kaizen/pyproject.toml (#1995).
-known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact"]
+known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact", "kailash_mcp"]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -248,7 +248,7 @@ line_length = 88
 # reclassifies `kailash` as THIRD-party for every file under this package — which
 # is the blank-line-between-import-blocks that flip-flopped on every run and left
 # ~2,000 files permanently modified (#1995).
-known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact"]
+known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact", "kailash_mcp"]
 
 [tool.ruff]
 line-length = 88

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -29,10 +29,9 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-from kailash_mcp.client import MCPClient
-
 from kailash.nodes.base import Node, NodeParameter
 from kailash.workflow.builder import WorkflowBuilder
+from kailash_mcp.client import MCPClient
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.tools.types import ToolCategory, ToolDefinition, ToolParameter
 

--- a/packages/kailash-kaizen/tests/unit/examples/test_agent_as_client.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_agent_as_client.py
@@ -49,7 +49,6 @@ ResultSynthesisSignature = agent_as_client_example.ResultSynthesisSignature
 
 # Production MCP infrastructure - kailash_mcp
 from kailash_mcp import MCPClient
-
 from kaizen.memory import SharedMemoryPool
 
 logger = logging.getLogger(__name__)

--- a/packages/kailash-kaizen/tests/unit/examples/test_agent_as_server.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_agent_as_server.py
@@ -48,7 +48,6 @@ TextAnalysisSignature = agent_as_server_example.TextAnalysisSignature
 
 # Production MCP infrastructure - kailash_mcp
 from kailash_mcp import MCPServer
-
 from kaizen.memory import SharedMemoryPool
 
 logger = logging.getLogger(__name__)

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -79,6 +79,7 @@ from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optiona
 from urllib.parse import urlparse
 
 import jsonschema
+
 from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.protocol.protocol import ProgressToken, get_protocol_manager
 

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
@@ -22,11 +22,10 @@ except ImportError:
     redis: Any = None  # type: ignore[no-redef]
     REDIS_AVAILABLE = False
 
+from kailash.utils.redis_validation import validate_redis_url
 from kailash_mcp.auth.providers import AuthManager
 from kailash_mcp.auth.providers import PermissionError as PermissionDeniedError
 from kailash_mcp.protocol.protocol import ResourceChange, ResourceChangeType
-
-from kailash.utils.redis_validation import validate_redis_url
 
 
 class SubscriptionError(Exception):

--- a/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
+++ b/packages/kailash-mcp/src/kailash_mcp/discovery/discovery.py
@@ -48,11 +48,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
+from kailash.utils.url_credentials import mask_error_text
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, ServiceDiscoveryError
 from kailash_mcp.security import SpawnSecurityError, validate_spawn_command
-
-from kailash.utils.url_credentials import mask_error_text
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-mcp/src/kailash_mcp/security.py
+++ b/packages/kailash-mcp/src/kailash_mcp/security.py
@@ -27,9 +27,8 @@ from __future__ import annotations
 import os
 from typing import Optional, Sequence
 
-from kailash_mcp.errors import MCPError, MCPErrorCode
-
 from kailash.utils.command_safety import safe_command_ref
+from kailash_mcp.errors import MCPError, MCPErrorCode
 
 # Standard MCP launcher executables considered safe to spawn without an
 # explicit per-caller allowlist. Deliberately EXCLUDES shells (``sh``,

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -74,6 +74,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 from urllib.parse import urlparse
 
+# Credential scrubber for SERVER-SIDE diagnostics. kailash-mcp already depends
+# on it (``transports.py`` uses the same helper), so no new dependency: a driver
+# or client library routinely quotes the connection string it failed on, and the
+# raw text reaches a log file that is far more widely readable than the
+# database it names (observability.md § "No secrets in logs"). It is NOT the
+# caller-facing defence — nothing derived from an exception is returned to an
+# unauthenticated caller; see ``MCPServer._internal_error_envelope``.
+from kailash.utils.url_credentials import mask_error_text
 from kailash_mcp.advanced.features import (
     ElicitationSystem,
     StructuredTool,
@@ -115,15 +123,6 @@ from kailash_mcp.utils import (
     build_input_schema,
     format_response,
 )
-
-# Credential scrubber for SERVER-SIDE diagnostics. kailash-mcp already depends
-# on it (``transports.py`` uses the same helper), so no new dependency: a driver
-# or client library routinely quotes the connection string it failed on, and the
-# raw text reaches a log file that is far more widely readable than the
-# database it names (observability.md § "No secrets in logs"). It is NOT the
-# caller-facing defence — nothing derived from an exception is returned to an
-# unauthenticated caller; see ``MCPServer._internal_error_envelope``.
-from kailash.utils.url_credentials import mask_error_text
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
+++ b/packages/kailash-mcp/src/kailash_mcp/transports/transports.py
@@ -73,12 +73,12 @@ from urllib.parse import urljoin, urlparse
 
 import aiohttp
 import websockets
+
+from kailash.utils.url_credentials import mask_error_text, mask_url
 from kailash_mcp.auth.providers import AuthProvider
 from kailash_mcp.errors import MCPError, MCPErrorCode, TransportError
 from kailash_mcp.protocol.protocol import MetaData, ProtocolManager
 from kailash_mcp.security import validate_spawn_command
-
-from kailash.utils.url_credentials import mask_error_text, mask_url
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-mcp/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/packages/kailash-mcp/tests/integration/mcp_server/test_elicitation_integration.py
@@ -67,6 +67,7 @@ import asyncio
 from typing import Any, Callable, Coroutine, Dict, List
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
+++ b/packages/kailash-mcp/tests/integration/mcp_server/test_ws_server_initiated_roundtrip.py
@@ -25,6 +25,7 @@ import socket
 
 import pytest
 import websockets
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.transports.transports import WebSocketServerTransport
 

--- a/packages/kailash-mcp/tests/regression/test_cache_clear_reports_only_what_it_did.py
+++ b/packages/kailash-mcp/tests/regression/test_cache_clear_reports_only_what_it_did.py
@@ -20,6 +20,7 @@ the original vacuous test asserted nothing at all.
 import logging
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.utils.cache import UnifiedCache
 

--- a/packages/kailash-mcp/tests/regression/test_credential_extraction_hygiene.py
+++ b/packages/kailash-mcp/tests/regression/test_credential_extraction_hygiene.py
@@ -37,6 +37,7 @@ import asyncio
 import logging
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/regression/test_credential_kwargs_and_rate_limit_typing.py
+++ b/packages/kailash-mcp/tests/regression/test_credential_kwargs_and_rate_limit_typing.py
@@ -96,6 +96,7 @@ import logging
 import textwrap
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.errors import MCPErrorCode, RateLimitError
 from kailash_mcp.server import _CREDENTIAL_KWARGS, MCPServer

--- a/packages/kailash-mcp/tests/regression/test_cross_principal_cache_isolation.py
+++ b/packages/kailash-mcp/tests/regression/test_cross_principal_cache_isolation.py
@@ -49,6 +49,7 @@ or a tool body that never read the client at all, cannot make this suite pass.
 import asyncio
 
 import pytest
+
 from kailash_mcp.server import _CURRENT_TOOL_CLIENT, MCPServer
 
 CACHE_NAME = "answers"

--- a/packages/kailash-mcp/tests/regression/test_gated_tool_invocation_requires_credentials.py
+++ b/packages/kailash-mcp/tests/regression/test_gated_tool_invocation_requires_credentials.py
@@ -55,6 +55,7 @@ import io
 import json
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.errors import ToolError
 from kailash_mcp.server import MCPServer

--- a/packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py
@@ -47,6 +47,7 @@ import unicodedata
 from pathlib import Path
 
 import pytest
+
 from kailash_mcp.protocol.messages import (
     JsonRpcError,
     JsonRpcRequest,

--- a/packages/kailash-mcp/tests/regression/test_issue_1708_w2_mcp_tool_duration_histogram.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1708_w2_mcp_tool_duration_histogram.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import re
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.utils import metrics as metrics_module
 from kailash_mcp.utils.metrics import MetricsCollector

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_audience_validation.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_audience_validation.py
@@ -26,6 +26,7 @@ import logging
 
 import jwt
 import pytest
+
 from kailash_mcp.auth.providers import AuthenticationError, BearerTokenAuth, JWTAuth
 
 SECRET = "test-hs256-secret-for-1712"

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_cursor_bound.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_cursor_bound.py
@@ -17,6 +17,7 @@ round-trip.
 """
 
 import pytest
+
 from kailash_mcp.advanced.subscriptions import CursorManager
 
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_elicitation_2025_11_25.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_elicitation_2025_11_25.py
@@ -38,6 +38,7 @@ for real client transports.
 import asyncio
 
 import pytest
+
 from kailash_mcp.advanced.features import ElicitationSystem
 from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.server import MCPServer

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_lifecycle_lists.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_lifecycle_lists.py
@@ -20,6 +20,7 @@ server-side gaps:
 """
 
 import pytest
+
 from kailash_mcp.server import (
     LATEST_PROTOCOL_VERSION,
     SUPPORTED_PROTOCOL_VERSIONS,

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_mcp_spec_parity.py
@@ -20,6 +20,7 @@ per ``rules/testing.md``) for the three in-shard fixes:
 import asyncio
 
 import pytest
+
 from kailash_mcp.client import MCPClient
 from kailash_mcp.discovery.discovery import HealthChecker, ServerInfo
 from kailash_mcp.errors import MCPErrorCode

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_discovery.py
@@ -31,6 +31,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+
 from kailash_mcp.auth.oauth import (
     OAuth2Client,
     OAuthDiscoveryError,

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_hardening.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_hardening.py
@@ -35,6 +35,7 @@ import hashlib
 import secrets
 
 import pytest
+
 from kailash_mcp.auth.oauth import (
     AuthorizationCode,
     AuthorizationServer,

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_server_prm.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_oauth_server_prm.py
@@ -35,6 +35,9 @@ driven directly through the ASGI protocol.
 import asyncio
 
 import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
 from kailash_mcp.auth.oauth import (
     AuthorizationServer,
     JWTManager,
@@ -48,8 +51,6 @@ from kailash_mcp.auth.well_known import (
     protected_resource_metadata_url,
 )
 from kailash_mcp.errors import AuthenticationError, AuthorizationError
-from starlette.applications import Starlette
-from starlette.testclient import TestClient
 
 _ISSUER = "https://as.example.com"
 _RESOURCE = "https://mcp.example.com"  # origin-root → bare well-known path

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_progress_cancel_roots.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_progress_cancel_roots.py
@@ -29,6 +29,7 @@ gaps:
 import asyncio
 
 import pytest
+
 from kailash_mcp.protocol.protocol import (
     RootsManager,
     cancel_request,

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_sampling.py
@@ -31,6 +31,7 @@ import asyncio
 import re
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.server import MCPServer, validate_sampling_messages
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_server_conformance.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_server_conformance.py
@@ -27,6 +27,7 @@ Group C - live WebSocket lifecycle
 import base64
 
 import pytest
+
 from kailash_mcp.advanced.features import StructuredTool, ToolAnnotation
 from kailash_mcp.protocol.protocol import ToolResult
 from kailash_mcp.server import MCPServer

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w5_convergence.py
@@ -20,6 +20,7 @@ transport double satisfies the ``send_message`` structural contract only.
 import asyncio
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w6_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w6_convergence.py
@@ -20,6 +20,7 @@ capturing transport double satisfies the ``send_message`` structural contract.
 import asyncio
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_w7_convergence.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_w7_convergence.py
@@ -8,6 +8,7 @@ re-open it.
 import asyncio
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.transports.transports import WebSocketServerTransport
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1712_wave2_hardening.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1712_wave2_hardening.py
@@ -28,6 +28,7 @@ Covers four confirmed findings, each pinned behaviorally against a real
 from __future__ import annotations
 
 import pytest
+
 from kailash_mcp.errors import ToolError
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1840_transport_cred_redaction.py
@@ -24,6 +24,7 @@ themselves are exercised for real (never mocked).
 import logging
 
 import pytest
+
 from kailash_mcp.errors import TransportError
 from kailash_mcp.transports import transports as T
 from kailash_mcp.transports.transports import (

--- a/packages/kailash-mcp/tests/regression/test_issue_1998_default_transport_gated_projection.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1998_default_transport_gated_projection.py
@@ -34,10 +34,11 @@ and execute on ``tools/call``. Each was the observed pre-fix behaviour.
 """
 
 import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.errors import MCPError, ToolError
 from kailash_mcp.server import MCPServer
-from mcp.shared.memory import create_connected_server_and_client_session
 
 pytestmark = pytest.mark.regression
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1998_r3_container_liveness.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1998_r3_container_liveness.py
@@ -52,6 +52,7 @@ FALSIFYING RESULTS, each observed against the pre-fix code:
 """
 
 import pytest
+
 from kailash_mcp.advanced.features import ToolAnnotation
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.errors import MCPError

--- a/packages/kailash-mcp/tests/regression/test_issue_1998_r3_registration_hygiene.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1998_r3_registration_hygiene.py
@@ -46,11 +46,12 @@ import asyncio
 from typing import TypedDict
 
 import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+from pydantic import BaseModel
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.errors import MCPError, ToolError
 from kailash_mcp.server import MCPServer
-from mcp.shared.memory import create_connected_server_and_client_session
-from pydantic import BaseModel
 
 pytestmark = pytest.mark.regression
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1998_sampling_approver_error_leak.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1998_sampling_approver_error_leak.py
@@ -45,6 +45,7 @@ import asyncio
 import re
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode, ToolError
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/regression/test_issue_1998_unauthenticated_error_detail_leak.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1998_unauthenticated_error_detail_leak.py
@@ -31,6 +31,7 @@ import re
 import sys
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 
 pytestmark = pytest.mark.regression

--- a/packages/kailash-mcp/tests/regression/test_issue_1999_tools_list_input_schema.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1999_tools_list_input_schema.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import List, Literal, Optional
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.utils import build_input_schema
 

--- a/packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py
@@ -36,6 +36,7 @@ from datetime import datetime, timedelta, timezone
 
 import jwt
 import pytest
+
 from kailash_mcp.auth.providers import (
     AuthenticationError as ProvidersAuthenticationError,
 )

--- a/packages/kailash-mcp/tests/regression/test_per_tool_rate_limit_wiring.py
+++ b/packages/kailash-mcp/tests/regression/test_per_tool_rate_limit_wiring.py
@@ -41,6 +41,7 @@ import asyncio
 import inspect
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth, RateLimiter
 from kailash_mcp.errors import MCPErrorCode, RateLimitError
 from kailash_mcp.server import _RATE_LIMIT_KEYS, MCPServer

--- a/packages/kailash-mcp/tests/regression/test_stdio_disconnect_does_not_orphan_the_subprocess.py
+++ b/packages/kailash-mcp/tests/regression/test_stdio_disconnect_does_not_orphan_the_subprocess.py
@@ -25,6 +25,7 @@ import asyncio
 import logging
 
 import pytest
+
 from kailash_mcp.transports.transports import EnhancedStdioTransport
 
 pytestmark = pytest.mark.regression

--- a/packages/kailash-mcp/tests/regression/test_stdio_tools_call_handler_key.py
+++ b/packages/kailash-mcp/tests/regression/test_stdio_tools_call_handler_key.py
@@ -22,6 +22,7 @@ import io
 import json
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 
 

--- a/packages/kailash-mcp/tests/regression/test_sync_tool_redis_cache_degradation_is_loud.py
+++ b/packages/kailash-mcp/tests/regression/test_sync_tool_redis_cache_degradation_is_loud.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 from kailash_mcp.utils.cache import UnifiedCache
 

--- a/packages/kailash-mcp/tests/regression/test_tools_list_permission_gated_schema_disclosure.py
+++ b/packages/kailash-mcp/tests/regression/test_tools_list_permission_gated_schema_disclosure.py
@@ -59,6 +59,7 @@ import io
 import json
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.server import MCPServer
 

--- a/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
+++ b/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
@@ -18,6 +18,7 @@ import inspect
 from pathlib import Path
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode
 
 

--- a/packages/kailash-mcp/tests/unit/test_prompt_injection_security.py
+++ b/packages/kailash-mcp/tests/unit/test_prompt_injection_security.py
@@ -10,6 +10,7 @@ from being accepted as valid tool metadata.
 from __future__ import annotations
 
 import pytest
+
 from kailash_mcp.protocol.messages import JsonRpcValidationError, McpToolInfo
 
 

--- a/packages/kailash-mcp/tests/unit/test_protocol_messages.py
+++ b/packages/kailash-mcp/tests/unit/test_protocol_messages.py
@@ -10,6 +10,7 @@ and that invalid inputs are rejected with JsonRpcValidationError.
 from __future__ import annotations
 
 import pytest
+
 from kailash_mcp.protocol.messages import (
     JsonRpcError,
     JsonRpcRequest,

--- a/packages/kailash-ml/tests/integration/autolog/test_autolog_ddp_rank0_only_emission.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_autolog_ddp_rank0_only_emission.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from kailash_ml.autolog import _distribution, autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 

--- a/packages/kailash-ml/tests/integration/autolog/test_lightning_autolog_wiring.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_lightning_autolog_wiring.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from kailash_ml.autolog import autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 

--- a/packages/kailash-ml/tests/integration/autolog/test_transformers_autolog_wiring.py
+++ b/packages/kailash-ml/tests/integration/autolog/test_transformers_autolog_wiring.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 import pytest
 import torch
-
 from kailash_ml.autolog import autolog
 from kailash_ml.tracking import SqliteTrackerStore, track
 

--- a/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
@@ -21,12 +21,12 @@ import pytest
 torch = pytest.importorskip("torch")
 nn = pytest.importorskip("torch.nn")
 
-from kailash.diagnostics.protocols import Diagnostic  # noqa: E402
-
 # Import through the facade — NOT `from kailash_ml.diagnostics.dl import ...`
 # per orphan-detection §1 (downstream consumers see the public attribute,
 # so the wiring test MUST exercise the same surface).
 from kailash_ml.diagnostics import DLDiagnostics  # noqa: E402
+
+from kailash.diagnostics.protocols import Diagnostic  # noqa: E402
 
 # Issue #2076: this file is the deep-learning diagnostics wiring test —
 # tags it into the `test-dl` CI job's selection (`-m dl`).

--- a/packages/kailash-ml/tests/integration/test_onnx_roundtrip_lightning.py
+++ b/packages/kailash-ml/tests/integration/test_onnx_roundtrip_lightning.py
@@ -38,7 +38,6 @@ def test_lightning_onnx_roundtrip_prediction_parity(tmp_path: Path) -> None:
     import pytorch_lightning as pl
     import torch
     import torch.nn as nn
-
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)

--- a/packages/kailash-ml/tests/integration/test_onnx_roundtrip_torch.py
+++ b/packages/kailash-ml/tests/integration/test_onnx_roundtrip_torch.py
@@ -35,7 +35,6 @@ def test_torch_onnx_roundtrip_prediction_parity(tmp_path: Path) -> None:
     import onnxruntime as ort
     import torch
     import torch.nn as nn
-
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)
@@ -119,7 +118,6 @@ def test_torch_onnx_roundtrip_dynamic_batch_size(tmp_path: Path) -> None:
     import onnxruntime as ort
     import torch
     import torch.nn as nn
-
     from kailash_ml.bridge.onnx_bridge import OnnxBridge
 
     torch.manual_seed(42)

--- a/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
+++ b/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
@@ -35,7 +35,6 @@ import numpy as np
 import polars as pl
 import pytest
 import torch
-
 from kailash_ml._device_report import DeviceReport
 from kailash_ml.trainable import (
     HDBSCANTrainable,

--- a/packages/kailash-ml/tests/regression/test_issue_701_diagnose_dl_pytorch_dataloader_end_to_end.py
+++ b/packages/kailash-ml/tests/regression/test_issue_701_diagnose_dl_pytorch_dataloader_end_to_end.py
@@ -48,9 +48,8 @@ def test_diagnose_dl_pytorch_dataloader_end_to_end() -> None:
     (``n_batches > 0``, ``n_samples == 64``).
     """
     torch = pytest.importorskip("torch")
-    from torch.utils.data import DataLoader, TensorDataset
-
     from kailash_ml import diagnose
+    from torch.utils.data import DataLoader, TensorDataset
 
     # Deterministic seed — rules/testing.md § Rules: no random data
     # without seeds. The DataLoader's `shuffle=False` default plus a

--- a/packages/kailash-nexus/src/nexus/resources.py
+++ b/packages/kailash-nexus/src/nexus/resources.py
@@ -9,9 +9,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-from kailash_mcp import MCPServer
-
 from kailash.workflow import Workflow
+from kailash_mcp import MCPServer
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -143,7 +143,7 @@ profile = "black"
 # MUST match the root pyproject.toml list exactly — this previously carried only
 # 3 of the 6 entries, so dataflow/nexus/pact were third-party here and
 # first-party everywhere else (#1995).
-known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact"]
+known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact", "kailash_mcp"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,7 @@ known-first-party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", 
 
 [tool.isort]
 profile = "black"
-known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact"]
+known_first_party = ["kailash", "kaizen", "kaizen_agents", "dataflow", "nexus", "pact", "kailash_mcp"]
 # Scaffold templates are NOT valid Python — they carry `{Placeholder}` substitution tokens
 # (e.g. `class Test{AgentName}Initialization:`), so every formatter fails to parse them.
 # Excluded at CONFIG level, not in the pre-commit hook alone, so a direct `isort .` /

--- a/tests/e2e/mcp_server/conftest.py
+++ b/tests/e2e/mcp_server/conftest.py
@@ -8,12 +8,12 @@ from typing import Any, Dict
 import pytest
 import pytest_asyncio
 from aiohttp import web
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.auth.providers import AuthManager
 from kailash_mcp.protocol.protocol import get_protocol_manager
 from kailash_mcp.server import MCPServer
 from kailash_mcp.transports.transports import WebSocketServerTransport
-
-from kailash.middleware.gateway.event_store import EventStore
 
 # from tests.utils.mcp_utils import create_test_mcp_server
 

--- a/tests/e2e/mcp_server/test_graphql_field_selection_e2e.py
+++ b/tests/e2e/mcp_server/test_graphql_field_selection_e2e.py
@@ -9,14 +9,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.advanced.subscriptions import (
     ResourceChange,
     ResourceChangeType,
     ResourceSubscriptionManager,
 )
 from kailash_mcp.server import MCPServer
-
-from kailash.middleware.gateway.event_store import EventStore
 from tests.integration.docker_test_base import DockerIntegrationTestBase
 
 

--- a/tests/e2e/mcp_server/test_mcp_resource_subscriptions_e2e.py
+++ b/tests/e2e/mcp_server/test_mcp_resource_subscriptions_e2e.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import pytest_asyncio
 import websockets
+
 from kailash_mcp.protocol.protocol import ResourceChange, ResourceChangeType
 from kailash_mcp.server import MCPServer
 

--- a/tests/e2e/mcp_server/test_missing_handlers_e2e.py
+++ b/tests/e2e/mcp_server/test_missing_handlers_e2e.py
@@ -9,12 +9,12 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 import websockets
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.auth.providers import AuthManager
 from kailash_mcp.protocol.protocol import get_protocol_manager
 from kailash_mcp.server import MCPServer
 from kailash_mcp.transports.transports import WebSocketServerTransport
-
-from kailash.middleware.gateway.event_store import EventStore
 
 # Note: These utilities will be created when needed for E2E testing infrastructure
 # from tests.utils.docker_utils import wait_for_postgres

--- a/tests/e2e/nexus/test_multi_channel_deployment_e2e.py
+++ b/tests/e2e/nexus/test_multi_channel_deployment_e2e.py
@@ -382,7 +382,6 @@ class TestResourceSystemE2E:
         E2E Test: Validates resource system end-to-end.
         """
         from kailash_mcp import MCPServer
-
         from nexus.resources import NexusResourceManager
 
         nexus = Nexus(
@@ -434,7 +433,6 @@ class TestResourceSystemE2E:
         E2E Test: Validates documentation resource endpoints.
         """
         from kailash_mcp import MCPServer
-
         from nexus.resources import NexusResourceManager
 
         nexus = Nexus(auto_discovery=False, enable_durability=False)

--- a/tests/e2e/test_mcp_production_ha_scenarios.py
+++ b/tests/e2e/test_mcp_production_ha_scenarios.py
@@ -17,6 +17,7 @@ import aiohttp
 import pytest
 import pytest_asyncio
 import redis.asyncio as redis
+
 from kailash_mcp import MCPClient, MCPServer
 from kailash_mcp.auth.oauth import ResourceServer
 from kailash_mcp.auth.providers import APIKeyAuth
@@ -27,7 +28,6 @@ from kailash_mcp.discovery.discovery import (
     ServiceMesh,
     ServiceRegistry,
 )
-
 from tests.utils.docker_config import (
     ensure_docker_services,
     get_postgres_connection_string,

--- a/tests/e2e/test_mcp_production_workflows.py
+++ b/tests/e2e/test_mcp_production_workflows.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from kailash_mcp import (
     MCPClient,
     MCPServer,
@@ -21,7 +22,6 @@ from kailash_mcp import (
 )
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.discovery.discovery import ServerInfo
-
 from tests.utils.docker_config import ensure_docker_services, get_redis_url
 
 

--- a/tests/integration/channels/test_channel_framework.py
+++ b/tests/integration/channels/test_channel_framework.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-
 from src.kailash.channels.base import (
     Channel,
     ChannelConfig,

--- a/tests/integration/mcp_server/test_advanced_features.py
+++ b/tests/integration/mcp_server/test_advanced_features.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.advanced.features import (
     BinaryResourceHandler,
     CancellationContext,

--- a/tests/integration/mcp_server/test_client.py
+++ b/tests/integration/mcp_server/test_client.py
@@ -12,6 +12,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.auth.providers import (
     APIKeyAuth,
     AuthManager,

--- a/tests/integration/mcp_server/test_discovery.py
+++ b/tests/integration/mcp_server/test_discovery.py
@@ -6,6 +6,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.discovery.discovery import (
     DiscoveryBackend,
     FileBasedDiscovery,

--- a/tests/integration/mcp_server/test_discovery_docker.py
+++ b/tests/integration/mcp_server/test_discovery_docker.py
@@ -14,6 +14,7 @@ import pytest_asyncio
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
+
 from kailash_mcp.discovery.discovery import (
     FileBasedDiscovery,
     HealthChecker,
@@ -25,7 +26,6 @@ from kailash_mcp.discovery.discovery import (
     create_default_registry,
     discover_mcp_servers,
 )
-
 from tests.integration.docker_test_base import DockerIntegrationTestBase
 
 

--- a/tests/integration/mcp_server/test_distributed_subscriptions.py
+++ b/tests/integration/mcp_server/test_distributed_subscriptions.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+
 from kailash_mcp.advanced.subscriptions import (
     REDIS_AVAILABLE,
     DistributedSubscriptionManager,

--- a/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/tests/integration/mcp_server/test_elicitation_integration.py
@@ -43,6 +43,7 @@ import asyncio
 from typing import Any, Dict, List
 
 import pytest
+
 from kailash_mcp.advanced.features import ElicitationSystem
 from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.server import MCPServer

--- a/tests/integration/mcp_server/test_graphql_field_selection_integration.py
+++ b/tests/integration/mcp_server/test_graphql_field_selection_integration.py
@@ -6,6 +6,8 @@ from typing import Any, Dict
 
 import pytest
 import pytest_asyncio
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.advanced.subscriptions import (
     ResourceChange,
     ResourceChangeType,
@@ -13,8 +15,6 @@ from kailash_mcp.advanced.subscriptions import (
 )
 from kailash_mcp.auth.providers import AuthManager
 from kailash_mcp.server import MCPServer
-
-from kailash.middleware.gateway.event_store import EventStore
 from tests.integration.docker_test_base import DockerIntegrationTestBase
 
 

--- a/tests/integration/mcp_server/test_mcp_comprehensive_integration.py
+++ b/tests/integration/mcp_server/test_mcp_comprehensive_integration.py
@@ -11,6 +11,7 @@ import time
 
 import aiohttp
 import pytest
+
 from kailash_mcp import (
     MCPClient,
     MCPServer,
@@ -21,7 +22,6 @@ from kailash_mcp import (
 from kailash_mcp.auth.providers import APIKeyAuth, AuthManager
 from kailash_mcp.discovery.discovery import ServerInfo
 from kailash_mcp.errors import AuthenticationError, MCPError
-
 from tests.utils.docker_config import ensure_docker_services, get_redis_url
 
 

--- a/tests/integration/mcp_server/test_mcp_real_server_integration.py
+++ b/tests/integration/mcp_server/test_mcp_real_server_integration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import aiohttp
 import pytest
 import redis.asyncio as redis
+
 from kailash_mcp import MCPClient, MCPServer
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.discovery.discovery import (
@@ -26,7 +27,6 @@ from kailash_mcp.transports.transports import (
     StreamableHTTPTransport,
     WebSocketTransport,
 )
-
 from tests.utils.docker_config import (
     REDIS_CONFIG,
     ensure_docker_services,

--- a/tests/integration/mcp_server/test_mcp_stress_testing.py
+++ b/tests/integration/mcp_server/test_mcp_stress_testing.py
@@ -13,8 +13,8 @@ import aiohttp
 import pytest
 import pytest_asyncio
 import redis.asyncio as redis
-from kailash_mcp import MCPServer
 
+from kailash_mcp import MCPServer
 from tests.utils.docker_config import ensure_docker_services, get_redis_url
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/mcp_server/test_metrics.py
+++ b/tests/integration/mcp_server/test_metrics.py
@@ -12,6 +12,7 @@ from collections import deque
 from unittest.mock import patch
 
 import pytest
+
 from kailash_mcp.utils.metrics import (
     MetricsCollector,
     get_metrics,

--- a/tests/integration/mcp_server/test_missing_handlers_integration.py
+++ b/tests/integration/mcp_server/test_missing_handlers_integration.py
@@ -7,11 +7,11 @@ from typing import Any, Dict
 
 import pytest
 import pytest_asyncio
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.protocol.protocol import get_protocol_manager
 from kailash_mcp.server import MCPServer
-
-from kailash.middleware.gateway.event_store import EventStore
 from tests.integration.docker_test_base import DockerIntegrationTestBase
 from tests.utils.docker_config import ensure_docker_services
 

--- a/tests/integration/mcp_server/test_protocol.py
+++ b/tests/integration/mcp_server/test_protocol.py
@@ -7,6 +7,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.protocol.protocol import (
     CancellationManager,

--- a/tests/integration/mcp_server/test_resource_subscriptions_integration.py
+++ b/tests/integration/mcp_server/test_resource_subscriptions_integration.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import pytest_asyncio
 import websockets
+
 from kailash_mcp.advanced.subscriptions import ResourceSubscriptionManager
 from kailash_mcp.auth.providers import APIKeyAuth, AuthManager
 from kailash_mcp.protocol.protocol import ResourceChange, ResourceChangeType

--- a/tests/integration/mcp_server/test_transformation_pipeline_integration.py
+++ b/tests/integration/mcp_server/test_transformation_pipeline_integration.py
@@ -6,6 +6,8 @@ from typing import Any, Dict
 
 import pytest
 import pytest_asyncio
+
+from kailash.middleware.gateway.event_store import EventStore
 from kailash_mcp.advanced.subscriptions import (
     AggregationTransformer,
     DataEnrichmentTransformer,
@@ -15,8 +17,6 @@ from kailash_mcp.advanced.subscriptions import (
     ResourceSubscriptionManager,
 )
 from kailash_mcp.server import MCPServer
-
-from kailash.middleware.gateway.event_store import EventStore
 from tests.integration.docker_test_base import DockerIntegrationTestBase
 
 

--- a/tests/integration/mcp_server/test_websocket_connection_pool_integration.py
+++ b/tests/integration/mcp_server/test_websocket_connection_pool_integration.py
@@ -9,9 +9,10 @@ import time
 
 import pytest
 import websockets
+from websockets import serve
+
 from kailash_mcp.client import MCPClient
 from kailash_mcp.errors import TransportError
-from websockets import serve
 
 
 @pytest.mark.integration

--- a/tests/integration/mcp_server/test_websocket_integration.py
+++ b/tests/integration/mcp_server/test_websocket_integration.py
@@ -9,9 +9,10 @@ import json
 
 import pytest
 import websockets
+from websockets import serve
+
 from kailash_mcp.client import MCPClient
 from kailash_mcp.errors import TransportError
-from websockets import serve
 
 
 class TestWebSocketTransportOriginalBugFix:

--- a/tests/integration/nexus/test_resource_system_integration.py
+++ b/tests/integration/nexus/test_resource_system_integration.py
@@ -8,9 +8,9 @@ import json
 import os
 
 import pytest
-from kailash_mcp import MCPServer
 
 from kailash.workflow.builder import WorkflowBuilder
+from kailash_mcp import MCPServer
 from nexus import Nexus
 from nexus.resources import NexusResourceManager
 

--- a/tests/integration/test_mcp_subscriptions.py
+++ b/tests/integration/test_mcp_subscriptions.py
@@ -9,12 +9,12 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from kailash_mcp import MCPServer
-from kailash_mcp.advanced.subscriptions import ResourceSubscriptionManager
-from kailash_mcp.auth.providers import APIKeyAuth
 
 from kailash.middleware.communication.realtime import ConnectionManager, SSEManager
 from kailash.middleware.gateway.event_store import EventStore
+from kailash_mcp import MCPServer
+from kailash_mcp.advanced.subscriptions import ResourceSubscriptionManager
+from kailash_mcp.auth.providers import APIKeyAuth
 from tests.utils.docker_manager import DockerTestManager
 from tests.utils.test_helpers import wait_for_condition
 

--- a/tests/integration/test_prometheus_endpoint.py
+++ b/tests/integration/test_prometheus_endpoint.py
@@ -6,7 +6,6 @@ valid Prometheus text format with registered metrics.
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.servers import EnterpriseWorkflowServer, WorkflowServer
 from src.kailash.servers.durable_workflow_server import DurableWorkflowServer
 

--- a/tests/regression/test_1708_w1c_prometheus_type_mislabel.py
+++ b/tests/regression/test_1708_w1c_prometheus_type_mislabel.py
@@ -24,7 +24,6 @@ from typing import Dict
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.core.monitoring.connection_metrics import ConnectionMetricsCollector
 from src.kailash.servers import WorkflowServer
 

--- a/tests/regression/test_issue_1708_g1_pool_metrics_production_path.py
+++ b/tests/regression/test_issue_1708_g1_pool_metrics_production_path.py
@@ -48,7 +48,6 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.core.monitoring.connection_metrics import ConnectionMetricsCollector
 from src.kailash.servers import EnterpriseWorkflowServer, WorkflowServer
 

--- a/tests/tier2_integration/mcp_server/test_subscriptions.py
+++ b/tests/tier2_integration/mcp_server/test_subscriptions.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import pytest_asyncio
+
 from kailash_mcp.advanced.subscriptions import (
     CursorManager,
     ResourceMonitor,

--- a/tests/tier2_integration/runtime/test_distributed_runtime.py
+++ b/tests/tier2_integration/runtime/test_distributed_runtime.py
@@ -12,7 +12,6 @@ import time
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-
 from src.kailash.runtime.distributed import (
     _HEARTBEAT_PREFIX,
     _PROCESSING_KEY,

--- a/tests/tier2_integration/servers/test_enterprise_workflow_server.py
+++ b/tests/tier2_integration/servers/test_enterprise_workflow_server.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.gateway.security import SecretManager
 from src.kailash.resources.registry import ResourceRegistry
 from src.kailash.servers import EnterpriseWorkflowServer

--- a/tests/tier2_integration/servers/test_workflow_server.py
+++ b/tests/tier2_integration/servers/test_workflow_server.py
@@ -11,7 +11,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.servers import WorkflowServer
 from src.kailash.utils.server_auth import mounted_subapp_auth_kwargs
 from src.kailash.workflow import Workflow

--- a/tests/tier2_integration/test_live_dashboard.py
+++ b/tests/tier2_integration/test_live_dashboard.py
@@ -6,7 +6,6 @@ on WorkflowServer.
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.servers import WorkflowServer
 from src.kailash.visualization.live_dashboard import LiveDashboard
 

--- a/tests/tier2_integration/test_pool_metrics_use_completeness.py
+++ b/tests/tier2_integration/test_pool_metrics_use_completeness.py
@@ -22,7 +22,6 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
-
 from src.kailash.core.monitoring.connection_metrics import ConnectionMetricsCollector
 from src.kailash.servers import WorkflowServer
 

--- a/tests/unit/cross_sdk/test_jsonrpc_round_trip.py
+++ b/tests/unit/cross_sdk/test_jsonrpc_round_trip.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 
 import pytest
+
 from kailash_mcp.protocol import (
     JSONRPC_VERSION,
     JsonRpcError,

--- a/tests/unit/mcp/test_server_enhanced.py
+++ b/tests/unit/mcp/test_server_enhanced.py
@@ -7,6 +7,7 @@ import builtins
 from unittest.mock import Mock, patch
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 
 

--- a/tests/unit/mcp_server/test_auth.py
+++ b/tests/unit/mcp_server/test_auth.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
+
 from kailash_mcp.auth.providers import (
     APIKeyAuth,
     AuthenticationError,

--- a/tests/unit/mcp_server/test_batch_operations.py
+++ b/tests/unit/mcp_server/test_batch_operations.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
+
 from kailash_mcp.advanced.subscriptions import ResourceSubscriptionManager
 from kailash_mcp.server import MCPServer
 

--- a/tests/unit/mcp_server/test_client.py
+++ b/tests/unit/mcp_server/test_client.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth
 from kailash_mcp.client import MCPClient
 from kailash_mcp.errors import (

--- a/tests/unit/mcp_server/test_client_resources_prompts.py
+++ b/tests/unit/mcp_server/test_client_resources_prompts.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.client import MCPClient
 
 

--- a/tests/unit/mcp_server/test_config.py
+++ b/tests/unit/mcp_server/test_config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
 from kailash_mcp.utils.config import (
     ConfigManager,
     create_default_config,

--- a/tests/unit/mcp_server/test_discovery.py
+++ b/tests/unit/mcp_server/test_discovery.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.discovery.discovery import (
     DiscoveryBackend,
     FileBasedDiscovery,

--- a/tests/unit/mcp_server/test_errors.py
+++ b/tests/unit/mcp_server/test_errors.py
@@ -10,6 +10,7 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
+
 from kailash_mcp.errors import (
     AuthenticationError,
     AuthorizationError,

--- a/tests/unit/mcp_server/test_formatters.py
+++ b/tests/unit/mcp_server/test_formatters.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime
 
 import pytest
+
 from kailash_mcp.utils.formatters import (
     JSONFormatter,
     MarkdownFormatter,

--- a/tests/unit/mcp_server/test_graphql_field_selection.py
+++ b/tests/unit/mcp_server/test_graphql_field_selection.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
+
 from kailash_mcp.advanced.subscriptions import (
     ResourceSubscription,
     ResourceSubscriptionManager,

--- a/tests/unit/mcp_server/test_missing_handlers.py
+++ b/tests/unit/mcp_server/test_missing_handlers.py
@@ -8,6 +8,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.errors import MCPError
 from kailash_mcp.protocol.protocol import get_protocol_manager
 from kailash_mcp.server import MCPServer

--- a/tests/unit/mcp_server/test_server.py
+++ b/tests/unit/mcp_server/test_server.py
@@ -5,6 +5,7 @@ FUNCTIONAL TESTS - Tests actual behavior, not external dependencies.
 """
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth, BasicAuth
 from kailash_mcp.server import MCPServer, MCPServerBase
 

--- a/tests/unit/mcp_server/test_server_comprehensive.py
+++ b/tests/unit/mcp_server/test_server_comprehensive.py
@@ -18,6 +18,7 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth, BasicAuth
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.server import MCPServer, MCPServerBase

--- a/tests/unit/mcp_server/test_server_comprehensive_fixed.py
+++ b/tests/unit/mcp_server/test_server_comprehensive_fixed.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+
 from kailash_mcp.auth.providers import APIKeyAuth, BasicAuth
 from kailash_mcp.errors import MCPError, MCPErrorCode
 from kailash_mcp.server import MCPServer, MCPServerBase

--- a/tests/unit/mcp_server/test_transformation_pipeline.py
+++ b/tests/unit/mcp_server/test_transformation_pipeline.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+
 from kailash_mcp.advanced.subscriptions import (
     AggregationTransformer,
     DataEnrichmentTransformer,

--- a/tests/unit/mcp_server/test_websocket_compression.py
+++ b/tests/unit/mcp_server/test_websocket_compression.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from kailash_mcp.server import MCPServer
 
 

--- a/tests/unit/mcp_server/test_websocket_connection_pool.py
+++ b/tests/unit/mcp_server/test_websocket_connection_pool.py
@@ -9,6 +9,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kailash_mcp.client import MCPClient
 from kailash_mcp.errors import TransportError
 

--- a/tests/unit/mcp_server/utils/test_formatters.py
+++ b/tests/unit/mcp_server/utils/test_formatters.py
@@ -5,6 +5,7 @@ NO MOCKING - This is a unit test file for isolated component testing.
 """
 
 import pytest
+
 from kailash_mcp.utils.formatters import (
     JSONFormatter,
     MarkdownFormatter,

--- a/tests/unit/mcp_server/utils/test_mcp_cache.py
+++ b/tests/unit/mcp_server/utils/test_mcp_cache.py
@@ -22,6 +22,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from kailash_mcp.utils.cache import (
     CacheManager,
     LRUCache,

--- a/tests/unit/servers/test_gateway_creation.py
+++ b/tests/unit/servers/test_gateway_creation.py
@@ -11,7 +11,6 @@ import warnings
 from unittest.mock import Mock, patch
 
 import pytest
-
 from src.kailash.servers import (
     DurableWorkflowServer,
     EnterpriseWorkflowServer,


### PR DESCRIPTION
## Summary
- `pre-commit run isort --all-files` and a restricted/single-file invocation (the shape `--from-ref/--to-ref` and commit-time hooks use) classified `from kailash_mcp.client import MCPClient` into different sections, so each run undid the other's grouping — the same non-convergent flip-flop failure mode as #1995.
- Root cause: isort resolves **one config for the entire invocation** from `file_names[0]`'s directory (isort `main.py`, `settings_path` derivation) rather than per-file. Whichever file happens to be first in a batch decides which of this monorepo's several `[tool.isort]` blocks (root `pyproject.toml` plus per-package overrides in `kailash-dataflow`, `kailash-kaizen`, `kaizen-agents`) governs the whole run. `kailash_mcp` was absent from `known_first_party` in **every** copy, so classification fell through to the `src_paths` filesystem check, which only the root block's `src_paths` covers broadly enough (`packages/kailash-mcp/src`) — root-first batches classified it first-party, package-first batches didn't.
- Fixed by adding `kailash_mcp` to `known_first_party` in **all four** duplicated blocks, per this repo's own documented convention ("MUST match the root pyproject.toml list exactly", #1995) — a root-only fix would have left package-scoped batches re-diverging.

## Test plan
- [x] Reproduced the disagreement pre-fix: `--all-files` removed the blank line before the `kailash_mcp` import in `packages/kailash-kaizen/src/kaizen/core/base_agent.py`; a restricted single-file run (and a real `--from-ref`/`--to-ref` range) left it in place.
- [x] Confirmed mechanism by reading isort's `settings.py`/`main.py` and finding the per-package `[tool.isort]` block missing `kailash_mcp`.
- [x] Post-fix: `pre-commit run isort --all-files` converges — 119 files changed (4 config edits + import reordering).
- [x] Fixed point verified: two additional `--all-files` runs made zero further changes (contrast with #1995's ~2,000-file non-convergent churn).
- [x] Restricted/single-file invocations now agree with `--all-files` on every file checked (`kailash-kaizen` and `kailash-mcp` packages both spot-checked).
- [x] `black` hook passes on the isort output (no interaction issue).
- [x] All changed `.py` files verified to compile (`py_compile`).
- [x] Full pre-commit hook suite passed at commit time, including Tier 1 unit tests.

## Related issues
Fixes the isort self-contradiction defect (decision D3). References #1995 (prior non-convergent isort/black incident, ~2,000 permanently-modified files) as the precedent this fix avoids repeating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)