### PR TITLE
test(kaizen): make the Tier-1 unit tier hermetic (no DNS, no egress)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/token_counter.py
+++ b/packages/kailash-kaizen/src/kaizen/core/token_counter.py
@@ -283,10 +283,24 @@ class TokenCounter:
 
         # Fallback: character-based estimate
         if not self._tiktoken_warning_shown:
-            logger.warning(
-                "Using character-based token estimation. "
-                "Install tiktoken for accurate counting: pip install tiktoken"
-            )
+            if TIKTOKEN_AVAILABLE:
+                # tiktoken IS installed, so the encoder lookup itself failed --
+                # most often the one-time fetch of the BPE table from
+                # openaipublic.blob.core.windows.net. Telling the operator to
+                # install a package they already have sends them the wrong way;
+                # the preceding "Failed to get encoder" warning carries the
+                # real cause.
+                logger.warning(
+                    "Using character-based token estimation: tiktoken is "
+                    "installed but its encoding data could not be loaded "
+                    "(see the preceding 'Failed to get encoder' warning). "
+                    "Counts are approximate until the encoding is available."
+                )
+            else:
+                logger.warning(
+                    "Using character-based token estimation. "
+                    "Install tiktoken for accurate counting: pip install tiktoken"
+                )
             self._tiktoken_warning_shown = True
 
         return self._estimate_tokens(text)

--- a/packages/kailash-kaizen/tests/integration/core/test_token_counter_tiktoken.py
+++ b/packages/kailash-kaizen/tests/integration/core/test_token_counter_tiktoken.py
@@ -1,0 +1,61 @@
+"""Tier-2 tests for TokenCounter against REAL tiktoken encoding data.
+
+Moved out of ``tests/unit/core/test_token_counter.py``. These assert the
+content of tiktoken's own BPE tables ("Hello, world!" is exactly 4 tokens in
+``cl100k_base``), and tiktoken does not ship those tables in its wheel — it
+fetches them from ``openaipublic.blob.core.windows.net`` on first use. A test
+that downloads 1.7MB before it can assert is an integration test regardless of
+which directory it sits in (``rules/testing.md`` § 3-Tier: Tier-1 MUST NOT
+touch the network).
+
+They passed for as long as they did because a developer machine, and any CI
+runner with a warm tiktoken cache, already had the file on disk. On a cold
+cache with no network ``_get_encoder`` returns None and ``count`` falls back
+to the character estimate, so ``count("Hello, world!")`` returns 3 rather
+than 4.
+
+The Tier-1 half of this contract — that ``count`` DELEGATES to an encoder when
+one exists rather than silently estimating — is covered offline with a stub
+encoder in ``tests/unit/core/test_token_counter.py::TestEncoderDelegation``.
+What lives here is only the part that genuinely needs the real tables.
+"""
+
+import pytest
+
+from kaizen.core.token_counter import TokenCounter
+
+try:
+    import tiktoken
+
+    TIKTOKEN_AVAILABLE = True
+except ImportError:
+    TIKTOKEN_AVAILABLE = False
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not TIKTOKEN_AVAILABLE,
+    reason="tiktoken not installed - tests require tiktoken",
+)
+class TestTiktokenSpecific:
+    """Tests that specifically require real tiktoken encoding data."""
+
+    def test_tiktoken_exact_count(self):
+        """Test exact token count with tiktoken."""
+        counter = TokenCounter()
+        # "Hello, world!" is exactly 4 tokens in cl100k_base
+        tokens = counter.count("Hello, world!", encoding_name="cl100k_base")
+        assert tokens == 4
+
+    def test_tiktoken_encoding_for_model(self):
+        """Test tiktoken-based encoding selection."""
+        import tiktoken
+
+        counter = TokenCounter()
+        # Get encoding directly from tiktoken
+        expected = tiktoken.encoding_for_model("gpt-4")
+        actual = counter._get_encoder("cl100k_base")
+        assert actual is not None
+        # Verify they produce same result
+        text = "Test text"
+        assert len(expected.encode(text)) == len(actual.encode(text))

