### PR TITLE
fix(kaizen): correct a delegation claim shipped in #2150, and pin what it promises

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/url_safety.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/url_safety.py
@@ -88,9 +88,17 @@ def _url_fingerprint(raw: str | None) -> str:
     #617: migrated from hashlib.sha256 to the canonical BLAKE2b helper in
     `kailash.utils.url_credentials` to stay aligned with
     `errors._fingerprint` after the same migration. The two MUST use the same
-    algorithm or log-to-exception correlation breaks — and they still do:
-    `fingerprint_value` IS the implementation `fingerprint_secret` delegates
-    to, so both names return byte-identical output.
+    algorithm or log-to-exception correlation breaks.
+
+    They do, but NOT by delegation. `errors._fingerprint` calls
+    `fingerprint_secret`; this one calls `fingerprint_value`; the two helpers
+    hold SEPARATE, byte-identical bodies and neither calls the other. That is
+    deliberate — see `url_credentials.fingerprint_value` § "Why this repeats
+    the three-line digest instead of delegating" — and it means the identity
+    is held by a test (`test_url_safety_log_fingerprint_contract.py`, 70
+    input x length combinations), not by the call graph. Simplifying one body
+    into a call to the other silently breaks the correlation this docstring
+    promises, and re-numbers the CodeQL alert the other body's line carries.
 
     `fingerprint_value` rather than `fingerprint_secret` because the value
     fingerprinted here is a URL, not a credential, and the tag goes to a LOG

--- a/packages/kailash-kaizen/tests/unit/llm/security/test_url_safety_log_fingerprint_contract.py
+++ b/packages/kailash-kaizen/tests/unit/llm/security/test_url_safety_log_fingerprint_contract.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import ast
 import inspect
 import logging
+import textwrap
 
 import pytest
 
@@ -188,3 +189,66 @@ def test_exactly_one_rejection_logging_site() -> None:
         f"url_safety must have exactly ONE logging site, found "
         f"{len(log_calls)}; _reject routes through _rejecting_error_factory"
     )
+
+
+# ---------------------------------------------------------------------------
+# 5. The separation itself — which byte-identity alone cannot see.
+# ---------------------------------------------------------------------------
+
+
+def _calls_within(func) -> set[str]:
+    """Names called inside `func`'s own body."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Name):
+                names.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                names.add(f.attr)
+    return names
+
+
+def test_the_two_fingerprint_helpers_do_not_call_each_other() -> None:
+    """Separate bodies, held apart on purpose — and byte-identity is blind to it.
+
+    `test_fingerprint_value_is_byte_identical_to_fingerprint_secret` passes
+    whether the two helpers are independent OR one delegates to the other:
+    delegation produces identical output by construction. So the property
+    that actually has to hold is unpinned by that test, and it is the one
+    that matters:
+
+    * if `fingerprint_secret` delegated to `fingerprint_value`, credential-
+      classified taint would flow into the latter and CodeQL would report
+      `py/weak-sensitive-data-hashing` at its line;
+    * if `fingerprint_value` delegated to `fingerprint_secret`, a
+      `secret`-named callee would be back on the logging path and
+      `py/clear-text-logging-sensitive-data` (HIGH) would return;
+    * and either collapse RE-NUMBERS the surviving `hashlib.blake2b` line,
+      which invalidates the disposition written against the alert that line
+      carries.
+
+    A future reader who sees two identical bodies will reasonably try to
+    remove one. This is the test that tells them why not.
+    """
+    secret_calls = _calls_within(fingerprint_secret)
+    value_calls = _calls_within(fingerprint_value)
+
+    assert "fingerprint_value" not in secret_calls, (
+        "fingerprint_secret now delegates to fingerprint_value: credential "
+        "taint reaches that body and re-reports py/weak-sensitive-data-hashing "
+        "there. Keep the bodies separate; byte-identity is pinned by test, not "
+        "by the call graph."
+    )
+    assert "fingerprint_secret" not in value_calls, (
+        "fingerprint_value now delegates to fingerprint_secret: a `secret`-named "
+        "callee is back on the logging path and py/clear-text-logging-sensitive-"
+        "data (HIGH) returns. Keep the bodies separate."
+    )
+    # Both must still actually compute the digest themselves.
+    for name, calls in (
+        ("fingerprint_secret", secret_calls),
+        ("fingerprint_value", value_calls),
+    ):
+        assert "blake2b" in calls, f"{name} no longer computes its own digest"


### PR DESCRIPTION
## What

`_url_fingerprint`'s docstring in `kaizen/llm/url_safety.py` claims:

> `fingerprint_value` IS the implementation `fingerprint_secret` delegates to, so both names return byte-identical output.

That was true when written and false by the time it merged. The follow-up commit in #2150 gave the two helpers **separate** bodies, deliberately, so their taint graphs stay apart — and I did not walk the docstring back with the code. It landed on `main` in #2150 (`602570a00`).

Verified on merged main:

```
src/kailash/utils/url_credentials.py :: fingerprint_secret
    if not value: ...
    return hashlib.blake2b(value.encode("utf-8"), digest_size=digest_bytes).hexdigest()[:length]
    # ^ its own body; it does NOT call fingerprint_value
```

## Why it matters

The claim names the **mechanism** that keeps the two fingerprints byte-identical. A reader who believes the mechanism is delegation will reasonably delete one body as redundant. That collapse:

- re-numbers the surviving `hashlib.blake2b` line, which is the alert (#11474) that #2181's ceremony is written against; and
- re-reports whichever of `py/weak-sensitive-data-hashing` or `py/clear-text-logging-sensitive-data` the collapse points at — the two rules #2150 spent three attempts separating.

## The test gap this exposed

`test_fingerprint_value_is_byte_identical_to_fingerprint_secret` passes whether the helpers are independent **or** one delegates to the other — delegation produces identical output by construction. So the property that actually has to hold was unpinned by the test that looks like it covers it.

`test_the_two_fingerprint_helpers_do_not_call_each_other` walks each body's AST and asserts neither calls the other, and that both still compute their own digest.

**Verified discriminating.** Collapsing `fingerprint_secret` into `return fingerprint_value(value, length=length)`:

```
outputs still identical: True          <- byte-identity stays green, as predicted
1 failed, 16 passed                    <- only the new test reds
```

## Scope

Docstring accuracy plus the missing pin. This does **not** touch `fingerprint_secret`'s own self-contradictory docstring (`url_credentials.py:689` "fast keyed-hash" vs `:714` "no secret keying material", with no `key=` passed) — that is pre-existing on main, predates #2150, and belongs to #2170 with the co-owner, since keying the hash would make fingerprints non-reproducible across processes and break the cross-log correlation `_url_fingerprint` exists for.

## Verification

- `tests/unit/llm` + `cross_sdk_parity` + `test_issue_617_fingerprint_sweep.py`: **1759 passed, 1 xfailed**
- `pre-commit run --files <each>` per file: 14 Passed / 7 Skipped / 0 Failed on both

## Related issues

Relates to #2170, #2181. Follow-up to #2150.