### PR TITLE
fix(tools): resolve sweep-redteam's two scan blindspots — 70 findings, 48 were noise

### DIFF
--- a/tests/unit/tools/test_sweep_redteam.py
+++ b/tests/unit/tools/test_sweep_redteam.py
@@ -335,3 +335,107 @@ def test_sentinel_field_shape_matches_spec(tmp_path, monkeypatch):
         "orphans=0 coverage_gaps=0 stubs=0 -->"
     )
     assert sentinel == expected
+
+
+# --- Resolution-blindspot regressions ---------------------------------------
+# Both cases below reported a finding before the multi-root / class-index fix
+# and MUST NOT report one after it. Each is paired with a negative control in
+# the same class so the fix cannot pass by suppressing findings wholesale.
+
+
+def test_tier2_coverage_found_in_package_test_root(tmp_path, monkeypatch):
+    """A package-local Tier-2 suite counts as coverage.
+
+    Before the fix `has_tier2_coverage` scanned only the repo-root
+    `tests/integration/` tree, so a symbol covered by
+    `packages/<pkg>/tests/integration/` was reported as a `coverage_gap`.
+    """
+    spec_body = "# Spec\nEvery request MUST route through `myapp.gateway.Router`.\n"
+    source = "class Router:\n    def dispatch(self, request):\n        return request\n"
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"packages/pkg-a/src/myapp/gateway.py": source},
+        integration_tests={},
+    )
+    pkg_tests = tmp_path / "packages" / "pkg-a" / "tests" / "integration"
+    pkg_tests.mkdir(parents=True, exist_ok=True)
+    (pkg_tests / "test_gateway.py").write_text(
+        "from myapp.gateway import Router\n\n\ndef test_router():\n    assert Router\n",
+        encoding="utf-8",
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert findings == [], findings
+    assert exit_code == 0
+    parsed = _parse_sentinel(sentinel)
+    assert parsed["coverage_gaps"] == 0
+    assert parsed["orphans"] == 0
+
+
+def test_class_member_citation_resolves_via_class_index(tmp_path, monkeypatch):
+    """`ClassName.member` names no module but MUST still resolve.
+
+    Covers a plain method AND an annotated dataclass field — the latter is
+    how every dataclass attribute is spelled, and omitting `ast.AnnAssign`
+    was the single largest false-positive source in the live corpus.
+    """
+    spec_body = (
+        "# Spec\n"
+        "The dispatcher MUST expose `Router.dispatch`.\n"
+        "The schema MUST carry `FeatureField.dtype`.\n"
+    )
+    source = (
+        "import dataclasses\n\n\n"
+        "class Router:\n"
+        "    def dispatch(self, request):\n"
+        "        return request\n\n\n"
+        "@dataclasses.dataclass(frozen=True)\n"
+        "class FeatureField:\n"
+        "    name: str\n"
+        "    dtype: str\n"
+    )
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"src/myapp/gateway.py": source},
+        integration_tests={
+            "test_gateway.py": "from myapp.gateway import Router, FeatureField\n"
+        },
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert findings == [], findings
+    assert exit_code == 0
+    assert _parse_sentinel(sentinel)["orphans"] == 0
+
+
+def test_class_member_citation_absent_member_still_orphans(tmp_path, monkeypatch):
+    """Negative control for the class-index resolver.
+
+    The resolver MUST discriminate member-by-member: a real class missing the
+    cited member, and an entirely absent class, both stay orphans. Without
+    this, the fix above could pass by suppressing every `ClassName.member`.
+    """
+    spec_body = (
+        "# Spec\n"
+        "The dispatcher MUST expose `Router.never_implemented`.\n"
+        "The registry MUST expose `NoSuchClass.member`.\n"
+    )
+    source = "class Router:\n    def dispatch(self, request):\n        return request\n"
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"src/myapp/gateway.py": source},
+        integration_tests={"test_gateway.py": "from myapp.gateway import Router\n"},
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert exit_code == 1
+    symbols = sorted(f["symbol"] for f in findings)
+    assert symbols == ["NoSuchClass.member", "Router.never_implemented"], findings
+    assert all(f["category"] == "orphan" for f in findings), findings
+    assert _parse_sentinel(sentinel)["orphans"] == 2

--- a/tools/sweep-redteam.py
+++ b/tools/sweep-redteam.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import functools
 import json
 import re
 import sys
@@ -346,6 +347,104 @@ def _source_roots() -> list[Path]:
     return roots
 
 
