### PR TITLE
docs(sweep,notes): cont-21 decision report + wrapup

### DIFF
--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -1,147 +1,124 @@
-# Session Notes — 2026-08-18 (cont-21: PR queue cleared, #2189 sweep executed)
+# Session Notes — 2026-08-19 (cont-21: loom sync repaired, two gaps filed upstream)
 
 ## Where we are
 
-main — green. **The PR queue is empty.** Both PRs the last session left open
-are merged; the #2189 sweep has run and produced one fix PR plus one filed decision.
+main — green, PR queue empty, working tree clean. The 2026-08-19 loom COC artifact update
+landed with its path-mapping defect repaired rather than merged as delivered. Two loom-side
+defects filed upstream. Sweep 5 was run correctly for the first time on this repo shape and
+surfaced a 70-finding corpus that the tool's own default invocation reports as clean.
 
-## Read first (in this order)
+Verify state with `gh pr list` and `git status --porcelain` rather than trusting this line;
+no SHA is pinned here because one goes stale the moment these notes are themselves merged.
 
-1. **§ In flight** below — the one open PR and what still has to happen to it
-2. **§ What the #2189 sweep found** — the results, including the clean surfaces, so the
-   next sweep does not re-walk them
-3. **§ Traps** — carried forward from cont-20, plus three measured this block
-4. `sweep-cont20-report.md` — still current for the value-ranked queue and D1/D2/D3
+## Read first
 
----
-
-## In flight
-
-**Nothing is open.** PR queue empty, working tree clean — verify with `gh pr list` and
-`git status --porcelain` rather than trusting this line; a pinned SHA here goes stale the
-moment these notes are themselves merged, which is why none is quoted.
-
-**#2141 — reconciled, NOT implemented, and the reason is load-bearing.** Every claim in the
-issue re-verified true on current main (`self._auth` assigned once, read nowhere; DELETE
-mounted unconditionally; zero middleware on a driven app). Two NEW findings posted to the
-issue: (1) spec §8.3's claim that `--enable-control` "permits writes only on 127.0.0.1" is
-FALSE — `create_app` never receives `enable_control` and the DELETE route is registered
-unconditionally; (2) **the spec never says what `--auth` DOES** — §8.3 specifies only the
-pairing refusal, and the flag's help calls it a policy URL. So fixing this means DECIDING
-what a security flag means on a released CLI. Recommendation posted (make `--auth` a
-require-auth switch + wire the shared `resolve_server_auth`/`install_server_auth_middleware`
-helper, since that is the only reading under which `_validate_bind`'s own error message is
-true), with implications: **dependency floor must rise `kailash>=2.31.0` → `>=2.63.0`**
-(server_auth first ships in 2.63.0 — verified by object presence across tags with a negative
-control), it is a behaviour change on a released CLI, and it needs a kailash-ml RELEASE to
-reach users. Awaiting the semantics call.
-
-**Merged this block:** #2192 (mounted-subapp auth tristate, red established before merge —
-4 of 6 tests flip) · #2123 (loom Gate-2 sync, rebased 177 commits forward, zero conflicts).
+1. `sweep-cont21-report.md` — completion status, ETA in cycles, the 5 decision points
+2. § Next-session directives below — the only imperative surface in this file
+3. § Traps — measured this block, do not rediscover
 
 ---
 
-## What the #2189 sweep found
+## Next-session directives
 
-The class: *a mechanism that learned NOTHING reports the same value as one that checked and
-passed.* Swept by AST over 2431 non-test source files for the issue's five shapes.
+1. **Check the next loom Gate-2 sync for the path regression BEFORE merging it.**
+   re-validate: `git ls-tree -r --name-only <sync-branch> -- codex gemini` → empty ⇒ fixed.
+   Non-empty ⇒ loom#1826 has not landed; do NOT merge, repair or close as before.
+   Checking that `.codex/` is populated does NOT discriminate — it was populated throughout
+   the incident.
 
-### Fixed (in the open PR)
+2. **Do not implement #2141, #2166, or #2194 without the co-owner's schema decision.**
+   Each needs a security semantics call that no spec contains; guessing ships a wrong
+   authz/auth control in place of an honest gap.
+   re-validate: `gh issue view 2141 --comments` (and 2166 / 2194) → a co-owner comment
+   naming the schema ⇒ unblocked. Absent ⇒ still blocked.
 
