### PR TITLE
fix(ci): collapse duplicate push/PR runs, and make job fan-out a declared act

### DIFF
--- a/.claude/rules/ci-job-budget.md
+++ b/.claude/rules/ci-job-budget.md
@@ -1,0 +1,191 @@
+---
+priority: 10
+scope: path-scoped
+paths:
+  - "**/.github/workflows/**"
+  - "**/scripts/ci/job_budget_audit.py"
+  - "**/scripts/ci/job-budget.d/**"
+  - "**/.pre-commit-config.yaml"
+---
+
+# CI Job Budget — Adding A Job Is A Declared Act, Never An Unremarked One
+
+CI jobs accrete one unremarkable job at a time. Each addition is individually
+defensible; nothing says anything at the moment each is added; and the fan-out is
+discovered only when the queue is full or the bill arrives. The defect is not any
+one job — it is that **no surface makes the accretion visible at the moment it
+happens**.
+
+Measured in this repo on PR #2205 (2026-08-21): **25 runner-consuming jobs**
+across 5 workflow runs, of which **3** gate anything. Nine of the 25 were an exact
+duplicate of another nine — one workflow ran twice on the identical SHA, and the
+failing copy read as a real break until both runs were compared.
+
+The census is `scripts/ci/job_budget_audit.py`, declared by
+`scripts/ci/job-budget.d/_meta.json`, and it runs as a **pre-commit** hook on
+workflow edits. It is deliberately NOT a CI job: a gate about runner fan-out that
+itself consumes a runner on every PR would be self-defeating.
+
+## MUST Rules
+
+### 1. A Workflow Triggered By BOTH `push` And `pull_request` MUST Share One Concurrency Group Across The Two Events
+
+A workflow reachable from both events MUST declare a `concurrency.group` that
+resolves to the **same value** for a push and a pull_request on the same branch.
+A group interpolating `github.run_id` / `github.run_number` / `github.sha`, or
+falling back off `pull_request.number` to anything that is not the branch, is
+BLOCKED — it puts every push run in its own private group, so the run is never
+deduplicated against the PR run for the same commit, nor against an earlier push
+to the same branch.
+
+```yaml
+# DO — resolves to the branch on BOTH events, so the two runs collapse
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+# DO NOT — `pull_request.number` is empty on push, so this falls back to
+# `run_id`, which is unique per run: the group can never match anything
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+```
+
+**BLOCKED rationalizations:** "`cancel-in-progress: true` is already set, so
+duplicates are handled" (the flag is armed; the key defeats it) / "the two runs
+test different refs, so both are meaningful" (they ran the identical 9 jobs on the
+identical SHA) / "`run_id` guarantees uniqueness, which is what a group key wants"
+(a concurrency key wants COLLISION — uniqueness is the anti-goal) / "it has always
+been that way and CI is green" / "only one of them is required, the other is
+harmless".
+
+**Why:** `cancel-in-progress` cannot fire on a group that never collides, so the
+armed machinery reads as protection while providing none — and the duplicate is
+not merely wasted spend: when the two copies disagree, the failing one is
+indistinguishable from a real regression until someone compares runs by SHA.
+
+### 2. A New PR-Reachable Job Is Declared, Gated, Or Budgeted — Never Silent
+
+A job added to a `pull_request`-triggered workflow MUST be one of: a branch-
+protection **required context**; **`paths:`-gated** so it fires only on relevant
+diffs; or carry a **dated budgeted exemption** in
+`scripts/ci/job-budget.d/_meta.json` naming why it runs ungated and when that is
+revisited. Adding a job that is none of the three is BLOCKED.
+
+```json
+// DO — budgeted, with a reason and an expiry that will actually fire
+{ "workflow": "project-automation.yml", "jobs": 5,
+  "reason": "Board bookkeeping; every job is `if:`-gated and skips on ordinary PRs.",
+  "declared_on": "2026-08-21", "revisit_on": "2027-02-21" }
+
+// DO NOT — a job that runs on every PR, gates nothing, and is written down nowhere
+```
+
+**BLOCKED rationalizations:** "it is one small job" (the failure mode is
+accretion, so every instance is one small job) / "we will gate it later" /
+"it is fast, so it does not count" (it still occupies a runner slot) / "the
+exemption list is bureaucracy" / "I will add the `paths:` filter in a follow-up".
+
+**Why:** The per-addition cost is always defensible and the aggregate never gets
+examined, so the only place accretion can be caught is the moment of addition —
+which is exactly where nothing was looking.
+
+### 3. The Ceiling Is A RATCHET, And A Breach Is Reported, Never Silently Raised
+
+`per_pr_job_ceiling` is set just above the measured baseline so it fires on
+GROWTH. Raising it to clear a breach requires a dated rationale in the
+declaration; editing the number to make the gate quiet is BLOCKED. A ceiling
+breach names the count and the ceiling — it never merely says "over budget".
+
+**Why:** A ceiling silently raised to match reality measures nothing; the ratchet
+only works if crossing it costs a written justification.
+
+## MUST NOT
+
+- Interpolate a per-run-unique value into a concurrency group key
+
+**Why:** It guarantees the group never collides, which is the one thing a
+concurrency group exists to do.
+
+- Read a green `job_budget_audit.py` run as evidence the CI surface is healthy
+  without checking the advisory notes
+
+**Why:** Freeloader jobs are reported at `note` severity and exit 0 by design;
+treating exit 0 as "nothing to see" discards the rule's entire advisory tier.
+
+- Add the census itself as a CI job
+
+**Why:** A fan-out gate that consumes a runner on every PR pays the cost it
+exists to prevent; pre-commit fires exactly when a workflow is edited, for free.
+
+## Trust Posture Wiring
+
+- **Severity:** `block` at the pre-commit layer for MUST-1 and MUST-3 — both are
+  STRUCTURAL facts read off the workflow YAML and the declaration (a group key
+  either interpolates a per-run token or it does not; a count either exceeds a
+  declared integer or it does not), which is the narrow class
+  `hook-output-discipline.md` MUST-2 reserves `block` for. MUST-2's freeloader
+  arm is `advisory` — whether an ungated job is legitimate is a judgment, and
+  adding a CI job is a legitimate act. `halt-and-report` at gate-review (reviewer
+  at `/implement` + cc-architect at `/codify` confirm a new PR-reachable job was
+  required, `paths:`-gated, or budgeted).
+- **Grace period:** 7 days from rule landing (2026-08-21 → 2026-08-28).
+- **Cumulative posture impact:** same-class violations (a shared-trigger workflow
+  with a non-colliding group key; an ungated, unbudgeted PR-reachable job; a
+  ceiling raised with no dated rationale) contribute to `trust-posture.md` MUST-4
+  cumulative-window math (3× same-rule in 30d → drop 1 posture; 5× total in 30d →
+  drop 1 posture).
+- **Regression-within-grace:** routes through the GENERIC
+  `regression_within_grace` emergency trigger per `trust-posture.md` MUST-4 (1× =
+  drop 1 posture) — NO dedicated per-clause key. Named deviation from the
+  key-per-clause shape, recorded here per `trust-posture.md` Rule 8: the
+  structural arms already fail closed at pre-commit, so a per-clause instant-drop
+  key would double-count the clauses that cannot silently pass, and minting one
+  would drag `trust-posture.md` — a `self-referential-codify.md` allowlist file —
+  into a self-referential edit. Same disposition `burn-down-reporting.md` and
+  `security.md` § Enforcement-Surface Parity took.
+- **Receipt requirement:** SessionStart soft-gate `[ack: ci-job-budget]` IFF
+  `posture.json::pending_verification` includes the `ci-job-budget` rule_id.
+- **Detection mechanism:** structural, SHIPPED — nothing here is deferred.
+  `scripts/ci/job_budget_audit.py` runs as the `ci-job-budget` pre-commit hook,
+  scoped by `files:` to workflow / declaration / engine edits, so a repo touching
+  none of them pays nothing. It carries `--selftest`, which drives every check
+  against a NEGATIVE control that must trip it and a positive control that must
+  stay quiet, plus an **anti-vacuity floor** that fails when a check ships with no
+  negative control — that is what an inert gate looks like from the outside. It
+  exits **2 (UNRUN, explicitly NOT a pass)** on an unreadable declaration or a
+  missing workflows directory, so a silent no-op cannot read as clean.
+  Discrimination was MEASURED at landing, both poles on one tree: **8 errors**
+  against `origin/main`'s pre-fix workflows, **0** against the fixed tree, and the
+  hook was driven red and green again through the real `pre-commit run` path.
+  Re-measure rather than citing those figures. **No probe suite ships for this
+  rule** — stated explicitly rather than naming a phantom path; the semantic tier
+  is UNCOVERED and owed at gate-review via `/test-harness-probe`, the same
+  disposition `agents.md` § Worktree-Orchestration wiring records.
+- **Violation scope:** MUST-1 (non-colliding concurrency group on a shared-trigger
+  workflow) + MUST-2 (PR-reachable job that is neither required, `paths:`-gated,
+  nor budgeted) + MUST-3 (ceiling raised without a dated rationale). Every
+  `violations.jsonl` row names the workflow and which MUST fired.
+- **Origin:** See § Origin.
+
+## Origin
+
+2026-08-21 — incorporated from loom#1877, which proposed a `ci-job-budget`
+artifact set originating in a sibling BUILD repo. Adopted here ahead of the loom
+cascade at the co-owner's direction, so the eventual cascade is a merge-and-
+validate rather than a first landing.
+
+**Deliberately NOT carried over from the source proposal:** its declaration
+encoded self-hosted fleet topology — runner labels, per-pool capacities, a fleet
+total, a host id, internal workflow names. loom's Gate-1 refused it on exactly
+that ground, and this repo is PUBLIC, so the same refusal binds harder here.
+Capacity is expressed instead as a per-PR job ceiling, which is the metric that
+actually bites on GitHub-hosted runners and which carries no infrastructure
+detail. The source's `--verify-capacity` reader is also not carried: it needs an
+`admin:org` credential no configured secret holds, and adopting an instrument
+nothing can run would book teeth that cannot arrive.
+
+The duplicate-run defect this rule's MUST-1 blocks was found here, not inherited:
+12 workflows carried `${{ github.event.pull_request.number || github.run_id }}`
+verbatim, all with `cancel-in-progress: true`. `docs-build.yml` already carried
+the correct form, so the fix was a pattern the repo had and had not propagated.

