### PR TITLE
fix(docker): converge four ollama stacks on one volume, free 11434, make health mean "models present" (#2201)

### DIFF
--- a/docker/docker-compose.sdk-dev.yml
+++ b/docker/docker-compose.sdk-dev.yml
@@ -144,16 +144,17 @@ services:
     image: ollama/ollama:latest
     container_name: kailash-sdk-ollama
     volumes:
-      - sdk_ollama_models:/root/.ollama
+      - kailash_ollama_models:/root/.ollama
     ports:
-      - "11434:11434"
+      - "11437:11434"
     environment:
       OLLAMA_KEEP_ALIVE: 24h
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD-SHELL", "ollama list 2>/dev/null | grep -q 'llama3.2:1b' || exit 1"]
+      interval: 15s
+      timeout: 10s
       retries: 5
+      start_period: 600s
     restart: unless-stopped
     # Pull a small model on startup
     entrypoint: ["/bin/sh", "-c"]
@@ -241,8 +242,8 @@ volumes:
     name: kailash_sdk_zookeeper_logs
   sdk_kafka_data:
     name: kailash_sdk_kafka_data
-  sdk_ollama_models:
-    name: kailash_sdk_ollama_models
+  kailash_ollama_models:
+    name: kailash_ollama_models
 
 networks:
   default:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -92,16 +92,17 @@ services:
     image: ollama/ollama:latest
     container_name: kailash-ollama
     volumes:
-      - ollama_models:/root/.ollama
+      - kailash_ollama_models:/root/.ollama
     ports:
-      - "11434:11434"
+      - "11436:11434"
     environment:
       OLLAMA_KEEP_ALIVE: 24h
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD-SHELL", "ollama list 2>/dev/null | grep -q 'nomic-embed-text' || exit 1"]
+      interval: 15s
+      timeout: 10s
       retries: 5
+      start_period: 600s
     restart: unless-stopped
     # Pull models needed for testing and examples
     entrypoint: ["/bin/sh", "-c"]
@@ -263,7 +264,7 @@ volumes:
     name: kailash_mongo_data
   qdrant_data:
     name: kailash_qdrant_data
-  ollama_models:
+  kailash_ollama_models:
     name: kailash_ollama_models
   admin_postgres_data:
     name: kailash_admin_postgres_data

--- a/tests/test-environment/docker-compose.yml
+++ b/tests/test-environment/docker-compose.yml
@@ -76,15 +76,27 @@ services:
     ports:
       - "11435:11434"
     volumes:
-      - ollama_models:/root/.ollama
+      - kailash_ollama_models:/root/.ollama
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_MODELS=/root/.ollama/models
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:11434/api/version || exit 1"]
-      interval: 30s
+      test: ["CMD-SHELL", "ollama list 2>/dev/null | grep -q 'llama3.2:3b' || exit 1"]
+      interval: 15s
       timeout: 10s
       retries: 5
+      start_period: 600s
+    # Pull the model the tests reference before reporting healthy. Without this the
+    # test stacks start an EMPTY ollama: /api/tags and /api/version both answer 200
+    # with zero models, so the old healthcheck reported healthy in exactly the state
+    # that makes every LLM-dependent test vacuous (#2201).
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "ollama serve &
+       sleep 5 &&
+       ollama pull llama3.2:1b &&
+       ollama pull llama3.2:3b &&
+       wait"
     networks:
       - kailash-test-network
 
@@ -266,7 +278,8 @@ volumes:
   postgres_test_data:
   mysql_test_data:
   mongodb_test_data:
-  ollama_models:
+  kailash_ollama_models:
+    name: kailash_ollama_models
   qdrant_test_data:
   minio_test_data:
   elasticsearch_data:

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -19,7 +19,7 @@ TEST_DB_CONFIG = {
 
 # Ollama configuration
 OLLAMA_CONFIG = {
-    "host": os.getenv("OLLAMA_HOST", "http://localhost:11434"),
+    "host": os.getenv("OLLAMA_HOST", "http://localhost:11435"),
     "model": os.getenv("OLLAMA_MODEL", "llama3.2:1b"),
 }
 

--- a/tests/utils/docker-compose.test.yml
+++ b/tests/utils/docker-compose.test.yml
@@ -59,14 +59,26 @@ services:
     ports:
       - "11435:11434"
     volumes:
-      - kailash_sdk_ollama_models:/root/.ollama
+      - kailash_ollama_models:/root/.ollama
     environment:
       - OLLAMA_MODELS=/root/.ollama/models
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:11434/api/tags || exit 1"]
-      interval: 30s
+      test: ["CMD-SHELL", "ollama list 2>/dev/null | grep -q 'llama3.2:3b' || exit 1"]
+      interval: 15s
       timeout: 10s
-      retries: 3
+      retries: 5
+      start_period: 600s
+    # Pull the model the tests reference before reporting healthy. Without this the
+    # test stacks start an EMPTY ollama: /api/tags and /api/version both answer 200
+    # with zero models, so the old healthcheck reported healthy in exactly the state
+    # that makes every LLM-dependent test vacuous (#2201).
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "ollama serve &
+       sleep 5 &&
+       ollama pull llama3.2:1b &&
+       ollama pull llama3.2:3b &&
+       wait"
     deploy:
       resources:
         limits:
@@ -149,7 +161,8 @@ volumes:
   kailash_sdk_postgres_data:
   kailash_sdk_mysql_data:
   kailash_sdk_mongodb_data:
-  kailash_sdk_ollama_models:
+  kailash_ollama_models:
+    name: kailash_ollama_models
 
 networks:
   default:


### PR DESCRIPTION
Resolves #2201. Every structural claim in the issue re-derives against current `main` — but two of them are wrong in ways that change the fix, so both are corrected below rather than implemented as written.

PCF-Category: BUG

## Correction 1 — the volume table lists compose ALIASES, not real volumes

Resolved with `docker compose config` rather than read off the YAML, because `name:` keys and project prefixing rename two of the four:

| file | container_name | port | **real** volume |
|---|---|---|---|
| `docker/docker-compose.yml` | `kailash-ollama` | 11434 | `kailash_ollama_models` |
| `docker/docker-compose.sdk-dev.yml` | `kailash-sdk-ollama` | 11434 | `kailash_sdk_ollama_models` |
| `tests/utils/docker-compose.test.yml` | `kailash_sdk_test_ollama` | 11435 | **`utils_kailash_sdk_ollama_models`** |
| `tests/test-environment/docker-compose.yml` | `kailash_sdk_test_ollama` | 11435 | **`kailash_sdk_ollama_models`** |

`tests/utils` has no `name:` and no project name, so compose prefixes it with the directory (`utils`). `tests/test-environment` sets `name: kailash_sdk`, which makes its `ollama_models` alias resolve to `kailash_sdk_ollama_models` — **already sharing with `docker-compose.sdk-dev.yml`**. That sharing is invisible in the source and is why renaming either one in isolation would have orphaned the other's models.

## Correction 2 — the healthchecks never reported healthy, they reported 127

The issue's point 5 says `/api/tags` and `/api/version` "both return success on an ollama with zero models". Not in this image. Measured against a real `ollama/ollama:latest` container:

```
is curl present?     (no output — not installed)
is wget present?     (no output — not installed)
ollama CLI reaches the server: YES
shipped healthcheck: sh: 1: curl: not found  -> exit=127
```

So the shipped healthcheck could never pass — the container reported **unhealthy forever**, not healthy-while-empty. The conclusion the issue drew is still right (the check distinguished nothing), but the mechanism is the opposite, and it matters: a check that always fails is inert here only because every `depends_on` uses the short list form and waits for *started*, not *healthy*.

## Correction 3 — the volume split is not why the test ollama was empty

Neither test compose file had a model-pull step at all. Only the two `docker/` files pull. A test-only workflow would have started an empty ollama no matter how the volumes were named, so unifying the volume alone would not have fixed this.

## Changes

1. **One volume** — `kailash_ollama_models`, with an explicit `name:` in all four files so project prefixing cannot split it again.
2. **11434 freed** for a native `ollama serve`; dev stacks move to 11436 / 11437, ending the bind collision between the two `docker/` files.
3. **Test stacks keep 11435** — load-bearing, hardcoded in `tests/conftest.py`, `tests/docker_infrastructure.py`, `tests/config_unified.py`, `tests/utils/setup_local_docker.py`.
4. **Both test stacks now pull models** (`llama3.2:1b` + `llama3.2:3b` — `tests/config_unified.py` resolves ollama at 11435 and names both).
5. **Healthchecks gate on the LAST model pulled**, so healthy implies all of them are present, not just the first.
6. **`tests/utils/config.py`** defaulted `OLLAMA_HOST` to 11434 while every other test surface uses 11435. Fixed — found while re-deriving, not in the issue.

## Declining point 3 of the issue, deliberately

The two test files keep the same `container_name`. Now that they share a volume, that name is what prevents two ollama servers writing one model store concurrently. Making the names unique would let both start and then collide on port 11435 — or worse, if ports were also split, run two servers against one volume. Failing fast on the name is the safer behaviour, and it is more important after this change than before it. Happy to revisit if you'd rather consolidate the two test stacks into one (issue point 4), which is the real fix for having two at all.

## Verification

New healthcheck proven to discriminate, against a real empty ollama:

```
models present: 0
  shipped /api/version -> exit 1   (127: curl absent)
  shipped /api/tags    -> exit 1   (127: curl absent)
  model-presence check -> exit 1   correctly refuses to report healthy
  CONTROL, model listed -> exit 0   so the check is not simply always-failing
```

The control is the part that matters: without it, "the new check fails on an empty ollama" is equally consistent with a check that can never pass.

All four files parse (`docker compose config -q`), with a deliberately malformed file as a negative control confirming the validator rejects bad input.

**Not verified:** I did not run a full `up` to completion — that pulls ~3.3 GB per stack. The pull commands follow the same shape already proven in `docker/docker-compose.yml`.