### PR TITLE
fix(security): redact credentials at every log sink they reach (#2167)

### DIFF
--- a/src/kailash/nodes/api/http.py
+++ b/src/kailash/nodes/api/http.py
@@ -6,6 +6,7 @@ the best features from both the original HTTPRequestNode and HTTPClientNode.
 
 import asyncio
 import base64
+import json
 import time
 from enum import Enum
 from typing import Any
@@ -35,6 +36,41 @@ from kailash.utils.resource_manager import (
     ResourcePool,
     managed_resource,
 )
+from kailash.utils.secure_logging import redact_mapping, sanitize_log_value
+from kailash.utils.url_credentials import mask_error_text, mask_url
+
+
+def _log_safe_body(body: Any, limit: int = 500) -> str:
+    """Render a request/response body for a log line without leaking credentials.
+
+    Issue #2167. These nodes logged bodies verbatim, and the bodies genuinely
+    carry credentials in both directions: ``nodes/auth/sso.py`` POSTs an OAuth
+    token exchange through this node with ``client_secret`` in the payload, and
+    the RESPONSE to that exchange is a JSON object whose ``access_token`` field
+    is the credential itself.
+
+    Structured bodies keep their shape and lose only credential-named values, so
+    the diagnostic survives. An OPAQUE body -- a raw string or bytes that is not
+    JSON -- is withheld entirely and reported by type and size: there are no keys
+    to redact by, so there is no way to withhold the secret half while keeping
+    the rest, and guessing would be the "control that reports success without
+    doing its job" shape.
+    """
+    if body is None:
+        return "<empty>"
+    if isinstance(body, (dict, list)):
+        return sanitize_log_value(str(redact_mapping(body)), limit)
+    if isinstance(body, (bytes, bytearray)):
+        return f"<{len(body)} bytes withheld>"
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except (ValueError, TypeError):
+            return f"<{len(body)} chars withheld>"
+        if isinstance(parsed, (dict, list)):
+            return sanitize_log_value(str(redact_mapping(parsed)), limit)
+        return f"<{len(body)} chars withheld>"
+    return f"<{type(body).__name__} withheld>"
 
 
 class HTTPMethod(str, Enum):
@@ -535,13 +571,31 @@ class HTTPRequestNode(Node):
             request_kwargs["data"] = data
 
         # Execute request with retries
+        # CREDENTIAL-SAFE LOGGING (issue #2167, CodeQL 11506/11507).
+        #
+        # `url` goes through `mask_url` because it is the SDK's single source of
+        # truth for credential masking -- its own docstring: "Every log line,
+        # error message, exception payload, or stdout writeback that mentions a
+        # connection string MUST route the URL through this helper first." It
+        # handles http(s) userinfo (`https://svc:pw@host`) and credential query
+        # params (a presigned `?X-Amz-Signature=...`). Nothing in this file
+        # imported any masker before this change.
+        #
+        # `headers` is redacted because `_apply_authentication` puts the
+        # credential THERE: `Authorization: Basic <base64(user:pass)>`. Base64
+        # is an encoding, not a mask -- the password is trivially recoverable
+        # from a log. The redactor is separator-normalized so the default
+        # `X-API-Key` header name matches too.
+        #
+        # NOTE the else-branch is the DEFAULT path (`log_requests` defaults
+        # False), so the unmasked URL was logged on EVERY request.
         if log_requests:
-            self.logger.info(f"Request: {method} {url}")
-            self.logger.info(f"Headers: {headers}")
+            self.logger.info("Request: %s %s", method, mask_url(url))
+            self.logger.info("Headers: %s", redact_mapping(headers))
             if data or json_data:
-                self.logger.info(f"Body: {json_data or data}")
+                self.logger.info("Body: %s", _log_safe_body(json_data or data))
         else:
-            self.logger.info(f"Making {method} request to {url}")
+            self.logger.info("Making %s request to %s", method, mask_url(url))
 
         response = None
         response_time: float = 0.0
@@ -564,15 +618,25 @@ class HTTPRequestNode(Node):
 
                 # Log response if enabled
                 if log_requests:
-                    self.logger.info(f"Response: {response.status_code}")
-                    self.logger.info(f"Headers: {dict(response.headers)}")
-                    self.logger.info(f"Body: {response.text[:500]}...")
+                    # Response headers and body carry credentials too (#2167):
+                    # `Set-Cookie` is a session credential, and the RESPONSE to the
+                    # OAuth token exchange `nodes/auth/sso.py` drives through this
+                    # node is a JSON object whose `access_token` IS the credential.
+                    self.logger.info("Response: %s", response.status_code)
+                    self.logger.info(
+                        "Headers: %s", redact_mapping(dict(response.headers))
+                    )
+                    self.logger.info("Body: %s", _log_safe_body(response.text))
 
                 # Success, break the retry loop
                 break
 
             except requests.RequestException as e:
-                self.logger.warning(f"Request failed: {str(e)}")
+                # The driver renders the FULL request URL into its exception text --
+                # credentials and all. `mask_error_text` is the canonical helper for
+                # exactly this "opaque {e} that may embed a credential-bearing URL"
+                # case (#2167).
+                self.logger.warning("Request failed: %s", mask_error_text(e))
 
                 # Last attempt, no more retries
                 if attempt == retry_count:
@@ -581,7 +645,10 @@ class HTTPRequestNode(Node):
                         "response": None,
                         "status_code": None,
                         "success": False,
-                        "error": str(e),
+                        # Returned into workflow results, which are themselves
+                        # logged and persisted -- masked for the same reason
+                        # the log line above is (#2167).
+                        "error": mask_error_text(e),
                         "error_type": type(e).__name__,
                         "recovery_suggestions": [
                             "Check network connectivity",
@@ -615,7 +682,8 @@ class HTTPRequestNode(Node):
                 content = response.text  # Fallback to text
         except Exception as e:
             self.logger.warning(
-                f"Failed to parse response as {response_format}: {str(e)}"
+                f"Failed to parse response as {response_format}: "
+                f"{mask_error_text(e)}"
             )
             content = response.text  # Fallback to text
 
@@ -884,13 +952,31 @@ class AsyncHTTPRequestNode(AsyncNode):
             request_kwargs["data"] = data
 
         # Execute request with retries
+        # CREDENTIAL-SAFE LOGGING (issue #2167, CodeQL 11506/11507).
+        #
+        # `url` goes through `mask_url` because it is the SDK's single source of
+        # truth for credential masking -- its own docstring: "Every log line,
+        # error message, exception payload, or stdout writeback that mentions a
+        # connection string MUST route the URL through this helper first." It
+        # handles http(s) userinfo (`https://svc:pw@host`) and credential query
+        # params (a presigned `?X-Amz-Signature=...`). Nothing in this file
+        # imported any masker before this change.
+        #
+        # `headers` is redacted because `_apply_authentication` puts the
+        # credential THERE: `Authorization: Basic <base64(user:pass)>`. Base64
+        # is an encoding, not a mask -- the password is trivially recoverable
+        # from a log. The redactor is separator-normalized so the default
+        # `X-API-Key` header name matches too.
+        #
+        # NOTE the else-branch is the DEFAULT path (`log_requests` defaults
+        # False), so the unmasked URL was logged on EVERY request.
         if log_requests:
-            self.logger.info(f"Request: {method} {url}")
-            self.logger.info(f"Headers: {headers}")
+            self.logger.info("Request: %s %s", method, mask_url(url))
+            self.logger.info("Headers: %s", redact_mapping(headers))
             if data or json_data:
-                self.logger.info(f"Body: {json_data or data}")
+                self.logger.info("Body: %s", _log_safe_body(json_data or data))
         else:
-            self.logger.info(f"Making async {method} request to {url}")
+            self.logger.info("Making async %s request to %s", method, mask_url(url))
 
         response = None
 
@@ -919,10 +1005,15 @@ class AsyncHTTPRequestNode(AsyncNode):
 
                         # Log response if enabled
                         if log_requests:
-                            self.logger.info(f"Response: {response.status}")
-                            self.logger.info(f"Headers: {dict(response.headers)}")
+                            # Same reasoning as the sync sibling above (#2167):
+                            # `Set-Cookie` and an OAuth `access_token` both live
+                            # on the response side.
+                            self.logger.info("Response: %s", response.status)
+                            self.logger.info(
+                                "Headers: %s", redact_mapping(dict(response.headers))
+                            )
                             text_preview = await response.text()
-                            self.logger.info(f"Body: {text_preview[:500]}...")
+                            self.logger.info("Body: %s", _log_safe_body(text_preview))
 
                         # Determine response format
                         actual_format = response_format
@@ -946,7 +1037,8 @@ class AsyncHTTPRequestNode(AsyncNode):
                                 content = await response.text()  # Fallback to text
                         except Exception as e:
                             self.logger.warning(
-                                f"Failed to parse response as {actual_format}: {str(e)}"
+                                f"Failed to parse response as {actual_format}: "
+                                f"{mask_error_text(e)}"
                             )
                             content = await response.text()  # Fallback to text
 
@@ -977,7 +1069,8 @@ class AsyncHTTPRequestNode(AsyncNode):
                         return result
 
             except (TimeoutError, aiohttp.ClientError) as e:
-                self.logger.warning(f"Async request failed: {str(e)}")
+                # Same as the sync sibling: the URL is inside the exception text.
+                self.logger.warning("Async request failed: %s", mask_error_text(e))
 
                 # Last attempt, no more retries
                 if attempt == retry_count:
@@ -986,7 +1079,10 @@ class AsyncHTTPRequestNode(AsyncNode):
                         "response": None,
                         "status_code": None,
                         "success": False,
-                        "error": str(e),
+                        # Returned into workflow results, which are themselves
+                        # logged and persisted -- masked for the same reason
+                        # the log line above is (#2167).
+                        "error": mask_error_text(e),
                         "error_type": type(e).__name__,
                         "recovery_suggestions": [
                             "Check network connectivity",

--- a/src/kailash/nodes/auth/_log_hygiene.py
+++ b/src/kailash/nodes/auth/_log_hygiene.py
@@ -20,38 +20,19 @@ One helper, used at every sink call site in this package, rather than an inline
 ``replace`` per site: five hand-rolled copies is how the sites drift
 (``rules/security.md`` § Multi-Site Kwarg Plumbing).
 
-The durable fix belongs one layer down, inside ``SecurityEventNode.execute``
-and ``AuditLogNode.execute``, so that EVERY caller in the SDK is covered rather
-than only this package's. That is outside this change's file scope; the helper
-here closes the exposure this change creates.
+The durable fix DID land one layer down, inside ``SecurityEventNode.execute``
+and ``AuditLogNode.execute``, so every caller in the SDK is covered rather than
+only this package's (issue #2167). ``redact_mapping`` moved with it, to
+``kailash.utils.secure_logging`` beside ``sanitize_log_value``, because a node
+outside this package must not reach into a private module of it. Import it from
+there; this module no longer defines it.
 """
 
 from typing import Any
 
 from kailash.utils.secure_logging import sanitize_log_value
 
-__all__ = ["log_safe", "redact_mapping"]
-
-# Keys whose values are credential material or bulk personal data and must not
-# be copied into a log record. Matched case-insensitively as substrings, so
-# "access_token", "refresh_token" and "totp_secret" are all caught.
-_SENSITIVE_KEY_FRAGMENTS = (
-    "secret",
-    "token",
-    "password",
-    "passwd",
-    "credential",
-    "backup_code",
-    "recovery_code",
-    "private_key",
-    "api_key",
-    "qr_code",
-    "provisioning_uri",
-    "assertion",
-    "authorization",
-    "cookie",
-    "session_id",
-)
+__all__ = ["log_safe"]
 
 
 def log_safe(value: Any, limit: int = 256) -> str:
@@ -73,31 +54,3 @@ def log_safe(value: Any, limit: int = 256) -> str:
     if value is None:
         return ""
     return sanitize_log_value(value, limit)
-
-
-def redact_mapping(data: Any, _depth: int = 0) -> Any:
-    """Recursively replace credential-bearing values with a redaction marker.
-
-    Used for the free-form attribute bags the SSO and directory nodes attach to
-    audit records: a provisioning record carries whatever the IdP returned,
-    which routinely includes tokens and, for a directory sync, the full mapped
-    LDAP/AD entry. The record keeps its shape -- the key stays, so an auditor
-    can still see WHICH fields were present -- while the value is withheld.
-
-    Depth is bounded so a self-referential or pathologically nested attribute
-    bag cannot exhaust the stack inside a logging call.
-    """
-    if _depth >= 6:
-        return "[REDACTED_DEPTH]"
-    if isinstance(data, dict):
-        redacted = {}
-        for key, value in data.items():
-            lowered = str(key).lower()
-            if any(fragment in lowered for fragment in _SENSITIVE_KEY_FRAGMENTS):
-                redacted[key] = "[REDACTED]"
-            else:
-                redacted[key] = redact_mapping(value, _depth + 1)
-        return redacted
-    if isinstance(data, (list, tuple)):
-        return [redact_mapping(item, _depth + 1) for item in data]
-    return data

--- a/src/kailash/nodes/auth/directory_integration.py
+++ b/src/kailash/nodes/auth/directory_integration.py
@@ -24,11 +24,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from kailash.nodes.api import AsyncHTTPRequestNode
-from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security import AuditLogNode, SecurityEventNode
+from kailash.utils.secure_logging import redact_mapping
 
 
 def _is_enabled(value: Any) -> bool:

--- a/src/kailash/nodes/auth/enterprise_auth_provider.py
+++ b/src/kailash/nodes/auth/enterprise_auth_provider.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 
 from kailash.nodes.api import AsyncHTTPRequestNode
 from kailash.nodes.auth._http_response import http_body
-from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.auth.directory_integration import DirectoryIntegrationNode
 from kailash.nodes.auth.mfa import MultiFactorAuthNode
 from kailash.nodes.auth.session_management import SessionManagementNode
@@ -36,6 +36,7 @@ from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security import AuditLogNode, SecurityEventNode
+from kailash.utils.secure_logging import redact_mapping
 
 # One-time-per-process latch for the "JWT issuer is not pinned" warning
 # (issue #2089). Module-level, not per-instance: a provider constructed per

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -27,12 +27,13 @@ from kailash.nodes.auth._actor import (
     MFAActor,
     NullActorResolver,
 )
-from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
 from kailash.nodes.security.security_event import SecurityEventNode
 from kailash.sdk_exceptions import NodeExecutionError
+from kailash.utils.secure_logging import redact_mapping
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -22,7 +22,6 @@ from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
 from kailash.nodes.security.security_event import SecurityEventNode
-from kailash.utils.secure_logging import redact_mapping
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/nodes/auth/session_management.py
+++ b/src/kailash/nodes/auth/session_management.py
@@ -17,11 +17,12 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
-from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
 from kailash.nodes.security.security_event import SecurityEventNode
+from kailash.utils.secure_logging import redact_mapping
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -29,11 +29,12 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 from kailash.nodes.api import AsyncHTTPRequestNode
 from kailash.nodes.auth._http_response import http_body
-from kailash.nodes.auth._log_hygiene import log_safe, redact_mapping
+from kailash.nodes.auth._log_hygiene import log_safe
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security import AuditLogNode, SecurityEventNode
+from kailash.utils.secure_logging import redact_mapping
 
 
 # Shared, BOUNDED executor for the sync->async bridge in ``run()``. A per-call

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -37,6 +37,7 @@ from kailash.sdk_exceptions import (
     NodeExecutionError,
     NodeValidationError,
 )
+from kailash.utils.secure_logging import redact_mapping
 
 # ADR-002: Module-level logger for node registration messages
 _logger = logging.getLogger(__name__)
@@ -1560,7 +1561,25 @@ class Node(ABC):
 
             # Validate inputs
             validated_inputs = self.validate_inputs(**merged_inputs)
-            self.logger.debug(f"Validated inputs for {self.id}: {validated_inputs}")
+            # REDACTED (#2167). This logged EVERY node's full validated input
+            # dict, so any credential parameter -- `auth_password`, `api_key`,
+            # `secret_key`, a connection string -- reached the log in clear text,
+            # for every node in the SDK rather than one. Surfaced by the #2167
+            # http.py regression test, which caught `auth_password` here after the
+            # http-level leak beside it was already fixed. DEBUG is not a defence:
+            # debug logging is routinely enabled in staging and shipped to an
+            # aggregator. Keys are preserved so the diagnostic still says which
+            # inputs bound.
+            # Guarded: `redact_mapping` walks the whole input structure, and this
+            # runs on EVERY node execution. Passing it as a lazy `%s` arg is not
+            # enough -- the call itself would still evaluate before `debug()` is
+            # entered. `isEnabledFor` keeps the cost at zero when DEBUG is off.
+            if self.logger.isEnabledFor(logging.DEBUG):
+                self.logger.debug(
+                    "Validated inputs for %s: %s",
+                    self.id,
+                    redact_mapping(validated_inputs),
+                )
 
             # Execute node logic with progress context
             from kailash.runtime.progress import _current_node_id
@@ -2155,9 +2174,25 @@ class AsyncTypedNode(TypedNode):
 
             # Validate inputs (includes port validation and setting port values)
             validated_inputs = self.validate_inputs(**merged_inputs)
-            self.logger.debug(
-                f"Validated inputs for async node {self.id}: {validated_inputs}"
-            )
+            # REDACTED (#2167). This logged EVERY node's full validated input
+            # dict, so any credential parameter -- `auth_password`, `api_key`,
+            # `secret_key`, a connection string -- reached the log in clear text,
+            # for every node in the SDK rather than one. Surfaced by the #2167
+            # http.py regression test, which caught `auth_password` here after the
+            # http-level leak beside it was already fixed. DEBUG is not a defence:
+            # debug logging is routinely enabled in staging and shipped to an
+            # aggregator. Keys are preserved so the diagnostic still says which
+            # inputs bound.
+            # Guarded: `redact_mapping` walks the whole input structure, and this
+            # runs on EVERY node execution. Passing it as a lazy `%s` arg is not
+            # enough -- the call itself would still evaluate before `debug()` is
+            # entered. `isEnabledFor` keeps the cost at zero when DEBUG is off.
+            if self.logger.isEnabledFor(logging.DEBUG):
+                self.logger.debug(
+                    "Validated inputs for async node %s: %s",
+                    self.id,
+                    redact_mapping(validated_inputs),
+                )
 
             # Execute async node logic with progress context
             from kailash.runtime.progress import _current_node_id

--- a/src/kailash/nodes/security/audit_log.py
+++ b/src/kailash/nodes/security/audit_log.py
@@ -8,7 +8,11 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 
 from kailash.nodes.base import Node, NodeParameter, register_node
-from kailash.utils.secure_logging import sanitize_log_structure, sanitize_log_value
+from kailash.utils.secure_logging import (
+    redact_mapping,
+    sanitize_log_structure,
+    sanitize_log_value,
+)
 
 
 @register_node()
@@ -81,7 +85,31 @@ class AuditLogNode(Node):
         # Covering the non-json path is what promotes this from latent to
         # fixed, so ``event_data`` is sanitized recursively rather than only
         # at its top level.
-        event_data = sanitize_log_structure(inputs.get("event_data", {}))
+        #
+        # REDACTION IS COMPOSED WITH THAT, NOT SUBSTITUTED FOR IT (issue #2167).
+        # The two helpers answer different questions and BOTH are needed here:
+        # `redact_mapping` decides WHETHER a value may be recorded (by key
+        # name), `sanitize_log_structure` decides HOW the survivors render.
+        # Swapping one for the other trades a credential leak for a
+        # log-injection hole, or the reverse -- `sanitize_log_value`'s own
+        # docstring says it plainly: "NOT a redaction step. A short
+        # attacker-chosen value survives on purpose."
+        #
+        # Without the redaction half, a credential up to the 256-char sanitizer
+        # bound reached this log BYTE-INTACT. `event_data` is a free-form
+        # caller bag and real producers put credentials in it: kaizen's
+        # `nodes/auth/sso.py` forwards the raw IdP attribute bag, while the
+        # core-SDK sibling for the SAME bag already redacted it -- the SDK
+        # disagreeing with itself about whether that bag is credential-bearing.
+        # CodeQL flagged the three sinks below as 11503/11504/11505.
+        #
+        # This is the fix `nodes/auth/_log_hygiene.py` named as belonging
+        # "one layer down ... so that EVERY caller in the SDK is covered
+        # rather than only this package's". Redact FIRST: the sanitizer then
+        # never handles the credential at all.
+        event_data = sanitize_log_structure(
+            redact_mapping(inputs.get("event_data", {}))
+        )
         event_type = sanitize_log_value(inputs.get("event_type", "info"), 128)
         raw_user_id = inputs.get("user_id")
         # Preserve the None/absent distinction rather than recording the

--- a/src/kailash/nodes/security/security_event.py
+++ b/src/kailash/nodes/security/security_event.py
@@ -10,7 +10,11 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from kailash.nodes.base import Node, NodeParameter, register_node
-from kailash.utils.secure_logging import sanitize_log_structure, sanitize_log_value
+from kailash.utils.secure_logging import (
+    redact_mapping,
+    sanitize_log_structure,
+    sanitize_log_value,
+)
 
 
 class SeverityLevel(str, Enum):
@@ -139,6 +143,19 @@ class SecurityEventNode(Node):
         # ``metadata`` is sanitized recursively because this node returns it
         # and downstream consumers render it; a nested string is a record
         # field exactly as a top-level one is.
+        #
+        # It is also REDACTED first (issue #2167), composed with the sanitizer
+        # rather than replacing it -- see the longer note in
+        # ``AuditLogNode.execute`` for why both halves are required.
+        #
+        # The exposure here is narrower than its sibling's and is recorded so a
+        # later reader does not "simplify" this away: ``log_message`` below does
+        # NOT interpolate ``metadata``, so this bag does not reach ``self.logger``.
+        # It reaches the RETURN value (and this class's own docstring notes
+        # "downstream consumers render it"), which is a rendering surface just
+        # as a log line is -- workflow results are themselves routinely logged
+        # and persisted. Same class, same fix, which is why
+        # ``_log_hygiene.py`` named BOTH nodes.
         event_type = sanitize_log_value(inputs.get("event_type", "security_check"), 128)
         severity = self._coerce_severity(inputs.get("severity", "INFO"))
         message = sanitize_log_value(inputs.get("message", ""), 512)
@@ -147,7 +164,7 @@ class SecurityEventNode(Node):
         # the string "None" and would render "(User: None)" on every anonymous
         # event, and would make the `if user_id:` branch below always true.
         user_id = None if raw_user_id is None else sanitize_log_value(raw_user_id, 128)
-        metadata = sanitize_log_structure(inputs.get("metadata", {}))
+        metadata = sanitize_log_structure(redact_mapping(inputs.get("metadata", {})))
 
         # Create security event
         security_event = SecurityEvent(

--- a/src/kailash/utils/secure_logging.py
+++ b/src/kailash/utils/secure_logging.py
@@ -518,6 +518,11 @@ _SENSITIVE_KEY_FRAGMENTS = (
     "authorization",
     "cookie",
     "session_id",
+    # `pwd` is NOT reachable as a substring of `passwd` (p-a-s-s-w-d has no
+    # adjacent p-w-d), so this fragment is doing real work rather than
+    # duplicating the entry above it: it is what catches `pwd`, `db_pwd` and
+    # `user_pwd`, all of which passed through byte-intact before.
+    "pwd",
 )
 
 _MAX_REDACTION_DEPTH = 6
@@ -561,13 +566,30 @@ def redact_mapping(data: Any, _depth: int = 0) -> Any:
     if isinstance(data, dict):
         redacted = {}
         for key, value in data.items():
-            lowered = str(key).lower().replace("-", "_")
+            # Normalize every separator a producer might spell the same
+            # concept with, not just the hyphen. SAML/OIDC attribute bags
+            # arrive dotted (`X.API.Key`, or a full claim URI whose last
+            # segment is dotted) and hand-built dicts arrive spaced
+            # (`"api key"`); both reached the log byte-intact when only `-`
+            # was folded, because neither `x.api.key` nor `api key` contains
+            # the `api_key` fragment.
+            lowered = (
+                str(key).lower().replace("-", "_").replace(".", "_").replace(" ", "_")
+            )
             if any(fragment in lowered for fragment in _SENSITIVE_KEY_FRAGMENTS):
                 redacted[key] = "[REDACTED]"
             else:
                 redacted[key] = redact_mapping(value, _depth + 1)
         return redacted
     if isinstance(data, (list, tuple)):
+        # Sets are deliberately NOT walked. Walking one was tried and MEASURED
+        # to close nothing: a set can only hold hashables, so it never contains
+        # a dict, so there is no KEY for this function to match on -- the walk
+        # returned `{'s': ['SUPERSECRET']}`, the same credential in a different
+        # shape. A set under a credential-NAMED key (`{"tokens": {...}}`) is
+        # already withheld whole by the key check above. Adding the walk would
+        # have mutated set->list for zero redaction gain, which is a change
+        # that reads as a fix and is not one.
         return [redact_mapping(item, _depth + 1) for item in data]
     if isinstance(data, str):
         # KEY-BASED WITHHOLDING IS NOT SUFFICIENT ON ITS OWN. A credential also

--- a/src/kailash/utils/secure_logging.py
+++ b/src/kailash/utils/secure_logging.py
@@ -37,7 +37,7 @@ import unicodedata
 from functools import wraps
 from typing import Any, Dict, List, Optional, Pattern, Set, Union
 
-from kailash.utils.url_credentials import is_sensitive_query_key
+from kailash.utils.url_credentials import is_sensitive_query_key, mask_error_text
 
 # Module-level logger. Added with the totality-wrapper telemetry below: this
 # module had NO module-scope logger, only an instance one on the mixin, so a
@@ -392,8 +392,8 @@ def sanitize_log_value(value: object, limit: int = _DEFAULT_LOG_VALUE_CHARS) -> 
 
     NOT a redaction step. A short attacker-chosen value survives on purpose --
     it is usually the only diagnostic there is. For withholding credential
-    material by key name, compose
-    :func:`kailash.nodes.auth._log_hygiene.redact_mapping` instead.
+    material by key name, compose :func:`redact_mapping` (in this module)
+    with it -- redact first, then sanitize what survives.
 
     Total: never raises. A logging call site must not fail on the thing it is
     describing, so a value whose ``__str__`` raises degrades to a marker.
@@ -496,6 +496,94 @@ def sanitize_log_structure(
     if data is None or isinstance(data, (bool, int, float)):
         return data
     return sanitize_log_value(data, limit)
+
+
+#: Keys whose VALUES are credential material or bulk personal data and must not
+#: be copied into a log record. Matched case-insensitively as substrings after
+#: separator normalization, so ``access_token``, ``refresh_token``,
+#: ``totp_secret`` and the header spelling ``X-API-Key`` are all caught.
+_SENSITIVE_KEY_FRAGMENTS = (
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "credential",
+    "backup_code",
+    "recovery_code",
+    "private_key",
+    "api_key",
+    "qr_code",
+    "provisioning_uri",
+    "assertion",
+    "authorization",
+    "cookie",
+    "session_id",
+)
+
+_MAX_REDACTION_DEPTH = 6
+
+
+def redact_mapping(data: Any, _depth: int = 0) -> Any:
+    """Recursively replace credential-bearing VALUES with a redaction marker.
+
+    THE COMPANION TO, NOT A REPLACEMENT FOR, :func:`sanitize_log_structure`.
+    The two answer different questions and a sink that needs both must compose
+    them: this one decides WHETHER a value may be recorded (by key name), and
+    ``sanitize_log_structure`` decides HOW the survivors are rendered (flattened
+    and bounded, so none can forge a second record). Swapping one for the other
+    trades a credential leak for a log-injection hole, or the reverse.
+
+    Used for the free-form attribute bags that audit and security sinks accept:
+    a provisioning record carries whatever the IdP returned, which routinely
+    includes tokens, and a directory sync carries the full mapped LDAP/AD entry.
+    The record KEEPS ITS SHAPE -- the key stays, so an auditor can still see
+    WHICH fields were present -- while the value is withheld.
+
+    **Separator-normalized**, which is load-bearing rather than cosmetic: HTTP
+    headers spell the same concept with hyphens, so ``X-API-Key`` lowercases to
+    ``x-api-key`` and would NOT have matched the ``api_key`` fragment. That is
+    the exact default header name ``HTTPRequestNode`` carries an API key in
+    (``http.py``, ``api_key_header="X-API-Key"``), so without this the header
+    redaction would have silently passed the credential through.
+
+    Depth is bounded so a self-referential or pathologically nested attribute
+    bag cannot exhaust the stack inside a logging call.
+
+    Args:
+        data: Any structure. Mappings are walked; lists and tuples are walked
+            element-wise; every other value is returned unchanged.
+
+    Returns:
+        The same shape with credential-named values replaced by ``"[REDACTED]"``.
+    """
+    if _depth >= _MAX_REDACTION_DEPTH:
+        return "[REDACTED_DEPTH]"
+    if isinstance(data, dict):
+        redacted = {}
+        for key, value in data.items():
+            lowered = str(key).lower().replace("-", "_")
+            if any(fragment in lowered for fragment in _SENSITIVE_KEY_FRAGMENTS):
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = redact_mapping(value, _depth + 1)
+        return redacted
+    if isinstance(data, (list, tuple)):
+        return [redact_mapping(item, _depth + 1) for item in data]
+    if isinstance(data, str):
+        # KEY-BASED WITHHOLDING IS NOT SUFFICIENT ON ITS OWN. A credential also
+        # hides INSIDE an innocently-named value: `{"url":
+        # "https://svc:pw@host/x?api_key=..."}` has no sensitive key, and a
+        # purely key-based pass returns it verbatim. Measured -- the #2167
+        # regression test caught exactly this after the key-based half was
+        # already working, with `auth_password` correctly `[REDACTED]` and the
+        # same password still readable in the sibling `url` field.
+        #
+        # `mask_error_text` is the canonical helper for credentials embedded in
+        # arbitrary text (userinfo plus the sensitive-query-key set), and it
+        # returns non-credential input unchanged, so this is a no-op for the
+        # overwhelming majority of leaves.
+        return mask_error_text(data)
+    return data
 
 
 def safe_type_name(obj: object) -> str:

--- a/tests/regression/test_issue_2060_auth_async_surface.py
+++ b/tests/regression/test_issue_2060_auth_async_surface.py
@@ -925,7 +925,7 @@ def test_directory_security_events_redact_credential_bearing_fields():
 
 
 def test_redact_mapping_withholds_values_and_keeps_shape():
-    from kailash.nodes.auth._log_hygiene import redact_mapping
+    from kailash.utils.secure_logging import redact_mapping
 
     out = redact_mapping(
         {
@@ -945,7 +945,7 @@ def test_redact_mapping_withholds_values_and_keeps_shape():
 def test_redact_mapping_bounds_recursion_depth():
     """A self-referential attribute bag must not blow the stack inside a
     logging call."""
-    from kailash.nodes.auth._log_hygiene import redact_mapping
+    from kailash.utils.secure_logging import redact_mapping
 
     node: dict = {}
     node["self"] = node

--- a/tests/regression/test_issue_2167_credential_log_redaction.py
+++ b/tests/regression/test_issue_2167_credential_log_redaction.py
@@ -300,3 +300,53 @@ def test_http_node_still_logs_a_usable_diagnostic():
     assert (
         "api.example.com" in cap.text
     ), f"the host must survive masking or the log is useless: {cap.text!r}"
+
+
+class TestRedactionKeyMatching:
+    """Key-shape gaps found by adversarially probing `redact_mapping` directly.
+
+    All three were live after the sink fixes above were already passing: the
+    sink tests exercise the keys a producer in THIS repo happens to emit, so a
+    key-matching gap is invisible to them. Probing the matcher itself is what
+    surfaced these.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "pwd",  # `passwd` has no adjacent p-w-d, so it never covered this
+            "db_pwd",
+            "X.API.Key",  # SAML/OIDC attribute bags arrive dotted
+            "api key",  # hand-built dicts arrive spaced
+            "X-API-Key",  # the header form, guarded before -- kept as a pin
+        ],
+        ids=["pwd", "db_pwd", "dotted", "spaced", "hyphenated"],
+    )
+    def test_credential_key_separator_and_alias_forms_are_withheld(self, key):
+        from kailash.utils.secure_logging import redact_mapping
+
+        out = redact_mapping({key: _SECRET})
+        assert _SECRET not in repr(
+            out
+        ), f"{key!r} passed the credential through: {out!r}"
+        assert out[key] == "[REDACTED]"
+
+    def test_non_credential_keys_stay_readable(self):
+        """The separator folding must not over-match and blind the auditor."""
+        from kailash.utils.secure_logging import redact_mapping
+
+        out = redact_mapping({"user_id": "alice", "status": "ok", "attempt": 3})
+        assert out == {"user_id": "alice", "status": "ok", "attempt": 3}
+
+    def test_a_set_is_left_alone_rather_than_reshaped(self):
+        """Pins the MEASURED decision not to walk sets (see redact_mapping).
+
+        A set holds only hashables, so it never contains a dict and there is no
+        key to match; walking it returned the same credential as a list. This
+        asserts the shape is preserved so nobody re-adds a walk believing it
+        redacts something.
+        """
+        from kailash.utils.secure_logging import redact_mapping
+
+        out = redact_mapping({"plain": {"a", "b"}})
+        assert isinstance(out["plain"], set)

--- a/tests/regression/test_issue_2167_credential_log_redaction.py
+++ b/tests/regression/test_issue_2167_credential_log_redaction.py
@@ -1,0 +1,302 @@
+"""Regression tests for issue #2167 — credentials reaching clear-text log sinks.
+
+Two defects, five CodeQL HIGH alerts:
+
+* **A** — ``AuditLogNode.execute`` passed the caller's ``event_data`` bag through
+  ``sanitize_log_structure``, which is explicitly NOT a redaction step, so a
+  credential up to 256 characters reached the log byte-intact
+  (alerts 11503/11504/11505 — one bug, three sinks sharing one value).
+* **B** — ``HTTPRequestNode`` / ``AsyncHTTPRequestNode`` logged the request URL
+  unmasked, plus the assembled ``Authorization`` header and the request body
+  (alerts 11506/11507, and the byte-identical sync sibling CodeQL never flagged).
+
+**These assert on the EMITTED STREAM, not on ``LogRecord`` objects.** A leaked
+credential is produced at *format* time: ``logger.info(f"...{secret}...")``
+renders before the record exists, so a test that inspects ``record.args`` or
+counts records cannot tell a redacted call from an unredacted one. Attaching a
+real ``StreamHandler`` with a real ``Formatter`` and searching the resulting text
+is the only instrument here that discriminates.
+
+No ``Mock`` for the nodes or the redaction helpers: a mock accepts every call
+and passes identically whether the fix is present or absent.
+"""
+
+import base64
+import logging
+from io import StringIO
+
+import pytest
+
+# The literal secrets these tests hunt for in the emitted log text. Distinctive
+# enough that a substring search cannot match incidentally.
+_SECRET = "s3cr3t-issue-2167-must-not-appear"
+_PASSWORD = "pw-issue-2167-must-not-appear"
+_TOKEN = "tok-issue-2167-must-not-appear"
+
+
+class _Capture:
+    """Attach a real handler+formatter to a logger and collect emitted TEXT."""
+
+    def __init__(self, logger_name: str):
+        self._logger = logging.getLogger(logger_name)
+        self._stream = StringIO()
+        self._handler = logging.StreamHandler(self._stream)
+        self._handler.setFormatter(
+            logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        )
+        self._prev_level = self._logger.level
+        self._prev_propagate = self._logger.propagate
+
+    def __enter__(self) -> "_Capture":
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.DEBUG)
+        # Keep the records off the root handlers so a pytest capture plugin is
+        # not what this test is actually measuring.
+        self._logger.propagate = False
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._handler.flush()
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._prev_level)
+        self._logger.propagate = self._prev_propagate
+
+    @property
+    def text(self) -> str:
+        self._handler.flush()
+        return self._stream.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Defect A — AuditLogNode / SecurityEventNode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("output_format", ["json", "text"])
+def test_audit_log_node_withholds_credential_valued_keys(output_format):
+    """LOAD-BEARING for defect A: a credential-named key must not reach the log.
+
+    Both formats are exercised because they are separate sinks: ``json.dumps``
+    escapes control characters but does NOT withhold values, and the ``else``
+    branch interpolates ``event_data`` into an f-string with no escaping at all.
+    A fix applied to only one leaves the other live.
+    """
+    from kailash.nodes.security.audit_log import AuditLogNode
+
+    node = AuditLogNode(name="issue2167_audit", output_format=output_format)
+
+    with _Capture("audit.issue2167_audit") as cap:
+        node.execute(
+            event_type="info",
+            message="provisioning complete",
+            user_id="alice",
+            event_data={
+                "api_key": _SECRET,
+                "nested": {"refresh_token": _TOKEN},
+                "password": _PASSWORD,
+            },
+        )
+
+    for leaked in (_SECRET, _TOKEN, _PASSWORD):
+        assert (
+            leaked not in cap.text
+        ), f"credential reached the audit log ({output_format} format): {cap.text!r}"
+    assert (
+        "[REDACTED]" in cap.text
+    ), f"expected a redaction marker recording that a field was withheld: {cap.text!r}"
+
+
+def test_audit_log_node_keeps_non_credential_fields_readable():
+    """CONTROL: redaction must withhold values, not gut the record.
+
+    Without this, a fix that dropped ``event_data`` wholesale — or replaced the
+    whole bag with one marker — would pass the test above for the wrong reason.
+    """
+    from kailash.nodes.security.audit_log import AuditLogNode
+
+    node = AuditLogNode(name="issue2167_audit_ctl", output_format="text")
+
+    with _Capture("audit.issue2167_audit_ctl") as cap:
+        node.execute(
+            event_type="info",
+            message="provisioning complete",
+            event_data={"tenant": "acme-corp", "record_count": 42, "api_key": _SECRET},
+        )
+
+    assert "acme-corp" in cap.text, f"diagnostic field was lost: {cap.text!r}"
+    assert "42" in cap.text, f"diagnostic field was lost: {cap.text!r}"
+    assert (
+        "api_key" in cap.text
+    ), f"the KEY must survive so an auditor sees which field was withheld: {cap.text!r}"
+    assert _SECRET not in cap.text
+
+
+def test_audit_log_node_returned_entry_is_also_redacted():
+    """The returned entry must agree with what was logged.
+
+    Returning the unredacted bag while logging a redacted one would put the
+    credential straight back into workflow results, which are themselves
+    routinely logged and persisted.
+    """
+    from kailash.nodes.security.audit_log import AuditLogNode
+
+    node = AuditLogNode(name="issue2167_audit_ret")
+    result = node.execute(event_type="info", event_data={"api_key": _SECRET})
+
+    assert _SECRET not in str(
+        result
+    ), f"credential survived in the return value: {result!r}"
+
+
+def test_security_event_node_withholds_credential_valued_metadata():
+    """Defect A's sibling: ``SecurityEventNode`` metadata is returned and rendered.
+
+    Its ``log_message`` does not interpolate ``metadata``, so the exposure here
+    is the returned bag rather than the log line — the same class, and the same
+    fix `_log_hygiene.py:23-26` prescribes for both nodes.
+    """
+    from kailash.nodes.security.security_event import SecurityEventNode
+
+    node = SecurityEventNode(name="issue2167_secevent")
+    result = node.execute(
+        event_type="login_failed",
+        severity="HIGH",
+        message="bad credential",
+        metadata={"totp_secret": _SECRET, "nested": {"authorization": _TOKEN}},
+    )
+
+    assert _SECRET not in str(result), f"credential survived: {result!r}"
+    assert _TOKEN not in str(result), f"credential survived: {result!r}"
+
+
+def test_log_injection_defence_is_preserved_alongside_redaction():
+    """CONTROL: the #2088 sanitizer must still run — redaction is ADDITIVE.
+
+    A fix that swapped ``sanitize_log_structure`` for ``redact_mapping`` rather
+    than composing them would withhold credentials while re-opening the
+    newline-forgery hole. This asserts both properties hold at once.
+    """
+    from kailash.nodes.security.audit_log import AuditLogNode
+
+    node = AuditLogNode(name="issue2167_audit_inj", output_format="text")
+
+    with _Capture("audit.issue2167_audit_inj") as cap:
+        node.execute(
+            event_type="info",
+            message="ok",
+            event_data={
+                "note": "line1\nINFO:audit:forged second record",
+                "api_key": _SECRET,
+            },
+        )
+
+    emitted = cap.text.rstrip("\n")
+    assert (
+        len(emitted.splitlines()) == 1
+    ), f"a newline in event_data forged a second log record: {cap.text!r}"
+    assert _SECRET not in cap.text
+
+
+# ---------------------------------------------------------------------------
+# Defect B — HTTPRequestNode / AsyncHTTPRequestNode
+# ---------------------------------------------------------------------------
+
+_CRED_URL = f"https://svc:{_PASSWORD}@api.example.com/v1/items?api_key={_SECRET}"
+
+
+def _http_logger_name(node) -> str:
+    """The node's own logger, so the capture measures the node and nothing else."""
+    return node.logger.name
+
+
+@pytest.mark.parametrize("log_requests", [False, True])
+def test_sync_http_node_masks_credentials_in_the_request_url(log_requests, monkeypatch):
+    """LOAD-BEARING for defect B (sync class — CodeQL never flagged this one).
+
+    ``log_requests=False`` is the DEFAULT path and still logs the URL, so both
+    branches are measured.
+    """
+    from kailash.nodes.api.http import HTTPRequestNode
+
+    node = HTTPRequestNode(name="issue2167_http_sync")
+
+    with _Capture(_http_logger_name(node)) as cap:
+        try:
+            node.execute(
+                url=_CRED_URL,
+                method="GET",
+                log_requests=log_requests,
+                auth_type="basic",
+                auth_username="svc",
+                auth_password=_PASSWORD,
+                retry_count=0,
+                timeout=1,
+            )
+        except Exception:
+            # The request itself is expected to fail (no network). The logging
+            # under test happens BEFORE the call is made.
+            pass
+
+    assert _PASSWORD not in cap.text, f"password reached the log: {cap.text!r}"
+    assert (
+        _SECRET not in cap.text
+    ), f"credential query param reached the log: {cap.text!r}"
+    b64 = base64.b64encode(f"svc:{_PASSWORD}".encode()).decode()
+    assert (
+        b64 not in cap.text
+    ), f"base64 Basic credential reached the log (encoding is not masking): {cap.text!r}"
+
+
+@pytest.mark.parametrize("log_requests", [False, True])
+async def test_async_http_node_masks_credentials_in_the_request_url(log_requests):
+    """LOAD-BEARING for defect B (async class — alerts 11506/11507)."""
+    from kailash.nodes.api.http import AsyncHTTPRequestNode
+
+    node = AsyncHTTPRequestNode(name="issue2167_http_async")
+
+    with _Capture(_http_logger_name(node)) as cap:
+        try:
+            await node.async_run(
+                url=_CRED_URL,
+                method="POST",
+                log_requests=log_requests,
+                auth_type="basic",
+                auth_username="svc",
+                auth_password=_PASSWORD,
+                json_data={
+                    "client_secret": _SECRET,
+                    "grant_type": "client_credentials",
+                },
+                retry_count=0,
+                timeout=1,
+            )
+        except Exception:
+            pass
+
+    assert _PASSWORD not in cap.text, f"password reached the log: {cap.text!r}"
+    assert _SECRET not in cap.text, f"client_secret reached the log: {cap.text!r}"
+    b64 = base64.b64encode(f"svc:{_PASSWORD}".encode()).decode()
+    assert (
+        b64 not in cap.text
+    ), f"base64 Basic credential reached the log (encoding is not masking): {cap.text!r}"
+
+
+def test_http_node_still_logs_a_usable_diagnostic():
+    """CONTROL: masking must not silence the log line entirely.
+
+    Without this, deleting the logging calls would pass every assertion above
+    while destroying the operator's only record that a request was made.
+    """
+    from kailash.nodes.api.http import HTTPRequestNode
+
+    node = HTTPRequestNode(name="issue2167_http_diag")
+
+    with _Capture(_http_logger_name(node)) as cap:
+        try:
+            node.execute(url=_CRED_URL, method="GET", retry_count=0, timeout=1)
+        except Exception:
+            pass
+
+    assert (
+        "api.example.com" in cap.text
+    ), f"the host must survive masking or the log is useless: {cap.text!r}"