--- a/packages/kailash-kaizen/tests/unit/conftest.py
+++ b/packages/kailash-kaizen/tests/unit/conftest.py
@@ -1,5 +1,10 @@
 """Tier-1 unit-test conftest for kailash-kaizen.
 
+Holds the autouse fixtures that keep the unit tier offline: an LLM stub
+(``_stub_trait_derivation``, below) and a DNS stub (``_hermetic_dns``, at the
+foot of this file). Both exist for the same reason — ``rules/testing.md``
+§ 3-Tier requires Tier-1 tests to run with no live service and no network.
+
 Issue #829: trait derivation is now LLM-first via ``RoleToTraitsSignature``.
 Tier-1 unit tests MUST NOT depend on a live LLM (``rules/testing.md``
 § 3-Tier Testing). The autouse fixture below stubs
@@ -21,8 +26,11 @@ The stub returns the same default list the keyword classifier returned for
 
 from __future__ import annotations
 
+import errno
+import ipaddress
 import os
-from typing import List
+import socket
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -53,3 +61,143 @@ def _stub_trait_derivation(monkeypatch: pytest.MonkeyPatch) -> None:
         return list(_DEFAULT_TIER1_TRAITS)
 
     monkeypatch.setattr(Kaizen, "_generate_role_based_traits", _stub)
+
+
+# ---------------------------------------------------------------------------
+# Hermetic DNS
+# ---------------------------------------------------------------------------
+#
+# ``Endpoint.base_url`` routes every URL through ``url_safety.check_url()``,
+# whose DNS-rebinding defense calls ``socket.getaddrinfo``. Constructing an
+# endpoint therefore performs a LIVE DNS LOOKUP, so any unit test that builds
+# a deployment/preset silently depends on a working resolver — a Tier-1
+# network dependency (``rules/testing.md`` § 3-Tier: unit tests MUST NOT touch
+# the network).
+#
+# The dependency was invisible because the fake fixture hostnames split by
+# accident: ``myresource.openai.azure.com`` RESOLVES (Azure publishes a
+# wildcard record for ``*.openai.azure.com``) while the equally-fake
+# ``myfoundry.services.ai.azure.com`` does NOT. Measured on an air-gapped
+# runner (``socket.getaddrinfo`` raising for every host), 255 of 1615 tests
+# under ``tests/unit/llm`` plus 6 under ``tests/unit/providers`` failed — the
+# handful of Azure-AI-Foundry failures were only the visible corner.
+#
+# The stub below removes the dependency without touching production code.
+# Whether a DNS lookup belongs inside endpoint construction at all is a real
+# design question, tracked separately; this fixture does not prejudge it.
+
+# Returned for every host without an explicit mapping. It must be an address
+# the guard classifies as PUBLIC, which rules out the RFC 5737 documentation
+# ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24): Python's
+# ``ipaddress`` reports all three as ``.is_private``, so ``_is_private_ipv4``
+# would reject them and every endpoint construction would fail.
+_STUB_PUBLIC_IPV4 = "93.184.216.34"
+
+# Hosts whose real-world address the guard is expected to act on. The cloud
+# metadata hostnames are already rejected by NAME (``_METADATA_HOSTNAMES``)
+# before resolution runs, so these entries are defense-in-depth: if that
+# name check is ever narrowed, the resolution-path ``_METADATA_IPS`` check
+# still fires under the stub instead of silently passing.
+_STUB_DNS: Dict[str, Tuple[str, ...]] = {
+    "localhost": ("127.0.0.1", "::1"),
+    "metadata.google.internal": ("169.254.169.254",),
+    "metadata.azure.com": ("169.254.169.254",),
+    "metadata.aws.internal": ("169.254.169.254",),
+}
+
+
+def _addrinfo(ip: str, port: int) -> Tuple[Any, ...]:
+    """One ``getaddrinfo`` 5-tuple: (family, type, proto, canonname, sockaddr)."""
+    if ":" in ip:
+        sockaddr: Tuple[Any, ...] = (ip, port, 0, 0)
+        family = socket.AF_INET6
+    else:
+        sockaddr = (ip, port)
+        family = socket.AF_INET
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
+def _stub_getaddrinfo(host: Any, port: Any = None, *args: Any, **kwargs: Any) -> list:
+    """Deterministic in-process stand-in for ``socket.getaddrinfo``.
+
+    Unknown hosts resolve to a fixed public address rather than raising. An
+    explicit allowlist was rejected: it would have to enumerate every fixture
+    hostname in the tier and would fail closed the moment a test introduced a
+    new one — re-creating exactly the trap this fixture removes.
+
+    A host that is ALREADY a literal IP is returned unchanged, matching real
+    ``getaddrinfo``. Remapping it would silently redirect every loopback
+    client in the tier: the ollama fallback dials ``127.0.0.1:11434`` and,
+    when that was rewritten to a public address, spent 75s black-holed across
+    its retry budget instead of being refused in 0.05s.
+    """
+    host_s = str(host).strip("[]")
+    port_num = port if isinstance(port, int) else 0
+
+    try:
+        ipaddress.ip_address(host_s)
+    except ValueError:
+        ips = _STUB_DNS.get(host_s.lower(), (_STUB_PUBLIC_IPV4,))
+    else:
+        ips = (host_s,)
+
+    return [_addrinfo(ip, port_num) for ip in ips]
+
+
+_real_connect = socket.socket.connect
+_real_connect_ex = socket.socket.connect_ex
+
+
+def _is_loopback(address: Any) -> bool:
+    """True if an AF_INET/AF_INET6 sockaddr points at loopback."""
+    if not isinstance(address, tuple) or not address:
+        return False
+    try:
+        return ipaddress.ip_address(str(address[0]).strip("[]")).is_loopback
+    except ValueError:
+        return False
+
+
+def _refuse(self: socket.socket, address: Any) -> Any:
+    """Refuse non-loopback TCP/UDP connects the way a closed port would."""
+    if self.family in (socket.AF_INET, socket.AF_INET6) and not _is_loopback(address):
+        raise ConnectionRefusedError(
+            errno.ECONNREFUSED,
+            "Tier-1 unit tests MUST NOT touch the network "
+            f"(blocked connect to {address!r}); see tests/unit/conftest.py",
+        )
+    return _real_connect(self, address)
+
+
+def _refuse_ex(self: socket.socket, address: Any) -> Any:
+    if self.family in (socket.AF_INET, socket.AF_INET6) and not _is_loopback(address):
+        return errno.ECONNREFUSED
+    return _real_connect_ex(self, address)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every Tier-1 unit test resolve hostnames in-process.
+
+    Patches the same seam the SSRF rebinding tests already use
+    (``monkeypatch.setattr(socket, "getaddrinfo", ...)``), so a test that
+    needs to drive resolution itself simply re-patches inside its own body —
+    the function-scoped patch applied later wins for that test's duration.
+
+    Only the DNS-rebinding branch of ``check_url`` is affected. Every other
+    rejection (scheme, ``metadata_host``, encoded-IP bypass, inet_aton
+    short-form, literal-IP range checks) runs BEFORE resolution and is
+    exercised unchanged.
+
+    Non-loopback connects are refused as well. Resolving a name is only half
+    the dependency: several tests deliberately drive an ungoverned egress and
+    swallow the result (``except Exception: pass``), so they were fast only
+    because the lookup failed first. Once the name resolves, the same tests
+    black-hole for their full 60s timeout — and on a runner where the address
+    is reachable they would issue a REAL request from the unit tier. Refusing
+    the connect gives them the same fast, offline failure they always relied
+    on. Loopback is left alone so an in-process helper server still works.
+    """
+    monkeypatch.setattr(socket, "getaddrinfo", _stub_getaddrinfo)
+    monkeypatch.setattr(socket.socket, "connect", _refuse)
+    monkeypatch.setattr(socket.socket, "connect_ex", _refuse_ex)