-1. **`MultiDimensionEvaluator.evaluate` reported a constraint set it never evaluated as
-   `satisfied=True`.** An unregistered dimension was appended to `warnings` and `continue`d —
-   dropped from `dimension_results` AND `failed_dimensions`. Every-dimension-unknown returned
-   `satisfied=True, failed=[], results={}`, identical on the gated field to a passing run.
-   Partial case was worse: CONJUNCTIVE "ALL must pass" computed over the shrunk subset.
-2. **Stripe/Slack webhook verifiers guarded the timestamp parse but not the conversion.**
-   `math.isfinite` admits `1e300`; `datetime.fromtimestamp` then raised `OverflowError`
-   OUTSIDE the guarded block, past `handle_webhook`'s documented return contract, skipping
-   `metrics.record_webhook` — so the rejected delivery was invisible, not merely mis-reported.
-   `handle_webhook`'s own generic path already caught `OverflowError`; the two provider
-   verifiers stopped one step short.
+3. **Take the Sweep-5 scoped first pass on `ml-feature-store` + `ml-tracking`** (15 orphans,
+   4 coverage gaps) to measure the spec-over-promised vs source-missing ratio before sizing
+   the remaining ~55.
+   re-validate: `python tools/sweep-redteam.py specs/ml-feature-store.md --json` →
+   `orphans=0` ⇒ that spec is done.
 
-### Clean — verified, do not re-walk
+4. **Check loom#1826 / loom#1827 before re-filing anything upstream.**
+   re-validate: `gh issue view 1826 --repo <loom-private-org>/loom --json state -q .state`
+   → `CLOSED` ⇒ fix landed; re-verify locally per directive 1.
 
-- `pact/mcp/enforcer.py` — `cost_estimate` non-finite → fail-closed BLOCK (Step 2), AND
-  `McpToolPolicy.__post_init__` validates `max_cost` finite. **Both** operands guarded.
-- All three financial-constraint classes validate finite + non-negative:
-  `trust/envelope.py::FinancialConstraint`, `trust/plane/models.py::FinancialConstraints`,
-  `trust/pact/config.py::FinancialConstraintConfig`.
-- `trust/enforce/proximity.py::scan` — non-finite usage escalates to HELD, with a comment
-  naming the exact hazard.
-- `trust/plane/project.py::check` — `action_cost` isfinite + negative → BLOCKED.
-- `security.py`, `gateway/security.py`, `utils/network_guard.py` exception paths — every one
-  deliberate, with a comment saying why.
-- `migrations/performance_validator.py` — RAISES on an empty baseline set.
-
-**`trust/plane/conformance/__init__.py::_level_passes` is the reference implementation of
-the right answer**: `if not must_tests: return False` — *"cannot claim a level without
-evidence."* Cite it when arguing the shape.
-
-### Latent / design-level — recorded, NOT fixed
-
-- **`PlanSuspension.all_conditions_met()` returns True vacuously on empty `resume_conditions`,
-  and `tests/trust/pact/unit/test_plan_suspension.py:597` asserts that vacuity as intended
-  behaviour.** This is the issue's hardest flavour — a test named for the vacuous outcome,
-  green, that anyone checking "is it covered?" would count as coverage. No production caller
-  builds an empty tuple today (`suspend_plan` always passes one condition), but `from_dict`
-  accepts `"resume_conditions": []` and the resume gate at `pact/engine.py:777` reads it.
-- **`verify_chain()` returns True on an empty chain** in three places (`trust/audit_store.py`
-  ×2, `kaizen_agents/audit/trail.py`). Semantically defensible; the caller cannot tell
-  "nothing to verify" from "the store did not load." Fixing means a richer return type on a
-  released public API — a decision, not a patch.
-- **`api_channel` / `mcp_channel` / `cli_channel` `health_check`**: `all(checks.values())`
-  where one value is a nested dict. A non-empty dict is always truthy, so the
-  `enterprise_features` sub-checks never affect `all_healthy` — reported, never enforced.
-
-### The meta-finding
-
-The pre-existing `test_unknown_dimension_warning` asserted that a warning was emitted and
-**never looked at `satisfied`**. A green test, correctly named for the case, that did not
-touch the consequential field. `"is it tested?"` is itself an instance of the class; the
-question that discriminates is `"has this test been shown to fail for the right reason?"`
+5. **Close #2199 only after a clean Gate-2 re-emit is verified here**, not when loom#1826
+   closes — the local tracker is for the delivered state, not the upstream fix.
+   re-validate: directive 1's command on the post-fix sync branch → empty ⇒ closable.
 
 ---
 