### PR DESCRIPTION
## Summary

Five CodeQL HIGH alerts pointed at two sinks. The regression test written for them surfaced a third that is far wider than either.

**A — audit sinks (alerts 11503/11504/11505).** `AuditLogNode` / `SecurityEventNode` passed the caller's free-form `event_data` bag through `sanitize_log_structure` alone. That helper's own docstring says it is **not** a redaction step — it decides *how* a value renders, not *whether* it may be recorded — so a credential up to its 256-char bound reached the log byte-intact. Redaction is now **composed** with sanitization rather than substituted for it: dropping either half trades a credential leak for a log-injection hole, or the reverse.

**B — HTTP nodes (alerts 11506/11507).** `HTTPRequestNode` / `AsyncHTTPRequestNode` logged the request URL, the assembled `Authorization` header, and the request body unmasked. Both classes are fixed; CodeQL flagged only the async one and the sync sibling is byte-identical.

**C — `Node.execute` (found by B's test, flagged by nothing).** It logged every node's full validated input dict. That is not one node's leak but **every** node's: `auth_password`, `api_key`, `secret_key`, and connection strings all landed in clear text. DEBUG is not a defence — debug logging is routinely enabled in staging and shipped to an aggregator. The call is guarded by `isEnabledFor` so the structure walk costs nothing when DEBUG is off, and keys are preserved so the diagnostic still reports which inputs bound.

`redact_mapping` moves from `nodes/auth/_log_hygiene` (private to that package) to `kailash.utils.secure_logging`, beside `sanitize_log_value`, because nodes outside that package must not reach into its private module. The five auth call sites follow the move. No deprecation shim — `_log_hygiene` is private.

## Verification

The tests assert on the **emitted stream** via a real handler and formatter. A credential is rendered at format time, so inspecting `LogRecord.args` cannot tell a redacted call from an unredacted one.

Discrimination established, not assumed:

| run | result |
| --- | --- |
| the 11 new tests vs **unfixed main** | **10 failed** |
| the 11 new tests vs this branch | **11 passed** |

The 11th is the deliberate no-false-positive control (`test_http_node_still_logs_a_usable_diagnostic`) and passes on both by design.

Full local sweep (`tests/unit tests/security tests/regression`, untruncated both sides):

```
main   : 115 failed, 7141 passed, 50 errors
branch : 114 failed, 7153 passed, 50 errors
new failures introduced: 0
```

`pre-commit` run per-file across all 13 changed files: 14 hooks each, 0 failures.

## Related issues

Fixes #2167

## CodeQL deferrals on this PR — Rule 1b

Two sets of alerts are deferred as false positives rather than suppressed. **No suppression comments, no rule disabling, no config changes** — the alerts stay visible and each has a tracking issue carrying a runtime-safety proof.

| Tracking issue | Alerts | Disposition |
|---|---|---|
| **#2178** | 5 × `py/clear-text-logging-sensitive-data` at the `http.py` **fix lines** | The rule follows the taint into the masking helpers; each guard was executed against a password-bearing input to prove no credential survives. |
| **#2181** | 11474 (`py/weak-sensitive-data-hashing`), 11484 + 11485 (`py/clear-text-logging`) | Rule premises do not hold: authentication completes before any hashing and no fingerprint gates an auth decision; the two logging sinks carry a filesystem path matched by identifier NAME. |

**Rule 1b condition 4 — release-specialist signoff — is NOT given.** These should not be dismissed in the security tab until it is recorded, or until dismissed by someone with the authority to do so.

**Scope caveat carried from #2181, repeated here because it is the sentence most likely to be misread:** the 11474 disposition covers **the rule only**. `fingerprint_secret` is genuinely unkeyed and low-entropy inputs genuinely reach it — that weakness is real and tracked as **#2170** (a docstring claiming "non-reversible" when it is not) and **#2171** (a rate-limit privacy control that does not conceal an enumerable IP). Neither is closed by this dismissal.