+def _iter_source_files() -> Iterator[Path]:
+    """Every `.py` under every import root, `__pycache__` excluded."""
+    for root in _source_roots():
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
+
+@functools.lru_cache(maxsize=1)
+def _class_index() -> dict[str, tuple[tuple[Path, int], ...]]:
+    """Map every top-level-or-nested ClassDef name → the sites defining it.
+
+    Built once per process by AST-parsing every source file. This exists so a
+    spec citation of the shape `ClassName.member` — which names no module and
+    therefore resolves to zero candidate FILES — can still be verified
+    structurally instead of being reported as an orphan by default.
+    """
+    index: dict[str, list[tuple[Path, int]]] = {}
+    for path in _iter_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, ValueError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                index.setdefault(node.name, []).append((path, node.lineno))
+    return {k: tuple(v) for k, v in index.items()}
+
+
+def _class_defines_member(path: Path, class_name: str, member: str) -> int | None:
+    """Return the line number where `class_name` defines `member`, else None.
+
+    Walks the class body for methods, nested classes, plain assignments AND
+    annotated assignments — the last of these is how every dataclass field
+    (`dtype: str`, `fields: tuple[...]`) is spelled, so omitting it would
+    mis-report every dataclass attribute a spec cites.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, ValueError):
+        return None
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.ClassDef) and node.name == class_name):
+            continue
+        for stmt in node.body:
+            if (
+                isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+                and stmt.name == member
+            ):
+                return stmt.lineno
+            if isinstance(stmt, ast.AnnAssign):
+                tgt = stmt.target
+                if isinstance(tgt, ast.Name) and tgt.id == member:
+                    return stmt.lineno
+            if isinstance(stmt, ast.Assign):
+                for tgt in stmt.targets:
+                    if isinstance(tgt, ast.Name) and tgt.id == member:
+                        return stmt.lineno
+    return None
+
+
+def _module_for_path(path: Path) -> str:
+    """Dotted module name for a source file, relative to its import root."""
+    for root in _source_roots():
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        parts = list(rel.parts)
+        if parts and parts[-1] == "__init__.py":
+            parts = parts[:-1]
+        elif parts:
+            parts[-1] = parts[-1][:-3] if parts[-1].endswith(".py") else parts[-1]
+        return ".".join(parts)
+    return ""
+
+
+def resolve_class_member(symbol: str) -> tuple[Path, int] | None:
+    """Resolve a `ClassName.member[.rest]` citation against the class index.
+
+    Returns the (path, lineno) of the member definition, or None when either
+    the class or the member is genuinely absent — the latter is a REAL orphan
+    and MUST keep reporting as one.
+    """
+    parts = symbol.split(".")
+    if len(parts) < 2:
+        return None
+    class_name, member = parts[0], parts[1]
+    if not class_name[:1].isupper():
+        return None
+    for path, _cls_line in _class_index().get(class_name, ()):
+        line = _class_defines_member(path, class_name, member)
+        if line is not None:
+            return (path, line)
+    return None
+
+
 def _dotted_path_is_module(symbol: str) -> bool:
     """True if the FULL dotted path names an importable module or package on disk.
 
@@ -598,6 +697,30 @@ def verify_symbol(symbol: SpecSymbol) -> list[Finding]:
         # `.register`, `.changed`), so the CapWords-tail carve-out preserves the
         # false-positive suppression while restoring genuine missing-symbol drift.
         root = symbol.name.split(".")[0]