-## Traps
+## In-play branches and worktrees
 
-Everything in the cont-20 notes still holds (`git log` them if needed — they were replaced,
-not deleted: `git show d386a18a3:workspaces/issue-1720-llm-consolidation/.session-notes`).
-Highest-value carried forward, plus what this block measured:
+- **At risk** — none known. Every branch this session opened was merged and deleted
+  (#2192, #2195, #2196, #2197, #2198 + the two docs branches).
+  re-check, because this was written from memory and not measured:
+  `for b in $(git for-each-ref --format='%(refname:short)' refs/heads); do git cherry origin/main $b | grep -q '^+' && echo "AT RISK $b"; done`
+  → any output ⇒ that branch holds content nothing upstream has. An ahead-count does NOT
+  discriminate (a rebased branch reads ahead long after its content landed).
+- **Remote non-main refs** — `docs/notes-cont18-execution`, `fix/2070-logging-hook-redaction-defeat`.
+  Both believed superseded (the latter by PR #2101); neither re-verified this session.
+- **Worktrees** — 1 (the main checkout). No reap verdicts run this block.
+  Removing a worktree deletes a DIRECTORY, never a branch (`worktree-isolation.md` Rule 8).
+  re-check: `node .claude/bin/worktree-reap.mjs`
+- **169 local branches** — carried, unexamined, since cont-20. Sweep-report D5: leave.
 
-- **`pre-commit run --from-ref X --to-ref Y --files ...` silently checks NOTHING.** Every
-  hook printed `(no files to check) Skipped` and the run "passed." Combining the ref range
-  with `--files` yields an empty set. Use `--files <paths>` alone, and read the hook lines,
-  not the exit code. Black then reformatted a file the "passing" run had not opened.
-- **`node --check` over a glob proves nothing without a count and a positive control.** Print
-  the file count AND run the checker against a deliberately malformed file in the same breath.
-- **`git -C <repo> worktree add <relative-path>` resolves the path INSIDE that repo**, creating
-  a nested worktree the rules forbid. Pass an absolute path.
-- **`$?` after a pipe is the LAST stage's status, not the command's.** `node x.mjs | tail`
-  reported `EXIT=0` for a run that exited 1. Redirect to a file, then read the exit code.
+---
+
+## Executed this session (external — not recoverable from git log)
+
+- Merged #2192, #2123, #2195, #2196, #2197, #2198.
+- Filed #2199 (local tracker) and #2194 (governance actor provenance).
+- Filed TWO issues upstream into private loom: **#1826** (Gate-2 delivers the emitter's
+  staging layout) and **#1827** (`ci-cost-discipline.md` push-time MUSTs unreachable).
+  Both cross-repo writes carried a `/cross-repo-authorize` write-tier receipt written
+  BEFORE the write; receipts are in `.claude/cross-repo-authz/`, uncommitted per the
+  `coc-build` branch of the ceremony.
+- Posted reconciliation + recommendation comments to #2141 and #2189.
+
+---
+
+## Traps (measured this block)
+
+- **`tools/sweep-redteam.py --all` returns `specs=0 … OK` on this repo.** It scans
+  `workspaces/*/specs/**/*.md`, which is empty here — spec authority is at repo-root
+  `specs/`. The OK sentinel is a vacuous green: same output whether the corpus is clean or
+  unexamined. Pointing the tool at each `specs/*.md` explicitly DOES work and found
+  52 orphans / 18 coverage gaps. Never cite the `--all` sentinel on this repo.
+- **`ci-cost-discipline.md` cannot fire.** Its push-time MUSTs are path-scoped to
+  `**/todos/**`, `**/.wave-tracker*`, `**/.github/workflows/**` — globs a push never
+  touches. Measured: 1150 files changed across this session's merges, 0 matching, with a
+  control proving the matcher works. Filed loom#1827. Until it lands, push discipline comes
+  from `git.md` (baseline) alone.
+- **The burndown hooks + new wrapup skill landed mid-session and were inert for it.**
+  `settings.json` gained 66 lines in the sync; a running session keeps the config it
+  started with. Fixtures pass (64 + 39, exit 0) and both hooks execute — nothing is broken,
+  it just needs a session boundary. This session's notes were written under the NEW wrapup
+  contract manually.
+- **In zsh, `"$var:src/..."` applies a `:s///` history modifier.** `git cat-file -e
+  "$tag:src/kailash/utils/server_auth.py"` silently asked for `v2.63.0_auth.py` and reported
+  ABSENT for every tag. Brace it: `"${tag}:path"`. A control that hardcodes the string
+  cannot catch this — the bug lives in the expansion the control does not use.
+- **`pre-commit run --from-ref X --to-ref Y --files ...` checks NOTHING.** Every hook prints
+  `(no files to check) Skipped` and the run "passes"; black then reformatted a file that run
+  never opened. Use `--files <paths>` alone and read the hook lines, not the exit code.
 - **A validator failing identically on both sides is not a regression.** `validate-emit`
-  reported 4 blocking failures on the sync PR; `main` produced the byte-identical fail set,
-  all rooted in `.claude/sync-manifest.yaml` being loom-only. Always run the baseline before
-  reading a red as caused by the change.
-- **Establish the red with a positive control that the mutation reached the code.** Revert the
-  source, then assert the fix is *absent* from the imported module (`inspect.getsource`,
-  signature check) BEFORE reading the test result — otherwise a non-reddening test has two
-  explanations and you cannot tell which.
-- **Write controls that would fail if the fix were "always return False."** Four of the nine
-  new tests exist only for that; without them the suite could not distinguish a real fix from
-  a uniformly negative one.
+  reports 4 blocking failures here and on main alike — all rooted in `sync-manifest.yaml`
+  being loom-only, which a `coc-build` repo does not have. Diff the FAIL SETS, not counts.
 
 ---
 
-## Local full-suite baseline (for regression comparison)
+## Outstanding ledger (forest)
 
-`tests/unit tests/security tests/regression` on main, untruncated: **115 failed, 7141 passed,
-50 errors** — local-environment failures (optional deps, no infra); the per-package CI matrix
-installs extras and is green. **Never read a local failure count as a regression without
-diffing against a same-selection baseline, untruncated on BOTH sides.**
+| id | workstream | state | receipt |
+| --- | --- | --- | --- |
+| `gate2-regression` | loom Gate-2 path mapping | filed upstream, awaiting loom | loom#1826, local #2199 |
+| `ci-cost-reach` | ci-cost-discipline unreachable | filed upstream, awaiting loom | loom#1827 |
+| `sweep5-orphans` | 52 spec orphans / 18 coverage gaps | open, newly measured | sweep-cont21-report.md § 4 |
+| `auth-semantics` | #2141 `--auth` + kailash-ml release | blocked on co-owner (D1) | #2141 comment |
+| `authz-schema` | #2166 + #2194 actor/authz schema | blocked on co-owner (D2, D3) | #2194 |
+| `mcp-health` | `mcp_channel.py:961` non-discriminating check | blocked on co-owner | sweep report D3 |
+| `hist-branches` | 169 unexamined local branches | deferred by judgment | sweep report D5 |
 
-## Open decisions
-
-`sweep-cont20-report.md` § 5 — **D1** wire `tests/integration/` (131 files, real CI cost) ·
-**D2** authorization schema for #2166 · **D3** the 165 historical branches (recommend: leave).
-**New: D4** — the #2194 governance-API actor schema (three options laid out in the issue).
+Closed this session: `pr-queue` (both cont-20 PRs merged), `absence-sweep` (#2189 fixes
+merged in #2195).

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -38,7 +38,8 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
    re-validate: `python tools/sweep-redteam.py specs/ml-feature-store.md --json` →
    `orphans=0` ⇒ that spec is done.
 
-4. **Check loom#1826 / loom#1827 before re-filing anything upstream.**
+4. **Check loom#1826 before re-filing anything upstream.** (loom#1827 was mine and is
+   WITHDRAWN — see Traps.)
    re-validate: `gh issue view 1826 --repo <loom-private-org>/loom --json state -q .state`
    → `CLOSED` ⇒ fix landed; re-verify locally per directive 1.
 
@@ -70,7 +71,8 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
 - Merged #2192, #2123, #2195, #2196, #2197, #2198.
 - Filed #2199 (local tracker) and #2194 (governance actor provenance).
 - Filed TWO issues upstream into private loom: **#1826** (Gate-2 delivers the emitter's
-  staging layout) and **#1827** (`ci-cost-discipline.md` push-time MUSTs unreachable).
+  staging layout) — still open and believed correct — and **#1827**, which I then
+  WITHDREW and closed the same session as a duplicate of loom's own T4.
   Both cross-repo writes carried a `/cross-repo-authorize` write-tier receipt written
   BEFORE the write; receipts are in `.claude/cross-repo-authz/`, uncommitted per the
   `coc-build` branch of the ceremony.