--- a/.github/workflows/coc-hook-registration.yml
+++ b/.github/workflows/coc-hook-registration.yml
@@ -41,7 +41,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 3 * * 0"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/cross-sdk-interop.yml
+++ b/.github/workflows/cross-sdk-interop.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/example-validation.yml
+++ b/.github/workflows/example-validation.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/spec-drift-gate.yml
+++ b/.github/workflows/spec-drift-gate.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: spec-drift-gate-${{ github.head_ref || github.run_id }}
+  group: spec-drift-gate-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-kailash-align.yml
+++ b/.github/workflows/test-kailash-align.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-kailash-kaizen.yml
+++ b/.github/workflows/test-kailash-kaizen.yml
@@ -296,7 +296,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -66,7 +66,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-with-infrastructure.yml
+++ b/.github/workflows/test-with-infrastructure.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 0 * * 0" # Sunday at midnight UTC
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/trust-plane.yml
+++ b/.github/workflows/trust-plane.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trust-tests.yml
+++ b/.github/workflows/trust-tests.yml
@@ -28,7 +28,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -63,7 +63,7 @@ permissions:
 
 concurrency:
   # Improved concurrency: Group by PR number for PR events, unique run_id for push events
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,22 @@ repos:
   # package or the lint script itself changes. Pure-stdlib script; no
   # external dependencies; resolves the venv via find-venv-python.sh
   # for worktree compatibility (same pattern as spec-drift-gate above).