--- a/packages/kailash-kaizen/tests/unit/core/test_token_counter.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_token_counter.py
@@ -5,6 +5,8 @@ Tests the token counting utility with both tiktoken-based counting
 and fallback heuristics when tiktoken is unavailable.
 """
 
+import logging
+
 import pytest
 
 from kaizen.core.token_counter import (
@@ -278,46 +280,120 @@ class TestGlobalCounter:
         assert tokens > 0
 
 
+class _StubEncoder:
+    """Deterministic stand-in for a tiktoken ``Encoding``.
+
+    Counts one token per whitespace-separated word, which is deliberately
+    NOT what the character-based fallback produces for the strings used
+    below — that difference is what makes the delegation assertions able to
+    fail.
+    """
+
+    def __init__(self) -> None:
+        self.encode_calls = 0
+
+    def encode(self, text: str) -> list:
+        self.encode_calls += 1
+        return list(range(len(text.split())))
+
+
+@pytest.fixture
+def stub_encoder(monkeypatch):
+    """Install a stub encoder in place of real tiktoken lookups.
+
+    Requires tiktoken to be importable (``_get_encoder`` returns None early
+    otherwise), but never touches tiktoken's BPE tables or the network.
+    """
+    if not TIKTOKEN_AVAILABLE:
+        pytest.skip("tiktoken not installed")
+
+    from kaizen.core import token_counter as tc
+
+    encoder = _StubEncoder()
+    calls = []
+
+    def _fake_get_encoding(name):
+        calls.append(name)
+        return encoder
+
+    monkeypatch.setattr(tc.tiktoken, "get_encoding", _fake_get_encoding)
+    encoder.get_encoding_calls = calls
+    return encoder
+
+
 class TestEncoderCaching:
     """Tests for encoder caching."""
 
-    def test_encoder_caching(self):
-        """Test that encoders are cached."""
+    def test_encoder_caching(self, stub_encoder):
+        """Test that encoders are cached.
+
+        Asserts unconditionally. The previous version guarded the assertion
+        with ``if encoder1 is not None``, so on any runner where the encoding
+        was unavailable it asserted nothing and still passed.
+        """
         counter = TokenCounter()
-        # First call should create encoder
+
         encoder1 = counter._get_encoder("cl100k_base")
-        # Second call should return cached
         encoder2 = counter._get_encoder("cl100k_base")
-        if encoder1 is not None:
-            assert encoder1 is encoder2
+
+        assert encoder1 is not None
+        assert encoder1 is encoder2
+        # Cached: the underlying lookup ran exactly once for two calls.
+        assert stub_encoder.get_encoding_calls == ["cl100k_base"]
 
 
-@pytest.mark.skipif(
-    not TIKTOKEN_AVAILABLE,
-    reason="tiktoken not installed - tests require tiktoken",
-)
-class TestTiktokenSpecific:
-    """Tests that specifically require tiktoken."""
+class TestEncoderDelegation:
+    """``count`` must USE an available encoder, not silently estimate.
 