@@ -88,8 +90,15 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
 - **`ci-cost-discipline.md` cannot fire.** Its push-time MUSTs are path-scoped to
   `**/todos/**`, `**/.wave-tracker*`, `**/.github/workflows/**` — globs a push never
   touches. Measured: 1150 files changed across this session's merges, 0 matching, with a
-  control proving the matcher works. Filed loom#1827. Until it lands, push discipline comes
-  from `git.md` (baseline) alone.
+  control proving the matcher works. **My inference from that was WRONG and I filed it
+  upstream before catching it (loom#1827, now withdrawn).** A glob cannot be TRIGGERED BY a
+  push, but injection is sticky-once per session, so a glob matching a file touched EARLIER
+  leaves the rule loaded AT push time — reaching some pushes by coincidence, not never.
+  loom had already shipped the real fix in the sync I was reviewing:
+  `.claude/hooks/lib/ci-cost-reach.js`, composed by `validate-bash-command.js` on the
+  PreToolUse Bash matcher, delivering the contract at the moment CI spend is decided. It
+  fired on my next push, which is how I found the error. loom had also already narrowed this
+  exact over-claim once (their #1715 M-4) — I reproduced a corrected mistake.
 - **The burndown hooks + new wrapup skill landed mid-session and were inert for it.**
   `settings.json` gained 66 lines in the sync; a running session keeps the config it
   started with. Fixtures pass (64 + 39, exit 0) and both hooks execute — nothing is broken,
@@ -113,7 +122,6 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
 | id | workstream | state | receipt |
 | --- | --- | --- | --- |
 | `gate2-regression` | loom Gate-2 path mapping | filed upstream, awaiting loom | loom#1826, local #2199 |
-| `ci-cost-reach` | ci-cost-discipline unreachable | filed upstream, awaiting loom | loom#1827 |
 | `sweep5-orphans` | 52 spec orphans / 18 coverage gaps | open, newly measured | sweep-cont21-report.md § 4 |
 | `auth-semantics` | #2141 `--auth` + kailash-ml release | blocked on co-owner (D1) | #2141 comment |
 | `authz-schema` | #2166 + #2194 actor/authz schema | blocked on co-owner (D2, D3) | #2194 |
@@ -121,4 +129,5 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
 | `hist-branches` | 169 unexamined local branches | deferred by judgment | sweep report D5 |
 
 Closed this session: `pr-queue` (both cont-20 PRs merged), `absence-sweep` (#2189 fixes
-merged in #2195).
+merged in #2195), `ci-cost-reach` (WITHDRAWN — my filing was a duplicate of loom's shipped
+T4; closed with evidence at loom `9cff8704e293…` / local `d0a756ef9…`).

--- a/workspaces/issue-1720-llm-consolidation/.session-notes
+++ b/workspaces/issue-1720-llm-consolidation/.session-notes
@@ -129,5 +129,6 @@ no SHA is pinned here because one goes stale the moment these notes are themselv
 | `hist-branches` | 169 unexamined local branches | deferred by judgment | sweep report D5 |
 
 Closed this session: `pr-queue` (both cont-20 PRs merged), `absence-sweep` (#2189 fixes
-merged in #2195), `ci-cost-reach` (WITHDRAWN — my filing was a duplicate of loom's shipped
-T4; closed with evidence at loom `9cff8704e293…` / local `d0a756ef9…`).
+merged in #2195), `ci-cost-reach` (row MOVED here from the open ledger above, not retained
+there — WITHDRAWN; my filing duplicated loom's shipped T4, closed with evidence at loom
+`9cff8704e293…` / local `d0a756ef9…`. The lesson is retained as a Traps entry).

--- a/workspaces/issue-1720-llm-consolidation/sweep-cont21-report.md
+++ b/workspaces/issue-1720-llm-consolidation/sweep-cont21-report.md
@@ -1,0 +1,156 @@
+# /sweep — Management Decision Report (cont-21)
+
+main `b44c65b27` · **6 PRs merged this block** · **0 open PRs** · 46 open issues ·
+2 issues filed upstream to loom
+
+Every "complete" claim below cites a durable receipt. No self-attested completion.
+
+---
+
+## 1. Completion status
+
+### The COC artifact update landed, and the defect it carried did not
+
+The 2026-08-19 loom Gate-2 distribution is in, with its path-mapping defect repaired
+rather than merged as delivered.
+
+| item | receipt |
+| --- | --- |
+| #2192 mounted-subapp auth tristate | merged `c23836a17` |
+| #2123 loom Gate-2 sync (2026-08-13) | merged `6fb3f5d0f` |
+| #2195 #2189 sweep fixes + deadline flake | merged `257113226` |
+| #2196 / #2197 session notes | merged `8293d7e28` / `15caf73ee` |
+| #2198 loom Gate-2 sync (2026-08-19), repaired | merged `b44c65b27` |
+
+**Post-merge invariant verified on main, in the direction that can fail:**
+
+```
+files at top-level codex/ or gemini/:  0
+installed .codex: 477   .gemini: 476
+.codex/skills/wrapup/SKILL.md   PRESENT
+.gemini/skills/wrapup/SKILL.md  PRESENT
+```
+
+### Is the product complete and visible?
+
+**The delivery surface is healthy; the correctness backlog is larger than it looked.**
+Sweep 5 was run properly for the first time on this repo shape and surfaced 52 spec
+orphans + 18 coverage gaps that the tool's own `--all` path reports as clean (§ 4).
+
+---
+
+## 2. ETA to completion — in autonomous cycles
+
+**~4–6 cycles**, up from cont-20's 3–4. The increase is not regression; it is the
+Sweep-5 corpus becoming visible for the first time.
+
+| bucket | items | est. cycles |
+| --- | --- | --- |
+| Sweep-5 spec orphans + coverage gaps (52 + 18, ML-concentrated) | 70 findings | 2–3 |
+| Un-gated HTTP surfaces (#2141, #2142) | 2 | 0.75 |
+| #2194 governance actor provenance — needs schema decision | 1 | 0.5 after decision |
+| #2166 `check_session_access` — needs authz schema | 1 | 0.5 after decision |
+| Correctness set (#2138, #2151, #2153, #2162, #2163, #2172, #2175) | 7 | 1 |
+| Docs/claim accuracy (#2168, #2170, #2171, #2173) | 4 | 0.5 |
+
+---
+
+## 3. Prioritized immediate queue
+
+Value anchor: the co-owner's directives this block — *"resolve the gaps at root cause"*,
+*"I dont want to waste cycles"* — i.e. fix causes, not symptoms, and do not re-pay for
+the same discovery twice.
+
+1. **Sweep-5 orphan corpus (52 orphans / 18 coverage gaps).** Highest yield and newly
+   visible. Concentrated in ML specs: `ml-feature-store` (8/1), `ml-tracking` (7/3),
+   `ml-engines-v2` (6/1), `ml-registry` (5/0). An orphan is a spec promising a symbol
+   the source does not have — the `orphan-detection.md` § 1 class.
+2. **#2141 / #2142 un-gated HTTP surfaces.** #2141 is blocked on the `--auth` semantics
+   decision (§ 5 D1), not on implementation.
+3. **loom#1826 / loom#1827** — filed upstream, awaiting loom. Nothing for this repo to do.
+4. **#2199** — local tracker for the Gate-2 defect; closes when a clean re-emit verifies.
+
+---
+
+## 4. Sweep results
+
+**Sweep 4 — branch enumeration (unfiltered; `--no-merged` used only as a ranker).**
+4 remote refs, of which 2 survive `--no-merged`; the 1 the filter would have hidden is a
+candidate, not a non-finding. No `worktree-agent-*` harness orphans. Remaining non-main
+remote refs: `docs/notes-cont18-execution` (superseded), `fix/2070-logging-hook-redaction-defeat`
+(superseded by #2101). **169 local branches**, 1 worktree (the main checkout).
+
+**Sweep 5 — repo-level-specs mode, option (a) genuinely run.**
+`spec_count=0` (no `workspaces/*/specs`) AND `specs/` exists → repo-level mode.
+`spec-corpus-conformance.mjs` is absent here, but `tools/sweep-redteam.py` accepts a
+repo-level spec path, so option (a) was runnable and was run over all 85 specs:
+
+```
+spec files scanned : 85 / 85
+MUST symbols found : 162
+orphans            : 52
+coverage_gaps      : 18
+stubs              : 0
+```
+
+**Tooling finding, and it is the reason this was never seen before:** invoking the tool
+as documented — `tools/sweep-redteam.py --all` — returns
+`<!-- sweep-redteam:v1:OK specs=0 symbols=0 orphans=0 coverage_gaps=0 stubs=0 -->` on
+this repo, because `--all` scans `workspaces/*/specs/**/*.md`, which is empty here. A
+`specs=0 ... OK` sentinel is a **vacuous green**: it reports the same value whether the
+corpus is clean or unexamined. That is the § 6a failure mode wearing the tool's own OK
+sentinel, and it is why the 52 orphans sat unreported.
+
+**Sweep-N — deferred-quality backlog: EMPTY.** `gh issue list --label deferred-quality`
+returns nothing; no revisit gates fire.
+
+**Closure step 2 — unadjudicated-escalation:** `threshold=3 runs=43 keys=0 escalations=0`.
+No standing `manual-supplement-required` streak.
+
+---
+
+## 5. Decision points
+
+**D1 — #2141: what does `--auth` mean?** Recommend making it a require-authentication
+switch wired to the shared `resolve_server_auth` helper. *Pro:* it is the only reading
+under which the CLI's own refusal message is true, and it reuses the gate 8 core servers
+already use. *Con, real:* dependency floor rises `kailash>=2.31.0` → `>=2.63.0`; it
+changes behaviour on a released CLI (`--host 0.0.0.0 --auth x` currently serves openly
+and would then refuse without a credential); and it needs a kailash-ml release to reach
+users. Spec §8.3 cannot settle it — two of its claims are false against the code.
+
+**D2 — #2194: governance API actor schema.** No per-principal identity exists to derive
+a grantor from (`verify_token` returns the constant `"authenticated"`). Three options in
+the issue. *Recommendation: you specify; guessing ships a wrong authz check.*
+
+**D3 — `mcp_channel.py:961`.** `len(registry) >= 0` can never report unhealthy; siblings
+use `> 0`. *Pro of fixing:* removes a check that cannot discriminate. *Con:* a tools-only
+MCP channel would start reporting unhealthy, which may be correct for that channel.
+
+**D4 (NEW) — the Sweep-5 orphan corpus.** 52 orphans + 18 coverage gaps, ML-concentrated.
+*Pro of taking it now:* it is the largest correctness surface open and newly measured.
+*Con:* an orphan can mean either "source is missing the symbol" or "spec over-promised" —
+the tool cannot adjudicate which, so each needs a judgment call. Recommend a scoped first
+pass on `ml-feature-store` + `ml-tracking` (15 orphans, 4 gaps) to establish the ratio
+before committing to all 70.
+
+**D5 — 169 local branches** (carried from cont-20 D3, unchanged). Recommend: leave;
+audit as a separately scoped task.
+
+---
+
+## 6. Recommendation
+
+1. **Ratify D1 and D2** — both are blocked on a schema decision, not on work.
+2. **Take D4's scoped first pass** (`ml-feature-store` + `ml-tracking`) to measure the
+   spec-over-promised vs source-missing ratio before sizing the rest.
+3. **Watch the next loom sync** for the Gate-2 regression: on the next sync branch,
+   `git ls-tree -r --name-only <branch> -- codex gemini` must be empty. Checking that
+   `.codex/` is populated will NOT catch it — it was populated throughout the incident.
+
+**The pattern worth carrying from this block:** three separate things reported success
+without having measured anything — a Gate-2 sync that "delivered" 38 artifacts to paths
+no CLI reads, a `--all` sweep that returned OK over zero specs, and a rule governing
+push-time that can never load at push time. Each was individually plausible and each
+required asking the same question: *what result would this produce if the thing it
+checks were false?*

--- a/workspaces/issue-1720-llm-consolidation/sweep-cont21-report.md
+++ b/workspaces/issue-1720-llm-consolidation/sweep-cont21-report.md
@@ -67,7 +67,10 @@ the same discovery twice.
    the source does not have — the `orphan-detection.md` § 1 class.
 2. **#2141 / #2142 un-gated HTTP surfaces.** #2141 is blocked on the `--auth` semantics
    decision (§ 5 D1), not on implementation.
-3. **loom#1826 / loom#1827** — filed upstream, awaiting loom. Nothing for this repo to do.
+3. **loom#1826** — filed upstream, awaiting loom. Nothing for this repo to do.
+   (A second filing, loom#1827, was withdrawn the same session: it duplicated loom's already
+   shipped T4 fix and repeated an over-claim loom had already narrowed. Recorded in the notes
+   as a trap rather than quietly deleted.)
 4. **#2199** — local tracker for the Gate-2 defect; closes when a clean re-emit verifies.
 
 ---


### PR DESCRIPTION
Closes out cont-21. Docs-only; no source or test changes.

**The load-bearing finding is in the sweep report § 4.** Sweep 5 was run correctly for the first time on this repo shape. The tool's documented invocation — `tools/sweep-redteam.py --all` — returns `<!-- sweep-redteam:v1:OK specs=0 symbols=0 orphans=0 coverage_gaps=0 stubs=0 -->` here, because `--all` scans `workspaces/*/specs/**/*.md` and this repo's spec authority is at repo-root `specs/`. A `specs=0 … OK` sentinel returns the same value whether the corpus is clean or unexamined, which is why the corpus had never been reported.

Pointed at each of the 85 repo-level specs explicitly:

```
spec files scanned : 85 / 85
MUST symbols found : 162
orphans            :  52
coverage_gaps      :  18
stubs              :   0
```

Concentrated in ML specs — `ml-feature-store` (8/1), `ml-tracking` (7/3), `ml-engines-v2` (6/1), `ml-registry` (5/0). Recorded as decision point D4 with a scoped first pass recommended, because an orphan can mean either the source is missing the symbol or the spec over-promised, and the tool cannot adjudicate which.

Notes are written under the new wrapup contract that arrived in this sync: next-session directives are imperative, capped at 5, and each carries the command that tells a future session whether it is still true; the in-play inventory judges durability by `git cherry` content rather than ahead-count, and states plainly that the at-risk set was written from memory and not measured.

Sweep 4 enumerated unfiltered, using `--no-merged` only as a ranker. Sweep-N: deferred-quality backlog empty. Closure step 2: `threshold=3 runs=43 keys=0 escalations=0`.

## Related issues

Refs #2199

PCF-Category: INCREMENTAL

Rationale for the category: docs-only close-out (sweep decision report + session notes). It blocks no testing or closure of an in-scope item and no shipped path depends on it. I considered INVEST-NOW — the notes carry the directive that stops a broken loom sync being re-merged — but routing a docs close-out into the judgment bucket that needs co-owner direction would inflate it rather than classify it.

Three follow-up commits on this branch correct the record rather than amend it, per `git.md` § Discipline: `e0271dd4b` over-claimed that a ledger row was kept when the diff deleted it, `fabeb9704` corrected that but quoted a diff line the shell had command-substituted (backticks inside a double-quoted `-m`), and `4cf98c71d` restores the correct quote and records the root cause. All three are in `git log --grep` deliberately.