### PR TITLE
fix(kaizen): stop shipping a mock embedder as the production default (#2174)

### DIFF
--- a/packages/kailash-kaizen/docs/reference/memory-patterns-guide.md
+++ b/packages/kailash-kaizen/docs/reference/memory-patterns-guide.md
@@ -235,8 +235,18 @@ class LongConversationAgent(BaseAgent):
 ```python
 from kaizen.memory.vector import VectorMemory
 
-# Default: Mock hash-based embedder (testing only)
-memory = VectorMemory(embedding_fn=None, top_k=5)
+# embedding_fn is REQUIRED. Omitting it (or passing None) raises
+# ConfigurationError. It used to fall back to a hash-based pseudo-embedder,
+# which returned vectors of the right shape with no semantic signal, so
+# similarity search silently ranked MD5 noise (#2174).
+memory = VectorMemory(embedding_fn=custom_embedder, top_k=5)
+
+# For tests ONLY, an explicitly-named stand-in is available. It carries no
+# semantic signal — use it to exercise storage/retrieval mechanics, never to
+# assert on ranking quality.
+from kaizen.memory.vector import hash_embedder_for_tests
+
+memory = VectorMemory(embedding_fn=hash_embedder_for_tests, top_k=5)
 
 # Custom embedder (production)
 def custom_embedder(text: str) -> List[float]:

--- a/packages/kailash-kaizen/examples/1-single-agent/memory-showcase/demo.py
+++ b/packages/kailash-kaizen/examples/1-single-agent/memory-showcase/demo.py
@@ -21,7 +21,7 @@ from kaizen.core.base_agent import BaseAgent, BaseAgentConfig
 from kaizen.memory.buffer import BufferMemory
 from kaizen.memory.knowledge_graph import KnowledgeGraphMemory
 from kaizen.memory.summary import SummaryMemory
-from kaizen.memory.vector import VectorMemory
+from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 from kaizen.signatures import InputField, OutputField, Signature
 
 # ============================================================================
@@ -200,8 +200,18 @@ def demo_vector_memory():
         "Perfect for: Large knowledge bases, RAG applications, finding related context"
     )
 
-    # Create agent with VectorMemory
-    memory = VectorMemory(top_k=2)
+    # Create agent with VectorMemory.
+    #
+    # NOTE: this demo wires the explicitly-named test stand-in so it runs with
+    # no embedding service. That function hashes text, so the retrieval below
+    # is NOT semantically meaningful — it demonstrates the STORAGE and
+    # RETRIEVAL mechanics only. Swap in a real embedder to see actual semantic
+    # matching:
+    #
+    #     from sentence_transformers import SentenceTransformer
+    #     encoder = SentenceTransformer("all-MiniLM-L6-v2")
+    #     memory = VectorMemory(top_k=2, embedding_fn=lambda t: encoder.encode(t).tolist())
+    memory = VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
     agent = DemoAgent(DemoConfig(), memory=memory)
 
     # Conversation with semantically related and unrelated questions
@@ -231,6 +241,10 @@ def demo_vector_memory():
 
     print(
         "\n  Key Feature: Semantic search - finds related conversations, not just recent"
+    )
+    print(
+        "  (This run uses hash_embedder_for_tests, so the ranking above is NOT"
+        " semantic. Wire a real embedder to see the feature itself.)"
     )
 
 

--- a/packages/kailash-kaizen/examples/1-single-agent/rag-research/workflow.py
+++ b/packages/kailash-kaizen/examples/1-single-agent/rag-research/workflow.py
@@ -106,9 +106,12 @@ class RAGResearchAgent(BaseAgent):
         # Initialize memory if enabled
         memory = None
         if config.memory_config and config.memory_config.get("enabled"):
-            embedding_fn = config.memory_config.get(
-                "embedder"
-            )  # Optional custom embedder
+            # REQUIRED when memory is enabled. There is no fallback embedder:
+            # VectorMemory used to substitute a hash-based one, which returned
+            # vectors of the right shape with no semantic signal, so retrieval
+            # ranked MD5 noise while looking like it worked (#2174). Omitting
+            # this now raises ConfigurationError naming the wiring.
+            embedding_fn = config.memory_config.get("embedder")
             top_k = config.memory_config.get("top_k", 5)
             similarity_threshold = config.memory_config.get("similarity_threshold", 0.7)
             memory = VectorMemory(embedding_fn=embedding_fn, top_k=top_k)

--- a/packages/kailash-kaizen/src/kaizen/memory/vector.py
+++ b/packages/kailash-kaizen/src/kaizen/memory/vector.py
@@ -5,9 +5,15 @@ This memory implementation uses vector embeddings to enable semantic search
 over conversation history, retrieving the most relevant past turns based on
 similarity to the current query.
 
+``embedding_fn`` is REQUIRED. It previously defaulted to a hash-based
+pseudo-embedder, so a caller who omitted it got vectors of the right shape
+carrying no semantic signal — every similarity search still returned ranked
+results, but the ranking was over MD5 noise (#2174, ``zero-tolerance.md``
+Rule 2). Nothing raised and nothing warned, which is why it survived.
+
 Example:
     >>> from kaizen.memory.vector import VectorMemory
-    >>> memory = VectorMemory(top_k=3)
+    >>> memory = VectorMemory(top_k=3, embedding_fn=my_embedder)
     >>> memory.save_turn("session1", {"user": "Python programming", "agent": "Great!"})
     >>> memory.save_turn("session1", {"user": "What's for dinner?", "agent": "Pizza"})
     >>> context = memory.load_context("session1", query="coding in Python")
@@ -21,7 +27,26 @@ VectorStoreRetrieverMemory but NOT integrated with LangChain.
 import hashlib
 from typing import Any, Callable, Dict, List, Optional
 
+from kaizen.config.providers import ConfigurationError
 from kaizen.memory.conversation_base import KaizenMemory
+
+
+def hash_embedder_for_tests(text: str, dimensions: int = 128) -> List[float]:
+    """NOT AN EMBEDDER. A deterministic hash-derived vector, for tests only.
+
+    Produces a stable vector of the right shape so storage/retrieval mechanics
+    can be exercised without an embedding service. It carries NO semantic
+    signal whatsoever: nearest-neighbour over these vectors is nearest-
+    neighbour over MD5 noise, so any test asserting on the QUALITY of a
+    ranking is meaningless with this function.
+
+    It is deliberately module-level and explicitly named rather than a default
+    on ``VectorMemory``. As ``VectorMemory._default_embedder`` it silently
+    served every caller who omitted ``embedding_fn`` (#2174); the name has to
+    make its status unmistakable at the call site.
+    """
+    hash_val = int(hashlib.md5(text.encode()).hexdigest(), 16)
+    return [float((hash_val >> i) & 1) for i in range(dimensions)]
 
 
 class VectorMemory(KaizenMemory):
@@ -47,40 +72,26 @@ class VectorMemory(KaizenMemory):
 
         Args:
             top_k: Maximum number of relevant turns to return in search (default: 5)
-            embedding_fn: Optional custom embedding function that takes text
-                         and returns a vector (list of floats). If None, uses
-                         default mock embedder for testing.
+            embedding_fn: REQUIRED. Embedding function taking text and returning
+                         a vector (list of floats).
+
+        Raises:
+            ConfigurationError: if ``embedding_fn`` is not supplied.
         """
+        if embedding_fn is None:
+            raise ConfigurationError(
+                "VectorMemory: 'embedding_fn' is required. It no longer "
+                "defaults to a hash-based pseudo-embedder, which returned "
+                "vectors of the correct shape carrying no semantic signal — "
+                "similarity search kept returning ranked results, but the "
+                "ranking was over MD5 noise, with nothing raised and nothing "
+                "logged (#2174). Pass a real embedding function (OpenAI, "
+                "sentence-transformers, HuggingFace, ...), or for tests pass "
+                "kaizen.memory.vector.hash_embedder_for_tests explicitly."
+            )
         self.top_k = top_k
-        self.embedding_fn = embedding_fn or self._default_embedder
+        self.embedding_fn = embedding_fn
         self._stores: Dict[str, Dict[str, Any]] = {}
-
-    def _default_embedder(self, text: str) -> List[float]:
-        """
-        Default mock embedder for testing.
-
-        In production, this would use actual embedding models like:
-        - sentence-transformers
-        - OpenAI embeddings
-        - HuggingFace models
-
-        For testing, we create a simple hash-based embedding.
-
-        Args:
-            text: Text to embed
-
-        Returns:
-            Vector embedding (128-dimensional)
-        """
-        # Simple hash-based embedding for testing
-        hash_val = int(hashlib.md5(text.encode()).hexdigest(), 16)
-        # Generate 128-dimensional vector from hash
-        vector = []
-        for i in range(128):
-            # Extract bits from hash to create pseudo-random but deterministic values
-            bit_val = (hash_val >> i) & 1
-            vector.append(float(bit_val))
-        return vector
 
     def _cosine_similarity(self, vec1: List[float], vec2: List[float]) -> float:
         """

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/semantic_memory.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/semantic_memory.py
@@ -22,6 +22,16 @@ if TYPE_CHECKING:
     import numpy as np
 
 
+class EmbeddingUnavailable(RuntimeError):
+    """Raised when embeddings cannot be produced by the configured model.
+
+    Exists so the failure is typed and catchable. It replaces a silent
+    fallback to MD5-derived vectors (#2174): callers that genuinely tolerate
+    degraded retrieval can catch this and decide, which is a choice they
+    could not previously make because the degradation was invisible.
+    """
+
+
 @dataclass
 class EmbeddingResult:
     """Result of an embedding operation."""
@@ -109,23 +119,45 @@ class SimpleEmbeddingProvider:
 
                 data = {"model": self.model_name, "prompt": txt}
 
+                # #2174 sibling: both arms below used to fall back to
+                # `_hash_embedding` — MD5-derived vectors returned as if they
+                # came from `self.model_name`, with no raise and no log. The
+                # EmbeddingResult even carried `model=self.model_name`, so the
+                # fabricated vectors were labelled with the real model's
+                # provenance and were indistinguishable downstream.
+                #
+                # Failing loud instead: a caller asking this provider for
+                # embeddings gets embeddings or an error, never hash noise
+                # ranked as if it were semantic. Mirrors the #1952 fix on
+                # EmbeddingGeneratorNode.
                 try:
                     async with session.post(self.embed_url, json=data) as response:
-                        if response.status == 200:
-                            result = await response.json()
-                            embedding = np.array(result["embedding"])
-                            all_embeddings.append(embedding)
+                        if response.status != 200:
+                            body = await response.text()
+                            raise EmbeddingUnavailable(
+                                f"SimpleEmbeddingProvider: embedding request to "
+                                f"{self.embed_url} returned HTTP {response.status} "
+                                f"for model '{self.model_name}'. Refusing to "
+                                f"substitute hash-derived vectors, which would "
+                                f"rank as if semantic (#2174). Response: "
+                                f"{body[:200]}"
+                            )
+                        result = await response.json()
+                        embedding = np.array(result["embedding"])
+                        all_embeddings.append(embedding)
 
-                            # Cache the embedding
-                            self._cache[cache_key] = embedding
-                        else:
-                            # Fallback to simple hash-based embedding
-                            embedding = self._hash_embedding(txt)
-                            all_embeddings.append(embedding)
-                except Exception:
-                    # Fallback to simple hash-based embedding
-                    embedding = self._hash_embedding(txt)
-                    all_embeddings.append(embedding)
+                        # Cache the embedding
+                        self._cache[cache_key] = embedding
+                except EmbeddingUnavailable:
+                    raise
+                except Exception as e:
+                    raise EmbeddingUnavailable(
+                        f"SimpleEmbeddingProvider: embedding request to "
+                        f"{self.embed_url} failed for model "
+                        f"'{self.model_name}': {type(e).__name__}: {e}. "
+                        f"Refusing to substitute hash-derived vectors, which "
+                        f"would rank as if semantic (#2174)."
+                    ) from e
 
         embeddings_array = np.vstack(all_embeddings)
 
@@ -135,21 +167,6 @@ class SimpleEmbeddingProvider:
             dimension=embeddings_array.shape[1],
             metadata={"host": self.host},
         )
-
-    def _hash_embedding(self, text: str, dimension: int = 384) -> np.ndarray:
-        """Create a simple hash-based embedding as fallback."""
-        np = require_numpy("hash-based embedding fallback")
-        # Simple deterministic embedding based on text content
-        hash_str = hashlib.md5(text.encode()).hexdigest()
-        # Convert hex to numbers and normalize
-        values = [
-            int(hash_str[i : i + 2], 16) / 255.0
-            for i in range(0, min(len(hash_str), dimension * 2), 2)
-        ]
-        # Pad or truncate to desired dimension
-        while len(values) < dimension:
-            values.extend(values[: dimension - len(values)])
-        return np.array(values[:dimension])
 
 
 class InMemoryVectorStore:

--- a/packages/kailash-kaizen/tests/regression/test_issue_f31_fu5_numpy_lazy_import.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f31_fu5_numpy_lazy_import.py
@@ -168,18 +168,26 @@ def test_require_numpy_returns_module_when_present():
 
 @pytest.mark.regression
 @pytest.mark.asyncio
-async def test_hash_embedding_and_search_still_work_with_numpy_present():
+async def test_vector_search_still_works_with_numpy_present():
     """Behavioral: the lazy-import refactor must not change numeric behavior."""
     from datetime import UTC, datetime
 
-    from kaizen.nodes.ai.semantic_memory import (
-        InMemoryVectorStore,
-        SemanticMemoryItem,
-        SimpleEmbeddingProvider,
-    )
+    from kaizen.nodes._optional import require_numpy
+    from kaizen.nodes.ai.semantic_memory import InMemoryVectorStore, SemanticMemoryItem
 
-    provider = SimpleEmbeddingProvider()
-    emb = provider._hash_embedding("hello world")
+    # The numeric path under test is InMemoryVectorStore.search_similar, which
+    # resolves numpy through require_numpy("vector similarity search"). The
+    # embedding is only a vector factory here.
+    #
+    # It used to be SimpleEmbeddingProvider._hash_embedding, which #2174
+    # deleted: that method fabricated MD5-derived vectors and was reachable
+    # only as a SILENT fallback when the real embedding request failed, so it
+    # returned hash noise labelled with the real model's provenance. Building
+    # the probe vector directly keeps this regression pinned on the lazy
+    # import — which is what F31/FU5 is about — without depending on a
+    # fabricating code path to supply it.
+    np = require_numpy("regression probe vector")
+    emb = np.linspace(0.0, 1.0, num=384)
     assert emb.shape == (384,)
 
     store = InMemoryVectorStore()

--- a/packages/kailash-kaizen/tests/unit/examples/test_memory_showcase.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_memory_showcase.py
@@ -32,7 +32,7 @@ demo_session_isolation = _demo_module.demo_session_isolation
 from kaizen.memory.buffer import BufferMemory
 from kaizen.memory.knowledge_graph import KnowledgeGraphMemory
 from kaizen.memory.summary import SummaryMemory
-from kaizen.memory.vector import VectorMemory
+from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
 
 class TestMemoryShowcaseDemoFunctions:
@@ -168,7 +168,9 @@ class TestMemoryShowcaseIntegration:
         # Create agents with different memory types
         buffer_agent = DemoAgent(config, memory=BufferMemory(max_turns=3))
         summary_agent = DemoAgent(config, memory=SummaryMemory(keep_recent=2))
-        vector_agent = DemoAgent(config, memory=VectorMemory(top_k=2))
+        vector_agent = DemoAgent(
+            config, memory=VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
+        )
         kg_agent = DemoAgent(config, memory=KnowledgeGraphMemory())
         no_memory_agent = DemoAgent(config, memory=None)
 
@@ -270,7 +272,7 @@ class TestMemoryShowcaseMemoryInteraction:
     def test_vector_memory_stores_all_turns(self):
         """Test VectorMemory stores all conversation turns."""
         config = DemoConfig()
-        memory = VectorMemory(top_k=2)
+        memory = VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
         agent = DemoAgent(config, memory=memory)
 
         session_id = "test_vector"

--- a/packages/kailash-kaizen/tests/unit/examples/test_rag_research_memory.py
+++ b/packages/kailash-kaizen/tests/unit/examples/test_rag_research_memory.py
@@ -19,6 +19,8 @@ import pytest
 # Standardized example loading
 from example_import_helper import import_example_module
 
+from kaizen.memory.vector import hash_embedder_for_tests
+
 # Load rag-research example
 _rag_module = import_example_module("examples/1-single-agent/rag-research")
 RAGResearchAgent = _rag_module.RAGResearchAgent
@@ -108,7 +110,12 @@ class TestRAGResearchMemoryInitialization:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5, "similarity_threshold": 0.7},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+                "similarity_threshold": 0.7,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -163,7 +170,11 @@ class TestRAGResearchMemoryContextLoading:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -203,7 +214,11 @@ class TestRAGResearchMemoryContextLoading:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -245,7 +260,11 @@ class TestRAGResearchTurnSaving:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -277,7 +296,11 @@ class TestRAGResearchTurnSaving:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -328,7 +351,11 @@ class TestRAGResearchTurnSaving:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -358,7 +385,12 @@ class TestRAGResearchSemanticSearch:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 3, "similarity_threshold": 0.0},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 3,
+                "similarity_threshold": 0.0,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -405,6 +437,7 @@ class TestRAGResearchSemanticSearch:
             model="test",
             memory_config={
                 "enabled": True,
+                "embedder": hash_embedder_for_tests,
                 "top_k": 1,
                 "similarity_threshold": 0.9,
             },  # High threshold
@@ -438,7 +471,12 @@ class TestRAGResearchSemanticSearch:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5, "similarity_threshold": 0.95},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+                "similarity_threshold": 0.95,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -473,7 +511,11 @@ class TestRAGResearchMultiTurnWithMemory:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -518,7 +560,11 @@ class TestRAGResearchMultiTurnWithMemory:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 3},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 3,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -575,7 +621,11 @@ class TestRAGResearchSessionIsolation:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -620,7 +670,11 @@ class TestRAGResearchSessionIsolation:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -649,7 +703,12 @@ class TestRAGResearchMemoryIntegration:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 3, "similarity_threshold": 0.5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 3,
+                "similarity_threshold": 0.5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -704,7 +763,11 @@ class TestRAGResearchMemoryIntegration:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -749,7 +812,11 @@ class TestRAGResearchMemoryIntegration:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 3},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 3,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -792,7 +859,11 @@ class TestRAGResearchMemoryEdgeCases:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
         )
         agent = create_agent_with_config(config)
 
@@ -818,7 +889,11 @@ class TestRAGResearchMemoryEdgeCases:
         config = RAGConfig(
             llm_provider="mock",
             model="test",
-            memory_config={"enabled": True, "top_k": 5},
+            memory_config={
+                "enabled": True,
+                "embedder": hash_embedder_for_tests,
+                "top_k": 5,
+            },
             similarity_threshold=0.99,  # Very high threshold - no docs
         )
         agent = create_agent_with_config(config)
@@ -843,7 +918,9 @@ class TestRAGResearchMemoryEdgeCases:
         """Test that research() method accepts session_id parameter."""
         import inspect
 
-        config = RAGConfig(memory_config={"enabled": True})
+        config = RAGConfig(
+            memory_config={"enabled": True, "embedder": hash_embedder_for_tests}
+        )
         agent = create_agent_with_config(config)
 
         # Check method signature

--- a/packages/kailash-kaizen/tests/unit/memory/test_base_agent_memory_integration.py
+++ b/packages/kailash-kaizen/tests/unit/memory/test_base_agent_memory_integration.py
@@ -175,7 +175,7 @@ class TestBaseAgentVectorMemoryIntegration:
     def test_agent_with_vector_memory(self):
         """Test agent with VectorMemory integration."""
         from kaizen.core.base_agent import BaseAgent, BaseAgentConfig
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
         from kaizen.signatures import InputField, OutputField, Signature
 
         class TestSignature(Signature):
@@ -186,7 +186,7 @@ class TestBaseAgentVectorMemoryIntegration:
             llm_provider="mock", model="mock-model", memory_enabled=True
         )
 
-        memory = VectorMemory(top_k=2)
+        memory = VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
         agent = BaseAgent(config=config, signature=TestSignature(), memory=memory)
 
         # Mock strategy

--- a/packages/kailash-kaizen/tests/unit/memory/test_vector_memory.py
+++ b/packages/kailash-kaizen/tests/unit/memory/test_vector_memory.py
@@ -10,37 +10,39 @@ Test Strategy:
 
 from typing import List
 
+import pytest
+
 
 class TestVectorMemoryBasics:
     """Test basic VectorMemory functionality."""
 
     def test_vector_memory_instantiation(self):
         """Test VectorMemory can be instantiated."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
         assert memory is not None
         assert isinstance(memory, VectorMemory)
 
     def test_vector_memory_with_top_k(self):
         """Test VectorMemory can be instantiated with top_k."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory(top_k=3)
+        memory = VectorMemory(top_k=3, embedding_fn=hash_embedder_for_tests)
         assert memory.top_k == 3
 
     def test_vector_memory_default_top_k(self):
         """Test VectorMemory defaults to 5 for top_k."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
         assert memory.top_k == 5
 
     def test_empty_vector_memory_loads_empty_context(self):
         """Test loading context from empty vector memory returns empty structure."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
         context = memory.load_context("session1")
 
         assert isinstance(context, dict)
@@ -55,9 +57,9 @@ class TestVectorMemorySaving:
 
     def test_save_single_turn(self):
         """Test saving a single conversation turn."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
         turn = {
             "user": "Hello",
             "agent": "Hi there!",
@@ -72,9 +74,9 @@ class TestVectorMemorySaving:
 
     def test_save_multiple_turns(self):
         """Test saving multiple turns to vector store."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         turns = [
             {"user": "Hello", "agent": "Hi!"},
@@ -90,9 +92,9 @@ class TestVectorMemorySaving:
 
     def test_turns_stored_with_embeddings(self):
         """Test that turns are embedded when saved."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         memory.save_turn(
             "session1", {"user": "Machine learning is cool", "agent": "Yes!"}
@@ -108,9 +110,9 @@ class TestVectorMemorySemanticSearch:
 
     def test_search_with_query_returns_relevant_turns(self):
         """Test that semantic search returns relevant turns."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory(top_k=2)
+        memory = VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
 
         # Add diverse turns
         memory.save_turn(
@@ -130,9 +132,9 @@ class TestVectorMemorySemanticSearch:
 
     def test_search_without_query_returns_empty_relevant(self):
         """Test that load_context without query doesn't do semantic search."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         memory.save_turn("session1", {"user": "Hello", "agent": "Hi"})
 
@@ -144,9 +146,9 @@ class TestVectorMemorySemanticSearch:
 
     def test_top_k_limits_results(self):
         """Test that top_k parameter limits search results."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory(top_k=2)
+        memory = VectorMemory(top_k=2, embedding_fn=hash_embedder_for_tests)
 
         # Add 5 turns
         for i in range(5):
@@ -161,7 +163,7 @@ class TestVectorMemorySemanticSearch:
 
     def test_custom_embedder_injection(self):
         """Test that custom embedder can be injected."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
         def custom_embedder(text: str) -> List[float]:
             # Simple custom embedder - length-based vector
@@ -185,9 +187,9 @@ class TestVectorMemorySessionIsolation:
 
     def test_multiple_sessions_isolated(self):
         """Test that different sessions maintain separate vector stores."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         # Session 1
         memory.save_turn("session1", {"user": "Python", "agent": "Response 1"})
@@ -207,9 +209,9 @@ class TestVectorMemorySessionIsolation:
 
     def test_clear_only_affects_target_session(self):
         """Test that clearing one session doesn't affect others."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         memory.save_turn("session1", {"user": "S1", "agent": "R1"})
         memory.save_turn("session2", {"user": "S2", "agent": "R2"})
@@ -229,9 +231,9 @@ class TestVectorMemoryClear:
 
     def test_clear_removes_all_turns(self):
         """Test that clear removes all conversation history and embeddings."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         # Add multiple turns
         for i in range(5):
@@ -253,9 +255,9 @@ class TestVectorMemoryClear:
 
     def test_clear_nonexistent_session_no_error(self):
         """Test clearing nonexistent session doesn't raise error."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
         memory.clear("nonexistent_session")
 
         context = memory.load_context("nonexistent_session")
@@ -263,9 +265,9 @@ class TestVectorMemoryClear:
 
     def test_turns_can_be_added_after_clear(self):
         """Test that new turns can be added after clearing."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         # Add, clear, add again
         memory.save_turn("session1", {"user": "Before", "agent": "Response"})
@@ -282,9 +284,9 @@ class TestVectorMemoryEdgeCases:
 
     def test_empty_query_string(self):
         """Test that empty query string doesn't trigger search."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         memory.save_turn("session1", {"user": "Hello", "agent": "Hi"})
 
@@ -296,9 +298,9 @@ class TestVectorMemoryEdgeCases:
 
     def test_search_returns_metadata(self):
         """Test that search results include full turn metadata."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         turn = {
             "user": "Python",
@@ -317,9 +319,9 @@ class TestVectorMemoryEdgeCases:
 
     def test_load_context_format_consistency(self):
         """Test that load_context always returns consistent format."""
-        from kaizen.memory.vector import VectorMemory
+        from kaizen.memory.vector import VectorMemory, hash_embedder_for_tests
 
-        memory = VectorMemory()
+        memory = VectorMemory(embedding_fn=hash_embedder_for_tests)
 
         # Empty session
         context1 = memory.load_context("empty_session")
@@ -336,3 +338,72 @@ class TestVectorMemoryEdgeCases:
         context3 = memory.load_context("session2", query="greeting")
         assert "relevant_turns" in context3
         assert "all_turns" in context3
+
+
+class TestEmbeddingFnIsRequired:
+    """#2174: the default path MUST NOT silently produce hash-derived vectors.
+
+    ``embedding_fn`` used to default to ``VectorMemory._default_embedder``, an
+    MD5-derived pseudo-embedder. Callers who omitted it got vectors of the
+    correct shape with no semantic signal, so similarity search returned
+    ranked results over hash noise — no raise, no log, nothing observable from
+    the outside (``zero-tolerance.md`` Rule 2).
+    """
+
+    def test_omitting_embedding_fn_raises(self):
+        from kaizen.config.providers import ConfigurationError
+        from kaizen.memory.vector import VectorMemory
+
+        with pytest.raises(ConfigurationError) as exc:
+            VectorMemory()
+
+        # The error must name the wiring, not merely complain.
+        msg = str(exc.value)
+        assert "embedding_fn" in msg
+        assert "hash_embedder_for_tests" in msg
+
+    def test_explicit_none_raises(self):
+        """`embedding_fn=None` is the documented old spelling of the default."""
+        from kaizen.config.providers import ConfigurationError
+        from kaizen.memory.vector import VectorMemory
+
+        with pytest.raises(ConfigurationError):
+            VectorMemory(embedding_fn=None, top_k=5)
+
+    def test_no_hash_embedder_attribute_survives_on_the_class(self):
+        """The old default must not remain reachable as an instance method.
+
+        Guards the regression where the raise is added but `_default_embedder`
+        stays on the class, so a caller (or a merge) can re-wire it.
+        """
+        from kaizen.memory.vector import VectorMemory
+
+        assert not hasattr(VectorMemory, "_default_embedder")
+
+    def test_supplied_embedder_is_the_one_used(self):
+        """A real embedder must be called; nothing may substitute for it."""
+        from kaizen.memory.vector import VectorMemory
+
+        calls = []
+
+        def tracking_embedder(text):
+            calls.append(text)
+            # Deliberately unlike the hash embedder's 128-dim 0/1 output.
+            return [0.5, 0.25, 0.125]
+
+        memory = VectorMemory(embedding_fn=tracking_embedder)
+        memory.save_turn("s1", {"user": "hello", "agent": "hi"})
+
+        assert calls, "supplied embedding_fn was never called"
+        stored = memory._stores["s1"]["embeddings"][0]
+        assert stored == [0.5, 0.25, 0.125]
+
+    def test_hash_embedder_for_tests_is_explicitly_named_and_shaped(self):
+        """The stand-in stays available for tests, under an unmistakable name."""
+        from kaizen.memory.vector import hash_embedder_for_tests
+
+        vec = hash_embedder_for_tests("hello")
+        assert len(vec) == 128
+        assert all(v in (0.0, 1.0) for v in vec)
+        # Deterministic, which is the only property tests may rely on.
+        assert hash_embedder_for_tests("hello") == vec

--- a/packages/kailash-kaizen/tests/unit/nodes/ai/test_semantic_memory_no_hash_fallback.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/ai/test_semantic_memory_no_hash_fallback.py
@@ -1,0 +1,69 @@
+"""#2174 sibling: SimpleEmbeddingProvider must not fabricate hash embeddings.
+
+Both arms of the embedding request used to fall back to an MD5-derived vector
+when the embedding service returned non-200 or raised — with no log line and
+no raise. The resulting ``EmbeddingResult`` even carried ``model=<the real
+model name>``, so the fabricated vectors were labelled with the real model's
+provenance and were indistinguishable downstream.
+
+`hybrid_search.py` constructs this provider, so the degraded path was live in
+production, not just reachable in theory.
+"""
+
+import pytest
+
+from kaizen.nodes.ai.semantic_memory import (
+    EmbeddingUnavailable,
+    SimpleEmbeddingProvider,
+)
+
+# A non-loopback host, so the unit tier's egress block refuses the connect
+# deterministically. The provider's DEFAULT host is http://localhost:11434,
+# which the block deliberately permits — on a developer machine with ollama
+# running, the request SUCCEEDS and a test written against the default would
+# pass for the wrong reason, then fail in CI. That is the same ambient-state
+# dependency #2169 removed from this tier, so it is not reintroduced here.
+_UNREACHABLE_HOST = "http://embedding-service.invalid:11434"
+
+
+class TestNoHashFallback:
+    def test_hash_embedding_helper_is_gone(self):
+        """The fabricating helper must not survive on the class.
+
+        If it comes back, the fallback can be silently re-wired.
+        """
+        assert not hasattr(SimpleEmbeddingProvider, "_hash_embedding")
+
+    @pytest.mark.asyncio
+    async def test_unreachable_service_raises_instead_of_fabricating(self):
+        """A failed embedding request raises rather than returning hash noise.
+
+        The unit tier refuses non-loopback egress (see tests/unit/conftest.py),
+        so the request genuinely fails here — which is exactly the condition
+        that used to yield fabricated vectors.
+        """
+        provider = SimpleEmbeddingProvider(host=_UNREACHABLE_HOST, ungoverned=True)
+
+        with pytest.raises(EmbeddingUnavailable) as exc:
+            await provider.embed_text("hello world")
+
+        msg = str(exc.value)
+        # The error must say what failed and refuse explicitly, so the next
+        # reader does not reintroduce the fallback as a "fix".
+        assert "SimpleEmbeddingProvider" in msg
+        assert "hash-derived" in msg
+
+    @pytest.mark.asyncio
+    async def test_failure_is_not_reported_as_a_successful_embedding(self):
+        """No EmbeddingResult may be returned for a failed request.
+
+        The regression this guards is the original defect's shape: a control
+        that reports success without doing its job.
+        """
+        provider = SimpleEmbeddingProvider(host=_UNREACHABLE_HOST, ungoverned=True)
+
+        result = None
+        with pytest.raises(EmbeddingUnavailable):
+            result = await provider.embed_text("hello world")
+
+        assert result is None


### PR DESCRIPTION
Fixes #2174.

## The defect

`VectorMemory.__init__` did:

```python
self.embedding_fn = embedding_fn or self._default_embedder
```

and `_default_embedder` was, by its own docstring, `"""Default mock embedder for testing."""` — MD5 of the text expanded to a 128-dimensional 0/1 vector.

A caller who omitted `embedding_fn` got hash-derived pseudo-embeddings presented as real ones. Nothing raised, nothing logged, and everything downstream kept working: similarity search returned ranked results, with scores. The ranking was over MD5 noise.

## Disposition: fail closed

`rules/security.md` § Secure-Default allows two outcomes — fail closed, or a loud one-time WARN if backward-compat forbids it. **The WARN branch was not needed**: a sweep of every construction found no production caller relying on the default. Every one was a test, an example, or a docs snippet. So `embedding_fn` is now required and its absence raises `ConfigurationError` naming the wiring.

This mirrors **#1952** on `EmbeddingGeneratorNode`, which removed the identical hazard one surface over — *"a forgotten provider used to become 'mock' here and silently return fabricated mock vectors as real embeddings."* Same shape, same disposition; the two surfaces now agree.

The hash function survives as a module-level `hash_embedder_for_tests`, out of the default path. The name is the whole point: as `VectorMemory._default_embedder` it silently served everyone who omitted the argument.

## Sibling sweep (AC4) — one worse instance, one verified clean

**`SimpleEmbeddingProvider.embed_text` — worse than the original.** Both the non-200 arm and a bare `except Exception:` fell back to `_hash_embedding`, with no raise and no log:

```python
except Exception:
    # Fallback to simple hash-based embedding
    embedding = self._hash_embedding(txt)
```

and the returned `EmbeddingResult` carried `model=self.model_name` — so the fabricated vectors were **labelled with the real model's provenance** and were indistinguishable downstream. `hybrid_search.py:337` constructs this provider, so the degraded path was live, not theoretical.

Both arms now raise a typed `EmbeddingUnavailable`. `_hash_embedding` is **deleted** rather than left reachable.

**`EmbeddingGeneratorNode._generate_mock_embedding` — CLEAN.** Reachable only through an explicit `provider == "mock"`; #1952 already removed the silent default. Recorded here so nobody re-checks it.

## Collateral: the examples and docs taught the broken pattern

- **`docs/reference/memory-patterns-guide.md`** documented `VectorMemory(embedding_fn=None, top_k=5)` under the heading *"Default: Mock hash-based embedder (testing only)"*. The defect was the documented API.
- **`memory-showcase/demo.py`** printed *"Key Feature: Semantic search - finds related conversations"* while ranking hash noise, with its questions annotated `# Related to Q1`. It now wires the stand-in explicitly, states plainly that the ranking is not semantic, and shows the real-embedder swap.
- **`rag-research/workflow.py`** forwards `memory_config["embedder"]`, which was `None` whenever unset — the forwarded-default case a call-site grep does not surface. Now documented as required.

## Verification

**Positive control**, because a test that cannot fail is the same defect class as the bug. Reverting `vector.py` to `main` leaves the new tests RED, then GREEN after restore:

```
vector.py at main:  4 failed, 1 passed
    E   Failed: DID NOT RAISE ConfigurationError
    E   Failed: DID NOT RAISE ConfigurationError
    E   AssertionError: assert not True
         +  where True = hasattr(VectorMemory, '_default_embedder')
after restore:      5 passed
```

The one test that passes both ways is `test_supplied_embedder_is_the_one_used` — supplying an embedder always worked, so it correctly does not discriminate on this change.

**The sibling tests point at a non-loopback host deliberately.** `SimpleEmbeddingProvider`'s default is `http://localhost:11434`, which the unit tier's egress block permits — on a developer machine with ollama running, the request *succeeds*, and a test written against the default would pass for the wrong reason and then fail in CI. I hit exactly that (`DID NOT RAISE`) while writing them.

```
1193 passed, 10 skipped   (tests/unit/memory + tests/unit/nodes + tests/unit/examples)
```

Full-tier run in progress; will report.

## Related issues

Fixes #2174