-    def test_tiktoken_exact_count(self):
-        """Test exact token count with tiktoken."""
+    This is the Tier-1 half of what the tiktoken tests used to cover. The
+    other half — that real tiktoken tables produce a specific count — needs
+    the downloaded BPE data and now lives in
+    ``tests/integration/core/test_token_counter_tiktoken.py``.
+
+    The regression this guards is exactly the one that hid a network
+    dependency for so long: when the encoder cannot be obtained, ``count``
+    falls back to a character estimate and returns a plausible-but-wrong
+    number instead of failing.
+    """
+
+    def test_count_delegates_to_encoder_when_available(self, stub_encoder):
         counter = TokenCounter()
-        # "Hello, world!" is exactly 4 tokens in cl100k_base
+
         tokens = counter.count("Hello, world!", encoding_name="cl100k_base")
-        assert tokens == 4
 
-    def test_tiktoken_encoding_for_model(self):
-        """Test tiktoken-based encoding selection."""
-        import tiktoken
+        # Stub counts words (2); the fallback estimate for this string is 3.
+        # Asserting the encoder's answer AND that it differs from the
+        # estimate is what makes a silent regression to the fallback visible.
+        assert tokens == 2
+        assert tokens != counter._estimate_tokens("Hello, world!")
+        assert stub_encoder.encode_calls == 1
+
+    def test_count_falls_back_and_warns_when_encoder_unavailable(
+        self, monkeypatch, caplog
+    ):
+        if not TIKTOKEN_AVAILABLE:
+            pytest.skip("tiktoken not installed")
+
+        from kaizen.core import token_counter as tc
+
+        def _unavailable(name):
+            raise RuntimeError("encoding data unavailable")
+
+        monkeypatch.setattr(tc.tiktoken, "get_encoding", _unavailable)
 
         counter = TokenCounter()
-        # Get encoding directly from tiktoken
-        expected = tiktoken.encoding_for_model("gpt-4")
-        actual = counter._get_encoder("cl100k_base")
-        assert actual is not None
-        # Verify they produce same result
-        text = "Test text"
-        assert len(expected.encode(text)) == len(actual.encode(text))
+        with caplog.at_level(logging.WARNING):
+            tokens = counter.count("Hello, world!", encoding_name="cl100k_base")
+
+        assert tokens == counter._estimate_tokens("Hello, world!")
+        # The degraded path MUST announce itself; a silent fallback is what
+        # made "3 instead of 4" look like a passing test for so long.
+        assert any(
+            "Failed to get encoder cl100k_base" in r.message for r in caplog.records
+        )
+        assert any(
+            "character-based token estimation" in r.message for r in caplog.records
+        )
 
 
 class TestModelContextSizes:


### PR DESCRIPTION
## Summary

**Unblocks `main`.** Five tests under `packages/kailash-kaizen/tests/unit/llm/` are failing on `main` with `kaizen.llm.errors.InvalidEndpoint: reason=resolution_failed`. This makes the Tier-1 unit tier hermetic, which fixes them — and fixes the 250 more that were failing for the same reason without anyone noticing.

## These tests are not a regression

They were **deselected for as long as they have existed**. The old kaizen conftest matched the 2-letter fragment `"ai"` against test names — `azure_**ai**_foundry`, `open**ai**` — and marked them `requires_ollama`. Replacing that heuristic with fixture-graph derivation released them, and they failed on their first ever run. This is first-run exposure.

## The actual defect

`Endpoint.base_url` routes every URL through `url_safety.check_url()` (`deployment.py:129`), whose DNS-rebinding defense calls `socket.getaddrinfo` and rejects with `resolution_failed` when a hostname does not resolve (`url_safety.py:367-371`). **Constructing an endpoint performs a live DNS lookup.**

The dependency stayed invisible because two fake fixture hostnames split by accident:

```
myresource.openai.azure.com        RESOLVES        -> 20.89.12.205   (Azure wildcard record)
myfoundry.services.ai.azure.com    does NOT resolve (gaierror)
```

Both are fake. Both take the same code path. The only reason the other tests passed is that one fake hostname happens to land under a real Azure wildcard record and the runner has network.

Measured by poisoning `socket.getaddrinfo` to raise for every host, against the **unfixed** code:

| scope | with DNS | without DNS |
|---|---|---|
| `tests/unit/llm/` | 5 failed, 1610 passed | **255 failed**, 1360 passed |
| `tests/unit/providers`, `rag`, `strategies` | 323 passed | **6 failed**, 317 passed |

So `tests/unit/` had a hidden network dependency: on an air-gapped or DNS-restricted runner the *passing* tests fail too. 29 of the fixture hostnames resolve only because the runner has real internet DNS.

## The fix

Test-side only, in `packages/kailash-kaizen/tests/unit/conftest.py` — the file that already carries an autouse LLM stub for exactly this reason (`rules/testing.md` § 3-Tier). Two autouse patches:

1. **In-process resolver.** Unknown hosts resolve to a fixed public address; literal IPs pass through unchanged; `localhost` and the cloud-metadata hostnames keep their real addresses. It patches the same seam the existing SSRF rebinding tests already use, so a test that drives resolution itself just re-patches and wins for its own duration.

2. **Non-loopback connects refused.** Resolving a name is only half the dependency. Several tests deliberately drive an ungoverned egress and swallow the result (`except Exception: pass`), so they were fast *only because the lookup failed first*. Once names resolve they black-hole for their full 60s timeout — and on a runner where the address is reachable they would issue a real request from the unit tier.

Two details worth flagging, both found the hard way:

- The RFC 5737 documentation ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) are unusable as the stub address: Python's `ipaddress` reports all three as `.is_private`, so the guard's own `_is_private_ipv4` would reject them and every endpoint construction would fail.
- Literal IPs must pass through unchanged. Remapping them silently redirected the ollama fallback's `127.0.0.1:11434` to a public address, turning a 0.05s connection refusal into 75s black-holed across its retry budget.

## What was NOT done

`check_url`'s production behaviour is unchanged. Whether a DNS lookup belongs inside endpoint construction is a real design question with security implications — raised as **#2168** with the evidence, not decided here. Note that `check_url`'s own comment names a `resolve_dns=False` affordance that is **not reachable through `Endpoint`**; that is part of #2168.

No test was skipped, xfailed, or given a hostname that happens to resolve.

## Verification

**Direction 1 — the 5 previously-failing tests.**

```
BEFORE: 5 failed, 73 passed in 15.97s
AFTER:  78 passed in 34.92s
```

**Direction 2 — the rest no longer depend on DNS.** Real `socket.getaddrinfo` poisoned to raise for every host, and instrumented to count any call that escapes the stub:

```
tests/unit/llm/          1615 passed in 21.98s
[nodns] real getaddrinfo calls that escaped the stub: 0

full tests/unit/         11151 passed, 152 skipped in 1415s
[nodns] real getaddrinfo calls that escaped the stub: 0
```

The instrument is known to discriminate: the same plugin produced 255 failures against the unfixed code.

`pre-commit run` is green end-to-end, including the `Run Tier 1 unit tests` hook.

## Note for reviewers

Two **pre-existing** wall-clock perf assertions flake under heavy parallel load and are unrelated to this change (both pass 5/5 in isolation, and timings are identical with and without this fix — 4.46/4.68/4.79s vs 4.65/4.38s):

- `tests/unit/examples/test_simple_qa_async.py::TestSimpleQAAsyncPerformance::test_async_execution_overhead` — `assert elapsed < 5.0`, ~4.5s unloaded, so ~10% headroom
- `tests/unit/nodes/test_async_node_comprehensive.py::TestAsyncNodePerformance::test_concurrent_execution_performance`

They are not addressed here; flagging them rather than silently leaving them for the next reader.

## Related issues

Unblocks `main`. Follow-up design question: #2168