+  # CI job-budget census (loom#1877). Fires only on workflow edits, so a new
+  # CI job becomes a DECLARED act instead of an unremarked one. Deliberately a
+  # pre-commit hook rather than a CI job: this repo has an active CI-spend
+  # concern, and a gate about runner fan-out that itself consumes a runner on
+  # every PR would be self-defeating.
+  - repo: local
+    hooks:
+      - id: ci-job-budget
+        name: CI job-budget census (loom#1877)
+        description: "Block push/PR duplicate-run defects and unremarked CI job fan-out."
+        entry: scripts/development/find-venv-python.sh scripts/ci/job_budget_audit.py
+        language: system
+        files: ^(\.github/workflows/|scripts/ci/job_budget_audit\.py|scripts/ci/job-budget\.d/)
+        pass_filenames: false
+        stages: [pre-commit, manual]
+
   - repo: local
     hooks:
       - id: kailash-delegate-fences

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Phase commands replace the manual copy-paste workflow. Each loads the correspond
 | 3-tier testing, no mocking Tiers 2-3  | `rules/testing.md`              | `tests/**`, `**/*test*`, `**/*spec*`, `conftest.py`                   |
 | Infrastructure SQL safety             | `rules/infrastructure-sql.md`   | `src/kailash/db/**`, `src/kailash/infrastructure/**`                  |
 | PACT governance security              | `rules/pact-governance.md`      | `packages/kailash-pact/**`                                            |
+| CI job budget & duplicate runs        | `rules/ci-job-budget.md`        | `.github/workflows/**`, `scripts/ci/job-budget.d/**`                  |
 
 **Note**: Rules with path scoping are loaded only when editing matching files. Global rules load every session.
 

--- a/packages/kailash-kaizen/tests/unit/trust/test_evaluator.py
+++ b/packages/kailash-kaizen/tests/unit/trust/test_evaluator.py
@@ -270,8 +270,17 @@ class TestIndependentMode:
 class TestUnknownDimension:
     """Tests for handling unknown dimensions."""
 
-    def test_unknown_dimension_warning(self, evaluator: MultiDimensionEvaluator):
-        """Unknown dimensions generate warnings but don't fail."""
+    def test_unknown_dimension_fails_closed(self, evaluator: MultiDimensionEvaluator):
+        """An unregistered dimension is unsatisfied, not silently dropped.
+
+        This asserted the opposite until #2189: an unknown dimension warned and
+        was dropped from ``dimension_results``, so a constraint the caller asked
+        to enforce that NOTHING enforced came back ``satisfied=True`` -- and with
+        every dimension unknown the verdict was byte-identical to a genuinely
+        passing evaluation, produced exactly when the registry is misconfigured
+        and the caller most needs the truth. The evaluator now fails closed; this
+        test was left asserting the pre-#2189 behaviour and is corrected here.
+        """
         result = evaluator.evaluate(
             constraints={
                 "cost_limit": 1000,
@@ -281,9 +290,18 @@ class TestUnknownDimension:
             mode=InteractionMode.CONJUNCTIVE,
         )
 
-        assert result.satisfied is True
+        # Fail-closed: the unevaluated dimension makes the whole result unsatisfied.
+        assert result.satisfied is False
         assert "Unknown dimension: unknown_dimension" in result.warnings
-        assert "unknown_dimension" not in result.dimension_results
+
+        # It is RECORDED rather than dropped -- being absent from the result set
+        # is what made it indistinguishable from a satisfied dimension.
+        assert "unknown_dimension" in result.dimension_results
+        assert result.dimension_results["unknown_dimension"].satisfied is False
+        assert "unknown_dimension" in result.failed_dimensions
+
+        # The known dimension is still evaluated on its own merits.
+        assert result.dimension_results["cost_limit"].satisfied is True
 
 
 class TestAntiGaming:

--- a/scripts/ci/job-budget.d/_meta.json
+++ b/scripts/ci/job-budget.d/_meta.json
@@ -1,0 +1,61 @@
+{
+  "$comment": [
+    "Declaration for scripts/ci/job_budget_audit.py.",
+    "",
+    "PUBLIC-REPO SAFE BY CONSTRUCTION. This repo runs GitHub-hosted runners, so",
+    "there is no self-hosted fleet topology here — no runner labels, no host ids,",
+    "no per-pool capacities, no internal hostnames. Do not add any. loom#1877's",
+    "Gate-1 refused the originating repo's declaration for exactly that reason:",
+    "it encoded self-hosted topology and the cascade reaches public surfaces.",
+    "",
+    "Capacity here is expressed as a per-PR job ceiling, which is the metric that",
+    "actually bites on GitHub-hosted runners (queue depth and spend), and which",
+    "carries no infrastructure detail."
+  ],
+
+  "required_contexts": [
+    "CodeQL",
+    "Analyze Python",
+    "test-with-infrastructure"
+  ],
+
+  "required_contexts_source": {
+    "$comment": "Re-measure rather than trusting this line; branch protection is mutable.",
+    "command": "gh api repos/:owner/:repo/branches/main/protection --jq '.required_status_checks.contexts'",
+    "measured_on": "2026-08-21",
+    "measured_value": ["CodeQL", "Analyze Python", "test-with-infrastructure"]
+  },
+
+  "per_pr_job_ceiling": 30,
+  "per_pr_job_ceiling_rationale": [
+    "Measured 2026-08-21 on PR #2205: 25 runner-consuming jobs across 5 runs.",
+    "The ceiling is set just above the measured baseline so it is a RATCHET —",
+    "it fires when fan-out grows, not retroactively on today's state.",
+    "Lowering it is the goal; raising it requires a dated entry below."
+  ],
+
+  "budgeted_exemptions": [
+    {
+      "workflow": "project-automation.yml",
+      "jobs": 5,
+      "reason": "Issue/project board bookkeeping. Every job is `if:`-gated on event type and skips on ordinary PRs — measured on PR #2205: all 5 reported `skipping`.",
+      "declared_on": "2026-08-21",
+      "revisit_on": "2027-02-21"
+    },
+    {
+      "workflow": "claude.yml",
+      "jobs": 3,
+      "reason": "Interactive assistant workflow, gated on an explicit mention trigger; does not fire on ordinary PR synchronize events.",
+      "declared_on": "2026-08-21",
+      "revisit_on": "2027-02-21"
+    }
+  ],
+
+  "dedup_exempt_workflows": [
+    {
+      "workflow": "docs-deploy.yml",
+      "reason": "Uses the fixed group `pages` deliberately — GitHub Pages deployments must serialize globally, not per-branch, and must NOT cancel in progress.",
+      "declared_on": "2026-08-21"
+    }
+  ]
+}

--- a/scripts/ci/job_budget_audit.py
+++ b/scripts/ci/job_budget_audit.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Census PR-reachable CI jobs and make unremarked fan-out loud.
+
+loom#1877 — "CI jobs accrete one unremarkable job at a time, and nothing says
+anything at the moment each is added."
+
+Measured in this repo on PR #2205 (2026-08-21): **25 runner-consuming jobs**
+across 5 workflow runs, of which **3** gate anything (the branch-protection
+required contexts). Nine of those 25 were an exact duplicate of another nine —
+the same workflow ran twice on the identical SHA.
+
+That duplicate had a single root cause, and this tool's first check is its
+regression guard:
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+
+On a ``pull_request`` event that resolves to the PR number. On a ``push`` event
+``pull_request.number`` is empty, so it falls back to ``github.run_id`` — which
+is **unique per run**. Every push run therefore lands in its own private
+concurrency group and can never be deduplicated: not against the PR run for the
+same commit, and not even against an earlier push to the same branch. Twelve
+workflows carried that expression verbatim, all with ``cancel-in-progress: true``
+— the cancellation machinery was armed and the group key defeated it.
+
+The fix is a key that resolves identically for both events::
+
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
+``head_ref`` is set only on pull_request events (the source branch); ``ref_name``
+is the branch on push. Both resolve to the same branch name, so the two runs
+collapse into one group and the later cancels the earlier.
+
+What is an ERROR (exit 1)
+-------------------------
+1. **Dedup defect** — a workflow triggered by BOTH ``push`` and ``pull_request``
+   whose concurrency group cannot resolve identically for the two events (it
+   interpolates ``run_id``, or ``pull_request.number`` as the *fallback*), or
+   which declares no ``concurrency:`` block at all. This is the #2205 duplicate.
+2. **Ceiling breach** — declared PR-reachable job count above
+   ``per_pr_job_ceiling``, after subtracting budgeted exemptions.
+3. **Stale exemption** — a budgeted exemption past its ``revisit_on`` date, or
+   naming a workflow that no longer exists.
+
+What is ADVISORY (exit 0, still printed)
+----------------------------------------
+* **Freeloaders** — PR-reachable jobs that are neither a required context nor
+  ``paths:``-gated. Adding a CI job is legitimate; the goal is that it becomes a
+  *declared* act, not that it is refused. Matching ``ci-job-budget.md``'s
+  contract and ``hook-output-discipline.md`` MUST-2, this never blocks.
+
+Exit codes: 0 = no errors; 1 = >=1 error; 2 = the tool could not run (unreadable
+declaration, unparseable workflow). Exit 2 is UNRUN, explicitly NOT a pass — a
+silent no-op must never read as clean.
+
+Run ``--selftest`` to prove the gate can still go red: it drives every check
+against a NEGATIVE control that must trip it and a positive control that must
+stay quiet. A check with no negative control is itself reported as an error
+(anti-vacuity floor) — that is what an inert gate looks like from the outside.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+DECLARATION = ROOT / "scripts" / "ci" / "job-budget.d" / "_meta.json"
+
+# A group key that resolves identically on push and pull_request. `head_ref` is
+# empty off a PR, so the fallback carries the push case.
+_SAFE_FALLBACKS = (
+    "github.ref_name",
+    "github.ref",
+    "github.event.pull_request.head.ref",
+)
+# Interpolations that make a group unique per run, defeating dedup entirely.
+_UNIQUE_TOKENS = ("github.run_id", "github.run_number", "github.sha")
+
+
+class Finding:
+    def __init__(self, severity: str, check: str, workflow: str, message: str):
+        self.severity = severity
+        self.check = check
+        self.workflow = workflow
+        self.message = message
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity,
+            "check": self.check,
+            "workflow": self.workflow,
+            "message": self.message,
+        }
+
+    def __str__(self) -> str:
+        tag = "ERROR " if self.severity == "error" else "note  "
+        return f"{tag} [{self.check}] {self.workflow}: {self.message}"
+
+
+def load_declaration(path: Path = DECLARATION) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _on_block(text: str) -> str:
+    """The workflow's `on:` block, as raw text.
+
+    Deliberately textual rather than YAML-parsed: `on` is the YAML 1.1 boolean
+    `True` after a safe_load, which silently renames the key and is exactly the
+    kind of quiet mis-read this tool exists to prevent.
+    """
+    m = re.search(
+        r"^on:(.*?)^(?:jobs|permissions|env|concurrency|defaults):", text, re.S | re.M
+    )
+    return m.group(1) if m else text
+
+
+def _concurrency_group(text: str) -> str | None:
+    m = re.search(r"^concurrency:\s*$(.*?)(?=^\S)", text, re.S | re.M)
+    if not m:
+        m = re.search(r"^concurrency:(.*?)(?=^\S)", text, re.S | re.M)
+        if not m:
+            return None
+    g = re.search(r"group:\s*(.+)$", m.group(1), re.M)
+    return g.group(1).strip() if g else None
+
+
+def _job_names(text: str) -> list[str]:
+    if "jobs:" not in text:
+        return []
+    body = text.split("jobs:", 1)[1]
+    return re.findall(r"^  ([A-Za-z0-9_-]+):\s*$", body, re.M)
+
+
+def group_dedups_push_and_pr(group: str | None) -> tuple[bool, str]:
+    """Does this concurrency group collapse a push run and a PR run for one branch?
+
+    Returns (ok, reason). The reason is the falsifying detail, so a caller can
+    print WHY rather than just that something failed.
+    """
+    if group is None:
+        return (
+            False,
+            "no `concurrency:` group declared — push and PR runs cannot collapse",
+        )
+    for tok in _UNIQUE_TOKENS:
+        if tok in group:
+            return False, (
+                f"group interpolates `{tok}`, which is unique per run — the push run "
+                f"lands in its own group and is never deduplicated"
+            )
+    if "pull_request.number" in group and "||" in group:
+        head, _, tail = group.partition("||")
+        if "pull_request.number" in head and not any(
+            f in tail for f in _SAFE_FALLBACKS
+        ):
+            return False, (
+                "group falls back off `pull_request.number` to something that does not "
+                "resolve to the branch on a push event"
+            )
+    if any(f in group for f in _SAFE_FALLBACKS) or "head_ref" in group:
+        return True, "resolves to the branch on both push and pull_request"
+    return (
+        False,
+        f"group `{group}` does not demonstrably resolve identically for push and pull_request",
+    )
+
+
+def audit(
+    decl: dict[str, Any], workflows_dir: Path = WORKFLOWS, today: _dt.date | None = None
+) -> list[Finding]:
+    today = today or _dt.date.today()
+    findings: list[Finding] = []
+
+    exempt_dedup = {e["workflow"] for e in decl.get("dedup_exempt_workflows", [])}
+    budgeted = {e["workflow"]: e for e in decl.get("budgeted_exemptions", [])}
+    required = set(decl.get("required_contexts", []))
+
+    pr_job_total = 0
+    present: set[str] = set()
+
+    for f in sorted(workflows_dir.iterdir()):
+        if f.suffix not in (".yml", ".yaml"):
+            continue
+        present.add(f.name)
+        text = f.read_text(encoding="utf-8", errors="replace")
+        on = _on_block(text)
+        on_pr = "pull_request" in on
+        on_push = re.search(r"^\s+push:", on, re.M) is not None
+        if not on_pr:
+            continue
+
+        jobs = _job_names(text)
+        if f.name in budgeted:
+            pass  # declared, does not count toward the ceiling
+        else:
+            pr_job_total += len(jobs)
+
+        # Check 1 — dedup defect. Only bites when BOTH triggers are present:
+        # a pull_request-only workflow cannot produce the duplicate.
+        if on_push and f.name not in exempt_dedup:
+            ok, why = group_dedups_push_and_pr(_concurrency_group(text))
+            if not ok:
+                findings.append(Finding("error", "dedup", f.name, why))
+
+        # Advisory — freeloaders: neither required nor paths-gated.
+        if (
+            not any(j in required for j in jobs)
+            and "paths:" not in on
+            and f.name not in budgeted
+        ):
+            findings.append(
+                Finding(
+                    "note",
+                    "freeloader",
+                    f.name,
+                    f"{len(jobs)} job(s) run on every PR but gate nothing and are not `paths:`-gated",
+                )
+            )
+
+    # Check 3 — stale / dangling exemptions.
+    for name, e in budgeted.items():
+        if name not in present:
+            findings.append(
+                Finding(
+                    "error",
+                    "exemption",
+                    name,
+                    "budgeted exemption names a workflow that no longer exists",
+                )
+            )
+            continue
+        rv = e.get("revisit_on")
+        if rv and _dt.date.fromisoformat(rv) < today:
+            findings.append(
+                Finding(
+                    "error",
+                    "exemption",
+                    name,
+                    f"budgeted exemption passed its revisit_on date ({rv})",
+                )
+            )
+
+    # Check 2 — ceiling.
+    ceiling = decl.get("per_pr_job_ceiling")
+    if isinstance(ceiling, int) and pr_job_total > ceiling:
+        findings.append(
+            Finding(
+                "error",
+                "ceiling",
+                "(repo)",
+                f"{pr_job_total} PR-reachable jobs declared, ceiling is {ceiling}",
+            )
+        )
+
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Selftest — every check gets a NEGATIVE control that must trip it and a
+# positive control that must stay quiet. A check with no negative control is
+# reported as an error: that is precisely what an inert gate looks like.
+# --------------------------------------------------------------------------
+
+_NEG = {
+    "dedup-run_id": (
+        "on:\n  push:\n    branches: [x]\n  pull_request:\n    branches: [main]\n"
+        "concurrency:\n  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}\n"
+        "  cancel-in-progress: true\njobs:\n  a:\n    runs-on: x\n"
+    ),
+    "dedup-missing": (
+        "on:\n  push:\n    branches: [x]\n  pull_request:\n    branches: [main]\n"
+        "jobs:\n  a:\n    runs-on: x\n"
+    ),
+}
+_POS = {
+    "dedup-ok": (
+        "on:\n  push:\n    branches: [x]\n  pull_request:\n    branches: [main]\n"
+        "concurrency:\n  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}\n"
+        "  cancel-in-progress: true\njobs:\n  a:\n    runs-on: x\n"
+    ),
+    "dedup-pr-only": (  # pull_request only: cannot duplicate, must not be flagged
+        "on:\n  pull_request:\n    branches: [main]\n" "jobs:\n  a:\n    runs-on: x\n"
+    ),
+}
+
+
+def selftest() -> int:
+    cases = 0
+    failures: list[str] = []
+
+    for name, text in _NEG.items():
+        cases += 1
+        ok, why = group_dedups_push_and_pr(_concurrency_group(text))
+        if ok:
+            failures.append(f"NEGATIVE control '{name}' did NOT trip the dedup check")
+
+    for name, text in _POS.items():
+        cases += 1
+        if name == "dedup-pr-only":
+            on = _on_block(text)
+            if re.search(r"^\s+push:", on, re.M):
+                failures.append(f"POSITIVE control '{name}' misread as push-triggered")
+            continue
+        ok, why = group_dedups_push_and_pr(_concurrency_group(text))
+        if not ok:
+            failures.append(f"POSITIVE control '{name}' was flagged: {why}")
+
+    # Ceiling: negative control must breach, positive must not.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "w.yml").write_text(
+            "on:\n  pull_request:\n    branches: [main]\n"
+            "jobs:\n" + "".join(f"  j{i}:\n    runs-on: x\n" for i in range(9)),
+            encoding="utf-8",
+        )
+        cases += 1
+        breached = audit({"per_pr_job_ceiling": 5, "required_contexts": []}, d)
+        if not any(f.check == "ceiling" for f in breached):
+            failures.append(
+                "NEGATIVE control 'ceiling' did NOT trip (9 jobs vs ceiling 5)"
+            )
+        cases += 1
+        quiet = audit({"per_pr_job_ceiling": 50, "required_contexts": []}, d)
+        if any(f.check == "ceiling" for f in quiet):
+            failures.append(
+                "POSITIVE control 'ceiling' tripped at ceiling 50 with 9 jobs"
+            )
+
+    # Exemption expiry: negative control must trip.
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "w.yml").write_text(
+            "on:\n  pull_request:\njobs:\n  a:\n    runs-on: x\n", encoding="utf-8"
+        )
+        cases += 1
+        stale = audit(
+            {
+                "per_pr_job_ceiling": 99,
+                "required_contexts": [],
+                "budgeted_exemptions": [
+                    {"workflow": "w.yml", "revisit_on": "2020-01-01"}
+                ],
+            },
+            d,
+            today=_dt.date(2026, 1, 1),
+        )
+        if not any(f.check == "exemption" for f in stale):
+            failures.append("NEGATIVE control 'stale exemption' did NOT trip")
+
+    # Anti-vacuity floor: every check this tool can emit must own a negative control.
+    checks_with_negative = {"dedup", "ceiling", "exemption"}
+    emitted_checks = {"dedup", "ceiling", "exemption", "freeloader"}
+    advisory_only = {"freeloader"}
+    uncovered = emitted_checks - checks_with_negative - advisory_only
+    if uncovered:
+        failures.append(
+            f"anti-vacuity: check(s) with no negative control: {sorted(uncovered)}"
+        )
+
+    for f in failures:
+        print(f"SELFTEST FAIL: {f}", file=sys.stderr)
+    print(f"selftest: {cases} case(s), {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--json", action="store_true", help="emit findings as JSON")
+    p.add_argument("--selftest", action="store_true", help="prove the gate can go red")
+    args = p.parse_args(list(argv) if argv is not None else None)
+
+    if args.selftest:
+        return selftest()
+
+    try:
+        decl = load_declaration()
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"UNRUN: cannot read declaration {DECLARATION}: {e}", file=sys.stderr)
+        return 2
+    if not WORKFLOWS.is_dir():
+        print(f"UNRUN: no workflows directory at {WORKFLOWS}", file=sys.stderr)
+        return 2
+
+    findings = audit(decl)
+    errors = [f for f in findings if f.severity == "error"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "errors": len(errors),
+                    "notes": len(findings) - len(errors),
+                    "findings": [f.as_dict() for f in findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        for f in findings:
+            print(f)
+        print(
+            f"\njob-budget-audit: {len(errors)} error(s), "
+            f"{len(findings) - len(errors)} advisory note(s)"
+        )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Incorporates the `ci-job-budget` contract from [loom#1877](https://github.com/esperie-enterprise/loom/issues/1877) ahead of the cascade — so when loom does cascade, it is a merge-and-validate rather than a first landing — and fixes a **duplicate-run defect found here while doing it**.

## The defect

Twelve workflows declared:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
```

On a `pull_request` event that resolves to the PR number. On a **`push`** event `pull_request.number` is empty, so it falls back to **`github.run_id` — which is unique per run**. Every push run therefore landed in its own private concurrency group and could never be deduplicated: not against the PR run for the same commit, and not even against an earlier push to the same branch.

All twelve carried `cancel-in-progress: true`. The cancellation machinery was armed the whole time; the group key defeated it. `docs-build.yml` already used the correct form — this was a pattern the repo *had* and had not propagated.

**Measured on PR #2205:** "CI Pipeline" ran twice on the identical SHA, 9 jobs each.

| run | conclusion |
| --- | --- |
| 32402148738 | failure |
| 32402192881 | success |

The duplicate is not only spend. The two copies **disagreed**, and the failing one was indistinguishable from a real regression until the runs were compared by SHA — it cost a full investigation before resolving as a known flake (#2206).

## The fix

`${{ github.head_ref || github.ref_name }}` — `head_ref` is the source branch on PR events, `ref_name` the branch on push, so both resolve identically and the runs collapse. 13 workflows updated (12 plus `spec-drift-gate.yml`, same `run_id` fallback).

## The census

`scripts/ci/job_budget_audit.py` guards against regression *and* silent accretion: a new PR-reachable job must be a required context, `paths:`-gated, or carry a dated budgeted exemption in `scripts/ci/job-budget.d/_meta.json`.

It runs as a **pre-commit hook scoped to workflow edits, not as a CI job** — a gate about runner fan-out that itself consumes a runner on every PR would pay the cost it exists to prevent.

### Discrimination — measured, both poles, one tree

| | errors |
| --- | --- |
| `origin/main` workflows (pre-fix) | **8** |
| this branch (post-fix) | **0** |

It correctly does **not** flag the 4 workflows that carried the broken pattern but are `pull_request`-only — those cannot duplicate. The hook was also driven red and green again through the real `pre-commit run` path, not just the library API.

`--selftest` carries a negative control per check plus an **anti-vacuity floor** that fails when a check ships with no control. The tool exits **2 (UNRUN, explicitly not a pass)** rather than reporting clean when it cannot run.

## What was deliberately not carried over

- **The source's declaration** encoded self-hosted fleet topology (runner labels, per-pool capacities, fleet total, host id, internal workflow names). loom's Gate-1 refused it on exactly that ground, and **this repo is public**, so the refusal binds harder. Capacity is expressed as a per-PR job ceiling instead — the metric that actually bites on GitHub-hosted runners, carrying no infrastructure detail.
- **`--verify-capacity`** — it needs an `admin:org` credential no configured secret holds. Adopting an instrument nothing can run books teeth that cannot arrive.
- **The hook-as-CI-job placement** — see above.

## Current advisory state (exit 0, reported not blocked)

```
note [freeloader] auto-merge.yml: 1 job(s) run on every PR but gate nothing and are not `paths:`-gated
note [freeloader] codeql.yml:     1 job(s) run on every PR but gate nothing and are not `paths:`-gated
```

`codeql.yml` is a required context, so its note is a known false positive of the freeloader heuristic (it gates via branch protection, not via a job name this static check can see). Left visible rather than special-cased, so the heuristic's limit stays honest.

## Related issues

Refs loom#1877

PCF-Category: BUG


---

## Also in this PR: one pre-existing test failure, fixed in-branch

CI on this branch went red on a single failure unrelated to the workflow changes (my diff touches no kaizen source — only `test-kailash-kaizen.yml`, a workflow):

```
FAILED tests/unit/trust/test_evaluator.py::TestUnknownDimension::test_unknown_dimension_warning
       - AssertionError: assert False is True
```

The test asserted `result.satisfied is True` for an **unregistered constraint dimension** — precisely the fail-**open** behaviour that #2189 (`73c45fa43`) deliberately removed. That commit made unknown dimensions fail closed, because dropping one from the result set made a constraint the caller asked to enforce *that nothing enforced* return `satisfied=True`, byte-identical to a genuinely passing evaluation and produced exactly when the registry is misconfigured.

#2189 added its regression suite at the **root** `tests/` tree and left this kaizen-side test on the old contract — the `zero-tolerance` Rule 3e shape: a contract restated in a second location and not re-derived when the source moved.

**The test is corrected; the evaluator is untouched.** Fixing it the other way — relaxing the evaluator to make the test green — would have re-opened the #2189 security hole. The direction was established from the code's own rationale *before* either side was edited.

- **Swept for siblings:** one stale test, not a class. The other three kaizen trust files and all 207 root trust/regression tests already pass against fail-closed.
- **Discrimination verified, both poles:** with the evaluator temporarily reverted to fail-open the corrected test FAILS (`assert True is False`); restored, it passes and the evaluator diff is empty.
- Full kaizen trust suite: **1633 passed, 16 skipped**.

## A consequence of the dedup fix, stated plainly

Cancelled duplicate runs surface as `fail` in `gh pr checks`. On this PR that is most of the red: measured on head `f97bc2d67`, 4 runs were `cancelled` (the duplicates being killed) and exactly **1** was a genuine `failure` (the stale test above). All **3 required contexts pass**.

This is a real readability cost of the fix and worth knowing when reading a PR's check list — but it replaces a worse failure mode, where the duplicate ran to completion and its result *disagreed* with its twin, which is what cost an investigation on #2205.