+        # A `ClassName.member` citation names no MODULE, so it resolves to zero
+        # candidate files. Resolve it against the class index before concluding
+        # drift — otherwise every dataclass field a spec cites reads as an
+        # orphan while being present in source.
+        member_hit = resolve_class_member(symbol.name)
+        if member_hit is not None:
+            hit_path, hit_line = member_hit
+            hit_rel = str(hit_path.relative_to(ROOT))
+            hit_module = _module_for_path(hit_path)
+            if hit_module and not has_tier2_coverage(f"{hit_module}.{tail}"):
+                return [
+                    Finding(
+                        category="coverage_gap",
+                        symbol=symbol.name,
+                        spec=str(symbol.spec_path.relative_to(ROOT)),
+                        spec_line=symbol.spec_line,
+                        source=f"{hit_rel}:{hit_line}",
+                        evidence=(
+                            f"no Tier-2 integration test imports module "
+                            f"{hit_module} (resolved via class index)"
+                        ),
+                    )
+                ]
+            return []
         if (
             root[:1].islower()
             and not root.startswith(_KAILASH_FAMILY_PREFIXES)
@@ -679,34 +802,58 @@ def verify_symbol(symbol: SpecSymbol) -> list[Finding]:
     return findings
 
 
+def _test_roots() -> list[Path]:
+    """Every Tier-2 test root: `tests/integration/` plus each
+    `packages/*/tests/integration/`.
+
+    Mirrors `_source_roots()`. The single-root form this replaced scanned
+    only the repo-root tree, so every package that keeps its own Tier-2
+    suite (kailash-ml alone has 82 files there) was invisible and every
+    symbol it covered was reported as a `coverage_gap`.
+    """
+    roots: list[Path] = []
+    root_tests = ROOT / "tests" / "integration"
+    if root_tests.is_dir():
+        roots.append(root_tests)
+    pkg_dir = ROOT / "packages"
+    if pkg_dir.is_dir():
+        for pkg in sorted(pkg_dir.iterdir()):
+            cand = pkg / "tests" / "integration"
+            if cand.is_dir():
+                roots.append(cand)
+    return roots
+
+
 def has_tier2_coverage(symbol_name: str) -> bool:
-    """Return True if any tests/integration/**/*.py imports the module."""
+    """Return True if any Tier-2 integration test imports the module.
+
+    Scans EVERY root from `_test_roots()`, not just the repo-root tree.
+    """
     module_path = ".".join(symbol_name.split(".")[:-1])
     if not module_path:
         return False
-    tests_root = ROOT / "tests" / "integration"
-    if not tests_root.is_dir():
+    roots = _test_roots()
+    if not roots:
         return False
     # Build the structural import-line patterns:
     #   "from <module>" / "import <module>"
     # Use plain substring search per-file — fast, deterministic, scans bytes.
     import_needle_from = f"from {module_path}".encode()
     import_needle_imp = f"import {module_path}".encode()
-    for path in tests_root.rglob("*.py"):
-        try:
-            data = path.read_bytes()
-        except OSError:
-            continue
-        if import_needle_from in data or import_needle_imp in data:
-            return True
-        # Also accept the parent module (sub-pkg convention shifts the path)
-        parent = ".".join(module_path.split(".")[:-1])
-        if parent:
-            if (
-                f"from {parent}".encode() in data
-                and module_path.split(".")[-1].encode() in data
-            ):
+    parent = ".".join(module_path.split(".")[:-1])
+    tail_needle = module_path.split(".")[-1].encode()
+    for tests_root in roots:
+        for path in tests_root.rglob("*.py"):
+            try:
+                data = path.read_bytes()
+            except OSError:
+                continue
+            if import_needle_from in data or import_needle_imp in data:
                 return True
+            # Also accept the parent module (sub-pkg convention shifts the path)
+            if parent:
+                if f"from {parent}".encode() in data and tail_needle in data:
+                    return True
     return False
 
 


### PR DESCRIPTION
## Summary

The Sweep-5 corpus has been carried as **\"52 orphans / 18 coverage gaps\"** across three sweep blocks and sits on the outstanding ledger as `sweep5-orphans`. Sampling the two specs the cont-22 report recommended (`ml-feature-store`, `ml-tracking`) and hand-verifying each finding against source showed **16 of 19 were false positives** — produced by two mechanical defects in the scanner, not by drift in the specs.

Measured over all 85 specs, per-spec (the `--all` form scans `workspaces/*/specs`, empty here, and returns a vacuous `OK` — see Traps):

| | findings | orphan | coverage_gap |
|---|---|---|---|
| before | 70 | 52 | 18 |
| after | **22** | 22 | **0** |

`removed=48, newly-reported=0`.

## The two defects

**1. The Tier-2 coverage scan read one test root.** `has_tier2_coverage` hardcoded `<root>/tests/integration`. This repo has **nine** integration-test roots; the other eight are `packages/*/tests/integration`. kailash-ml keeps all 82 of its Tier-2 tests there, so every ML symbol they cover read as uncovered. `_source_roots()` already mirrored `packages/*/src` for source resolution — the test side never got the same treatment, and that asymmetry is the whole bug. **All 18 coverage gaps were this.**

**2. `ClassName.member` citations resolved to zero candidate files.** A citation naming no module (`FeatureField.dtype`) made the resolver look for a *module* named `FeatureField` and report an orphan. The code documented this as deliberate, premised on the tool being unable to resolve a class as a module — the intent being to avoid silently suppressing genuine contracts. That intent is better served by resolving the citation than by defaulting it to a finding. Adds an AST class index (built once) that walks the class body for methods, nested classes, plain assignments, and **annotated** assignments — `AnnAssign` matters most, being how every dataclass field is spelled.

## What this deliberately does not do

Resolution is **member-by-member**, so it cannot pass by blanket suppression. A real class missing the cited member, and an absent class, both still orphan. A resolved member's coverage is checked against the module derived from the file it resolved in — checking it against the class name would have traded these false positives for a fresh crop of coverage gaps.

Left visible in the remaining 22, as spec-citation questions rather than scanner defects: negative MUSTs (\"X MUST be DELETED\") still orphan when correctly absent; citations naming a DB table (`_kml_run.device_used`) or dropping a subpackage (`dataflow.transform` for `dataflow.ml.transform`) still report. Folding these into the scanner would start suppressing real contracts.

## The 22 that remain are real

Three were confirmed by hand in the sample:

- **`TrackerMCPServer`** — spec §11.1 MUST; no `kailash_ml/tracker/` package exists. Unimplemented.
- **`SQLiteStorageDriver`** — spec §2.3 mandates `kailash_ml._storage.sqlite_driver`; the implementation shipped as `tracking.storage.sqlite.SqliteTrackerStore`. Spec stale.
- **`diff_runs`** — spec §5.3 requires it module-level at `engines.experiment_tracker`; it ships as an async method on the tracker, and `km.diff_runs` is not exported. (The spec's own Origin note already conceded \"grep currently empty\".)

## Tests

Three regression tests, each paired with a control so a suppressing \"fix\" fails them: package-local Tier-2 coverage; class-member resolution across a method **and** a dataclass field; and absent-member/absent-class, which must keep orphaning.

Verified the first two **fail against the pre-fix tool** — a green suite here would otherwise prove nothing. Full suite 13/13; pre-commit clean.

## Related issues

Refs #1129

PCF-Category: BUG
